### PR TITLE
Exception expose what line number

### DIFF
--- a/src/Psalm/Checker/CommentChecker.php
+++ b/src/Psalm/Checker/CommentChecker.php
@@ -21,6 +21,7 @@ class CommentChecker
      * @param  string           $var_id
      * @param  array<string, string>|null   $template_types
      * @param  int|null         $var_line_number
+     * @param  int|null         $came_from_line_number what line number in $source that $comment came from
      * @return Type\Union|null
      * @throws DocblockParseException If there was a problem parsing the docblock.
      * @psalm-suppress MixedArrayAccess
@@ -31,7 +32,8 @@ class CommentChecker
         StatementsSource $source,
         $var_id = null,
         array $template_types = null,
-        &$var_line_number = null
+        &$var_line_number = null,
+        $came_from_line_number = null
     ) {
         $type_in_comments_var_id = null;
 
@@ -86,6 +88,17 @@ class CommentChecker
         try {
             $defined_type = Type::parseString($type_in_comments);
         } catch (TypeParseTreeException $e) {
+            if (is_int($came_from_line_number)) {
+                throw new DocblockParseException(
+                    $type_in_comments .
+                    ' is not a valid type' .
+                    ' (from ' .
+                    $source->getCheckedFilePath() .
+                    ':' .
+                    $came_from_line_number .
+                    ')'
+                );
+            }
             throw new DocblockParseException($type_in_comments . ' is not a valid type');
         }
 

--- a/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
@@ -64,6 +64,7 @@ class AssignmentChecker
      * @param  Context                  $context
      * @param  string                   $doc_comment
      * @param  bool                     $by_reference
+     * @param  int|null                 $came_from_line_number
      * @return false|Type\Union
      */
     public static function analyze(
@@ -73,7 +74,8 @@ class AssignmentChecker
         Type\Union $assign_value_type = null,
         Context $context,
         $doc_comment,
-        $by_reference = false
+        $by_reference = false,
+        $came_from_line_number = null
     ) {
         $var_id = ExpressionChecker::getVarId(
             $assign_var,
@@ -88,11 +90,15 @@ class AssignmentChecker
         );
 
         if ($doc_comment) {
+            $null = null;
             $type_in_comments = CommentChecker::getTypeFromComment(
                 $doc_comment,
                 $context,
                 $statements_checker->getSource(),
-                $var_id
+                $var_id,
+                null,
+                $null,
+                $came_from_line_number
             );
         } else {
             $type_in_comments = null;

--- a/src/Psalm/Checker/Statements/ExpressionChecker.php
+++ b/src/Psalm/Checker/Statements/ExpressionChecker.php
@@ -89,7 +89,9 @@ class ExpressionChecker
                 $stmt->expr,
                 null,
                 $context,
-                (string)$stmt->getDocComment()
+                (string)$stmt->getDocComment(),
+                false,
+                $stmt->getLine()
             );
 
             if ($assignment_type === false) {


### PR DESCRIPTION
managed to trigger an exception while running psalm on nikic/FastRoute, but it wasn't clear what docblock the exception was originating on.

was:
> Fatal error: Uncaught Psalm\Exception\DocblockParseException: FastRoute\RouteParser\(array<mixed,mixed>FastRoute\RouteParser\)[] is not a valid type in D:\sites\github\FastRoute\vendor\vimeo\psalm\src\Psalm\Checker\CommentChecker.php:90

now:
> Fatal error: Uncaught Psalm\Exception\DocblockParseException: FastRoute\RouteParser\(array<mixed,mixed>FastRoute\RouteParser\)[] is not a valid type (from D:\sites\github\FastRoute\src\RouteParser\Std.php:43) in D:\sites\github\FastRoute\vendor\vimeo\psalm\src\Psalm\Checker\CommentChecker.php:92