### PR TITLE
Lazy evaluation

### DIFF
--- a/bin/psalm
+++ b/bin/psalm
@@ -128,20 +128,20 @@ if ($path_to_config) {
     ProjectChecker::setConfigXML($path_to_config);
 }
 
-$project_checker = new ProjectChecker($use_color, $show_info, $output_format);
+$project_checker = new ProjectChecker($use_color, $show_info, $output_format, $debug);
 
 \Psalm\IssueBuffer::setStartTime(microtime(true));
 
 if (array_key_exists('self-check', $options)) {
-    $project_checker->checkDir(dirname(__DIR__) . '/src', $debug);
+    $project_checker->checkDir(dirname(__DIR__) . '/src');
 } elseif ($paths_to_check === null) {
-    $project_checker->check($debug, $is_diff);
+    $project_checker->check($is_diff);
 } elseif ($paths_to_check) {
     foreach ($paths_to_check as $path_to_check) {
         if (is_dir($path_to_check)) {
-            $project_checker->checkDir($path_to_check, $debug, $update_docblocks);
+            $project_checker->checkDir($path_to_check, $update_docblocks);
         } else {
-            $project_checker->checkFile($path_to_check, $debug, $update_docblocks);
+            $project_checker->checkFile($path_to_check, $update_docblocks);
         }
     }
 }

--- a/psalm.xml
+++ b/psalm.xml
@@ -9,6 +9,9 @@
     <projectFiles>
         <directory name="src" />
         <directory name="tests" />
+        <ignoreFiles>
+            <file name="src/Psalm/CallMap.php" />
+        </ignoreFiles>
     </projectFiles>
 
     <issueHandlers>

