### PR TITLE
re-Config-uration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ cat > psalm.xml << EOF
   stopOnFirstError="false"
   useDocblockTypes="true"
 >
-    <inspectFiles>
+    <projectFiles>
         <directory name="src" />
-    </inspectFiles>
+    </projectFiles>
 </psalm>
 EOF
 ```

--- a/config.xsd
+++ b/config.xsd
@@ -1,0 +1,159 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+    <xs:element name="psalm" type="PsalmType" />
+
+    <xs:complexType name="PsalmType">
+        <xs:sequence>
+            <xs:element name="projectFiles" type="ProjectFilesType" minOccurs="1" maxOccurs="1" />
+            <xs:element name="fileExtensions" type="FileExtensionsType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="mockClasses" type="MockClassesType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="plugins" type="PluginsType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="issueHandlers" type="IssueHandlersType" minOccurs="0" maxOccurs="1" />
+        </xs:sequence>
+
+        <xs:attribute name="name" type="xs:string" />
+        <xs:attribute name="stopOnFirstError" type="xs:string" />
+        <xs:attribute name="useDocblockTypes" type="xs:string" />
+        <xs:attribute name="throwExceptionOnError" type="xs:string" />
+        <xs:attribute name="hideExternalErrors" type="xs:string" />
+        <xs:attribute name="autoloader" type="xs:string" />
+        <xs:attribute name="cacheDirectory" type="xs:string" />
+        <xs:attribute name="usePropertyDefaultForType" type="xs:string" />
+        <xs:attribute name="allowFileIncludes" type="xs:string" />
+        <xs:attribute name="totallyTyped" type="xs:string" />
+        <xs:attribute name="strictBinaryOperands" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="ProjectFilesType">
+        <xs:sequence>
+            <xs:element name="directory" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+            <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+            <xs:element name="ignoreFiles" minOccurs="0" maxOccurs="1">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="directory" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+                        <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+                    </xs:sequence>
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="NameAttributeType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="FileExtensionsType">
+        <xs:sequence>
+            <xs:element name="extension">
+                <xs:complexType>
+                    <xs:attribute name="name" type="xs:string" use="required" />
+                    <xs:attribute name="filetypeHandler" type="xs:string" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="MockClassesType">
+        <xs:sequence>
+            <xs:element name="class" maxOccurs="unbounded" type="NameAttributeType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="PluginsType">
+        <xs:sequence>
+            <xs:element name="plugin" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:attribute name="filename" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="IssueHandlersType">
+        <xs:choice minOccurs="0" maxOccurs="unbounded">
+            <xs:element name="ContinueOutsideLoop" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="DeprecatedMethod" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="FailedTypeResolution" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="ForbiddenCode" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="ImplicitToStringCast" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InaccessibleClassConstant" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InaccessibleMethod" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InaccessibleProperty" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidArgument" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidArrayAccess" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidArrayAssignment" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidClass" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidDocblock" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidGlobal" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidIterator" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidNamespace" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidOperand" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidPropertyAssignment" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidPropertyFetch" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidReturnType" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidScalarArgument" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidScope" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidStaticInvocation" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidStaticVariable" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidToString" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MethodSignatureMismatch" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MissingPropertyDeclaration" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MissingPropertyType" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MissingReturnType" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedArgument" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedArrayAccess" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedArrayOffset" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedAssignment" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedInferredReturnType" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedMethodCall" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedOperand" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedPropertyAssignment" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedPropertyFetch" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MixedStringOffsetAssignment" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NoInterfaceProperties" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NullArgument" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NullArrayAccess" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NullOperand" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NullPropertyAssignment" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NullPropertyFetch" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NullReference" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="ParentNotFound" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="PossiblyUndefinedVariable" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="TooFewArguments" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="TooManyArguments" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="TypeCoercion" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="TypeDoesNotContainType" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedClass" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedConstant" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedFunction" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedMethod" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedPropertyAssignment" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedPropertyFetch" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedThisPropertyAssignment" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedThisPropertyFetch" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedTrait" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedVariable" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UnimplementedInterfaceMethod" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UnrecognizedExpression" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UnrecognizedStatement" type="IssueHandlerType" minOccurs="0" />
+        </xs:choice>
+    </xs:complexType>
+
+    <xs:complexType name="IssueHandlerType">
+        <xs:sequence>
+            <xs:element name="errorLevel" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:sequence>
+                        <xs:element name="directory" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+                        <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+                    </xs:sequence>
+
+                    <xs:attribute name="type" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+
+        <xs:attribute name="errorLevel" type="xs:string" />
+    </xs:complexType>
+</xs:schema>

--- a/config.xsd
+++ b/config.xsd
@@ -25,18 +25,18 @@
     </xs:complexType>
 
     <xs:complexType name="ProjectFilesType">
-        <xs:sequence>
+        <xs:choice maxOccurs="unbounded">
             <xs:element name="directory" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
             <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
             <xs:element name="ignoreFiles" minOccurs="0" maxOccurs="1">
                 <xs:complexType>
-                    <xs:sequence>
+                    <xs:choice maxOccurs="unbounded">
                         <xs:element name="directory" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                         <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
-                    </xs:sequence>
+                    </xs:choice>
                 </xs:complexType>
             </xs:element>
-        </xs:sequence>
+        </xs:choice>
     </xs:complexType>
 
     <xs:complexType name="NameAttributeType">
@@ -144,10 +144,10 @@
         <xs:sequence>
             <xs:element name="errorLevel" minOccurs="0" maxOccurs="unbounded">
                 <xs:complexType>
-                    <xs:sequence>
+                    <xs:choice maxOccurs="unbounded">
                         <xs:element name="directory" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                         <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
-                    </xs:sequence>
+                    </xs:choice>
 
                     <xs:attribute name="type" type="xs:string" use="required" />
                 </xs:complexType>

--- a/examples/psalm.default.xml
+++ b/examples/psalm.default.xml
@@ -5,15 +5,15 @@
     useDocblockTypes="true"
     totallyTyped="false"
 >
-    <inspectFiles>
+    <projectFiles>
         <directory name="src" />
-    </inspectFiles>
+    </projectFiles>
 
-    <issueHandler>
+    <issueHandlers>
         <InvalidDocblock errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <MissingReturnType errorLevel="info" />
         <DeprecatedMethod errorLevel="info" />
         <PossiblyUndefinedVariable errorLevel="info" />
-    </issueHandler>
+    </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,7 +11,6 @@
         <directory name="tests" />
     </projectFiles>
 
-
     <issueHandler>
         <NullOperand errorLevel="suppress" />
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -6,66 +6,67 @@
     totallyTyped="true"
     strictBinaryOperands="false"
 >
-    <inspectFiles>
+    <projectFiles>
         <directory name="src" />
         <directory name="tests" />
-    </inspectFiles>
+    </projectFiles>
+
 
     <issueHandler>
         <NullOperand errorLevel="suppress" />
 
         <MissingReturnType>
-            <excludeFiles>
+            <ignoreFiles>
                 <directory name="tests" />
-            </excludeFiles>
+            </ignoreFiles>
         </MissingReturnType>
 
         <MissingPropertyType>
-            <excludeFiles>
+            <ignoreFiles>
                 <directory name="tests" />
-            </excludeFiles>
+            </ignoreFiles>
         </MissingPropertyType>
 
         <MixedArgument>
-            <excludeFiles>
+            <ignoreFiles>
                 <directory name="tests" />
-            </excludeFiles>
+            </ignoreFiles>
         </MixedArgument>
 
         <MixedOperand>
-            <excludeFiles>
+            <ignoreFiles>
                 <directory name="tests" />
-            </excludeFiles>
+            </ignoreFiles>
         </MixedOperand>
 
         <MixedPropertyFetch>
-            <excludeFiles>
+            <ignoreFiles>
                 <directory name="tests" />
-            </excludeFiles>
+            </ignoreFiles>
         </MixedPropertyFetch>
 
         <NoInterfaceProperties>
-            <excludeFiles>
+            <ignoreFiles>
                 <directory name="tests" />
-            </excludeFiles>
+            </ignoreFiles>
         </NoInterfaceProperties>
 
         <NullArrayAccess>
-            <excludeFiles>
+            <ignoreFiles>
                 <directory name="tests" />
-            </excludeFiles>
+            </ignoreFiles>
         </NullArrayAccess>
 
         <NullPropertyFetch>
-            <excludeFiles>
+            <ignoreFiles>
                 <directory name="tests" />
-            </excludeFiles>
+            </ignoreFiles>
         </NullPropertyFetch>
 
         <NullArgument>
-            <excludeFiles>
+            <ignoreFiles>
                 <directory name="tests" />
-            </excludeFiles>
+            </ignoreFiles>
         </NullArgument>
     </issueHandler>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,61 +11,61 @@
         <directory name="tests" />
     </projectFiles>
 
-    <issueHandler>
+    <issueHandlers>
         <NullOperand errorLevel="suppress" />
 
         <MissingReturnType>
-            <ignoreFiles>
+            <errorLevel type="suppress">
                 <directory name="tests" />
-            </ignoreFiles>
+            </errorLevel>
         </MissingReturnType>
 
         <MissingPropertyType>
-            <ignoreFiles>
+            <errorLevel type="suppress">
                 <directory name="tests" />
-            </ignoreFiles>
+            </errorLevel>
         </MissingPropertyType>
 
         <MixedArgument>
-            <ignoreFiles>
+            <errorLevel type="suppress">
                 <directory name="tests" />
-            </ignoreFiles>
+            </errorLevel>
         </MixedArgument>
 
         <MixedOperand>
-            <ignoreFiles>
+            <errorLevel type="suppress">
                 <directory name="tests" />
-            </ignoreFiles>
+            </errorLevel>
         </MixedOperand>
 
         <MixedPropertyFetch>
-            <ignoreFiles>
+            <errorLevel type="suppress">
                 <directory name="tests" />
-            </ignoreFiles>
+            </errorLevel>
         </MixedPropertyFetch>
 
         <NoInterfaceProperties>
-            <ignoreFiles>
+            <errorLevel type="suppress">
                 <directory name="tests" />
-            </ignoreFiles>
+            </errorLevel>
         </NoInterfaceProperties>
 
         <NullArrayAccess>
-            <ignoreFiles>
+            <errorLevel type="suppress">
                 <directory name="tests" />
-            </ignoreFiles>
+            </errorLevel>
         </NullArrayAccess>
 
         <NullPropertyFetch>
-            <ignoreFiles>
+            <errorLevel type="suppress">
                 <directory name="tests" />
-            </ignoreFiles>
+            </errorLevel>
         </NullPropertyFetch>
 
         <NullArgument>
-            <ignoreFiles>
+            <errorLevel type="suppress">
                 <directory name="tests" />
-            </ignoreFiles>
+            </errorLevel>
         </NullArgument>
-    </issueHandler>
+    </issueHandlers>
 </psalm>

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -101,7 +101,7 @@ class ProjectChecker
             $deleted_files = FileChecker::getDeletedReferencedFiles();
             $diff_files = $deleted_files;
 
-            foreach ($this->config->getIncludeDirs() as $dir_name) {
+            foreach ($this->config->getProjectDirectories() as $dir_name) {
                 $diff_files = array_merge($diff_files, self::getDiffFilesInDir($dir_name, $this->config));
             }
         }
@@ -109,7 +109,7 @@ class ProjectChecker
         $files_checked = [];
 
         if ($diff_files === null || $deleted_files === null || count($diff_files) > 200) {
-            foreach ($this->config->getIncludeDirs() as $dir_name) {
+            foreach ($this->config->getProjectDirectories() as $dir_name) {
                 $this->checkDirWithConfig($dir_name, $this->config, $debug, $update_docblocks);
             }
         } else {
@@ -211,7 +211,7 @@ class ProjectChecker
         $file_extensions = $config->getFileExtensions();
         $file_names = [];
 
-        foreach ($config->getIncludeDirs() as $dir_name) {
+        foreach ($config->getProjectDirectories() as $dir_name) {
             /** @var RecursiveDirectoryIterator */
             $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir_name));
             $iterator->rewind();
@@ -371,7 +371,7 @@ class ProjectChecker
             $maybe_path = $dir_path . Config::DEFAULT_FILE_NAME;
 
             if (file_exists($maybe_path)) {
-                $config = Config::loadFromXML($maybe_path);
+                $config = Config::loadFromXMLFile($maybe_path);
 
                 if ($config->autoloader) {
                     require_once($dir_path . $config->autoloader);
@@ -405,7 +405,7 @@ class ProjectChecker
 
         $dir_path = dirname($path_to_config) . '/';
 
-        $this->config = Config::loadFromXML($path_to_config);
+        $this->config = Config::loadFromXMLFile($path_to_config);
 
         if ($this->config->autoloader) {
             require_once($dir_path . $this->config->autoloader);

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -405,7 +405,7 @@ class Config
 
         $file_name = $this->shortenFileName($file_name);
 
-        if ($this->getProjectDirectories() && $this->hide_external_errors) {
+        if ($this->project_files && $this->hide_external_errors) {
             if (!$this->isInProjectDirs($file_name)) {
                 return true;
             }
@@ -424,13 +424,7 @@ class Config
      */
     public function isInProjectDirs($file_name)
     {
-        foreach ($this->getProjectDirectories() as $dir_name) {
-            if (preg_match('/^' . preg_quote($dir_name, '/') . '/', $file_name)) {
-                return true;
-            }
-        }
-
-        return false;
+        return $this->project_files && $this->project_files->allows($file_name);
     }
 
     /**

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -88,7 +88,7 @@ class Config
     /**
      * @var FileFilter|null
      */
-    protected $inspect_files;
+    protected $project_files;
 
     /**
      * The base directory of this config file
@@ -228,8 +228,8 @@ class Config
             $config->strict_binary_operands = $attribute_text === 'true' || $attribute_text === '1';
         }
 
-        if (isset($config_xml->inspectFiles)) {
-            $config->inspect_files = FileFilter::loadFromXML($config_xml->inspectFiles, true);
+        if (isset($config_xml->projectFiles)) {
+            $config->project_files = FileFilter::loadFromXML($config_xml->projectFiles, true);
         }
 
         if (isset($config_xml->fileExtensions)) {
@@ -289,12 +289,12 @@ class Config
                     $config->custom_error_levels[$key] = $error_level;
                 }
 
-                if (isset($issue_handler->excludeFiles)) {
-                    $config->issue_handlers[$key] = FileFilter::loadFromXML($issue_handler->excludeFiles, false);
+                if (isset($issue_handler->ignoreFiles)) {
+                    $config->issue_handlers[$key] = FileFilter::loadFromXML($issue_handler->ignoreFiles, false);
                 }
 
-                if (isset($issue_handler->includeFiles)) {
-                    $config->issue_handlers[$key] = FileFilter::loadFromXML($issue_handler->includeFiles, true);
+                if (isset($issue_handler->onlyFiles)) {
+                    $config->issue_handlers[$key] = FileFilter::loadFromXML($issue_handler->onlyFiles, true);
                 }
             }
         }
@@ -439,11 +439,11 @@ class Config
      */
     public function getIncludeDirs()
     {
-        if (!$this->inspect_files) {
+        if (!$this->project_files) {
             return [];
         }
 
-        return $this->inspect_files->getIncludeDirs();
+        return $this->project_files->getIncludeDirs();
     }
 
     /**

--- a/src/Psalm/Config/ErrorLevelFileFilter.php
+++ b/src/Psalm/Config/ErrorLevelFileFilter.php
@@ -1,0 +1,44 @@
+<?php
+namespace Psalm\Config;
+
+use SimpleXMLElement;
+
+class ErrorLevelFileFilter extends FileFilter
+{
+    /**
+     * @var string
+     */
+    protected $error_level;
+
+    /**
+     * @param  SimpleXMLElement $e
+     * @param  bool             $inclusive
+     * @return self
+     */
+    public static function loadFromXMLElement(
+        SimpleXMLElement $e,
+        $inclusive
+    ) {
+        $filter = parent::loadFromXMLElement($e, $inclusive);
+
+        if (isset($e['type'])) {
+            $filter->error_level = (string) $e['type'];
+
+            if (!in_array($filter->error_level, \Psalm\Config::$ERROR_LEVELS)) {
+                throw new \Psalm\Exception\ConfigException('Unexepected error level ' . $filter->error_level);
+            }
+        } else {
+            throw new \Psalm\Exception\ConfigException('<type> element expects a level');
+        }
+
+        return $filter;
+    }
+
+    /**
+     * @return string
+     */
+    public function getErrorLevel()
+    {
+        return $this->error_level;
+    }
+}

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -21,11 +21,6 @@ class FileFilter
     protected $files_lowercase = [];
 
     /**
-     * @var FileFilter|null
-     */
-    protected $file_filter = null;
-
-    /**
      * @var array<string>
      */
     protected $patterns = [];
@@ -52,11 +47,13 @@ class FileFilter
     /**
      * @param  SimpleXMLElement $e
      * @param  bool             $inclusive
-     * @return self
+     * @return static
      */
-    public static function loadFromXMLElement(SimpleXMLElement $e, $inclusive)
-    {
-        $filter = new self($inclusive);
+    public static function loadFromXMLElement(
+        SimpleXMLElement $e,
+        $inclusive
+    ) {
+        $filter = new static($inclusive);
 
         if ($e->directory) {
             /** @var \SimpleXMLElement $directory */
@@ -70,15 +67,6 @@ class FileFilter
             foreach ($e->file as $file) {
                 $filter->addFile((string)$file['name']);
             }
-        }
-
-        if (isset($e->ignoreFiles)) {
-            if (!$inclusive) {
-                throw new \Psalm\Exception\ConfigException('Cannot nest ignoreFiles inside itself');
-            }
-
-            /** @var \SimpleXMLElement $e->ignoreFiles */
-            $filter->file_filter = self::loadFromXMLElement($e->ignoreFiles, false);
         }
 
         return $filter;
@@ -101,12 +89,6 @@ class FileFilter
     public function allows($file_name, $case_sensitive = false)
     {
         if ($this->inclusive) {
-            if ($this->file_filter) {
-                if (!$this->file_filter->allows($file_name, $case_sensitive)) {
-                    return false;
-                }
-            }
-
             foreach ($this->directories as $include_dir) {
                 if ($case_sensitive) {
                     if (strpos($file_name, $include_dir) === 0) {

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -8,32 +8,32 @@ class FileFilter
     /**
      * @var array<string>
      */
-    protected $include_dirs = [];
+    protected $only_dirs = [];
 
     /**
      * @var array<string>
      */
-    protected $exclude_dirs = [];
+    protected $ignore_dirs = [];
 
     /**
      * @var array<string>
      */
-    protected $include_files = [];
+    protected $only_files = [];
 
     /**
      * @var array<string>
      */
-    protected $include_files_lowercase = [];
+    protected $only_files_lowercase = [];
 
     /**
      * @var array<string>
      */
-    protected $exclude_files = [];
+    protected $ignore_files = [];
 
     /**
      * @var array<string>
      */
-    protected $exclude_files_lowercase = [];
+    protected $ignore_files_lowercase = [];
 
     /**
      * @var array<string>
@@ -77,28 +77,28 @@ class FileFilter
             if ($e->directory) {
                 /** @var \SimpleXMLElement $directory */
                 foreach ($e->directory as $directory) {
-                    $filter->addIncludeDirectory((string)$directory['name']);
+                    $filter->addOnlyDirectory((string)$directory['name']);
                 }
             }
 
             if ($e->file) {
                 /** @var \SimpleXMLElement $file */
                 foreach ($e->file as $file) {
-                    $filter->addIncludeFile((string)$file['name']);
+                    $filter->addOnlyFile((string)$file['name']);
                 }
             }
         } else {
             if ($e->directory) {
                 /** @var \SimpleXMLElement $directory */
                 foreach ($e->directory as $directory) {
-                    $filter->addExcludeDirectory((string)$directory['name']);
+                    $filter->addIgnoreDirectory((string)$directory['name']);
                 }
             }
 
             if ($e->file) {
                 /** @var \SimpleXMLElement $file */
                 foreach ($e->file as $file) {
-                    $filter->addExcludeFile((string)$file['name']);
+                    $filter->addIgnoreFile((string)$file['name']);
                 }
             }
         }
@@ -123,7 +123,7 @@ class FileFilter
     public function allows($file_name, $case_sensitive = false)
     {
         if ($this->inclusive) {
-            foreach ($this->include_dirs as $include_dir) {
+            foreach ($this->only_dirs as $include_dir) {
                 if ($case_sensitive) {
                     if (strpos($file_name, $include_dir) === 0) {
                         return true;
@@ -136,11 +136,11 @@ class FileFilter
             }
 
             if ($case_sensitive) {
-                if (in_array($file_name, $this->include_files)) {
+                if (in_array($file_name, $this->only_files)) {
                     return true;
                 }
             } else {
-                if (in_array(strtolower($file_name), $this->include_files_lowercase)) {
+                if (in_array(strtolower($file_name), $this->only_files_lowercase)) {
                     return true;
                 }
             }
@@ -149,7 +149,7 @@ class FileFilter
         }
 
         // exclusive
-        foreach ($this->exclude_dirs as $exclude_dir) {
+        foreach ($this->ignore_dirs as $exclude_dir) {
             if ($case_sensitive) {
                 if (strpos($file_name, $exclude_dir) === 0) {
                     return false;
@@ -162,11 +162,11 @@ class FileFilter
         }
 
         if ($case_sensitive) {
-            if (in_array($file_name, $this->exclude_files)) {
+            if (in_array($file_name, $this->ignore_files)) {
                 return false;
             }
         } else {
-            if (in_array(strtolower($file_name), $this->exclude_files_lowercase)) {
+            if (in_array(strtolower($file_name), $this->ignore_files_lowercase)) {
                 return false;
             }
         }
@@ -179,7 +179,7 @@ class FileFilter
      */
     public function getIncludeDirs()
     {
-        return $this->include_dirs;
+        return $this->only_dirs;
     }
 
     /**
@@ -187,7 +187,7 @@ class FileFilter
      */
     public function getExcludeDirs()
     {
-        return $this->exclude_dirs;
+        return $this->ignore_dirs;
     }
 
     /**
@@ -195,7 +195,7 @@ class FileFilter
      */
     public function getIncludeFiles()
     {
-        return $this->include_files;
+        return $this->only_files;
     }
 
     /**
@@ -203,52 +203,52 @@ class FileFilter
      */
     public function getExcludeFiles()
     {
-        return $this->exclude_files;
+        return $this->ignore_files;
     }
 
     /**
      * @param   string $file_name
      * @return  void
      */
-    public function addExcludeFile($file_name)
+    public function addIgnoreFile($file_name)
     {
         if ($this->inclusive !== false) {
             throw new \UnexpectedValueException('Cannot add exclude file when filter is not exclusive');
         }
 
-        $this->exclude_files[] = $file_name;
-        $this->exclude_files_lowercase[] = strtolower($file_name);
+        $this->ignore_files[] = $file_name;
+        $this->ignore_files_lowercase[] = strtolower($file_name);
     }
 
     /**
      * @param   string $file_name
      * @return  void
      */
-    public function addIncludeFile($file_name)
+    public function addOnlyFile($file_name)
     {
         if ($this->inclusive !== true) {
             throw new \UnexpectedValueException('Cannot add include file when filter is not inclusive');
         }
 
-        $this->include_files[] = $file_name;
-        $this->include_files_lowercase[] = strtolower($file_name);
+        $this->only_files[] = $file_name;
+        $this->only_files_lowercase[] = strtolower($file_name);
     }
 
     /**
      * @param string $dir_name
      * @return void
      */
-    public function addExcludeDirectory($dir_name)
+    public function addIgnoreDirectory($dir_name)
     {
-        $this->exclude_dirs[] = self::slashify($dir_name);
+        $this->ignore_dirs[] = self::slashify($dir_name);
     }
 
     /**
      * @param string $dir_name
      * @return void
      */
-    public function addIncludeDirectory($dir_name)
+    public function addOnlyDirectory($dir_name)
     {
-        $this->include_dirs[] = self::slashify($dir_name);
+        $this->only_dirs[] = self::slashify($dir_name);
     }
 }

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -8,42 +8,22 @@ class FileFilter
     /**
      * @var array<string>
      */
-    protected $only_dirs = [];
+    protected $directories = [];
 
     /**
      * @var array<string>
      */
-    protected $ignore_dirs = [];
+    protected $files = [];
 
     /**
      * @var array<string>
      */
-    protected $only_files = [];
+    protected $files_lowercase = [];
 
     /**
      * @var array<string>
      */
-    protected $only_files_lowercase = [];
-
-    /**
-     * @var array<string>
-     */
-    protected $ignore_files = [];
-
-    /**
-     * @var array<string>
-     */
-    protected $ignore_files_lowercase = [];
-
-    /**
-     * @var array<string>
-     */
-    protected $include_patterns = [];
-
-    /**
-     * @var array<string>
-     */
-    protected $exclude_patterns = [];
+    protected $patterns = [];
 
     /**
      * @var bool
@@ -69,37 +49,21 @@ class FileFilter
      * @param  bool             $inclusive
      * @return self
      */
-    public static function loadFromXML(SimpleXMLElement $e, $inclusive)
+    public static function loadFromXMLElement(SimpleXMLElement $e, $inclusive)
     {
         $filter = new self($inclusive);
 
-        if ($inclusive) {
-            if ($e->directory) {
-                /** @var \SimpleXMLElement $directory */
-                foreach ($e->directory as $directory) {
-                    $filter->addOnlyDirectory((string)$directory['name']);
-                }
+        if ($e->directory) {
+            /** @var \SimpleXMLElement $directory */
+            foreach ($e->directory as $directory) {
+                $filter->addDirectory((string)$directory['name']);
             }
+        }
 
-            if ($e->file) {
-                /** @var \SimpleXMLElement $file */
-                foreach ($e->file as $file) {
-                    $filter->addOnlyFile((string)$file['name']);
-                }
-            }
-        } else {
-            if ($e->directory) {
-                /** @var \SimpleXMLElement $directory */
-                foreach ($e->directory as $directory) {
-                    $filter->addIgnoreDirectory((string)$directory['name']);
-                }
-            }
-
-            if ($e->file) {
-                /** @var \SimpleXMLElement $file */
-                foreach ($e->file as $file) {
-                    $filter->addIgnoreFile((string)$file['name']);
-                }
+        if ($e->file) {
+            /** @var \SimpleXMLElement $file */
+            foreach ($e->file as $file) {
+                $filter->addFile((string)$file['name']);
             }
         }
 
@@ -123,7 +87,7 @@ class FileFilter
     public function allows($file_name, $case_sensitive = false)
     {
         if ($this->inclusive) {
-            foreach ($this->only_dirs as $include_dir) {
+            foreach ($this->directories as $include_dir) {
                 if ($case_sensitive) {
                     if (strpos($file_name, $include_dir) === 0) {
                         return true;
@@ -136,11 +100,11 @@ class FileFilter
             }
 
             if ($case_sensitive) {
-                if (in_array($file_name, $this->only_files)) {
+                if (in_array($file_name, $this->files)) {
                     return true;
                 }
             } else {
-                if (in_array(strtolower($file_name), $this->only_files_lowercase)) {
+                if (in_array(strtolower($file_name), $this->files_lowercase)) {
                     return true;
                 }
             }
@@ -149,7 +113,7 @@ class FileFilter
         }
 
         // exclusive
-        foreach ($this->ignore_dirs as $exclude_dir) {
+        foreach ($this->directories as $exclude_dir) {
             if ($case_sensitive) {
                 if (strpos($file_name, $exclude_dir) === 0) {
                     return false;
@@ -162,11 +126,11 @@ class FileFilter
         }
 
         if ($case_sensitive) {
-            if (in_array($file_name, $this->ignore_files)) {
+            if (in_array($file_name, $this->files)) {
                 return false;
             }
         } else {
-            if (in_array(strtolower($file_name), $this->ignore_files_lowercase)) {
+            if (in_array(strtolower($file_name), $this->files_lowercase)) {
                 return false;
             }
         }
@@ -177,78 +141,35 @@ class FileFilter
     /**
      * @return array<string>
      */
-    public function getIncludeDirs()
+    public function getDirectories()
     {
-        return $this->only_dirs;
+        return $this->directories;
     }
 
     /**
      * @return array
      */
-    public function getExcludeDirs()
+    public function getFiles()
     {
-        return $this->ignore_dirs;
-    }
-
-    /**
-     * @return array
-     */
-    public function getIncludeFiles()
-    {
-        return $this->only_files;
-    }
-
-    /**
-     * @return array
-     */
-    public function getExcludeFiles()
-    {
-        return $this->ignore_files;
+        return $this->files;
     }
 
     /**
      * @param   string $file_name
      * @return  void
      */
-    public function addIgnoreFile($file_name)
+    public function addFile($file_name)
     {
-        if ($this->inclusive !== false) {
-            throw new \UnexpectedValueException('Cannot add exclude file when filter is not exclusive');
-        }
-
-        $this->ignore_files[] = $file_name;
-        $this->ignore_files_lowercase[] = strtolower($file_name);
-    }
-
-    /**
-     * @param   string $file_name
-     * @return  void
-     */
-    public function addOnlyFile($file_name)
-    {
-        if ($this->inclusive !== true) {
-            throw new \UnexpectedValueException('Cannot add include file when filter is not inclusive');
-        }
-
-        $this->only_files[] = $file_name;
-        $this->only_files_lowercase[] = strtolower($file_name);
+        $this->files[] = $file_name;
+        $this->files_lowercase[] = strtolower($file_name);
     }
 
     /**
      * @param string $dir_name
      * @return void
      */
-    public function addIgnoreDirectory($dir_name)
+    public function addDirectory($dir_name)
     {
-        $this->ignore_dirs[] = self::slashify($dir_name);
-    }
-
-    /**
-     * @param string $dir_name
-     * @return void
-     */
-    public function addOnlyDirectory($dir_name)
-    {
-        $this->only_dirs[] = self::slashify($dir_name);
+        $this->directories[] = self::slashify($dir_name);
     }
 }

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -1,0 +1,69 @@
+<?php
+namespace Psalm\Config;
+
+use SimpleXMLElement;
+
+class IssueHandler
+{
+    /**
+     * @var string
+     */
+    protected $error_level = \Psalm\Config::REPORT_ERROR;
+
+    /**
+     * @var array<ErrorLevelFileFilter>
+     */
+    protected $custom_levels = [];
+
+    /**
+     * @param  SimpleXMLElement $e
+     * @return self
+     */
+    public static function loadFromXMLElement(SimpleXMLElement $e)
+    {
+        $handler = new self();
+
+        if (isset($e['errorLevel'])) {
+            $handler->error_level = (string) $e['errorLevel'];
+
+            if (!in_array($handler->error_level, \Psalm\Config::$ERROR_LEVELS)) {
+                throw new \Psalm\Exception\ConfigException('Unexepected error level ' . $handler->error_level);
+            }
+        }
+
+        /** @var \SimpleXMLElement $error_level */
+        foreach ($e->errorLevel as $error_level) {
+            $handler->custom_levels[] = ErrorLevelFileFilter::loadFromXMLElement($error_level, true);
+        }
+
+        return $handler;
+    }
+
+    /**
+     * @param string $error_level
+     * @return void
+     */
+    public function setErrorLevel($error_level)
+    {
+        if (!in_array($error_level, \Psalm\Config::$ERROR_LEVELS)) {
+            throw new \Psalm\Exception\ConfigException('Unexepected error level ' . $error_level);
+        }
+
+        $this->error_level = $error_level;
+    }
+
+    /**
+     * @param string $file_name
+     * @return string
+     */
+    public function getReportingLevelForFile($file_name)
+    {
+        foreach ($this->custom_levels as $custom_level) {
+            if ($custom_level->allows($file_name)) {
+                return $custom_level->getErrorLevel();
+            }
+        }
+
+        return $this->error_level;
+    }
+}

--- a/src/Psalm/Config/ProjectFileFilter.php
+++ b/src/Psalm/Config/ProjectFileFilter.php
@@ -1,0 +1,53 @@
+<?php
+namespace Psalm\Config;
+
+use SimpleXMLElement;
+
+class ProjectFileFilter extends FileFilter
+{
+    /**
+     * @var ProjectFileFilter|null
+     */
+    protected $file_filter = null;
+
+    /**
+     * @param  SimpleXMLElement $e
+     * @param  bool             $inclusive
+     * @return static
+     */
+    public static function loadFromXMLElement(
+        SimpleXMLElement $e,
+        $inclusive
+    ) {
+        $filter = parent::loadFromXMLElement($e, $inclusive);
+
+        if (isset($e->ignoreFiles)) {
+            if (!$inclusive) {
+                throw new \Psalm\Exception\ConfigException('Cannot nest ignoreFiles inside itself');
+            }
+
+            /** @var \SimpleXMLElement $e->ignoreFiles */
+            $filter->file_filter = static::loadFromXMLElement($e->ignoreFiles, false);
+        }
+
+        return $filter;
+    }
+
+    /**
+     * @param  string  $file_name
+     * @param  boolean $case_sensitive
+     * @return boolean
+     */
+    public function allows($file_name, $case_sensitive = false)
+    {
+        if ($this->inclusive) {
+            if ($this->file_filter) {
+                if (!$this->file_filter->allows($file_name, $case_sensitive)) {
+                    return false;
+                }
+            }
+        }
+
+        return parent::allows($file_name, $case_sensitive);
+    }
+}

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -63,7 +63,7 @@ class IssueBuffer
 
         $error_message = $issue_type . ' - ' . $e->getShortLocation() . ' - ' . $e->getMessage();
 
-        $reporting_level = $config->getReportingLevel($issue_type);
+        $reporting_level = $config->getReportingLevelForFile($issue_type, $e->getFileName());
 
         if ($reporting_level === Config::REPORT_SUPPRESS) {
             return false;

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -120,9 +120,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
      */
     public function testMixedArrayAccess()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $context = new Context('somefile.php');
         $stmts = self::$parser->parse('<?php
@@ -141,9 +139,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
      */
     public function testMixedArrayOffset()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $context = new Context('somefile.php');
         $stmts = self::$parser->parse('<?php

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -121,7 +121,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
     public function testMixedArrayAccess()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $context = new Context('somefile.php');
@@ -142,7 +142,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
     public function testMixedArrayOffset()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $context = new Context('somefile.php');

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -121,7 +121,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
     public function testMixedArrayAccess()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $context = new Context('somefile.php');
@@ -142,7 +142,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
     public function testMixedArrayOffset()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $context = new Context('somefile.php');

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -661,9 +661,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
      */
     public function testMixedStringOffsetAssignment()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $context = new Context('somefile.php');
         $stmts = self::$parser->parse('<?php

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -662,7 +662,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
     public function testMixedStringOffsetAssignment()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $context = new Context('somefile.php');

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -662,7 +662,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
     public function testMixedStringOffsetAssignment()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $context = new Context('somefile.php');

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -87,5 +87,8 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($config->excludeIssueInFile('MissingReturnType', 'tests/somefile.php'));
         $this->assertFalse($config->excludeIssueInFile('MissingReturnType', 'src/somefile.php'));
         $this->assertFalse($config->excludeIssueInFile('MissingReturnType', 'src/Core/somefile.php'));
+
+        $this->assertSame('info', $config->getReportingLevelForFile('MissingReturnType', 'src/somefile.php'));
+        $this->assertSame('error', $config->getReportingLevelForFile('MissingReturnType', 'src/Core/somefile.php'));
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -44,4 +44,48 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($config->isInProjectDirs('src/ignoreme/main.php'));
         $this->assertFalse($config->isInProjectDirs('main.php'));
     }
+
+    public function testIssueHandler()
+    {
+        $config = Config::loadFromXML('psalm.xml', '<?xml version="1.0"?>
+<psalm>
+    <projectFiles>
+        <directory name="src" />
+        <directory name="tests" />
+    </projectFiles>
+
+    <issueHandlers>
+        <MissingReturnType errorLevel="suppress" />
+    </issueHandlers>
+</psalm>');
+
+        $this->assertTrue($config->excludeIssueInFile('MissingReturnType', 'tests/somefile.php'));
+        $this->assertTrue($config->excludeIssueInFile('MissingReturnType', 'src/somefile.php'));
+    }
+
+    public function testIssueHandlerWithCustomErrorLevels()
+    {
+        $config = Config::loadFromXML('psalm.xml', '<?xml version="1.0"?>
+<psalm>
+    <projectFiles>
+        <directory name="src" />
+        <directory name="tests" />
+    </projectFiles>
+
+    <issueHandlers>
+        <MissingReturnType errorLevel="info">
+            <errorLevel type="suppress">
+                <directory name="tests" />
+            </errorLevel>
+            <errorLevel type="error">
+                <directory name="src/Core" />
+            </errorLevel>
+        </MissingReturnType>
+    </issueHandlers>
+</psalm>');
+
+        $this->assertTrue($config->excludeIssueInFile('MissingReturnType', 'tests/somefile.php'));
+        $this->assertFalse($config->excludeIssueInFile('MissingReturnType', 'src/somefile.php'));
+        $this->assertFalse($config->excludeIssueInFile('MissingReturnType', 'src/Core/somefile.php'));
+    }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -27,4 +27,21 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($config->isInProjectDirs('src/main.php'));
         $this->assertFalse($config->isInProjectDirs('main.php'));
     }
+
+    public function testIgnoreProjectDirectory()
+    {
+        $config = Config::loadFromXML('psalm.xml', '<?xml version="1.0"?>
+<psalm>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="src/ignoreme" />
+        </ignoreFiles>
+    </projectFiles>
+</psalm>');
+
+        $this->assertTrue($config->isInProjectDirs('src/main.php'));
+        $this->assertFalse($config->isInProjectDirs('src/ignoreme/main.php'));
+        $this->assertFalse($config->isInProjectDirs('main.php'));
+    }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,30 @@
+<?php
+namespace Psalm\Tests;
+
+use PhpParser\ParserFactory;
+use PHPUnit_Framework_TestCase;
+use Psalm\Checker\FileChecker;
+use Psalm\Config;
+
+class ConfigTest extends PHPUnit_Framework_TestCase
+{
+    protected static $file_filter;
+
+    public function setUp()
+    {
+        FileChecker::clearCache();
+    }
+
+    public function testBarebonesConfig()
+    {
+        $config = Config::loadFromXML('psalm.xml', '<?xml version="1.0"?>
+<psalm>
+    <projectFiles>
+        <directory name="src" />
+    </projectFiles>
+</psalm>');
+
+        $this->assertTrue($config->isInProjectDirs('src/main.php'));
+        $this->assertFalse($config->isInProjectDirs('main.php'));
+    }
+}

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -46,7 +46,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
     public function testMixedArgument()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $stmts = self::$parser->parse('<?php

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -45,9 +45,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
      */
     public function testMixedArgument()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $stmts = self::$parser->parse('<?php
         function foo(int $a) : void {}

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -46,7 +46,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
     public function testMixedArgument()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $stmts = self::$parser->parse('<?php

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -44,11 +44,9 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
         $file_checker->check();
     }
 
-    public function testExcludeFile()
+    public function testExcludeIssue()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
+        Config::getInstance()->setCustomErrorLevel('UndefinedFunction', Config::REPORT_SUPPRESS);
 
         $stmts = self::$parser->parse('<?php
         foo();
@@ -56,69 +54,5 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $stmts);
         $file_checker->check();
-    }
-
-    /**
-     * @expectedException \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedFunction - somefile.php:2 - Function foo does not exist
-     */
-    public function testIncludeFile()
-    {
-        $filter = new Config\FileFilter(true);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
-
-        $stmts = self::$parser->parse('<?php
-        foo();
-        ');
-
-        $file_checker = new FileChecker('someotherfile.php', $stmts);
-        $file_checker->check();
-
-        $stmts = self::$parser->parse('<?php
-        foo();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
-    }
-
-    public function testExcludeDirectory()
-    {
-        $filter = new Config\FileFilter(false);
-        $filter->addDirectory('src');
-        Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
-
-        $stmts = self::$parser->parse('<?php
-        foo();
-        ');
-
-        $file_checker = new FileChecker('src/somefile.php', $stmts);
-        $file_checker->check();
-    }
-
-    /**
-     * @expectedException \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedFunction - src2/somefile.php:2 - Function foo does not exist
-     */
-    public function testIncludeDirectory()
-    {
-        $filter = new Config\FileFilter(true);
-        $filter->addDirectory('src2');
-        Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
-
-        (new FileChecker(
-            'src1/somefile.php',
-            self::$parser->parse('<?php
-            foo();
-            ')
-        ))->check();
-
-        (new FileChecker(
-            'src2/somefile.php',
-            self::$parser->parse('<?php
-            foo();
-            ')
-        ))->check();
     }
 }

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -47,7 +47,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
     public function testExcludeFile()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
 
         $stmts = self::$parser->parse('<?php
@@ -65,7 +65,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
     public function testIncludeFile()
     {
         $filter = new Config\FileFilter(true);
-        $filter->addOnlyFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
 
         $stmts = self::$parser->parse('<?php
@@ -86,7 +86,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
     public function testExcludeDirectory()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreDirectory('src');
+        $filter->addDirectory('src');
         Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
 
         $stmts = self::$parser->parse('<?php
@@ -104,7 +104,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
     public function testIncludeDirectory()
     {
         $filter = new Config\FileFilter(true);
-        $filter->addOnlyDirectory('src2');
+        $filter->addDirectory('src2');
         Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
 
         (new FileChecker(

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -47,7 +47,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
     public function testExcludeFile()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
 
         $stmts = self::$parser->parse('<?php
@@ -65,7 +65,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
     public function testIncludeFile()
     {
         $filter = new Config\FileFilter(true);
-        $filter->addIncludeFile('somefile.php');
+        $filter->addOnlyFile('somefile.php');
         Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
 
         $stmts = self::$parser->parse('<?php
@@ -86,7 +86,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
     public function testExcludeDirectory()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeDirectory('src');
+        $filter->addIgnoreDirectory('src');
         Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
 
         $stmts = self::$parser->parse('<?php
@@ -104,7 +104,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
     public function testIncludeDirectory()
     {
         $filter = new Config\FileFilter(true);
-        $filter->addIncludeDirectory('src2');
+        $filter->addOnlyDirectory('src2');
         Config::getInstance()->setIssueHandler('UndefinedFunction', $filter);
 
         (new FileChecker(

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -64,7 +64,7 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
     public function testMixedMethodCall()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -64,7 +64,7 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
     public function testMixedMethodCall()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -63,10 +63,8 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
      */
     public function testMixedMethodCall()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MissingPropertyType', Config::REPORT_SUPPRESS);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $stmts = self::$parser->parse('<?php
         class Foo {

--- a/tests/Php70Test.php
+++ b/tests/Php70Test.php
@@ -74,7 +74,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
     public function testNullCoalesce()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $stmts = self::$parser->parse('<?php
@@ -172,7 +172,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
     public function testGeneratorDelegation()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $stmts = self::$parser->parse('<?php

--- a/tests/Php70Test.php
+++ b/tests/Php70Test.php
@@ -73,9 +73,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
     public function testNullCoalesce()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $stmts = self::$parser->parse('<?php
         $a = $_GET["bar"] ?? "nobody";
@@ -171,9 +169,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
     public function testGeneratorDelegation()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $stmts = self::$parser->parse('<?php
         /**

--- a/tests/Php70Test.php
+++ b/tests/Php70Test.php
@@ -74,7 +74,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
     public function testNullCoalesce()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $stmts = self::$parser->parse('<?php
@@ -172,7 +172,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
     public function testGeneratorDelegation()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
         $stmts = self::$parser->parse('<?php

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -55,7 +55,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
     public function testPropertyWithoutTypeSuppressingIssue()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
@@ -134,7 +134,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
             public function foo() : void {
                 echo $this->foo;
             }
-        }        
+        }
         ');
 
         $file_checker = new FileChecker('somefile.php', $stmts);
@@ -291,7 +291,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
     public function testMixedPropertyFetch()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
@@ -319,7 +319,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
     public function testMixedPropertyAssignment()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addExcludeFile('somefile.php');
+        $filter->addIgnoreFile('somefile.php');
         Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -55,7 +55,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
     public function testPropertyWithoutTypeSuppressingIssue()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
@@ -291,7 +291,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
     public function testMixedPropertyFetch()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 
@@ -319,7 +319,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
     public function testMixedPropertyAssignment()
     {
         $filter = new Config\FileFilter(false);
-        $filter->addIgnoreFile('somefile.php');
+        $filter->addFile('somefile.php');
         Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
         Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
 

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -54,10 +54,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
     public function testPropertyWithoutTypeSuppressingIssue()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MissingPropertyType', Config::REPORT_SUPPRESS);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $stmts = self::$parser->parse('<?php
         class A {
@@ -290,10 +288,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
      */
     public function testMixedPropertyFetch()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MissingPropertyType', Config::REPORT_SUPPRESS);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $stmts = self::$parser->parse('<?php
         class Foo {
@@ -318,10 +314,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
      */
     public function testMixedPropertyAssignment()
     {
-        $filter = new Config\FileFilter(false);
-        $filter->addFile('somefile.php');
-        Config::getInstance()->setIssueHandler('MissingPropertyType', $filter);
-        Config::getInstance()->setIssueHandler('MixedAssignment', $filter);
+        Config::getInstance()->setCustomErrorLevel('MissingPropertyType', Config::REPORT_SUPPRESS);
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
 
         $stmts = self::$parser->parse('<?php
         class Foo {

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -18,9 +18,6 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
 
         $config = new TestConfig();
-        $config->throw_exception = true;
-
-        self::$file_filter = null;
     }
 
     public function setUp()
@@ -135,8 +132,6 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         echo $array;
         ');
-
-        Config::getInstance()->setIssueHandler('PossiblyUndefinedVariable', self::$file_filter);
 
         $file_checker = new FileChecker('somefile.php', $stmts);
         $file_checker->check();


### PR DESCRIPTION
This fixes #26 and #21 by changing how the config works, simplifying it while giving users more flexible ways to progressively check their code.

Now, instead of writing
```xml
<issueHandlers>
  <PossiblyUndefinedVariable>
    <includeFiles>
      <directory name="src/Core" />
    </includeFiles>
  </PossiblyUndefinedVariable>
</issueHandlers>
```

you'll write

```xml
<issueHandlers>
  <PossiblyUndefinedVariable errorLevel="suppress">
    <errorLevel type="error">
      <directory name="src/Core" />
    </errorLevel>
  </PossiblyUndefinedVariable>
</issueHandlers>
```
,
which gives you the ability to gradually introduce warnings in other parts of your codebase e.g.

```xml
<issueHandlers>
  <PossiblyUndefinedVariable errorLevel="info">
    <errorLevel type="error">
      <directory name="src/Core" />
    </errorLevel>
    <errorLevel type="suppress">
      <directory name="tests" />
    </errorLevel>
  </PossiblyUndefinedVariable>
</issueHandlers>
```

This also introduces the ability to hide certain subfolders from Psalm's view in the `<projectFiles>` config:

```xml
<projectFiles>
  <directory name="src" />
  <ignoreFiles>
    <directory name="src/ignoreme" />
  </ignoreFiles>
</projectFiles>
```

cc @erunion @nickyr 