### PR TITLE
Fixed Dependency Bounds

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
-        "nikic/PHP-Parser": ">=3.0.2"
+        "php": "^5.5 || ^7.0",
+        "nikic/PHP-Parser": "^3.0.2"
     },
     "bin": ["bin/psalm"],
     "autoload": {
@@ -25,7 +25,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": ">=5.7.4",
+        "phpunit/phpunit": "^5.7.4",
         "squizlabs/php_codesniffer": "^2.7"
     },
     "scripts": {


### PR DESCRIPTION
Current definition of dependencies would result in **any** version being installed that is greater than the one specified. This is problematic since new major releases imply breaking changes and nothing ensures that psalm will be compatible with those updated dependencies. Using an operator that instructs Composer to ensure that this does not happen is therefore inalienable.