--- a/src/Psalm/Checker/CanAlias.php
+++ b/src/Psalm/Checker/CanAlias.php
@@ -1,0 +1,121 @@
+<?php
+namespace Psalm\Checker;
+
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser;
+use Psalm\Context;
+use Psalm\StatementsSource;
+use Psalm\Type;
+
+trait CanAlias
+{
+    /**
+     * @var array<string, string>
+     */
+    protected $aliased_classes = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $aliased_classes_flipped = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $aliased_functions = [];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $aliased_constants = [];
+
+    /**
+     * @param  PhpParser\Node\Stmt\Use_ $stmt
+     * @return void
+     */
+    public function visitUse(PhpParser\Node\Stmt\Use_ $stmt)
+    {
+        foreach ($stmt->uses as $use) {
+            $use_path = implode('\\', $use->name->parts);
+
+            switch ($use->type !== PhpParser\Node\Stmt\Use_::TYPE_UNKNOWN ? $use->type : $stmt->type) {
+                case PhpParser\Node\Stmt\Use_::TYPE_FUNCTION:
+                    $this->aliased_functions[strtolower($use->alias)] = $use_path;
+                    break;
+
+                case PhpParser\Node\Stmt\Use_::TYPE_CONSTANT:
+                    $this->aliased_constants[$use->alias] = $use_path;
+                    break;
+
+                case PhpParser\Node\Stmt\Use_::TYPE_NORMAL:
+                    $this->aliased_classes[strtolower($use->alias)] = $use_path;
+                    $this->aliased_classes_flipped[strtolower($use_path)] = $use->alias;
+                    break;
+            }
+        }
+    }
+
+    /**
+     * @param  PhpParser\Node\Stmt\GroupUse $stmt
+     * @return void
+     */
+    public function visitGroupUse(PhpParser\Node\Stmt\GroupUse $stmt)
+    {
+        $use_prefix = implode('\\', $stmt->prefix->parts);
+
+        foreach ($stmt->uses as $use) {
+            $use_path = $use_prefix . '\\' . implode('\\', $use->name->parts);
+
+            switch ($use->type !== PhpParser\Node\Stmt\Use_::TYPE_UNKNOWN ? $use->type : $stmt->type) {
+                case PhpParser\Node\Stmt\Use_::TYPE_FUNCTION:
+                    $this->aliased_functions[strtolower($use->alias)] = $use_path;
+                    break;
+
+                case PhpParser\Node\Stmt\Use_::TYPE_CONSTANT:
+                    $this->aliased_constants[$use->alias] = $use_path;
+                    break;
+
+                case PhpParser\Node\Stmt\Use_::TYPE_NORMAL:
+                    $this->aliased_classes[strtolower($use->alias)] = $use_path;
+                    $this->aliased_classes_flipped[strtolower($use_path)] = $use->alias;
+                    break;
+            }
+        }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAliasedClasses()
+    {
+        return $this->aliased_classes;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getAliasedClassesFlipped()
+    {
+        return $this->aliased_classes_flipped;
+    }
+
+    /**
+     * Gets a list of all aliased constants
+     *
+     * @return array<string, string>
+     */
+    public function getAliasedConstants()
+    {
+        return $this->aliased_constants;
+    }
+
+    /**
+     * Gets a list of all aliased functions
+     *
+     * @return array<string, string>
+     */
+    public function getAliasedFunctions()
+    {
+        return $this->aliased_functions;
+    }
+}

--- a/src/Psalm/Checker/ClassChecker.php
+++ b/src/Psalm/Checker/ClassChecker.php
@@ -41,18 +41,16 @@ class ClassChecker extends ClassLikeChecker
         self::$class_extends[$this->fq_class_name] = [];
 
         if ($this->class->extends) {
-            $this->parent_class = self::getFQCLNFromNameObject(
+            $this->parent_fq_class_name = self::getFQCLNFromNameObject(
                 $this->class->extends,
-                $this->namespace,
-                $this->aliased_classes
+                $this->source
             );
         }
 
         foreach ($class->implements as $interface_name) {
             $fq_interface_name = self::getFQCLNFromNameObject(
                 $interface_name,
-                $this->namespace,
-                $this->aliased_classes
+                $this->source
             );
 
             $storage->class_implements[strtolower($fq_interface_name)] = $fq_interface_name;

--- a/src/Psalm/Checker/ClassChecker.php
+++ b/src/Psalm/Checker/ClassChecker.php
@@ -62,23 +62,22 @@ class ClassChecker extends ClassLikeChecker
     /**
      * Determine whether or not a given class exists
      *
-     * @param  string $fq_class_name
+     * @param  string       $fq_class_name
+     * @param  FileChecker  $file_checker
      * @return bool
      */
-    public static function classExists($fq_class_name)
+    public static function classExists($fq_class_name, FileChecker $file_checker)
     {
+        if (isset(self::$SPECIAL_TYPES[$fq_class_name])) {
+            return false;
+        }
+
+        if ($file_checker->evaluateClassLike($fq_class_name) === false) {
+            return false;
+        }
+
         if (isset(self::$existing_classes_ci[strtolower($fq_class_name)])) {
             return self::$existing_classes_ci[strtolower($fq_class_name)];
-        }
-
-        if (in_array($fq_class_name, self::$SPECIAL_TYPES)) {
-            return false;
-        }
-
-        if (parent::registerClassLike($fq_class_name) === false) {
-            self::$existing_classes[$fq_class_name] = false;
-
-            return false;
         }
 
         if (!isset(self::$existing_classes_ci[strtolower($fq_class_name)])) {
@@ -93,12 +92,12 @@ class ClassChecker extends ClassLikeChecker
     /**
      * Determine whether or not a class has the correct casing
      *
-     * @param  string  $fq_class_name
+     * @param  string       $fq_class_name
      * @return bool
      */
     public static function hasCorrectCasing($fq_class_name)
     {
-        if (!self::classExists($fq_class_name)) {
+        if (!isset(self::$existing_classes_ci[strtolower($fq_class_name)])) {
             throw new \InvalidArgumentException('Cannot check casing on nonexistent class ' . $fq_class_name);
         }
 
@@ -108,30 +107,17 @@ class ClassChecker extends ClassLikeChecker
     /**
      * Determine whether or not a class extends a parent
      *
-     * @param  string $fq_class_name
-     * @param  string $possible_parent
+     * @param  string       $fq_class_name
+     * @param  string       $possible_parent
      * @return bool
      */
     public static function classExtends($fq_class_name, $possible_parent)
     {
-        if (isset(self::$class_extends[$fq_class_name][$possible_parent])) {
-            return self::$class_extends[$fq_class_name][$possible_parent];
+        if (!isset(self::$storage[$fq_class_name])) {
+            throw new \UnexpectedValueException('$storage should not be null for ' . $fq_class_name);
         }
 
-        if (!self::classExists($fq_class_name) || !self::classExists($possible_parent)) {
-            return false;
-        }
-
-        if (!isset(self::$class_extends[$fq_class_name])) {
-            self::$class_extends[$fq_class_name] = [];
-        }
-
-        $old_level = error_reporting();
-        error_reporting(0);
-        self::$class_extends[$fq_class_name][$possible_parent] = is_subclass_of($fq_class_name, $possible_parent);
-        error_reporting($old_level);
-
-        return self::$class_extends[$fq_class_name][$possible_parent];
+        return in_array($possible_parent, self::$storage[$fq_class_name]->parent_classes);
     }
 
     /**
@@ -142,16 +128,14 @@ class ClassChecker extends ClassLikeChecker
      */
     public static function getInterfacesForClass($fq_class_name)
     {
-        self::registerClassLike($fq_class_name);
-
         return self::$storage[$fq_class_name]->class_implements;
     }
 
     /**
      * Check whether a class implements an interface
      *
-     * @param  string $fq_class_name
-     * @param  string $interface
+     * @param  string       $fq_class_name
+     * @param  string       $interface
      * @return bool
      */
     public static function classImplements($fq_class_name, $interface)
@@ -163,10 +147,6 @@ class ClassChecker extends ClassLikeChecker
         }
 
         if (in_array($interface_id, self::$SPECIAL_TYPES) || in_array($fq_class_name, self::$SPECIAL_TYPES)) {
-            return false;
-        }
-
-        if (self::registerClassLike($fq_class_name) === false) {
             return false;
         }
 

--- a/src/Psalm/Checker/ClassChecker.php
+++ b/src/Psalm/Checker/ClassChecker.php
@@ -140,15 +140,17 @@ class ClassChecker extends ClassLikeChecker
     {
         $interface_id = strtolower($interface);
 
-        if ($interface_id === 'callable' && $fq_class_name === 'Closure') {
+        $fq_class_name = strtolower($fq_class_name);
+
+        if ($interface_id === 'callable' && $fq_class_name === 'closure') {
             return true;
         }
 
-        if (in_array($interface_id, self::$SPECIAL_TYPES) || in_array($fq_class_name, self::$SPECIAL_TYPES)) {
+        if (isset(self::$SPECIAL_TYPES[$interface_id]) || isset(self::$SPECIAL_TYPES[$fq_class_name])) {
             return false;
         }
 
-        $storage = self::$storage[strtolower($fq_class_name)];
+        $storage = self::$storage[$fq_class_name];
 
         return isset($storage->class_implements[$interface_id]);
     }

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -515,7 +515,6 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
 
                             if ($context->self && $context->self !== $this->fq_class_name) {
                                 $analyzed_method_id = (string)$method_checker->getMethodId($context->self);
-
                                 $declaring_method_id = MethodChecker::getDeclaringMethodId($analyzed_method_id);
 
                                 if ($actual_method_id !== $declaring_method_id) {

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -180,7 +180,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
      * @param Context|null  $global_context
      * @return false|null
      */
-    public function check(
+    public function visit(
         Context $class_context = null,
         Context $global_context = null
     ) {
@@ -313,7 +313,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
         }
 
         if ($leftover_stmts) {
-            (new StatementsChecker($this))->check($leftover_stmts, $class_context);
+            (new StatementsChecker($this))->analyze($leftover_stmts, $class_context);
         }
 
         $config = Config::getInstance();
@@ -374,10 +374,6 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
             }
         }
 
-        if (!$this->class->name) {
-            $this->class->name = $this->fq_class_name;
-        }
-
         return null;
     }
 
@@ -387,7 +383,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
      * @param bool          $update_docblocks
      * @return void
      */
-    public function checkMethods(
+    public function analyzeMethods(
         Context $class_context = null,
         Context $global_context = null,
         $update_docblocks = false
@@ -419,7 +415,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
             if ($stmt instanceof PhpParser\Node\Stmt\ClassMethod) {
                 $method_checker = new MethodChecker($stmt, $this);
 
-                $method_checker->check(clone $class_context, clone $global_context);
+                $method_checker->analyze(clone $class_context, clone $global_context);
 
                 $method_id = (string)$method_checker->getMethodId();
 
@@ -431,7 +427,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
                         $secondary_return_type_location
                     );
 
-                    $method_checker->checkReturnTypes(
+                    $method_checker->verifyReturnType(
                         $update_docblocks,
                         MethodChecker::getMethodReturnType($method_id),
                         $class_context->self,
@@ -448,7 +444,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
 
                     $trait_checker = self::$trait_checkers[$trait_name];
 
-                    $trait_checker->checkMethods($class_context, $global_context, $update_docblocks);
+                    $trait_checker->analyzeMethods($class_context, $global_context, $update_docblocks);
                 }
             }
         }
@@ -593,7 +589,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
 
                 $trait_checker->setMethodMap($method_map);
 
-                $trait_checker->check($class_context);
+                $trait_checker->visit($class_context);
 
                 self::registerInheritedProperties($this->fq_class_name, $trait_name);
 

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -193,7 +193,6 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
         $config = Config::getInstance();
 
         $storage->user_defined = true;
-        $storage->registered = true;
 
         $leftover_stmts = [];
 
@@ -336,6 +335,8 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
                 }
             }
         }
+
+        $storage->registered = true;
 
         return null;
     }

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -433,19 +433,24 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
 
                 $method_checker->analyze(clone $class_context, clone $global_context);
 
-                $method_id = (string)$method_checker->getMethodId();
+                $actual_method_id = (string)$method_checker->getMethodId();
+                $analyzed_method_id = (string)$method_checker->getMethodId((string)$class_context->self);
 
-                if (!$config->excludeIssueInFile('InvalidReturnType', $this->source->getFileName())) {
+                $declaring_method_id = MethodChecker::getDeclaringMethodId($analyzed_method_id);
+
+                if ($actual_method_id === $declaring_method_id &&
+                    !$config->excludeIssueInFile('InvalidReturnType', $this->source->getFileName())
+                ) {
                     $secondary_return_type_location = null;
 
                     $return_type_location = MethodChecker::getMethodReturnTypeLocation(
-                        $method_id,
+                        $actual_method_id,
                         $secondary_return_type_location
                     );
 
                     $method_checker->verifyReturnType(
                         $update_docblocks,
-                        MethodChecker::getMethodReturnType($method_id),
+                        MethodChecker::getMethodReturnType($actual_method_id),
                         $class_context->self,
                         $return_type_location,
                         $secondary_return_type_location

--- a/src/Psalm/Checker/CommentChecker.php
+++ b/src/Psalm/Checker/CommentChecker.php
@@ -45,8 +45,7 @@ class CommentChecker
                 $type_in_comments = FunctionLikeChecker::fixUpLocalType(
                     $line_parts[0],
                     $source->getFQCLN(),
-                    $source->getNamespace(),
-                    $source->getAliasedClasses()
+                    $source
                 );
 
                 // support PHPStorm-style docblocks like

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -32,12 +32,12 @@ class FileChecker extends SourceChecker implements StatementsSource
     /**
      * @var string|null
      */
-    protected $include_file_name;
+    protected $actual_file_name;
 
     /**
      * @var string|null
      */
-    protected $include_file_path;
+    protected $actual_file_path;
 
     /**
      * @var array<string, string>
@@ -978,30 +978,17 @@ class FileChecker extends SourceChecker implements StatementsSource
     }
 
     /**
-     * @return null|string
-     */
-    public function getIncludeFileName()
-    {
-        return $this->include_file_name;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getIncludeFilePath()
-    {
-        return $this->include_file_path;
-    }
-
-    /**
-     * @param string|null $file_name
-     * @param string|null $file_path
+     * @param string $file_name
+     * @param string $file_path
      * @return void
      */
-    public function setIncludeFileName($file_name, $file_path)
+    public function setFileName($file_name, $file_path)
     {
-        $this->include_file_name = $file_name;
-        $this->include_file_path = $file_path;
+        $this->actual_file_name = $this->file_name;
+        $this->actual_file_path = $this->file_path;
+
+        $this->file_name = $file_name;
+        $this->file_path = $file_path;
     }
 
     /**
@@ -1009,7 +996,7 @@ class FileChecker extends SourceChecker implements StatementsSource
      */
     public function getCheckedFileName()
     {
-        return $this->include_file_name ?: $this->file_name;
+        return $this->actual_file_name ?: $this->file_name;
     }
 
     /**
@@ -1017,7 +1004,7 @@ class FileChecker extends SourceChecker implements StatementsSource
      */
     public function getCheckedFilePath()
     {
-        return $this->include_file_path ?: $this->file_path;
+        return $this->actual_file_path ?: $this->file_path;
     }
 
     public function getSuppressedIssues()

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -203,8 +203,6 @@ class FileChecker extends SourceChecker implements StatementsSource
 
         $statements_checker = new StatementsChecker($this);
 
-        $this->registerUses();
-
         $classes_to_check = [];
         $interfaces_to_check = [];
         $function_stmts = [];
@@ -249,6 +247,10 @@ class FileChecker extends SourceChecker implements StatementsSource
                 }
             } elseif ($stmt instanceof PhpParser\Node\Stmt\Function_) {
                 $function_stmts[] = $stmt;
+            } elseif ($stmt instanceof PhpParser\Node\Stmt\Use_) {
+                $this->visitUse($stmt);
+            } elseif ($stmt instanceof PhpParser\Node\Stmt\GroupUse) {
+                $this->visitGroupUse($stmt);
             } else {
                 $leftover_stmts[] = $stmt;
             }
@@ -614,22 +616,6 @@ class FileChecker extends SourceChecker implements StatementsSource
         }
 
         return $this->aliased_classes_flipped;
-    }
-
-    /**
-     * @return void
-     */
-    protected function registerUses()
-    {
-        foreach ($this->getStatements() as $stmt) {
-            if ($stmt instanceof PhpParser\Node\Stmt\Use_) {
-                $this->visitUse($stmt);
-            }
-
-            if ($stmt instanceof PhpParser\Node\Stmt\GroupUse) {
-                $this->visitGroupUse($stmt);
-            }
-        }
     }
 
     /**

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -236,7 +236,7 @@ class FileChecker extends SourceChecker implements StatementsSource
 
         // hoist functions to the top
         foreach ($function_stmts as $stmt) {
-            $function_checkers[$stmt->name] = new FunctionChecker($stmt, $this, $this->file_path);
+            $function_checkers[$stmt->name] = new FunctionChecker($stmt, $this);
             $function_id = $function_checkers[$stmt->name]->getMethodId();
             $this->function_checkers[$function_id] = $function_checkers[$stmt->name];
         }

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -422,6 +422,15 @@ class FileChecker extends SourceChecker implements StatementsSource
     }
 
     /**
+     * @param  string $file_path
+     * @return bool
+     */
+    public function fileExists($file_path)
+    {
+        return file_exists($file_path) || isset($this->project_checker->fake_files[$file_path]);
+    }
+
+    /**
      * @param  string   $file_path
      * @param  bool     $debug_output
      * @return array<int, \PhpParser\Node\Expr|\PhpParser\Node\Stmt>
@@ -916,8 +925,14 @@ class FileChecker extends SourceChecker implements StatementsSource
      * @param  string               $phpdoc_type
      * @return void
      */
-    public static function updateDocblock(array &$file_lines, $line_number, &$line_upset, $existing_docblock, $type, $phpdoc_type)
-    {
+    public static function updateDocblock(
+        array &$file_lines,
+        $line_number,
+        &$line_upset,
+        $existing_docblock,
+        $type,
+        $phpdoc_type
+    ) {
         $line_number += $line_upset;
         $function_line = $file_lines[$line_number - 1];
         $left_padding = str_replace(ltrim($function_line), '', $function_line);

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -12,6 +12,8 @@ use Psalm\Type;
 
 class FileChecker extends SourceChecker implements StatementsSource
 {
+    use CanAlias;
+
     const PARSER_CACHE_DIRECTORY = 'php-parser';
     const FILE_HASHES = 'file_hashes';
     const REFERENCE_CACHE_NAME = 'references';
@@ -20,7 +22,27 @@ class FileChecker extends SourceChecker implements StatementsSource
     /**
      * @var string
      */
+    protected $file_name;
+
+    /**
+     * @var string
+     */
     protected $file_path;
+
+    /**
+     * @var string|null
+     */
+    protected $include_file_name;
+
+    /**
+     * @var string|null
+     */
+    protected $include_file_path;
+
+    /**
+     * @var array<string, string>
+     */
+    protected $suppressed_issues = [];
 
     /**
      * @var array<string, array<string, string>>
@@ -893,8 +915,7 @@ class FileChecker extends SourceChecker implements StatementsSource
 
         if ($existing_docblock) {
             $parsed_docblock = CommentChecker::parseDocComment($existing_docblock);
-        }
-        else {
+        } else {
             $parsed_docblock['description'] = '';
         }
 
@@ -909,5 +930,79 @@ class FileChecker extends SourceChecker implements StatementsSource
         $line_upset += count($new_docblock_lines) - $existing_line_count;
 
         array_splice($file_lines, $line_number - $existing_line_count - 1, $existing_line_count, $new_docblock_lines);
+    }
+
+    /**
+     * @return string
+     */
+    public function getFileName()
+    {
+        return $this->file_name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFilePath()
+    {
+        return $this->file_path;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getIncludeFileName()
+    {
+        return $this->include_file_name;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getIncludeFilePath()
+    {
+        return $this->include_file_path;
+    }
+
+    /**
+     * @param string|null $file_name
+     * @param string|null $file_path
+     * @return void
+     */
+    public function setIncludeFileName($file_name, $file_path)
+    {
+        $this->include_file_name = $file_name;
+        $this->include_file_path = $file_path;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCheckedFileName()
+    {
+        return $this->include_file_name ?: $this->file_name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCheckedFilePath()
+    {
+        return $this->include_file_path ?: $this->file_path;
+    }
+
+    public function getSuppressedIssues()
+    {
+        return $this->suppressed_issues;
+    }
+
+    public function getFQCLN()
+    {
+        return null;
+    }
+
+    public function isStatic()
+    {
+        return false;
     }
 }

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -8,6 +8,7 @@ use Psalm\Context;
 use Psalm\IssueBuffer;
 use Psalm\StatementsSource;
 use Psalm\Storage\FileStorage;
+use Psalm\Type;
 
 class FileChecker extends SourceChecker implements StatementsSource
 {
@@ -35,21 +36,6 @@ class FileChecker extends SourceChecker implements StatementsSource
      * @var array<int, \PhpParser\Node\Expr|\PhpParser\Node\Stmt>
      */
     protected $preloaded_statements = [];
-
-    /**
-     * @var array<string, static>
-     */
-    protected static $file_checkers = [];
-
-    /**
-     * @var array<string, bool>
-     */
-    protected static $functions_checked = [];
-
-    /**
-     * @var array<string, bool>
-     */
-    protected static $classes_checked = [];
 
     /**
      * @var array<string, bool>
@@ -121,16 +107,50 @@ class FileChecker extends SourceChecker implements StatementsSource
     public static $storage = [];
 
     /**
+     * @var array<string, ClassLikeChecker>
+     */
+    protected $interface_checkers_no_methods = [];
+
+    /**
+     * @var array<string, ClassLikeChecker>
+     */
+    protected $class_checkers_no_methods = [];
+
+    /**
+     * @var array<int, ClassLikeChecker>
+     */
+    protected $class_checkers = [];
+
+    /**
+     * @var array<string, FunctionChecker>
+     */
+    protected $function_checkers = [];
+
+    /**
+     * @var array<int, NamespaceChecker>
+     */
+    protected $namespace_checkers = [];
+
+    /**
+     * @var Context|null
+     */
+    public $context = null;
+
+    /**
+     * @var ProjectChecker
+     */
+    public $project_checker;
+
+    /**
      * @param string                                               $file_path
+     * @param ProjectChecker                                       $project_checker
      * @param array<int, PhpParser\Node\Expr|PhpParser\Node\Stmt>  $preloaded_statements
      */
-    public function __construct($file_path, array $preloaded_statements = [])
+    public function __construct($file_path, ProjectChecker $project_checker, array $preloaded_statements = [])
     {
         $this->file_path = $file_path;
         $this->file_name = Config::getInstance()->shortenFileName($this->file_path);
-
-        self::$file_checkers[$this->file_name] = $this;
-        self::$file_checkers[$this->file_path] = $this;
+        $this->project_checker = $project_checker;
 
         if (!isset(self::$storage[$file_path])) {
             self::$storage[$file_path] = new FileStorage();
@@ -142,35 +162,12 @@ class FileChecker extends SourceChecker implements StatementsSource
     }
 
     /**
-     * @param   bool            $check_classes
-     * @param   bool            $check_functions
      * @param   Context|null    $file_context
-     * @param   bool            $cache
-     * @param   bool            $update_docblocks
-     * @return  array|null
+     * @return  void
      */
-    public function check(
-        $check_classes = true,
-        $check_functions = true,
-        Context $file_context = null,
-        $cache = true,
-        $update_docblocks = false
-    ) {
-        if ($cache && isset(self::$functions_checked[$this->file_path])) {
-            return null;
-        }
-
-        if ($cache && $check_classes && !$check_functions && isset(self::$classes_checked[$this->file_path])) {
-            return null;
-        }
-
-        if ($cache && !$check_classes && !$check_functions && isset(self::$files_checked[$this->file_path])) {
-            return null;
-        }
-
-        if (!$file_context) {
-            $file_context = new Context($this->file_name);
-        }
+    public function visit(Context $file_context = null)
+    {
+        $this->context = $file_context ?: new Context($this->file_name);
 
         $config = Config::getInstance();
 
@@ -179,21 +176,16 @@ class FileChecker extends SourceChecker implements StatementsSource
         /** @var array<int, PhpParser\Node\Expr|PhpParser\Node\Stmt> */
         $leftover_stmts = [];
 
-        $statments_checker = new StatementsChecker($this);
+        /** @var array<int, PhpParser\Node\Stmt\Const_> */
+        $leftover_const_stmts = [];
 
-        $function_checkers = [];
+        $statements_checker = new StatementsChecker($this);
 
         $this->registerUses();
 
-        // hoist functions to the top
-        foreach ($stmts as $stmt) {
-            if ($stmt instanceof PhpParser\Node\Stmt\Function_) {
-                $function_checkers[$stmt->name] = new FunctionChecker($stmt, $this, $this->file_path);
-            }
-        }
-
         $classes_to_check = [];
         $interfaces_to_check = [];
+        $function_stmts = [];
 
         foreach ($stmts as $stmt) {
             if ($stmt instanceof PhpParser\Node\Stmt\Class_
@@ -201,34 +193,23 @@ class FileChecker extends SourceChecker implements StatementsSource
                 || $stmt instanceof PhpParser\Node\Stmt\Trait_
                 || ($stmt instanceof PhpParser\Node\Stmt\Namespace_ &&
                     $stmt->name instanceof PhpParser\Node\Name)
-                || $stmt instanceof PhpParser\Node\Stmt\Function_
             ) {
-                if ($leftover_stmts) {
-                    $statments_checker->check($leftover_stmts, $file_context);
-                    $leftover_stmts = [];
-                }
-
                 if ($stmt instanceof PhpParser\Node\Stmt\Class_ && $stmt->name) {
-                    if ($check_classes) {
-                        $class_checker = ClassLikeChecker::getClassLikeCheckerFromClass($stmt->name)
-                            ?: new ClassChecker($stmt, $this, $stmt->name);
+                    $class_checker = new ClassChecker($stmt, $this, $stmt->name);
 
-                        $this->declared_classes[$class_checker->getFQCLN()] = true;
-                        $classes_to_check[] = $class_checker;
-                    }
+                    $fq_class_name = $class_checker->getFQCLN();
+
+                    $this->class_checkers_no_methods[$fq_class_name] = $class_checker;
+                    $classes_to_check[] = $class_checker;
                 } elseif ($stmt instanceof PhpParser\Node\Stmt\Interface_ && $stmt->name) {
-                    if ($check_classes) {
-                        $class_checker = ClassLikeChecker::getClassLikeCheckerFromClass($stmt->name)
-                            ?: new InterfaceChecker($stmt, $this, $stmt->name);
+                    $class_checker = new InterfaceChecker($stmt, $this, $stmt->name);
 
-                        $this->declared_classes[$class_checker->getFQCLN()] = true;
-                        $interfaces_to_check[] = $class_checker;
-                    }
+                    $fq_class_name = $class_checker->getFQCLN();
+
+                    $this->interface_checkers_no_methods[$fq_class_name] = $class_checker;
+                    $interfaces_to_check[] = $class_checker;
                 } elseif ($stmt instanceof PhpParser\Node\Stmt\Trait_ && $stmt->name) {
-                    if ($check_classes) {
-                        $trait_checker = ClassLikeChecker::getClassLikeCheckerFromClass($stmt->name)
-                            ?: new TraitChecker($stmt, $this, $stmt->name);
-                    }
+                    $trait_checker = new TraitChecker($stmt, $this, $stmt->name);
                 } elseif ($stmt instanceof PhpParser\Node\Stmt\Namespace_ &&
                     $stmt->name instanceof PhpParser\Node\Name
                 ) {
@@ -236,76 +217,102 @@ class FileChecker extends SourceChecker implements StatementsSource
 
                     $namespace_checker = new NamespaceChecker($stmt, $this);
 
-                    $namespace_checker->check(
-                        $check_classes,
-                        $check_functions,
-                        $update_docblocks
-                    );
+                    $namespace_checker->visit();
+
+                    $this->namespace_checkers[] = $namespace_checker;
 
                     $this->namespace_aliased_classes[$namespace_name] = $namespace_checker->getAliasedClasses();
                     $this->namespace_aliased_classes_flipped[$namespace_name] =
                         $namespace_checker->getAliasedClassesFlipped();
-
-                    $this->declared_classes = array_merge($namespace_checker->getDeclaredClasses());
                 }
+            } elseif ($stmt instanceof PhpParser\Node\Stmt\Function_) {
+                $function_stmts[] = $stmt;
             } else {
                 $leftover_stmts[] = $stmt;
             }
         }
 
-        foreach ($interfaces_to_check as $interface_checker) {
-            $interface_checker->check(false);
+        $function_checkers = [];
+
+        // hoist functions to the top
+        foreach ($function_stmts as $stmt) {
+            $function_checkers[$stmt->name] = new FunctionChecker($stmt, $this, $this->file_path);
+            $function_id = $function_checkers[$stmt->name]->getMethodId();
+            $this->function_checkers[$function_id] = $function_checkers[$stmt->name];
         }
 
-        foreach ($classes_to_check as $class_checker) {
-            $class_checker->check(false, null, $update_docblocks);
-        }
-
-        if ($check_functions) {
-            foreach ($classes_to_check as $class_checker) {
-                $class_checker->check(true, null, $update_docblocks);
-            }
-
-            foreach ($function_checkers as $function_checker) {
-                $function_context = new Context($this->file_name, $file_context->self);
-                $function_checker->check($function_context, $file_context);
-
-                if (!$config->excludeIssueInFile('InvalidReturnType', $this->file_name)) {
-                    /** @var string */
-                    $method_id = $function_checker->getMethodId();
-
-                    $return_type = FunctionChecker::getFunctionReturnType(
-                        $method_id,
-                        $this->file_path
-                    );
-
-                    $return_type_location = FunctionChecker::getFunctionReturnTypeLocation(
-                        $method_id,
-                        $this->file_path
-                    );
-
-                    $function_checker->checkReturnTypes(
-                        false,
-                        $return_type,
-                        $return_type_location
-                    );
-                }
-            }
-        }
-
+        // if there are any leftover statements, evaluate them,
+        // in turn causing the classes/interfaces be evaluated
         if ($leftover_stmts) {
-            $statments_checker->check($leftover_stmts, $file_context);
+            $statements_checker->check($leftover_stmts, $this->context);
         }
 
-        if ($check_functions) {
-            self::$functions_checked[$this->file_path] = true;
+        // check any leftover interfaces not already evaluated
+        foreach ($this->interface_checkers_no_methods as $interface_checker) {
+            $interface_checker->check();
         }
 
-        if ($check_classes) {
-            self::$classes_checked[$this->file_path] = true;
+        // check any leftover classes not already evaluated
+        foreach ($this->class_checkers_no_methods as $class_checker) {
+            $class_checker->check();
         }
+
+        $this->class_checkers = $classes_to_check;
+        $this->function_checkers = $function_checkers;
 
         self::$files_checked[$this->file_path] = true;
+    }
+
+    /**
+     * @param  boolean $update_docblocks
+     * @return void
+     */
+    public function checkMethods($update_docblocks = false)
+    {
+        $config = Config::getInstance();
+
+        if ($this->context === null) {
+            throw new \UnexpectedValueException('Cannot check methods without a context');
+        }
+
+        foreach ($this->namespace_checkers as $namespace_checker) {
+            $namespace_checker->checkMethods(clone $this->context);
+        }
+
+        foreach ($this->class_checkers as $class_checker) {
+            $class_checker->checkMethods(null, $this->context, $update_docblocks);
+        }
+
+        foreach ($this->function_checkers as $function_checker) {
+            $function_context = new Context($this->file_name, $this->context->self);
+            $function_checker->check($function_context, $this->context);
+
+            if (!$config->excludeIssueInFile('InvalidReturnType', $this->file_name)) {
+                /** @var string */
+                $method_id = $function_checker->getMethodId();
+
+                $return_type = FunctionChecker::getFunctionReturnType(
+                    $method_id,
+                    $this->file_path
+                );
+
+                $return_type_location = FunctionChecker::getFunctionReturnTypeLocation(
+                    $method_id,
+                    $this->file_path
+                );
+
+                $function_checker->checkReturnTypes(
+                    false,
+                    $return_type,
+                    null,
+                    $return_type_location
+                );
+            }
+        }
+
+        $this->class_checkers = [];
+
+        $this->function_checkers = [];
 
         if ($update_docblocks && isset(self::$docblock_return_types[$this->file_name])) {
             $line_upset = 0;
@@ -322,45 +329,50 @@ class FileChecker extends SourceChecker implements StatementsSource
 
             echo 'Added/updated ' . count($file_docblock_updates) . ' docblocks in ' . $this->file_name . PHP_EOL;
         }
-
-        return $stmts;
     }
 
     /**
-     * @param  string $class
-     * @param  string $namespace
-     * @param  string $file_name
-     * @return string
+     * @param  Context|null $file_context
+     * @param  boolean      $update_docblocks
+     * @return void
      */
-    public static function getFQCLNFromNameInFile($class, $namespace, $file_name)
+    public function visitAndCheckMethods(Context $file_context = null, $update_docblocks = false)
     {
-        if (isset(self::$file_checkers[$file_name])) {
-            $aliased_classes = self::$file_checkers[$file_name]->getAliasedClasses($namespace);
-        } else {
-            $file_checker = new FileChecker($file_name);
-            $file_checker->check(false, false, new Context($file_name));
-            $aliased_classes = $file_checker->getAliasedClasses($namespace);
-        }
-
-        return ClassLikeChecker::getFQCLNFromString($class, $namespace, $aliased_classes);
+        $this->visit($file_context);
+        $this->checkMethods($update_docblocks);
     }
 
     /**
-     * Gets a list of the classes declared in that file
+     * When evaluating a file, we wait until a class is actually used to evaluate its contents
      *
-     * @param  string $file_name
-     * @return array<int, string>
+     * @param  string $fq_class_name
+     * @return null|false
      */
-    public static function getDeclaredClassesInFile($file_name)
+    public function evaluateClassLike($fq_class_name)
     {
-        if (isset(self::$file_checkers[$file_name])) {
-            $file_checker = self::$file_checkers[$file_name];
-        } else {
-            $file_checker = new FileChecker($file_name);
-            $file_checker->check(false, false, new Context($file_name));
+        if (!$this->context) {
+            throw new \UnexpectedValueException('Not expecting $this->context to be empty');
         }
 
-        return array_keys($file_checker->getDeclaredClasses());
+        if (isset($this->interface_checkers_no_methods[$fq_class_name])) {
+            if ($this->interface_checkers_no_methods[$fq_class_name]->check() === false) {
+                return false;
+            }
+
+            unset($this->interface_checkers_no_methods[$fq_class_name]);
+            return;
+        }
+
+        if (isset($this->class_checkers_no_methods[$fq_class_name])) {
+            if ($this->class_checkers_no_methods[$fq_class_name]->check(null, $this->context) === false) {
+                return false;
+            }
+
+            unset($this->class_checkers_no_methods[$fq_class_name]);
+            return;
+        }
+
+        $this->project_checker->visitFileForClassLike($fq_class_name);
     }
 
     /**
@@ -370,14 +382,15 @@ class FileChecker extends SourceChecker implements StatementsSource
     {
         return $this->preloaded_statements
             ? $this->preloaded_statements
-            : self::getStatementsForFile($this->file_path);
+            : $this->getStatementsForFile($this->file_path, $this->project_checker->debug_output);
     }
 
     /**
-     * @param  string $file_path
+     * @param  string   $file_path
+     * @param  bool     $debug_output
      * @return array<int, \PhpParser\Node\Expr|\PhpParser\Node\Stmt>
      */
-    public static function getStatementsForFile($file_path)
+    public static function getStatementsForFile($file_path, $debug_output = false)
     {
         $stmts = [];
 
@@ -420,6 +433,10 @@ class FileChecker extends SourceChecker implements StatementsSource
         }
 
         if (!$stmts) {
+            if ($debug_output) {
+                echo 'Parsing ' . $file_path . PHP_EOL;
+            }
+
             $lexer = new PhpParser\Lexer([
                 'usedAttributes' => [
                     'comments', 'startLine', 'startFilePos', 'endFilePos'
@@ -552,37 +569,6 @@ class FileChecker extends SourceChecker implements StatementsSource
         }
 
         return $this->aliased_classes_flipped;
-    }
-
-    /**
-     * @param   string  $file_name
-     * @return  mixed
-     */
-    public static function getFileCheckerFromFileName($file_name)
-    {
-        return self::$file_checkers[$file_name];
-    }
-
-    /**
-     * @param  string $class_name
-     * @return ClassLikeChecker|null
-     */
-    public static function getClassLikeCheckerFromClass($class_name)
-    {
-        $old_level = error_reporting();
-        error_reporting(0);
-        $file_name = (string)(new \ReflectionClass($class_name))->getFileName();
-        error_reporting($old_level);
-
-        if (isset(self::$file_checkers[$file_name])) {
-            $file_checker = self::$file_checkers[$file_name];
-        } else {
-            $file_checker = new FileChecker($file_name);
-        }
-
-        $file_checker->check(true, false, null, false);
-
-        return ClassLikeChecker::getClassLikeCheckerFromClass($class_name);
     }
 
     /**
@@ -788,11 +774,8 @@ class FileChecker extends SourceChecker implements StatementsSource
      */
     public static function clearCache()
     {
-        self::$file_checkers = [];
-
-        self::$functions_checked = [];
-        self::$classes_checked = [];
         self::$files_checked = [];
+
         self::$storage = [];
 
         ClassLikeChecker::clearCache();

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -289,7 +289,7 @@ class FileChecker extends SourceChecker implements StatementsSource
      * @param  boolean $update_docblocks
      * @return void
      */
-    public function analyzeMethods($update_docblocks = false)
+    public function analyze($update_docblocks = false)
     {
         $config = Config::getInstance();
 
@@ -298,11 +298,11 @@ class FileChecker extends SourceChecker implements StatementsSource
         }
 
         foreach ($this->namespace_checkers as $namespace_checker) {
-            $namespace_checker->analyzeMethods(clone $this->context);
+            $namespace_checker->analyze(clone $this->context);
         }
 
         foreach ($this->class_checkers as $class_checker) {
-            $class_checker->analyzeMethods(null, $this->context, $update_docblocks);
+            $class_checker->analyze(null, $this->context, $update_docblocks);
         }
 
         foreach ($this->function_checkers as $function_checker) {
@@ -331,6 +331,8 @@ class FileChecker extends SourceChecker implements StatementsSource
                 );
             }
         }
+
+        $this->namespace_checkers = [];
 
         $this->class_checkers = [];
 
@@ -361,7 +363,7 @@ class FileChecker extends SourceChecker implements StatementsSource
     public function visitAndAnalyzeMethods(Context $file_context = null, $update_docblocks = false)
     {
         $this->visit($file_context);
-        $this->analyzeMethods($update_docblocks);
+        $this->analyze($update_docblocks);
     }
 
     /**

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -393,20 +393,26 @@ class FileChecker extends SourceChecker implements StatementsSource
         }
 
         if (isset($this->interface_checkers_no_methods[$fq_class_name])) {
-            if ($this->interface_checkers_no_methods[$fq_class_name]->visit() === false) {
+            $interface_checker = $this->interface_checkers_no_methods[$fq_class_name];
+
+            unset($this->interface_checkers_no_methods[$fq_class_name]);
+
+            if ($interface_checker->visit() === false) {
                 return false;
             }
 
-            unset($this->interface_checkers_no_methods[$fq_class_name]);
             return;
         }
 
         if (isset($this->class_checkers_no_methods[$fq_class_name])) {
-            if ($this->class_checkers_no_methods[$fq_class_name]->visit(null, $this->context) === false) {
+            $class_checker = $this->class_checkers_no_methods[$fq_class_name];
+
+            unset($this->class_checkers_no_methods[$fq_class_name]);
+
+            if ($class_checker->visit(null, $this->context) === false) {
                 return false;
             }
 
-            unset($this->class_checkers_no_methods[$fq_class_name]);
             return;
         }
 

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -1010,6 +1010,11 @@ class FileChecker extends SourceChecker implements StatementsSource
         return null;
     }
 
+    public function getClassName()
+    {
+        return null;
+    }
+
     public function isStatic()
     {
         return false;

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -367,6 +367,18 @@ class FileChecker extends SourceChecker implements StatementsSource
     }
 
     /**
+     * Used when checking single files with multiple classlike declarations
+     *
+     * @param  string $fq_class_name
+     * @return bool
+     */
+    public function containsUnEvaluatedClassLike($fq_class_name)
+    {
+        return isset($this->interface_checkers_no_methods[$fq_class_name]) ||
+            isset($this->class_checkers_no_methods[$fq_class_name]);
+    }
+
+    /**
      * When evaluating a file, we wait until a class is actually used to evaluate its contents
      *
      * @param  string $fq_class_name

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -384,9 +384,10 @@ class FileChecker extends SourceChecker implements StatementsSource
      * When evaluating a file, we wait until a class is actually used to evaluate its contents
      *
      * @param  string $fq_class_name
+     * @param  bool   $visit_file
      * @return null|false
      */
-    public function evaluateClassLike($fq_class_name)
+    public function evaluateClassLike($fq_class_name, $visit_file)
     {
         if (!$this->context) {
             throw new \UnexpectedValueException('Not expecting $this->context to be empty');

--- a/src/Psalm/Checker/FunctionChecker.php
+++ b/src/Psalm/Checker/FunctionChecker.php
@@ -601,6 +601,7 @@ class FunctionChecker extends FunctionLikeChecker
      *
      * @return array<array<string, string>>
      * @psalm-suppress MixedInferredReturnType as the use of require buggers things up
+     * @psalm-suppress MixedAssignment
      */
     protected static function getCallMap()
     {

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -362,11 +362,13 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
             $function_id = $fq_class_name . '::' . strtolower($function->name);
             $cased_function_id = $fq_class_name . '::' . $function->name;
 
-            if (!isset(ClassLikeChecker::$storage[$fq_class_name])) {
+            $fq_class_name_lower = strtolower($fq_class_name);
+
+            if (!isset(ClassLikeChecker::$storage[$fq_class_name_lower])) {
                 throw new \UnexpectedValueException('$class_storage cannot be empty for ' . $function_id);
             }
 
-            $class_storage = ClassLikeChecker::$storage[$fq_class_name];
+            $class_storage = ClassLikeChecker::$storage[$fq_class_name_lower];
 
             if (isset($class_storage->methods[strtolower($function->name)])) {
                 throw new \InvalidArgumentException('Cannot re-register ' . $function_id);

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -352,7 +352,7 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
             $file_storage = FileChecker::$storage[$source->getFilePath()];
 
             if (isset($file_storage->functions[$function_id])) {
-                throw new \InvalidArgumentException('Cannot re-register ' . $function_id);
+                return $file_storage->functions[$function_id];
             }
 
             $storage = $file_storage->functions[$function_id] = new FunctionLikeStorage();

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -99,6 +99,10 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
         $cased_method_id = null;
 
         if ($this->function instanceof ClassMethod) {
+            $real_method_id = (string)$this->getMethodId();
+
+            $method_id = (string)$this->getMethodId($context->self);
+
             if ($add_mutations) {
                 $hash = $this->getMethodId() . json_encode([
                     $context->vars_in_scope,
@@ -117,10 +121,6 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
             } elseif ($context->self) {
                 $context->vars_in_scope['$this'] = new Type\Union([new Type\Atomic($context->self)]);
             }
-
-            $real_method_id = (string)$this->getMethodId();
-
-            $method_id = (string)$this->getMethodId($context->self);
 
             $declaring_method_id = (string)MethodChecker::getDeclaringMethodId($method_id);
 

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -88,7 +88,7 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
      * @param Context|null  $global_context
      * @return false|null
      */
-    public function check(Context $context, Context $global_context = null)
+    public function analyze(Context $context, Context $global_context = null)
     {
         /** @var array<PhpParser\Node\Expr|PhpParser\Node\Stmt> */
         $function_stmts = $this->function->getStmts() ?: [];
@@ -269,12 +269,12 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
             );
         }
 
-        $statements_checker->check($function_stmts, $context, null, $global_context);
+        $statements_checker->analyze($function_stmts, $context, null, $global_context);
 
         if ($this->function instanceof Closure) {
             $closure_yield_types = [];
 
-            $this->checkReturnTypes(
+            $this->verifyReturnType(
                 false,
                 $storage->return_type,
                 $this->source->getFQCLN(),
@@ -658,7 +658,7 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
      * @param   CodeLocation|null   $secondary_return_type_location
      * @return  false|null
      */
-    public function checkReturnTypes(
+    public function verifyReturnType(
         $update_docblock = false,
         Type\Union $return_type = null,
         $fq_class_name = null,

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -1009,15 +1009,6 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
                     implode('\\', $param_typehint->parts),
                     $source
                 );
-
-                if (!in_array(strtolower($param_type_string), ClassLikeChecker::$SPECIAL_TYPES)) {
-                    ClassLikeChecker::checkFullyQualifiedClassLikeName(
-                        $param_type_string,
-                        $source->getFileChecker(),
-                        new CodeLocation($source, $param_typehint),
-                        $source->getSuppressedIssues()
-                    );
-                }
             }
 
             if ($param_type_string) {

--- a/src/Psalm/Checker/InterfaceChecker.php
+++ b/src/Psalm/Checker/InterfaceChecker.php
@@ -48,7 +48,7 @@ class InterfaceChecker extends ClassLikeChecker
      */
     public static function interfaceExists($fq_interface_name, FileChecker $file_checker, $visit_file = false)
     {
-        if (isset(self::$SPECIAL_TYPES[$fq_interface_name])) {
+        if (isset(self::$SPECIAL_TYPES[strtolower($fq_interface_name)])) {
             return false;
         }
 

--- a/src/Psalm/Checker/InterfaceChecker.php
+++ b/src/Psalm/Checker/InterfaceChecker.php
@@ -9,20 +9,22 @@ class InterfaceChecker extends ClassLikeChecker
     /**
      * @param PhpParser\Node\Stmt\ClassLike  $interface
      * @param StatementsSource               $source
-     * @param string                         $interface_name
+     * @param string                         $fq_interface_name
      */
-    public function __construct(PhpParser\Node\Stmt\ClassLike $interface, StatementsSource $source, $interface_name)
+    public function __construct(PhpParser\Node\Stmt\ClassLike $interface, StatementsSource $source, $fq_interface_name)
     {
         if (!$interface instanceof PhpParser\Node\Stmt\Interface_) {
             throw new \InvalidArgumentException('Expecting an interface');
         }
 
-        parent::__construct($interface, $source, $interface_name);
+        parent::__construct($interface, $source, $fq_interface_name);
 
-        $storage = self::$storage[$interface_name];
+        $fq_interface_name_lower = strtolower($fq_interface_name);
 
-        self::$existing_interfaces[$interface_name] = true;
-        self::$existing_interfaces_ci[strtolower($interface_name)] = true;
+        $storage = self::$storage[$fq_interface_name_lower];
+
+        $project_checker = $source->getFileChecker()->project_checker;
+        $project_checker->addFullyQualifiedInterfaceName($fq_interface_name);
 
         if ($interface->extends) {
             foreach ($interface->extends as $extended_interface) {
@@ -31,7 +33,7 @@ class InterfaceChecker extends ClassLikeChecker
                     $this
                 );
 
-                $source->getFileChecker()->evaluateClassLike($extended_interface_name);
+                $source->getFileChecker()->evaluateClassLike($extended_interface_name, false);
 
                 $storage->parent_interfaces[] = $extended_interface_name;
             }
@@ -39,43 +41,32 @@ class InterfaceChecker extends ClassLikeChecker
     }
 
     /**
-     * @param  string $interface
+     * @param  string       $fq_interface_name
      * @param  FileChecker  $file_checker
+     * @param  bool         $visit_file
      * @return boolean
      */
-    public static function interfaceExists($interface, FileChecker $file_checker)
+    public static function interfaceExists($fq_interface_name, FileChecker $file_checker, $visit_file = false)
     {
-        if (isset(self::$SPECIAL_TYPES[$interface])) {
+        if (isset(self::$SPECIAL_TYPES[$fq_interface_name])) {
             return false;
         }
 
-        if ($file_checker->evaluateClassLike($interface) === false) {
+        if ($file_checker->evaluateClassLike($fq_interface_name, $visit_file) === false) {
             return false;
         }
 
-        if (isset(self::$existing_interfaces_ci[strtolower($interface)])) {
-            return self::$existing_interfaces_ci[strtolower($interface)];
-        }
-
-        if (!isset(self::$existing_interfaces_ci[strtolower($interface)])) {
-            // it exists, but it's not an interface
-            self::$existing_interfaces_ci[strtolower($interface)] = false;
-            return false;
-        }
-
-        return true;
+        return $file_checker->project_checker->hasFullyQualifiedInterfaceName($fq_interface_name);
     }
 
     /**
-     * @param  string       $interface_name
+     * @param  string       $fq_interface_name
+     * @param  FileChecker  $file_checker
      * @return boolean
      */
-    public static function hasCorrectCasing($interface_name)
+    public static function hasCorrectCasing($fq_interface_name, FileChecker $file_checker)
     {
-        if (!isset(self::$existing_interfaces_ci[strtolower($interface_name)])) {
-            throw new \UnexpectedValueException('Invalid storage for ' . $interface_name);
-        }
-        return isset(self::$existing_interfaces[$interface_name]);
+        return isset($file_checker->project_checker->existing_interfaces[$fq_interface_name]);
     }
 
     /**
@@ -89,18 +80,20 @@ class InterfaceChecker extends ClassLikeChecker
     }
 
     /**
-     * @param  string       $interface_name
+     * @param  string       $fq_interface_name
      * @return array<string>   all interfaces extended by $interface_name
      */
-    public static function getParentInterfaces($interface_name)
+    public static function getParentInterfaces($fq_interface_name)
     {
-        if (!isset(self::$storage[$interface_name])) {
-            throw new \UnexpectedValueException('Invalid storage for ' . $interface_name);
+        $fq_interface_name = strtolower($fq_interface_name);
+
+        if (!isset(self::$storage[$fq_interface_name])) {
+            throw new \UnexpectedValueException('Invalid storage for ' . $fq_interface_name);
         }
 
         $extended_interfaces = [];
 
-        $storage = self::$storage[$interface_name];
+        $storage = self::$storage[$fq_interface_name];
 
         foreach ($storage->parent_interfaces as $extended_interface_name) {
             $extended_interfaces[] = $extended_interface_name;

--- a/src/Psalm/Checker/InterfaceChecker.php
+++ b/src/Psalm/Checker/InterfaceChecker.php
@@ -28,8 +28,7 @@ class InterfaceChecker extends ClassLikeChecker
             foreach ($interface->extends as $extended_interface) {
                 $extended_interface_name = self::getFQCLNFromNameObject(
                     $extended_interface,
-                    $this->namespace,
-                    $this->aliased_classes
+                    $this
                 );
 
                 $source->getFileChecker()->evaluateClassLike($extended_interface_name);

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -32,9 +32,6 @@ class MethodChecker extends FunctionLikeChecker
         }
 
         parent::__construct($function, $source);
-
-        $this->registerMethod($function);
-        $this->is_static = $function->isStatic();
     }
 
     /**
@@ -148,6 +145,13 @@ class MethodChecker extends FunctionLikeChecker
         $method_name = strtolower($method->getName());
 
         $class_storage = ClassLikeChecker::$storage[$method->class];
+
+        if (isset($class_storage->methods[strtolower($method_name)])) {
+            return;
+        }
+
+        $method_id = $method->class . '::' . $method_name;
+
         $storage = $class_storage->methods[strtolower($method_name)] = new MethodStorage();
 
         $storage->cased_name = $method->name;
@@ -157,14 +161,8 @@ class MethodChecker extends FunctionLikeChecker
             self::setAppearingMethodId($method->class . '::__construct', $method->class . '::' . $method_name);
         }
 
-        if ($storage->reflected) {
-            return null;
-        }
-
         /** @var \ReflectionClass */
         $declaring_class = $method->getDeclaringClass();
-
-        $storage->reflected = true;
 
         $storage->is_static = $method->isStatic();
         $storage->file_name = $method->getFileName();
@@ -188,19 +186,10 @@ class MethodChecker extends FunctionLikeChecker
 
         /** @var \ReflectionParameter $param */
         foreach ($params as $param) {
-            $param_array = self::getReflectionParamArray($param);
+            $param_array = self::getReflectionParamData($param);
             $storage->params[] = $param_array;
-            $method_param_names[$param->name] = true;
-            $method_param_types[$param->name] = $param_array->type;
+            $storage->param_types[$param->name] = $param_array->type;
         }
-
-        $return_types = null;
-
-        $config = Config::getInstance();
-
-        $return_type = null;
-
-        $storage->return_type = $return_type;
         return null;
     }
 
@@ -253,206 +242,6 @@ class MethodChecker extends FunctionLikeChecker
         }
 
         return true;
-    }
-
-    /**
-     * @param PhpParser\Node\Stmt\ClassMethod $method
-     * @return null|false
-     * @psalm-suppress MixedAssignment
-     */
-    protected function registerMethod(PhpParser\Node\Stmt\ClassMethod $method)
-    {
-        $method_id = $this->fq_class_name . '::' . strtolower($method->name);
-
-        $class_storage = ClassLikeChecker::$storage[$this->fq_class_name];
-        $storage = $class_storage->methods[strtolower($method->name)] = new MethodStorage();
-
-        $cased_method_id = $storage->cased_name = $method->name;
-
-        if (strtolower((string)$method->name) === strtolower((string)$this->class_name)) {
-            self::setDeclaringMethodId($this->fq_class_name . '::__construct', $method_id);
-            self::setAppearingMethodId($this->fq_class_name . '::__construct', $method_id);
-        }
-
-        if ($storage->reflected || $storage->registered) {
-            $this->suppressed_issues = $storage->suppressed_issues;
-
-            return null;
-        }
-
-        if (!$this->source instanceof TraitChecker) {
-            $storage->registered = true;
-        }
-
-        $class_storage->declaring_method_ids[strtolower($method->name)] = $method_id;
-        $class_storage->appearing_method_ids[strtolower($method->name)] = $method_id;
-
-        if (!isset($class_storage->overridden_method_ids[strtolower($method->name)])) {
-            $class_storage->overridden_method_ids[strtolower($method->name)] = [];
-        }
-
-        $storage->is_static = $method->isStatic();
-
-        $storage->namespace = $this->namespace;
-        $storage->file_name = $this->file_name;
-
-        if ($method->isPrivate()) {
-            $storage->visibility = ClassLikeChecker::VISIBILITY_PRIVATE;
-        } elseif ($method->isProtected()) {
-            $storage->visibility = ClassLikeChecker::VISIBILITY_PROTECTED;
-        } else {
-            $storage->visibility = ClassLikeChecker::VISIBILITY_PUBLIC;
-        }
-
-        $method_param_names = [];
-
-        foreach ($method->getParams() as $param) {
-            $param_array = $this->getTranslatedParam(
-                $param,
-                $this
-            );
-
-            $storage->params[] = $param_array;
-
-            if (isset($function_param_names[$param->name])) {
-                if (IssueBuffer::accepts(
-                    new DuplicateParam(
-                        'Duplicate param $' . $param->name . ' in docblock for ' . $cased_method_id,
-                        new CodeLocation($this, $param, true)
-                    ),
-                    $this->suppressed_issues
-                )) {
-                    return false;
-                }
-            }
-
-            $method_param_names[$param->name] = $param_array->type;
-        }
-
-        $config = Config::getInstance();
-        $return_type = null;
-        $return_type_location = null;
-
-        $doc_comment = $method->getDocComment();
-
-        $storage->suppressed_issues = [];
-
-        if (isset($method->returnType)) {
-            $parser_return_type = $method->returnType;
-
-            $suffix = '';
-
-            if ($parser_return_type instanceof PhpParser\Node\NullableType) {
-                $suffix = '|null';
-                $parser_return_type = $parser_return_type->type;
-            }
-
-            if (is_string($parser_return_type)) {
-                $return_type_string = $parser_return_type . $suffix;
-            } else {
-                $fq_class_name = ClassLikeChecker::getFQCLNFromNameObject(
-                    $parser_return_type,
-                    $this->namespace,
-                    $this->getAliasedClasses()
-                );
-
-                if ($fq_class_name !== 'self') {
-                    ClassLikeChecker::checkFullyQualifiedClassLikeName(
-                        $fq_class_name,
-                        $this->getFileChecker(),
-                        new CodeLocation($this, $parser_return_type),
-                        $this->suppressed_issues
-                    );
-                }
-
-                $return_type_string = $fq_class_name . $suffix;
-            }
-
-            $return_type = Type::parseString($return_type_string);
-
-            $return_type_location = new CodeLocation($this->getSource(), $method, false, self::RETURN_TYPE_REGEX);
-        }
-
-        if ($doc_comment) {
-            $docblock_info = null;
-
-            try {
-                $docblock_info = CommentChecker::extractDocblockInfo((string)$doc_comment, $doc_comment->getLine());
-            } catch (DocblockParseException $e) {
-                if (IssueBuffer::accepts(
-                    new InvalidDocblock(
-                        'Invalid type passed in docblock for ' . $cased_method_id,
-                        new CodeLocation($this, $method)
-                    )
-                )) {
-                    return false;
-                }
-            }
-
-            if ($docblock_info) {
-                if ($docblock_info->deprecated) {
-                    $storage->deprecated = true;
-                }
-
-                if ($docblock_info->variadic) {
-                    $storage->variadic = true;
-                }
-
-                $this->suppressed_issues = $docblock_info->suppress;
-                $storage->suppressed_issues = $this->suppressed_issues;
-
-                if ($config->use_docblock_types) {
-                    if ($docblock_info->return_type) {
-                        $docblock_return_type = Type::parseString(
-                            $this->fixUpLocalType(
-                                (string)$docblock_info->return_type,
-                                $this->fq_class_name,
-                                $this->namespace,
-                                $this->getAliasedClasses()
-                            )
-                        );
-
-                        if (!$return_type_location) {
-                            $return_type_location = new CodeLocation($this->getSource(), $method, true);
-                        }
-
-                        if ($return_type &&
-                            !TypeChecker::hasIdenticalTypes(
-                                $return_type,
-                                $docblock_return_type,
-                                $this->getFileChecker()
-                            )
-                        ) {
-                            if (IssueBuffer::accepts(
-                                new InvalidDocblock(
-                                    'Docblock return type does not match method return type for ' . $this->getMethodId(),
-                                    new CodeLocation($this, $method, true)
-                                )
-                            )) {
-                                return false;
-                            }
-                        } else {
-                            $return_type = $docblock_return_type;
-                        }
-
-                        $return_type_location->setCommentLine($docblock_info->return_type_line_number);
-                    }
-
-                    if ($docblock_info->params) {
-                        $this->improveParamsFromDocblock(
-                            $docblock_info->params,
-                            $method_param_names,
-                            $storage->params,
-                            new CodeLocation($this, $method, true)
-                        );
-                    }
-                }
-            }
-        }
-
-        $storage->return_type_location = $return_type_location;
-        $storage->return_type = $return_type;
-        return null;
     }
 
     /**
@@ -575,7 +364,7 @@ class MethodChecker extends FunctionLikeChecker
 
     /**
      * @param  string $method_id
-     * @return MethodStorage|null
+     * @return MethodStorage
      */
     public static function getStorage($method_id)
     {
@@ -583,11 +372,11 @@ class MethodChecker extends FunctionLikeChecker
 
         $class_storage = ClassLikeChecker::$storage[$fq_class_name];
 
-        if (isset($class_storage->methods[strtolower($method_name)])) {
-            return $class_storage->methods[strtolower($method_name)];
+        if (!isset($class_storage->methods[strtolower($method_name)])) {
+            throw new \UnexpectedValueException('$storage should not be null for ' . $method_id);
         }
 
-        return null;
+        return $class_storage->methods[strtolower($method_name)];
     }
 
     /**
@@ -600,10 +389,6 @@ class MethodChecker extends FunctionLikeChecker
     {
         $method_id = (string) self::getDeclaringMethodId($method_id);
         $storage = self::getStorage($method_id);
-
-        if (!$storage) {
-            throw new \UnexpectedValueException('$storage should not be null');
-        }
 
         if ($storage->deprecated) {
             if (IssueBuffer::accepts(
@@ -751,6 +536,10 @@ class MethodChecker extends FunctionLikeChecker
     {
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
+        if (!isset(ClassLikeChecker::$storage[$fq_class_name])) {
+            throw new \UnexpectedValueException('$storage should not be null for ' . $fq_class_name);
+        }
+
         if (isset(ClassLikeChecker::$storage[$fq_class_name]->declaring_method_ids[$method_name])) {
             return ClassLikeChecker::$storage[$fq_class_name]->declaring_method_ids[$method_name];
         }
@@ -765,6 +554,10 @@ class MethodChecker extends FunctionLikeChecker
     public static function getAppearingMethodId($method_id)
     {
         list($fq_class_name, $method_name) = explode('::', $method_id);
+
+        if (!isset(ClassLikeChecker::$storage[$fq_class_name])) {
+            throw new \UnexpectedValueException('$storage should not be null for ' . $fq_class_name);
+        }
 
         if (isset(ClassLikeChecker::$storage[$fq_class_name]->appearing_method_ids[$method_name])) {
             return ClassLikeChecker::$storage[$fq_class_name]->appearing_method_ids[$method_name];

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -202,7 +202,7 @@ class MethodChecker extends FunctionLikeChecker
      * @param  array<string>   $suppressed_issues
      * @return bool
      */
-    public static function analyzeMethodstatic(
+    public static function analyzetatic(
         $method_id,
         $self_call,
         CodeLocation $code_location,

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -206,7 +206,7 @@ class MethodChecker extends FunctionLikeChecker
      * @param  array<string>   $suppressed_issues
      * @return bool
      */
-    public static function analyzetatic(
+    public static function checkStatic(
         $method_id,
         $self_call,
         CodeLocation $code_location,
@@ -488,9 +488,11 @@ class MethodChecker extends FunctionLikeChecker
      */
     public static function getDeclaringMethodId($method_id)
     {
+        $method_id = strtolower($method_id);
+
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
-        $fq_class_name = strtolower($fq_class_name);
+        $fq_class_name = $fq_class_name;
 
         if (!isset(ClassLikeChecker::$storage[$fq_class_name])) {
             throw new \UnexpectedValueException('$storage should not be null for ' . $fq_class_name);
@@ -509,9 +511,9 @@ class MethodChecker extends FunctionLikeChecker
      */
     public static function getAppearingMethodId($method_id)
     {
-        list($fq_class_name, $method_name) = explode('::', $method_id);
+        $method_id = strtolower($method_id);
 
-        $fq_class_name = strtolower($fq_class_name);
+        list($fq_class_name, $method_name) = explode('::', $method_id);
 
         if (!isset(ClassLikeChecker::$storage[$fq_class_name])) {
             throw new \UnexpectedValueException('$storage should not be null for ' . $fq_class_name);

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -59,6 +59,8 @@ class MethodChecker extends FunctionLikeChecker
 
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
+        $fq_class_name = strtolower($fq_class_name);
+
         return ClassLikeChecker::$storage[$fq_class_name]->methods[$method_name]->variadic;
     }
 
@@ -86,6 +88,8 @@ class MethodChecker extends FunctionLikeChecker
         if ($storage->return_type) {
             return clone $storage->return_type;
         }
+
+        $fq_class_name = strtolower($fq_class_name);
 
         $class_storage = ClassLikeChecker::$storage[$fq_class_name];
 
@@ -144,7 +148,7 @@ class MethodChecker extends FunctionLikeChecker
     {
         $method_name = strtolower($method->getName());
 
-        $class_storage = ClassLikeChecker::$storage[$method->class];
+        $class_storage = ClassLikeChecker::$storage[strtolower($method->class)];
 
         if (isset($class_storage->methods[strtolower($method_name)])) {
             return;
@@ -256,6 +260,8 @@ class MethodChecker extends FunctionLikeChecker
             return true;
         }
 
+        list($fq_class_name, $method_name) = explode('::', $method_id);
+
         if (IssueBuffer::accepts(
             new UndefinedMethod('Method ' . $method_id . ' does not exist', $code_location),
             $suppressed_issues
@@ -282,11 +288,13 @@ class MethodChecker extends FunctionLikeChecker
 
         $old_method_id = null;
 
-        if (!isset(ClassLikeChecker::$storage[$fq_class_name])) {
+        $fq_class_name_lower = strtolower($fq_class_name);
+
+        if (!isset(ClassLikeChecker::$storage[$fq_class_name_lower])) {
             throw new \UnexpectedValueException('Storage should exist for ' . $fq_class_name);
         }
 
-        $class_storage = ClassLikeChecker::$storage[$fq_class_name];
+        $class_storage = ClassLikeChecker::$storage[$fq_class_name_lower];
 
         if (isset($class_storage->declaring_method_ids[$method_name])) {
             return true;
@@ -314,7 +322,9 @@ class MethodChecker extends FunctionLikeChecker
     {
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
-        $class_storage = ClassLikeChecker::$storage[$fq_class_name];
+        $fq_class_name_lower = strtolower($fq_class_name);
+
+        $class_storage = ClassLikeChecker::$storage[$fq_class_name_lower];
 
         if (!isset($class_storage->methods[strtolower($method_name)])) {
             throw new \UnexpectedValueException('$storage should not be null for ' . $method_id);
@@ -457,7 +467,7 @@ class MethodChecker extends FunctionLikeChecker
     {
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
-        ClassLikeChecker::$storage[$fq_class_name]->declaring_method_ids[$method_name] = $declaring_method_id;
+        ClassLikeChecker::$storage[strtolower($fq_class_name)]->declaring_method_ids[$method_name] = $declaring_method_id;
     }
 
     /**
@@ -469,7 +479,7 @@ class MethodChecker extends FunctionLikeChecker
     {
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
-        ClassLikeChecker::$storage[$fq_class_name]->appearing_method_ids[$method_name] = $appearing_method_id;
+        ClassLikeChecker::$storage[strtolower($fq_class_name)]->appearing_method_ids[$method_name] = $appearing_method_id;
     }
 
     /**
@@ -479,6 +489,8 @@ class MethodChecker extends FunctionLikeChecker
     public static function getDeclaringMethodId($method_id)
     {
         list($fq_class_name, $method_name) = explode('::', $method_id);
+
+        $fq_class_name = strtolower($fq_class_name);
 
         if (!isset(ClassLikeChecker::$storage[$fq_class_name])) {
             throw new \UnexpectedValueException('$storage should not be null for ' . $fq_class_name);
@@ -499,6 +511,8 @@ class MethodChecker extends FunctionLikeChecker
     {
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
+        $fq_class_name = strtolower($fq_class_name);
+
         if (!isset(ClassLikeChecker::$storage[$fq_class_name])) {
             throw new \UnexpectedValueException('$storage should not be null for ' . $fq_class_name);
         }
@@ -517,7 +531,7 @@ class MethodChecker extends FunctionLikeChecker
     {
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
-        ClassLikeChecker::$storage[$fq_class_name]->overridden_method_ids[$method_name][] = $overridden_method_id;
+        ClassLikeChecker::$storage[strtolower($fq_class_name)]->overridden_method_ids[$method_name][] = $overridden_method_id;
     }
 
     /**
@@ -528,7 +542,7 @@ class MethodChecker extends FunctionLikeChecker
     {
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
-        $class_storage = ClassLikeChecker::$storage[$fq_class_name];
+        $class_storage = ClassLikeChecker::$storage[strtolower($fq_class_name)];
 
         if (isset($class_storage->overridden_method_ids[$method_name])) {
             return $class_storage->overridden_method_ids[$method_name];

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -245,62 +245,6 @@ class MethodChecker extends FunctionLikeChecker
     }
 
     /**
-     * @param  string $return_type
-     * @param  string $method_id
-     * @return string
-     */
-    protected static function fixUpReturnType($return_type, $method_id)
-    {
-        $storage = self::getStorage($method_id);
-
-        if (!$storage) {
-            throw new \UnexpectedValueException('$storage should not be null');
-        }
-
-        if (strpos($return_type, '[') !== false) {
-            $return_type = Type::convertSquareBrackets($return_type);
-        }
-
-        $return_type_tokens = Type::tokenize($return_type);
-
-        foreach ($return_type_tokens as $i => &$return_type_token) {
-            if ($return_type_token[0] === '\\') {
-                $return_type_token = substr($return_type_token, 1);
-                continue;
-            }
-
-            if (in_array($return_type_token, ['<', '>', '|', '?', ',', '{', '}', ':'])) {
-                continue;
-            }
-
-            if (isset($return_type_token[$i + 1]) && $return_type_token[$i + 1] === ':') {
-                continue;
-            }
-
-            $return_type_token = Type::fixScalarTerms($return_type_token);
-
-            if ($return_type_token[0] === strtoupper($return_type_token[0])) {
-                $fq_class_name = explode('::', $method_id)[0];
-
-                if ($return_type_token === '$this') {
-                    $return_type_token = $fq_class_name;
-                    continue;
-                }
-
-                $class_storage = ClassLikeChecker::$storage[$return_type_token];
-
-                $return_type_token = ClassLikeChecker::getFQCLNFromString(
-                    $return_type_token,
-                    $class_storage->namespace,
-                    $class_storage->aliased_classes
-                );
-            }
-        }
-
-        return implode('', $return_type_tokens);
-    }
-
-    /**
      * @param  string       $method_id
      * @param  CodeLocation $code_location
      * @param  array        $suppressed_issues

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -202,7 +202,7 @@ class MethodChecker extends FunctionLikeChecker
      * @param  array<string>   $suppressed_issues
      * @return bool
      */
-    public static function checkMethodStatic(
+    public static function analyzeMethodstatic(
         $method_id,
         $self_call,
         CodeLocation $code_location,

--- a/src/Psalm/Checker/NamespaceChecker.php
+++ b/src/Psalm/Checker/NamespaceChecker.php
@@ -29,7 +29,7 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
     /**
      * @var array<int, ClassChecker>
      */
-    protected $class_checkers = [];
+    public $class_checkers = [];
 
     /**
      * A lookup table for public namespace constants
@@ -100,15 +100,18 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
 
     /**
      * @param  Context $context
+     * @param  bool    $preserve_checkers
      * @return void
      */
-    public function analyze(Context $context)
+    public function analyze(Context $context, $preserve_checkers = false)
     {
         foreach ($this->class_checkers as $class_checker) {
             $class_checker->analyze(null, $context);
         }
 
-        $this->class_checkers = [];
+        if (!$preserve_checkers) {
+            $this->class_checkers = [];
+        }
     }
 
     /**

--- a/src/Psalm/Checker/NamespaceChecker.php
+++ b/src/Psalm/Checker/NamespaceChecker.php
@@ -102,10 +102,10 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
      * @param  Context $context
      * @return void
      */
-    public function analyzeMethods(Context $context)
+    public function analyze(Context $context)
     {
         foreach ($this->class_checkers as $class_checker) {
-            $class_checker->analyzeMethods(null, $context);
+            $class_checker->analyze(null, $context);
         }
 
         $this->class_checkers = [];

--- a/src/Psalm/Checker/NamespaceChecker.php
+++ b/src/Psalm/Checker/NamespaceChecker.php
@@ -84,17 +84,17 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
 
         foreach ($classlike_checkers as $classlike_checker) {
             if ($classlike_checker instanceof ClassChecker) {
-                $classlike_checker->check(null, null);
+                $classlike_checker->visit(null, null);
                 $this->class_checkers[] = $classlike_checker;
             } elseif ($classlike_checker instanceof InterfaceChecker) {
-                $classlike_checker->check();
+                $classlike_checker->visit();
             }
         }
 
         if ($leftover_stmts) {
             $statements_checker = new StatementsChecker($this);
             $context = new Context($this->source->getFileName());
-            $statements_checker->check($leftover_stmts, $context);
+            $statements_checker->analyze($leftover_stmts, $context);
         }
     }
 
@@ -102,10 +102,10 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
      * @param  Context $context
      * @return void
      */
-    public function checkMethods(Context $context)
+    public function analyzeMethods(Context $context)
     {
         foreach ($this->class_checkers as $class_checker) {
-            $class_checker->checkMethods(null, $context);
+            $class_checker->analyzeMethods(null, $context);
         }
 
         $this->class_checkers = [];

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -204,7 +204,7 @@ class ProjectChecker
                 echo 'Analyzing ' . $file_checker->getFilePath() . PHP_EOL;
             }
 
-            $file_checker->checkMethods();
+            $file_checker->analyzeMethods();
         }
     }
 
@@ -368,7 +368,7 @@ class ProjectChecker
             }
 
             $file_checker->visit();
-            $file_checker->checkMethods();
+            $file_checker->analyzeMethods();
         }
     }
 
@@ -414,7 +414,7 @@ class ProjectChecker
             echo 'Analyzing ' . $file_checker->getFilePath() . PHP_EOL;
         }
 
-        $file_checker->checkMethods();
+        $file_checker->analyzeMethods();
 
         IssueBuffer::finish(false, $start_checks, $this->debug_output);
     }
@@ -451,7 +451,7 @@ class ProjectChecker
             echo 'Analyzing ' . $file_checker->getFilePath() . PHP_EOL;
         }
 
-        $file_checker->checkMethods();
+        $file_checker->analyzeMethods();
     }
 
     /**

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -204,7 +204,7 @@ class ProjectChecker
                 echo 'Analyzing ' . $file_checker->getFilePath() . PHP_EOL;
             }
 
-            $file_checker->analyzeMethods();
+            $file_checker->analyze();
         }
     }
 
@@ -368,7 +368,7 @@ class ProjectChecker
             }
 
             $file_checker->visit();
-            $file_checker->analyzeMethods();
+            $file_checker->analyze();
         }
     }
 
@@ -414,7 +414,7 @@ class ProjectChecker
             echo 'Analyzing ' . $file_checker->getFilePath() . PHP_EOL;
         }
 
-        $file_checker->analyzeMethods();
+        $file_checker->analyze();
 
         IssueBuffer::finish(false, $start_checks, $this->debug_output);
     }
@@ -451,7 +451,7 @@ class ProjectChecker
             echo 'Analyzing ' . $file_checker->getFilePath() . PHP_EOL;
         }
 
-        $file_checker->analyzeMethods();
+        $file_checker->analyze();
     }
 
     /**

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -450,13 +450,13 @@ class ProjectChecker
      */
     public function visitFile($file_path, array $filetype_handlers)
     {
-        $this->visited_files[$file_path] = true;
-
         $file_checker = $this->getFileChecker($file_path, $filetype_handlers);
 
         if ($this->debug_output) {
             echo (isset($this->visited_files[$file_path]) ? 'Rev' : 'V') . 'isiting ' . $file_path . PHP_EOL;
         }
+
+        $this->visited_files[$file_path] = true;
 
         $file_checker->visit();
 

--- a/src/Psalm/Checker/SourceChecker.php
+++ b/src/Psalm/Checker/SourceChecker.php
@@ -60,6 +60,11 @@ abstract class SourceChecker implements StatementsSource
     protected $declared_classes = [];
 
     /**
+     * @var StatementsSource|null
+     */
+    protected $source = null;
+
+    /**
      * @param  PhpParser\Node\Stmt\Use_ $stmt
      * @return void
      */
@@ -114,15 +119,6 @@ abstract class SourceChecker implements StatementsSource
     }
 
     /**
-     * @param   string $class_name
-     * @return  bool
-     */
-    public function containsClass($class_name)
-    {
-        return isset($this->declared_classes[$class_name]);
-    }
-
-    /**
      * @return array<string, string>
      */
     public function getAliasedClasses()
@@ -159,16 +155,6 @@ abstract class SourceChecker implements StatementsSource
     }
 
     /**
-     * Gets a list of the classes declared
-     *
-     * @return array<string, bool>
-     */
-    public function getDeclaredClasses()
-    {
-        return $this->declared_classes;
-    }
-
-    /**
      * @return null
      */
     public function getFQCLN()
@@ -190,6 +176,22 @@ abstract class SourceChecker implements StatementsSource
     public function getClassLikeChecker()
     {
         return null;
+    }
+
+    /**
+     * @return FileChecker
+     */
+    public function getFileChecker()
+    {
+        if ($this instanceof FileChecker) {
+            return $this;
+        }
+
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$this->source should not be null');
+        }
+
+        return $this->source->getFileChecker();
     }
 
     /**
@@ -268,11 +270,11 @@ abstract class SourceChecker implements StatementsSource
     }
 
     /**
-     * @return null
+     * @return StatementsSource
      */
     public function getSource()
     {
-        return null;
+        return $this->source ?: $this;
     }
 
     /**

--- a/src/Psalm/Checker/SourceChecker.php
+++ b/src/Psalm/Checker/SourceChecker.php
@@ -143,41 +143,17 @@ abstract class SourceChecker implements StatementsSource
     }
 
     /**
-     * @return null|string
-     */
-    public function getIncludeFileName()
-    {
-        if ($this->source === null) {
-            throw new \UnexpectedValueException('$source cannot be null');
-        }
-
-        return $this->source->getIncludeFileName();
-    }
-
-    /**
-     * @return null|string
-     */
-    public function getIncludeFilePath()
-    {
-        if ($this->source === null) {
-            throw new \UnexpectedValueException('$source cannot be null');
-        }
-
-        return $this->source->getIncludeFilePath();
-    }
-
-    /**
      * @param string|null $file_name
      * @param string|null $file_path
      * @return void
      */
-    public function setIncludeFileName($file_name, $file_path)
+    public function setFileName($file_name, $file_path)
     {
         if ($this->source === null) {
             throw new \UnexpectedValueException('$source cannot be null');
         }
 
-        $this->source->setIncludeFileName($file_name, $file_path);
+        $this->source->setFileName($file_name, $file_path);
     }
 
     /**

--- a/src/Psalm/Checker/SourceChecker.php
+++ b/src/Psalm/Checker/SourceChecker.php
@@ -287,6 +287,9 @@ abstract class SourceChecker implements StatementsSource
         return $this->suppressed_issues;
     }
 
+    /**
+     * @return string
+     */
     public function getNamespace()
     {
         return '';

--- a/src/Psalm/Checker/SourceChecker.php
+++ b/src/Psalm/Checker/SourceChecker.php
@@ -10,172 +10,84 @@ use Psalm\Type;
 abstract class SourceChecker implements StatementsSource
 {
     /**
-     * @var array<string, string>
-     */
-    protected $aliased_classes = [];
-
-    /**
-     * @var array<string, string>
-     */
-    protected $aliased_classes_flipped = [];
-
-    /**
-     * @var array<string, string>
-     */
-    protected $aliased_functions = [];
-
-    /**
-     * @var array<string, string>
-     */
-    protected $aliased_constants = [];
-
-    /**
-     * @var string
-     */
-    protected $file_name;
-
-    /**
-     * @var string
-     */
-    protected $file_path;
-
-    /**
-     * @var string|null
-     */
-    protected $include_file_name;
-
-    /**
-     * @var string|null
-     */
-    protected $include_file_path;
-
-    /**
-     * @var array<int, string>
-     */
-    protected $suppressed_issues = [];
-
-    /**
-     * @var array<string, bool>
-     */
-    protected $declared_classes = [];
-
-    /**
      * @var StatementsSource|null
      */
     protected $source = null;
-
-    /**
-     * @param  PhpParser\Node\Stmt\Use_ $stmt
-     * @return void
-     */
-    public function visitUse(PhpParser\Node\Stmt\Use_ $stmt)
-    {
-        foreach ($stmt->uses as $use) {
-            $use_path = implode('\\', $use->name->parts);
-
-            switch ($use->type !== PhpParser\Node\Stmt\Use_::TYPE_UNKNOWN ? $use->type : $stmt->type) {
-                case PhpParser\Node\Stmt\Use_::TYPE_FUNCTION:
-                    $this->aliased_functions[strtolower($use->alias)] = $use_path;
-                    break;
-
-                case PhpParser\Node\Stmt\Use_::TYPE_CONSTANT:
-                    $this->aliased_constants[$use->alias] = $use_path;
-                    break;
-
-                case PhpParser\Node\Stmt\Use_::TYPE_NORMAL:
-                    $this->aliased_classes[strtolower($use->alias)] = $use_path;
-                    $this->aliased_classes_flipped[strtolower($use_path)] = $use->alias;
-                    break;
-            }
-        }
-    }
-
-    /**
-     * @param  PhpParser\Node\Stmt\GroupUse $stmt
-     * @return void
-     */
-    public function visitGroupUse(PhpParser\Node\Stmt\GroupUse $stmt)
-    {
-        $use_prefix = implode('\\', $stmt->prefix->parts);
-
-        foreach ($stmt->uses as $use) {
-            $use_path = $use_prefix . '\\' . implode('\\', $use->name->parts);
-
-            switch ($use->type !== PhpParser\Node\Stmt\Use_::TYPE_UNKNOWN ? $use->type : $stmt->type) {
-                case PhpParser\Node\Stmt\Use_::TYPE_FUNCTION:
-                    $this->aliased_functions[strtolower($use->alias)] = $use_path;
-                    break;
-
-                case PhpParser\Node\Stmt\Use_::TYPE_CONSTANT:
-                    $this->aliased_constants[$use->alias] = $use_path;
-                    break;
-
-                case PhpParser\Node\Stmt\Use_::TYPE_NORMAL:
-                    $this->aliased_classes[strtolower($use->alias)] = $use_path;
-                    $this->aliased_classes_flipped[strtolower($use_path)] = $use->alias;
-                    break;
-            }
-        }
-    }
 
     /**
      * @return array<string, string>
      */
     public function getAliasedClasses()
     {
-        return $this->aliased_classes;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getAliasedClasses();
     }
 
     /**
-     * @return array
+     * @return array<string, string>
      */
     public function getAliasedClassesFlipped()
     {
-        return $this->aliased_classes_flipped;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getAliasedClassesFlipped();
     }
 
     /**
      * Gets a list of all aliased constants
      *
-     * @return array
+     * @return array<string, string>
      */
     public function getAliasedConstants()
     {
-        return $this->aliased_constants;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getAliasedConstants();
     }
 
     /**
      * Gets a list of all aliased functions
      *
-     * @return array
+     * @return array<string, string>
      */
     public function getAliasedFunctions()
     {
-        return $this->aliased_functions;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getAliasedFunctions();
     }
 
     /**
-     * @return null
+     * @return string|null
      */
     public function getFQCLN()
     {
-        return null;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getFQCLN();
     }
 
     /**
-     * @return null
+     * @return string|null
      */
     public function getClassName()
     {
-        return null;
-    }
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
 
-    /**
-     * @return null
-     */
-    public function getClassLikeChecker()
-    {
-        return null;
+        return $this->source->getClassName();
     }
 
     /**
@@ -197,9 +109,13 @@ abstract class SourceChecker implements StatementsSource
     /**
      * @return string|null
      */
-    public function getParentClass()
+    public function getParentFQCLN()
     {
-        return null;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getParentFQCLN();
     }
 
     /**
@@ -207,7 +123,11 @@ abstract class SourceChecker implements StatementsSource
      */
     public function getFileName()
     {
-        return $this->file_name;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getFileName();
     }
 
     /**
@@ -215,7 +135,11 @@ abstract class SourceChecker implements StatementsSource
      */
     public function getFilePath()
     {
-        return $this->file_path;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getFilePath();
     }
 
     /**
@@ -223,7 +147,11 @@ abstract class SourceChecker implements StatementsSource
      */
     public function getIncludeFileName()
     {
-        return $this->include_file_name;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getIncludeFileName();
     }
 
     /**
@@ -231,7 +159,11 @@ abstract class SourceChecker implements StatementsSource
      */
     public function getIncludeFilePath()
     {
-        return $this->include_file_path;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getIncludeFilePath();
     }
 
     /**
@@ -241,8 +173,11 @@ abstract class SourceChecker implements StatementsSource
      */
     public function setIncludeFileName($file_name, $file_path)
     {
-        $this->include_file_name = $file_name;
-        $this->include_file_path = $file_path;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        $this->source->setIncludeFileName($file_name, $file_path);
     }
 
     /**
@@ -250,7 +185,11 @@ abstract class SourceChecker implements StatementsSource
      */
     public function getCheckedFileName()
     {
-        return $this->include_file_name ?: $this->file_name;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getCheckedFileName();
     }
 
     /**
@@ -258,15 +197,11 @@ abstract class SourceChecker implements StatementsSource
      */
     public function getCheckedFilePath()
     {
-        return $this->include_file_path ?: $this->file_path;
-    }
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
 
-    /**
-     * @return bool
-     */
-    public function isStatic()
-    {
-        return false;
+        return $this->source->getCheckedFilePath();
     }
 
     /**
@@ -284,7 +219,11 @@ abstract class SourceChecker implements StatementsSource
      */
     public function getSuppressedIssues()
     {
-        return $this->suppressed_issues;
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getSuppressedIssues();
     }
 
     /**
@@ -292,6 +231,22 @@ abstract class SourceChecker implements StatementsSource
      */
     public function getNamespace()
     {
-        return '';
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->getNamespace();
+    }
+
+    /**
+     * @return bool
+     */
+    public function isStatic()
+    {
+        if ($this->source === null) {
+            throw new \UnexpectedValueException('$source cannot be null');
+        }
+
+        return $this->source->isStatic();
     }
 }

--- a/src/Psalm/Checker/Statements/Block/ForChecker.php
+++ b/src/Psalm/Checker/Statements/Block/ForChecker.php
@@ -15,7 +15,7 @@ class ForChecker
      * @param   Context                     $context
      * @return  false|null
      */
-    public static function check(
+    public static function analyze(
         StatementsChecker $statements_checker,
         PhpParser\Node\Stmt\For_ $stmt,
         Context $context
@@ -24,24 +24,24 @@ class ForChecker
         $for_context->in_loop = true;
 
         foreach ($stmt->init as $init) {
-            if (ExpressionChecker::check($statements_checker, $init, $for_context) === false) {
+            if (ExpressionChecker::analyze($statements_checker, $init, $for_context) === false) {
                 return false;
             }
         }
 
         foreach ($stmt->cond as $condition) {
-            if (ExpressionChecker::check($statements_checker, $condition, $for_context) === false) {
+            if (ExpressionChecker::analyze($statements_checker, $condition, $for_context) === false) {
                 return false;
             }
         }
 
         foreach ($stmt->loop as $expr) {
-            if (ExpressionChecker::check($statements_checker, $expr, $for_context) === false) {
+            if (ExpressionChecker::analyze($statements_checker, $expr, $for_context) === false) {
                 return false;
             }
         }
 
-        $statements_checker->check($stmt->stmts, $for_context, $context);
+        $statements_checker->analyze($stmt->stmts, $for_context, $context);
 
         foreach ($context->vars_in_scope as $var => $type) {
             if ($type->isMixed()) {

--- a/src/Psalm/Checker/Statements/Block/ForeachChecker.php
+++ b/src/Psalm/Checker/Statements/Block/ForeachChecker.php
@@ -131,6 +131,19 @@ class ForeachChecker
                         break;
 
                     default:
+                        if ($return_type->value !== 'Traversable' &&
+                            $return_type->value !== $statements_checker->getClassName()
+                        ) {
+                            if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
+                                $return_type->value,
+                                $statements_checker->getFileChecker(),
+                                new CodeLocation($statements_checker->getSource(), $stmt->expr),
+                                $statements_checker->getSuppressedIssues()
+                            ) === false) {
+                                return false;
+                            }
+                        }
+
                         if (ClassChecker::classImplements(
                             $return_type->value,
                             'Iterator'
@@ -153,19 +166,6 @@ class ForeachChecker
                                 }
                             } else {
                                 $value_type = Type::getMixed();
-                            }
-                        }
-
-                        if ($return_type->value !== 'Traversable' &&
-                            $return_type->value !== $statements_checker->getClassName()
-                        ) {
-                            if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
-                                $return_type->value,
-                                $statements_checker->getFileChecker(),
-                                new CodeLocation($statements_checker->getSource(), $stmt->expr),
-                                $statements_checker->getSuppressedIssues()
-                            ) === false) {
-                                return false;
                             }
                         }
                 }

--- a/src/Psalm/Checker/Statements/Block/ForeachChecker.php
+++ b/src/Psalm/Checker/Statements/Block/ForeachChecker.php
@@ -24,12 +24,12 @@ class ForeachChecker
      * @param   Context                         $context
      * @return  false|null
      */
-    public static function check(
+    public static function analyze(
         StatementsChecker $statements_checker,
         PhpParser\Node\Stmt\Foreach_ $stmt,
         Context $context
     ) {
-        if (ExpressionChecker::check($statements_checker, $stmt->expr, $context) === false) {
+        if (ExpressionChecker::analyze($statements_checker, $stmt->expr, $context) === false) {
             return false;
         }
 
@@ -178,7 +178,7 @@ class ForeachChecker
             $statements_checker->registerVariable('$' . $stmt->keyVar->name, $stmt->getLine());
         }
 
-        AssignmentChecker::check(
+        AssignmentChecker::analyze(
             $statements_checker,
             $stmt->valueVar,
             null,
@@ -194,7 +194,7 @@ class ForeachChecker
             null
         );
 
-        $statements_checker->check($stmt->stmts, $foreach_context, $context);
+        $statements_checker->analyze($stmt->stmts, $foreach_context, $context);
 
         foreach ($context->vars_in_scope as $var => $type) {
             if ($type->isMixed()) {

--- a/src/Psalm/Checker/Statements/Block/ForeachChecker.php
+++ b/src/Psalm/Checker/Statements/Block/ForeachChecker.php
@@ -45,8 +45,7 @@ class ForeachChecker
         $var_id = ExpressionChecker::getVarId(
             $stmt->expr,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         if (isset($stmt->expr->inferredType)) {

--- a/src/Psalm/Checker/Statements/Block/ForeachChecker.php
+++ b/src/Psalm/Checker/Statements/Block/ForeachChecker.php
@@ -132,7 +132,10 @@ class ForeachChecker
                         break;
 
                     default:
-                        if (ClassChecker::classImplements($return_type->value, 'Iterator')) {
+                        if (ClassChecker::classImplements(
+                            $return_type->value,
+                            'Iterator'
+                        )) {
                             $iterator_method = $return_type->value . '::current';
                             $iterator_class_type = MethodChecker::getMethodReturnType($iterator_method);
 
@@ -159,6 +162,7 @@ class ForeachChecker
                         ) {
                             if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
                                 $return_type->value,
+                                $statements_checker->getFileChecker(),
                                 new CodeLocation($statements_checker->getSource(), $stmt->expr),
                                 $statements_checker->getSuppressedIssues()
                             ) === false) {

--- a/src/Psalm/Checker/Statements/Block/IfChecker.php
+++ b/src/Psalm/Checker/Statements/Block/IfChecker.php
@@ -41,7 +41,7 @@ class IfChecker
      * @param  Context|null            $loop_context
      * @return null|false
      */
-    public static function check(
+    public static function analyze(
         StatementsChecker $statements_checker,
         PhpParser\Node\Stmt\If_ $stmt,
         Context $context,
@@ -56,7 +56,7 @@ class IfChecker
         $first_if_cond_expr = self::getDefinitelyEvaluatedExpression($stmt->cond);
 
         if ($first_if_cond_expr &&
-            ExpressionChecker::check($statements_checker, $first_if_cond_expr, $context) === false
+            ExpressionChecker::analyze($statements_checker, $first_if_cond_expr, $context) === false
         ) {
             return false;
         }
@@ -71,7 +71,7 @@ class IfChecker
         $original_context = clone $context;
 
         if ($first_if_cond_expr !== $stmt->cond &&
-            ExpressionChecker::check($statements_checker, $stmt->cond, $if_context) === false
+            ExpressionChecker::analyze($statements_checker, $stmt->cond, $if_context) === false
         ) {
             return false;
         }
@@ -153,7 +153,7 @@ class IfChecker
         $pre_assignment_else_redefined_vars = Context::getRedefinedVars($context, $temp_else_context);
 
         // check the if
-        self::checkIfBlock(
+        self::analyzeIfBlock(
             $statements_checker,
             $stmt,
             $if_scope,
@@ -167,7 +167,7 @@ class IfChecker
         foreach ($stmt->elseifs as $elseif) {
             $elseif_context = clone $original_context;
 
-            self::checkElseIfBlock(
+            self::analyzeElseIfBlock(
                 $statements_checker,
                 $elseif,
                 $if_scope,
@@ -181,7 +181,7 @@ class IfChecker
         if ($stmt->else) {
             $else_context = clone $original_context;
 
-            self::checkElseBlock(
+            self::analyzeElseBlock(
                 $statements_checker,
                 $stmt->else,
                 $if_scope,
@@ -252,7 +252,7 @@ class IfChecker
      * @param  array<string,Type\Union> $pre_assignment_else_redefined_vars
      * @return false|null
      */
-    protected static function checkIfBlock(
+    protected static function analyzeIfBlock(
         StatementsChecker $statements_checker,
         PhpParser\Node\Stmt\If_ $stmt,
         IfScope $if_scope,
@@ -265,7 +265,7 @@ class IfChecker
 
         $has_leaving_statements = $has_ending_statements || ScopeChecker::doesAlwaysBreakOrContinue($stmt->stmts);
 
-        if ($statements_checker->check($stmt->stmts, $if_context, $if_scope->loop_context) === false) {
+        if ($statements_checker->analyze($stmt->stmts, $if_context, $if_scope->loop_context) === false) {
             return false;
         }
 
@@ -356,7 +356,7 @@ class IfChecker
      * @param  array<Clause>               $negated_clauses
      * @return false|null
      */
-    protected static function checkElseIfBlock(
+    protected static function analyzeElseIfBlock(
         StatementsChecker $statements_checker,
         PhpParser\Node\Stmt\ElseIf_ $elseif,
         IfScope $if_scope,
@@ -386,7 +386,7 @@ class IfChecker
         }
 
         // check the elseif
-        if (ExpressionChecker::check($statements_checker, $elseif->cond, $elseif_context) === false) {
+        if (ExpressionChecker::analyze($statements_checker, $elseif->cond, $elseif_context) === false) {
             return false;
         }
 
@@ -446,7 +446,7 @@ class IfChecker
 
         $old_elseif_context = clone $elseif_context;
 
-        if ($statements_checker->check($elseif->stmts, $elseif_context, $if_scope->loop_context) === false) {
+        if ($statements_checker->analyze($elseif->stmts, $elseif_context, $if_scope->loop_context) === false) {
             return false;
         }
 
@@ -575,7 +575,7 @@ class IfChecker
      * @param  array<Clause>             $negated_clauses
      * @return false|null
      */
-    protected static function checkElseBlock(
+    protected static function analyzeElseBlock(
         StatementsChecker $statements_checker,
         PhpParser\Node\Stmt\Else_ $else,
         IfScope $if_scope,
@@ -615,7 +615,7 @@ class IfChecker
 
         $old_else_context = clone $else_context;
 
-        if ($statements_checker->check($else->stmts, $else_context, $if_scope->loop_context) === false) {
+        if ($statements_checker->analyze($else->stmts, $else_context, $if_scope->loop_context) === false) {
             return false;
         }
 

--- a/src/Psalm/Checker/Statements/Block/IfChecker.php
+++ b/src/Psalm/Checker/Statements/Block/IfChecker.php
@@ -102,6 +102,7 @@ class IfChecker
                     $reconcilable_if_types,
                     $if_context->vars_in_scope,
                     $changed_vars,
+                    $statements_checker->getFileChecker(),
                     new CodeLocation($statements_checker->getSource(), $stmt->cond),
                     $statements_checker->getSuppressedIssues()
                 );
@@ -136,6 +137,7 @@ class IfChecker
                 $if_scope->negated_types,
                 $temp_else_context->vars_in_scope,
                 $changed_vars,
+                $statements_checker->getFileChecker(),
                 new CodeLocation($statements_checker->getSource(), $stmt->cond),
                 $statements_checker->getSuppressedIssues()
             );
@@ -289,6 +291,7 @@ class IfChecker
                 $if_scope->negated_types,
                 $outer_context->vars_in_scope,
                 $changed_vars,
+                $statements_checker->getFileChecker(),
                 new CodeLocation($statements_checker->getSource(), $stmt->cond),
                 $statements_checker->getSuppressedIssues()
             );
@@ -371,6 +374,7 @@ class IfChecker
                 $if_scope->negated_types,
                 $elseif_context->vars_in_scope,
                 $changed_vars,
+                $statements_checker->getFileChecker(),
                 new CodeLocation($statements_checker->getSource(), $elseif->cond),
                 $statements_checker->getSuppressedIssues()
             );
@@ -430,6 +434,7 @@ class IfChecker
                 $reconcilable_elseif_types,
                 $elseif_context->vars_in_scope,
                 $changed_vars,
+                $statements_checker->getFileChecker(),
                 new CodeLocation($statements_checker->getSource(), $elseif->cond),
                 $statements_checker->getSuppressedIssues()
             );
@@ -598,6 +603,7 @@ class IfChecker
                 $else_types,
                 $else_context->vars_in_scope,
                 $changed_vars,
+                $statements_checker->getFileChecker(),
                 new CodeLocation($statements_checker->getSource(), $else),
                 $statements_checker->getSuppressedIssues()
             );

--- a/src/Psalm/Checker/Statements/Block/IfChecker.php
+++ b/src/Psalm/Checker/Statements/Block/IfChecker.php
@@ -80,9 +80,8 @@ class IfChecker
 
         $if_clauses = TypeChecker::getFormula(
             $stmt->cond,
-            $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $context->self,
+            $statements_checker
         );
 
         $if_context->clauses = TypeChecker::simplifyCNF(array_merge($context->clauses, $if_clauses));
@@ -394,8 +393,7 @@ class IfChecker
         $elseif_clauses = TypeChecker::getFormula(
             $elseif->cond,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         $elseif_context->clauses = TypeChecker::simplifyCNF(
@@ -738,14 +736,6 @@ class IfChecker
      */
     protected static function getDefinitelyEvaluatedExpression(PhpParser\Node\Expr $stmt)
     {
-        if ($stmt instanceof PhpParser\Node\Expr\MethodCall
-            || $stmt instanceof PhpParser\Node\Expr\StaticCall
-            || $stmt instanceof PhpParser\Node\Expr\FuncCall
-            || $stmt instanceof PhpParser\Node\Expr\Assign
-        ) {
-            return $stmt;
-        }
-
         if ($stmt instanceof PhpParser\Node\Expr\BinaryOp) {
             if ($stmt instanceof PhpParser\Node\Expr\BinaryOp\BooleanAnd ||
                 $stmt instanceof PhpParser\Node\Expr\BinaryOp\LogicalXor
@@ -764,6 +754,6 @@ class IfChecker
             return self::getDefinitelyEvaluatedExpression($stmt->expr);
         }
 
-        return null;
+        return $stmt;
     }
 }

--- a/src/Psalm/Checker/Statements/Block/SwitchChecker.php
+++ b/src/Psalm/Checker/Statements/Block/SwitchChecker.php
@@ -20,7 +20,7 @@ class SwitchChecker
      * @param   Context|null                    $loop_context
      * @return  false|null
      */
-    public static function check(
+    public static function analyze(
         StatementsChecker $statements_checker,
         PhpParser\Node\Stmt\Switch_ $stmt,
         Context $context,
@@ -28,7 +28,7 @@ class SwitchChecker
     ) {
         $type_candidate_var = null;
 
-        if (ExpressionChecker::check($statements_checker, $stmt->cond, $context) === false) {
+        if (ExpressionChecker::analyze($statements_checker, $stmt->cond, $context) === false) {
             return false;
         }
 
@@ -80,7 +80,7 @@ class SwitchChecker
             $case_type = null;
 
             if ($case->cond) {
-                if (ExpressionChecker::check($statements_checker, $case->cond, $context) === false) {
+                if (ExpressionChecker::analyze($statements_checker, $case->cond, $context) === false) {
                     return false;
                 }
 
@@ -113,7 +113,7 @@ class SwitchChecker
                 $leftover_statements = [];
             }
 
-            $statements_checker->check($case_stmts, $case_context, $loop_context);
+            $statements_checker->analyze($case_stmts, $case_context, $loop_context);
 
             // has a return/throw at end
             $has_ending_statements = ScopeChecker::doesAlwaysReturnOrThrow($case_stmts);

--- a/src/Psalm/Checker/Statements/Block/TryChecker.php
+++ b/src/Psalm/Checker/Statements/Block/TryChecker.php
@@ -45,6 +45,7 @@ class TryChecker
                 if ($context->check_classes) {
                     if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
                         $fq_catch_class,
+                        $statements_checker->getFileChecker(),
                         new CodeLocation($statements_checker->getSource(), $catch_type),
                         $statements_checker->getSuppressedIssues()
                     ) === false) {

--- a/src/Psalm/Checker/Statements/Block/TryChecker.php
+++ b/src/Psalm/Checker/Statements/Block/TryChecker.php
@@ -18,13 +18,13 @@ class TryChecker
      * @param   Context|null                    $loop_context
      * @return  false|null
      */
-    public static function check(
+    public static function analyze(
         StatementsChecker $statements_checker,
         PhpParser\Node\Stmt\TryCatch $stmt,
         Context $context,
         Context $loop_context = null
     ) {
-        $statements_checker->check($stmt->stmts, $context, $loop_context);
+        $statements_checker->analyze($stmt->stmts, $context, $loop_context);
 
         // clone context for catches after running the try block, as
         // we optimistically assume it only failed at the very end
@@ -72,7 +72,7 @@ class TryChecker
 
             $statements_checker->registerVariable('$' . $catch->var, $catch->getLine());
 
-            $statements_checker->check($catch->stmts, $catch_context, $loop_context);
+            $statements_checker->analyze($catch->stmts, $catch_context, $loop_context);
 
             if (!ScopeChecker::doesAlwaysReturnOrThrow($catch->stmts)) {
                 foreach ($catch_context->vars_in_scope as $catch_var => $type) {
@@ -95,7 +95,7 @@ class TryChecker
         }
 
         if ($stmt->finally) {
-            $statements_checker->check($stmt->finally->stmts, $context, $loop_context);
+            $statements_checker->analyze($stmt->finally->stmts, $context, $loop_context);
         }
 
         return null;

--- a/src/Psalm/Checker/Statements/Block/TryChecker.php
+++ b/src/Psalm/Checker/Statements/Block/TryChecker.php
@@ -38,8 +38,7 @@ class TryChecker
             foreach ($catch->types as $catch_type) {
                 $fq_catch_class = ClassLikeChecker::getFQCLNFromNameObject(
                     $catch_type,
-                    $statements_checker->getNamespace(),
-                    $statements_checker->getAliasedClasses()
+                    $statements_checker
                 );
 
                 if ($context->check_classes) {

--- a/src/Psalm/Checker/Statements/Block/WhileChecker.php
+++ b/src/Psalm/Checker/Statements/Block/WhileChecker.php
@@ -18,14 +18,14 @@ class WhileChecker
      * @param   Context                     $context
      * @return  false|null
      */
-    public static function check(
+    public static function analyze(
         StatementsChecker $statements_checker,
         PhpParser\Node\Stmt\While_ $stmt,
         Context $context
     ) {
         $while_context = clone $context;
 
-        if (ExpressionChecker::check($statements_checker, $stmt->cond, $while_context) === false) {
+        if (ExpressionChecker::analyze($statements_checker, $stmt->cond, $while_context) === false) {
             return false;
         }
 
@@ -59,7 +59,7 @@ class WhileChecker
             $while_context->vars_in_scope = $while_vars_in_scope_reconciled;
         }
 
-        if ($statements_checker->check($stmt->stmts, $while_context, $context) === false) {
+        if ($statements_checker->analyze($stmt->stmts, $while_context, $context) === false) {
             return false;
         }
 

--- a/src/Psalm/Checker/Statements/Block/WhileChecker.php
+++ b/src/Psalm/Checker/Statements/Block/WhileChecker.php
@@ -48,6 +48,7 @@ class WhileChecker
                 $while_types,
                 $while_context->vars_in_scope,
                 $changed_vars,
+                $statements_checker->getFileChecker(),
                 new CodeLocation($statements_checker->getSource(), $stmt->cond),
                 $statements_checker->getSuppressedIssues()
             );

--- a/src/Psalm/Checker/Statements/Block/WhileChecker.php
+++ b/src/Psalm/Checker/Statements/Block/WhileChecker.php
@@ -5,7 +5,7 @@ use PhpParser;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\Checker\Statements\ExpressionChecker;
-use Psalm\Checker\Statements\Expression\AssertionChecker;
+use Psalm\Checker\Statements\Expression\AssertionFinder;
 use Psalm\Checker\StatementsChecker;
 use Psalm\Checker\TypeChecker;
 use Psalm\Type;
@@ -29,11 +29,10 @@ class WhileChecker
             return false;
         }
 
-        $while_types = AssertionChecker::getAssertions(
+        $while_types = AssertionFinder::getAssertions(
             $stmt->cond,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         // if the while has an or as the main component, we cannot safely reason about it

--- a/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
@@ -54,15 +54,13 @@ class AssignmentChecker
         $var_id = ExpressionChecker::getVarId(
             $assign_var,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         $array_var_id = ExpressionChecker::getArrayVarId(
             $assign_var,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         if ($array_var_id) {
@@ -150,8 +148,7 @@ class AssignmentChecker
                 $list_var_id = ExpressionChecker::getVarId(
                     $var,
                     $statements_checker->getFQCLN(),
-                    $statements_checker->getNamespace(),
-                    $statements_checker->getAliasedClasses()
+                    $statements_checker
                 );
 
                 if ($list_var_id) {
@@ -250,8 +247,7 @@ class AssignmentChecker
         $var_id = ExpressionChecker::getVarId(
             $stmt->var,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         $var_type = isset($stmt->var->inferredType) ? clone $stmt->var->inferredType : null;
@@ -358,15 +354,13 @@ class AssignmentChecker
             $lhs_var_id = ExpressionChecker::getVarId(
                 $stmt->var,
                 $statements_checker->getFQCLN(),
-                $statements_checker->getNamespace(),
-                $statements_checker->getAliasedClasses()
+                $statements_checker
             );
 
             $var_id = ExpressionChecker::getVarId(
                 $stmt,
                 $statements_checker->getFQCLN(),
-                $statements_checker->getNamespace(),
-                $statements_checker->getAliasedClasses()
+                $statements_checker
             );
 
             if ($lhs_type->isMixed()) {
@@ -655,8 +649,7 @@ class AssignmentChecker
         $var_id = ExpressionChecker::getVarId(
             $stmt,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         $fq_class_name = (string)$stmt->class->inferredType;
@@ -817,8 +810,7 @@ class AssignmentChecker
         $var_id = ExpressionChecker::getVarId(
             $stmt->var,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses(),
+            $statements_checker,
             $nesting
         );
 
@@ -842,8 +834,7 @@ class AssignmentChecker
         $array_var_id = ExpressionChecker::getArrayVarId(
             $stmt->var,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         $is_string = isset($stmt->var->inferredType)

--- a/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
@@ -335,7 +335,7 @@ class AssignmentChecker
 
             $declaring_property_class = ClassLikeChecker::getDeclaringClassForProperty($property_id);
 
-            $class_storage = ClassLikeChecker::$storage[$declaring_property_class];
+            $class_storage = ClassLikeChecker::$storage[strtolower((string)$declaring_property_class)];
 
             $class_property_type = $class_storage->properties[$prop_name]->type;
 
@@ -430,17 +430,6 @@ class AssignmentChecker
                     continue;
                 }
 
-                if (!$lhs_type_part->isObject() && MethodChecker::methodExists($lhs_type_part . '::__set')) {
-                    $context->vars_in_scope[$var_id] = Type::getMixed();
-                    continue;
-                }
-
-                $has_regular_setter = true;
-
-                if ($lhs_type_part->isObject()) {
-                    continue;
-                }
-
                 // stdClass and SimpleXMLElement are special cases where we cannot infer the return types
                 // but we don't want to throw an error
                 // Hack has a similar issue: https://github.com/facebook/hhvm/issues/5164
@@ -457,6 +446,17 @@ class AssignmentChecker
                     }
 
                     return null;
+                }
+
+                if (!$lhs_type_part->isObject() && MethodChecker::methodExists($lhs_type_part . '::__set')) {
+                    $context->vars_in_scope[$var_id] = Type::getMixed();
+                    continue;
+                }
+
+                $has_regular_setter = true;
+
+                if ($lhs_type_part->isObject()) {
+                    continue;
                 }
 
                 if (ExpressionChecker::isMock($lhs_type_part->value)) {
@@ -547,7 +547,8 @@ class AssignmentChecker
                     $lhs_type_part->value . '::$' . $prop_name
                 );
 
-                $property_storage = ClassLikeChecker::$storage[$declaring_property_class]->properties[$stmt->name];
+                $property_storage =
+                    ClassLikeChecker::$storage[strtolower((string)$declaring_property_class)]->properties[$stmt->name];
 
                 $class_property_type = $property_storage->type;
 
@@ -720,7 +721,8 @@ class AssignmentChecker
             $fq_class_name . '::$' . $prop_name
         );
 
-        $property_storage = ClassLikeChecker::$storage[$declaring_property_class]->properties[$stmt->name];
+        $property_storage =
+            ClassLikeChecker::$storage[strtolower((string)$declaring_property_class)]->properties[$stmt->name];
 
         $context->vars_in_scope[$var_id] = $assignment_value_type;
 

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -473,7 +473,7 @@ class CallChecker
 
                 $method_id = $statements_checker->getFQCLN() . '::' . strtolower($stmt->name);
 
-                if ($file_checker->getMethodMutations($method_id, $context) === false) {
+                if ($file_checker->project_checker->getMethodMutations($method_id, $context) === false) {
                     return false;
                 }
             }
@@ -710,7 +710,7 @@ class CallChecker
                         if ($context->collect_mutations) {
                             $method_id = $fq_class_name . '::' . strtolower($stmt->name);
 
-                            if ($file_checker->getMethodMutations($method_id, $context) === false) {
+                            if ($file_checker->project_checker->getMethodMutations($method_id, $context) === false) {
                                 return false;
                             }
                         }

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -40,7 +40,7 @@ class CallChecker
      * @param   Context                         $context
      * @return  false|null
      */
-    public static function checkFunctionCall(
+    public static function analyzeFunctionCall(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\FuncCall $stmt,
         Context $context
@@ -80,7 +80,7 @@ class CallChecker
             } elseif ($method->parts === ['define']) {
                 if ($first_arg && $first_arg->value instanceof PhpParser\Node\Scalar\String_) {
                     $second_arg = $stmt->args[1];
-                    ExpressionChecker::check($statements_checker, $second_arg->value, $context);
+                    ExpressionChecker::analyze($statements_checker, $second_arg->value, $context);
                     $const_name = $first_arg->value->value;
 
                     $statements_checker->setConstType(
@@ -104,7 +104,7 @@ class CallChecker
             $code_location = new CodeLocation($statements_checker->getSource(), $stmt);
 
             if ($stmt->name instanceof PhpParser\Node\Expr) {
-                if (ExpressionChecker::check($statements_checker, $stmt->name, $context) === false) {
+                if (ExpressionChecker::analyze($statements_checker, $stmt->name, $context) === false) {
                     return false;
                 }
 
@@ -250,7 +250,7 @@ class CallChecker
      * @param   Context                     $context
      * @return  false|null
      */
-    public static function checkNew(
+    public static function analyzeNew(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\New_ $stmt,
         Context $context
@@ -295,10 +295,10 @@ class CallChecker
                 }
             }
         } elseif ($stmt->class instanceof PhpParser\Node\Stmt\Class_) {
-            $statements_checker->check([$stmt->class], $context);
+            $statements_checker->analyze([$stmt->class], $context);
             $fq_class_name = $stmt->class->name;
         } else {
-            ExpressionChecker::check($statements_checker, $stmt->class, $context);
+            ExpressionChecker::analyze($statements_checker, $stmt->class, $context);
         }
 
         if ($fq_class_name) {
@@ -399,12 +399,12 @@ class CallChecker
      * @param   Context                         $context
      * @return  false|null
      */
-    public static function checkMethodCall(
+    public static function analyzeMethodCall(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\MethodCall $stmt,
         Context $context
     ) {
-        if (ExpressionChecker::check($statements_checker, $stmt->var, $context) === false) {
+        if (ExpressionChecker::analyze($statements_checker, $stmt->var, $context) === false) {
             return false;
         }
 
@@ -654,7 +654,7 @@ class CallChecker
      * @param   Context                         $context
      * @return  false|null
      */
-    public static function checkStaticCall(
+    public static function analyzeStaticCall(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\StaticCall $stmt,
         Context $context
@@ -741,7 +741,7 @@ class CallChecker
                 $lhs_type = new Type\Union([new Type\Atomic($fq_class_name)]);
             }
         } else {
-            ExpressionChecker::check($statements_checker, $stmt->class, $context);
+            ExpressionChecker::analyze($statements_checker, $stmt->class, $context);
 
             /** @var Type\Union */
             $lhs_type = $stmt->class->inferredType;
@@ -796,7 +796,7 @@ class CallChecker
                         || !ClassChecker::classExtends($context->self, $fq_class_name)
                     )
                 ) {
-                    if (MethodChecker::checkMethodStatic(
+                    if (MethodChecker::analyzeMethodstatic(
                         $method_id,
                         $stmt->class instanceof PhpParser\Node\Name && $stmt->class->parts[0] === 'self',
                         new CodeLocation($statements_checker->getSource(), $stmt),
@@ -894,7 +894,7 @@ class CallChecker
                     if ($by_ref && $by_ref_type) {
                         ExpressionChecker::assignByRefParam($statements_checker, $arg->value, $by_ref_type, $context);
                     } else {
-                        if (FetchChecker::checkPropertyFetch($statements_checker, $arg->value, $context) === false) {
+                        if (FetchChecker::analyzePropertyFetch($statements_checker, $arg->value, $context) === false) {
                             return false;
                         }
                     }
@@ -923,7 +923,7 @@ class CallChecker
                         ? clone $function_params[$argument_offset]->type
                         : null;
 
-                    if (ExpressionChecker::checkVariable(
+                    if (ExpressionChecker::analyzeVariable(
                         $statements_checker,
                         $arg->value,
                         $context,
@@ -944,7 +944,7 @@ class CallChecker
                     }
                 }
             } else {
-                if (ExpressionChecker::check($statements_checker, $arg->value, $context) === false) {
+                if (ExpressionChecker::analyze($statements_checker, $arg->value, $context) === false) {
                     return false;
                 }
             }

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -130,8 +130,7 @@ class CallChecker
                             $var_id = ExpressionChecker::getVarId(
                                 $stmt->name,
                                 $statements_checker->getFQCLN(),
-                                $statements_checker->getNamespace(),
-                                $statements_checker->getAliasedClasses()
+                                $statements_checker
                             );
 
                             if (IssueBuffer::accepts(
@@ -262,8 +261,7 @@ class CallChecker
             if (!in_array($stmt->class->parts[0], ['self', 'static', 'parent'])) {
                 $fq_class_name = ClassLikeChecker::getFQCLNFromNameObject(
                     $stmt->class,
-                    $statements_checker->getNamespace(),
-                    $statements_checker->getAliasedClasses()
+                    $statements_checker
                 );
 
                 if ($context->check_classes) {
@@ -430,8 +428,7 @@ class CallChecker
         $var_id = ExpressionChecker::getVarId(
             $stmt->var,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         $class_type = isset($context->vars_in_scope[$var_id]) ? $context->vars_in_scope[$var_id] : null;
@@ -452,14 +449,16 @@ class CallChecker
         ) {
             $this_method_id = $source->getMethodId();
 
+            $fq_class_name = (string)$statements_checker->getFQCLN();
+
             if (($this_class = ClassLikeChecker::getThisClass()) &&
                 (
-                    $this_class === $statements_checker->getFQCLN() ||
+                    $this_class === $fq_class_name ||
                     ClassChecker::classExtends(
                         $this_class,
-                        $statements_checker->getFQCLN()
+                        $fq_class_name
                     ) ||
-                    TraitChecker::traitExists($statements_checker->getFQCLN(), $statements_checker->getFileChecker())
+                    TraitChecker::traitExists($fq_class_name, $statements_checker->getFileChecker())
                 )
             ) {
                 $method_id = $statements_checker->getFQCLN() . '::' . strtolower($stmt->name);
@@ -680,7 +679,7 @@ class CallChecker
 
             if (count($stmt->class->parts) === 1 && in_array($stmt->class->parts[0], ['self', 'static', 'parent'])) {
                 if ($stmt->class->parts[0] === 'parent') {
-                    $fq_class_name = $statements_checker->getParentClass();
+                    $fq_class_name = $statements_checker->getParentFQCLN();
 
                     if ($fq_class_name === null) {
                         if (IssueBuffer::accepts(
@@ -709,8 +708,7 @@ class CallChecker
             } elseif ($context->check_classes) {
                 $fq_class_name = ClassLikeChecker::getFQCLNFromNameObject(
                     $stmt->class,
-                    $statements_checker->getNamespace(),
-                    $statements_checker->getAliasedClasses()
+                    $statements_checker
                 );
 
                 if ($context->isPhantomClass($fq_class_name)) {
@@ -904,8 +902,7 @@ class CallChecker
                     $var_id = ExpressionChecker::getVarId(
                         $arg->value,
                         $statements_checker->getFQCLN(),
-                        $statements_checker->getNamespace(),
-                        $statements_checker->getAliasedClasses()
+                        $statements_checker
                     );
 
                     if ($var_id &&
@@ -1063,7 +1060,7 @@ class CallChecker
                     ),
                     $statements_checker->getSuppressedIssues()
                 )) {
-                    return false;
+                    // fall through
                 }
 
                 return null;

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -796,7 +796,7 @@ class CallChecker
                         || !ClassChecker::classExtends($context->self, $fq_class_name)
                     )
                 ) {
-                    if (MethodChecker::analyzeMethodstatic(
+                    if (MethodChecker::analyzetatic(
                         $method_id,
                         $stmt->class instanceof PhpParser\Node\Name && $stmt->class->parts[0] === 'self',
                         new CodeLocation($statements_checker->getSource(), $stmt),

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -1337,7 +1337,7 @@ class CallChecker
             }
         }
 
-        if (!$type_match_found) {
+        if (!$type_match_found && !$coerced_type) {
             if ($scalar_type_match_found) {
                 if ($cased_method_id !== 'echo') {
                     if (IssueBuffer::accepts(

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -111,7 +111,7 @@ class CallChecker
                 if (isset($stmt->name->inferredType)) {
                     foreach ($stmt->name->inferredType->types as $var_type_part) {
                         if ($var_type_part instanceof Type\Fn) {
-                            $function_params = $var_type_part->parameters;
+                            $function_params = $var_type_part->params;
 
                             if ($var_type_part->return_type) {
                                 if (isset($stmt->inferredType)) {
@@ -1147,7 +1147,7 @@ class CallChecker
                     continue;
                 }
 
-                if (count($closure_type->parameters) > $expected_closure_param_count) {
+                if (count($closure_type->params) > $expected_closure_param_count) {
                     if (IssueBuffer::accepts(
                         new TooManyArguments(
                             'Too many arguments in closure for ' . $method_id,
@@ -1157,7 +1157,7 @@ class CallChecker
                     )) {
                         return false;
                     }
-                } elseif (count($closure_type->parameters) < $expected_closure_param_count) {
+                } elseif (count($closure_type->params) < $expected_closure_param_count) {
                     if (IssueBuffer::accepts(
                         new TooFewArguments(
                             'You must supply a param in the closure for ' . $method_id,
@@ -1170,11 +1170,14 @@ class CallChecker
                 }
 
 
-                $closure_params = $closure_type->parameters;
+                $closure_params = $closure_type->params;
                 $closure_return_type = $closure_type->return_type;
 
-                foreach ($closure_params as $i => $closure_param) {
+                $i = 0;
+
+                foreach ($closure_params as $param_name => $closure_param) {
                     if (!$array_arg_types[$i]) {
+                        $i++;
                         continue;
                     }
 
@@ -1184,6 +1187,7 @@ class CallChecker
                     $input_type = $array_arg_type->type_params[1];
 
                     if ($input_type->isMixed()) {
+                        $i++;
                         continue;
                     }
 
@@ -1234,6 +1238,8 @@ class CallChecker
                             return false;
                         }
                     }
+
+                    $i++;
                 }
             }
         }

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -273,7 +273,8 @@ class CallChecker
                         $fq_class_name,
                         $statements_checker->getFileChecker(),
                         new CodeLocation($statements_checker->getSource(), $stmt->class),
-                        $statements_checker->getSuppressedIssues()
+                        $statements_checker->getSuppressedIssues(),
+                        true
                     ) === false) {
                         return false;
                     }
@@ -304,7 +305,9 @@ class CallChecker
         if ($fq_class_name) {
             $stmt->inferredType = new Type\Union([new Type\Atomic($fq_class_name)]);
 
-            if (MethodChecker::methodExists($fq_class_name . '::__construct')) {
+            if (strtolower($fq_class_name) !== 'stdclass' &&
+                MethodChecker::methodExists($fq_class_name . '::__construct')
+            ) {
                 $method_id = $fq_class_name . '::__construct';
 
                 $file_checker = $statements_checker->getFileChecker();
@@ -544,7 +547,8 @@ class CallChecker
                             $fq_class_name,
                             $statements_checker->getFileChecker(),
                             new CodeLocation($statements_checker->getSource(), $stmt->var),
-                            $statements_checker->getSuppressedIssues()
+                            $statements_checker->getSuppressedIssues(),
+                            true
                         );
 
                         if (!$does_class_exist) {
@@ -719,7 +723,8 @@ class CallChecker
                     $fq_class_name,
                     $file_checker,
                     new CodeLocation($statements_checker->getSource(), $stmt->class),
-                    $statements_checker->getSuppressedIssues()
+                    $statements_checker->getSuppressedIssues(),
+                    true
                 );
 
                 if (!$does_class_exist) {

--- a/src/Psalm/Checker/Statements/Expression/FetchChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/FetchChecker.php
@@ -262,7 +262,8 @@ class FetchChecker
 
             $declaring_property_class = ClassLikeChecker::getDeclaringClassForProperty($property_id);
 
-            $property_storage = ClassLikeChecker::$storage[$declaring_property_class]->properties[$stmt->name];
+            $property_storage =
+                ClassLikeChecker::$storage[strtolower((string)$declaring_property_class)]->properties[$stmt->name];
 
             $class_property_type = $property_storage->type;
 
@@ -400,7 +401,8 @@ class FetchChecker
                     $fq_class_name,
                     $statements_checker->getFileChecker(),
                     new CodeLocation($statements_checker->getSource(), $stmt->class),
-                    $statements_checker->getSuppressedIssues()
+                    $statements_checker->getSuppressedIssues(),
+                    true
                 ) === false) {
                     return false;
                 }
@@ -535,7 +537,8 @@ class FetchChecker
                     $fq_class_name,
                     $statements_checker->getFileChecker(),
                     new CodeLocation($statements_checker->getSource(), $stmt->class),
-                    $statements_checker->getSuppressedIssues()
+                    $statements_checker->getSuppressedIssues(),
+                    true
                 ) === false) {
                     return false;
                 }
@@ -591,7 +594,8 @@ class FetchChecker
                 $fq_class_name . '::$' . $stmt->name
             );
 
-            $property = ClassLikeChecker::$storage[$declaring_property_class]->properties[$stmt->name];
+            $property =
+                ClassLikeChecker::$storage[strtolower((string)$declaring_property_class)]->properties[$stmt->name];
 
             $context->vars_in_scope[$var_id] = $property->type
                 ? clone $property->type

--- a/src/Psalm/Checker/Statements/Expression/FetchChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/FetchChecker.php
@@ -41,21 +41,21 @@ class FetchChecker
      * @param   bool                                $array_assignment
      * @return  false|null
      */
-    public static function checkPropertyFetch(
+    public static function analyzePropertyFetch(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\PropertyFetch $stmt,
         Context $context,
         $array_assignment = false
     ) {
         if (!is_string($stmt->name)) {
-            if (ExpressionChecker::check($statements_checker, $stmt->name, $context) === false) {
+            if (ExpressionChecker::analyze($statements_checker, $stmt->name, $context) === false) {
                 return false;
             }
         }
 
         $var_id = null;
 
-        if (ExpressionChecker::check($statements_checker, $stmt->var, $context) === false) {
+        if (ExpressionChecker::analyze($statements_checker, $stmt->var, $context) === false) {
             return false;
         }
 
@@ -300,7 +300,7 @@ class FetchChecker
      * @param   Context                         $context
      * @return  false|null
      */
-    public static function checkConstFetch(
+    public static function analyzeConstFetch(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\ConstFetch $stmt,
         Context $context
@@ -351,7 +351,7 @@ class FetchChecker
      * @param   Context                             $context
      * @return  null|false
      */
-    public static function checkClassConstFetch(
+    public static function analyzeClassConstFetch(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\ClassConstFetch $stmt,
         Context $context
@@ -457,7 +457,7 @@ class FetchChecker
         }
 
         if ($stmt->class instanceof PhpParser\Node\Expr) {
-            if (ExpressionChecker::check($statements_checker, $stmt->class, $context) === false) {
+            if (ExpressionChecker::analyze($statements_checker, $stmt->class, $context) === false) {
                 return false;
             }
         }
@@ -471,7 +471,7 @@ class FetchChecker
      * @param   Context                                 $context
      * @return  null|false
      */
-    public static function checkStaticPropertyFetch(
+    public static function analyzeStaticPropertyFetch(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\StaticPropertyFetch $stmt,
         Context $context
@@ -605,7 +605,7 @@ class FetchChecker
      * @param   string|null                         $assignment_key_value
      * @return  false|null
      */
-    public static function checkArrayAccess(
+    public static function analyzeArrayAccess(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\ArrayDimFetch $stmt,
         Context $context,
@@ -643,7 +643,7 @@ class FetchChecker
             $statements_checker
         );
 
-        if ($stmt->dim && ExpressionChecker::check($statements_checker, $stmt->dim, $context) === false) {
+        if ($stmt->dim && ExpressionChecker::analyze($statements_checker, $stmt->dim, $context) === false) {
             return false;
         }
 
@@ -736,7 +736,7 @@ class FetchChecker
             }
         }
 
-        if (ExpressionChecker::check(
+        if (ExpressionChecker::analyze(
             $statements_checker,
             $stmt->var,
             $context,

--- a/src/Psalm/Checker/Statements/Expression/FetchChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/FetchChecker.php
@@ -388,6 +388,14 @@ class FetchChecker
                     $statements_checker
                 );
 
+                // edge case when evaluating single files
+                if ($stmt->name === 'class' &&
+                    $statements_checker->getFileChecker()->containsUnEvaluatedClassLike($fq_class_name)
+                ) {
+                    $stmt->inferredType = Type::getString();
+                    return null;
+                }
+
                 if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
                     $fq_class_name,
                     $statements_checker->getFileChecker(),
@@ -398,12 +406,12 @@ class FetchChecker
                 }
             }
 
-            $const_id = $fq_class_name . '::' . $stmt->name;
-
             if ($stmt->name === 'class') {
                 $stmt->inferredType = Type::getString();
                 return null;
             }
+
+            $const_id = $fq_class_name . '::' . $stmt->name;
 
             if ($fq_class_name === $context->self
                 || (

--- a/src/Psalm/Checker/Statements/Expression/FetchChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/FetchChecker.php
@@ -62,15 +62,13 @@ class FetchChecker
         $stmt_var_id = ExpressionChecker::getVarId(
             $stmt->var,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         $var_id = ExpressionChecker::getVarId(
             $stmt,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         $var_name = is_string($stmt->name) ? $stmt->name : null;
@@ -163,8 +161,7 @@ class FetchChecker
                 $stmt_var_id = ExpressionChecker::getVarId(
                     $stmt->var,
                     $statements_checker->getFQCLN(),
-                    $statements_checker->getNamespace(),
-                    $statements_checker->getAliasedClasses()
+                    $statements_checker
                 );
 
                 if (IssueBuffer::accepts(
@@ -370,7 +367,7 @@ class FetchChecker
 
                 $fq_class_name = (string)$context->self;
             } elseif ($stmt->class->parts[0] === 'parent') {
-                $fq_class_name = $statements_checker->getParentClass();
+                $fq_class_name = $statements_checker->getParentFQCLN();
 
                 if ($fq_class_name === null) {
                     if (IssueBuffer::accepts(
@@ -388,8 +385,7 @@ class FetchChecker
             } else {
                 $fq_class_name = ClassLikeChecker::getFQCLNFromNameObject(
                     $stmt->class,
-                    $statements_checker->getNamespace(),
-                    $statements_checker->getAliasedClasses()
+                    $statements_checker
                 );
 
                 if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
@@ -493,7 +489,7 @@ class FetchChecker
         if ($stmt->class instanceof PhpParser\Node\Name) {
             if (count($stmt->class->parts) === 1 && in_array($stmt->class->parts[0], ['self', 'static', 'parent'])) {
                 if ($stmt->class->parts[0] === 'parent') {
-                    $fq_class_name = $statements_checker->getParentClass();
+                    $fq_class_name = $statements_checker->getParentFQCLN();
 
                     if ($fq_class_name === null) {
                         if (IssueBuffer::accepts(
@@ -520,8 +516,7 @@ class FetchChecker
             } elseif ($context->check_classes) {
                 $fq_class_name = ClassLikeChecker::getFQCLNFromNameObject(
                     $stmt->class,
-                    $statements_checker->getNamespace(),
-                    $statements_checker->getAliasedClasses()
+                    $statements_checker
                 );
 
                 if ($context->isPhantomClass($fq_class_name)) {
@@ -549,8 +544,7 @@ class FetchChecker
             $var_id = ExpressionChecker::getVarId(
                 $stmt,
                 $statements_checker->getFQCLN(),
-                $statements_checker->getNamespace(),
-                $statements_checker->getAliasedClasses()
+                $statements_checker
             );
 
             if ($var_id && isset($context->vars_in_scope[$var_id])) {
@@ -628,8 +622,7 @@ class FetchChecker
         $var_id = ExpressionChecker::getVarId(
             $stmt->var,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses(),
+            $statements_checker,
             $nesting
         );
 
@@ -641,15 +634,13 @@ class FetchChecker
         $array_var_id = ExpressionChecker::getArrayVarId(
             $stmt->var,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         $keyed_array_var_id = ExpressionChecker::getArrayVarId(
             $stmt,
             $statements_checker->getFQCLN(),
-            $statements_checker->getNamespace(),
-            $statements_checker->getAliasedClasses()
+            $statements_checker
         );
 
         if ($stmt->dim && ExpressionChecker::check($statements_checker, $stmt->dim, $context) === false) {

--- a/src/Psalm/Checker/Statements/ExpressionChecker.php
+++ b/src/Psalm/Checker/Statements/ExpressionChecker.php
@@ -46,7 +46,7 @@ class ExpressionChecker
      * @param   string|null         $assignment_key_value
      * @return  false|null
      */
-    public static function check(
+    public static function analyze(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr $stmt,
         Context $context,
@@ -56,11 +56,11 @@ class ExpressionChecker
         $assignment_key_value = null
     ) {
         if ($stmt instanceof PhpParser\Node\Expr\Variable) {
-            if (self::checkVariable($statements_checker, $stmt, $context, false, null, $array_assignment) === false) {
+            if (self::analyzeVariable($statements_checker, $stmt, $context, false, null, $array_assignment) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Assign) {
-            $assignment_type = AssignmentChecker::check(
+            $assignment_type = AssignmentChecker::analyze(
                 $statements_checker,
                 $stmt->var,
                 $stmt->expr,
@@ -75,19 +75,19 @@ class ExpressionChecker
 
             $stmt->inferredType = $assignment_type;
         } elseif ($stmt instanceof PhpParser\Node\Expr\AssignOp) {
-            if (AssignmentChecker::checkAssignmentOperation($statements_checker, $stmt, $context) === false) {
+            if (AssignmentChecker::analyzeAssignmentOperation($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\MethodCall) {
-            if (CallChecker::checkMethodCall($statements_checker, $stmt, $context) === false) {
+            if (CallChecker::analyzeMethodCall($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\StaticCall) {
-            if (CallChecker::checkStaticCall($statements_checker, $stmt, $context) === false) {
+            if (CallChecker::analyzeStaticCall($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\ConstFetch) {
-            if (FetchChecker::checkConstFetch($statements_checker, $stmt, $context) === false) {
+            if (FetchChecker::analyzeConstFetch($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Scalar\String_) {
@@ -101,12 +101,12 @@ class ExpressionChecker
         } elseif ($stmt instanceof PhpParser\Node\Scalar\DNumber) {
             $stmt->inferredType = Type::getFloat();
         } elseif ($stmt instanceof PhpParser\Node\Expr\UnaryMinus) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
             $stmt->inferredType = isset($stmt->expr->inferredType) ? $stmt->expr->inferredType : null;
         } elseif ($stmt instanceof PhpParser\Node\Expr\UnaryPlus) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
@@ -125,23 +125,23 @@ class ExpressionChecker
             }
             $stmt->inferredType = Type::getBool();
         } elseif ($stmt instanceof PhpParser\Node\Expr\ClassConstFetch) {
-            if (FetchChecker::checkClassConstFetch($statements_checker, $stmt, $context) === false) {
+            if (FetchChecker::analyzeClassConstFetch($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\PropertyFetch) {
-            if (FetchChecker::checkPropertyFetch($statements_checker, $stmt, $context, $array_assignment) === false) {
+            if (FetchChecker::analyzePropertyFetch($statements_checker, $stmt, $context, $array_assignment) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\StaticPropertyFetch) {
-            if (FetchChecker::checkStaticPropertyFetch($statements_checker, $stmt, $context) === false) {
+            if (FetchChecker::analyzeStaticPropertyFetch($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\BitwiseNot) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\BinaryOp) {
-            if (self::checkBinaryOp($statements_checker, $stmt, $context) === false) {
+            if (self::analyzeBinaryOp($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\PostInc ||
@@ -149,7 +149,7 @@ class ExpressionChecker
             $stmt instanceof PhpParser\Node\Expr\PreInc ||
             $stmt instanceof PhpParser\Node\Expr\PreDec
         ) {
-            if (self::check($statements_checker, $stmt->var, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->var, $context) === false) {
                 return false;
             }
 
@@ -159,37 +159,37 @@ class ExpressionChecker
                 $stmt->inferredType = Type::getMixed();
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\New_) {
-            if (CallChecker::checkNew($statements_checker, $stmt, $context) === false) {
+            if (CallChecker::analyzeNew($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Array_) {
-            if (self::checkArray($statements_checker, $stmt, $context) === false) {
+            if (self::analyzeArray($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Scalar\Encapsed) {
-            if (self::checkEncapsulatedString($statements_checker, $stmt, $context) === false) {
+            if (self::analyzeEncapsulatedString($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\FuncCall) {
-            if (CallChecker::checkFunctionCall($statements_checker, $stmt, $context) === false) {
+            if (CallChecker::analyzeFunctionCall($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Ternary) {
-            if (self::checkTernary($statements_checker, $stmt, $context) === false) {
+            if (self::analyzeTernary($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\BooleanNot) {
-            if (self::checkBooleanNot($statements_checker, $stmt, $context) === false) {
+            if (self::analyzeBooleanNot($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Empty_) {
-            if (self::checkEmpty($statements_checker, $stmt, $context) === false) {
+            if (self::analyzeEmpty($statements_checker, $stmt, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Closure) {
             $closure_checker = new ClosureChecker($stmt, $statements_checker->getSource());
 
-            if (self::checkClosureUses($statements_checker, $stmt, $context) === false) {
+            if (self::analyzeClosureUses($statements_checker, $stmt, $context) === false) {
                 return false;
             }
 
@@ -236,13 +236,13 @@ class ExpressionChecker
                 $use_context->vars_possibly_in_scope['$' . $use->var] = true;
             }
 
-            $closure_checker->check($use_context);
+            $closure_checker->analyze($use_context);
 
             if (!isset($stmt->inferredType)) {
                 $stmt->inferredType = Type::getClosure();
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\ArrayDimFetch) {
-            if (FetchChecker::checkArrayAccess(
+            if (FetchChecker::analyzeArrayAccess(
                 $statements_checker,
                 $stmt,
                 $context,
@@ -254,49 +254,49 @@ class ExpressionChecker
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Cast\Int_) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
             $stmt->inferredType = Type::getInt();
         } elseif ($stmt instanceof PhpParser\Node\Expr\Cast\Double) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
             $stmt->inferredType = Type::getFloat();
         } elseif ($stmt instanceof PhpParser\Node\Expr\Cast\Bool_) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
             $stmt->inferredType = Type::getBool();
         } elseif ($stmt instanceof PhpParser\Node\Expr\Cast\String_) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
             $stmt->inferredType = Type::getString();
         } elseif ($stmt instanceof PhpParser\Node\Expr\Cast\Object_) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
             $stmt->inferredType = Type::getObject();
         } elseif ($stmt instanceof PhpParser\Node\Expr\Cast\Array_) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
             $stmt->inferredType = Type::getArray();
         } elseif ($stmt instanceof PhpParser\Node\Expr\Cast\Unset_) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
             $stmt->inferredType = Type::getNull();
         } elseif ($stmt instanceof PhpParser\Node\Expr\Clone_) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
@@ -304,7 +304,7 @@ class ExpressionChecker
                 $stmt->inferredType = $stmt->expr->inferredType;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Instanceof_) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
 
@@ -332,12 +332,12 @@ class ExpressionChecker
         } elseif ($stmt instanceof PhpParser\Node\Expr\Exit_) {
             // do nothing
         } elseif ($stmt instanceof PhpParser\Node\Expr\Include_) {
-            $statements_checker->checkInclude($stmt, $context);
+            $statements_checker->analyzeInclude($stmt, $context);
         } elseif ($stmt instanceof PhpParser\Node\Expr\Eval_) {
             $context->check_classes = false;
             $context->check_variables = false;
 
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\AssignRef) {
@@ -347,17 +347,17 @@ class ExpressionChecker
                     $context->vars_possibly_in_scope['$' . $stmt->var->name] = true;
                     $statements_checker->registerVariable('$' . $stmt->var->name, $stmt->var->getLine());
                 } else {
-                    if (self::check($statements_checker, $stmt->var->name, $context) === false) {
+                    if (self::analyze($statements_checker, $stmt->var->name, $context) === false) {
                         return false;
                     }
                 }
             } else {
-                if (self::check($statements_checker, $stmt->var, $context) === false) {
+                if (self::analyze($statements_checker, $stmt->var, $context) === false) {
                     return false;
                 }
             }
 
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\ErrorSuppress) {
@@ -373,13 +373,13 @@ class ExpressionChecker
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Print_) {
-            if (self::check($statements_checker, $stmt->expr, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Yield_) {
-            self::checkYield($statements_checker, $stmt, $context);
+            self::analyzeYield($statements_checker, $stmt, $context);
         } elseif ($stmt instanceof PhpParser\Node\Expr\YieldFrom) {
-            self::checkYieldFrom($statements_checker, $stmt, $context);
+            self::analyzeYieldFrom($statements_checker, $stmt, $context);
         } else {
             if (IssueBuffer::accepts(
                 new UnrecognizedExpression(
@@ -422,7 +422,7 @@ class ExpressionChecker
      * @param   bool                            $array_assignment
      * @return  false|null
      */
-    public static function checkVariable(
+    public static function analyzeVariable(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\Variable $stmt,
         Context $context,
@@ -480,7 +480,7 @@ class ExpressionChecker
         }
 
         if (!is_string($stmt->name)) {
-            return self::check($statements_checker, $stmt->name, $context);
+            return self::analyze($statements_checker, $stmt->name, $context);
         }
 
         if ($passed_by_reference && $by_ref_type) {
@@ -580,7 +580,7 @@ class ExpressionChecker
      * @param   Context                     $context
      * @return  false|null
      */
-    protected static function checkArray(
+    protected static function analyzeArray(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\Array_ $stmt,
         Context $context
@@ -602,7 +602,7 @@ class ExpressionChecker
 
         foreach ($stmt->items as $item) {
             if ($item->key) {
-                if (self::check($statements_checker, $item->key, $context) === false) {
+                if (self::analyze($statements_checker, $item->key, $context) === false) {
                     return false;
                 }
 
@@ -619,7 +619,7 @@ class ExpressionChecker
                 $item_key_type = Type::getInt();
             }
 
-            if (self::check($statements_checker, $item->value, $context) === false) {
+            if (self::analyze($statements_checker, $item->value, $context) === false) {
                 return false;
             }
 
@@ -662,7 +662,7 @@ class ExpressionChecker
      * @param   int                             $nesting
      * @return  false|null
      */
-    protected static function checkBinaryOp(
+    protected static function analyzeBinaryOp(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\BinaryOp $stmt,
         Context $context,
@@ -681,7 +681,7 @@ class ExpressionChecker
 
             $left_type_assertions = TypeChecker::getTruthsFromFormula($simplified_clauses);
 
-            if (self::check($statements_checker, $stmt->left, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->left, $context) === false) {
                 return false;
             }
 
@@ -705,7 +705,7 @@ class ExpressionChecker
             $op_context = clone $context;
             $op_context->vars_in_scope = $op_vars_in_scope;
 
-            if (self::check($statements_checker, $stmt->right, $op_context) === false) {
+            if (self::analyze($statements_checker, $stmt->right, $op_context) === false) {
                 return false;
             }
 
@@ -738,7 +738,7 @@ class ExpressionChecker
 
             $negated_type_assertions = TypeChecker::getTruthsFromFormula($rhs_clauses);
 
-            if (self::check($statements_checker, $stmt->left, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->left, $context) === false) {
                 return false;
             }
 
@@ -763,7 +763,7 @@ class ExpressionChecker
             $op_context->clauses = $rhs_clauses;
             $op_context->vars_in_scope = $op_vars_in_scope;
 
-            if (self::check($statements_checker, $stmt->right, $op_context) === false) {
+            if (self::analyze($statements_checker, $stmt->right, $op_context) === false) {
                 return false;
             }
 
@@ -776,31 +776,31 @@ class ExpressionChecker
         } elseif ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Concat) {
             $stmt->inferredType = Type::getString();
 
-            if (self::check($statements_checker, $stmt->left, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->left, $context) === false) {
                 return false;
             }
 
-            if (self::check($statements_checker, $stmt->right, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->right, $context) === false) {
                 return false;
             }
         } else {
 
             if ($stmt->left instanceof PhpParser\Node\Expr\BinaryOp) {
-                if (self::checkBinaryOp($statements_checker, $stmt->left, $context, ++$nesting) === false) {
+                if (self::analyzeBinaryOp($statements_checker, $stmt->left, $context, ++$nesting) === false) {
                     return false;
                 }
             } else {
-                if (self::check($statements_checker, $stmt->left, $context) === false) {
+                if (self::analyze($statements_checker, $stmt->left, $context) === false) {
                     return false;
                 }
             }
 
             if ($stmt->right instanceof PhpParser\Node\Expr\BinaryOp) {
-                if (self::checkBinaryOp($statements_checker, $stmt->right, $context, ++$nesting) === false) {
+                if (self::analyzeBinaryOp($statements_checker, $stmt->right, $context, ++$nesting) === false) {
                     return false;
                 }
             } else {
-                if (self::check($statements_checker, $stmt->right, $context) === false) {
+                if (self::analyze($statements_checker, $stmt->right, $context) === false) {
                     return false;
                 }
             }
@@ -814,7 +814,7 @@ class ExpressionChecker
                 $stmt instanceof PhpParser\Node\Expr\BinaryOp\Mul ||
                 $stmt instanceof PhpParser\Node\Expr\BinaryOp\Pow
             ) {
-                self::checkNonDivArithmenticOp(
+                self::analyzeNonDivArithmenticOp(
                     $statements_checker,
                     $stmt->left,
                     $stmt->right,
@@ -831,7 +831,7 @@ class ExpressionChecker
             ) {
                 $stmt->inferredType = Type::combineUnionTypes(Type::getFloat(), Type::getInt());
             } elseif ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Concat) {
-                self::checkConcatOp(
+                self::analyzeConcatOp(
                     $statements_checker,
                     $stmt->left,
                     $stmt->right,
@@ -874,7 +874,7 @@ class ExpressionChecker
      * @param  Type\Union|null   &$result_type
      * @return void
      */
-    public static function checkNonDivArithmenticOp(
+    public static function analyzeNonDivArithmenticOp(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr $left,
         PhpParser\Node\Expr $right,
@@ -1040,7 +1040,7 @@ class ExpressionChecker
      * @param  Type\Union|null   &$result_type
      * @return void
      */
-    public static function checkConcatOp(
+    public static function analyzeConcatOp(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr $left,
         PhpParser\Node\Expr $right,
@@ -1316,7 +1316,7 @@ class ExpressionChecker
      * @param   Context                     $context
      * @return  false|null
      */
-    protected static function checkClosureUses(
+    protected static function analyzeClosureUses(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\Closure $stmt,
         Context $context
@@ -1380,7 +1380,7 @@ class ExpressionChecker
      * @param   Context                     $context
      * @return  false|null
      */
-    protected static function checkYield(
+    protected static function analyzeYield(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\Yield_ $stmt,
         Context $context
@@ -1392,13 +1392,13 @@ class ExpressionChecker
         );
 
         if ($stmt->key) {
-            if (self::check($statements_checker, $stmt->key, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->key, $context) === false) {
                 return false;
             }
         }
 
         if ($stmt->value) {
-            if (self::check($statements_checker, $stmt->value, $context) === false) {
+            if (self::analyze($statements_checker, $stmt->value, $context) === false) {
                 return false;
             }
 
@@ -1422,12 +1422,12 @@ class ExpressionChecker
      * @param   Context                         $context
      * @return  false|null
      */
-    protected static function checkYieldFrom(
+    protected static function analyzeYieldFrom(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\YieldFrom $stmt,
         Context $context
     ) {
-        if (self::check($statements_checker, $stmt->expr, $context) === false) {
+        if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
             return false;
         }
 
@@ -1444,12 +1444,12 @@ class ExpressionChecker
      * @param   Context                     $context
      * @return  false|null
      */
-    protected static function checkTernary(
+    protected static function analyzeTernary(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\Ternary $stmt,
         Context $context
     ) {
-        if (self::check($statements_checker, $stmt->cond, $context) === false) {
+        if (self::analyze($statements_checker, $stmt->cond, $context) === false) {
             return false;
         }
 
@@ -1489,7 +1489,7 @@ class ExpressionChecker
         $t_if_context->vars_in_scope = $t_if_vars_in_scope_reconciled;
 
         if ($stmt->if) {
-            if (self::check($statements_checker, $stmt->if, $t_if_context) === false) {
+            if (self::analyze($statements_checker, $stmt->if, $t_if_context) === false) {
                 return false;
             }
         }
@@ -1513,7 +1513,7 @@ class ExpressionChecker
             $t_else_context->vars_in_scope = $t_else_vars_in_scope_reconciled;
         }
 
-        if (self::check($statements_checker, $stmt->else, $t_else_context) === false) {
+        if (self::analyze($statements_checker, $stmt->else, $t_else_context) === false) {
             return false;
         }
 
@@ -1557,14 +1557,14 @@ class ExpressionChecker
      * @param   Context                         $context
      * @return  false|null
      */
-    protected static function checkBooleanNot(
+    protected static function analyzeBooleanNot(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\BooleanNot $stmt,
         Context $context
     ) {
         $stmt->inferredType = Type::getBool();
 
-        if (self::check($statements_checker, $stmt->expr, $context) === false) {
+        if (self::analyze($statements_checker, $stmt->expr, $context) === false) {
             return false;
         }
     }
@@ -1575,12 +1575,12 @@ class ExpressionChecker
      * @param   Context                     $context
      * @return  false|null
      */
-    protected static function checkEmpty(
+    protected static function analyzeEmpty(
         StatementsChecker $statements_checker,
         PhpParser\Node\Expr\Empty_ $stmt,
         Context $context
     ) {
-        return self::check($statements_checker, $stmt->expr, $context);
+        return self::analyze($statements_checker, $stmt->expr, $context);
     }
 
     /**
@@ -1589,14 +1589,14 @@ class ExpressionChecker
      * @param   Context                         $context
      * @return  false|null
      */
-    protected static function checkEncapsulatedString(
+    protected static function analyzeEncapsulatedString(
         StatementsChecker $statements_checker,
         PhpParser\Node\Scalar\Encapsed $stmt,
         Context $context
     ) {
         /** @var PhpParser\Node\Expr $part */
         foreach ($stmt->parts as $part) {
-            if (self::check($statements_checker, $part, $context) === false) {
+            if (self::analyze($statements_checker, $part, $context) === false) {
                 return false;
             }
         }

--- a/src/Psalm/Checker/Statements/ExpressionChecker.php
+++ b/src/Psalm/Checker/Statements/ExpressionChecker.php
@@ -196,17 +196,16 @@ class ExpressionChecker
             $use_context = new Context($statements_checker->getFileName(), $context->self);
 
             if (!$statements_checker->isStatic()) {
-                $this_class = ClassLikeChecker::getThisClass();
-                $this_class = $this_class &&
+                if ($context->collect_mutations &&
+                    $context->self &&
                     ClassChecker::classExtends(
-                        $this_class,
+                        $context->self,
                         (string)$statements_checker->getFQCLN()
                     )
-                        ? $this_class
-                        : $context->self;
-
-                if ($this_class) {
-                    $use_context->vars_in_scope['$this'] = new Type\Union([new Type\Atomic($this_class)]);
+                ) {
+                    $use_context->vars_in_scope['$this'] = clone $context->vars_in_scope['$this'];
+                } elseif ($context->self) {
+                    $use_context->vars_in_scope['$this'] = new Type\Union([new Type\Atomic($context->self)]);
                 }
             }
 

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -650,13 +650,13 @@ class StatementsChecker extends SourceChecker implements StatementsSource
             }
              */
 
-            if (file_exists($path_to_file)) {
+            $current_file_checker = $this->getFileChecker();
+
+            if ($this->getFileChecker()->fileExists($path_to_file)) {
                 $include_stmts = FileChecker::getStatementsForFile($path_to_file);
-                $old_include_file_name = $this->getIncludeFileName();
-                $old_include_file_path = $this->getIncludeFilePath();
-                $this->setIncludeFileName($config->shortenFileName($path_to_file), $path_to_file);
-                $this->analyze($include_stmts, $context);
-                $this->setIncludeFileName($old_include_file_name, $old_include_file_path);
+                $include_file_checker = new FileChecker($path_to_file, $current_file_checker->project_checker);
+                $include_file_checker->visit($context);
+                $include_file_checker->analyze();
                 return null;
             }
         }
@@ -731,6 +731,10 @@ class StatementsChecker extends SourceChecker implements StatementsSource
      */
     protected static function resolveIncludePath($file_name, $current_directory)
     {
+        if (!$current_directory) {
+            return $file_name;
+        }
+
         $paths = PATH_SEPARATOR == ':'
             ? preg_split('#(?<!phar):#', get_include_path())
             : explode(PATH_SEPARATOR, get_include_path());

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -171,7 +171,7 @@ class StatementsChecker
         // hoist functions to the top
         foreach ($stmts as $stmt) {
             if ($stmt instanceof PhpParser\Node\Stmt\Function_) {
-                $function_checker = new FunctionChecker($stmt, $this->source, $this->file_path);
+                $function_checker = new FunctionChecker($stmt, $this->source);
                 $function_checkers[$stmt->name] = $function_checker;
             }
         }

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -641,15 +641,6 @@ class StatementsChecker extends SourceChecker implements StatementsSource
                 return null;
             }
 
-            /*
-            if (in_array($path_to_file, FileChecker::getIncludesToIgnore())) {
-                $context->check_classes = false;
-                $context->check_variables = false;
-
-                return null;
-            }
-             */
-
             $current_file_checker = $this->getFileChecker();
 
             if ($this->getFileChecker()->fileExists($path_to_file)) {

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -626,7 +626,7 @@ class StatementsChecker extends SourceChecker implements StatementsSource
                 $path_to_file = getcwd() . '/' . $path_to_file;
             }
         } else {
-            $path_to_file = self::getPathTo($stmt->expr, $this->getIncludeFileName() ?: $this->getFileName());
+            $path_to_file = self::getPathTo($stmt->expr, $this->getFileName());
         }
 
         if ($path_to_file) {
@@ -654,7 +654,12 @@ class StatementsChecker extends SourceChecker implements StatementsSource
 
             if ($this->getFileChecker()->fileExists($path_to_file)) {
                 $include_stmts = FileChecker::getStatementsForFile($path_to_file);
-                $include_file_checker = new FileChecker($path_to_file, $current_file_checker->project_checker);
+                $include_file_checker = new FileChecker(
+                    $path_to_file,
+                    $current_file_checker->project_checker,
+                    $include_stmts
+                );
+                $include_file_checker->setFileName($this->getFileName(), $this->getFilePath());
                 $include_file_checker->visit($context);
                 $include_file_checker->analyze();
                 return null;

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -397,49 +397,6 @@ class StatementsChecker extends SourceChecker implements StatementsSource
     }
 
     /**
-     * @param  string  $method_id
-     * @param  Context $context
-     * @return void
-     */
-    public function checkInsideMethod($method_id, Context $context)
-    {
-        /**
-        $method_checker = ClassLikeChecker::getMethodChecker($method_id);
-
-        if ($method_checker &&
-            $this->source instanceof FunctionLikeChecker &&
-            $method_checker->getMethodId() !== $this->source->getMethodId()
-        ) {
-            $this_context = new Context($this->file_name, (string) $context->vars_in_scope['$this']);
-
-            foreach ($context->vars_possibly_in_scope as $var => $type) {
-                if (strpos($var, '$this->') === 0) {
-                    $this_context->vars_possibly_in_scope[$var] = true;
-                }
-            }
-
-            foreach ($context->vars_in_scope as $var => $type) {
-                if (strpos($var, '$this->') === 0) {
-                    $this_context->vars_in_scope[$var] = $type;
-                }
-            }
-
-            $this_context->vars_in_scope['$this'] = $context->vars_in_scope['$this'];
-
-            $method_checker->analyze($this_context);
-
-            foreach ($this_context->vars_in_scope as $var => $type) {
-                $context->vars_possibly_in_scope[$var] = true;
-            }
-
-            foreach ($this_context->vars_in_scope as $var => $type) {
-                $context->vars_in_scope[$var] = $type;
-            }
-        }
-        **/
-    }
-
-    /**
      * @param   PhpParser\Node\Stmt\Const_  $stmt
      * @param   Context                     $context
      * @return  void
@@ -549,6 +506,8 @@ class StatementsChecker extends SourceChecker implements StatementsSource
         } else {
             $stmt->inferredType = Type::getVoid();
         }
+
+
 
         if ($this->source instanceof FunctionLikeChecker) {
             $this->source->addReturnTypes($stmt->expr ? (string) $stmt->inferredType : '', $context);

--- a/src/Psalm/Checker/TraitChecker.php
+++ b/src/Psalm/Checker/TraitChecker.php
@@ -36,23 +36,15 @@ class TraitChecker extends ClassLikeChecker
 
         $this->source = $source;
         $this->class = $class;
-        $this->namespace = $source->getNamespace();
-        $this->aliased_classes = $source->getAliasedClasses();
-        $this->file_name = $source->getFileName();
-        $this->file_path = $source->getFilePath();
         $this->fq_class_name = $fq_class_name;
-
-        $this->parent_class = null;
-
-        $this->suppressed_issues = $source->getSuppressedIssues();
 
         if (!isset(self::$storage[$fq_class_name])) {
             self::$storage[$fq_class_name] = new ClassLikeStorage();
-            self::$storage[$fq_class_name]->file_name = $this->file_name;
-            self::$storage[$fq_class_name]->file_path = $this->file_path;
+            self::$storage[$fq_class_name]->file_name = $this->source->getFileName();
+            self::$storage[$fq_class_name]->file_path = $this->source->getFilePath();
         }
 
-        self::$trait_names[strtolower($this->fq_class_name)] = $this->fq_class_name;
+        self::$trait_names[strtolower($fq_class_name)] = $fq_class_name;
 
         self::$trait_checkers[$fq_class_name] = $this;
     }

--- a/src/Psalm/Checker/TraitChecker.php
+++ b/src/Psalm/Checker/TraitChecker.php
@@ -54,7 +54,7 @@ class TraitChecker extends ClassLikeChecker
      * @param   Context|null    $global_context
      * @return void
      */
-    public function check(
+    public function visit(
         Context $class_context = null,
         Context $global_context = null
     ) {
@@ -62,7 +62,7 @@ class TraitChecker extends ClassLikeChecker
             throw new \InvalidArgumentException('TraitChecker::check must be called with a $class_context');
         }
 
-        parent::check($class_context, $global_context);
+        parent::visit($class_context, $global_context);
     }
 
     /**

--- a/src/Psalm/Checker/TraitChecker.php
+++ b/src/Psalm/Checker/TraitChecker.php
@@ -38,13 +38,15 @@ class TraitChecker extends ClassLikeChecker
         $this->class = $class;
         $this->fq_class_name = $fq_class_name;
 
-        if (!isset(self::$storage[$fq_class_name])) {
-            self::$storage[$fq_class_name] = new ClassLikeStorage();
-            self::$storage[$fq_class_name]->file_name = $this->source->getFileName();
-            self::$storage[$fq_class_name]->file_path = $this->source->getFilePath();
+        $fq_class_name_lower = strtolower($fq_class_name);
+
+        if (!isset(self::$storage[$fq_class_name_lower])) {
+            self::$storage[$fq_class_name_lower] = $storage = new ClassLikeStorage();
+            $storage->file_name = $this->source->getFileName();
+            $storage->file_path = $this->source->getFilePath();
         }
 
-        self::$trait_names[strtolower($fq_class_name)] = $fq_class_name;
+        self::$trait_names[$fq_class_name_lower] = $fq_class_name;
 
         self::$trait_checkers[$fq_class_name] = $this;
     }
@@ -102,7 +104,7 @@ class TraitChecker extends ClassLikeChecker
             return self::$existing_traits[strtolower($trait_name)];
         }
 
-        if ($file_checker->evaluateClassLike($trait_name) === false) {
+        if ($file_checker->evaluateClassLike($trait_name, false) === false) {
             self::$existing_traits[strtolower($trait_name)] = false;
             return false;
         }

--- a/src/Psalm/Checker/TraitChecker.php
+++ b/src/Psalm/Checker/TraitChecker.php
@@ -24,11 +24,6 @@ class TraitChecker extends ClassLikeChecker
     protected static $existing_traits = [];
 
     /**
-     * @var array<MethodChecker>
-     */
-    protected $methods = [];
-
-    /**
      * @param   PhpParser\Node\Stmt\ClassLike   $class
      * @param   StatementsSource                $source
      * @param   string                          $fq_class_name
@@ -39,6 +34,7 @@ class TraitChecker extends ClassLikeChecker
             throw new \InvalidArgumentException('Trait checker must be passed a trait');
         }
 
+        $this->source = $source;
         $this->class = $class;
         $this->namespace = $source->getNamespace();
         $this->aliased_classes = $source->getAliasedClasses();
@@ -58,33 +54,23 @@ class TraitChecker extends ClassLikeChecker
 
         self::$trait_names[strtolower($this->fq_class_name)] = $this->fq_class_name;
 
-        self::$class_checkers[$fq_class_name] = $this;
+        self::$trait_checkers[$fq_class_name] = $this;
     }
 
     /**
-     * @param   bool            $check_methods
      * @param   Context|null    $class_context
-     * @param   bool            $update_docblocks
+     * @param   Context|null    $global_context
      * @return void
      */
-    public function check($check_methods = true, Context $class_context = null, $update_docblocks = false)
-    {
+    public function check(
+        Context $class_context = null,
+        Context $global_context = null
+    ) {
         if (!$class_context) {
             throw new \InvalidArgumentException('TraitChecker::check must be called with a $class_context');
         }
 
-        parent::check(false, $class_context);
-    }
-
-    /**
-     * @param   Context    $class_context
-     * @return  void
-     */
-    public function checkMethods(Context $class_context)
-    {
-        foreach ($this->methods as $method_checker) {
-            $method_checker->check($class_context, null);
-        }
+        parent::check($class_context, $global_context);
     }
 
     /**
@@ -110,10 +96,11 @@ class TraitChecker extends ClassLikeChecker
     }
 
     /**
-     * @param  string $trait_name
+     * @param  string       $trait_name
+     * @param  FileChecker  $file_checker
      * @return boolean
      */
-    public static function traitExists($trait_name)
+    public static function traitExists($trait_name, FileChecker $file_checker)
     {
         if (isset(self::$trait_names[strtolower($trait_name)])) {
             return true;
@@ -123,14 +110,14 @@ class TraitChecker extends ClassLikeChecker
             return self::$existing_traits[strtolower($trait_name)];
         }
 
-        $old_level = error_reporting();
-        error_reporting(0);
-        $trait_exists = trait_exists($trait_name);
-        error_reporting($old_level);
+        if ($file_checker->evaluateClassLike($trait_name) === false) {
+            self::$existing_traits[strtolower($trait_name)] = false;
+            return false;
+        }
 
-        self::$existing_traits[strtolower($trait_name)] = $trait_exists;
+        self::$existing_traits[strtolower($trait_name)] = true;
 
-        return $trait_exists;
+        return true;
     }
 
     /**

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -699,10 +699,12 @@ class TypeChecker
                 $input_is_object = $input_type_part->isObjectType();
                 $container_is_object = $container_type_part->isObjectType();
 
-                if ($input_type_part->value === $container_type_part->value ||
+                if (strtolower($input_type_part->value) === strtolower($container_type_part->value) ||
                     (
                         $input_is_object &&
                         $container_is_object &&
+                        !$input_type_part->isObject() &&
+                        ClassChecker::classExists($input_type_part->value, $file_checker) &&
                         (
                             ClassChecker::classExtendsOrImplements(
                                 $input_type_part->value,

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -827,7 +827,7 @@ class TypeChecker
                 } elseif ($input_is_object &&
                     $container_is_object &&
                     ClassChecker::classExists($container_type_part->value, $file_checker) &&
-                    ClassChecker::classExists($input_type_part->value, $file_checker) &&
+                    ClassChecker::classOrInterfaceExists($input_type_part->value, $file_checker) &&
                     ClassChecker::classExtendsOrImplements(
                         $container_type_part->value,
                         $input_type_part->value

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -1196,8 +1196,8 @@ class TypeChecker
                         break;
                     }
 
-                    if (isset(ClassLikeChecker::$SPECIAL_TYPES[$simple_declared_type]) ||
-                        isset(ClassLikeChecker::$SPECIAL_TYPES[$differing_type])
+                    if (isset(ClassLikeChecker::$SPECIAL_TYPES[strtolower($simple_declared_type)]) ||
+                        isset(ClassLikeChecker::$SPECIAL_TYPES[strtolower($differing_type)])
                     ) {
                         if (in_array($differing_type, ['float', 'int']) &&
                             in_array($simple_declared_type, ['float', 'int'])

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -834,7 +834,6 @@ class TypeChecker
                     )
                 ) {
                     $type_coerced = true;
-                    $type_match_found = true;
                     break;
                 }
             }
@@ -1188,6 +1187,11 @@ class TypeChecker
 
                 foreach ($simple_declared_types as $simple_declared_type) {
                     if ($simple_declared_type === 'mixed') {
+                        $is_match = true;
+                        break;
+                    }
+
+                    if (strtolower($simple_declared_type) === 'callable' && strtolower($differing_type) === 'closure') {
                         $is_match = true;
                         break;
                     }

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -794,7 +794,9 @@ class TypeChecker
                     !$input_type_part->isObject()
                 ) {
                     // check whether the object has a __toString method
-                    if (MethodChecker::methodExists($input_type_part->value . '::__toString')) {
+                    if (ClassChecker::classExists($input_type_part->value, $file_checker) &&
+                        MethodChecker::methodExists($input_type_part->value . '::__toString')
+                    ) {
                         $type_match_found = true;
                         $to_string_cast = true;
                     }
@@ -879,7 +881,10 @@ class TypeChecker
                 foreach ($existing_keys[$base_key]->types as $existing_key_type_part) {
                     if ($existing_key_type_part->isNull()) {
                         $class_property_type = Type::getNull();
-                    } elseif ($existing_key_type_part->isMixed()) {
+                    } elseif ($existing_key_type_part->isMixed() ||
+                        $existing_key_type_part->isObject() ||
+                        strtolower($existing_key_type_part->value) === 'stdclass'
+                    ) {
                         $class_property_type = Type::getMixed();
                     } else {
                         $property_id = $existing_key_type_part->value . '::$' . $key_parts[$i];
@@ -890,7 +895,7 @@ class TypeChecker
 
                         $declaring_property_class = ClassLikeChecker::getDeclaringClassForProperty($property_id);
 
-                        $class_storage = ClassLikeChecker::$storage[$declaring_property_class];
+                        $class_storage = ClassLikeChecker::$storage[strtolower((string)$declaring_property_class)];
 
                         $class_property_type = $class_storage->properties[$key_parts[$i]]->type;
 

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -416,6 +416,7 @@ class TypeChecker
      * @param  array<string, string>     $new_types
      * @param  array<string, Type\Union> $existing_types
      * @param  array<string>             $changed_types
+     * @param  FileChecker               $file_checker
      * @param  CodeLocation              $code_location
      * @param  array<string>             $suppressed_issues
      * @return array<string, Type\Union>|false
@@ -424,6 +425,7 @@ class TypeChecker
         array $new_types,
         array $existing_types,
         array &$changed_types,
+        FileChecker $file_checker,
         CodeLocation $code_location,
         array $suppressed_issues = []
     ) {
@@ -469,6 +471,7 @@ class TypeChecker
                     (string) $new_type_part,
                     $result_type,
                     $key,
+                    $file_checker,
                     $code_location,
                     $suppressed_issues
                 );
@@ -509,6 +512,7 @@ class TypeChecker
      * @param   string       $new_var_type
      * @param   Type\Union   $existing_var_type
      * @param   string       $key
+     * @param   FileChecker  $file_checker
      * @param   CodeLocation $code_location
      * @param   array        $suppressed_issues
      * @return  Type\Union|null|false
@@ -517,6 +521,7 @@ class TypeChecker
         $new_var_type,
         Type\Union $existing_var_type = null,
         $key = null,
+        FileChecker $file_checker,
         CodeLocation $code_location = null,
         array $suppressed_issues = []
     ) {
@@ -631,8 +636,8 @@ class TypeChecker
             return $new_type;
         }
 
-        if (!TypeChecker::isContainedBy($new_type, $existing_var_type) &&
-            !TypeChecker::isContainedBy($existing_var_type, $new_type) &&
+        if (!TypeChecker::isContainedBy($new_type, $existing_var_type, $file_checker) &&
+            !TypeChecker::isContainedBy($existing_var_type, $new_type, $file_checker) &&
             $code_location) {
             if (IssueBuffer::accepts(
                 new TypeDoesNotContainType(
@@ -651,17 +656,19 @@ class TypeChecker
 /**
      * Does the input param type match the given param type
      *
-     * @param  Type\Union $input_type
-     * @param  Type\Union $container_type
-     * @param  bool       $ignore_null
-     * @param  bool       &$has_scalar_match
-     * @param  bool       &$type_coerced    whether or not there was type coercion involved
-     * @param  bool       &$to_string_cast
+     * @param  Type\Union   $input_type
+     * @param  Type\Union   $container_type
+     * @param  FileChecker  $file_checker
+     * @param  bool         $ignore_null
+     * @param  bool         &$has_scalar_match
+     * @param  bool         &$type_coerced    whether or not there was type coercion involved
+     * @param  bool         &$to_string_cast
      * @return bool
      */
     public static function isContainedBy(
         Type\Union $input_type,
         Type\Union $container_type,
+        FileChecker $file_checker,
         $ignore_null = false,
         &$has_scalar_match = null,
         &$type_coerced = null,
@@ -689,9 +696,21 @@ class TypeChecker
                     continue;
                 }
 
+                $input_is_object = $input_type_part->isObjectType();
+                $container_is_object = $container_type_part->isObjectType();
+
                 if ($input_type_part->value === $container_type_part->value ||
-                    ClassChecker::classExtendsOrImplements($input_type_part->value, $container_type_part->value) ||
-                    ExpressionChecker::isMock($input_type_part->value)
+                    (
+                        $input_is_object &&
+                        $container_is_object &&
+                        (
+                            ClassChecker::classExtendsOrImplements(
+                                $input_type_part->value,
+                                $container_type_part->value
+                            ) ||
+                            ExpressionChecker::isMock($input_type_part->value)
+                        )
+                    )
                 ) {
                     $all_types_contain = true;
 
@@ -703,12 +722,13 @@ class TypeChecker
                                 !self::isContainedBy(
                                     $input_param,
                                     $container_param,
+                                    $file_checker,
                                     $ignore_null,
                                     $has_scalar_match,
                                     $type_coerced
                                 )
                             ) {
-                                if (self::isContainedBy($container_param, $input_param)) {
+                                if (self::isContainedBy($container_param, $input_param, $file_checker)) {
                                     $type_coerced = true;
                                 }
 
@@ -747,7 +767,10 @@ class TypeChecker
                 if ($container_type_part->isIterable() &&
                     (
                         $input_type_part->isArray() ||
-                        ClassChecker::classExtendsOrImplements($input_type_part->value, 'Traversable')
+                        ClassChecker::classExtendsOrImplements(
+                            $input_type_part->value,
+                            'Traversable'
+                        )
                     )
                 ) {
                     $type_match_found = true;
@@ -757,7 +780,10 @@ class TypeChecker
                     $type_match_found = true;
                 }
 
-                if ($container_type_part->isString() && $input_type_part->isObjectType() && !$input_type_part->isObject()) {
+                if ($container_type_part->isString() &&
+                    $input_type_part->isObjectType() &&
+                    !$input_type_part->isObject()
+                ) {
                     // check whether the object has a __toString method
                     if (MethodChecker::methodExists($input_type_part->value . '::__toString')) {
                         $type_match_found = true;
@@ -787,9 +813,15 @@ class TypeChecker
                     !$input_type_part->isResource()
                 ) {
                     $type_match_found = true;
-                }
-
-                if (ClassChecker::classExtendsOrImplements($container_type_part->value, $input_type_part->value)) {
+                } elseif ($input_is_object &&
+                    $container_is_object &&
+                    ClassChecker::classExists($container_type_part->value, $file_checker) &&
+                    ClassChecker::classExists($input_type_part->value, $file_checker) &&
+                    ClassChecker::classExtendsOrImplements(
+                        $container_type_part->value,
+                        $input_type_part->value
+                    )
+                ) {
                     $type_coerced = true;
                     $type_match_found = true;
                     break;
@@ -1086,12 +1118,16 @@ class TypeChecker
     }
 
     /**
-     * @param  Type\Union $declared_type
-     * @param  Type\Union $inferred_type
+     * @param  Type\Union   $declared_type
+     * @param  Type\Union   $inferred_type
+     * @param  FileChecker  $file_checker
      * @return boolean
      */
-    public static function hasIdenticalTypes(Type\Union $declared_type, Type\Union $inferred_type)
-    {
+    public static function hasIdenticalTypes(
+        Type\Union $declared_type,
+        Type\Union $inferred_type,
+        FileChecker $file_checker
+    ) {
         if ($declared_type->isMixed() || $inferred_type->isEmpty()) {
             return true;
         }
@@ -1137,14 +1173,38 @@ class TypeChecker
                 }
 
                 foreach ($simple_declared_types as $simple_declared_type) {
-                    if ($simple_declared_type === 'mixed'
-                        || ($simple_declared_type === 'object' &&
-                            ClassLikeChecker::classOrInterfaceExists($differing_type))
-                        || ClassChecker::classExtendsOrImplements($differing_type, $simple_declared_type)
-                        || (InterfaceChecker::interfaceExists($differing_type) &&
-                            InterfaceChecker::interfaceExtends($differing_type, $simple_declared_type))
-                        || (in_array($differing_type, ['float', 'int']) &&
-                            in_array($simple_declared_type, ['float', 'int']))
+                    if ($simple_declared_type === 'mixed') {
+                        $is_match = true;
+                        break;
+                    }
+
+                    if (isset(ClassLikeChecker::$SPECIAL_TYPES[$simple_declared_type]) ||
+                        isset(ClassLikeChecker::$SPECIAL_TYPES[$differing_type])
+                    ) {
+                        if (in_array($differing_type, ['float', 'int']) &&
+                            in_array($simple_declared_type, ['float', 'int'])
+                        ) {
+                            $is_match = true;
+                            break;
+                        }
+
+                        continue;
+                    }
+
+                    if ($simple_declared_type === 'object' &&
+                        ClassLikeChecker::classOrInterfaceExists($differing_type, $file_checker)
+                    ) {
+                        $is_match = true;
+                        break;
+                    }
+
+                    if (ClassChecker::classExtendsOrImplements($differing_type, $simple_declared_type)) {
+                        $is_match = true;
+                        break;
+                    }
+
+                    if (InterfaceChecker::interfaceExists($differing_type, $file_checker) &&
+                        InterfaceChecker::interfaceExtends($differing_type, $simple_declared_type)
                     ) {
                         $is_match = true;
                         break;
@@ -1176,7 +1236,8 @@ class TypeChecker
             foreach ($declared_atomic_type->type_params as $offset => $type_param) {
                 if (!self::hasIdenticalTypes(
                     $declared_atomic_type->type_params[$offset],
-                    $inferred_atomic_type->type_params[$offset]
+                    $inferred_atomic_type->type_params[$offset],
+                    $file_checker
                 )) {
                     return false;
                 }
@@ -1206,7 +1267,8 @@ class TypeChecker
 
                 if (!self::hasIdenticalTypes(
                     $type_param,
-                    $inferred_atomic_type->properties[$property_name]
+                    $inferred_atomic_type->properties[$property_name],
+                    $file_checker
                 )) {
                     return false;
                 }

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -386,7 +386,7 @@ class Config
 
             require_once($path);
 
-            if (!ClassLikeChecker::classExtends($declared_classes[0], 'Psalm\\Checker\\FileChecker')) {
+            if (!\Psalm\Checker\ClassChecker::classExtends($declared_classes[0], 'Psalm\\Checker\\FileChecker')) {
                 throw new \InvalidArgumentException(
                     'Filetype handlers must extend \Psalm\Checker\FileChecker - ' . $path . ' does not'
                 );

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1,7 +1,9 @@
 <?php
 namespace Psalm;
 
+use Psalm\Checker\ClassLikeChecker;
 use Psalm\Checker\FileChecker;
+use Psalm\Checker\ProjectChecker;
 use Psalm\Config\IssueHandler;
 use Psalm\Config\ProjectFileFilter;
 use Psalm\Exception\ConfigException;
@@ -77,7 +79,7 @@ class Config
      *
      * @var boolean
      */
-    public $use_property_default_for_type = true;
+    public $use_property_default_for_type = false;
 
     /**
      * Path to the autoader
@@ -341,9 +343,6 @@ class Config
      * @param  array<\SimpleXMLElement> $extensions
      * @return void
      * @throws ConfigException If a Config file could not be found.
-     * @psalm-suppress MixedArrayAccess
-     * @psalm-suppress MixedAssignment
-     * @psalm-suppress MixedOperand
      */
     protected function loadFileExtensions($extensions)
     {
@@ -358,25 +357,42 @@ class Config
                     throw new Exception\ConfigException('Error parsing config: cannot find file ' . $path);
                 }
 
-                $declared_classes = FileChecker::getDeclaredClassesInFile($path);
-
-                if (count($declared_classes) !== 1) {
-                    throw new \InvalidArgumentException(
-                        'Filetype handlers must have exactly one class in the file - ' . $path . ' has ' .
-                            count($declared_classes)
-                    );
-                }
-
-                require_once($path);
-
-                if (!is_subclass_of($declared_classes[0], 'Psalm\\Checker\\FileChecker')) {
-                    throw new \InvalidArgumentException(
-                        'Filetype handlers must extend \Psalm\Checker\FileChecker - ' . $path . ' does not'
-                    );
-                }
-
-                $this->filetype_handlers[$extension_name] = $declared_classes[0];
+                $this->filetype_handlers[$extension_name] = $path;
             }
+        }
+    }
+
+    /**
+     * Initialises all the plugins (done once the config is fully loaded)
+     * @return void
+     * @psalm-suppress MixedArrayAccess
+     * @psalm-suppress MixedAssignment
+     * @psalm-suppress MixedOperand
+     */
+    public function initializePlugins(ProjectChecker $project_checker)
+    {
+        foreach ($this->filetype_handlers as $extension_name => &$path) {
+            $plugin_file_checker = new FileChecker($path, $project_checker);
+            $plugin_file_checker->visit();
+
+            $declared_classes = ClassLikeChecker::getClassesForFile($path);
+
+            if (count($declared_classes) !== 1) {
+                throw new \InvalidArgumentException(
+                    'Filetype handlers must have exactly one class in the file - ' . $path . ' has ' .
+                        count($declared_classes)
+                );
+            }
+
+            require_once($path);
+
+            if (!ClassLikeChecker::classExtends($declared_classes[0], 'Psalm\\Checker\\FileChecker')) {
+                throw new \InvalidArgumentException(
+                    'Filetype handlers must extend \Psalm\Checker\FileChecker - ' . $path . ' does not'
+                );
+            }
+
+            $path = $declared_classes[0];
         }
     }
 
@@ -416,12 +432,12 @@ class Config
     }
 
     /**
-     * @param   string $file_name
+     * @param   string $file_path
      * @return  bool
      */
-    public function isInProjectDirs($file_name)
+    public function isInProjectDirs($file_path)
     {
-        return $this->project_files && $this->project_files->allows($file_name);
+        return $this->project_files && $this->project_files->allows($file_path);
     }
 
     /**

--- a/src/Psalm/Config/ProjectFileFilter.php
+++ b/src/Psalm/Config/ProjectFileFilter.php
@@ -40,11 +40,9 @@ class ProjectFileFilter extends FileFilter
      */
     public function allows($file_name, $case_sensitive = false)
     {
-        if ($this->inclusive) {
-            if ($this->file_filter) {
-                if (!$this->file_filter->allows($file_name, $case_sensitive)) {
-                    return false;
-                }
+        if ($this->inclusive && $this->file_filter) {
+            if (!$this->file_filter->allows($file_name, $case_sensitive)) {
+                return false;
             }
         }
 

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -73,6 +73,13 @@ class Context
     public $clauses = [];
 
     /**
+     * Whether or not to do a deep analysis and collect mutations to this context
+     *
+     * @var boolean
+     */
+    public $collect_mutations = false;
+
+    /**
      * @param string      $file_name
      * @param string|null $self
      */

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -179,7 +179,7 @@ class IssueBuffer
 
         if ($start_time) {
             echo('Checks took ' . ((float)microtime(true) - self::$start_time));
-            echo(' and used ' . memory_get_peak_usage() . PHP_EOL);
+            echo(' and used ' . number_format(memory_get_peak_usage() / (1024 * 1024), 3) . 'MB' . PHP_EOL);
         }
 
         if (count(self::$emitted)) {

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -177,7 +177,7 @@ class IssueBuffer
     {
         Checker\FileChecker::updateReferenceCache();
 
-        if ($debug) {
+        if ($start_time) {
             echo('Checks took ' . ((float)microtime(true) - self::$start_time));
             echo(' and used ' . memory_get_peak_usage() . PHP_EOL);
         }

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -2,36 +2,47 @@
 namespace Psalm;
 
 use PhpParser;
+use Psalm\Checker\StatementsChecker;
 
 abstract class Plugin
 {
     /**
      * Checks an expression
      *
+     * @param  StatementsChecker    $statements_checker
      * @param  PhpParser\Node\Expr  $stmt
      * @param  Context              $context
      * @param  CodeLocation         $code_location
      * @param  array                $suppressed_issues
      * @return null|false
-     * @psalm-suppress InvalidReturnType
      */
-    public function checkExpression(PhpParser\Node\Expr $stmt, Context $context, CodeLocation $code_location, array $suppressed_issues)
-    {
+    public function checkExpression(
+        StatementsChecker $statements_checker,
+        PhpParser\Node\Expr $stmt,
+        Context $context,
+        CodeLocation $code_location,
+        array $suppressed_issues
+    ) {
         return null;
     }
 
     /**
      * Checks a statement
      *
+     * @param  StatementsChecker                        $statements_checker
      * @param  PhpParser\Node\Stmt|PhpParser\Node\Expr  $stmt
      * @param  Context                                  $context
      * @param  CodeLocation                             $code_location
      * @param  array                                    $suppressed_issues
      * @return null|false
-     * @psalm-suppress InvalidReturnType
      */
-    public function checkStatement(PhpParser\Node $stmt, Context $context, CodeLocation $code_location, array $suppressed_issues)
-    {
+    public function checkStatement(
+        StatementsChecker $statements_checker,
+        PhpParser\Node $stmt,
+        Context $context,
+        CodeLocation $code_location,
+        array $suppressed_issues
+    ) {
         return null;
     }
 }

--- a/src/Psalm/StatementsSource.php
+++ b/src/Psalm/StatementsSource.php
@@ -66,16 +66,6 @@ interface StatementsSource
     public function getFilePath();
 
     /**
-     * @return string|null
-     */
-    public function getIncludeFileName();
-
-    /**
-     * @return string|null
-     */
-    public function getIncludeFilePath();
-
-    /**
      * @return string
      */
     public function getCheckedFileName();
@@ -89,7 +79,7 @@ interface StatementsSource
      * @param string|null $file_name
      * @param string|null $file_path
      */
-    public function setIncludeFileName($file_name, $file_path);
+    public function setFileName($file_name, $file_path);
 
     /**
      * @return bool

--- a/src/Psalm/StatementsSource.php
+++ b/src/Psalm/StatementsSource.php
@@ -36,19 +36,14 @@ interface StatementsSource
     public function getAliasedFunctions();
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getFQCLN();
 
     /**
-     * @return string
+     * @return string|null
      */
     public function getClassName();
-
-    /**
-     * @return ClassLikeChecker
-     */
-    public function getClassLikeChecker();
 
     /**
      * @return FileChecker
@@ -58,7 +53,7 @@ interface StatementsSource
     /**
      * @return string|null
      */
-    public function getParentClass();
+    public function getParentFQCLN();
 
     /**
      * @return string

--- a/src/Psalm/StatementsSource.php
+++ b/src/Psalm/StatementsSource.php
@@ -1,6 +1,9 @@
 <?php
 namespace Psalm;
 
+use Psalm\Checker\ClassLikeChecker;
+use Psalm\Checker\FileChecker;
+
 interface StatementsSource
 {
     /**
@@ -43,9 +46,14 @@ interface StatementsSource
     public function getClassName();
 
     /**
-     * @return string
+     * @return ClassLikeChecker
      */
     public function getClassLikeChecker();
+
+    /**
+     * @return FileChecker
+     */
+    public function getFileChecker();
 
     /**
      * @return string|null

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -37,6 +37,16 @@ class ClassLikeStorage
     public $reflected = false;
 
     /**
+     * @var string;
+     */
+    public $namespace;
+
+    /**
+     * @var array<string, string>
+     */
+    public $aliased_classes;
+
+    /**
      * Is this class user-defined
      *
      * @var bool
@@ -56,6 +66,13 @@ class ClassLikeStorage
      * @var  array<string>
      */
     public $parent_interfaces = [];
+
+    /**
+     * Parent interfaces
+     *
+     * @var  array<string>
+     */
+    public $parent_classes = [];
 
     /**
      * @var string

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -18,6 +18,11 @@ class FunctionLikeStorage
     public $params = [];
 
     /**
+     * @var array<string, Type\Union>
+     */
+    public $param_types = [];
+
+    /**
      * @var string
      */
     public $namespace;

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -1,6 +1,7 @@
 <?php
 namespace Psalm\Storage;
 
+use PhpParser;
 use Psalm\Type;
 use Psalm\CodeLocation;
 use Psalm\FunctionLikeParameter;

--- a/src/Psalm/Storage/MethodStorage.php
+++ b/src/Psalm/Storage/MethodStorage.php
@@ -6,6 +6,11 @@ use Psalm\Type;
 class MethodStorage extends FunctionLikeStorage
 {
     /**
+     * @var string
+     */
+    public $fq_class_name;
+
+    /**
      * @var bool
      */
     public $is_static;

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -76,7 +76,8 @@ abstract class Type
                 'object',
                 'mixed',
                 'resource',
-                'iterable'
+                'callable',
+                'iterable',
             ]
         )) {
             return strtolower($type_string);

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -4,6 +4,7 @@ namespace Psalm\Type;
 use Psalm\Type;
 use Psalm\Checker\ClassChecker;
 use Psalm\Checker\ClassLikeChecker;
+use Psalm\Checker\FileChecker;
 
 class Atomic extends Type
 {
@@ -63,16 +64,17 @@ class Atomic extends Type
     }
 
     /**
-     * @param   Union   $parent
+     * @param   Union        $parent
+     * @param   FileChecker  $file_checker
      * @return  bool
      */
-    public function isIn(Union $parent)
+    public function isIn(Union $parent, FileChecker $file_checker)
     {
         if ($parent->isMixed()) {
             return true;
         }
 
-        if ($parent->hasType('object') && ClassLikeChecker::classOrInterfaceExists($this->value)) {
+        if ($parent->hasType('object') && ClassLikeChecker::classOrInterfaceExists($this->value, $file_checker)) {
             return true;
         }
 
@@ -94,7 +96,7 @@ class Atomic extends Type
         }
 
         // last check to see if class is subclass
-        if (ClassChecker::classExists($this->value)) {
+        if (ClassChecker::classExists($this->value, $file_checker)) {
             $this_is_subclass = false;
 
             foreach ($parent->types as $parent_type) {

--- a/src/Psalm/Type/Fn.php
+++ b/src/Psalm/Type/Fn.php
@@ -13,7 +13,7 @@ class Fn extends Atomic
     /**
      * @var array<int, FunctionLikeParameter>
      */
-    public $parameters = [];
+    public $params = [];
 
     /**
      * @var Union
@@ -24,12 +24,12 @@ class Fn extends Atomic
      * Constructs a new instance of a generic type
      *
      * @param string                            $value
-     * @param array<int, FunctionLikeParameter> $parameters
+     * @param array<int, FunctionLikeParameter> $params
      * @param Union                             $return_type
      */
-    public function __construct($value, array $parameters, Union $return_type)
+    public function __construct($value, array $params, Union $return_type)
     {
-        $this->parameters = $parameters;
+        $this->params = $params;
         $this->return_type = $return_type;
     }
 }

--- a/src/Psalm/Type/Generic.php
+++ b/src/Psalm/Type/Generic.php
@@ -44,7 +44,7 @@ class Generic extends Atomic
 
     /**
      * @param  array<string> $aliased_classes
-     * @param  string        $this_class
+     * @param  string|null   $this_class
      * @param  bool          $use_phpdoc_format
      * @return string
      */

--- a/src/Psalm/Type/ObjectLike.php
+++ b/src/Psalm/Type/ObjectLike.php
@@ -53,7 +53,7 @@ class ObjectLike extends Atomic
 
     /**
      * @param  array<string> $aliased_classes
-     * @param  string        $this_class
+     * @param  string|null   $this_class
      * @param  bool          $use_phpdoc_format
      * @return string
      */

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1,6 +1,8 @@
 <?php
 namespace Psalm\Type;
 
+use Psalm\CodeLocation;
+use Psalm\StatementsSource;
 use Psalm\Type;
 
 class Union extends Type
@@ -47,7 +49,7 @@ class Union extends Type
 
     /**
      * @param  array<string> $aliased_classes
-     * @param  string        $this_class
+     * @param  string|null   $this_class
      * @param  bool          $use_phpdoc_format
      * @return string
      */
@@ -318,5 +320,18 @@ class Union extends Type
         }
 
         return $type->type_params[count($type->type_params) - 1]->isSingle();
+    }
+
+    /**
+     * @param  StatementsSource $source
+     * @param  CodeLocation     $code_location
+     * @param  array<string>    $suppressed_issues
+     * @return void
+     */
+    public function check(StatementsSource $source, CodeLocation $code_location, array $suppressed_issues)
+    {
+        foreach ($this->types as $atomic_type) {
+            $atomic_type->check($source, $code_location, $suppressed_issues);
+        }
     }
 }

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -181,9 +181,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
 
         /**
-         * @return array<int, array<int, string>>
+         * @return array<int, string>
          */
-        function foo2() : array {
+        function foo3() : array {
             return ["hello"];
         }
         ');

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -12,6 +12,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testDeprecatedMethod()
@@ -36,9 +40,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -59,9 +63,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         Foo::barBar();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -78,9 +82,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -97,9 +101,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -116,9 +120,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -135,9 +139,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -154,9 +158,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testValidDocblockReturn()
@@ -184,9 +188,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testNopType()
@@ -197,9 +201,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         /** @var int $a */
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -216,9 +220,9 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testGoodDocblockInNamespace()
@@ -236,8 +240,8 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -42,7 +42,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -65,7 +65,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -84,7 +84,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -103,7 +103,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -122,7 +122,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -141,7 +141,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -160,7 +160,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testValidDocblockReturn()
@@ -190,7 +190,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testNopType()
@@ -203,7 +203,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -222,7 +222,7 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testGoodDocblockInNamespace()
@@ -242,6 +242,6 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -12,6 +12,9 @@ class ArgTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class ArgTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testCallMapClassOptionalArg()
@@ -31,8 +35,8 @@ class ArgTest extends PHPUnit_Framework_TestCase
         $m->invoke("cool");
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -37,6 +37,6 @@ class ArgTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -12,6 +12,9 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -21,6 +24,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
     {
         $config = new TestConfig();
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testInstanceOfStringOffset()
@@ -35,9 +39,9 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
             }
         }
         ');
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testInstanceOfIntOffset()
@@ -54,8 +58,8 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testNotEmptyStringOffset()
@@ -74,8 +78,8 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testNotEmptyIntOffset()
@@ -94,8 +98,8 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -110,8 +114,8 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         echo $a[0];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -129,8 +133,8 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         echo $a[0];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -148,8 +152,8 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         echo [1, 2, 3, 4][$a];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -164,7 +168,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         echo $a[0];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -41,7 +41,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         ');
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testInstanceOfIntOffset()
@@ -59,7 +59,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testNotEmptyStringOffset()
@@ -79,7 +79,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testNotEmptyIntOffset()
@@ -99,7 +99,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -115,7 +115,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -134,7 +134,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -153,7 +153,7 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -169,6 +169,6 @@ class ArrayAccessTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -696,4 +696,28 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $file_checker->visitAndAnalyzeMethods($context);
     }
+
+    /**
+     * @expectedException \Psalm\Exception\CodeException
+     * @expectedExceptionMessage TypeCoercion
+     */
+    public function testMixedArrayArgument()
+    {
+        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
+
+        $context = new Context('somefile.php');
+        $stmts = self::$parser->parse('<?php
+        /** @param array<mixed, int|string> $foo */
+        function fooFoo(array $foo) : void { }
+
+        function barBar(array $bar) : void {
+            fooFoo($bar);
+        }
+
+        barBar([1, "2"]);
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndAnalyzeMethods($context);
+    }
 }

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -3,6 +3,7 @@ namespace Psalm\Tests;
 
 use PhpParser\ParserFactory;
 use PHPUnit_Framework_TestCase;
+use Psalm\Checker\FileChecker;
 use Psalm\Config;
 use Psalm\Context;
 use Psalm\Type;
@@ -11,6 +12,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 {
     /** @var \PhpParser\Parser */
     protected static $parser;
+
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
 
     public static function setUpBeforeClass()
     {
@@ -21,6 +25,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
     {
         $config = new TestConfig();
         \Psalm\Checker\FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testGenericArrayCreation()
@@ -33,9 +38,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -49,9 +54,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, array<int, int>>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -76,9 +81,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, array<int, int>>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -94,9 +99,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, B>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -115,9 +120,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -137,9 +142,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, int|string>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -162,9 +167,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, int|string>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -175,9 +180,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo[] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -188,9 +193,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo[][] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, array<int, string>>', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -201,9 +206,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo[][][] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, array<int, array<int, string>>>', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -214,9 +219,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo[][][][] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals(
             'array<int, array<int, array<int, array<int, string>>>>',
             (string) $context->vars_in_scope['$foo']
@@ -240,9 +245,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$bar']);
         $this->assertEquals('array<string, int>', (string) $context->vars_in_scope['$bat']);
@@ -255,9 +260,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo["bar"] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{bar:string}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\']']);
     }
@@ -272,9 +277,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         // check array access of baz on foo
         // with some extra data – if we need to create an array for type $foo["bar"],
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{bar:array{baz:string}}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\']']);
     }
@@ -286,9 +291,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo["bar"]["baz"]["bat"] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{bar:array{baz:array{bat:string}}}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\'][\'bat\']']);
     }
@@ -300,9 +305,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo["bar"]["baz"]["bat"]["bap"] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals(
             'array{bar:array{baz:array{bat:array{bap:string}}}}',
             (string) $context->vars_in_scope['$foo']
@@ -318,9 +323,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo["bar"]["baz"] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{bar:array{baz:string}}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\']']);
     }
@@ -332,9 +337,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo["bar"]["baz"]["bat"] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{bar:array{baz:array{bat:string}}}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -347,9 +352,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         ];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{bar:array{a:string}, baz:array<int, int>}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -362,9 +367,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo["baz"] = "a";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{bar:int, baz:string}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -378,9 +383,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo["bar"]["bam"]["baz"] = "hello";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals(
             'array{bar:array{a:string, bam:array{baz:string}}, baz:array<int, int>}',
             (string) $context->vars_in_scope['$foo']
@@ -396,9 +401,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $bar = $foo["a"];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{a:string, b:array<int, string>}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'a\']']);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$foo[\'b\']']);
@@ -413,9 +418,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo["b"]["c"]["d"] = "goodbye";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{a:string, b:array{c:array{d:string}}}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -427,9 +432,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $foo["a"]["c"] = 1;
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{a:array{b:string, c:int}}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -445,16 +450,17 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array{a:string, b:int}', (string) $context->vars_in_scope['$foo']);
     }
 
     public function testIssetKeyedOffset()
     {
-        $file_checker = new \Psalm\Checker\FileChecker(
+        $file_checker = new FileChecker(
             'somefile.php',
+            $this->project_checker,
             self::$parser->parse('<?php
                 if (!isset($foo["a"])) {
                     $foo["a"] = "hello";
@@ -463,14 +469,15 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         );
         $context = new Context('somefile.php');
         $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('mixed', (string) $context->vars_in_scope['$foo[\'a\']']);
     }
 
     public function testConditionalAssignment()
     {
-        $file_checker = new \Psalm\Checker\FileChecker(
+        $file_checker = new FileChecker(
             'somefile.php',
+            $this->project_checker,
             self::$parser->parse('<?php
                 if ($b) {
                     $foo["a"] = "hello";
@@ -481,7 +488,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $context = new Context('somefile.php');
         $context->vars_in_scope['$b'] = \Psalm\Type::getBool();
         $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertFalse(isset($context->vars_in_scope['$foo[\'a\']']));
     }
 
@@ -508,17 +515,18 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $a["bar"] = "cool";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('A', (string) $context->vars_in_scope['$a']);
         $this->assertFalse(isset($context->vars_in_scope['$a[\'bar\']']));
     }
 
     public function testConditionalCheck()
     {
-        $file_checker = new \Psalm\Checker\FileChecker(
+        $file_checker = new FileChecker(
             'somefile.php',
+            $this->project_checker,
             self::$parser->parse('<?php
                 /**
                  * @param  array{b:string} $a
@@ -533,13 +541,14 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         );
 
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testArrayKey()
     {
-        $file_checker = new \Psalm\Checker\FileChecker(
+        $file_checker = new FileChecker(
             'somefile.php',
+            $this->project_checker,
             self::$parser->parse('<?php
             $a = ["foo", "bar"];
             $b = $a[0];
@@ -551,7 +560,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         );
 
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string', (string)$context->vars_in_scope['$b']);
         $this->assertEquals('string', (string)$context->vars_in_scope['$e']);
     }
@@ -567,9 +576,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $c[$b][$b][] = "bam";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<string, array<int, string>>', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('array<string, array<string, array<int, string>>>', (string) $context->vars_in_scope['$c']);
     }
@@ -582,9 +591,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $a["foo"] = ["bar" => "baz"];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<string, array<string, string>>', (string) $context->vars_in_scope['$a']);
     }
 
@@ -597,9 +606,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $b = [] + ["bar"];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$b']);
     }
@@ -613,9 +622,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $b = ["bar"] + [1];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<int, string|int>', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('array<int, string|int>', (string) $context->vars_in_scope['$b']);
     }
@@ -631,9 +640,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $a[$foo][] = "bat";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testPreset2DArrayTypeWithVarKeys()
@@ -648,9 +657,9 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $b[$foo][$bar][] = "bat";
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -665,8 +674,8 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $a[0] = 5;
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -684,7 +693,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         "hello"[0] = $a;
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -40,7 +40,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -56,7 +56,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, array<int, int>>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -83,7 +83,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, array<int, int>>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -101,7 +101,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, B>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -122,7 +122,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -144,7 +144,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, int|string>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -169,7 +169,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, int|string>', (string) $context->vars_in_scope['$out']);
     }
 
@@ -182,7 +182,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -195,7 +195,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, array<int, string>>', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -208,7 +208,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, array<int, array<int, string>>>', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -221,7 +221,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals(
             'array<int, array<int, array<int, array<int, string>>>>',
             (string) $context->vars_in_scope['$foo']
@@ -247,7 +247,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$bar']);
         $this->assertEquals('array<string, int>', (string) $context->vars_in_scope['$bat']);
@@ -262,7 +262,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{bar:string}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\']']);
     }
@@ -279,7 +279,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{bar:array{baz:string}}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\']']);
     }
@@ -293,7 +293,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{bar:array{baz:array{bat:string}}}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\'][\'bat\']']);
     }
@@ -307,7 +307,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals(
             'array{bar:array{baz:array{bat:array{bap:string}}}}',
             (string) $context->vars_in_scope['$foo']
@@ -325,7 +325,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{bar:array{baz:string}}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\']']);
     }
@@ -339,7 +339,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{bar:array{baz:array{bat:string}}}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -354,7 +354,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{bar:array{a:string}, baz:array<int, int>}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -369,7 +369,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{bar:int, baz:string}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -385,7 +385,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals(
             'array{bar:array{a:string, bam:array{baz:string}}, baz:array<int, int>}',
             (string) $context->vars_in_scope['$foo']
@@ -403,7 +403,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{a:string, b:array<int, string>}', (string) $context->vars_in_scope['$foo']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'a\']']);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$foo[\'b\']']);
@@ -420,7 +420,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{a:string, b:array{c:array{d:string}}}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -434,7 +434,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{a:array{b:string, c:int}}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -452,7 +452,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array{a:string, b:int}', (string) $context->vars_in_scope['$foo']);
     }
 
@@ -469,7 +469,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         );
         $context = new Context('somefile.php');
         $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('mixed', (string) $context->vars_in_scope['$foo[\'a\']']);
     }
 
@@ -488,7 +488,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         $context = new Context('somefile.php');
         $context->vars_in_scope['$b'] = \Psalm\Type::getBool();
         $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertFalse(isset($context->vars_in_scope['$foo[\'a\']']));
     }
 
@@ -517,7 +517,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('A', (string) $context->vars_in_scope['$a']);
         $this->assertFalse(isset($context->vars_in_scope['$a[\'bar\']']));
     }
@@ -541,7 +541,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         );
 
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testArrayKey()
@@ -560,7 +560,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         );
 
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string', (string)$context->vars_in_scope['$b']);
         $this->assertEquals('string', (string)$context->vars_in_scope['$e']);
     }
@@ -578,7 +578,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<string, array<int, string>>', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('array<string, array<string, array<int, string>>>', (string) $context->vars_in_scope['$c']);
     }
@@ -593,7 +593,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<string, array<string, string>>', (string) $context->vars_in_scope['$a']);
     }
 
@@ -608,7 +608,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$b']);
     }
@@ -624,7 +624,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<int, string|int>', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('array<int, string|int>', (string) $context->vars_in_scope['$b']);
     }
@@ -642,7 +642,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testPreset2DArrayTypeWithVarKeys()
@@ -659,7 +659,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -675,7 +675,7 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -694,6 +694,6 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/AssignmentTest.php
+++ b/tests/AssignmentTest.php
@@ -3,6 +3,7 @@ namespace Psalm\Tests;
 
 use PhpParser\ParserFactory;
 use PHPUnit_Framework_TestCase;
+use Psalm\Checker\FileChecker;
 use Psalm\Context;
 use Psalm\Type;
 
@@ -10,6 +11,9 @@ class AssignmentTest extends PHPUnit_Framework_TestCase
 {
     /** @var \PhpParser\Parser */
     protected static $parser;
+
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
 
     public static function setUpBeforeClass()
     {
@@ -21,6 +25,7 @@ class AssignmentTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         \Psalm\Checker\FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -36,7 +41,7 @@ class AssignmentTest extends PHPUnit_Framework_TestCase
         $b = $a;
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/AssignmentTest.php
+++ b/tests/AssignmentTest.php
@@ -42,6 +42,6 @@ class AssignmentTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -12,6 +12,9 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -20,6 +23,7 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
         $config = new TestConfig();
     }
 
@@ -29,9 +33,9 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
         echo 5 + 4;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -44,9 +48,9 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
         $a = "b" + 5;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testDifferingNumericTypesAdditionInWeakMode()
@@ -55,9 +59,9 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
         echo 5 + 4.1;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -72,9 +76,9 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
         echo 5 + 4.1;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testNumericAddition()
@@ -87,9 +91,9 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testConcatenation()
@@ -98,9 +102,9 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
         echo "Hey " + "Jude,";
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testConcatenationWithNumberInWeakMode()
@@ -109,9 +113,9 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
         echo "hi" . 5;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -121,13 +125,13 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
     public function testConcatenationWithNumberInStrictMode()
     {
         Config::getInstance()->strict_binary_operands = true;
-        
+
         $stmts = self::$parser->parse('<?php
         echo "hi" . 5;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -35,7 +35,7 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -50,7 +50,7 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testDifferingNumericTypesAdditionInWeakMode()
@@ -61,7 +61,7 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -78,7 +78,7 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testNumericAddition()
@@ -93,7 +93,7 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testConcatenation()
@@ -104,7 +104,7 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testConcatenationWithNumberInWeakMode()
@@ -115,7 +115,7 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -132,6 +132,6 @@ class BinaryOperationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/ClassScopeTest.php
+++ b/tests/ClassScopeTest.php
@@ -12,6 +12,9 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -40,8 +44,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         (new A())->fooFoo();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -60,8 +64,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         (new A())->fooFoo();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessiblePrivateMethodFromSubclass()
@@ -78,8 +82,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -102,8 +106,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessibleProtectedMethodFromSubclass()
@@ -121,8 +125,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessibleProtectedMethodFromOtherSubclass()
@@ -142,8 +146,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -171,8 +175,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -190,8 +194,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         echo (new A())->fooFoo;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -209,8 +213,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         echo (new A())->fooFoo;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -232,8 +236,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -251,8 +255,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         echo A::$fooFoo;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -270,8 +274,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         echo A::$fooFoo;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -293,8 +297,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessibleProtectedPropertyFromSubclass()
@@ -312,8 +316,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessibleProtectedPropertyFromGreatGrandparent()
@@ -335,8 +339,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessibleProtectedPropertyFromOtherSubclass()
@@ -358,8 +362,8 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessibleStaticPropertyFromSubclass()
@@ -381,7 +385,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 }

--- a/tests/ClassScopeTest.php
+++ b/tests/ClassScopeTest.php
@@ -45,7 +45,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -65,7 +65,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessiblePrivateMethodFromSubclass()
@@ -83,7 +83,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -107,7 +107,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessibleProtectedMethodFromSubclass()
@@ -126,7 +126,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessibleProtectedMethodFromOtherSubclass()
@@ -147,7 +147,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -176,7 +176,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -195,7 +195,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -214,7 +214,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -237,7 +237,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -256,7 +256,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -275,7 +275,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -298,7 +298,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessibleProtectedPropertyFromSubclass()
@@ -317,7 +317,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessibleProtectedPropertyFromGreatGrandparent()
@@ -340,7 +340,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessibleProtectedPropertyFromOtherSubclass()
@@ -363,7 +363,7 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessibleStaticPropertyFromSubclass()
@@ -386,6 +386,6 @@ class ClassScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 }

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -265,5 +265,41 @@ class ClassTest extends PHPUnit_Framework_TestCase
         $file_checker->visitAndAnalyzeMethods($context);
     }
 
+    public function testReferenceToSubclassInMethod()
+    {
+        $stmts = self::$parser->parse('<?php
+        class A {
+            public function b(B $b) : void {
 
+            }
+
+            public function c() : void {
+
+            }
+        }
+
+        class B extends A {
+            public function d() : void {
+                $this->c();
+            }
+        }
+        ');
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $context = new Context('somefile.php');
+        $file_checker->visitAndAnalyzeMethods($context);
+    }
+
+    public function testReferenceToClassInMethod()
+    {
+        $stmts = self::$parser->parse('<?php
+        class A {
+            public function b(A $b) : void {
+                $b->b(new A());
+            }
+        }
+        ');
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $context = new Context('somefile.php');
+        $file_checker->visitAndAnalyzeMethods($context);
+    }
 }

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -40,7 +40,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -56,7 +56,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -71,7 +71,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -86,7 +86,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -101,7 +101,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -117,7 +117,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testSingleFileInheritance()
@@ -138,7 +138,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -154,7 +154,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -171,7 +171,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -189,7 +189,7 @@ class ClassTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testConstSandwich()
@@ -201,6 +201,6 @@ class ClassTest extends PHPUnit_Framework_TestCase
         ');
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -59,7 +59,7 @@ class ClosureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -81,7 +81,7 @@ class ClosureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -102,7 +102,7 @@ class ClosureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testInferredArg()
@@ -123,7 +123,7 @@ class ClosureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testVarReturnType()
@@ -139,7 +139,7 @@ class ClosureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -153,7 +153,7 @@ class ClosureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -169,7 +169,7 @@ class ClosureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 }

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -12,6 +12,9 @@ class ClosureTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class ClosureTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testByRefUseVar()
@@ -53,9 +57,9 @@ class ClosureTest extends PHPUnit_Framework_TestCase
         fn();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -75,9 +79,9 @@ class ClosureTest extends PHPUnit_Framework_TestCase
         );
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -96,9 +100,9 @@ class ClosureTest extends PHPUnit_Framework_TestCase
         );
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testInferredArg()
@@ -117,9 +121,9 @@ class ClosureTest extends PHPUnit_Framework_TestCase
         );
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testVarReturnType()
@@ -133,9 +137,9 @@ class ClosureTest extends PHPUnit_Framework_TestCase
         $a = $add_one(1);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -147,9 +151,9 @@ class ClosureTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -163,9 +167,9 @@ class ClosureTest extends PHPUnit_Framework_TestCase
         $a = $bad_one(1);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 }

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -143,6 +143,24 @@ class ClosureTest extends PHPUnit_Framework_TestCase
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
+    public function testCallableToClosure()
+    {
+        $stmts = self::$parser->parse('<?php
+        /**
+         * @return callable
+         */
+        function foo() {
+            return function(string $a) : string {
+                return $a . "blah";
+            };
+        }
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $context = new Context('somefile.php');
+        $file_checker->visitAndAnalyzeMethods($context);
+    }
+
     public function testCallable()
     {
         $stmts = self::$parser->parse('<?php

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -10,9 +10,13 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 {
     protected static $file_filter;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public static function getAllIssues()

--- a/tests/ForbiddenCodeTest.php
+++ b/tests/ForbiddenCodeTest.php
@@ -12,6 +12,9 @@ class ForbiddenCodeTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class ForbiddenCodeTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -34,9 +38,9 @@ class ForbiddenCodeTest extends PHPUnit_Framework_TestCase
         var_dump("hello");
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -49,9 +53,9 @@ class ForbiddenCodeTest extends PHPUnit_Framework_TestCase
         `rm -rf`;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -64,8 +68,8 @@ class ForbiddenCodeTest extends PHPUnit_Framework_TestCase
         shell_exec("rm -rf");
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/ForbiddenCodeTest.php
+++ b/tests/ForbiddenCodeTest.php
@@ -40,7 +40,7 @@ class ForbiddenCodeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -55,7 +55,7 @@ class ForbiddenCodeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -70,6 +70,6 @@ class ForbiddenCodeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/ForeachTest.php
+++ b/tests/ForeachTest.php
@@ -40,7 +40,7 @@ class ForeachTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -57,6 +57,6 @@ class ForeachTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/ForeachTest.php
+++ b/tests/ForeachTest.php
@@ -12,6 +12,9 @@ class ForeachTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class ForeachTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -34,9 +38,9 @@ class ForeachTest extends PHPUnit_Framework_TestCase
         continue;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -51,8 +55,8 @@ class ForeachTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -12,6 +12,9 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -21,6 +24,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
     {
         $config = new TestConfig();
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -34,9 +38,9 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
         fooFoo("string");
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -54,9 +58,9 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
         fooFoo($a);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -70,9 +74,9 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
         fooFoo(null);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -86,9 +90,9 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
         fooFoo();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -102,9 +106,9 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
         fooFoo(5, "dfd");
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -121,9 +125,9 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
         fooFoo(new A());
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testTypedArrayWithDefault()
@@ -137,9 +141,9 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -152,8 +156,37 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
         function f($p, $p) {}
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
+    }
+
+    public function testByRef()
+    {
+        $stmts = self::$parser->parse('<?php
+        function fooFoo(string &$v) : void {}
+        fooFoo($a);
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $context = new Context('somefile.php');
+        $file_checker->visitAndCheckMethods($context);
+    }
+
+    /**
+     * @expectedException \Psalm\Exception\CodeException
+     * @expectedExceptionMessage InvalidPassByReference
+     */
+    public function testBadByRef()
+    {
+        $this->markTestIncomplete('Does not throw an error');
+        $stmts = self::$parser->parse('<?php
+        function fooFoo(string &$v) : void {}
+        fooFoo("a");
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $context = new Context('somefile.php');
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -40,7 +40,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -60,7 +60,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -76,7 +76,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -92,7 +92,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -108,7 +108,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -127,7 +127,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testTypedArrayWithDefault()
@@ -143,7 +143,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -158,7 +158,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testByRef()
@@ -170,7 +170,7 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -187,6 +187,6 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -39,7 +39,7 @@ class IncludeTest extends PHPUnit_Framework_TestCase
         );
 
         $file2_checker = new FileChecker(
-            'file2.php',
+            getcwd() . '/file2.php',
             $this->project_checker,
             self::$parser->parse('<?php
             require("file1.php");
@@ -79,7 +79,7 @@ class IncludeTest extends PHPUnit_Framework_TestCase
         );
 
         $file2_checker = new FileChecker(
-            'file3.php',
+            getcwd() . '/file3.php',
             $this->project_checker,
             self::$parser->parse('<?php
             require("file2.php");
@@ -108,7 +108,7 @@ class IncludeTest extends PHPUnit_Framework_TestCase
         );
 
         $file2_checker = new FileChecker(
-            'file2.php',
+            getcwd() . '/file2.php',
             $this->project_checker,
             self::$parser->parse('<?php
             require("file1.php");
@@ -118,6 +118,30 @@ class IncludeTest extends PHPUnit_Framework_TestCase
                     (new Foo\A);
                 }
             }
+            ')
+        );
+
+        $file2_checker->visitAndAnalyzeMethods();
+    }
+
+    public function testRequireFunction()
+    {
+        $this->project_checker->registerFile(
+            getcwd() . '/file1.php',
+            '<?php
+            function fooFoo() : void {
+
+            }
+            '
+        );
+
+        $file2_checker = new FileChecker(
+            getcwd() . '/file2.php',
+            $this->project_checker,
+            self::$parser->parse('<?php
+            require("file1.php");
+
+            fooFoo();
             ')
         );
 

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -1,0 +1,126 @@
+<?php
+namespace Psalm\Tests;
+
+use PhpParser\ParserFactory;
+use PHPUnit_Framework_TestCase;
+use Psalm\Checker\FileChecker;
+use Psalm\Config;
+
+class IncludeTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \PhpParser\Parser */
+    protected static $parser;
+
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+    protected static $file_filter;
+
+    public static function setUpBeforeClass()
+    {
+        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+    }
+
+    public function setUp()
+    {
+        $config = new TestConfig();
+        $config->throw_exception = true;
+        FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
+    }
+
+    public function testBasicRequire()
+    {
+        $this->project_checker->registerFile(
+            getcwd() . '/file1.php',
+            '<?php
+            class A{
+            }
+            '
+        );
+
+        $file2_checker = new FileChecker(
+            'file2.php',
+            $this->project_checker,
+            self::$parser->parse('<?php
+            require("file1.php");
+
+            class B {
+                public function foo() : void {
+                    (new A);
+                }
+            }
+            ')
+        );
+
+        $file2_checker->visitAndAnalyzeMethods();
+    }
+
+    public function testNestedRequire()
+    {
+        $this->project_checker->registerFile(
+            getcwd() . '/file1.php',
+            '<?php
+            class A{
+                public function fooFoo() : void {
+
+                }
+            }
+            '
+        );
+
+        $this->project_checker->registerFile(
+            getcwd() . '/file2.php',
+            '<?php
+            require("file1.php");
+
+            class B extends A{
+            }
+            '
+        );
+
+        $file2_checker = new FileChecker(
+            'file3.php',
+            $this->project_checker,
+            self::$parser->parse('<?php
+            require("file2.php");
+
+            class C extends B {
+                public function doFoo() : void {
+                    $this->fooFoo();
+                }
+            }
+            ')
+        );
+
+        $file2_checker->visitAndAnalyzeMethods();
+    }
+
+    public function testRequireNamespace()
+    {
+        $this->project_checker->registerFile(
+            getcwd() . '/file1.php',
+            '<?php
+            namespace Foo;
+
+            class A{
+            }
+            '
+        );
+
+        $file2_checker = new FileChecker(
+            'file2.php',
+            $this->project_checker,
+            self::$parser->parse('<?php
+            require("file1.php");
+
+            class B {
+                public function foo() : void {
+                    (new Foo\A);
+                }
+            }
+            ')
+        );
+
+        $file2_checker->visitAndAnalyzeMethods();
+    }
+}

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -147,4 +147,35 @@ class IncludeTest extends PHPUnit_Framework_TestCase
 
         $file2_checker->visitAndAnalyzeMethods();
     }
+
+    public function testRequireNamespaceWithUse()
+    {
+        $this->project_checker->registerFile(
+            getcwd() . '/file1.php',
+            '<?php
+            namespace Foo;
+
+            class A{
+            }
+            '
+        );
+
+        $file2_checker = new FileChecker(
+            getcwd() . '/file2.php',
+            $this->project_checker,
+            self::$parser->parse('<?php
+            require("file1.php");
+
+            use Foo\A;
+
+            class B {
+                public function foo() : void {
+                    (new A);
+                }
+            }
+            ')
+        );
+
+        $file2_checker->visitAndAnalyzeMethods();
+    }
 }

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -80,7 +80,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$cee']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$dee']);
     }
@@ -130,7 +130,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testExtendsWithMethod()
@@ -158,7 +158,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -180,7 +180,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -200,7 +200,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -224,7 +224,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testCorrectInterfaceMethodSignature()
@@ -244,7 +244,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testInterfaceMethodImplementedInParent()
@@ -266,7 +266,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -293,7 +293,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testInterfaceMethodSignatureInTrait()
@@ -316,7 +316,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -346,7 +346,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testDelayedInterface()
@@ -363,6 +363,6 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ');
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -12,6 +12,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testExtendsAndImplements()
@@ -74,9 +78,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$cee']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$dee']);
     }
@@ -124,9 +128,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testExtendsWithMethod()
@@ -152,9 +156,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -174,9 +178,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -194,9 +198,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -218,9 +222,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testCorrectInterfaceMethodSignature()
@@ -238,9 +242,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testInterfaceMethodImplementedInParent()
@@ -260,9 +264,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -287,9 +291,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testInterfaceMethodSignatureInTrait()
@@ -310,9 +314,9 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -340,8 +344,25 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
+    }
+
+    public function testDelayedInterface()
+    {
+        $stmts = self::$parser->parse('<?php
+        // fails in PHP, whatcha gonna do
+        $c = new C;
+
+        class A { }
+
+        interface B { }
+
+        class C extends A implements B { }
+        ');
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $context = new Context('somefile.php');
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -38,7 +38,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
              * @psalm-suppress MixedMethodCall
              * @psalm-suppress MissingReturnType
              */
-            public function a() {
+            public function b() {
                 B::fooFoo()->barBar()->bat()->baz()->bam()->bas()->bee()->bet()->bes()->bis();
             }
         }

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -45,7 +45,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testExcludeIssue()
@@ -57,6 +57,6 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 }

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -10,6 +10,9 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
 {
     /** @var \PhpParser\Parser */
     protected static $parser;
+
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
     protected static $file_filter;
 
     public static function setUpBeforeClass()
@@ -22,6 +25,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
         $config = new TestConfig();
         $config->throw_exception = true;
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testUndefinedClass()
@@ -40,8 +44,8 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testExcludeIssue()
@@ -52,7 +56,7 @@ class IssueSuppressionTest extends PHPUnit_Framework_TestCase
         fooFoo();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 }

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -46,7 +46,7 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
         );
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -72,7 +72,7 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
         );
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -98,7 +98,7 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
         );
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -124,7 +124,7 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
         );
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -153,7 +153,7 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
         );
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -180,7 +180,7 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
         );
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -14,6 +14,9 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -26,6 +29,7 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testJsonOutputForReturnTypeError()
@@ -41,8 +45,8 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
             $file_contents
         );
 
-        $file_checker = new FileChecker('somefile.php');
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
+        $file_checker->visitAndCheckMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -67,8 +71,8 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
             $file_contents
         );
 
-        $file_checker = new FileChecker('somefile.php');
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
+        $file_checker->visitAndCheckMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -93,8 +97,8 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
             $file_contents
         );
 
-        $file_checker = new FileChecker('somefile.php');
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
+        $file_checker->visitAndCheckMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -119,8 +123,8 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
             $file_contents
         );
 
-        $file_checker = new FileChecker('somefile.php');
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
+        $file_checker->visitAndCheckMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -148,8 +152,8 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
             $file_contents
         );
 
-        $file_checker = new FileChecker('somefile.php');
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
+        $file_checker->visitAndCheckMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
@@ -175,8 +179,8 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
             $file_contents
         );
 
-        $file_checker = new FileChecker('somefile.php');
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
+        $file_checker->visitAndCheckMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);

--- a/tests/ListTest.php
+++ b/tests/ListTest.php
@@ -12,6 +12,9 @@ class ListTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class ListTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testSimpleVars()
@@ -30,9 +34,9 @@ class ListTest extends PHPUnit_Framework_TestCase
         list($a, $b) = ["a", "b"];
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$b']);
     }
@@ -43,9 +47,9 @@ class ListTest extends PHPUnit_Framework_TestCase
         list($a, $b) = ["a", 2];
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('int', (string) $context->vars_in_scope['$b']);
     }
@@ -57,9 +61,9 @@ class ListTest extends PHPUnit_Framework_TestCase
         list($a, $b) = $bar;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int|string', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('int|string', (string) $context->vars_in_scope['$b']);
     }
@@ -83,9 +87,9 @@ class ListTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -111,8 +115,8 @@ class ListTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/ListTest.php
+++ b/tests/ListTest.php
@@ -36,7 +36,7 @@ class ListTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$b']);
     }
@@ -49,7 +49,7 @@ class ListTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('int', (string) $context->vars_in_scope['$b']);
     }
@@ -63,7 +63,7 @@ class ListTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int|string', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('int|string', (string) $context->vars_in_scope['$b']);
     }
@@ -89,7 +89,7 @@ class ListTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -117,6 +117,6 @@ class ListTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -43,7 +43,7 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testValidNonStaticInvocation()
@@ -58,7 +58,7 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -83,7 +83,7 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testValidStaticInvocation()
@@ -102,7 +102,7 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -123,7 +123,7 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -142,6 +142,6 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -12,6 +12,9 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -21,6 +24,7 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
     {
         $config = new TestConfig();
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -37,9 +41,9 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
         Foo::barBar();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testValidNonStaticInvocation()
@@ -52,9 +56,9 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
         (new Foo())->barBar();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -77,9 +81,9 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
         $a->barBar();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testValidStaticInvocation()
@@ -96,9 +100,9 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
         B::fooFoo();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -117,9 +121,9 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -136,8 +140,8 @@ class MethodCallTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/MethodMutationTest.php
+++ b/tests/MethodMutationTest.php
@@ -103,7 +103,7 @@ class MethodMutationTest extends PHPUnit_Framework_TestCase
         $file_checker->visit($context);
         $file_checker->analyze(false, true);
         $method_context = new Context('somefile.php');
-        $file_checker->getMethodMutations('FooController::barBar', $method_context);
+        $this->project_checker->getMethodMutations('FooController::barBar', $method_context);
 
         $this->assertEquals('UserViewData', (string)$method_context->vars_in_scope['$this->user_viewdata']);
         $this->assertEquals('string', (string)$method_context->vars_in_scope['$this->user_viewdata->name']);

--- a/tests/MethodMutationTest.php
+++ b/tests/MethodMutationTest.php
@@ -1,0 +1,111 @@
+<?php
+namespace Psalm\Tests;
+
+use PhpParser\ParserFactory;
+use PHPUnit_Framework_TestCase;
+use Psalm\Checker\FileChecker;
+use Psalm\Checker\MethodChecker;
+use Psalm\Config;
+use Psalm\Context;
+
+class MethodMutationTest extends PHPUnit_Framework_TestCase
+{
+    /** @var \PhpParser\Parser */
+    protected static $parser;
+
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
+    public static function setUpBeforeClass()
+    {
+        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+    }
+
+    public function setUp()
+    {
+        $config = new TestConfig();
+        FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
+    }
+
+    public function testControllerMutation()
+    {
+        $this->project_checker->registerFile(
+            getcwd() . '/somefile.php',
+            '<?php
+        class User {
+            /** @var string */
+            public $name;
+
+            /** @return User|null */
+            public static function loadUser(int $id) {
+                if ($id === 3) {
+                    $user = new User();
+                    $user->name = "Bob";
+                    return $user;
+                }
+
+                return null;
+            }
+        }
+
+        class UserViewData {
+            /** @var string|null */
+            public $name;
+        }
+
+        class Response {
+            public function __construct (UserViewData $viewdata) {}
+        }
+
+        class UnauthorizedException extends Exception { }
+
+        class Controller {
+            /** @var UserViewData */
+            public $user_viewdata;
+
+            /** @var string|null */
+            public $title;
+
+            public function __construct() {
+                $this->user_viewdata = new UserViewData();
+            }
+
+            public function setUser() : void
+            {
+                $user_id = (int)$_GET["id"];
+
+                if (!$user_id) {
+                    throw new UnauthorizedException("No user id supplied");
+                }
+
+                $user = User::loadUser($user_id);
+
+                if (!$user) {
+                    throw new UnauthorizedException("User not found");
+                }
+
+                $this->user_viewdata->name = $user->name;
+            }
+        }
+
+        class FooController extends Controller {
+            public function barBar() : Response {
+                $this->setUser();
+
+                return new Response($this->user_viewdata);
+            }
+        }'
+        );
+
+        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
+        $context = new Context('somefile.php');
+        $file_checker->visit($context);
+        $file_checker->analyze(false, true);
+        $method_context = new Context('somefile.php');
+        $file_checker->getMethodMutations('FooController::barBar', $method_context);
+
+        $this->assertEquals('UserViewData', (string)$method_context->vars_in_scope['$this->user_viewdata']);
+        $this->assertEquals('string', (string)$method_context->vars_in_scope['$this->user_viewdata->name']);
+    }
+}

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -46,7 +46,7 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -71,7 +71,7 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -96,7 +96,7 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -115,6 +115,6 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -12,6 +12,9 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testMoreArguments()
@@ -40,9 +44,9 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -65,9 +69,9 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -90,9 +94,9 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -109,8 +113,8 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/Php40Test.php
+++ b/tests/Php40Test.php
@@ -12,6 +12,9 @@ class Php40Test extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class Php40Test extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testExtendOldStyleConstructor()
@@ -43,8 +47,8 @@ class Php40Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/Php40Test.php
+++ b/tests/Php40Test.php
@@ -49,6 +49,6 @@ class Php40Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/Php55Test.php
+++ b/tests/Php55Test.php
@@ -56,7 +56,7 @@ class Php55Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('null|int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -73,7 +73,7 @@ class Php55Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testForeachList()
@@ -91,7 +91,7 @@ class Php55Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testArrayStringDereferencing()
@@ -103,7 +103,7 @@ class Php55Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$b']);
     }
@@ -119,7 +119,7 @@ class Php55Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
 
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
     }

--- a/tests/Php55Test.php
+++ b/tests/Php55Test.php
@@ -12,6 +12,9 @@ class Php55Test extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class Php55Test extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testGenerator()
@@ -50,9 +54,9 @@ class Php55Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('null|int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -67,9 +71,9 @@ class Php55Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testForeachList()
@@ -85,9 +89,9 @@ class Php55Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testArrayStringDereferencing()
@@ -97,9 +101,9 @@ class Php55Test extends PHPUnit_Framework_TestCase
         $b = "PHP"[0];
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$b']);
     }
@@ -113,9 +117,9 @@ class Php55Test extends PHPUnit_Framework_TestCase
         ?>
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
 
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
     }

--- a/tests/Php56Test.php
+++ b/tests/Php56Test.php
@@ -12,16 +12,19 @@ class Php56Test extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-
-        $config = new TestConfig();
     }
 
     public function setUp()
     {
+        $config = new TestConfig();
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testConstArray()
@@ -31,9 +34,9 @@ class Php56Test extends PHPUnit_Framework_TestCase
         $a = ARR[0];
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
     }
 
@@ -63,9 +66,9 @@ class Php56Test extends PHPUnit_Framework_TestCase
         $g = C::ONE_THIRD;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$d']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$e']);
         $this->assertEquals('int', (string) $context->vars_in_scope['$f']);
@@ -88,9 +91,9 @@ class Php56Test extends PHPUnit_Framework_TestCase
         f(1, 2, 3, 4, 5);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testVariadicArray()
@@ -116,9 +119,9 @@ class Php56Test extends PHPUnit_Framework_TestCase
         f(1, 2, 3);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testArgumentUnpacking()
@@ -138,9 +141,9 @@ class Php56Test extends PHPUnit_Framework_TestCase
         echo add(1, ...$operators);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testExponentiation()
@@ -150,9 +153,9 @@ class Php56Test extends PHPUnit_Framework_TestCase
         $a **= 3;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testConstantAliasInNamespace()
@@ -170,9 +173,9 @@ class Php56Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testConstantAliasInClass()
@@ -195,9 +198,9 @@ class Php56Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testFunctionAliasInNamespace()
@@ -218,9 +221,9 @@ class Php56Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testFunctionAliasInClass()
@@ -246,8 +249,8 @@ class Php56Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/Php56Test.php
+++ b/tests/Php56Test.php
@@ -36,7 +36,7 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
     }
 
@@ -68,7 +68,7 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$d']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$e']);
         $this->assertEquals('int', (string) $context->vars_in_scope['$f']);
@@ -93,7 +93,7 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testVariadicArray()
@@ -121,7 +121,7 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testArgumentUnpacking()
@@ -143,7 +143,7 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testExponentiation()
@@ -155,7 +155,7 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testConstantAliasInNamespace()
@@ -175,7 +175,7 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testConstantAliasInClass()
@@ -200,7 +200,7 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testFunctionAliasInNamespace()
@@ -223,7 +223,7 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testFunctionAliasInClass()
@@ -251,6 +251,6 @@ class Php56Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/Php70Test.php
+++ b/tests/Php70Test.php
@@ -46,7 +46,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -71,7 +71,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -85,7 +85,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('mixed', (string) $context->vars_in_scope['$a']);
     }
 
@@ -97,7 +97,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -115,7 +115,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
     }
 
@@ -147,7 +147,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testGeneratorWithReturn()
@@ -168,7 +168,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testGeneratorDelegation()
@@ -222,7 +222,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('Generator<int, int>', (string) $context->vars_in_scope['$gen']);
         $this->assertEquals('mixed', (string) $context->vars_in_scope['$gen2']);
     }
@@ -253,6 +253,6 @@ class Php70Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/Php70Test.php
+++ b/tests/Php70Test.php
@@ -12,6 +12,9 @@ class Php70Test extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -21,6 +24,7 @@ class Php70Test extends PHPUnit_Framework_TestCase
     {
         $config = new TestConfig();
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testFunctionTypeHints()
@@ -40,9 +44,9 @@ class Php70Test extends PHPUnit_Framework_TestCase
         $a = indexof("arr", "a");
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -65,9 +69,9 @@ class Php70Test extends PHPUnit_Framework_TestCase
         $a = Foo::indexof("arr", "a");
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -79,9 +83,9 @@ class Php70Test extends PHPUnit_Framework_TestCase
         $a = $_GET["bar"] ?? "nobody";
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('mixed', (string) $context->vars_in_scope['$a']);
     }
 
@@ -91,9 +95,9 @@ class Php70Test extends PHPUnit_Framework_TestCase
         $a = 1 <=> 1;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
     }
 
@@ -109,9 +113,9 @@ class Php70Test extends PHPUnit_Framework_TestCase
         $a = ANIMALS[1];
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
     }
 
@@ -141,9 +145,9 @@ class Php70Test extends PHPUnit_Framework_TestCase
         });
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testGeneratorWithReturn()
@@ -162,9 +166,9 @@ class Php70Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testGeneratorDelegation()
@@ -216,9 +220,9 @@ class Php70Test extends PHPUnit_Framework_TestCase
         $gen2 = $gen->getReturn();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('Generator<int, int>', (string) $context->vars_in_scope['$gen']);
         $this->assertEquals('mixed', (string) $context->vars_in_scope['$gen2']);
     }
@@ -247,8 +251,8 @@ class Php70Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/Php71Test.php
+++ b/tests/Php71Test.php
@@ -12,6 +12,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -23,6 +26,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
         $config->use_docblock_types = true;
 
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testNullableReturnType()
@@ -36,9 +40,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         $a = a();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$a']);
     }
 
@@ -54,9 +58,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         test(null);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testPrivateClassConst()
@@ -72,9 +76,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -92,9 +96,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         echo A::IS_PRIVATE;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -117,9 +121,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testProtectedClassConst()
@@ -138,9 +142,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -158,9 +162,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         echo A::IS_PROTECTED;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testPublicClassConstFetch()
@@ -184,9 +188,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         echo A::IS_ALSO_PUBLIC;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testArrayDestructuring()
@@ -204,9 +208,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         [$id2, $name2] = $data[1];
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string|int', (string) $context->vars_in_scope['$id1']);
         $this->assertEquals('string|int', (string) $context->vars_in_scope['$name1']);
         $this->assertEquals('string|int', (string) $context->vars_in_scope['$id2']);
@@ -228,9 +232,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testArrayDestructuringWithKeys()
@@ -248,9 +252,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         ["id" => $id2, "name" => $name2] = $data[1];
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$id1']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$name1']);
         $this->assertEquals('int', (string) $context->vars_in_scope['$id2']);
@@ -275,9 +279,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('null|int', (string) $context->vars_in_scope['$last_id']);
         $this->assertEquals('null|string', (string) $context->vars_in_scope['$last_name']);
     }
@@ -300,9 +304,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('null|int', (string) $context->vars_in_scope['$last_id']);
         $this->assertEquals('null|string', (string) $context->vars_in_scope['$last_name']);
     }
@@ -324,9 +328,9 @@ class Php71Test extends PHPUnit_Framework_TestCase
         iterator(new SplFixedArray(5));
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -352,8 +356,8 @@ class Php71Test extends PHPUnit_Framework_TestCase
         iterator(new A());
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/Php71Test.php
+++ b/tests/Php71Test.php
@@ -42,7 +42,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$a']);
     }
 
@@ -60,7 +60,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testPrivateClassConst()
@@ -78,7 +78,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -98,7 +98,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -123,7 +123,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testProtectedClassConst()
@@ -144,7 +144,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -164,7 +164,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testPublicClassConstFetch()
@@ -190,7 +190,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testArrayDestructuring()
@@ -210,7 +210,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string|int', (string) $context->vars_in_scope['$id1']);
         $this->assertEquals('string|int', (string) $context->vars_in_scope['$name1']);
         $this->assertEquals('string|int', (string) $context->vars_in_scope['$id2']);
@@ -234,7 +234,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testArrayDestructuringWithKeys()
@@ -254,7 +254,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$id1']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$name1']);
         $this->assertEquals('int', (string) $context->vars_in_scope['$id2']);
@@ -281,7 +281,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('null|int', (string) $context->vars_in_scope['$last_id']);
         $this->assertEquals('null|string', (string) $context->vars_in_scope['$last_name']);
     }
@@ -306,7 +306,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('null|int', (string) $context->vars_in_scope['$last_id']);
         $this->assertEquals('null|string', (string) $context->vars_in_scope['$last_name']);
     }
@@ -330,7 +330,7 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -358,6 +358,6 @@ class Php71Test extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -11,6 +11,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 {
     /** @var \PhpParser\Parser */
     protected static $parser;
+
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
     protected static $file_filter;
 
     public static function setUpBeforeClass()
@@ -23,6 +26,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $config = new TestConfig();
         $config->throw_exception = true;
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testNewVarInIf()
@@ -48,8 +52,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testPropertyWithoutTypeSuppressingIssue()
@@ -65,8 +69,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $a = (new A)->foo;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -82,8 +86,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         (new A)->foo = "cool";
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -99,8 +103,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         echo (new A)->foo;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -117,8 +121,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -135,8 +139,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -155,8 +159,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -171,8 +175,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -193,8 +197,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -208,8 +212,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $a->foo = "bar";
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -223,8 +227,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         echo $a->foo;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testSharedPropertyInIf()
@@ -247,9 +251,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('null|string|int', (string) $context->vars_in_scope['$b']);
     }
 
@@ -276,9 +280,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('null|string|int', (string) $context->vars_in_scope['$b']);
     }
 
@@ -303,9 +307,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         echo $a->foo;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -329,9 +333,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $a->foo = "hello";
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -351,9 +355,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $a->foo = "hello";
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -373,9 +377,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         echo $a->foo;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testNullablePropertyCheck()
@@ -398,9 +402,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testNullableStaticPropertyWithIfCheck()
@@ -420,9 +424,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testReflectionProperties()
@@ -436,9 +440,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         echo $a->name . " - " . $a->class;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testGrandparentReflectedProperties()
@@ -448,9 +452,9 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $owner = $a->ownerDocument;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('DOMDocument', (string) $context->vars_in_scope['$owner']);
     }
 
@@ -478,8 +482,8 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $c->is = [new A1, new B1];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -505,7 +509,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $c->bb = [new A, new B];
         ');
 
-        $file_checker = new \Psalm\Checker\FileChecker('somefile.php', $stmts);
-        $file_checker->check(true, true, $context);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -53,7 +53,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testPropertyWithoutTypeSuppressingIssue()
@@ -70,7 +70,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -87,7 +87,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -104,7 +104,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -122,7 +122,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -140,7 +140,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -160,7 +160,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -176,7 +176,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -198,7 +198,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -213,7 +213,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -228,7 +228,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testSharedPropertyInIf()
@@ -253,7 +253,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('null|string|int', (string) $context->vars_in_scope['$b']);
     }
 
@@ -282,7 +282,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('null|string|int', (string) $context->vars_in_scope['$b']);
     }
 
@@ -309,7 +309,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -335,7 +335,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -357,7 +357,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -379,7 +379,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testNullablePropertyCheck()
@@ -404,7 +404,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testNullablePropertyAfterGuard()
@@ -426,7 +426,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testNullableStaticPropertyWithIfCheck()
@@ -448,7 +448,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testReflectionProperties()
@@ -464,7 +464,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testGrandparentReflectedProperties()
@@ -476,7 +476,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('DOMDocument', (string) $context->vars_in_scope['$owner']);
     }
 
@@ -505,7 +505,7 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -532,6 +532,6 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -407,6 +407,28 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $file_checker->visitAndCheckMethods($context);
     }
 
+    public function testNullablePropertyAfterGuard()
+    {
+        $stmts = self::$parser->parse('<?php
+        class A {
+            /** @var string|null */
+            public $aa;
+        }
+
+        $a = new A();
+
+        if (!$a->aa) {
+            $a->aa = "hello";
+        }
+
+        echo substr($a->aa, 1);
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $context = new Context('somefile.php');
+        $file_checker->visitAndCheckMethods($context);
+    }
+
     public function testNullableStaticPropertyWithIfCheck()
     {
         $stmts = self::$parser->parse('<?php

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -12,6 +12,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -22,6 +25,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testReturnTypeAfterUselessNullcheck()
@@ -45,8 +49,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testReturnTypeNotEmptyCheck()
@@ -65,8 +69,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testReturnTypeNotEmptyCheckInElseIf()
@@ -88,8 +92,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testReturnTypeNotEmptyCheckInElse()
@@ -111,8 +115,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testReturnTypeAfterIf()
@@ -132,8 +136,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testReturnTypeAfterTwoIfsWithThrow()
@@ -158,8 +162,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testReturnTypeAfterIfElseIfWithThrow()
@@ -184,8 +188,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testTryCatchReturnType()
@@ -205,8 +209,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testSwitchReturnTypeWithFallthrough()
@@ -224,8 +228,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testSwitchReturnTypeWithFallthroughAndStatement()
@@ -244,8 +248,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -267,8 +271,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -292,8 +296,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -314,8 +318,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testSwitchReturnTypeWitDefaultException()
@@ -339,8 +343,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testExtendsStaticCallReturnType()
@@ -359,9 +363,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         $b = B::load();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
 
         $this->assertEquals('B', (string) $context->vars_in_scope['$b']);
     }
@@ -382,9 +386,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         $bees = B::loadMultiple();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
 
         $this->assertEquals('array<int, B>', (string) $context->vars_in_scope['$bees']);
     }
@@ -401,9 +405,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testThisReturnType()
@@ -417,9 +421,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testOverrideReturnType()
@@ -442,9 +446,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         $blah = (new B())->blah();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$blah']);
     }
 
@@ -465,9 +469,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         $blah = (new B())->blah();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$blah']);
     }
 
@@ -491,9 +495,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         $blah = (new C())->blah();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$blah']);
     }
 
@@ -509,9 +513,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -526,9 +530,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -545,9 +549,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -564,9 +568,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -581,9 +585,9 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -598,8 +602,8 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -50,7 +50,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testReturnTypeNotEmptyCheck()
@@ -70,7 +70,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testReturnTypeNotEmptyCheckInElseIf()
@@ -93,7 +93,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testReturnTypeNotEmptyCheckInElse()
@@ -116,7 +116,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testReturnTypeAfterIf()
@@ -137,7 +137,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testReturnTypeAfterTwoIfsWithThrow()
@@ -163,7 +163,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testReturnTypeAfterIfElseIfWithThrow()
@@ -189,7 +189,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testTryCatchReturnType()
@@ -210,7 +210,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testSwitchReturnTypeWithFallthrough()
@@ -229,7 +229,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testSwitchReturnTypeWithFallthroughAndStatement()
@@ -249,7 +249,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -272,7 +272,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -297,7 +297,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -319,7 +319,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testSwitchReturnTypeWitDefaultException()
@@ -344,7 +344,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testExtendsStaticCallReturnType()
@@ -365,7 +365,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
 
         $this->assertEquals('B', (string) $context->vars_in_scope['$b']);
     }
@@ -388,7 +388,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
 
         $this->assertEquals('array<int, B>', (string) $context->vars_in_scope['$bees']);
     }
@@ -407,7 +407,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testThisReturnType()
@@ -423,7 +423,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testOverrideReturnType()
@@ -448,7 +448,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string', (string) $context->vars_in_scope['$blah']);
     }
 
@@ -471,7 +471,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$blah']);
     }
 
@@ -497,7 +497,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$blah']);
     }
 
@@ -515,7 +515,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -532,7 +532,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -551,7 +551,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -570,7 +570,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -587,7 +587,7 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -604,6 +604,6 @@ class ReturnTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -11,6 +11,9 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 {
     /** @var \PhpParser\Parser */
     protected static $parser;
+
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
     protected static $file_filter;
 
     public static function setUpBeforeClass()
@@ -23,6 +26,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -40,8 +44,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         echo $b;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNewVarInIf()
@@ -57,8 +61,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         echo $badge;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNewVarInIfWithElseReturn()
@@ -74,8 +78,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         echo $badge;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -93,8 +97,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         echo $array;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -112,8 +116,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         echo $array;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -133,8 +137,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         echo $array;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -152,8 +156,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         echo $car;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testSwitchVariableWithContinue()
@@ -175,8 +179,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testSwitchVariableWithContinueAndIfs()
@@ -204,8 +208,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testSwitchVariableWithFallthrough()
@@ -227,8 +231,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testSwitchVariableWithFallthroughStatement()
@@ -252,8 +256,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testTryCatchVar()
@@ -268,9 +272,9 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('bool', (string) $context->vars_in_scope['$worked']);
     }
 
@@ -285,9 +289,9 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('bool', (string) $context->vars_in_scope['$worked']);
     }
 
@@ -302,9 +306,9 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         while (rand(0,100) === 10);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('bool', (string) $context->vars_in_scope['$worked']);
     }
 
@@ -316,8 +320,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNegatedAssignmentInIf()
@@ -332,8 +336,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAssignInElseIf()
@@ -346,8 +350,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testIfNotEqualsFalse()
@@ -358,8 +362,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testIfNotEqualsNull()
@@ -370,8 +374,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testIfNullNotEquals()
@@ -382,8 +386,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testIfNullEquals()
@@ -396,8 +400,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testPassByRefInIf()
@@ -408,8 +412,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testPassByRefInIfCheckAfter()
@@ -421,8 +425,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         echo (string)$matches[0];
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testPassByRefInIfWithBoolean()
@@ -434,8 +438,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -458,8 +462,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         Config::getInstance()->setIssueHandler('PossiblyUndefinedVariable', self::$file_filter);
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testFunctionExists()
@@ -470,8 +474,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNestedPropertyFetchInElseif()
@@ -496,8 +500,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testGlobalReturn()
@@ -512,8 +516,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testStatic()
@@ -526,8 +530,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -542,8 +546,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         global $a;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -560,8 +564,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testTwoVarLogic()
@@ -581,8 +585,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testThreeVarLogic()
@@ -605,8 +609,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -635,8 +639,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -667,8 +671,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNegateAssertionAndOther()
@@ -681,9 +685,9 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$a']);
     }
 
@@ -699,9 +703,9 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$a']);
     }
 
@@ -722,8 +726,8 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         class C extends A {}
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -45,7 +45,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNewVarInIf()
@@ -62,7 +62,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNewVarInIfWithElseReturn()
@@ -79,7 +79,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -98,7 +98,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -117,7 +117,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -138,7 +138,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -157,7 +157,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testSwitchVariableWithContinue()
@@ -180,7 +180,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testSwitchVariableWithContinueAndIfs()
@@ -209,7 +209,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testSwitchVariableWithFallthrough()
@@ -232,7 +232,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testSwitchVariableWithFallthroughStatement()
@@ -257,7 +257,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testTryCatchVar()
@@ -274,7 +274,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('bool', (string) $context->vars_in_scope['$worked']);
     }
 
@@ -291,7 +291,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('bool', (string) $context->vars_in_scope['$worked']);
     }
 
@@ -308,7 +308,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('bool', (string) $context->vars_in_scope['$worked']);
     }
 
@@ -321,7 +321,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNegatedAssignmentInIf()
@@ -337,7 +337,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAssignInElseIf()
@@ -351,7 +351,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testIfNotEqualsFalse()
@@ -363,7 +363,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testIfNotEqualsNull()
@@ -375,7 +375,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testIfNullNotEquals()
@@ -387,7 +387,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testIfNullEquals()
@@ -401,7 +401,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testPassByRefInIf()
@@ -413,7 +413,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testPassByRefInIfCheckAfter()
@@ -426,7 +426,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testPassByRefInIfWithBoolean()
@@ -439,7 +439,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -463,7 +463,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         Config::getInstance()->setIssueHandler('PossiblyUndefinedVariable', self::$file_filter);
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testFunctionExists()
@@ -475,7 +475,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNestedPropertyFetchInElseif()
@@ -501,7 +501,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testGlobalReturn()
@@ -517,7 +517,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testStatic()
@@ -531,7 +531,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -547,7 +547,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -565,7 +565,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testTwoVarLogic()
@@ -586,7 +586,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testThreeVarLogic()
@@ -610,7 +610,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -640,7 +640,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -672,7 +672,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNegateAssertionAndOther()
@@ -687,7 +687,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$a']);
     }
 
@@ -705,7 +705,7 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('string|null', (string) $context->vars_in_scope['$a']);
     }
 
@@ -728,6 +728,6 @@ class ScopeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/SwitchTypeTest.php
+++ b/tests/SwitchTypeTest.php
@@ -14,6 +14,9 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -24,6 +27,7 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testGetClassArg()
@@ -60,9 +64,9 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -95,9 +99,9 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testGetTypeArg()
@@ -124,9 +128,9 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -155,8 +159,8 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/SwitchTypeTest.php
+++ b/tests/SwitchTypeTest.php
@@ -66,7 +66,7 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -101,7 +101,7 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testGetTypeArg()
@@ -130,7 +130,7 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -161,6 +161,6 @@ class SwitchTypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/ToStringTest.php
+++ b/tests/ToStringTest.php
@@ -12,6 +12,9 @@ class ToStringTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -21,6 +24,7 @@ class ToStringTest extends PHPUnit_Framework_TestCase
     {
         $config = new TestConfig();
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -34,9 +38,9 @@ class ToStringTest extends PHPUnit_Framework_TestCase
         echo (new A);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -51,9 +55,9 @@ class ToStringTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -71,9 +75,9 @@ class ToStringTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testValidToString()
@@ -87,9 +91,9 @@ class ToStringTest extends PHPUnit_Framework_TestCase
         echo (new A);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     public function testValidInferredToStringType()
@@ -106,9 +110,9 @@ class ToStringTest extends PHPUnit_Framework_TestCase
         echo (new A);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 
     /**
@@ -129,8 +133,8 @@ class ToStringTest extends PHPUnit_Framework_TestCase
         fooFoo(new A());
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
     }
 }

--- a/tests/ToStringTest.php
+++ b/tests/ToStringTest.php
@@ -40,7 +40,7 @@ class ToStringTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -57,7 +57,7 @@ class ToStringTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -77,7 +77,7 @@ class ToStringTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testValidToString()
@@ -93,7 +93,7 @@ class ToStringTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testValidInferredToStringType()
@@ -112,7 +112,7 @@ class ToStringTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -135,6 +135,6 @@ class ToStringTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -90,6 +90,69 @@ class TraitTest extends PHPUnit_Framework_TestCase
         $file_checker->visitAndCheckMethods();
     }
 
+    public function testAccessiblePrivatePropertyFromTrait()
+    {
+        $stmts = self::$parser->parse('<?php
+        trait T {
+            /** @var string */
+            private $fooFoo;
+        }
+
+        class B {
+            use T;
+
+            public function doFoo() : void {
+                echo $this->fooFoo;
+            }
+        }
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
+    }
+
+    public function testAccessibleProtectedPropertyFromTrait()
+    {
+        $stmts = self::$parser->parse('<?php
+        trait T {
+            /** @var string */
+            protected $fooFoo;
+        }
+
+        class B {
+            use T;
+
+            public function doFoo() : void {
+                echo $this->fooFoo;
+            }
+        }
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
+    }
+
+    public function testAccessiblePublicPropertyFromTrait()
+    {
+        $stmts = self::$parser->parse('<?php
+        trait T {
+            /** @var string */
+            public $fooFoo;
+        }
+
+        class B {
+            use T;
+
+            public function doFoo() : void {
+                echo $this->fooFoo;
+            }
+        }
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
+    }
+
     /**
      * @expectedException \Psalm\Exception\CodeException
      * @expectedExceptionMessage InaccessibleMethod
@@ -194,6 +257,51 @@ class TraitTest extends PHPUnit_Framework_TestCase
         $stmts = self::$parser->parse('<?php
         class B {
             use A;
+        }
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
+    }
+
+    public function testRedefinedTraitMethod()
+    {
+        $stmts = self::$parser->parse('<?php
+        trait T {
+            public function fooFoo() : void {
+            }
+        }
+
+        class B {
+            use T;
+
+            public function fooFoo(string $a) : void {
+            }
+        }
+
+        (new B)->fooFoo("hello");
+        ');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
+    }
+
+    public function testRedefinedTraitMethodWithAlias()
+    {
+        $stmts = self::$parser->parse('<?php
+        trait T {
+            public function fooFoo() : void {
+            }
+        }
+
+        class B {
+            use T {
+                fooFoo as barBar;
+            }
+
+            public function fooFoo() : void {
+                $this->barBar();
+            }
         }
         ');
 

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -264,7 +264,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         $file_checker->visitAndAnalyzeMethods();
     }
 
-    public function testRedefinedTraitMethod()
+    public function testRedefinedTraitMethodWithoutAlias()
     {
         $stmts = self::$parser->parse('<?php
         trait T {

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -45,7 +45,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessibleProtectedMethodFromTrait()
@@ -66,7 +66,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessiblePublicMethodFromTrait()
@@ -87,7 +87,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessiblePrivatePropertyFromTrait()
@@ -108,7 +108,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessibleProtectedPropertyFromTrait()
@@ -129,7 +129,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessiblePublicPropertyFromTrait()
@@ -150,7 +150,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -177,7 +177,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessibleProtectedMethodFromInheritedTrait()
@@ -200,7 +200,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAccessiblePublicMethodFromInheritedTrait()
@@ -223,7 +223,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testStaticClassMethodFromWithinTrait()
@@ -245,7 +245,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -261,7 +261,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testRedefinedTraitMethod()
@@ -283,7 +283,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testRedefinedTraitMethodWithAlias()
@@ -306,7 +306,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testTraitSelf()
@@ -328,7 +328,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('A', (string) $context->vars_in_scope['$a']);
     }
 
@@ -358,7 +358,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('A', (string) $context->vars_in_scope['$a']);
     }
 }

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -12,6 +12,9 @@ class TraitTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -21,6 +24,7 @@ class TraitTest extends PHPUnit_Framework_TestCase
     {
         $config = new TestConfig();
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     public function testAccessiblePrivateMethodFromTrait()
@@ -40,8 +44,8 @@ class TraitTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessibleProtectedMethodFromTrait()
@@ -61,8 +65,8 @@ class TraitTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessiblePublicMethodFromTrait()
@@ -82,8 +86,8 @@ class TraitTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -109,8 +113,8 @@ class TraitTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessibleProtectedMethodFromInheritedTrait()
@@ -132,8 +136,8 @@ class TraitTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAccessiblePublicMethodFromInheritedTrait()
@@ -155,8 +159,8 @@ class TraitTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testStaticClassMethodFromWithinTrait()
@@ -177,8 +181,8 @@ class TraitTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -193,8 +197,8 @@ class TraitTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testTraitSelf()
@@ -214,9 +218,9 @@ class TraitTest extends PHPUnit_Framework_TestCase
         $a = (new A)->g();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('A', (string) $context->vars_in_scope['$a']);
     }
 
@@ -237,12 +241,16 @@ class TraitTest extends PHPUnit_Framework_TestCase
         class B extends A {
         }
 
+        class C {
+            use T;
+        }
+
         $a = (new B)->g();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('A', (string) $context->vars_in_scope['$a']);
     }
 }

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -206,6 +206,6 @@ class TypeCombinationTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 }

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -11,9 +11,18 @@ class TypeCombinationTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+    }
+
+    public function setUp()
+    {
+        FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -196,7 +205,7 @@ class TypeCombinationTest extends PHPUnit_Framework_TestCase
             $var[] = new B();
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 }

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -10,6 +10,9 @@ class TypeParseTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);

--- a/tests/TypeReconciliationTest.php
+++ b/tests/TypeReconciliationTest.php
@@ -297,7 +297,7 @@ class TypeReconciliationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -318,7 +318,7 @@ class TypeReconciliationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
@@ -336,7 +336,7 @@ class TypeReconciliationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 
     public function testNotInstanceOf()
@@ -359,7 +359,7 @@ class TypeReconciliationTest extends PHPUnit_Framework_TestCase
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
         $context->vars_in_scope['$a'] = Type::parseString('A');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('null|A', (string) $context->vars_in_scope['$out']);
     }
 
@@ -388,7 +388,7 @@ class TypeReconciliationTest extends PHPUnit_Framework_TestCase
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
         $context->vars_in_scope['$a'] = Type::parseString('A');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('null|B', (string) $context->vars_in_scope['$out']);
     }
 
@@ -420,7 +420,7 @@ class TypeReconciliationTest extends PHPUnit_Framework_TestCase
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
         $context->vars_in_scope['$a'] = Type::parseString('A');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('null|B', (string) $context->vars_in_scope['$out']);
     }
 
@@ -434,7 +434,7 @@ class TypeReconciliationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
         $this->assertEquals('int', (string) $context->vars_in_scope['$b']);
         $this->assertEquals('string', (string) $context->vars_in_scope['$c']);
@@ -459,6 +459,6 @@ class TypeReconciliationTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -46,7 +46,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithTernaryGuard()
@@ -65,7 +65,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithTernaryIfNullGuard()
@@ -84,7 +84,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithTernaryEmptyGuard()
@@ -103,7 +103,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithTernaryIsNullGuard()
@@ -122,7 +122,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithIfGuard()
@@ -143,7 +143,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -166,7 +166,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithTernaryGuardWithThis()
@@ -189,7 +189,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithTernaryIfNullGuardWithThis()
@@ -212,7 +212,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithIfGuardWithThis()
@@ -238,7 +238,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -267,7 +267,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithExceptionThrown()
@@ -290,7 +290,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithRedefinitionAndElse()
@@ -319,7 +319,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -348,7 +348,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithBooleanIfGuard()
@@ -374,7 +374,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithNonNullBooleanIfGuard()
@@ -400,7 +400,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithNonNullBooleanIfGuardAndBooleanAnd()
@@ -426,7 +426,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
 
@@ -460,7 +460,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -491,7 +491,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithBooleanIfGuardBefore()
@@ -519,7 +519,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -550,7 +550,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedRedefinition()
@@ -573,7 +573,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedRedefinitionInElse()
@@ -599,7 +599,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -625,7 +625,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -660,7 +660,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedNestedRedefinition()
@@ -695,7 +695,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedSwitchRedefinition()
@@ -728,7 +728,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -760,7 +760,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -795,7 +795,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedSwitchRedefinitionDueToException()
@@ -829,7 +829,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedSwitchThatAlwaysReturns()
@@ -860,7 +860,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedNestedRedefinitionWithReturn()
@@ -891,7 +891,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedNestedRedefinitionWithElseReturn()
@@ -922,7 +922,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -959,7 +959,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedNestedRedefinitionWithElseifReturn()
@@ -993,7 +993,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedSwitchBreak()
@@ -1022,7 +1022,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullableMethodWithGuardedRedefinitionOnThis()
@@ -1050,7 +1050,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testArrayUnionTypeAssertion()
@@ -1066,7 +1066,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<empty, empty>', (string) $context->vars_in_scope['$ids']);
     }
 
@@ -1083,7 +1083,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('array<empty, empty>', (string) $context->vars_in_scope['$ids']);
     }
 
@@ -1109,7 +1109,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testVariableReassignmentInIf()
@@ -1136,7 +1136,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -1168,7 +1168,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testUnionTypeFlow()
@@ -1206,7 +1206,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testUnionTypeFlowWithThrow()
@@ -1230,7 +1230,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testUnionTypeFlowWithElseif()
@@ -1256,7 +1256,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -1277,7 +1277,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -1302,7 +1302,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testTypeAdjustment()
@@ -1318,7 +1318,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int|string', (string) $context->vars_in_scope['$var']);
     }
 
@@ -1337,7 +1337,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('int|string', (string) $context->vars_in_scope['$var']);
     }
 
@@ -1355,7 +1355,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
         $this->assertEquals('A|B', (string) $context->vars_in_scope['$var']);
     }
 
@@ -1380,7 +1380,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -1401,7 +1401,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testPassingParam()
@@ -1419,7 +1419,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullToNullableParam()
@@ -1437,7 +1437,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -1458,7 +1458,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testObjectToNullableObjectParam()
@@ -1476,7 +1476,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     /**
@@ -1502,7 +1502,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testParamCoercion()
@@ -1525,7 +1525,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testParamElseifCoercion()
@@ -1555,7 +1555,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
         ');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testAssignInsideForeach()
@@ -1572,7 +1572,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
 
         $this->assertSame('bool', (string) $context->vars_in_scope['$b']);
     }
@@ -1592,7 +1592,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
 
         $this->assertSame('bool', (string) $context->vars_in_scope['$b']);
     }
@@ -1628,7 +1628,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testNullCheckInsideForeachWithContinue()
@@ -1658,7 +1658,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testTypeRefinementWithIsNumeric()
@@ -1673,7 +1673,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods();
+        $file_checker->visitAndAnalyzeMethods();
     }
 
     public function testPlusPlus()
@@ -1685,7 +1685,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
 
         $this->assertSame('int', (string) $context->vars_in_scope['$a']);
     }
@@ -1706,6 +1706,6 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }');
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndCheckMethods($context);
+        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -12,6 +12,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
     /** @var \PhpParser\Parser */
     protected static $parser;
 
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
     public static function setUpBeforeClass()
     {
         self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
@@ -23,6 +26,7 @@ class TypeTest extends PHPUnit_Framework_TestCase
     public function setUp()
     {
         FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
     }
 
     /**
@@ -41,8 +45,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithTernaryGuard()
@@ -60,8 +64,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithTernaryIfNullGuard()
@@ -79,8 +83,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithTernaryEmptyGuard()
@@ -98,8 +102,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithTernaryIsNullGuard()
@@ -117,8 +121,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithIfGuard()
@@ -138,8 +142,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -161,8 +165,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithTernaryGuardWithThis()
@@ -184,8 +188,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithTernaryIfNullGuardWithThis()
@@ -207,8 +211,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithIfGuardWithThis()
@@ -233,8 +237,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -262,8 +266,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithExceptionThrown()
@@ -285,8 +289,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithRedefinitionAndElse()
@@ -314,8 +318,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -343,8 +347,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithBooleanIfGuard()
@@ -369,8 +373,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithNonNullBooleanIfGuard()
@@ -395,8 +399,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithNonNullBooleanIfGuardAndBooleanAnd()
@@ -421,8 +425,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
 
@@ -455,8 +459,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -486,8 +490,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithBooleanIfGuardBefore()
@@ -514,8 +518,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -545,8 +549,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedRedefinition()
@@ -568,8 +572,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedRedefinitionInElse()
@@ -594,8 +598,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -620,8 +624,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -655,8 +659,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedNestedRedefinition()
@@ -690,8 +694,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedSwitchRedefinition()
@@ -723,8 +727,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -755,8 +759,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -790,8 +794,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedSwitchRedefinitionDueToException()
@@ -824,8 +828,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedSwitchThatAlwaysReturns()
@@ -855,8 +859,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedNestedRedefinitionWithReturn()
@@ -886,8 +890,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedNestedRedefinitionWithElseReturn()
@@ -917,8 +921,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -954,8 +958,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedNestedRedefinitionWithElseifReturn()
@@ -988,8 +992,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedSwitchBreak()
@@ -1017,8 +1021,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullableMethodWithGuardedRedefinitionOnThis()
@@ -1045,8 +1049,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         }');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testArrayUnionTypeAssertion()
@@ -1060,9 +1064,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<empty, empty>', (string) $context->vars_in_scope['$ids']);
     }
 
@@ -1077,9 +1081,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
             }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('array<empty, empty>', (string) $context->vars_in_scope['$ids']);
     }
 
@@ -1104,8 +1108,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testVariableReassignmentInIf()
@@ -1131,8 +1135,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -1163,8 +1167,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testUnionTypeFlow()
@@ -1201,8 +1205,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testUnionTypeFlowWithThrow()
@@ -1225,8 +1229,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testUnionTypeFlowWithElseif()
@@ -1251,8 +1255,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -1272,8 +1276,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -1297,8 +1301,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testTypeAdjustment()
@@ -1312,9 +1316,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         echo $var;
         ');
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int|string', (string) $context->vars_in_scope['$var']);
     }
 
@@ -1331,9 +1335,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         echo $var;
         ');
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('int|string', (string) $context->vars_in_scope['$var']);
     }
 
@@ -1349,9 +1353,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
             $var = new B;
         }
         ');
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
         $this->assertEquals('A|B', (string) $context->vars_in_scope['$var']);
     }
 
@@ -1375,8 +1379,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -1396,8 +1400,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         $b->barBar(5);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testPassingParam()
@@ -1414,8 +1418,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         $b->barBar(new A);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullToNullableParam()
@@ -1432,8 +1436,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         $b->barBar(null);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -1453,8 +1457,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         $b->barBar(5);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testObjectToNullableObjectParam()
@@ -1471,8 +1475,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         $b->barBar(new A);
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     /**
@@ -1497,8 +1501,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testParamCoercion()
@@ -1520,8 +1524,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testParamElseifCoercion()
@@ -1550,8 +1554,8 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
-        $file_checker->check();
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testAssignInsideForeach()
@@ -1566,9 +1570,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
 
         $this->assertSame('bool', (string) $context->vars_in_scope['$b']);
     }
@@ -1586,9 +1590,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
 
         $this->assertSame('bool', (string) $context->vars_in_scope['$b']);
     }
@@ -1622,9 +1626,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check();
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testNullCheckInsideForeachWithContinue()
@@ -1652,9 +1656,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check();
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testTypeRefinementWithIsNumeric()
@@ -1667,9 +1671,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
         }
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check();
+        $file_checker->visitAndCheckMethods();
     }
 
     public function testPlusPlus()
@@ -1679,9 +1683,9 @@ class TypeTest extends PHPUnit_Framework_TestCase
         $b = $a++;
         ');
 
-        $file_checker = new FileChecker('somefile.php', $stmts);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context('somefile.php');
-        $file_checker->check(true, true, $context);
+        $file_checker->visitAndCheckMethods($context);
 
         $this->assertSame('int', (string) $context->vars_in_scope['$a']);
     }

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -1689,4 +1689,23 @@ class TypeTest extends PHPUnit_Framework_TestCase
 
         $this->assertSame('int', (string) $context->vars_in_scope['$a']);
     }
+
+    public function testTypedValueAssertion()
+    {
+        $context = new Context('somefile.php');
+        $stmts = self::$parser->parse('<?php
+        /**
+         * @param array|string $a
+         */
+        function fooFoo($a) : void {
+            $b = "aadad";
+
+            if ($a === $b) {
+                echo substr($a, 1);
+            }
+        }');
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndCheckMethods($context);
+    }
 }


### PR DESCRIPTION
Allows files with multiple classes to be checked in the order that PHP evaluates those classes (vs the order they're declared). Also improves the structure of the codebase, with better separation of concerns.

