### PR TITLE
`SimpleXMLElement::asXML` returns a `string|boolean`. 

### DIFF
--- a/src/Psalm/CallMap.php
+++ b/src/Psalm/CallMap.php
@@ -8062,7 +8062,7 @@ return [
 'similar_text' => ['int', 'str1'=>'string', 'str2'=>'string', 'percent='=>'float'],
 'SimpleXMLElement::addAttribute' => ['', 'qname'=>'string', 'value'=>'string', 'ns='=>'string'],
 'SimpleXMLElement::addChild' => ['SimpleXMLElement', 'qname'=>'string', 'value='=>'string', 'ns='=>'string'],
-'SimpleXMLElement::asXML' => ['string', 'filename='=>'string'],
+'SimpleXMLElement::asXML' => ['string|boolean', 'filename='=>'string'],
 'SimpleXMLElement::attributes' => ['array', 'ns='=>'string', 'is_prefix='=>'bool'],
 'SimpleXMLElement::children' => ['SimpleXMLElement', 'ns='=>'string', 'is_prefix='=>'bool'],
 'SimpleXMLElement::__construct' => ['SimpleXMLElement', 'data'=>'string', 'options='=>'int', 'data_is_url='=>'bool', 'ns='=>'string', 'is_prefix='=>'bool'],


### PR DESCRIPTION
This updates the callmap for `SimpleXMLElement::asXML` to reflect it returning a `string|boolean` and not just `string`.

Resolves. #145