### PR TITLE
Rewriting and streamlining every unit test with data providers.

### DIFF
--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1,218 +1,13 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
-use Psalm\Config;
 use Psalm\Context;
 
-class AnnotationTest extends PHPUnit_Framework_TestCase
+class AnnotationTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testDeprecatedMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            /**
-             * @deprecated
-             */
-            public static function barBar() : void {
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage DeprecatedMethod
-     * @return                   void
-     */
-    public function testDeprecatedMethodWithCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            /**
-             * @deprecated
-             */
-            public static function barBar() : void {
-            }
-        }
-
-        Foo::barBar();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidDocblock
-     * @return                   void
-     */
-    public function testInvalidDocblockParam()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param int $bar
-         */
-        function fooFoo(array $bar) : void {
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidDocblock - somefile.php:3 - Parameter $bar does not appear in the argument list for fooBar
-     * @return                   void
-     */
-    public function testExtraneousDocblockParam()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param int $bar
-         */
-        function fooBar() : void {
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidDocblock - somefile.php:3 - Parameter $bar does not appear in the argument list for fooBar
-     * @return                   void
-     */
-    public function testMissingParamType()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param $bar
-         */
-        function fooBar() : void {
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidDocblock - somefile.php:5 - Badly-formatted @param in docblock for fooBar
-     * @return                   void
-     */
-    public function testMissingParamVar()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param string
-         */
-        function fooBar() : void {
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidDocblock
-     * @return                   void
-     */
-    public function testInvalidDocblockReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @return string
-         */
-        function fooFoo() : void {
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testValidDocblockReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @return string
-         */
-        function fooFoo() : string {
-            return "boop";
-        }
-
-        /**
-         * @return array<int, string>
-         */
-        function foo2() : array {
-            return ["hello"];
-        }
-
-        /**
-         * @return array<int, string>
-         */
-        function foo3() : array {
-            return ["hello"];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
      * @return void
@@ -232,109 +27,170 @@ class AnnotationTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testReassertWithIs()
+    public function providerFileCheckerValidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        /** @param array $a */
-        function foo($a) : void {
-            if (is_array($a)) {
-                // do something
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'deprecated-method' => [
+                '<?php
+                    class Foo {
+                        /**
+                         * @deprecated
+                         */
+                        public static function barBar() : void {
+                        }
+                    }'
+            ],
+            'valid-docblock-return' => [
+                '<?php
+                    /**
+                     * @return string
+                     */
+                    function fooFoo() : string {
+                        return "boop";
+                    }
+            
+                    /**
+                     * @return array<int, string>
+                     */
+                    function foo2() : array {
+                        return ["hello"];
+                    }
+            
+                    /**
+                     * @return array<int, string>
+                     */
+                    function foo3() : array {
+                        return ["hello"];
+                    }'
+            ],
+            'reassert-with-is' => [
+                '<?php
+                    /** @param array $a */
+                    function foo($a) : void {
+                        if (is_array($a)) {
+                            // do something
+                        }
+                    }'
+            ],
+            'check-array-with-is' => [
+                '<?php
+                    /** @param mixed $b */
+                    function foo($b) : void {
+                        /** @var array */
+                        $a = (array)$b;
+                        if (is_array($a)) {
+                            // do something
+                        }
+                    }'
+            ],
+            'check-array-with-is-inside-loop' => [
+                '<?php
+                    /** @param array<mixed, array<mixed, mixed>> $data */
+                    function foo($data) : void {
+                        foreach ($data as $key => $val) {
+                            if (!\is_array($data)) {
+                                $data = [$key => null];
+                            } else {
+                                $data[$key] = !empty($val);
+                            }
+                        }
+                    }'
+            ],
+            'good-docblock' => [
+                '<?php
+                    class A {
+                        /**
+                         * @param A $a
+                         * @param bool $b
+                         */
+                        public function g(A $a, $b) : void {
+                        }
+                    }'
+            ],
+            'good-docblock-in-namespace' => [
+                '<?php
+                    namespace Foo;
+            
+                    class A {
+                        /**
+                         * @param \Foo\A $a
+                         * @param bool $b
+                         */
+                        public function g(A $a, $b) : void {
+                        }
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testCheckArrayWithIs()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        /** @param mixed $b */
-        function foo($b) : void {
-            /** @var array */
-            $a = (array)$b;
-            if (is_array($a)) {
-                // do something
-            }
-        }
-        ');
+        return [
+            'deprecated-method-with-call' => [
+                '<?php
+                    class Foo {
+                        /**
+                         * @deprecated
+                         */
+                        public static function barBar() : void {
+                        }
+                    }
 
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testCheckArrayWithIsInsideLoop()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @param array<mixed, array<mixed, mixed>> $data */
-        function foo($data) : void {
-            foreach ($data as $key => $val) {
-                if (!\is_array($data)) {
-                    $data = [$key => null];
-                } else {
-                    $data[$key] = !empty($val);
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGoodDocblock()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /**
-             * @param A $a
-             * @param bool $b
-             */
-            public function g(A $a, $b) : void {
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGoodDocblockInNamespace()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Foo;
-
-        class A {
-            /**
-             * @param \Foo\A $a
-             * @param bool $b
-             */
-            public function g(A $a, $b) : void {
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+                    Foo::barBar();',
+                'error_message' => 'DeprecatedMethod'
+            ],
+            'invalid-docblock-param' => [
+                '<?php
+                    /**
+                     * @param int $bar
+                     */
+                    function fooFoo(array $bar) : void {
+                    }',
+                'error_message' => 'InvalidDocblock'
+            ],
+            'extraneous-docblock-param' => [
+                '<?php
+                    /**
+                     * @param int $bar
+                     */
+                    function fooBar() : void {
+                    }',
+                'error_message' => 'InvalidDocblock - somefile.php:3 - Parameter $bar does not appear in the ' .
+                    'argument list for fooBar'
+            ],
+            'missing-param-type' => [
+                '<?php
+                    /**
+                     * @param $bar
+                     */
+                    function fooBar() : void {
+                    }',
+                'error_message' => 'InvalidDocblock - somefile.php:3 - Parameter $bar does not appear in the ' .
+                    'argument list for fooBar'
+            ],
+            'missing-param-var' => [
+                '<?php
+                    /**
+                     * @param string
+                     */
+                    function fooBar() : void {
+                    }',
+                'error_message' => 'InvalidDocblock - somefile.php:5 - Badly-formatted @param in docblock for fooBar'
+            ],
+            'invalid-docblock-return' => [
+                '<?php
+                    /**
+                     * @return string
+                     */
+                    function fooFoo() : void {
+                    }',
+                'error_message' => 'InvalidDocblock'
+            ]
+        ];
     }
 }

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -32,7 +32,7 @@ class AnnotationTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'deprecated-method' => [
+            'deprecatedMethod' => [
                 '<?php
                     class Foo {
                         /**
@@ -42,7 +42,7 @@ class AnnotationTest extends TestCase
                         }
                     }'
             ],
-            'valid-docblock-return' => [
+            'validDocblockReturn' => [
                 '<?php
                     /**
                      * @return string
@@ -65,7 +65,7 @@ class AnnotationTest extends TestCase
                         return ["hello"];
                     }'
             ],
-            'reassert-with-is' => [
+            'reassertWithIs' => [
                 '<?php
                     /** @param array $a */
                     function foo($a) : void {
@@ -74,7 +74,7 @@ class AnnotationTest extends TestCase
                         }
                     }'
             ],
-            'check-array-with-is' => [
+            'checkArrayWithIs' => [
                 '<?php
                     /** @param mixed $b */
                     function foo($b) : void {
@@ -85,7 +85,7 @@ class AnnotationTest extends TestCase
                         }
                     }'
             ],
-            'check-array-with-is-inside-loop' => [
+            'checkArrayWithIsInsideLoop' => [
                 '<?php
                     /** @param array<mixed, array<mixed, mixed>> $data */
                     function foo($data) : void {
@@ -98,7 +98,7 @@ class AnnotationTest extends TestCase
                         }
                     }'
             ],
-            'good-docblock' => [
+            'goodDocblock' => [
                 '<?php
                     class A {
                         /**
@@ -109,7 +109,7 @@ class AnnotationTest extends TestCase
                         }
                     }'
             ],
-            'good-docblock-in-namespace' => [
+            'goodDocblockInNamespace' => [
                 '<?php
                     namespace Foo;
             
@@ -131,7 +131,7 @@ class AnnotationTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'deprecated-method-with-call' => [
+            'deprecatedMethodWithCall' => [
                 '<?php
                     class Foo {
                         /**
@@ -144,7 +144,7 @@ class AnnotationTest extends TestCase
                     Foo::barBar();',
                 'error_message' => 'DeprecatedMethod'
             ],
-            'invalid-docblock-param' => [
+            'invalidDocblockParam' => [
                 '<?php
                     /**
                      * @param int $bar
@@ -153,7 +153,7 @@ class AnnotationTest extends TestCase
                     }',
                 'error_message' => 'InvalidDocblock'
             ],
-            'extraneous-docblock-param' => [
+            'extraneousDocblockParam' => [
                 '<?php
                     /**
                      * @param int $bar
@@ -163,7 +163,7 @@ class AnnotationTest extends TestCase
                 'error_message' => 'InvalidDocblock - somefile.php:3 - Parameter $bar does not appear in the ' .
                     'argument list for fooBar'
             ],
-            'missing-param-type' => [
+            'missingParamType' => [
                 '<?php
                     /**
                      * @param $bar
@@ -173,7 +173,7 @@ class AnnotationTest extends TestCase
                 'error_message' => 'InvalidDocblock - somefile.php:3 - Parameter $bar does not appear in the ' .
                     'argument list for fooBar'
             ],
-            'missing-param-var' => [
+            'missingParamVar' => [
                 '<?php
                     /**
                      * @param string
@@ -182,7 +182,7 @@ class AnnotationTest extends TestCase
                     }',
                 'error_message' => 'InvalidDocblock - somefile.php:5 - Badly-formatted @param in docblock for fooBar'
             ],
-            'invalid-docblock-return' => [
+            'invalidDocblockReturn' => [
                 '<?php
                     /**
                      * @return string

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -12,7 +12,7 @@ class ArgTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'call-map-class-optional-arg' => [
+            'callMapClassOptionalArg' => [
                 '<?php
                     $m = new ReflectionMethod("hello", "goodbye");
                     $m->invoke("cool");'
@@ -26,7 +26,7 @@ class ArgTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'possibly-invalid-argument' => [
+            'possiblyInvalidArgument' => [
                 '<?php
                     $foo = [
                         "a",

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -1,80 +1,46 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ArgTest extends PHPUnit_Framework_TestCase
+class ArgTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testCallMapClassOptionalArg()
-    {
-        $stmts = self::$parser->parse('<?php
-        $m = new ReflectionMethod("hello", "goodbye");
-        $m->invoke("cool");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyInvalidArgument
-     * @return                   void
-     */
-    public function testPossiblyInvalidArgument()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [
-            "a",
-            ["b"],
+        return [
+            'call-map-class-optional-arg' => [
+                '<?php
+                    $m = new ReflectionMethod("hello", "goodbye");
+                    $m->invoke("cool");'
+            ]
         ];
+    }
 
-        $a = array_map(
-            function (string $uuid) : string {
-                return $uuid;
-            },
-            $foo[rand(0, 1)]
-        );
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+    /**
+     * @return array
+     */
+    public function providerFileCheckerInvalidCodeParse()
+    {
+        return [
+            'possibly-invalid-argument' => [
+                '<?php
+                    $foo = [
+                        "a",
+                        ["b"],
+                    ];
+            
+                    $a = array_map(
+                        function (string $uuid) : string {
+                            return $uuid;
+                        },
+                        $foo[rand(0, 1)]
+                    );',
+                'error_message' => 'PossiblyInvalidArgument'
+            ]
+        ];
     }
 }

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -1,230 +1,115 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ArrayAccessTest extends PHPUnit_Framework_TestCase
+class ArrayAccessTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        return [
+            'instance-of-string-offset' => [
+                '<?php
+                    class A {
+                        public function fooFoo() : void { }
+                    }
+                    function bar (array $a) : void {
+                        if ($a["a"] instanceof A) {
+                            $a["a"]->fooFoo();
+                        }
+                    }'
+            ],
+            'instance-of-int-offset' => [
+                '<?php
+                    class A {
+                        public function fooFoo() : void { }
+                    }
+                    function bar (array $a) : void {
+                        if ($a[0] instanceof A) {
+                            $a[0]->fooFoo();
+                        }
+                    }'
+            ],
+            'not-empty-string-offset' => [
+                '<?php
+                    /**
+                     * @param  array<string>  $a
+                     */
+                    function bar (array $a) : string {
+                        if ($a["bat"]) {
+                            return $a["bat"];
+                        }
+            
+                        return "blah";
+                    }'
+            ],
+            'not-empty-int-offset' => [
+                '<?php
+                    /**
+                     * @param  array<string>  $a
+                     */
+                    function bar (array $a) : string {
+                        if ($a[0]) {
+                            return $a[0];
+                        }
+            
+                        return "blah";
+                    }'
+            ],
+            'ignore-possibly-null-array-access' => [
+                '<?php
+                    $a = rand(0, 1) ? [1, 2] : null;
+                    echo $a[0];',
+                'assertions' => [],
+                'error_levels' => ['PossiblyNullArrayAccess']
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testInstanceOfStringOffset()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo() : void { }
-        }
-        function bar (array $a) : void {
-            if ($a["a"] instanceof A) {
-                $a["a"]->fooFoo();
-            }
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testInstanceOfIntOffset()
-    {
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo() : void { }
-        }
-        function bar (array $a) : void {
-            if ($a[0] instanceof A) {
-                $a[0]->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNotEmptyStringOffset()
-    {
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param  array<string>  $a
-         */
-        function bar (array $a) : string {
-            if ($a["bat"]) {
-                return $a["bat"];
-            }
-
-            return "blah";
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNotEmptyIntOffset()
-    {
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param  array<string>  $a
-         */
-        function bar (array $a) : string {
-            if ($a[0]) {
-                return $a[0];
-            }
-
-            return "blah";
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidArrayAccess
-     * @return                   void
-     */
-    public function testInvalidArrayAccess()
-    {
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        $a = 5;
-        echo $a[0];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MixedArrayAccess
-     * @return                   void
-     */
-    public function testMixedArrayAccess()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        /** @var mixed */
-        $a = [];
-        echo $a[0];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MixedArrayOffset
-     * @return                   void
-     */
-    public function testMixedArrayOffset()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        /** @var mixed */
-        $a = 5;
-        echo [1, 2, 3, 4][$a];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage NullArrayAccess
-     * @return                   void
-     */
-    public function testNullArrayAccess()
-    {
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        $a = null;
-        echo $a[0];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyNullArrayAccess
-     * @return                   void
-     */
-    public function testPossiblyNullArrayAccess()
-    {
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        $a = rand(0, 1) ? [1, 2] : null;
-        echo $a[0];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIgnorePossiblyNullArrayAccess()
-    {
-        Config::getInstance()->setCustomErrorLevel('PossiblyNullArrayAccess', Config::REPORT_SUPPRESS);
-
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        $a = rand(0, 1) ? [1, 2] : null;
-        echo $a[0];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'invalid-array-access' => [
+                '<?php
+                    $a = 5;
+                    echo $a[0];',
+                'error_message' => 'InvalidArrayAccess'
+            ],
+            'mixed-array-access' => [
+                '<?php
+                    /** @var mixed */
+                    $a = [];
+                    echo $a[0];',
+                'error_message' => 'MixedArrayAccess',
+                'error_level' => ['MixedAssignment']
+            ],
+            'mixed-array-offset' => [
+                '<?php
+                    /** @var mixed */
+                    $a = 5;
+                    echo [1, 2, 3, 4][$a];',
+                'error_message' => 'MixedArrayOffset',
+                'error_level' => ['MixedAssignment']
+            ],
+            'null-array-access' => [
+                '<?php
+                    $a = null;
+                    echo $a[0];',
+                'error_message' => 'NullArrayAccess'
+            ],
+            'possibly-null-array-access' => [
+                '<?php
+                    $a = rand(0, 1) ? [1, 2] : null;
+                    echo $a[0];',
+                'error_message' => 'PossiblyNullArrayAccess'
+            ]
+        ];
     }
 }

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -12,7 +12,7 @@ class ArrayAccessTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'instance-of-string-offset' => [
+            'instanceOfStringOffset' => [
                 '<?php
                     class A {
                         public function fooFoo() : void { }
@@ -23,7 +23,7 @@ class ArrayAccessTest extends TestCase
                         }
                     }'
             ],
-            'instance-of-int-offset' => [
+            'instanceOfIntOffset' => [
                 '<?php
                     class A {
                         public function fooFoo() : void { }
@@ -34,7 +34,7 @@ class ArrayAccessTest extends TestCase
                         }
                     }'
             ],
-            'not-empty-string-offset' => [
+            'notEmptyStringOffset' => [
                 '<?php
                     /**
                      * @param  array<string>  $a
@@ -47,7 +47,7 @@ class ArrayAccessTest extends TestCase
                         return "blah";
                     }'
             ],
-            'not-empty-int-offset' => [
+            'notEmptyIntOffset' => [
                 '<?php
                     /**
                      * @param  array<string>  $a
@@ -60,7 +60,7 @@ class ArrayAccessTest extends TestCase
                         return "blah";
                     }'
             ],
-            'ignore-possibly-null-array-access' => [
+            'ignorePossiblyNullArrayAccess' => [
                 '<?php
                     $a = rand(0, 1) ? [1, 2] : null;
                     echo $a[0];',
@@ -76,13 +76,13 @@ class ArrayAccessTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'invalid-array-access' => [
+            'invalidArrayAccess' => [
                 '<?php
                     $a = 5;
                     echo $a[0];',
                 'error_message' => 'InvalidArrayAccess'
             ],
-            'mixed-array-access' => [
+            'mixedArrayAccess' => [
                 '<?php
                     /** @var mixed */
                     $a = [];
@@ -90,7 +90,7 @@ class ArrayAccessTest extends TestCase
                 'error_message' => 'MixedArrayAccess',
                 'error_level' => ['MixedAssignment']
             ],
-            'mixed-array-offset' => [
+            'mixedArrayOffset' => [
                 '<?php
                     /** @var mixed */
                     $a = 5;
@@ -98,13 +98,13 @@ class ArrayAccessTest extends TestCase
                 'error_message' => 'MixedArrayOffset',
                 'error_level' => ['MixedAssignment']
             ],
-            'null-array-access' => [
+            'nullArrayAccess' => [
                 '<?php
                     $a = null;
                     echo $a[0];',
                 'error_message' => 'NullArrayAccess'
             ],
-            'possibly-null-array-access' => [
+            'possiblyNullArrayAccess' => [
                 '<?php
                     $a = rand(0, 1) ? [1, 2] : null;
                     echo $a[0];',

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -70,7 +70,7 @@ class ArrayAssignmentTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'generic-array-creation' => [
+            'genericArrayCreation' => [
                 '<?php
                     $out = [];
             
@@ -81,7 +81,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, int>' => '$out']
                 ]
             ],
-            'generic-2d-array-creation' => [
+            'generic2dArrayCreation' => [
                 '<?php
                     $out = [];
             
@@ -92,7 +92,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, array<int, int>>' => '$out']
                 ]
             ],
-            'generic-2d-array-creation-added-in-if' => [
+            'generic2dArrayCreationAddedInIf' => [
                 '<?php
                     $out = [];
             
@@ -114,7 +114,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, array<int, int>>' => '$out']
                 ]
             ],
-            'generic-array-creation-with-object-added-in-if' => [
+            'genericArrayCreationWithObjectAddedInIf' => [
                 '<?php
                     class B {}
             
@@ -127,7 +127,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, B>' => '$out']
                 ]
             ],
-            'generic-array-creation-with-element-added-in-switch' => [
+            'genericArrayCreationWithElementAddedInSwitch' => [
                 '<?php
                     $out = [];
             
@@ -143,7 +143,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, int>' => '$out']
                 ]
             ],
-            'generic-array-creation-with-elements-added-in-switch' => [
+            'genericArrayCreationWithElementsAddedInSwitch' => [
                 '<?php
                     $out = [];
             
@@ -160,7 +160,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, int|string>' => '$out']
                 ]
             ],
-            'generic-array-creation-with-elements-added-in-switch-with-nothing' => [
+            'genericArrayCreationWithElementsAddedInSwitchWithNothing' => [
                 '<?php
                     $out = [];
             
@@ -180,7 +180,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, int|string>' => '$out']
                 ]
             ],
-            'implicit-int-array-creation' => [
+            'implicitIntArrayCreation' => [
                 '<?php
                     $foo = [];
                     $foo[] = "hello";',
@@ -188,7 +188,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, string>' => '$foo']
                 ]
             ],
-            'implicit-2d-int-array-creation' => [
+            'implicit2dIntArrayCreation' => [
                 '<?php
                     $foo = [];
                     $foo[][] = "hello";',
@@ -196,7 +196,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, array<int, string>>' => '$foo']
                 ]
             ],
-            'implicit-3d-int-array-creation' => [
+            'implicit3dIntArrayCreation' => [
                 '<?php
                     $foo = [];
                     $foo[][][] = "hello";',
@@ -204,7 +204,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, array<int, array<int, string>>>' => '$foo']
                 ]
             ],
-            'implicit-4d-int-array-creation' => [
+            'implicit4dIntArrayCreation' => [
                 '<?php
                     $foo = [];
                     $foo[][][][] = "hello";',
@@ -212,7 +212,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, array<int, array<int, array<int, string>>>>' => '$foo']
                 ]
             ],
-            'implicit-indexed-int-array-creation' => [
+            'implicitIndexedIntArrayCreation' => [
                 '<?php
                     $foo = [];
                     $foo[0] = "hello";
@@ -232,7 +232,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<string, int>' => '$bat']
                 ]
             ],
-            'implicit-string-array-creation' => [
+            'implicitStringArrayCreation' => [
                 '<?php
                     $foo = [];
                     $foo["bar"] = "hello";',
@@ -241,7 +241,7 @@ class ArrayAssignmentTest extends TestCase
                     ['string' => '$foo[\'bar\']']
                 ]
             ],
-            'implicit-2d-string-array-creation' => [
+            'implicit2dStringArrayCreation' => [
                 '<?php
                     $foo = [];
                     $foo["bar"]["baz"] = "hello";',
@@ -250,7 +250,7 @@ class ArrayAssignmentTest extends TestCase
                     ['string' => '$foo[\'bar\'][\'baz\']']
                 ]
             ],
-            'implicit-3d-string-array-creation' => [
+            'implicit3dStringArrayCreation' => [
                 '<?php
                     $foo = [];
                     $foo["bar"]["baz"]["bat"] = "hello";',
@@ -259,7 +259,7 @@ class ArrayAssignmentTest extends TestCase
                     ['string' => '$foo[\'bar\'][\'baz\'][\'bat\']']
                 ]
             ],
-            'implicit-4d-string-array-creation' => [
+            'implicit4dStringArrayCreation' => [
                 '<?php
                     $foo = [];
                     $foo["bar"]["baz"]["bat"]["bap"] = "hello";',
@@ -268,7 +268,7 @@ class ArrayAssignmentTest extends TestCase
                     ['string' => '$foo[\'bar\'][\'baz\'][\'bat\'][\'bap\']']
                 ]
             ],
-            '2-step-2d-string-array-creation' => [
+            '2Step2dStringArrayCreation' => [
                 '<?php
                     $foo = ["bar" => []];
                     $foo["bar"]["baz"] = "hello";',
@@ -277,7 +277,7 @@ class ArrayAssignmentTest extends TestCase
                     ['string' => '$foo[\'bar\'][\'baz\']']
                 ]
             ],
-            '2-step-implicit-3d-string-array-creation' => [
+            '2StepImplicit3dStringArrayCreation' => [
                 '<?php
                     $foo = ["bar" => []];
                     $foo["bar"]["baz"]["bat"] = "hello";',
@@ -285,7 +285,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array{bar:array{baz:array{bat:string}}}' => '$foo']
                 ]
             ],
-            'conflicting-types' => [
+            'conflictingTypes' => [
                 '<?php
                     $foo = [
                         "bar" => ["a" => "b"],
@@ -295,7 +295,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array{bar:array{a:string}, baz:array<int, int>}' => '$foo']
                 ]
             ],
-            'implicit-object-like-creation' => [
+            'implicitObjectLikeCreation' => [
                 '<?php
                     $foo = [
                         "bar" => 1,
@@ -305,7 +305,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array{bar:int, baz:string}' => '$foo']
                 ]
             ],
-            'conflicting-types-with-assignment' => [
+            'conflictingTypesWithAssignment' => [
                 '<?php
                     $foo = [
                         "bar" => ["a" => "b"],
@@ -316,7 +316,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array{bar:array{a:string, bam:array{baz:string}}, baz:array<int, int>}' => '$foo']
                 ]
             ],
-            'conflicting-types-with-assignment-2' => [
+            'conflictingTypesWithAssignment2' => [
                 '<?php
                     $foo = [];
                     $foo["a"] = "hello";
@@ -329,7 +329,7 @@ class ArrayAssignmentTest extends TestCase
                     ['string' => '$bar']
                 ]
             ],
-            'conflicting-types-with-assignment-3' => [
+            'conflictingTypesWithAssignment3' => [
                 '<?php
                     $foo = [];
                     $foo["a"] = "hello";
@@ -338,7 +338,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array{a:string, b:array{c:array{d:string}}}' => '$foo']
                 ]
             ],
-            'nested-object-like-assignment' => [
+            'nestedObjectLikeAssignment' => [
                 '<?php
                     $foo = [];
                     $foo["a"]["b"] = "hello";
@@ -347,7 +347,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array{a:array{b:string, c:int}}' => '$foo']
                 ]
             ],
-            'conditional-object-like-assignment' => [
+            'conditionalObjectLikeAssignment' => [
                 '<?php
                     $foo = ["a" => "hello"];
                     if (rand(0, 10) === 5) {
@@ -360,7 +360,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array{a:string, b:int}' => '$foo']
                 ]
             ],
-            'array-key' => [
+            'arrayKey' => [
                 '<?php
                     $a = ["foo", "bar"];
                     $b = $a[0];
@@ -373,7 +373,7 @@ class ArrayAssignmentTest extends TestCase
                     ['string' => '$e']
                 ]
             ],
-            'conditional-check' => [
+            'conditionalCheck' => [
                 '<?php
                     /**
                      * @param  array{b:string} $a
@@ -386,7 +386,7 @@ class ArrayAssignmentTest extends TestCase
                     }',
                 'assertions' => []
             ],
-            'variable-key-array-create' => [
+            'variableKeyArrayCreate' => [
                 '<?php
                     $a = [];
                     $b = "boop";
@@ -399,7 +399,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<string, array<string, array<int, string>>>' => '$c']
                 ]
             ],
-            'assign-explicit-value-to-generic' => [
+            'assignExplicitValueToGeneric' => [
                 '<?php
                     /** @var array<string, array<string, string>> */
                     $a = [];
@@ -408,7 +408,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<string, array<string, string>>' => '$a']
                 ]
             ],
-            'addition-with-empty' => [
+            'additionWithEmpty' => [
                 '<?php
                     $a = [];
                     $a += ["bar"];
@@ -419,7 +419,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, string>' => '$b']
                 ]
             ],
-            'addition-different-type' => [
+            'additionDifferentType' => [
                 '<?php
                     $a = ["bar"];
                     $a += [1];
@@ -430,7 +430,7 @@ class ArrayAssignmentTest extends TestCase
                     ['array<int, string|int>' => '$b']
                 ]
             ],
-            'present-1d-array-type-with-var-keys' => [
+            'present1dArrayTypeWithVarKeys' => [
                 '<?php
                     /** @var array<string, array<int, string>> */
                     $a = [];
@@ -440,7 +440,7 @@ class ArrayAssignmentTest extends TestCase
                     $a[$foo][] = "bat";',
                 'assertions' => []
             ],
-            'present-2d-array-type-with-var-keys' => [
+            'present2dArrayTypeWithVarKeys' => [
                 '<?php
                     /** @var array<string, array<string, array<int, string>>> */
                     $b = [];
@@ -451,7 +451,7 @@ class ArrayAssignmentTest extends TestCase
                     $b[$foo][$bar][] = "bat";',
                 'assertions' => []
             ],
-            'object-like-with-integer-keys' => [
+            'objectLikeWithIntegerKeys' => [
                 '<?php
                     /** @var array{0: string, 1: int} **/
                     $a = ["hello", 5];
@@ -474,19 +474,19 @@ class ArrayAssignmentTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'object-assignment' => [
+            'objectAssignment' => [
                 '<?php
                     class A {}
                     (new A)["b"] = 1;',
                 'error_message' => 'InvalidArrayAssignment'
             ],
-            'invalid-array-access' => [
+            'invalidArrayAccess' => [
                 '<?php
                     $a = 5;
                     $a[0] = 5;',
                 'error_message' => 'InvalidArrayAssignment'
             ],
-            'mixed-string-offset-assignment' => [
+            'mixedStringOffsetAssignment' => [
                 '<?php
                     /** @var mixed */
                     $a = 5;
@@ -494,7 +494,7 @@ class ArrayAssignmentTest extends TestCase
                 'error_message' => 'MixedStringOffsetAssignment',
                 'error_level' => ['MixedAssignment']
             ],
-            'mixed-array-argument' => [
+            'mixedArrayArgument' => [
                 '<?php
                     /** @param array<mixed, int|string> $foo */
                     function fooFoo(array $foo) : void { }
@@ -507,7 +507,7 @@ class ArrayAssignmentTest extends TestCase
                 'error_message' => 'TypeCoercion',
                 'error_level' => ['MixedAssignment']
             ],
-            'array-property-assignment' => [
+            'arrayPropertyAssignment' => [
                 '<?php
                     class A {
                         /** @var string[] */
@@ -520,7 +520,7 @@ class ArrayAssignmentTest extends TestCase
                     }',
                 'error_message' => 'InvalidPropertyAssignment'
             ],
-            'incremental-array-property-assignment' => [
+            'incrementalArrayPropertyAssignment' => [
                 '<?php
                     class A {
                         /** @var string[] */

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1,543 +1,13 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
-use Psalm\Config;
 use Psalm\Context;
-use Psalm\Type;
 
-class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
+class ArrayAssignmentTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        \Psalm\Checker\FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testGenericArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $out = [];
-
-        foreach ([1, 2, 3, 4, 5] as $value) {
-            $out[] = 4;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$out']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGeneric2DArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $out = [];
-
-        foreach ([1, 2, 3, 4, 5] as $value) {
-            $out[] = [4];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, array<int, int>>', (string) $context->vars_in_scope['$out']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGeneric2DArrayCreationAddedInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        $out = [];
-
-        $bits = [];
-
-        foreach ([1, 2, 3, 4, 5] as $value) {
-            if (rand(0,100) > 50) {
-                $out[] = $bits;
-                $bits = [];
-            }
-
-            $bits[] = 4;
-        }
-
-        if ($bits) {
-            $out[] = $bits;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, array<int, int>>', (string) $context->vars_in_scope['$out']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGenericArrayCreationWithObjectAddedInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B {}
-
-        $out = [];
-
-        if (rand(0,10) === 10) {
-            $out[] = new B();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, B>', (string) $context->vars_in_scope['$out']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGenericArrayCreationWithElementAddedInSwitch()
-    {
-        $stmts = self::$parser->parse('<?php
-        $out = [];
-
-        switch (rand(0,10)) {
-            case 5:
-                $out[] = 4;
-                break;
-
-            case 6:
-                // do nothing
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$out']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGenericArrayCreationWithElementsAddedInSwitch()
-    {
-        $stmts = self::$parser->parse('<?php
-        $out = [];
-
-        switch (rand(0,10)) {
-            case 5:
-                $out[] = 4;
-                break;
-
-            case 6:
-                $out[] = "hello";
-                break;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, int|string>', (string) $context->vars_in_scope['$out']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGenericArrayCreationWithElementsAddedInSwitchWithNothing()
-    {
-        $stmts = self::$parser->parse('<?php
-        $out = [];
-
-        switch (rand(0,10)) {
-            case 5:
-                $out[] = 4;
-                break;
-
-            case 6:
-                $out[] = "hello";
-                break;
-
-            case 7:
-                // do nothing
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, int|string>', (string) $context->vars_in_scope['$out']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicitIntArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo[] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$foo']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicit2DIntArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo[][] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, array<int, string>>', (string) $context->vars_in_scope['$foo']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicit3DIntArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo[][][] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, array<int, array<int, string>>>', (string) $context->vars_in_scope['$foo']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicit4DIntArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo[][][][] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals(
-            'array<int, array<int, array<int, array<int, string>>>>',
-            (string) $context->vars_in_scope['$foo']
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicitIndexedIntArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo[0] = "hello";
-        $foo[1] = "hello";
-        $foo[2] = "hello";
-
-        $bar = [0, 1, 2];
-
-        $bat = [];
-
-        foreach ($foo as $i => $text) {
-            $bat[$text] = $bar[$i];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$foo']);
-        $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$bar']);
-        $this->assertEquals('array<string, int>', (string) $context->vars_in_scope['$bat']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicitStringArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo["bar"] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{bar:string}', (string) $context->vars_in_scope['$foo']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\']']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicit2DStringArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo["bar"]["baz"] = "hello";
-        ');
-
-        // check array access of baz on foo
-        // with some extra data – if we need to create an array for type $foo["bar"],
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{bar:array{baz:string}}', (string) $context->vars_in_scope['$foo']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\']']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicit3DStringArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo["bar"]["baz"]["bat"] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{bar:array{baz:array{bat:string}}}', (string) $context->vars_in_scope['$foo']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\'][\'bat\']']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicit4DStringArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo["bar"]["baz"]["bat"]["bap"] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals(
-            'array{bar:array{baz:array{bat:array{bap:string}}}}',
-            (string) $context->vars_in_scope['$foo']
-        );
-
-        $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\'][\'bat\'][\'bap\']']);
-    }
-
-    /**
-     * @return void
-     */
-    public function test2Step2DStringArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = ["bar" => []];
-        $foo["bar"]["baz"] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{bar:array{baz:string}}', (string) $context->vars_in_scope['$foo']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'bar\'][\'baz\']']);
-    }
-
-    /**
-     * @return void
-     */
-    public function test2StepImplicit3DStringArrayCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = ["bar" => []];
-        $foo["bar"]["baz"]["bat"] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{bar:array{baz:array{bat:string}}}', (string) $context->vars_in_scope['$foo']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConflictingTypes()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [
-            "bar" => ["a" => "b"],
-            "baz" => [1]
-        ];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{bar:array{a:string}, baz:array<int, int>}', (string) $context->vars_in_scope['$foo']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicitObjectLikeCreation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [
-            "bar" => 1,
-        ];
-        $foo["baz"] = "a";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{bar:int, baz:string}', (string) $context->vars_in_scope['$foo']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConflictingTypesWithAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [
-            "bar" => ["a" => "b"],
-            "baz" => [1]
-        ];
-        $foo["bar"]["bam"]["baz"] = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals(
-            'array{bar:array{a:string, bam:array{baz:string}}, baz:array<int, int>}',
-            (string) $context->vars_in_scope['$foo']
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testConflictingTypesWithAssignment2()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo["a"] = "hello";
-        $foo["b"][] = "goodbye";
-        $bar = $foo["a"];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{a:string, b:array<int, string>}', (string) $context->vars_in_scope['$foo']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$foo[\'a\']']);
-        $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$foo[\'b\']']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$bar']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConflictingTypesWithAssignment3()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo["a"] = "hello";
-        $foo["b"]["c"]["d"] = "goodbye";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{a:string, b:array{c:array{d:string}}}', (string) $context->vars_in_scope['$foo']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNestedObjectLikeAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = [];
-        $foo["a"]["b"] = "hello";
-        $foo["a"]["c"] = 1;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{a:array{b:string, c:int}}', (string) $context->vars_in_scope['$foo']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConditionalObjectLikeAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = ["a" => "hello"];
-        if (rand(0, 10) === 5) {
-            $foo["b"] = 1;
-        }
-        else {
-            $foo["b"] = 2;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array{a:string, b:int}', (string) $context->vars_in_scope['$foo']);
-    }
-
-
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
      * @return void
@@ -595,315 +65,474 @@ class ArrayAssignmentTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidArrayAssignment
-     * @return                   void
+     * @return array
      */
-    public function testObjectAssignment()
+    public function providerFileCheckerValidCodeParse()
     {
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        (new A)["b"] = 1;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConditionalCheck()
-    {
-        $file_checker = new FileChecker(
-            'somefile.php',
-            $this->project_checker,
-            self::$parser->parse('<?php
-                /**
-                 * @param  array{b:string} $a
-                 * @return null|string
-                 */
-                function fooFoo($a) {
-                    if ($a["b"]) {
-                        return $a["b"];
+        return [
+            'generic-array-creation' => [
+                '<?php
+                    $out = [];
+            
+                    foreach ([1, 2, 3, 4, 5] as $value) {
+                        $out[] = 4;
+                    }',
+                'assertions' => [
+                    ['array<int, int>' => '$out']
+                ]
+            ],
+            'generic-2d-array-creation' => [
+                '<?php
+                    $out = [];
+            
+                    foreach ([1, 2, 3, 4, 5] as $value) {
+                        $out[] = [4];
+                    }',
+                'assertions' => [
+                    ['array<int, array<int, int>>' => '$out']
+                ]
+            ],
+            'generic-2d-array-creation-added-in-if' => [
+                '<?php
+                    $out = [];
+            
+                    $bits = [];
+            
+                    foreach ([1, 2, 3, 4, 5] as $value) {
+                        if (rand(0,100) > 50) {
+                            $out[] = $bits;
+                            $bits = [];
+                        }
+            
+                        $bits[] = 4;
                     }
-                }
-            ')
-        );
-
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+            
+                    if ($bits) {
+                        $out[] = $bits;
+                    }',
+                'assertions' => [
+                    ['array<int, array<int, int>>' => '$out']
+                ]
+            ],
+            'generic-array-creation-with-object-added-in-if' => [
+                '<?php
+                    class B {}
+            
+                    $out = [];
+            
+                    if (rand(0,10) === 10) {
+                        $out[] = new B();
+                    }',
+                'assertions' => [
+                    ['array<int, B>' => '$out']
+                ]
+            ],
+            'generic-array-creation-with-element-added-in-switch' => [
+                '<?php
+                    $out = [];
+            
+                    switch (rand(0,10)) {
+                        case 5:
+                            $out[] = 4;
+                            break;
+            
+                        case 6:
+                            // do nothing
+                    }',
+                'assertions' => [
+                    ['array<int, int>' => '$out']
+                ]
+            ],
+            'generic-array-creation-with-elements-added-in-switch' => [
+                '<?php
+                    $out = [];
+            
+                    switch (rand(0,10)) {
+                        case 5:
+                            $out[] = 4;
+                            break;
+            
+                        case 6:
+                            $out[] = "hello";
+                            break;
+                    }',
+                'assertions' => [
+                    ['array<int, int|string>' => '$out']
+                ]
+            ],
+            'generic-array-creation-with-elements-added-in-switch-with-nothing' => [
+                '<?php
+                    $out = [];
+            
+                    switch (rand(0,10)) {
+                        case 5:
+                            $out[] = 4;
+                            break;
+            
+                        case 6:
+                            $out[] = "hello";
+                            break;
+            
+                        case 7:
+                            // do nothing
+                    }',
+                'assertions' => [
+                    ['array<int, int|string>' => '$out']
+                ]
+            ],
+            'implicit-int-array-creation' => [
+                '<?php
+                    $foo = [];
+                    $foo[] = "hello";',
+                'assertions' => [
+                    ['array<int, string>' => '$foo']
+                ]
+            ],
+            'implicit-2d-int-array-creation' => [
+                '<?php
+                    $foo = [];
+                    $foo[][] = "hello";',
+                'assertions' => [
+                    ['array<int, array<int, string>>' => '$foo']
+                ]
+            ],
+            'implicit-3d-int-array-creation' => [
+                '<?php
+                    $foo = [];
+                    $foo[][][] = "hello";',
+                'assertions' => [
+                    ['array<int, array<int, array<int, string>>>' => '$foo']
+                ]
+            ],
+            'implicit-4d-int-array-creation' => [
+                '<?php
+                    $foo = [];
+                    $foo[][][][] = "hello";',
+                'assertions' => [
+                    ['array<int, array<int, array<int, array<int, string>>>>' => '$foo']
+                ]
+            ],
+            'implicit-indexed-int-array-creation' => [
+                '<?php
+                    $foo = [];
+                    $foo[0] = "hello";
+                    $foo[1] = "hello";
+                    $foo[2] = "hello";
+            
+                    $bar = [0, 1, 2];
+            
+                    $bat = [];
+            
+                    foreach ($foo as $i => $text) {
+                        $bat[$text] = $bar[$i];
+                    }',
+                'assertions' => [
+                    ['array<int, string>' => '$foo'],
+                    ['array<int, int>' => '$bar'],
+                    ['array<string, int>' => '$bat']
+                ]
+            ],
+            'implicit-string-array-creation' => [
+                '<?php
+                    $foo = [];
+                    $foo["bar"] = "hello";',
+                'assertions' => [
+                    ['array{bar:string}' => '$foo'],
+                    ['string' => '$foo[\'bar\']']
+                ]
+            ],
+            'implicit-2d-string-array-creation' => [
+                '<?php
+                    $foo = [];
+                    $foo["bar"]["baz"] = "hello";',
+                'assertions' => [
+                    ['array{bar:array{baz:string}}' => '$foo'],
+                    ['string' => '$foo[\'bar\'][\'baz\']']
+                ]
+            ],
+            'implicit-3d-string-array-creation' => [
+                '<?php
+                    $foo = [];
+                    $foo["bar"]["baz"]["bat"] = "hello";',
+                'assertions' => [
+                    ['array{bar:array{baz:array{bat:string}}}' => '$foo'],
+                    ['string' => '$foo[\'bar\'][\'baz\'][\'bat\']']
+                ]
+            ],
+            'implicit-4d-string-array-creation' => [
+                '<?php
+                    $foo = [];
+                    $foo["bar"]["baz"]["bat"]["bap"] = "hello";',
+                'assertions' => [
+                    ['array{bar:array{baz:array{bat:array{bap:string}}}}' => '$foo'],
+                    ['string' => '$foo[\'bar\'][\'baz\'][\'bat\'][\'bap\']']
+                ]
+            ],
+            '2-step-2d-string-array-creation' => [
+                '<?php
+                    $foo = ["bar" => []];
+                    $foo["bar"]["baz"] = "hello";',
+                'assertions' => [
+                    ['array{bar:array{baz:string}}' => '$foo'],
+                    ['string' => '$foo[\'bar\'][\'baz\']']
+                ]
+            ],
+            '2-step-implicit-3d-string-array-creation' => [
+                '<?php
+                    $foo = ["bar" => []];
+                    $foo["bar"]["baz"]["bat"] = "hello";',
+                'assertions' => [
+                    ['array{bar:array{baz:array{bat:string}}}' => '$foo']
+                ]
+            ],
+            'conflicting-types' => [
+                '<?php
+                    $foo = [
+                        "bar" => ["a" => "b"],
+                        "baz" => [1]
+                    ];',
+                'assertions' => [
+                    ['array{bar:array{a:string}, baz:array<int, int>}' => '$foo']
+                ]
+            ],
+            'implicit-object-like-creation' => [
+                '<?php
+                    $foo = [
+                        "bar" => 1,
+                    ];
+                    $foo["baz"] = "a";',
+                'assertions' => [
+                    ['array{bar:int, baz:string}' => '$foo']
+                ]
+            ],
+            'conflicting-types-with-assignment' => [
+                '<?php
+                    $foo = [
+                        "bar" => ["a" => "b"],
+                        "baz" => [1]
+                    ];
+                    $foo["bar"]["bam"]["baz"] = "hello";',
+                'assertions' => [
+                    ['array{bar:array{a:string, bam:array{baz:string}}, baz:array<int, int>}' => '$foo']
+                ]
+            ],
+            'conflicting-types-with-assignment-2' => [
+                '<?php
+                    $foo = [];
+                    $foo["a"] = "hello";
+                    $foo["b"][] = "goodbye";
+                    $bar = $foo["a"];',
+                'assertions' => [
+                    ['array{a:string, b:array<int, string>}' => '$foo'],
+                    ['string' => '$foo[\'a\']'],
+                    ['array<int, string>' => '$foo[\'b\']'],
+                    ['string' => '$bar']
+                ]
+            ],
+            'conflicting-types-with-assignment-3' => [
+                '<?php
+                    $foo = [];
+                    $foo["a"] = "hello";
+                    $foo["b"]["c"]["d"] = "goodbye";',
+                'assertions' => [
+                    ['array{a:string, b:array{c:array{d:string}}}' => '$foo']
+                ]
+            ],
+            'nested-object-like-assignment' => [
+                '<?php
+                    $foo = [];
+                    $foo["a"]["b"] = "hello";
+                    $foo["a"]["c"] = 1;',
+                'assertions' => [
+                    ['array{a:array{b:string, c:int}}' => '$foo']
+                ]
+            ],
+            'conditional-object-like-assignment' => [
+                '<?php
+                    $foo = ["a" => "hello"];
+                    if (rand(0, 10) === 5) {
+                        $foo["b"] = 1;
+                    }
+                    else {
+                        $foo["b"] = 2;
+                    }',
+                'assertions' => [
+                    ['array{a:string, b:int}' => '$foo']
+                ]
+            ],
+            'array-key' => [
+                '<?php
+                    $a = ["foo", "bar"];
+                    $b = $a[0];
+        
+                    $c = ["a" => "foo", "b"=> "bar"];
+                    $d = "a";
+                    $e = $a[$d];',
+                'assertions' => [
+                    ['string' => '$b'],
+                    ['string' => '$e']
+                ]
+            ],
+            'conditional-check' => [
+                '<?php
+                    /**
+                     * @param  array{b:string} $a
+                     * @return null|string
+                     */
+                    function fooFoo($a) {
+                        if ($a["b"]) {
+                            return $a["b"];
+                        }
+                    }',
+                'assertions' => []
+            ],
+            'variable-key-array-create' => [
+                '<?php
+                    $a = [];
+                    $b = "boop";
+                    $a[$b][] = "bam";
+            
+                    $c = [];
+                    $c[$b][$b][] = "bam";',
+                'assertions' => [
+                    ['array<string, array<int, string>>' => '$a'],
+                    ['array<string, array<string, array<int, string>>>' => '$c']
+                ]
+            ],
+            'assign-explicit-value-to-generic' => [
+                '<?php
+                    /** @var array<string, array<string, string>> */
+                    $a = [];
+                    $a["foo"] = ["bar" => "baz"];',
+                'assertions' => [
+                    ['array<string, array<string, string>>' => '$a']
+                ]
+            ],
+            'addition-with-empty' => [
+                '<?php
+                    $a = [];
+                    $a += ["bar"];
+            
+                    $b = [] + ["bar"];',
+                'assertions' => [
+                    ['array<int, string>' => '$a'],
+                    ['array<int, string>' => '$b']
+                ]
+            ],
+            'addition-different-type' => [
+                '<?php
+                    $a = ["bar"];
+                    $a += [1];
+            
+                    $b = ["bar"] + [1];',
+                'assertions' => [
+                    ['array<int, string|int>' => '$a'],
+                    ['array<int, string|int>' => '$b']
+                ]
+            ],
+            'present-1d-array-type-with-var-keys' => [
+                '<?php
+                    /** @var array<string, array<int, string>> */
+                    $a = [];
+            
+                    $foo = "foo";
+            
+                    $a[$foo][] = "bat";',
+                'assertions' => []
+            ],
+            'present-2d-array-type-with-var-keys' => [
+                '<?php
+                    /** @var array<string, array<string, array<int, string>>> */
+                    $b = [];
+            
+                    $foo = "foo";
+                    $bar = "bar";
+            
+                    $b[$foo][$bar][] = "bat";',
+                'assertions' => []
+            ],
+            'object-like-with-integer-keys' => [
+                '<?php
+                    /** @var array{0: string, 1: int} **/
+                    $a = ["hello", 5];
+                    $b = $a[0]; // string
+                    $c = $a[1]; // int
+                    list($d, $e) = $a; // $d is string, $e is int',
+                'assertions' => [
+                    ['string' => '$b'],
+                    ['int' => '$c'],
+                    ['string' => '$d'],
+                    ['int' => '$e']
+                ]
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testArrayKey()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        $file_checker = new FileChecker(
-            'somefile.php',
-            $this->project_checker,
-            self::$parser->parse('<?php
-            $a = ["foo", "bar"];
-            $b = $a[0];
-
-            $c = ["a" => "foo", "b"=> "bar"];
-            $d = "a";
-            $e = $a[$d];
-            ')
-        );
-
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string', (string)$context->vars_in_scope['$b']);
-        $this->assertEquals('string', (string)$context->vars_in_scope['$e']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testVariableKeyArrayCreate()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = [];
-        $b = "boop";
-        $a[$b][] = "bam";
-
-        $c = [];
-        $c[$b][$b][] = "bam";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<string, array<int, string>>', (string) $context->vars_in_scope['$a']);
-        $this->assertEquals('array<string, array<string, array<int, string>>>', (string) $context->vars_in_scope['$c']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAssignExplicitValueToGeneric()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @var array<string, array<string, string>> */
-        $a = [];
-        $a["foo"] = ["bar" => "baz"];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<string, array<string, string>>', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAdditionWithEmpty()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = [];
-        $a += ["bar"];
-
-        $b = [] + ["bar"];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$a']);
-        $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAdditionDifferentType()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = ["bar"];
-        $a += [1];
-
-        $b = ["bar"] + [1];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, string|int>', (string) $context->vars_in_scope['$a']);
-        $this->assertEquals('array<int, string|int>', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testPreset1DArrayTypeWithVarKeys()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @var array<string, array<int, string>> */
-        $a = [];
-
-        $foo = "foo";
-
-        $a[$foo][] = "bat";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testPreset2DArrayTypeWithVarKeys()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @var array<string, array<string, array<int, string>>> */
-        $b = [];
-
-        $foo = "foo";
-        $bar = "bar";
-
-        $b[$foo][$bar][] = "bat";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidArrayAssignment
-     * @return                   void
-     */
-    public function testInvalidArrayAccess()
-    {
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        $a = 5;
-        $a[0] = 5;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MixedStringOffsetAssignment
-     * @return                   void
-     */
-    public function testMixedStringOffsetAssignment()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        /** @var mixed */
-        $a = 5;
-        "hello"[0] = $a;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage TypeCoercion
-     * @return                   void
-     */
-    public function testMixedArrayArgument()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        /** @param array<mixed, int|string> $foo */
-        function fooFoo(array $foo) : void { }
-
-        function barBar(array $bar) : void {
-            fooFoo($bar);
-        }
-
-        barBar([1, "2"]);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testObjectLikeWithIntegerKeys()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @var array{0: string, 1: int} **/
-        $a = ["hello", 5];
-        $b = $a[0]; // string
-        $c = $a[1]; // int
-        list($d, $e) = $a; // $d is string, $e is int
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$b']);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$c']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$d']);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$e']);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidPropertyAssignment
-     * @return                   void
-     */
-    public function testArrayPropertyAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string[] */
-            public $strs = ["a", "b", "c"];
-
-            /** @return void */
-            public function bar() {
-                $this->strs = [new stdClass()]; // no issue emitted
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidPropertyAssignment
-     * @return                   void
-     */
-    public function testIncrementalArrayPropertyAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string[] */
-            public $strs = ["a", "b", "c"];
-
-            /** @return void */
-            public function bar() {
-                $this->strs[] = new stdClass(); // no issue emitted
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'object-assignment' => [
+                '<?php
+                    class A {}
+                    (new A)["b"] = 1;',
+                'error_message' => 'InvalidArrayAssignment'
+            ],
+            'invalid-array-access' => [
+                '<?php
+                    $a = 5;
+                    $a[0] = 5;',
+                'error_message' => 'InvalidArrayAssignment'
+            ],
+            'mixed-string-offset-assignment' => [
+                '<?php
+                    /** @var mixed */
+                    $a = 5;
+                    "hello"[0] = $a;',
+                'error_message' => 'MixedStringOffsetAssignment',
+                'error_level' => ['MixedAssignment']
+            ],
+            'mixed-array-argument' => [
+                '<?php
+                    /** @param array<mixed, int|string> $foo */
+                    function fooFoo(array $foo) : void { }
+            
+                    function barBar(array $bar) : void {
+                        fooFoo($bar);
+                    }
+            
+                    barBar([1, "2"]);',
+                'error_message' => 'TypeCoercion',
+                'error_level' => ['MixedAssignment']
+            ],
+            'array-property-assignment' => [
+                '<?php
+                    class A {
+                        /** @var string[] */
+                        public $strs = ["a", "b", "c"];
+            
+                        /** @return void */
+                        public function bar() {
+                            $this->strs = [new stdClass()]; // no issue emitted
+                        }
+                    }',
+                'error_message' => 'InvalidPropertyAssignment'
+            ],
+            'incremental-array-property-assignment' => [
+                '<?php
+                    class A {
+                        /** @var string[] */
+                        public $strs = ["a", "b", "c"];
+            
+                        /** @return void */
+                        public function bar() {
+                            $this->strs[] = new stdClass(); // no issue emitted
+                        }
+                    }',
+                'error_message' => 'InvalidPropertyAssignment'
+            ]
+        ];
     }
 }

--- a/tests/AssignmentTest.php
+++ b/tests/AssignmentTest.php
@@ -12,7 +12,7 @@ class AssignmentTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'nested-assignment' => [
+            'nestedAssignment' => [
                 '<?php
                     $a = $b = $c = 5;',
                 'assertions' => [
@@ -28,7 +28,7 @@ class AssignmentTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'mixed-assignment' => [
+            'mixedAssignment' => [
                 '<?php
                     /** @var mixed */
                     $a = 5;

--- a/tests/BadFormatTest.php
+++ b/tests/BadFormatTest.php
@@ -1,49 +1,17 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
 
-class BadFormatTest extends PHPUnit_Framework_TestCase
+class BadFormatTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
     /**
      * @return void
      */
     public function testMissingSemicolon()
     {
         $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
+            'somefile.php',
             '<?php
         class A {
             /** @var int|null */
@@ -56,7 +24,7 @@ class BadFormatTest extends PHPUnit_Framework_TestCase
         }'
         );
 
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
         $file_checker->visitAndAnalyzeMethods();
     }
 }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -1,179 +1,76 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class BinaryOperationTest extends PHPUnit_Framework_TestCase
+class BinaryOperationTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        return [
+            'regular-addition' => [
+                '<?php
+                    $a = 5 + 4;'
+            ],
+            'differing-numeric-types-addition-in-weak-mode' => [
+                '<?php
+                    $a = 5 + 4.1;'
+            ],
+            'numeric-addition' => [
+                '<?php
+                    $a = "5";
+            
+                    if (is_numeric($a)) {
+                        $b = $a + 4;
+                    }'
+            ],
+            'concatenation' => [
+                '<?php
+                    $a = "Hey " . "Jude,";'
+            ],
+            'concatenation-with-number-in-weak-mode' => [
+                '<?php
+                    $a = "hi" . 5;'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testRegularAddition()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = 5 + 4;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidOperand
-     * @return                   void
-     */
-    public function testBadAddition()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = "b" + 5;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testDifferingNumericTypesAdditionInWeakMode()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = 5 + 4.1;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidOperand
-     * @return                   void
-     */
-    public function testDifferingNumericTypesAdditionInStrictMode()
-    {
-        Config::getInstance()->strict_binary_operands = true;
-
-        $stmts = self::$parser->parse('<?php
-        $a = 5 + 4.1;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNumericAddition()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = "5";
-
-        if (is_numeric($a)) {
-            $b = $a + 4;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConcatenation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = "Hey " . "Jude,";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConcatenationWithNumberInWeakMode()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = "hi" . 5;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidOperand
-     * @return                   void
-     */
-    public function testConcatenationWithNumberInStrictMode()
-    {
-        Config::getInstance()->strict_binary_operands = true;
-
-        $stmts = self::$parser->parse('<?php
-        $a = "hi" . 5;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidOperand
-     * @return                   void
-     */
-    public function testAddArrayToNumber()
-    {
-        Config::getInstance()->strict_binary_operands = true;
-
-        $stmts = self::$parser->parse('<?php
-        $a = [1] + 1;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'bad-addition' => [
+                '<?php
+                    $a = "b" + 5;',
+                'error_message' => 'InvalidOperand'
+            ],
+            'differing-numeric-types-addition-in-strict-mode' => [
+                '<?php
+                    $a = 5 + 4.1;',
+                'error_message' => 'InvalidOperand',
+                'error_levels' => [],
+                'strict_mode' => true
+            ],
+            'concatenation-with-number-in-strict-mode' => [
+                '<?php
+                    $a = "hi" . 5;',
+                'error_message' => 'InvalidOperand',
+                'error_levels' => [],
+                'strict_mode' => true
+            ],
+            'add-array-to-number' => [
+                '<?php
+                    $a = [1] + 1;',
+                'error_message' => 'InvalidOperand',
+                'error_levels' => [],
+                'strict_mode' => true
+            ]
+        ];
     }
 }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -12,15 +12,15 @@ class BinaryOperationTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'regular-addition' => [
+            'regularAddition' => [
                 '<?php
                     $a = 5 + 4;'
             ],
-            'differing-numeric-types-addition-in-weak-mode' => [
+            'differingNumericTypesAdditionInWeakMode' => [
                 '<?php
                     $a = 5 + 4.1;'
             ],
-            'numeric-addition' => [
+            'numericAddition' => [
                 '<?php
                     $a = "5";
             
@@ -32,7 +32,7 @@ class BinaryOperationTest extends TestCase
                 '<?php
                     $a = "Hey " . "Jude,";'
             ],
-            'concatenation-with-number-in-weak-mode' => [
+            'concatenationWithNumberInWeakMode' => [
                 '<?php
                     $a = "hi" . 5;'
             ]
@@ -45,26 +45,26 @@ class BinaryOperationTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'bad-addition' => [
+            'badAddition' => [
                 '<?php
                     $a = "b" + 5;',
                 'error_message' => 'InvalidOperand'
             ],
-            'differing-numeric-types-addition-in-strict-mode' => [
+            'differingNumericTypesAdditionInStrictMode' => [
                 '<?php
                     $a = 5 + 4.1;',
                 'error_message' => 'InvalidOperand',
                 'error_levels' => [],
                 'strict_mode' => true
             ],
-            'concatenation-with-number-in-strict-mode' => [
+            'concatenationWithNumberInStrictMode' => [
                 '<?php
                     $a = "hi" . 5;',
                 'error_message' => 'InvalidOperand',
                 'error_levels' => [],
                 'strict_mode' => true
             ],
-            'add-array-to-number' => [
+            'addArrayToNumber' => [
                 '<?php
                     $a = [1] + 1;',
                 'error_message' => 'InvalidOperand',

--- a/tests/ClassScopeTest.php
+++ b/tests/ClassScopeTest.php
@@ -12,7 +12,7 @@ class ClassScopeTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'accessible-private-method-from-subclass' => [
+            'accessiblePrivateMethodFromSubclass' => [
                 '<?php
                     class A {
                         private function fooFoo() : void {
@@ -24,7 +24,7 @@ class ClassScopeTest extends TestCase
                         }
                     }'
             ],
-            'accessible-protected-method-from-subclass' => [
+            'accessibleProtectedMethodFromSubclass' => [
                 '<?php
                     class A {
                         protected function fooFoo() : void {
@@ -37,7 +37,7 @@ class ClassScopeTest extends TestCase
                         }
                     }'
             ],
-            'accessible-protected-method-from-other-subclass' => [
+            'accessibleProtectedMethodFromOtherSubclass' => [
                 '<?php
                     class A {
                         protected function fooFoo() : void {
@@ -52,7 +52,7 @@ class ClassScopeTest extends TestCase
                         }
                     }'
             ],
-            'accessible-protected-property-from-subclass' => [
+            'accessibleProtectedPropertyFromSubclass' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -65,7 +65,7 @@ class ClassScopeTest extends TestCase
                         }
                     }'
             ],
-            'accessible-protected-property-from-great-grandparent' => [
+            'accessibleProtectedPropertyFromGreatGrandparent' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -82,7 +82,7 @@ class ClassScopeTest extends TestCase
                         }
                     }'
             ],
-            'accessible-protected-property-from-other-subclass' => [
+            'accessibleProtectedPropertyFromOtherSubclass' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -99,7 +99,7 @@ class ClassScopeTest extends TestCase
                         }
                     }'
             ],
-            'accessible-static-property-from-subclass' => [
+            'accessibleStaticPropertyFromSubclass' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -116,7 +116,7 @@ class ClassScopeTest extends TestCase
                         }
                     }'
             ],
-            'defined-private-method' => [
+            'definedPrivateMethod' => [
                 '<?php
                     class A {
                         public function foo() : void {
@@ -141,7 +141,7 @@ class ClassScopeTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'inaccessible-private-method' => [
+            'inaccessiblePrivateMethod' => [
                 '<?php
                     class A {
                         private function fooFoo() : void {
@@ -152,7 +152,7 @@ class ClassScopeTest extends TestCase
                     (new A())->fooFoo();',
                 'error_message' => 'InaccessibleMethod'
             ],
-            'inaccessible-protect-method' => [
+            'inaccessibleProtectMethod' => [
                 '<?php
                     class A {
                         protected function fooFoo() : void {
@@ -163,7 +163,7 @@ class ClassScopeTest extends TestCase
                     (new A())->fooFoo();',
                 'error_message' => 'InaccessibleMethod'
             ],
-            'inaccessible-private-method-from-subclass' => [
+            'inaccessiblePrivateMethodFromSubclass' => [
                 '<?php
                     class A {
                         private function fooFoo() : void {
@@ -178,7 +178,7 @@ class ClassScopeTest extends TestCase
                     }',
                 'error_message' => 'InaccessibleMethod'
             ],
-            'inaccessible-protectred-method-from-other-subclass' => [
+            'inaccessibleProtectredMethodFromOtherSubclass' => [
                 '<?php
                     trait T {
                         protected function fooFoo() : void {
@@ -198,7 +198,7 @@ class ClassScopeTest extends TestCase
                     }',
                 'error_message' => 'InaccessibleMethod'
             ],
-            'inaccessible-private-property' => [
+            'inaccessiblePrivateProperty' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -208,7 +208,7 @@ class ClassScopeTest extends TestCase
                     echo (new A())->fooFoo;',
                 'error_message' => 'InaccessibleProperty'
             ],
-            'inaccessible-protected-property' => [
+            'inaccessibleProtectedProperty' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -218,7 +218,7 @@ class ClassScopeTest extends TestCase
                     echo (new A())->fooFoo;',
                 'error_message' => 'InaccessibleProperty'
             ],
-            'inaccessible-private-property-from-subclass' => [
+            'inaccessiblePrivatePropertyFromSubclass' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -232,7 +232,7 @@ class ClassScopeTest extends TestCase
                     }',
                 'error_message' => 'InaccessibleProperty'
             ],
-            'inaccessible-static-private-property' => [
+            'inaccessibleStaticPrivateProperty' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -242,7 +242,7 @@ class ClassScopeTest extends TestCase
                     echo A::$fooFoo;',
                 'error_message' => 'InaccessibleProperty'
             ],
-            'inaccessible-static-protected-property' => [
+            'inaccessibleStaticProtectedProperty' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -252,7 +252,7 @@ class ClassScopeTest extends TestCase
                     echo A::$fooFoo;',
                 'error_message' => 'InaccessibleProperty'
             ],
-            'inaccessible-static-private-property-from-subclass' => [
+            'inaccessibleStaticPrivatePropertyFromSubclass' => [
                 '<?php
                     class A {
                         /** @var string */

--- a/tests/ClassScopeTest.php
+++ b/tests/ClassScopeTest.php
@@ -1,457 +1,271 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ClassScopeTest extends PHPUnit_Framework_TestCase
+class ClassScopeTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
+        return [
+            'accessible-private-method-from-subclass' => [
+                '<?php
+                    class A {
+                        private function fooFoo() : void {
+            
+                        }
+            
+                        private function barBar() : void {
+                            $this->fooFoo();
+                        }
+                    }'
+            ],
+            'accessible-protected-method-from-subclass' => [
+                '<?php
+                    class A {
+                        protected function fooFoo() : void {
+                        }
+                    }
+            
+                    class B extends A {
+                        public function doFoo() : void {
+                            $this->fooFoo();
+                        }
+                    }'
+            ],
+            'accessible-protected-method-from-other-subclass' => [
+                '<?php
+                    class A {
+                        protected function fooFoo() : void {
+                        }
+                    }
+            
+                    class B extends A { }
+            
+                    class C extends A {
+                        public function doFoo() : void {
+                            (new B)->fooFoo();
+                        }
+                    }'
+            ],
+            'accessible-protected-property-from-subclass' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        protected $fooFoo = "";
+                    }
+            
+                    class B extends A {
+                        public function doFoo() : void {
+                            echo $this->fooFoo;
+                        }
+                    }'
+            ],
+            'accessible-protected-property-from-great-grandparent' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        protected $fooFoo = "";
+                    }
+            
+                    class B extends A { }
+            
+                    class C extends B { }
+            
+                    class D extends C {
+                        public function doFoo() : void {
+                            echo $this->fooFoo;
+                        }
+                    }'
+            ],
+            'accessible-protected-property-from-other-subclass' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        protected $fooFoo = "";
+                    }
+            
+                    class B extends A {
+                    }
+            
+                    class C extends A {
+                        public function fooFoo() : void {
+                            $b = new B();
+                            $b->fooFoo = "hello";
+                        }
+                    }'
+            ],
+            'accessible-static-property-from-subclass' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        protected static $fooFoo = "";
+            
+                        public function barBar() : void {
+                            echo self::$fooFoo;
+                        }
+                    }
+            
+                    class B extends A {
+                        public function doFoo() : void {
+                            echo A::$fooFoo;
+                        }
+                    }'
+            ],
+            'defined-private-method' => [
+                '<?php
+                    class A {
+                        public function foo() : void {
+                            if ($this instanceof B) {
+                                $this->boop();
+                            }
+                        }
+            
+                        private function boop() : void {}
+                    }
+            
+                    class B extends A {
+                        private function boop() : void {}
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleMethod
-     * @return                   void
-     */
-    public function testInaccessiblePrivateMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            private function fooFoo() : void {
-
-            }
-        }
-
-        (new A())->fooFoo();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleMethod
-     * @return                   void
-     */
-    public function testInaccessibleProtectedMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            protected function fooFoo() : void {
-
-            }
-        }
-
-        (new A())->fooFoo();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessiblePrivateMethodFromSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            private function fooFoo() : void {
-
-            }
-
-            private function barBar() : void {
-                $this->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleMethod
-     * @return                   void
-     */
-    public function testInaccessiblePrivateMethodFromSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            private function fooFoo() : void {
-
-            }
-        }
-
-        class B extends A {
-            public function doFoo() : void {
-                $this->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessibleProtectedMethodFromSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            protected function fooFoo() : void {
-            }
-        }
-
-        class B extends A {
-            public function doFoo() : void {
-                $this->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessibleProtectedMethodFromOtherSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            protected function fooFoo() : void {
-            }
-        }
-
-        class B extends A { }
-
-        class C extends A {
-            public function doFoo() : void {
-                (new B)->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleMethod
-     * @return                   void
-     */
-    public function testInaccessibleProtectedMethodFromOtherSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            protected function fooFoo() : void {
-            }
-        }
-
-        class B {
-            use T;
-        }
-
-        class C {
-            use T;
-
-            public function doFoo() : void {
-                (new B)->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleProperty
-     * @return                   void
-     */
-    public function testInaccessiblePrivateProperty()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            private $fooFoo;
-        }
-
-        echo (new A())->fooFoo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleProperty
-     * @return                   void
-     */
-    public function testInaccessibleProtectedProperty()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            protected $fooFoo;
-        }
-
-        echo (new A())->fooFoo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleProperty
-     * @return                   void
-     */
-    public function testInaccessiblePrivatePropertyFromSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            private $fooFoo = "";
-        }
-
-        class B extends A {
-            public function doFoo() : void {
-                echo $this->fooFoo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleProperty
-     * @return                   void
-     */
-    public function testInaccessibleStaticPrivateProperty()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            private static $fooFoo;
-        }
-
-        echo A::$fooFoo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleProperty
-     * @return                   void
-     */
-    public function testInaccessibleStaticProtectedProperty()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            protected static $fooFoo;
-        }
-
-        echo A::$fooFoo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleProperty
-     * @return                   void
-     */
-    public function testInaccessibleStaticPrivatePropertyFromSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            private static $fooFoo;
-        }
-
-        class B extends A {
-            public function doFoo() : void {
-                echo A::$fooFoo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessibleProtectedPropertyFromSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            protected $fooFoo = "";
-        }
-
-        class B extends A {
-            public function doFoo() : void {
-                echo $this->fooFoo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessibleProtectedPropertyFromGreatGrandparent()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            protected $fooFoo = "";
-        }
-
-        class B extends A { }
-
-        class C extends B { }
-
-        class D extends C {
-            public function doFoo() : void {
-                echo $this->fooFoo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessibleProtectedPropertyFromOtherSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            protected $fooFoo = "";
-        }
-
-        class B extends A {
-        }
-
-        class C extends A {
-            public function fooFoo() : void {
-                $b = new B();
-                $b->fooFoo = "hello";
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessibleStaticPropertyFromSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            protected static $fooFoo = "";
-
-            public function barBar() : void {
-                echo self::$fooFoo;
-            }
-        }
-
-        class B extends A {
-            public function doFoo() : void {
-                echo A::$fooFoo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testDefinedPrivateMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function foo() : void {
-                if ($this instanceof B) {
-                    $this->boop();
-                }
-            }
-
-            private function boop() : void {}
-        }
-
-        class B extends A {
-            private function boop() : void {}
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'inaccessible-private-method' => [
+                '<?php
+                    class A {
+                        private function fooFoo() : void {
+            
+                        }
+                    }
+            
+                    (new A())->fooFoo();',
+                'error_message' => 'InaccessibleMethod'
+            ],
+            'inaccessible-protect-method' => [
+                '<?php
+                    class A {
+                        protected function fooFoo() : void {
+            
+                        }
+                    }
+            
+                    (new A())->fooFoo();',
+                'error_message' => 'InaccessibleMethod'
+            ],
+            'inaccessible-private-method-from-subclass' => [
+                '<?php
+                    class A {
+                        private function fooFoo() : void {
+            
+                        }
+                    }
+            
+                    class B extends A {
+                        public function doFoo() : void {
+                            $this->fooFoo();
+                        }
+                    }',
+                'error_message' => 'InaccessibleMethod'
+            ],
+            'inaccessible-protectred-method-from-other-subclass' => [
+                '<?php
+                    trait T {
+                        protected function fooFoo() : void {
+                        }
+                    }
+            
+                    class B {
+                        use T;
+                    }
+            
+                    class C {
+                        use T;
+            
+                        public function doFoo() : void {
+                            (new B)->fooFoo();
+                        }
+                    }',
+                'error_message' => 'InaccessibleMethod'
+            ],
+            'inaccessible-private-property' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        private $fooFoo;
+                    }
+            
+                    echo (new A())->fooFoo;',
+                'error_message' => 'InaccessibleProperty'
+            ],
+            'inaccessible-protected-property' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        protected $fooFoo;
+                    }
+            
+                    echo (new A())->fooFoo;',
+                'error_message' => 'InaccessibleProperty'
+            ],
+            'inaccessible-private-property-from-subclass' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        private $fooFoo = "";
+                    }
+            
+                    class B extends A {
+                        public function doFoo() : void {
+                            echo $this->fooFoo;
+                        }
+                    }',
+                'error_message' => 'InaccessibleProperty'
+            ],
+            'inaccessible-static-private-property' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        private static $fooFoo;
+                    }
+            
+                    echo A::$fooFoo;',
+                'error_message' => 'InaccessibleProperty'
+            ],
+            'inaccessible-static-protected-property' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        protected static $fooFoo;
+                    }
+            
+                    echo A::$fooFoo;',
+                'error_message' => 'InaccessibleProperty'
+            ],
+            'inaccessible-static-private-property-from-subclass' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        private static $fooFoo;
+                    }
+            
+                    class B extends A {
+                        public function doFoo() : void {
+                            echo A::$fooFoo;
+                        }
+                    }',
+                'error_message' => 'InaccessibleProperty'
+            ]
+        ];
     }
 }

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -12,7 +12,7 @@ class ClassTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'single-file-inheritance' => [
+            'singleFileInheritance' => [
                 '<?php
                     class A extends B {}
             
@@ -27,13 +27,13 @@ class ClassTest extends TestCase
                         }
                     }'
             ],
-            'const-sandwich' => [
+            'constSandwich' => [
                 '<?php
                     class A { const B = 42;}
                     $a = A::B;
                     class C {}'
             ],
-            'deferred-reference' => [
+            'deferredReference' => [
                 '<?php
                     class B {
                         const C = A;
@@ -46,7 +46,7 @@ class ClassTest extends TestCase
                     ['int' => '$a']
                 ]
             ],
-            'more-cyclical-references' => [
+            'moreCyclicalReferences' => [
                 '<?php
                     class B extends C {
                         public function d() : A {
@@ -64,7 +64,7 @@ class ClassTest extends TestCase
                         }
                     }'
             ],
-            'reference-to-subclass-in-method' => [
+            'referenceToSubclassInMethod' => [
                 '<?php
                     class A {
                         public function b(B $b) : void {
@@ -82,7 +82,7 @@ class ClassTest extends TestCase
                         }
                     }'
             ],
-            'reference-to-class-in-method' => [
+            'referenceToClassInMethod' => [
                 '<?php
                     class A {
                         public function b(A $b) : void {
@@ -90,7 +90,7 @@ class ClassTest extends TestCase
                         }
                     }'
             ],
-            'override-protected-access-level-to-public' => [
+            'overrideProtectedAccessLevelToPublic' => [
                 '<?php
                     class A {
                         protected function fooFoo() : void {}
@@ -100,7 +100,7 @@ class ClassTest extends TestCase
                         public function fooFoo() : void {}
                     }'
             ],
-            'reflected-parents' => [
+            'reflectedParents' => [
                 '<?php
                     $e = rand(0, 10)
                       ? new RuntimeException("m")
@@ -110,7 +110,7 @@ class ClassTest extends TestCase
                       echo "good";
                     }'
             ],
-            'namespaced-aliased-class-call' => [
+            'namespacedAliasedClassCall' => [
                 '<?php
                     namespace Aye {
                         class Foo {}
@@ -121,7 +121,7 @@ class ClassTest extends TestCase
                         new A\Foo();
                     }'
             ],
-            'abstract-extends-abstract' => [
+            'abstractExtendsAbstract' => [
                 '<?php
                     abstract class A {
                         /** @return void */
@@ -135,7 +135,7 @@ class ClassTest extends TestCase
                         }
                     }'
             ],
-            'missing-parent-with-function' => [
+            'missingParentWithFunction' => [
                 '<?php
                     class B extends C {
                         public function fooA() { }
@@ -146,7 +146,7 @@ class ClassTest extends TestCase
                     'MissingReturnType'
                 ]
             ],
-            'class-traversal' => [
+            'classTraversal' => [
                 '<?php
                     namespace Foo;
             
@@ -169,7 +169,7 @@ class ClassTest extends TestCase
                         const DOPE = "dope";
                     }'
             ],
-            'subclass-with-simpler-arg' => [
+            'subclassWithSimplerArg' => [
                 '<?php
                     class A {}
                     class B extends A {}
@@ -191,7 +191,7 @@ class ClassTest extends TestCase
                         }
                     }'
             ],
-            'PHP7-subclass-of-invalid-argument-exception-with-simpler-arg' => [
+            'PHP7-subclassOfInvalidArgumentExceptionWithSimplerArg' => [
                 '<?php
                     class A extends InvalidArgumentException {
                         /**
@@ -213,60 +213,60 @@ class ClassTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'undefined-class' => [
+            'undefinedClass' => [
                 '<?php
                     (new Foo());',
                 'error_message' => 'UndefinedClass'
             ],
-            'wrong-case-class' => [
+            'wrongCaseClass' => [
                 '<?php
                     class Foo {}
                     (new foo());',
                 'error_message' => 'InvalidClass'
             ],
-            'invalid-this-fetch' => [
+            'invalidThisFetch' => [
                 '<?php
                     echo $this;',
                 'error_message' => 'InvalidScope'
             ],
-            'invalid-this-argument' => [
+            'invalidThisArgument' => [
                 '<?php
                     $this = "hello";',
                 'error_message' => 'InvalidScope'
             ],
-            'undefined-constant' => [
+            'undefinedConstant' => [
                 '<?php
                     echo HELLO;',
                 'error_message' => 'UndefinedConstant'
             ],
-            'undefined-class-constant' => [
+            'undefinedClassConstant' => [
                 '<?php
                     class A {}
                     echo A::HELLO;',
                 'error_message' => 'UndefinedConstant'
             ],
             // Skipped. A bug.
-            'SKIPPED-inheritance-loop-one' => [
+            'SKIPPED-inheritanceLoopOne' => [
                 '<?php
                     class C extends C {}',
                 'error_message' => 'InvalidParent'
             ],
             // Skipped. A bug.
-            'SKIPPED-inheritance-loop-two' => [
+            'SKIPPED-inheritanceLoopTwo' => [
                 '<?php
                     class E extends F {}
                     class F extends E {}',
                 'error_message' => 'InvalidParent'
             ],
             // Skipped. A bug.
-            'SKIPPED-inheritance-loop-three' => [
+            'SKIPPED-inheritanceLoopThree' => [
                 '<?php
                     class G extends H {}
                     class H extends I {}
                     class I extends G {}',
                 'error_message' => 'InvalidParent'
             ],
-            'invalid-deferred-reference' => [
+            'invalidDeferredReference' => [
                 '<?php
                     class B {
                         const C = A;
@@ -277,7 +277,7 @@ class ClassTest extends TestCase
                     const A = 5;',
                 'error_message' => 'UndefinedConstant'
             ],
-            'override-public-access-level-to-public' => [
+            'overridePublicAccessLevelToPublic' => [
                 '<?php
                     class A {
                         public function fooFoo() : void {}
@@ -288,7 +288,7 @@ class ClassTest extends TestCase
                     }',
                 'error_message' => 'OverriddenMethodAccess'
             ],
-            'override-public-access-level-to-protected' => [
+            'overridePublicAccessLevelToProtected' => [
                 '<?php
                     class A {
                         public function fooFoo() : void {}
@@ -299,7 +299,7 @@ class ClassTest extends TestCase
                     }',
                 'error_message' => 'OverriddenMethodAccess'
             ],
-            'override-protected-access-level-to-private' => [
+            'overrideProtectedAccessLevelToPrivate' => [
                 '<?php
                     class A {
                         protected function fooFoo() : void {}
@@ -310,13 +310,13 @@ class ClassTest extends TestCase
                     }',
                 'error_message' => 'OverriddenMethodAccess'
             ],
-            'class-redefinition' => [
+            'classRedefinition' => [
                 '<?php
                     class Foo {}
                     class Foo {}',
                 'error_message' => 'DuplicateClass'
             ],
-            'class-redefinition-in-namespace' => [
+            'classRedefinitionInNamespace' => [
                 '<?php
                     namespace Aye {
                         class Foo {}
@@ -324,7 +324,7 @@ class ClassTest extends TestCase
                     }',
                 'error_message' => 'DuplicateClass'
             ],
-            'class-redefinition-in-separate-namespace' => [
+            'classRedefinitionInSeparateNamespace' => [
                 '<?php
                     namespace Aye {
                         class Foo {}
@@ -334,18 +334,18 @@ class ClassTest extends TestCase
                     }',
                 'error_message' => 'DuplicateClass'
             ],
-            'abstract-class-instantiation' => [
+            'abstractClassInstantiation' => [
                 '<?php
                     abstract class A {}
                     new A();',
                 'error_message' => 'AbstractInstantiation'
             ],
-            'missing-parent' => [
+            'missingParent' => [
                 '<?php
                     class A extends B { }',
                 'error_message' => 'UndefinedClass'
             ],
-            'more-specific-return-type' => [
+            'moreSpecificReturnType' => [
                 '<?php
                     class A {}
                     class B extends A {}

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -1,705 +1,360 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ClassTest extends PHPUnit_Framework_TestCase
+class ClassTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        return [
+            'single-file-inheritance' => [
+                '<?php
+                    class A extends B {}
+            
+                    class B {
+                        public function fooFoo() : void {
+                            $a = new A();
+                            $a->barBar();
+                        }
+            
+                        protected function barBar() : void {
+                            echo "hello";
+                        }
+                    }'
+            ],
+            'const-sandwich' => [
+                '<?php
+                    class A { const B = 42;}
+                    $a = A::B;
+                    class C {}'
+            ],
+            'deferred-reference' => [
+                '<?php
+                    class B {
+                        const C = A;
+                    }
+            
+                    const A = 5;
+            
+                    $a = B::C;',
+                'assertions' => [
+                    ['int' => '$a']
+                ]
+            ],
+            'more-cyclical-references' => [
+                '<?php
+                    class B extends C {
+                        public function d() : A {
+                            return new A;
+                        }
+                    }
+                    class C {
+                        /** @var string */
+                        public $p = A::class;
+                        public static function e() : void {}
+                    }
+                    class A extends B {
+                        private function f() : void {
+                            self::e();
+                        }
+                    }'
+            ],
+            'reference-to-subclass-in-method' => [
+                '<?php
+                    class A {
+                        public function b(B $b) : void {
+            
+                        }
+            
+                        public function c() : void {
+            
+                        }
+                    }
+            
+                    class B extends A {
+                        public function d() : void {
+                            $this->c();
+                        }
+                    }'
+            ],
+            'reference-to-class-in-method' => [
+                '<?php
+                    class A {
+                        public function b(A $b) : void {
+                            $b->b(new A());
+                        }
+                    }'
+            ],
+            'override-protected-access-level-to-public' => [
+                '<?php
+                    class A {
+                        protected function fooFoo() : void {}
+                    }
+            
+                    class B extends A {
+                        public function fooFoo() : void {}
+                    }'
+            ],
+            'reflected-parents' => [
+                '<?php
+                    $e = rand(0, 10)
+                      ? new RuntimeException("m")
+                      : null;
+            
+                    if ($e instanceof Exception) {
+                      echo "good";
+                    }'
+            ],
+            'namespaced-aliased-class-call' => [
+                '<?php
+                    namespace Aye {
+                        class Foo {}
+                    }
+                    namespace Bee {
+                        use Aye as A;
+            
+                        new A\Foo();
+                    }'
+            ],
+            'abstract-extends-abstract' => [
+                '<?php
+                    abstract class A {
+                        /** @return void */
+                        abstract public function foo();
+                    }
+            
+                    abstract class B extends A {
+                        /** @return void */
+                        public function bar() {
+                            $this->foo();
+                        }
+                    }'
+            ],
+            'missing-parent-with-function' => [
+                '<?php
+                    class B extends C {
+                        public function fooA() { }
+                    }',
+                'assertions' => [],
+                'error_levels' => [
+                    'UndefinedClass',
+                    'MissingReturnType'
+                ]
+            ],
+            'class-traversal' => [
+                '<?php
+                    namespace Foo;
+            
+                    class A {
+                        /** @var string */
+                        protected $foo = C::DOPE;
+            
+                        /** @return string */
+                        public function __get() { }
+                    }
+            
+                    class B extends A {
+                        /** @return void */
+                        public function foo() {
+                            echo (string)(new C)->bar;
+                        }
+                    }
+            
+                    class C extends B {
+                        const DOPE = "dope";
+                    }'
+            ],
+            'subclass-with-simpler-arg' => [
+                '<?php
+                    class A {}
+                    class B extends A {}
+            
+                    class E1 {
+                        /**
+                         * @param A|B|null $a
+                         */
+                        public function __construct($a) {
+                        }
+                    }
+            
+                    class E2 extends E1 {
+                        /**
+                         * @param A|null $a
+                         */
+                        public function __construct($a) {
+                            parent::__construct($a);
+                        }
+                    }'
+            ],
+            'PHP7-subclass-of-invalid-argument-exception-with-simpler-arg' => [
+                '<?php
+                    class A extends InvalidArgumentException {
+                        /**
+                         * @param string $message
+                         * @param int $code
+                         * @param Throwable|null $previous_exception
+                         */
+                        public function __construct($message, $code, $previous_exception) {
+                            parent::__construct($message, $code, $previous_exception);
+                        }
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedClass
-     * @return                   void
-     */
-    public function testUndefinedClass()
-    {
-        $stmts = self::$parser->parse('<?php
-        (new Foo());
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidClass
-     * @return                   void
-     */
-    public function testWrongCaseClass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {}
-        (new foo());
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScope
-     * @return                   void
-     */
-    public function testInvalidThisFetch()
-    {
-        $stmts = self::$parser->parse('<?php
-        echo $this;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScope
-     * @return                   void
-     */
-    public function testInvalidThisAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        $this = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedConstant
-     * @return                   void
-     */
-    public function testUndefinedConstant()
-    {
-        $stmts = self::$parser->parse('<?php
-        echo HELLO;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedConstant
-     * @return                   void
-     */
-    public function testUndefinedClassConstant()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        echo A::HELLO;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSingleFileInheritance()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A extends B {}
-
-        class B {
-            public function fooFoo() : void {
-                $a = new A();
-                $a->barBar();
-            }
-
-            protected function barBar() : void {
-                echo "hello";
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidParent
-     * @return                   void
-     */
-    public function testInheritanceLoopOne()
-    {
-        $this->markTestSkipped('A bug');
-        $stmts = self::$parser->parse('<?php
-        class C extends C {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidParent
-     * @return                   void
-     */
-    public function testInheritanceLoopTwo()
-    {
-        $this->markTestSkipped('A bug');
-        $stmts = self::$parser->parse('<?php
-        class E extends F {}
-        class F extends E {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidParent
-     * @return                   void
-     */
-    public function testInheritanceLoopThree()
-    {
-        $this->markTestSkipped('A bug');
-        $stmts = self::$parser->parse('<?php
-        class G extends H {}
-        class H extends I {}
-        class I extends G {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstSandwich()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A { const B = 42;}
-        $a = A::B;
-        class C {}
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testDeferredReference()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B {
-            const C = A;
-        }
-
-        const A = 5;
-
-        $a = B::C;
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedConstant
-     * @return                   void
-     */
-    public function testInvalidDeferredReference()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B {
-            const C = A;
-        }
-
-        $b = (new B);
-
-        const A = 5;
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testMoreCyclicalReferences()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B extends C {
-            public function d() : A {
-                return new A;
-            }
-        }
-        class C {
-            /** @var string */
-            public $p = A::class;
-            public static function e() : void {}
-        }
-        class A extends B {
-            private function f() : void {
-                self::e();
-            }
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testReferenceToSubclassInMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function b(B $b) : void {
-
-            }
-
-            public function c() : void {
-
-            }
-        }
-
-        class B extends A {
-            public function d() : void {
-                $this->c();
-            }
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testReferenceToClassInMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function b(A $b) : void {
-                $b->b(new A());
-            }
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage OverriddenMethodAccess
-     * @return                   void
-     */
-    public function testOverridePublicAccessLevelToPrivate()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo() : void {}
-        }
-
-        class B extends A {
-            private function fooFoo() : void {}
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage OverriddenMethodAccess
-     * @return                   void
-     */
-    public function testOverridePublicAccessLevelToProtected()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo() : void {}
-        }
-
-        class B extends A {
-            protected function fooFoo() : void {}
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage OverriddenMethodAccess
-     * @return                   void
-     */
-    public function testOverrideProtectedAccessLevelToPrivate()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            protected function fooFoo() : void {}
-        }
-
-        class B extends A {
-            private function fooFoo() : void {}
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testOverrideProtectedAccessLevelToPublic()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            protected function fooFoo() : void {}
-        }
-
-        class B extends A {
-            public function fooFoo() : void {}
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testReflectedParents()
-    {
-        $stmts = self::$parser->parse('<?php
-        $e = rand(0, 10)
-          ? new RuntimeException("m")
-          : null;
-
-        if ($e instanceof Exception) {
-          echo "good";
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNamespacedAliasedClassCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Aye {
-            class Foo {}
-        }
-        namespace Bee {
-            use Aye as A;
-
-            new A\Foo();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage DuplicateClass
-     * @return                   void
-     */
-    public function testClassRedefinition()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {}
-        class Foo {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage DuplicateClass
-     * @return                   void
-     */
-    public function testClassRedefinitionInNamespace()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Aye {
-            class Foo {}
-            class Foo {}
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage DuplicateClass
-     * @return                   void
-     */
-    public function testClassRedefinitionInSeparateNamespace()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Aye {
-            class Foo {}
-        }
-        namespace Aye {
-            class Foo {}
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage AbstractInstantiation
-     * @return                   void
-     */
-    public function testAbstractClassInstantiation()
-    {
-        $stmts = self::$parser->parse('<?php
-        abstract class A {}
-        new A();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAbstractExtendsAbstract()
-    {
-        $stmts = self::$parser->parse('<?php
-        abstract class A {
-            /** @return void */
-            abstract public function foo();
-        }
-
-        abstract class B extends A {
-            /** @return void */
-            public function bar() {
-                $this->foo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedClass
-     * @return                   void
-     */
-    public function testMissingParent()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A extends B { }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testMissingParentWithFunction()
-    {
-        Config::getInstance()->setCustomErrorLevel('UndefinedClass', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MissingReturnType', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        class B extends C {
-            public function fooA() { }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MoreSpecificReturnType
-     * @return                   void
-     */
-    public function testMoreSpecificReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A {}
-
-        function foo(A $a) : B {
-            return $a;
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testClassTraversal()
-    {
-
-        $stmts = self::$parser->parse('<?php
-        namespace Foo;
-
-        class A {
-            /** @var string */
-            protected $foo = C::DOPE;
-
-            /** @return string */
-            public function __get() { }
-        }
-
-        class B extends A {
-            /** @return void */
-            public function foo() {
-                echo (string)(new C)->bar;
-            }
-        }
-
-        class C extends B {
-            const DOPE = "dope";
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSubclassWithSimplerArg()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A {}
-
-        class E1 {
-            /**
-             * @param A|B|null $a
-             */
-            public function __construct($a) {
-            }
-        }
-
-        class E2 extends E1 {
-            /**
-             * @param A|null $a
-             */
-            public function __construct($a) {
-                parent::__construct($a);
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSubclassOfInvalidArgumentExceptionWithSimplerArg()
-    {
-        if (version_compare(PHP_VERSION, '7.0.0dev', '<')) {
-            $this->markTestSkipped('Throwable needs PHP 7');
-        }
-
-        $stmts = self::$parser->parse('<?php
-        class A extends InvalidArgumentException {
-            /**
-             * @param string $message
-             * @param int $code
-             * @param Throwable|null $previous_exception
-             */
-            public function __construct($message, $code, $previous_exception) {
-                parent::__construct($message, $code, $previous_exception);
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'undefined-class' => [
+                '<?php
+                    (new Foo());',
+                'error_message' => 'UndefinedClass'
+            ],
+            'wrong-case-class' => [
+                '<?php
+                    class Foo {}
+                    (new foo());',
+                'error_message' => 'InvalidClass'
+            ],
+            'invalid-this-fetch' => [
+                '<?php
+                    echo $this;',
+                'error_message' => 'InvalidScope'
+            ],
+            'invalid-this-argument' => [
+                '<?php
+                    $this = "hello";',
+                'error_message' => 'InvalidScope'
+            ],
+            'undefined-constant' => [
+                '<?php
+                    echo HELLO;',
+                'error_message' => 'UndefinedConstant'
+            ],
+            'undefined-class-constant' => [
+                '<?php
+                    class A {}
+                    echo A::HELLO;',
+                'error_message' => 'UndefinedConstant'
+            ],
+            // Skipped. A bug.
+            'SKIPPED-inheritance-loop-one' => [
+                '<?php
+                    class C extends C {}',
+                'error_message' => 'InvalidParent'
+            ],
+            // Skipped. A bug.
+            'SKIPPED-inheritance-loop-two' => [
+                '<?php
+                    class E extends F {}
+                    class F extends E {}',
+                'error_message' => 'InvalidParent'
+            ],
+            // Skipped. A bug.
+            'SKIPPED-inheritance-loop-three' => [
+                '<?php
+                    class G extends H {}
+                    class H extends I {}
+                    class I extends G {}',
+                'error_message' => 'InvalidParent'
+            ],
+            'invalid-deferred-reference' => [
+                '<?php
+                    class B {
+                        const C = A;
+                    }
+            
+                    $b = (new B);
+            
+                    const A = 5;',
+                'error_message' => 'UndefinedConstant'
+            ],
+            'override-public-access-level-to-public' => [
+                '<?php
+                    class A {
+                        public function fooFoo() : void {}
+                    }
+            
+                    class B extends A {
+                        private function fooFoo() : void {}
+                    }',
+                'error_message' => 'OverriddenMethodAccess'
+            ],
+            'override-public-access-level-to-protected' => [
+                '<?php
+                    class A {
+                        public function fooFoo() : void {}
+                    }
+            
+                    class B extends A {
+                        protected function fooFoo() : void {}
+                    }',
+                'error_message' => 'OverriddenMethodAccess'
+            ],
+            'override-protected-access-level-to-private' => [
+                '<?php
+                    class A {
+                        protected function fooFoo() : void {}
+                    }
+            
+                    class B extends A {
+                        private function fooFoo() : void {}
+                    }',
+                'error_message' => 'OverriddenMethodAccess'
+            ],
+            'class-redefinition' => [
+                '<?php
+                    class Foo {}
+                    class Foo {}',
+                'error_message' => 'DuplicateClass'
+            ],
+            'class-redefinition-in-namespace' => [
+                '<?php
+                    namespace Aye {
+                        class Foo {}
+                        class Foo {}
+                    }',
+                'error_message' => 'DuplicateClass'
+            ],
+            'class-redefinition-in-separate-namespace' => [
+                '<?php
+                    namespace Aye {
+                        class Foo {}
+                    }
+                    namespace Aye {
+                        class Foo {}
+                    }',
+                'error_message' => 'DuplicateClass'
+            ],
+            'abstract-class-instantiation' => [
+                '<?php
+                    abstract class A {}
+                    new A();',
+                'error_message' => 'AbstractInstantiation'
+            ],
+            'missing-parent' => [
+                '<?php
+                    class A extends B { }',
+                'error_message' => 'UndefinedClass'
+            ],
+            'more-specific-return-type' => [
+                '<?php
+                    class A {}
+                    class B extends A {}
+            
+                    function foo(A $a) : B {
+                        return $a;
+                    }',
+                'error_message' => 'MoreSpecificReturnType'
+            ]
+        ];
     }
 }

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -12,7 +12,7 @@ class ClosureTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'by-ref-use-var' => [
+            'byRefUseVar' => [
                 '<?php
                     /** @return void */
                     function run_function(\Closure $fnc) {
@@ -39,7 +39,7 @@ class ClosureTest extends TestCase
             
                     fn();'
             ],
-            'inferred-arg' => [
+            'inferredArg' => [
                 '<?php
                     $bar = ["foo", "bar"];
             
@@ -53,7 +53,7 @@ class ClosureTest extends TestCase
                         $bar
                     );'
             ],
-            'var-return-type' => [
+            'varReturnType' => [
                 '<?php
                     $add_one = function(int $a) : int {
                         return $a + 1;
@@ -64,7 +64,7 @@ class ClosureTest extends TestCase
                     ['int' => '$a']
                 ]
             ],
-            'callable-to-closure' => [
+            'callableToClosure' => [
                 '<?php
                     /**
                      * @return callable
@@ -81,7 +81,7 @@ class ClosureTest extends TestCase
                         echo (string)$c();
                     }'
             ],
-            'callable-class' => [
+            'callableClass' => [
                 '<?php
                     class C {
                         public function __invoke() : string {
@@ -98,7 +98,7 @@ class ClosureTest extends TestCase
                     $c2 = new C();
                     $c2();'
             ],
-            'correct-param-type' => [
+            'correctParamType' => [
                 '<?php
                     $take_string = function(string $s) : string { return $s; };
                     $take_string("string");'
@@ -112,7 +112,7 @@ class ClosureTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'wrong-arg' => [
+            'wrongArg' => [
                 '<?php
                     $bar = ["foo", "bar"];
             
@@ -124,7 +124,7 @@ class ClosureTest extends TestCase
                     );',
                 'error_message' => 'InvalidScalarArgument'
             ],
-            'no-return' => [
+            'noReturn' => [
                 '<?php
                     $bar = ["foo", "bar"];
             
@@ -135,7 +135,7 @@ class ClosureTest extends TestCase
                     );',
                 'error_message' => 'InvalidReturnType'
             ],
-            'undefined-callable-class' => [
+            'undefinedCallableClass' => [
                 '<?php
                     class A {
                         public function getFoo() : Foo
@@ -151,7 +151,7 @@ class ClosureTest extends TestCase
                 'error_message' => 'InvalidFunctionCall',
                 'error_levels' => ['UndefinedClass']
             ],
-            'possibly-null-function-call' => [
+            'possiblyNullFunctionCall' => [
                 '<?php
                     /**
                      * @var Closure|null $foo
@@ -168,13 +168,13 @@ class ClosureTest extends TestCase
                     };',
                 'error_message' => 'PossiblyNullFunctionCall'
             ],
-            'string-function-call' => [
+            'stringFunctionCall' => [
                 '<?php
                     $bad_one = "hello";
                     $a = $bad_one(1);',
                 'error_message' => 'InvalidFunctionCall'
             ],
-            'wrong-param-type' => [
+            'wrongParamType' => [
                 '<?php
                     $take_string = function(string $s) : string { return $s; };
                     $take_string(42);',

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -1,334 +1,185 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ClosureTest extends PHPUnit_Framework_TestCase
+class ClosureTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        return [
+            'by-ref-use-var' => [
+                '<?php
+                    /** @return void */
+                    function run_function(\Closure $fnc) {
+                        $fnc();
+                    }
+            
+                    // here we have to make sure $data exists as a side-effect of calling `run_function`
+                    // because it could exist depending on how run_function is implemented
+                    /**
+                     * @return void
+                     * @psalm-suppress MixedArgument
+                     */
+                    function fn() {
+                        run_function(
+                            /**
+                             * @return void
+                             */
+                            function() use(&$data) {
+                                $data = 1;
+                            }
+                        );
+                        echo $data;
+                    }
+            
+                    fn();'
+            ],
+            'inferred-arg' => [
+                '<?php
+                    $bar = ["foo", "bar"];
+            
+                    $bam = array_map(
+                        /**
+                         * @psalm-suppress MissingClosureReturnType
+                         */
+                        function(string $a) {
+                            return $a . "blah";
+                        },
+                        $bar
+                    );'
+            ],
+            'var-return-type' => [
+                '<?php
+                    $add_one = function(int $a) : int {
+                        return $a + 1;
+                    };
+            
+                    $a = $add_one(1);',
+                'assertions' => [
+                    ['int' => '$a']
+                ]
+            ],
+            'callable-to-closure' => [
+                '<?php
+                    /**
+                     * @return callable
+                     */
+                    function foo() {
+                        return function(string $a) : string {
+                            return $a . "blah";
+                        };
+                    }'
+            ],
+            'callable' => [
+                '<?php
+                    function foo(callable $c) : void {
+                        echo (string)$c();
+                    }'
+            ],
+            'callable-class' => [
+                '<?php
+                    class C {
+                        public function __invoke() : string {
+                            return "You ran?";
+                        }
+                    }
+            
+                    function foo(callable $c) : void {
+                        echo (string)$c();
+                    }
+            
+                    foo(new C());
+            
+                    $c2 = new C();
+                    $c2();'
+            ],
+            'correct-param-type' => [
+                '<?php
+                    $take_string = function(string $s) : string { return $s; };
+                    $take_string("string");'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testByRefUseVar()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void */
-        function run_function(\Closure $fnc) {
-            $fnc();
-        }
-
-        // here we have to make sure $data exists as a side-effect of calling `run_function`
-        // because it could exist depending on how run_function is implemented
-        /**
-         * @return void
-         * @psalm-suppress MixedArgument
-         */
-        function fn() {
-            run_function(
-                /**
-                 * @return void
-                 */
-                function() use(&$data) {
-                    $data = 1;
-                }
-            );
-            echo $data;
-        }
-
-        fn();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScalarArgument
-     * @return                   void
-     */
-    public function testWrongArg()
-    {
-        $stmts = self::$parser->parse('<?php
-        $bar = ["foo", "bar"];
-
-        $bam = array_map(
-            function(int $a) : int {
-                return $a + 1;
-            },
-            $bar
-        );
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testNoReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        $bar = ["foo", "bar"];
-
-        $bam = array_map(
-            function(string $a) : string {
-            },
-            $bar
-        );
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testInferredArg()
-    {
-        $stmts = self::$parser->parse('<?php
-        $bar = ["foo", "bar"];
-
-        $bam = array_map(
-            /**
-             * @psalm-suppress MissingClosureReturnType
-             */
-            function(string $a) {
-                return $a . "blah";
-            },
-            $bar
-        );
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testVarReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-
-        $add_one = function(int $a) : int {
-            return $a + 1;
-        };
-
-        $a = $add_one(1);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testCallableToClosure()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @return callable
-         */
-        function foo() {
-            return function(string $a) : string {
-                return $a . "blah";
-            };
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testCallable()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(callable $c) : void {
-            echo (string)$c();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testCallableClass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class C {
-            public function __invoke() : string {
-                return "You ran?";
-            }
-        }
-
-        function foo(callable $c) : void {
-            echo (string)$c();
-        }
-
-        foo(new C());
-
-        $c2 = new C();
-        $c2();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidFunctionCall
-     * @return  void
-     */
-    public function testUndefinedCallableClass()
-    {
-        Config::getInstance()->setCustomErrorLevel('UndefinedClass', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function getFoo() : Foo
-            {
-                return new Foo([]);
-            }
-
-            public function bar($argOne, $argTwo)
-            {
-                $this->getFoo()($argOne, $argTwo);
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyNullFunctionCall
-     * @return                   void
-     */
-    public function testPossiblyNullFunctionCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-        * @var Closure|null $foo
-        */
-        $foo = null;
-
-        $foo = function ($bar) use (&$foo) : string
-        {
-            if (is_array($bar)) {
-                return $foo($bar);
-            }
-
-            return $bar;
-        };
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
-    }
-
-
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidFunctionCall
-     * @return                   void
-     */
-    public function testStringFunctionCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        $bad_one = "hello";
-        $a = $bad_one(1);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testCorrectParamType()
-    {
-        $stmts = self::$parser->parse('<?php
-        $take_string = function(string $s) : string { return $s; };
-        $take_string("string");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScalarArgument
-     * @return                   void
-     */
-    public function testWrongParamType()
-    {
-        $stmts = self::$parser->parse('<?php
-        $take_string = function(string $s) : string { return $s; };
-        $take_string(42);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'wrong-arg' => [
+                '<?php
+                    $bar = ["foo", "bar"];
+            
+                    $bam = array_map(
+                        function(int $a) : int {
+                            return $a + 1;
+                        },
+                        $bar
+                    );',
+                'error_message' => 'InvalidScalarArgument'
+            ],
+            'no-return' => [
+                '<?php
+                    $bar = ["foo", "bar"];
+            
+                    $bam = array_map(
+                        function(string $a) : string {
+                        },
+                        $bar
+                    );',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'undefined-callable-class' => [
+                '<?php
+                    class A {
+                        public function getFoo() : Foo
+                        {
+                            return new Foo([]);
+                        }
+            
+                        public function bar($argOne, $argTwo)
+                        {
+                            $this->getFoo()($argOne, $argTwo);
+                        }
+                    }',
+                'error_message' => 'InvalidFunctionCall',
+                'error_levels' => ['UndefinedClass']
+            ],
+            'possibly-null-function-call' => [
+                '<?php
+                    /**
+                     * @var Closure|null $foo
+                     */
+                    $foo = null;
+            
+                    $foo = function ($bar) use (&$foo) : string
+                    {
+                        if (is_array($bar)) {
+                            return $foo($bar);
+                        }
+            
+                        return $bar;
+                    };',
+                'error_message' => 'PossiblyNullFunctionCall'
+            ],
+            'string-function-call' => [
+                '<?php
+                    $bad_one = "hello";
+                    $a = $bad_one(1);',
+                'error_message' => 'InvalidFunctionCall'
+            ],
+            'wrong-param-type' => [
+                '<?php
+                    $take_string = function(string $s) : string { return $s; };
+                    $take_string(42);',
+                'error_message' => 'InvalidScalarArgument'
+            ]
+        ];
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -156,8 +156,21 @@ class ConfigTest extends PHPUnit_Framework_TestCase
             </psalm>'
         );
 
-        $this->assertSame('info', $config->getReportingLevelForFile('MissingReturnType', realpath('src/Psalm/Type.php')));
-        $this->assertSame('error', $config->getReportingLevelForFile('MissingReturnType', realpath('src/Psalm/Checker/FileChecker.php')));
+        $this->assertSame(
+            'info',
+            $config->getReportingLevelForFile(
+                'MissingReturnType',
+                realpath('src/Psalm/Type.php')
+            )
+        );
+
+        $this->assertSame(
+            'error',
+            $config->getReportingLevelForFile(
+                'MissingReturnType',
+                realpath('src/Psalm/Checker/FileChecker.php')
+            )
+        );
     }
 
     /**
@@ -490,6 +503,5 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         foreach (['1.xml', '2.xml', '3.xml', '4.xml', '5.xml'] as $file_name) {
             Config::loadFromXMLFile(realpath(dirname(__DIR__) . '/assets/config_levels/' . $file_name));
         }
-
     }
 }

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -12,7 +12,7 @@ class ConstantTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'constant-in-function' => [
+            'constantInFunction' => [
                 '<?php
                     useTest();
                     const TEST = 2;
@@ -21,7 +21,7 @@ class ConstantTest extends TestCase
                         return TEST;
                     }'
             ],
-            'constant-in-closure' => [
+            'constantInClosure' => [
                 '<?php
                     const TEST = 2;
                     
@@ -30,7 +30,7 @@ class ConstantTest extends TestCase
                     };
                     $useTest();'
             ],
-            'constant-defined-in-function' => [
+            'constantDefinedInFunction' => [
                 '<?php
                     /**
                      * @return void
@@ -52,7 +52,7 @@ class ConstantTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'constant-defined-in-function-but-not-called' => [
+            'constantDefinedInFunctionButNotCalled' => [
                 '<?php
                     /**
                      * @return void

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -1,123 +1,69 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ConstantTest extends PHPUnit_Framework_TestCase
+class ConstantTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
+        return [
+            'constant-in-function' => [
+                '<?php
+                    useTest();
+                    const TEST = 2;
+            
+                    function useTest() : int {
+                        return TEST;
+                    }'
+            ],
+            'constant-in-closure' => [
+                '<?php
+                    const TEST = 2;
+                    
+                    $useTest = function() : int {
+                        return TEST;
+                    };
+                    $useTest();'
+            ],
+            'constant-defined-in-function' => [
+                '<?php
+                    /**
+                     * @return void
+                     */
+                    function defineConstant() {
+                        define("CONSTANT", 1);
+                    }
+            
+                    defineConstant();
+            
+                    echo CONSTANT;'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstantInFunction()
-    {
-        $stmts = self::$parser->parse('<?php
-        useTest();
-        const TEST = 2;
-
-        function useTest() : int {
-            return TEST;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstantInClosure()
-    {
-        $stmts = self::$parser->parse('<?php
-        const TEST = 2;
-        
-        $useTest = function() : int {
-            return TEST;
-        };
-        $useTest();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstantDefinedInFunction()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @return void
-         */
-        function defineConstant() {
-            define("CONSTANT", 1);
-        }
-
-        defineConstant();
-
-        echo CONSTANT;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedConstant
-     * @return                   void
-     */
-    public function testConstantDefinedInFunctionButNotCalled()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @return void
-         */
-        function defineConstant() {
-            define("CONSTANT", 1);
-        }
-
-        echo CONSTANT;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'constant-defined-in-function-but-not-called' => [
+                '<?php
+                    /**
+                     * @return void
+                     */
+                    function defineConstant() {
+                        define("CONSTANT", 1);
+                    }
+            
+                    echo CONSTANT;',
+                'error_message' => 'UndefinedConstant'
+            ]
+        ];
     }
 }

--- a/tests/ForTest.php
+++ b/tests/ForTest.php
@@ -11,7 +11,7 @@ class ForTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'continue-outside-loop' => [
+            'continueOutsideLoop' => [
                 '<?php
                     class Node {
                         /** @var Node|null */
@@ -26,7 +26,7 @@ class ForTest extends TestCase
                         }
                     }'
             ],
-            'echo-after-for' => [
+            'echoAfterFor' => [
                 '<?php
                     for ($i = 0; $i < 5; $i++);
                     echo $i;'

--- a/tests/ForTest.php
+++ b/tests/ForTest.php
@@ -1,79 +1,36 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ForTest extends PHPUnit_Framework_TestCase
+class ForTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testContinueOutsideLoop()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Node {
-            /** @var Node|null */
-            public $next;
-        }
-
-        /** @return void */
-        function test(Node $head) {
-            for ($node = $head; $node; $node = $next) {
-                $next = $node->next;
-                $node->next = null;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testEchoAfterFor()
-    {
-        $stmts = self::$parser->parse('<?php
-        for ($i = 0; $i < 5; $i++);
-        echo $i;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'continue-outside-loop' => [
+                '<?php
+                    class Node {
+                        /** @var Node|null */
+                        public $next;
+                    }
+            
+                    /** @return void */
+                    function test(Node $head) {
+                        for ($node = $head; $node; $node = $next) {
+                            $next = $node->next;
+                            $node->next = null;
+                        }
+                    }'
+            ],
+            'echo-after-for' => [
+                '<?php
+                    for ($i = 0; $i < 5; $i++);
+                    echo $i;'
+            ]
+        ];
     }
 }

--- a/tests/ForbiddenCodeTest.php
+++ b/tests/ForbiddenCodeTest.php
@@ -11,12 +11,12 @@ class ForbiddenCodeTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'var-dump' => [
+            'varDump' => [
                 '<?php
                     var_dump("hello");',
                 'error_message' => 'ForbiddenCode'
             ],
-            'exec-ticks' => [
+            'execTicks' => [
                 '<?php
                     `rm -rf`;',
                 'error_message' => 'ForbiddenCode'

--- a/tests/ForbiddenCodeTest.php
+++ b/tests/ForbiddenCodeTest.php
@@ -1,87 +1,31 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ForbiddenCodeTest extends PHPUnit_Framework_TestCase
+class ForbiddenCodeTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ForbiddenCode
-     * @return                   void
-     */
-    public function testVarDump()
-    {
-        $stmts = self::$parser->parse('<?php
-        var_dump("hello");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ForbiddenCode
-     * @return                   void
-     */
-    public function testExecTicks()
-    {
-        $stmts = self::$parser->parse('<?php
-        `rm -rf`;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ForbiddenCode
-     * @return                   void
-     */
-    public function testExec()
-    {
-        $stmts = self::$parser->parse('<?php
-        shell_exec("rm -rf");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'var-dump' => [
+                '<?php
+                    var_dump("hello");',
+                'error_message' => 'ForbiddenCode'
+            ],
+            'exec-ticks' => [
+                '<?php
+                    `rm -rf`;',
+                'error_message' => 'ForbiddenCode'
+            ],
+            'exec' => [
+                '<?php
+                    shell_exec("rm -rf");',
+                'error_message' => 'ForbiddenCode'
+            ]
+        ];
     }
 }

--- a/tests/ForeachTest.php
+++ b/tests/ForeachTest.php
@@ -1,73 +1,28 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ForeachTest extends PHPUnit_Framework_TestCase
+class ForeachTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ContinueOutsideLoop
-     * @return                   void
-     */
-    public function testContinueOutsideLoop()
-    {
-        $stmts = self::$parser->parse('<?php
-        continue;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidIterator
-     * @return                   void
-     */
-    public function testInvalidIterator()
-    {
-        $stmts = self::$parser->parse('<?php
-        foreach (5 as $a) {
-
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'continue-outside-loop' => [
+                '<?php
+                    continue;',
+                'error_message' => 'ContinueOutsideLoop'
+            ],
+            'invalid-iterator' => [
+                '<?php
+                    foreach (5 as $a) {
+            
+                    }',
+                'error_message' => 'InvalidIterator'
+            ]
+        ];
     }
 }

--- a/tests/ForeachTest.php
+++ b/tests/ForeachTest.php
@@ -11,12 +11,12 @@ class ForeachTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'continue-outside-loop' => [
+            'continueOutsideLoop' => [
                 '<?php
                     continue;',
                 'error_message' => 'ContinueOutsideLoop'
             ],
-            'invalid-iterator' => [
+            'invalidIterator' => [
                 '<?php
                     foreach (5 as $a) {
             

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1,446 +1,13 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
-use Psalm\Config;
 use Psalm\Context;
 
-class FunctionCallTest extends PHPUnit_Framework_TestCase
+class FunctionCallTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScalarArgument
-     * @return                   void
-     */
-    public function testInvalidScalarArgument()
-    {
-        $stmts = self::$parser->parse('<?php
-        function fooFoo(int $a) : void {}
-        fooFoo("string");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MixedArgument
-     * @return                   void
-     */
-    public function testMixedArgument()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        function fooFoo(int $a) : void {}
-        /** @var mixed */
-        $a = "hello";
-        fooFoo($a);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage NullArgument
-     * @return                   void
-     */
-    public function testNullArgument()
-    {
-        $stmts = self::$parser->parse('<?php
-        function fooFoo(int $a) : void {}
-        fooFoo(null);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage TooFewArguments
-     * @return                   void
-     */
-    public function testTooFewArguments()
-    {
-        $stmts = self::$parser->parse('<?php
-        function fooFoo(int $a) : void {}
-        fooFoo();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage TooManyArguments
-     * @return                   void
-     */
-    public function testTooManyArguments()
-    {
-        $stmts = self::$parser->parse('<?php
-        function fooFoo(int $a) : void {}
-        fooFoo(5, "dfd");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage TypeCoercion
-     * @return                   void
-     */
-    public function testTypeCoercion()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A{}
-
-        function fooFoo(B $b) : void {}
-        fooFoo(new A());
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage TypeCoercion
-     * @return                   void
-     */
-    public function testArrayTypeCoercion()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A{}
-
-        /**
-         * @param  B[]  $b
-         * @return void
-         */
-        function fooFoo(array $b) {}
-        fooFoo([new A()]);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testTypedArrayWithDefault()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-
-        /** @param array<A> $a */
-        function fooFoo(array $a = []) : void {
-
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage DuplicateParam
-     * @return                   void
-     */
-    public function testDuplicateParam()
-    {
-        $stmts = self::$parser->parse('<?php
-        function f($p, $p) {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidParamDefault
-     * @return                   void
-     */
-    public function testInvalidParamDefault()
-    {
-        $stmts = self::$parser->parse('<?php
-        function f(int $p = false) {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidParamDefault
-     * @return                   void
-     */
-    public function testInvalidDocblockParamDefault()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param  int $p
-         * @return void
-         */
-        function f($p = false) {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testValidDocblockParamDefault()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param  int|false $p
-         * @return void
-         */
-        function f($p = false) {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testByRef()
-    {
-        $stmts = self::$parser->parse('<?php
-        function fooFoo(string &$v) : void {}
-        fooFoo($a);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidPassByReference
-     * @return                   void
-     */
-    public function testBadByRef()
-    {
-        $this->markTestSkipped('Does not throw an error');
-        $stmts = self::$parser->parse('<?php
-        function fooFoo(string &$v) : void {}
-        fooFoo("a");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNamespaced()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace A;
-
-        /** @return void */
-        function f(int $p) {}
-        f(5);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNamespacedRootFunctionCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace {
-            /** @return void */
-            function foo() { }
-        }
-        namespace A\B\C {
-            foo();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNamespacedAliasedFunctionCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Aye {
-            /** @return void */
-            function foo() { }
-        }
-        namespace Bee {
-            use Aye as A;
-
-            A\foo();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayKeys()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = array_keys(["a" => 1, "b" => 2]);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayKeysMixed()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedArgument', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        /** @var array */
-        $b = ["a" => 5];
-        $a = array_keys($b);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, mixed>', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayValues()
-    {
-        $stmts = self::$parser->parse('<?php
-        $b = array_values(["a" => 1, "b" => 2]);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, int>', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayCombine()
-    {
-        $stmts = self::$parser->parse('<?php
-        $c = array_combine(["a", "b", "c"], [1, 2, 3]);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<string, int>', (string) $context->vars_in_scope['$c']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayMerge()
-    {
-        $stmts = self::$parser->parse('<?php
-        $d = array_merge(["a", "b", "c"], [1, 2, 3]);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, int|string>', (string) $context->vars_in_scope['$d']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayDiff()
-    {
-        $stmts = self::$parser->parse('<?php
-        $d = array_diff(["a" => 5, "b" => 12], [5]);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<string, int>', (string) $context->vars_in_scope['$d']);
-    }
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
      * @return void
@@ -460,8 +27,12 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
 
         if (version_compare((string)phpversion(), '5.6.0', '>=')) {
             $stmts = self::$parser->parse('<?php
-            $f = array_filter(["a" => 5, "b" => 12, "c" => null], function(?int $val, string $key) : bool { return true; }, ARRAY_FILTER_USE_BOTH);
-            $g = array_filter(["a" => 5, "b" => 12, "c" => null], function(string $val) : bool { return true; }, ARRAY_FILTER_USE_KEY);
+            $f = array_filter(["a" => 5, "b" => 12, "c" => null], function(?int $val, string $key) : bool { 
+                return true; 
+            }, ARRAY_FILTER_USE_BOTH);
+            $g = array_filter(["a" => 5, "b" => 12, "c" => null], function(string $val) : bool { 
+                return true; 
+            }, ARRAY_FILTER_USE_KEY);
 
             $bar = "bar";
 
@@ -519,77 +90,247 @@ class FunctionCallTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testByRefAfterCallable()
+    public function providerFileCheckerValidCodeParse()
     {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedArrayAccess', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param callable $callback
-         * @return void
-         */
-        function route($callback) {
-          if (!is_callable($callback)) {  }
-          $a = preg_match("", "", $b);
-          if ($b[0]) {}
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'typed-array-with-default' => [
+                '<?php
+                    class A {}
+            
+                    /** @param array<A> $a */
+                    function fooFoo(array $a = []) : void {
+            
+                    }'
+            ],
+            'valid-docblock-param-default' => [
+                '<?php
+                    /**
+                     * @param  int|false $p
+                     * @return void
+                     */
+                    function f($p = false) {}'
+            ],
+            'by-ref' => [
+                '<?php
+                    function fooFoo(string &$v) : void {}
+                    fooFoo($a);'
+            ],
+            'namespaced' => [
+                '<?php
+                    namespace A;
+            
+                    /** @return void */
+                    function f(int $p) {}
+                    f(5);'
+            ],
+            'namespaced-root-function-call' => [
+                '<?php
+                    namespace {
+                        /** @return void */
+                        function foo() { }
+                    }
+                    namespace A\B\C {
+                        foo();
+                    }'
+            ],
+            'namespaced-aliased-function-call' => [
+                '<?php
+                    namespace Aye {
+                        /** @return void */
+                        function foo() { }
+                    }
+                    namespace Bee {
+                        use Aye as A;
+            
+                        A\foo();
+                    }'
+            ],
+            'array-keys' => [
+                '<?php
+                    $a = array_keys(["a" => 1, "b" => 2]);',
+                'assertions' => [
+                    ['array<int, string>' => '$a']
+                ]
+            ],
+            'array-keys-mixed' => [
+                '<?php
+                    /** @var array */
+                    $b = ["a" => 5];
+                    $a = array_keys($b);',
+                'assertions' => [
+                    ['array<int, mixed>' => '$a']
+                ],
+                'error_levels' => ['MixedArgument']
+            ],
+            'array-values' => [
+                '<?php
+                    $b = array_values(["a" => 1, "b" => 2]);',
+                'assertions' => [
+                    ['array<int, int>' => '$b']
+                ]
+            ],
+            'array-combine' => [
+                '<?php
+                    $c = array_combine(["a", "b", "c"], [1, 2, 3]);',
+                'assertions' => [
+                    ['array<string, int>' => '$c']
+                ]
+            ],
+            'array-merge' => [
+                '<?php
+                    $d = array_merge(["a", "b", "c"], [1, 2, 3]);',
+                'assertions' => [
+                    ['array<int, int|string>' => '$d']
+                ]
+            ],
+            'array-diff' => [
+                '<?php
+                    $d = array_diff(["a" => 5, "b" => 12], [5]);',
+                'assertions' => [
+                    ['array<string, int>' => '$d']
+                ]
+            ],
+            'by-ref-after-callable' => [
+                '<?php
+                    /**
+                     * @param callable $callback
+                     * @return void
+                     */
+                    function route($callback) {
+                      if (!is_callable($callback)) {  }
+                      $a = preg_match("", "", $b);
+                      if ($b[0]) {}
+                    }',
+                'assertions' => [],
+                'error_levels' => [
+                    'MixedAssignment',
+                    'MixedArrayAccess'
+                ]
+            ],
+            'extract-var-check' => [
+                '<?php
+                    function takesString(string $str) : void {}
+            
+                    $foo = null;
+                    $a = ["$foo" => "bar"];
+                    extract($a);
+                    takesString($foo);',
+                'assertions' => [],
+                'error_levels' => [
+                    'MixedAssignment',
+                    'MixedArrayAccess'
+                ]
+            ]
+        ];
     }
 
     /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScalarArgument
-     * @return                   void
+     * @return array
      */
-    public function testInvalidArgAfterCallable()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedArrayAccess', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param callable $callback
-         * @return void
-         */
-        function route($callback) {
-          if (!is_callable($callback)) {  }
-          takes_int("string");
-        }
-
-        function takes_int(int $i) {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testExtractVarCheck()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedArrayAccess', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        function takesString(string $str) : void {}
-
-        $foo = null;
-        $a = ["$foo" => "bar"];
-        extract($a);
-        takesString($foo);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'invalid-scalar-argument' => [
+                '<?php
+                    function fooFoo(int $a) : void {}
+                    fooFoo("string");',
+                'error_message' => 'InvalidScalarArgument'
+            ],
+            'mixed-argument' => [
+                '<?php
+                    function fooFoo(int $a) : void {}
+                    /** @var mixed */
+                    $a = "hello";
+                    fooFoo($a);',
+                'error_message' => 'MixedArgument',
+                'error_levels' => ['MixedAssignment']
+            ],
+            'null-argument' => [
+                '<?php
+                    function fooFoo(int $a) : void {}
+                    fooFoo(null);',
+                'error_message' => 'NullArgument'
+            ],
+            'too-few-arguments' => [
+                '<?php
+                    function fooFoo(int $a) : void {}
+                    fooFoo();',
+                'error_message' => 'TooFewArguments'
+            ],
+            'too-many-arguments' => [
+                '<?php
+                    function fooFoo(int $a) : void {}
+                    fooFoo(5, "dfd");',
+                'error_message' => 'TooManyArguments'
+            ],
+            'type-coercion' => [
+                '<?php
+                    class A {}
+                    class B extends A{}
+            
+                    function fooFoo(B $b) : void {}
+                    fooFoo(new A());',
+                'error_message' => 'TypeCoercion'
+            ],
+            'array-type-coercion' => [
+                '<?php
+                    class A {}
+                    class B extends A{}
+            
+                    /**
+                     * @param  B[]  $b
+                     * @return void
+                     */
+                    function fooFoo(array $b) {}
+                    fooFoo([new A()]);',
+                'error_message' => 'TypeCoercion'
+            ],
+            'duplicate-param' => [
+                '<?php
+                    function f($p, $p) {}',
+                'error_message' => 'DuplicateParam'
+            ],
+            'invalid-param-default' => [
+                '<?php
+                    function f(int $p = false) {}',
+                'error_message' => 'InvalidParamDefault'
+            ],
+            'invalid-docblock-param-default' => [
+                '<?php
+                    /**
+                     * @param  int $p
+                     * @return void
+                     */
+                    function f($p = false) {}',
+                'error_message' => 'InvalidParamDefault'
+            ],
+            // Skipped. Does not throw an error.
+            'SKIPPED-bad-by-ref' => [
+                '<?php
+                    function fooFoo(string &$v) : void {}
+                    fooFoo("a");',
+                'error_message' => 'InvalidPassByReference'
+            ],
+            'invalid-arg-after-callable' => [
+                '<?php
+                    /**
+                     * @param callable $callback
+                     * @return void
+                     */
+                    function route($callback) {
+                      if (!is_callable($callback)) {  }
+                      takes_int("string");
+                    }
+            
+                    function takes_int(int $i) {}',
+                'error_message' => 'InvalidScalarArgument',
+                'error_levels' => [
+                    'MixedAssignment',
+                    'MixedArrayAccess'
+                ]
+            ]
+        ];
     }
 }

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -95,7 +95,7 @@ class FunctionCallTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'typed-array-with-default' => [
+            'typedArrayWithDefault' => [
                 '<?php
                     class A {}
             
@@ -104,7 +104,7 @@ class FunctionCallTest extends TestCase
             
                     }'
             ],
-            'valid-docblock-param-default' => [
+            'validDocblockParamDefault' => [
                 '<?php
                     /**
                      * @param  int|false $p
@@ -112,7 +112,7 @@ class FunctionCallTest extends TestCase
                      */
                     function f($p = false) {}'
             ],
-            'by-ref' => [
+            'byRef' => [
                 '<?php
                     function fooFoo(string &$v) : void {}
                     fooFoo($a);'
@@ -125,7 +125,7 @@ class FunctionCallTest extends TestCase
                     function f(int $p) {}
                     f(5);'
             ],
-            'namespaced-root-function-call' => [
+            'namespacedRootFunctionCall' => [
                 '<?php
                     namespace {
                         /** @return void */
@@ -135,7 +135,7 @@ class FunctionCallTest extends TestCase
                         foo();
                     }'
             ],
-            'namespaced-aliased-function-call' => [
+            'namespacedAliasedFunctionCall' => [
                 '<?php
                     namespace Aye {
                         /** @return void */
@@ -147,14 +147,14 @@ class FunctionCallTest extends TestCase
                         A\foo();
                     }'
             ],
-            'array-keys' => [
+            'arrayKeys' => [
                 '<?php
                     $a = array_keys(["a" => 1, "b" => 2]);',
                 'assertions' => [
                     ['array<int, string>' => '$a']
                 ]
             ],
-            'array-keys-mixed' => [
+            'arrayKeysMixed' => [
                 '<?php
                     /** @var array */
                     $b = ["a" => 5];
@@ -164,35 +164,35 @@ class FunctionCallTest extends TestCase
                 ],
                 'error_levels' => ['MixedArgument']
             ],
-            'array-values' => [
+            'arrayValues' => [
                 '<?php
                     $b = array_values(["a" => 1, "b" => 2]);',
                 'assertions' => [
                     ['array<int, int>' => '$b']
                 ]
             ],
-            'array-combine' => [
+            'arrayCombine' => [
                 '<?php
                     $c = array_combine(["a", "b", "c"], [1, 2, 3]);',
                 'assertions' => [
                     ['array<string, int>' => '$c']
                 ]
             ],
-            'array-merge' => [
+            'arrayMerge' => [
                 '<?php
                     $d = array_merge(["a", "b", "c"], [1, 2, 3]);',
                 'assertions' => [
                     ['array<int, int|string>' => '$d']
                 ]
             ],
-            'array-diff' => [
+            'arrayDiff' => [
                 '<?php
                     $d = array_diff(["a" => 5, "b" => 12], [5]);',
                 'assertions' => [
                     ['array<string, int>' => '$d']
                 ]
             ],
-            'by-ref-after-callable' => [
+            'byRefAfterCallable' => [
                 '<?php
                     /**
                      * @param callable $callback
@@ -209,7 +209,7 @@ class FunctionCallTest extends TestCase
                     'MixedArrayAccess'
                 ]
             ],
-            'extract-var-check' => [
+            'extractVarCheck' => [
                 '<?php
                     function takesString(string $str) : void {}
             
@@ -232,13 +232,13 @@ class FunctionCallTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'invalid-scalar-argument' => [
+            'invalidScalarArgument' => [
                 '<?php
                     function fooFoo(int $a) : void {}
                     fooFoo("string");',
                 'error_message' => 'InvalidScalarArgument'
             ],
-            'mixed-argument' => [
+            'mixedArgument' => [
                 '<?php
                     function fooFoo(int $a) : void {}
                     /** @var mixed */
@@ -247,25 +247,25 @@ class FunctionCallTest extends TestCase
                 'error_message' => 'MixedArgument',
                 'error_levels' => ['MixedAssignment']
             ],
-            'null-argument' => [
+            'nullArgument' => [
                 '<?php
                     function fooFoo(int $a) : void {}
                     fooFoo(null);',
                 'error_message' => 'NullArgument'
             ],
-            'too-few-arguments' => [
+            'tooFewArguments' => [
                 '<?php
                     function fooFoo(int $a) : void {}
                     fooFoo();',
                 'error_message' => 'TooFewArguments'
             ],
-            'too-many-arguments' => [
+            'tooManyArguments' => [
                 '<?php
                     function fooFoo(int $a) : void {}
                     fooFoo(5, "dfd");',
                 'error_message' => 'TooManyArguments'
             ],
-            'type-coercion' => [
+            'typeCoercion' => [
                 '<?php
                     class A {}
                     class B extends A{}
@@ -274,7 +274,7 @@ class FunctionCallTest extends TestCase
                     fooFoo(new A());',
                 'error_message' => 'TypeCoercion'
             ],
-            'array-type-coercion' => [
+            'arrayTypeCoercion' => [
                 '<?php
                     class A {}
                     class B extends A{}
@@ -287,17 +287,17 @@ class FunctionCallTest extends TestCase
                     fooFoo([new A()]);',
                 'error_message' => 'TypeCoercion'
             ],
-            'duplicate-param' => [
+            'duplicateParam' => [
                 '<?php
                     function f($p, $p) {}',
                 'error_message' => 'DuplicateParam'
             ],
-            'invalid-param-default' => [
+            'invalidParamDefault' => [
                 '<?php
                     function f(int $p = false) {}',
                 'error_message' => 'InvalidParamDefault'
             ],
-            'invalid-docblock-param-default' => [
+            'invalidDocblockParamDefault' => [
                 '<?php
                     /**
                      * @param  int $p
@@ -307,13 +307,13 @@ class FunctionCallTest extends TestCase
                 'error_message' => 'InvalidParamDefault'
             ],
             // Skipped. Does not throw an error.
-            'SKIPPED-bad-by-ref' => [
+            'SKIPPED-badByRef' => [
                 '<?php
                     function fooFoo(string &$v) : void {}
                     fooFoo("a");',
                 'error_message' => 'InvalidPassByReference'
             ],
-            'invalid-arg-after-callable' => [
+            'invalidArgAfterCallable' => [
                 '<?php
                     /**
                      * @param callable $callback

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -33,7 +33,7 @@ class IncludeTest extends TestCase
     public function providerTestValidIncludes()
     {
         return [
-            'basic-require' => [
+            'basicRequire' => [
                 'file' => getcwd() . DIRECTORY_SEPARATOR . 'file2.php',
                 'code' => '<?php
                     require("file1.php");
@@ -49,7 +49,7 @@ class IncludeTest extends TestCase
                         }'
                 ]
             ],
-            'nested-require' => [
+            'nestedRequire' => [
                 'file' => getcwd() . DIRECTORY_SEPARATOR . 'file3.php',
                 'code' => '<?php
                     require("file2.php");
@@ -73,7 +73,7 @@ class IncludeTest extends TestCase
                         }'
                 ]
             ],
-            'require-namespace' => [
+            'requireNamespace' => [
                 'file' => getcwd() . DIRECTORY_SEPARATOR . 'file2.php',
                 'code' => '<?php
                     require("file1.php");
@@ -91,7 +91,7 @@ class IncludeTest extends TestCase
                         }'
                 ]
             ],
-            'require-function' => [
+            'requireFunction' => [
                 'file' => getcwd() . DIRECTORY_SEPARATOR . 'file2.php',
                 'code' => '<?php
                     require("file1.php");
@@ -104,7 +104,7 @@ class IncludeTest extends TestCase
                         }'
                 ]
             ],
-            'require-namespaced-with-use' => [
+            'requireNamespacedWithUse' => [
                 'file' => getcwd() . DIRECTORY_SEPARATOR . 'file2.php',
                 'code' => '<?php
                     require("file1.php");

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -33,7 +33,7 @@ class InterfaceTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'extends-and-implements' => [
+            'extendsAndImplements' => [
                 '<?php
                     interface A
                     {
@@ -84,7 +84,7 @@ class InterfaceTest extends TestCase
                     ['string' => '$dee']
                 ]
             ],
-            'is-extended-interface' => [
+            'isExtendedInterface' => [
                 '<?php
                     interface A
                     {
@@ -124,7 +124,7 @@ class InterfaceTest extends TestCase
             
                     qux(new C());'
             ],
-            'extends-with-method' => [
+            'extendsWithMethod' => [
                 '<?php
                     interface A
                     {
@@ -144,7 +144,7 @@ class InterfaceTest extends TestCase
                         $b->fooFoo();
                     }'
             ],
-            'correct-interface-method-signature' => [
+            'correctInterfaceMethodSignature' => [
                 '<?php
                     interface A {
                         public function fooFoo(int $a) : void;
@@ -156,7 +156,7 @@ class InterfaceTest extends TestCase
                         }
                     }'
             ],
-            'interface-method-implemented-in-parent' => [
+            'interfaceMethodImplementedInParent' => [
                 '<?php
                     interface MyInterface {
                         public function fooFoo(int $a) : void;
@@ -170,7 +170,7 @@ class InterfaceTest extends TestCase
             
                     class C extends B implements MyInterface { }'
             ],
-            'interface-method-signature-in-trait' => [
+            'interfaceMethodSignatureInTrait' => [
                 '<?php
                     interface A {
                         public function fooFoo(int $a, int $b) : void;
@@ -185,7 +185,7 @@ class InterfaceTest extends TestCase
                         use T;
                     }'
             ],
-            'delayed-interface' => [
+            'delayedInterface' => [
                 '<?php
                     // fails in PHP, whatcha gonna do
                     $c = new C;
@@ -196,7 +196,7 @@ class InterfaceTest extends TestCase
             
                     class C extends A implements B { }'
             ],
-            'type-does-not-contain-type' => [
+            'typeDoesNotContainType' => [
                 '<?php
                     interface A { }
                     interface B {
@@ -208,7 +208,7 @@ class InterfaceTest extends TestCase
                         }
                     }'
             ],
-            'abstract-interface-implements' => [
+            'abstractInterfaceImplements' => [
                 '<?php
                     interface I {
                         public function fnc();
@@ -216,7 +216,7 @@ class InterfaceTest extends TestCase
             
                     abstract class A implements I {}'
             ],
-            'abstract-interface-implements-but-call-method' => [
+            'abstractInterfaceImplementsButCallMethod' => [
                 '<?php
                     interface I {
                         public function foo();
@@ -228,7 +228,7 @@ class InterfaceTest extends TestCase
                         }
                     }'
             ],
-            'implements-partial-interface-methods' => [
+            'implementsPartialInterfaceMethods' => [
                 '<?php
                     namespace Bat;
             
@@ -249,7 +249,7 @@ class InterfaceTest extends TestCase
                 'assertions' => [],
                 'error_levels' => ['MissingReturnType']
             ],
-            'interface-constants' => [
+            'interfaceConstants' => [
                 '<?php
                     interface I1 {
                         const A = 5;
@@ -279,7 +279,7 @@ class InterfaceTest extends TestCase
                         public $bar3 = self::E;
                     }'
             ],
-            'interface-extends-return-type' => [
+            'interfaceExtendsReturnType' => [
                 '<?php
                     interface A {}
                     interface B extends A {}
@@ -297,7 +297,7 @@ class InterfaceTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'no-interface-properties' => [
+            'noInterfaceProperties' => [
                 '<?php
                     interface A { }
             
@@ -308,7 +308,7 @@ class InterfaceTest extends TestCase
                     }',
                 'error_message' => 'NoInterfaceProperties'
             ],
-            'unimplemented-interface-method' => [
+            'unimplementedInterfaceMethod' => [
                 '<?php
                     interface A {
                         public function fooFoo();
@@ -317,7 +317,7 @@ class InterfaceTest extends TestCase
                     class B implements A { }',
                 'error_message' => 'UnimplementedInterfaceMethod'
             ],
-            'mismatching-interface-method-signature' => [
+            'mismatchingInterfaceMethodSignature' => [
                 '<?php
                     interface A {
                         public function fooFoo(int $a) : void;
@@ -330,7 +330,7 @@ class InterfaceTest extends TestCase
                     }',
                 'error_message' => 'MethodSignatureMismatch'
             ],
-            'mismatching-interface-method-signature-in-trait' => [
+            'mismatchingInterfaceMethodSignatureInTrait' => [
                 '<?php
                     interface A {
                         public function fooFoo(int $a, int $b) : void;
@@ -346,7 +346,7 @@ class InterfaceTest extends TestCase
                     }',
                 'error_message' => 'MethodSignatureMismatch'
             ],
-            'mismatching-interface-method-signature-in-implementer' => [
+            'mismatchingInterfaceMethodSignatureInImplementer' => [
                 '<?php
                     interface A {
                         public function fooFoo(int $a, int $b) : void;
@@ -365,7 +365,7 @@ class InterfaceTest extends TestCase
                     }',
                 'error_message' => 'MethodSignatureMismatch'
             ],
-            'abstract-interface-implements-but-call-undefined-method' => [
+            'abstractInterfaceImplementsButCallUndefinedMethod' => [
                 '<?php
                     interface I {
                         public function foo();
@@ -378,7 +378,7 @@ class InterfaceTest extends TestCase
                     }',
                 'error_message' => 'UndefinedMethod'
             ],
-            'abstract-interface-implements-with-subclass' => [
+            'abstractInterfaceImplementsWithSubclass' => [
                 '<?php
                     interface I {
                         public function fnc();
@@ -389,7 +389,7 @@ class InterfaceTest extends TestCase
                     class B extends A {}',
                 'error_message' => 'UnimplementedInterfaceMethod'
             ],
-            'more-specific-return-type' => [
+            'moreSpecificReturnType' => [
                 '<?php
                     interface A {}
                     interface B extends A {}

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -1,401 +1,13 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
-use Psalm\Config;
 use Psalm\Context;
 
-class InterfaceTest extends PHPUnit_Framework_TestCase
+class InterfaceTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testExtendsAndImplements()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A
-        {
-            /**
-             * @return string
-             */
-            public function fooFoo();
-        }
-
-        interface B
-        {
-            /**
-             * @return string
-             */
-            public function barBar();
-        }
-
-        interface C extends A, B
-        {
-            /**
-             * @return string
-             */
-            public function baz();
-        }
-
-        class D implements C
-        {
-            public function fooFoo()
-            {
-                return "hello";
-            }
-
-            public function barBar()
-            {
-                return "goodbye";
-            }
-
-            public function baz()
-            {
-                return "hello again";
-            }
-        }
-
-        $cee = (new D())->baz();
-        $dee = (new D())->fooFoo();
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$cee']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$dee']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIsExtendedInterface()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A
-        {
-            /**
-             * @return string
-             */
-            public function fooFoo();
-        }
-
-        interface B extends A
-        {
-            /**
-             * @return string
-             */
-            public function baz();
-        }
-
-        class C implements B
-        {
-            public function fooFoo()
-            {
-                return "hello";
-            }
-
-            public function baz()
-            {
-                return "goodbye";
-            }
-        }
-
-        /**
-         * @param  A      $a
-         * @return void
-         */
-        function qux(A $a) {
-        }
-
-        qux(new C());
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testExtendsWithMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A
-        {
-            /**
-             * @return string
-             */
-            public function fooFoo();
-        }
-
-        interface B extends A
-        {
-            public function barBar();
-        }
-
-        /** @return void */
-        function mux(B $b) {
-            $b->fooFoo();
-        }
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage NoInterfaceProperties
-     * @return                   void
-     */
-    public function testNoInterfaceProperties()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A { }
-
-        function fooFoo(A $a) : void {
-            if ($a->bar) {
-
-            }
-        }
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UnimplementedInterfaceMethod
-     * @return                   void
-     */
-    public function testUnimplementedInterfaceMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A {
-            public function fooFoo();
-        }
-
-        class B implements A { }
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MethodSignatureMismatch
-     * @return                   void
-     */
-    public function testMismatchingInterfaceMethodSignature()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A {
-            public function fooFoo(int $a) : void;
-        }
-
-        class B implements A {
-            public function fooFoo(string $a) : void {
-
-            }
-        }
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testCorrectInterfaceMethodSignature()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A {
-            public function fooFoo(int $a) : void;
-        }
-
-        class B implements A {
-            public function fooFoo(int $a) : void {
-
-            }
-        }
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testInterfaceMethodImplementedInParent()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface MyInterface {
-            public function fooFoo(int $a) : void;
-        }
-
-        class B {
-            public function fooFoo(int $a) : void {
-
-            }
-        }
-
-        class C extends B implements MyInterface { }
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MethodSignatureMismatch
-     * @return                   void
-     */
-    public function testMismatchingInterfaceMethodSignatureInTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A {
-            public function fooFoo(int $a, int $b) : void;
-        }
-
-        trait T {
-            public function fooFoo(int $a) : void {
-            }
-        }
-
-        class B implements A {
-            use T;
-        }
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testInterfaceMethodSignatureInTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A {
-            public function fooFoo(int $a, int $b) : void;
-        }
-
-        trait T {
-            public function fooFoo(int $a, int $b) : void {
-            }
-        }
-
-        class B implements A {
-            use T;
-        }
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MethodSignatureMismatch
-     * @return                   void
-     */
-    public function testMismatchingInterfaceMethodSignatureInImplementer()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A {
-            public function fooFoo(int $a, int $b) : void;
-        }
-
-        trait T {
-            public function fooFoo(int $a, int $b) : void {
-            }
-        }
-
-        class B implements A {
-            use T;
-
-            public function fooFoo(int $a) : void {
-            }
-        }
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testDelayedInterface()
-    {
-        $stmts = self::$parser->parse('<?php
-        // fails in PHP, whatcha gonna do
-        $c = new C;
-
-        class A { }
-
-        interface B { }
-
-        class C extends A implements B { }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
      * @expectedException        \Psalm\Exception\CodeException
@@ -405,223 +17,388 @@ class InterfaceTest extends PHPUnit_Framework_TestCase
     public function testInvalidImplements()
     {
         $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
+            'somefile.php',
             '<?php
         class C2 implements A { }
         '
         );
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
         $context = new Context();
         $file_checker->visitAndAnalyzeMethods($context);
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testTypeDoesNotContainType()
+    public function providerFileCheckerValidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        interface A { }
-        interface B {
-            function foo();
-        }
-        function bar(A $a) : void {
-            if ($a instanceof B) {
-                $a->foo();
-            }
-        }');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'extends-and-implements' => [
+                '<?php
+                    interface A
+                    {
+                        /**
+                         * @return string
+                         */
+                        public function fooFoo();
+                    }
+            
+                    interface B
+                    {
+                        /**
+                         * @return string
+                         */
+                        public function barBar();
+                    }
+            
+                    interface C extends A, B
+                    {
+                        /**
+                         * @return string
+                         */
+                        public function baz();
+                    }
+            
+                    class D implements C
+                    {
+                        public function fooFoo()
+                        {
+                            return "hello";
+                        }
+            
+                        public function barBar()
+                        {
+                            return "goodbye";
+                        }
+            
+                        public function baz()
+                        {
+                            return "hello again";
+                        }
+                    }
+            
+                    $cee = (new D())->baz();
+                    $dee = (new D())->fooFoo();',
+                'assertions' => [
+                    ['string' => '$cee'],
+                    ['string' => '$dee']
+                ]
+            ],
+            'is-extended-interface' => [
+                '<?php
+                    interface A
+                    {
+                        /**
+                         * @return string
+                         */
+                        public function fooFoo();
+                    }
+            
+                    interface B extends A
+                    {
+                        /**
+                         * @return string
+                         */
+                        public function baz();
+                    }
+            
+                    class C implements B
+                    {
+                        public function fooFoo()
+                        {
+                            return "hello";
+                        }
+            
+                        public function baz()
+                        {
+                            return "goodbye";
+                        }
+                    }
+            
+                    /**
+                     * @param  A      $a
+                     * @return void
+                     */
+                    function qux(A $a) {
+                    }
+            
+                    qux(new C());'
+            ],
+            'extends-with-method' => [
+                '<?php
+                    interface A
+                    {
+                        /**
+                         * @return string
+                         */
+                        public function fooFoo();
+                    }
+            
+                    interface B extends A
+                    {
+                        public function barBar();
+                    }
+            
+                    /** @return void */
+                    function mux(B $b) {
+                        $b->fooFoo();
+                    }'
+            ],
+            'correct-interface-method-signature' => [
+                '<?php
+                    interface A {
+                        public function fooFoo(int $a) : void;
+                    }
+            
+                    class B implements A {
+                        public function fooFoo(int $a) : void {
+            
+                        }
+                    }'
+            ],
+            'interface-method-implemented-in-parent' => [
+                '<?php
+                    interface MyInterface {
+                        public function fooFoo(int $a) : void;
+                    }
+            
+                    class B {
+                        public function fooFoo(int $a) : void {
+            
+                        }
+                    }
+            
+                    class C extends B implements MyInterface { }'
+            ],
+            'interface-method-signature-in-trait' => [
+                '<?php
+                    interface A {
+                        public function fooFoo(int $a, int $b) : void;
+                    }
+            
+                    trait T {
+                        public function fooFoo(int $a, int $b) : void {
+                        }
+                    }
+            
+                    class B implements A {
+                        use T;
+                    }'
+            ],
+            'delayed-interface' => [
+                '<?php
+                    // fails in PHP, whatcha gonna do
+                    $c = new C;
+            
+                    class A { }
+            
+                    interface B { }
+            
+                    class C extends A implements B { }'
+            ],
+            'type-does-not-contain-type' => [
+                '<?php
+                    interface A { }
+                    interface B {
+                        function foo();
+                    }
+                    function bar(A $a) : void {
+                        if ($a instanceof B) {
+                            $a->foo();
+                        }
+                    }'
+            ],
+            'abstract-interface-implements' => [
+                '<?php
+                    interface I {
+                        public function fnc();
+                    }
+            
+                    abstract class A implements I {}'
+            ],
+            'abstract-interface-implements-but-call-method' => [
+                '<?php
+                    interface I {
+                        public function foo();
+                    }
+            
+                    abstract class A implements I {
+                        public function bar() : void {
+                            $this->foo();
+                        }
+                    }'
+            ],
+            'implements-partial-interface-methods' => [
+                '<?php
+                    namespace Bat;
+            
+                    interface I  {
+                      public function foo();
+                      public function bar();
+                    }
+                    abstract class A implements I {
+                      public function foo() {
+                        return "hello";
+                      }
+                    }
+                    class B extends A {
+                      public function bar() {
+                        return "goodbye";
+                      }
+                    }',
+                'assertions' => [],
+                'error_levels' => ['MissingReturnType']
+            ],
+            'interface-constants' => [
+                '<?php
+                    interface I1 {
+                        const A = 5;
+                        const B = "two";
+                        const C = 3.0;
+                    }
+            
+                    interface I2 extends I1 {
+                        const D = 5;
+                        const E = "two";
+                    }
+            
+                    class A implements I2 {
+                        /** @var int */
+                        public $foo = I1::A;
+            
+                        /** @var string */
+                        public $bar = self::B;
+            
+                        /** @var float */
+                        public $bar2 = I2::C;
+            
+                        /** @var int */
+                        public $foo2 = I2::D;
+            
+                        /** @var string */
+                        public $bar3 = self::E;
+                    }'
+            ],
+            'interface-extends-return-type' => [
+                '<?php
+                    interface A {}
+                    interface B extends A {}
+            
+                    function foo(B $a) : A {
+                        return $a;
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testAbstractInterfaceImplements()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        interface I {
-            public function fnc();
-        }
-
-        abstract class A implements I {}
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAbstractInterfaceImplementsButCallMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface I {
-            public function foo();
-        }
-
-        abstract class A implements I {
-            public function bar() : void {
-                $this->foo();
-            }
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedMethod
-     * @return                   void
-     */
-    public function testAbstractInterfaceImplementsButCallUndefinedMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface I {
-            public function foo();
-        }
-
-        abstract class A implements I {
-            public function bar() : void {
-                $this->foo2();
-            }
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplementsPartialInterfaceMethods()
-    {
-        Config::getInstance()->setCustomErrorLevel('MissingReturnType', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        namespace Bat;
-
-        interface I  {
-          public function foo();
-          public function bar();
-        }
-        abstract class A implements I {
-          public function foo() {
-            return "hello";
-          }
-        }
-        class B extends A {
-          public function bar() {
-            return "goodbye";
-          }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UnimplementedInterfaceMethod
-     * @return                   void
-     */
-    public function testAbstractInterfaceImplementsWithSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface I {
-            public function fnc();
-        }
-
-        abstract class A implements I {}
-
-        class B extends A {}
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testInterfaceConstants()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface I1 {
-            const A = 5;
-            const B = "two";
-            const C = 3.0;
-        }
-
-        interface I2 extends I1 {
-            const D = 5;
-            const E = "two";
-        }
-
-        class A implements I2 {
-            /** @var int */
-            public $foo = I1::A;
-
-            /** @var string */
-            public $bar = self::B;
-
-            /** @var float */
-            public $bar2 = I2::C;
-
-            /** @var int */
-            public $foo2 = I2::D;
-
-            /** @var string */
-            public $bar3 = self::E;
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testInterfaceExtendsReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A {}
-        interface B extends A {}
-
-        function foo(B $a) : A {
-            return $a;
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MoreSpecificReturnType
-     * @return                   void
-     */
-    public function testMoreSpecificReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A {}
-        interface B extends A {}
-
-        function foo(A $a) : B {
-            return $a;
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'no-interface-properties' => [
+                '<?php
+                    interface A { }
+            
+                    function fooFoo(A $a) : void {
+                        if ($a->bar) {
+            
+                        }
+                    }',
+                'error_message' => 'NoInterfaceProperties'
+            ],
+            'unimplemented-interface-method' => [
+                '<?php
+                    interface A {
+                        public function fooFoo();
+                    }
+            
+                    class B implements A { }',
+                'error_message' => 'UnimplementedInterfaceMethod'
+            ],
+            'mismatching-interface-method-signature' => [
+                '<?php
+                    interface A {
+                        public function fooFoo(int $a) : void;
+                    }
+            
+                    class B implements A {
+                        public function fooFoo(string $a) : void {
+            
+                        }
+                    }',
+                'error_message' => 'MethodSignatureMismatch'
+            ],
+            'mismatching-interface-method-signature-in-trait' => [
+                '<?php
+                    interface A {
+                        public function fooFoo(int $a, int $b) : void;
+                    }
+            
+                    trait T {
+                        public function fooFoo(int $a) : void {
+                        }
+                    }
+            
+                    class B implements A {
+                        use T;
+                    }',
+                'error_message' => 'MethodSignatureMismatch'
+            ],
+            'mismatching-interface-method-signature-in-implementer' => [
+                '<?php
+                    interface A {
+                        public function fooFoo(int $a, int $b) : void;
+                    }
+            
+                    trait T {
+                        public function fooFoo(int $a, int $b) : void {
+                        }
+                    }
+            
+                    class B implements A {
+                        use T;
+            
+                        public function fooFoo(int $a) : void {
+                        }
+                    }',
+                'error_message' => 'MethodSignatureMismatch'
+            ],
+            'abstract-interface-implements-but-call-undefined-method' => [
+                '<?php
+                    interface I {
+                        public function foo();
+                    }
+            
+                    abstract class A implements I {
+                        public function bar() : void {
+                            $this->foo2();
+                        }
+                    }',
+                'error_message' => 'UndefinedMethod'
+            ],
+            'abstract-interface-implements-with-subclass' => [
+                '<?php
+                    interface I {
+                        public function fnc();
+                    }
+            
+                    abstract class A implements I {}
+            
+                    class B extends A {}',
+                'error_message' => 'UnimplementedInterfaceMethod'
+            ],
+            'more-specific-return-type' => [
+                '<?php
+                    interface A {}
+                    interface B extends A {}
+            
+                    function foo(A $a) : B {
+                        return $a;
+                    }',
+                'error_message' => 'MoreSpecificReturnType'
+            ]
+        ];
     }
 }

--- a/tests/IssetTest.php
+++ b/tests/IssetTest.php
@@ -19,7 +19,7 @@ class IssetTest extends TestCase
                 ],
                 'error_levels' => ['MixedAssignment']
             ],
-            'null-coalesce' => [
+            'nullCoalesce' => [
                 '<?php
                     $a = $b ?? null;',
                 'assertions' => [
@@ -27,7 +27,7 @@ class IssetTest extends TestCase
                 ],
                 'error_levels' => ['MixedAssignment']
             ],
-            'null-coalesce-with-good-variable' => [
+            'nullCoalesceWithGoodVariable' => [
                 '<?php
                     $b = false;
                     $a = $b ?? null;',
@@ -35,7 +35,7 @@ class IssetTest extends TestCase
                     ['false|null' => '$a']
                 ]
             ],
-            'isset-keyed-offset' => [
+            'issetKeyedOffset' => [
                 '<?php
                     if (!isset($foo["a"])) {
                         $foo["a"] = "hello";
@@ -48,7 +48,7 @@ class IssetTest extends TestCase
                     '$foo' => \Psalm\Type::getArray()
                 ]
             ],
-            'isset-keyed-offset-or-false' => [
+            'issetKeyedOffsetORFalse' => [
                 '<?php
                     /** @return void */
                     function takesString(string $str) {}
@@ -64,7 +64,7 @@ class IssetTest extends TestCase
                     '$foo' => \Psalm\Type::getArray()
                 ]
             ],
-            'null-coalesce-keyed-offset' => [
+            'nullCoalesceKeyedOffset' => [
                 '<?php
                     $foo["a"] = $foo["a"] ?? "hello";',
                 'assertions' => [

--- a/tests/IssetTest.php
+++ b/tests/IssetTest.php
@@ -1,158 +1,80 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class IssetTest extends PHPUnit_Framework_TestCase
+class IssetTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testIsset()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $file_checker = new FileChecker(
-            'somefile.php',
-            $this->project_checker,
-            self::$parser->parse('<?php
-            $a = isset($b) ? $b : null;
-            ')
-        );
-        $context = new Context();
-        $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('mixed', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullCoalesce()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $file_checker = new FileChecker(
-            'somefile.php',
-            $this->project_checker,
-            self::$parser->parse('<?php
-            $a = $b ?? null;
-            ')
-        );
-        $context = new Context();
-        $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('mixed', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullCoalesceWithGoodVariable()
-    {
-        $file_checker = new FileChecker(
-            'somefile.php',
-            $this->project_checker,
-            self::$parser->parse('<?php
-            $b = false;
-            $a = $b ?? null;
-            ')
-        );
-        $context = new Context();
-        $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('false|null', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIssetKeyedOffset()
-    {
-        $file_checker = new FileChecker(
-            'somefile.php',
-            $this->project_checker,
-            self::$parser->parse('<?php
-                if (!isset($foo["a"])) {
-                    $foo["a"] = "hello";
-                }
-            ')
-        );
-        $context = new Context();
-        $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('mixed', (string) $context->vars_in_scope['$foo[\'a\']']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIssetKeyedOffsetOrFalse()
-    {
-        $file_checker = new FileChecker(
-            'somefile.php',
-            $this->project_checker,
-            self::$parser->parse('<?php
-            /** @return void */
-            function takesString(string $str) {}
-
-            $bar = rand(0, 1) ? ["foo" => "bar"] : false;
-
-            if (isset($bar["foo"])) {
-                takesString($bar["foo"]);
-            }
-            ')
-        );
-        $context = new Context();
-        $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullCoalesceKeyedOffset()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $file_checker = new FileChecker(
-            'somefile.php',
-            $this->project_checker,
-            self::$parser->parse('<?php
-                $foo["a"] = $foo["a"] ?? "hello";
-            ')
-        );
-        $context = new Context();
-        $context->vars_in_scope['$foo'] = \Psalm\Type::getArray();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('mixed', (string) $context->vars_in_scope['$foo[\'a\']']);
+        return [
+            'isset' => [
+                '<?php
+                    $a = isset($b) ? $b : null;',
+                'assertions' => [
+                    ['mixed' => '$a']
+                ],
+                'error_levels' => ['MixedAssignment']
+            ],
+            'null-coalesce' => [
+                '<?php
+                    $a = $b ?? null;',
+                'assertions' => [
+                    ['mixed' => '$a']
+                ],
+                'error_levels' => ['MixedAssignment']
+            ],
+            'null-coalesce-with-good-variable' => [
+                '<?php
+                    $b = false;
+                    $a = $b ?? null;',
+                'assertions' => [
+                    ['false|null' => '$a']
+                ]
+            ],
+            'isset-keyed-offset' => [
+                '<?php
+                    if (!isset($foo["a"])) {
+                        $foo["a"] = "hello";
+                    }',
+                'assertions' => [
+                    ['mixed' => '$foo[\'a\']']
+                ],
+                'error_levels' => [],
+                'scope_vars' => [
+                    '$foo' => \Psalm\Type::getArray()
+                ]
+            ],
+            'isset-keyed-offset-or-false' => [
+                '<?php
+                    /** @return void */
+                    function takesString(string $str) {}
+        
+                    $bar = rand(0, 1) ? ["foo" => "bar"] : false;
+        
+                    if (isset($bar["foo"])) {
+                        takesString($bar["foo"]);
+                    }',
+                'assertions' => [],
+                'error_levels' => [],
+                'scope_vars' => [
+                    '$foo' => \Psalm\Type::getArray()
+                ]
+            ],
+            'null-coalesce-keyed-offset' => [
+                '<?php
+                    $foo["a"] = $foo["a"] ?? "hello";',
+                'assertions' => [
+                    ['mixed' => '$foo[\'a\']']
+                ],
+                'error_levels' => ['MixedAssignment'],
+                'scope_vars' => [
+                    '$foo' => \Psalm\Type::getArray()
+                ]
+            ]
+        ];
     }
 }

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -1,72 +1,35 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-
-class IssueSuppressionTest extends PHPUnit_Framework_TestCase
+class IssueSuppressionTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testUndefinedClass()
-    {
-        $stmts = self::$parser->parse('<?php
-
-        class A{
-            /**
-             * @psalm-suppress UndefinedClass
-             * @psalm-suppress MixedMethodCall
-             * @psalm-suppress MissingReturnType
-             */
-            public function b() {
-                B::fooFoo()->barBar()->bat()->baz()->bam()->bas()->bee()->bet()->bes()->bis();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testExcludeIssue()
-    {
-        Config::getInstance()->setCustomErrorLevel('UndefinedFunction', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        fooFoo();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
+        return [
+            'undefined-class' => [
+                '<?php
+                    class A {
+                        /**
+                         * @psalm-suppress UndefinedClass
+                         * @psalm-suppress MixedMethodCall
+                         * @psalm-suppress MissingReturnType
+                         */
+                        public function b() {
+                            B::fooFoo()->barBar()->bat()->baz()->bam()->bas()->bee()->bet()->bes()->bis();
+                        }
+                    }'
+            ],
+            'exclude-issue' => [
+                '<?php
+                    fooFoo();',
+                'assertions' => [],
+                'error_levels' => ['UndefinedFunction']
+            ]
+        ];
     }
 }

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -11,7 +11,7 @@ class IssueSuppressionTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'undefined-class' => [
+            'undefinedClass' => [
                 '<?php
                     class A {
                         /**
@@ -24,7 +24,7 @@ class IssueSuppressionTest extends TestCase
                         }
                     }'
             ],
-            'exclude-issue' => [
+            'excludeIssue' => [
                 '<?php
                     fooFoo();',
                 'assertions' => [],

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -133,7 +133,7 @@ echo $a;';
     public function providerTestJsonOutputErrors()
     {
         return [
-            'return-type-error' => [
+            'returnTypeError' => [
                 '<?php
                     function fooFoo(int $a) : string {
                         return $a + 1;
@@ -142,7 +142,7 @@ echo $a;';
                 'line' => 2,
                 'error' => 'string'
             ],
-            'undefined-var' => [
+            'undefinedVar' => [
                 '<?php
                     function fooFoo(int $a) : int {
                         return $b + 1;
@@ -151,7 +151,7 @@ echo $a;';
                 'line' => 3,
                 'error' => '$b'
             ],
-            'unknown-param-class' => [
+            'unknownParamClass' => [
                 '<?php
                     function fooFoo(Badger\Bodger $a) : Badger\Bodger {
                         return $a;
@@ -160,7 +160,7 @@ echo $a;';
                 'line' => 2,
                 'error' => 'Badger\\Bodger'
             ],
-            'missing-return-type' => [
+            'missingReturnType' => [
                 '<?php
                     function fooFoo() {
                         return "hello";
@@ -169,7 +169,7 @@ echo $a;';
                 'line' => 2,
                 'error' => 'function fooFoo() {'
             ],
-            'wrong-multiline-return-type' => [
+            'wrongMultilineReturnType' => [
                 '<?php
                     /**
                      * @return int
@@ -181,7 +181,7 @@ echo $a;';
                 'line' => 3,
                 'error' => '@return int'
             ],
-            'wrong-single-line-return-type' => [
+            'wrongSingleLineReturnType' => [
                 '<?php
                     /** @return int */
                     function fooFoo() {

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -1,35 +1,19 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
 use Psalm\Checker\ProjectChecker;
-use Psalm\Config;
-use Psalm\Context;
 use Psalm\IssueBuffer;
 
-class JsonOutputTest extends PHPUnit_Framework_TestCase
+class JsonOutputTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-    }
-
     /**
      * @return void
      */
     public function setUp()
     {
+        // `TestCase::setUp()` creates its own ProjectChecker and Config instance, but we don't want to do that in this
+        // case, so don't run a `parent::setUp()` call here.
         FileChecker::clearCache();
         $this->project_checker = new ProjectChecker(false, true, ProjectChecker::TYPE_JSON);
 
@@ -40,174 +24,28 @@ class JsonOutputTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @dataProvider providerTestJsonOutputErrors
+     * @param string $code
+     * @param string $message
+     * @param integer $line_number
+     * @param string $error
      * @return void
      */
-    public function testJsonOutputForReturnTypeError()
+    public function testJsonOutputErrors($code, $message, $line_number, $error)
     {
-        $file_contents = '<?php
-        function fooFoo(int $a) : string {
-            return $a + 1;
-        }';
-
-        $this->project_checker->registerFile(
-            'somefile.php',
-            $file_contents
-        );
+        $this->project_checker->registerFile('somefile.php', $code);
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker);
         $file_checker->visitAndAnalyzeMethods();
         $issue_data = IssueBuffer::getIssueData()[0];
+
         $this->assertSame('somefile.php', $issue_data['file_path']);
         $this->assertSame('error', $issue_data['type']);
-        $this->assertSame("The declared return type 'string' for fooFoo is incorrect, got 'int'", $issue_data['message']);
-        $this->assertSame(2, $issue_data['line_number']);
+        $this->assertSame($message, $issue_data['message']);
+        $this->assertSame($line_number, $issue_data['line_number']);
         $this->assertSame(
-            'string',
-            substr($file_contents, $issue_data['from'], $issue_data['to'] - $issue_data['from'])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testJsonOutputForUndefinedVar()
-    {
-        $file_contents = '<?php
-        function fooFoo(int $a) : int {
-            return $b + 1;
-        }';
-
-        $this->project_checker->registerFile(
-            'somefile.php',
-            $file_contents
-        );
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndAnalyzeMethods();
-        $issue_data = IssueBuffer::getIssueData()[0];
-        $this->assertSame('somefile.php', $issue_data['file_path']);
-        $this->assertSame('error', $issue_data['type']);
-        $this->assertSame('Cannot find referenced variable $b', $issue_data['message']);
-        $this->assertSame(3, $issue_data['line_number']);
-        $this->assertSame(
-            '$b',
-            substr($file_contents, $issue_data['from'], $issue_data['to'] - $issue_data['from'])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testJsonOutputForUnknownParamClass()
-    {
-        $file_contents = '<?php
-        function fooFoo(Badger\Bodger $a) : Badger\Bodger {
-            return $a;
-        }';
-
-        $this->project_checker->registerFile(
-            'somefile.php',
-            $file_contents
-        );
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndAnalyzeMethods();
-        $issue_data = IssueBuffer::getIssueData()[0];
-        $this->assertSame('somefile.php', $issue_data['file_path']);
-        $this->assertSame('error', $issue_data['type']);
-        $this->assertSame('Class or interface Badger\\Bodger does not exist', $issue_data['message']);
-        $this->assertSame(2, $issue_data['line_number']);
-        $this->assertSame(
-            'Badger\\Bodger',
-            substr($file_contents, $issue_data['from'], $issue_data['to'] - $issue_data['from'])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testJsonOutputForMissingReturnType()
-    {
-        $file_contents = '<?php
-        function fooFoo() {
-            return "hello";
-        }';
-
-        $this->project_checker->registerFile(
-            'somefile.php',
-            $file_contents
-        );
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndAnalyzeMethods();
-        $issue_data = IssueBuffer::getIssueData()[0];
-        $this->assertSame('somefile.php', $issue_data['file_path']);
-        $this->assertSame('error', $issue_data['type']);
-        $this->assertSame('Method fooFoo does not have a return type, expecting string', $issue_data['message']);
-        $this->assertSame(2, $issue_data['line_number']);
-        $this->assertSame(
-            'function fooFoo() {',
-            substr($file_contents, $issue_data['from'], $issue_data['to'] - $issue_data['from'])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testJsonOutputForWrongMultilineReturnType()
-    {
-        $file_contents = '<?php
-        /**
-         * @return int
-         */
-        function fooFoo() {
-            return "hello";
-        }';
-
-        $this->project_checker->registerFile(
-            'somefile.php',
-            $file_contents
-        );
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndAnalyzeMethods();
-        $issue_data = IssueBuffer::getIssueData()[0];
-        $this->assertSame('somefile.php', $issue_data['file_path']);
-        $this->assertSame('error', $issue_data['type']);
-        $this->assertSame('The declared return type \'int\' for fooFoo is incorrect, got \'string\'', $issue_data['message']);
-        $this->assertSame(3, $issue_data['line_number']);
-        $this->assertSame(
-            '@return int',
-            substr($file_contents, $issue_data['from'], $issue_data['to'] - $issue_data['from'])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testJsonOutputForWrongSingleLineReturnType()
-    {
-        $file_contents = '<?php
-        /** @return int */
-        function fooFoo() {
-            return "hello";
-        }';
-
-        $this->project_checker->registerFile(
-            'somefile.php',
-            $file_contents
-        );
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker);
-        $file_checker->visitAndAnalyzeMethods();
-        $issue_data = IssueBuffer::getIssueData()[0];
-        $this->assertSame('somefile.php', $issue_data['file_path']);
-        $this->assertSame('error', $issue_data['type']);
-        $this->assertSame('The declared return type \'int\' for fooFoo is incorrect, got \'string\'', $issue_data['message']);
-        $this->assertSame(2, $issue_data['line_number']);
-        $this->assertSame(
-            '@return int',
-            substr($file_contents, $issue_data['from'], $issue_data['to'] - $issue_data['from'])
+            $error,
+            substr($code, $issue_data['from'], $issue_data['to'] - $issue_data['from'])
         );
     }
 
@@ -287,5 +125,72 @@ echo $a;';
             ],
             $issue_data
         );
+    }
+
+    /**
+     * @return array
+     */
+    public function providerTestJsonOutputErrors()
+    {
+        return [
+            'return-type-error' => [
+                '<?php
+                    function fooFoo(int $a) : string {
+                        return $a + 1;
+                    }',
+                'message' => "The declared return type 'string' for fooFoo is incorrect, got 'int'",
+                'line' => 2,
+                'error' => 'string'
+            ],
+            'undefined-var' => [
+                '<?php
+                    function fooFoo(int $a) : int {
+                        return $b + 1;
+                    }',
+                'message' => 'Cannot find referenced variable $b',
+                'line' => 3,
+                'error' => '$b'
+            ],
+            'unknown-param-class' => [
+                '<?php
+                    function fooFoo(Badger\Bodger $a) : Badger\Bodger {
+                        return $a;
+                    }',
+                'message' => 'Class or interface Badger\\Bodger does not exist',
+                'line' => 2,
+                'error' => 'Badger\\Bodger'
+            ],
+            'missing-return-type' => [
+                '<?php
+                    function fooFoo() {
+                        return "hello";
+                    }',
+                'message' => 'Method fooFoo does not have a return type, expecting string',
+                'line' => 2,
+                'error' => 'function fooFoo() {'
+            ],
+            'wrong-multiline-return-type' => [
+                '<?php
+                    /**
+                     * @return int
+                     */
+                    function fooFoo() {
+                        return "hello";
+                    }',
+                'message' => 'The declared return type \'int\' for fooFoo is incorrect, got \'string\'',
+                'line' => 3,
+                'error' => '@return int'
+            ],
+            'wrong-single-line-return-type' => [
+                '<?php
+                    /** @return int */
+                    function fooFoo() {
+                        return "hello";
+                    }',
+                'message' => 'The declared return type \'int\' for fooFoo is incorrect, got \'string\'',
+                'line' => 2,
+                'error' => '@return int'
+            ]
+        ];
     }
 }

--- a/tests/ListTest.php
+++ b/tests/ListTest.php
@@ -12,7 +12,7 @@ class ListTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'simple-vars' => [
+            'simpleVars' => [
                 '<?php
                     list($a, $b) = ["a", "b"];',
                 'assertions' => [
@@ -20,7 +20,7 @@ class ListTest extends TestCase
                     ['string' => '$b']
                 ]
             ],
-            'simple-vars-with-separate-types' => [
+            'simpleVarsWithSeparateTypes' => [
                 '<?php
                     list($a, $b) = ["a", 2];',
                 'assertions' => [
@@ -28,7 +28,7 @@ class ListTest extends TestCase
                     ['int' => '$b']
                 ]
             ],
-            'simple-vars-with-separate-types-in-var' => [
+            'simpleVarsWithSeparateTypesInVar' => [
                 '<?php
                     $bar = ["a", 2];
                     list($a, $b) = $bar;',
@@ -37,7 +37,7 @@ class ListTest extends TestCase
                     ['int|string' => '$b']
                 ]
             ],
-            'this-var' => [
+            'thisVar' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -63,7 +63,7 @@ class ListTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'this-var-with-bad-type' => [
+            'thisVarWithBadType' => [
                 '<?php
                     class A {
                         /** @var int */

--- a/tests/ListTest.php
+++ b/tests/ListTest.php
@@ -1,144 +1,86 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ListTest extends PHPUnit_Framework_TestCase
+class ListTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
+        return [
+            'simple-vars' => [
+                '<?php
+                    list($a, $b) = ["a", "b"];',
+                'assertions' => [
+                    ['string' => '$a'],
+                    ['string' => '$b']
+                ]
+            ],
+            'simple-vars-with-separate-types' => [
+                '<?php
+                    list($a, $b) = ["a", 2];',
+                'assertions' => [
+                    ['string' => '$a'],
+                    ['int' => '$b']
+                ]
+            ],
+            'simple-vars-with-separate-types-in-var' => [
+                '<?php
+                    $bar = ["a", 2];
+                    list($a, $b) = $bar;',
+                'assertions' => [
+                    ['int|string' => '$a'],
+                    ['int|string' => '$b']
+                ]
+            ],
+            'this-var' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        public $a = "";
+            
+                        /** @var string */
+                        public $b = "";
+            
+                        public function fooFoo() : string
+                        {
+                            list($this->a, $this->b) = ["a", "b"];
+            
+                            return $this->a;
+                        }
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSimpleVars()
-    {
-        $stmts = self::$parser->parse('<?php
-        list($a, $b) = ["a", "b"];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSimpleVarsWithSeparateTypes()
-    {
-        $stmts = self::$parser->parse('<?php
-        list($a, $b) = ["a", 2];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSimpleVarsWithSeparateTypesInVar()
-    {
-        $stmts = self::$parser->parse('<?php
-        $bar = ["a", 2];
-        list($a, $b) = $bar;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int|string', (string) $context->vars_in_scope['$a']);
-        $this->assertEquals('int|string', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testThisVar()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            public $a = "";
-
-            /** @var string */
-            public $b = "";
-
-            public function fooFoo() : string
-            {
-                list($this->a, $this->b) = ["a", "b"];
-
-                return $this->a;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidPropertyAssignment - somefile.php:11
-     * @return                   void
-     */
-    public function testThisVarWithBadType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var int */
-            public $a = 0;
-
-            /** @var string */
-            public $b = "";
-
-            public function fooFoo() : string
-            {
-                list($this->a, $this->b) = ["a", "b"];
-
-                return $this->a;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'this-var-with-bad-type' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a = 0;
+            
+                        /** @var string */
+                        public $b = "";
+            
+                        public function fooFoo() : string
+                        {
+                            list($this->a, $this->b) = ["a", "b"];
+            
+                            return $this->a;
+                        }
+                    }',
+                'error_message' => 'InvalidPropertyAssignment - somefile.php:11'
+            ]
+        ];
     }
 }

--- a/tests/LoopScopeTest.php
+++ b/tests/LoopScopeTest.php
@@ -12,7 +12,7 @@ class LoopScopeTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'switch-variable-with-continue' => [
+            'switchVariableWithContinue' => [
                 '<?php
                     foreach ([\'a\', \'b\', \'c\'] as $letter) {
                         switch ($letter) {
@@ -29,7 +29,7 @@ class LoopScopeTest extends TestCase
                         $moo = $foo;
                     }'
             ],
-            'switch-variable-with-continue-and-ifs' => [
+            'switchVariableWithContinueAndIfs' => [
                 '<?php
                     foreach ([\'a\', \'b\', \'c\'] as $letter) {
                         switch ($letter) {
@@ -52,7 +52,7 @@ class LoopScopeTest extends TestCase
                         $moo = $foo;
                     }'
             ],
-            'switch-variable-with-fallthrough' => [
+            'switchVariableWithFallthrough' => [
                 '<?php
                     foreach ([\'a\', \'b\', \'c\'] as $letter) {
                         switch ($letter) {
@@ -69,7 +69,7 @@ class LoopScopeTest extends TestCase
                         $moo = $foo;
                     }'
             ],
-            'switch-variable-with-fallthrough-statement' => [
+            'switchVariableWithFallthroughStatement' => [
                 '<?php
                     foreach ([\'a\', \'b\', \'c\'] as $letter) {
                         switch ($letter) {
@@ -88,7 +88,7 @@ class LoopScopeTest extends TestCase
                         $moo = $foo;
                     }'
             ],
-            'while-var' => [
+            'whileVar' => [
                 '<?php
                     $worked = false;
             
@@ -99,7 +99,7 @@ class LoopScopeTest extends TestCase
                     ['bool' => '$worked']
                 ]
             ],
-            'do-while-var' => [
+            'doWhileVar' => [
                 '<?php
                     $worked = false;
             
@@ -111,7 +111,7 @@ class LoopScopeTest extends TestCase
                     ['bool' => '$worked']
                 ]
             ],
-            'do-while-var-and-break' => [
+            'doWhileVarAndBreak' => [
                 '<?php
                     /** @return void */
                     function foo(string $b) {}
@@ -125,7 +125,7 @@ class LoopScopeTest extends TestCase
                     }
                     while (rand(0,100) === 10);'
             ],
-            'object-value' => [
+            'objectValue' => [
                 '<?php
                     class B {}
                     class A {
@@ -150,7 +150,7 @@ class LoopScopeTest extends TestCase
                     ['B' => '$a']
                 ]
             ],
-            'second-loop-with-not-null-check' => [
+            'secondLoopWithNotNullCheck' => [
                 '<?php
                     /** @return void **/
                     function takesInt(int $i) {}
@@ -162,7 +162,7 @@ class LoopScopeTest extends TestCase
                         $a = $i;
                     }'
             ],
-            'second-loop-with-int-check' => [
+            'secondLoopWithIntCheck' => [
                 '<?php
                     /** @return void **/
                     function takesInt(int $i) {}
@@ -174,7 +174,7 @@ class LoopScopeTest extends TestCase
                         $a = $i;
                     }'
             ],
-            'second-loop-with-int-check-and-conditional-set' => [
+            'secondLoopWithIntCheckAndConditionalSet' => [
                 '<?php
                     /** @return void **/
                     function takesInt(int $i) {}
@@ -189,7 +189,7 @@ class LoopScopeTest extends TestCase
                         }
                     }'
             ],
-            'second-loop-with-int-check-and-assignments-in-if-and-else' => [
+            'secondLoopWithIntCheckAndAssignmentsInIfAndElse' => [
                 '<?php
                     /** @return void **/
                     function takesInt(int $i) {}
@@ -204,7 +204,7 @@ class LoopScopeTest extends TestCase
                         }
                     }'
             ],
-            'second-loop-with-int-check-and-loop-set' => [
+            'secondLoopWithIntCheckAndLoopSet' => [
                 '<?php
                     /** @return void **/
                     function takesInt(int $i) {}
@@ -219,7 +219,7 @@ class LoopScopeTest extends TestCase
                         }
                     }'
             ],
-            'second-loop-with-return-in-elseif' => [
+            'secondLoopWithReturnInElseif' => [
                 '<?php
                     class A {}
                     class B extends A {}
@@ -241,7 +241,7 @@ class LoopScopeTest extends TestCase
                         $b = $a;
                     }'
             ],
-            'third-loop-with-int-check-and-loop-set' => [
+            'thirdLoopWithIntCheckAndLoopSet' => [
                 '<?php
                     /** @return void **/
                     function takesInt(int $i) {}
@@ -262,7 +262,7 @@ class LoopScopeTest extends TestCase
                         $a = $i;
                     }'
             ],
-            'implicit-fourth-loop' => [
+            'implicitFourthLoop' => [
                 '<?php
                     function test(): int {
                       $x = 0;
@@ -276,7 +276,7 @@ class LoopScopeTest extends TestCase
                       return $x;
                     }'
             ],
-            'unset-in-loop' => [
+            'unsetInLoop' => [
                 '<?php
                     $a = null;
             
@@ -285,7 +285,7 @@ class LoopScopeTest extends TestCase
                         unset($i);
                     }'
             ],
-            'assign-inside-foreach' => [
+            'assignInsideForeach' => [
                 '<?php
                     $b = false;
             
@@ -298,7 +298,7 @@ class LoopScopeTest extends TestCase
                     ['bool' => '$b']
                 ]
             ],
-            'assign-inside-foreach-with-break' => [
+            'assignInsideForeachWithBreak' => [
                 '<?php
                     $b = false;
             
@@ -312,7 +312,7 @@ class LoopScopeTest extends TestCase
                     ['bool' => '$b']
                 ]
             ],
-            'null-check-inside-foreach-with-continue' => [
+            'nullCheckInsideForeachWithContinue' => [
                 '<?php
                     class A {
                         /** @return array<A|null> */
@@ -344,7 +344,7 @@ class LoopScopeTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'possibly-undefined-array-in-foreach' => [
+            'possiblyUndefinedArrayInForeach' => [
                 '<?php
                     foreach ([1, 2, 3, 4] as $b) {
                         $array[] = "hello";
@@ -354,7 +354,7 @@ class LoopScopeTest extends TestCase
                 'error_message' => 'PossiblyUndefinedVariable - somefile.php:3 - Possibly undefined variable ' .
                     '$array, first seen on line 3'
             ],
-            'possibly-undefined-array-in-while-and-foreach' => [
+            'possiblyUndefinedArrayInWhileAndForeach' => [
                 '<?php
                     for ($i = 0; $i < 4; $i++) {
                         while (rand(0,10) === 5) {
@@ -366,7 +366,7 @@ class LoopScopeTest extends TestCase
                 'error_message' => 'PossiblyUndefinedVariable - somefile.php:4 - Possibly undefined variable ' .
                     '$array, first seen on line 4'
             ],
-            'possibly-undefined-variable-in-foreach' => [
+            'possiblyUndefinedVariableInForeach' => [
                 '<?php
                     foreach ([1, 2, 3, 4] as $b) {
                         $car = "Volvo";
@@ -376,7 +376,7 @@ class LoopScopeTest extends TestCase
                 'error_message' => 'PossiblyUndefinedVariable - somefile.php:6 - Possibly undefined variable ' .
                     '$car, first seen on line 3'
             ],
-            'possible-undefined-variable-in-foreach-and-if' => [
+            'possibleUndefinedVariableInForeachAndIf' => [
                 '<?php
                     foreach ([1,2,3,4] as $i) {
                         if ($i === 1) {
@@ -389,7 +389,7 @@ class LoopScopeTest extends TestCase
                 'error_message' => 'PossiblyUndefinedVariable - somefile.php:9 - Possibly undefined variable $a, ' .
                     'first seen on line 4'
             ],
-            'implicit-fourth-loop-with-bad-return-type' => [
+            'implicitFourthLoopWithBadReturnType' => [
                 '<?php
                     function test(): int {
                       $x = 0;
@@ -404,7 +404,7 @@ class LoopScopeTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'possibly-null-check-inside-foreach-with-no-leave-statement' => [
+            'possiblyNullCheckInsideForeachWithNoLeaveStatement' => [
                 '<?php
                     class A {
                         /** @return array<A|null> */

--- a/tests/LoopScopeTest.php
+++ b/tests/LoopScopeTest.php
@@ -1,681 +1,433 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class LoopScopeTest extends PHPUnit_Framework_TestCase
+class LoopScopeTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyUndefinedVariable - somefile.php:3 - Possibly undefined variable $array, first seen on line 3
-     * @return                   void
-     */
-    public function testPossiblyUndefinedArrayInForeach()
-    {
-        $stmts = self::$parser->parse('<?php
-        foreach ([1, 2, 3, 4] as $b) {
-            $array[] = "hello";
-        }
-
-        echo $array;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyUndefinedVariable - somefile.php:4 - Possibly undefined variable $array, first seen on line 4
-     * @return                   void
-     */
-    public function testPossiblyUndefinedArrayInWhileAndForeach()
-    {
-        $stmts = self::$parser->parse('<?php
-        for ($i = 0; $i < 4; $i++) {
-            while (rand(0,10) === 5) {
-                $array[] = "hello";
-            }
-        }
-
-        echo $array;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyUndefinedVariable - somefile.php:6 - Possibly undefined variable $car, first seen on line 3
-     * @return                   void
-     */
-    public function testPossiblyUndefinedVariableInForeach()
-    {
-        $stmts = self::$parser->parse('<?php
-        foreach ([1, 2, 3, 4] as $b) {
-            $car = "Volvo";
-        }
-
-        echo $car;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSwitchVariableWithContinue()
-    {
-        $stmts = self::$parser->parse('<?php
-        foreach ([\'a\', \'b\', \'c\'] as $letter) {
-            switch ($letter) {
-                case \'a\':
-                    $foo = 1;
-                    break;
-                case \'b\':
-                    $foo = 2;
-                    break;
-                default:
-                    continue;
-            }
-
-            $moo = $foo;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSwitchVariableWithContinueAndIfs()
-    {
-        $stmts = self::$parser->parse('<?php
-        foreach ([\'a\', \'b\', \'c\'] as $letter) {
-            switch ($letter) {
-                case \'a\':
-                    if (rand(0, 10) === 1) {
-                        continue;
+        return [
+            'switch-variable-with-continue' => [
+                '<?php
+                    foreach ([\'a\', \'b\', \'c\'] as $letter) {
+                        switch ($letter) {
+                            case \'a\':
+                                $foo = 1;
+                                break;
+                            case \'b\':
+                                $foo = 2;
+                                break;
+                            default:
+                                continue;
+                        }
+            
+                        $moo = $foo;
+                    }'
+            ],
+            'switch-variable-with-continue-and-ifs' => [
+                '<?php
+                    foreach ([\'a\', \'b\', \'c\'] as $letter) {
+                        switch ($letter) {
+                            case \'a\':
+                                if (rand(0, 10) === 1) {
+                                    continue;
+                                }
+                                $foo = 1;
+                                break;
+                            case \'b\':
+                                if (rand(0, 10) === 1) {
+                                    continue;
+                                }
+                                $foo = 2;
+                                break;
+                            default:
+                                continue;
+                        }
+            
+                        $moo = $foo;
+                    }'
+            ],
+            'switch-variable-with-fallthrough' => [
+                '<?php
+                    foreach ([\'a\', \'b\', \'c\'] as $letter) {
+                        switch ($letter) {
+                            case \'a\':
+                            case \'b\':
+                                $foo = 2;
+                                break;
+            
+                            default:
+                                $foo = 3;
+                                break;
+                        }
+            
+                        $moo = $foo;
+                    }'
+            ],
+            'switch-variable-with-fallthrough-statement' => [
+                '<?php
+                    foreach ([\'a\', \'b\', \'c\'] as $letter) {
+                        switch ($letter) {
+                            case \'a\':
+                                $bar = 1;
+            
+                            case \'b\':
+                                $foo = 2;
+                                break;
+            
+                            default:
+                                $foo = 3;
+                                break;
+                        }
+            
+                        $moo = $foo;
+                    }'
+            ],
+            'while-var' => [
+                '<?php
+                    $worked = false;
+            
+                    while (rand(0,100) === 10) {
+                        $worked = true;
+                    }',
+                'assertions' => [
+                    ['bool' => '$worked']
+                ]
+            ],
+            'do-while-var' => [
+                '<?php
+                    $worked = false;
+            
+                    do {
+                        $worked = true;
                     }
-                    $foo = 1;
-                    break;
-                case \'b\':
-                    if (rand(0, 10) === 1) {
-                        continue;
+                    while (rand(0,100) === 10);',
+                'assertions' => [
+                    ['bool' => '$worked']
+                ]
+            ],
+            'do-while-var-and-break' => [
+                '<?php
+                    /** @return void */
+                    function foo(string $b) {}
+            
+                    do {
+                        if (null === ($a = rand(0, 1) ? "hello" : null)) {
+                            break;
+                        }
+            
+                        foo($a);
                     }
-                    $foo = 2;
-                    break;
-                default:
-                    continue;
-            }
-
-            $moo = $foo;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
+                    while (rand(0,100) === 10);'
+            ],
+            'object-value' => [
+                '<?php
+                    class B {}
+                    class A {
+                        /** @var A|B */
+                        public $child;
+            
+                        public function __construct() {
+                            $this->child = rand(0, 1) ? new A() : new B();
+                        }
+                    }
+            
+                    function makeA() : A {
+                        return new A();
+                    }
+            
+                    $a = makeA();
+            
+                    while ($a instanceof A) {
+                        $a = $a->child;
+                    }',
+                'assertions' => [
+                    ['B' => '$a']
+                ]
+            ],
+            'second-loop-with-not-null-check' => [
+                '<?php
+                    /** @return void **/
+                    function takesInt(int $i) {}
+            
+                    $a = null;
+            
+                    foreach ([1, 2, 3] as $i) {
+                        if ($a !== null) takesInt($a);
+                        $a = $i;
+                    }'
+            ],
+            'second-loop-with-int-check' => [
+                '<?php
+                    /** @return void **/
+                    function takesInt(int $i) {}
+            
+                    $a = null;
+            
+                    foreach ([1, 2, 3] as $i) {
+                        if (is_int($a)) takesInt($a);
+                        $a = $i;
+                    }'
+            ],
+            'second-loop-with-int-check-and-conditional-set' => [
+                '<?php
+                    /** @return void **/
+                    function takesInt(int $i) {}
+            
+                    $a = null;
+            
+                    foreach ([1, 2, 3] as $i) {
+                        if (is_int($a)) takesInt($a);
+            
+                        if (rand(0, 1)) {
+                            $a = $i;
+                        }
+                    }'
+            ],
+            'second-loop-with-int-check-and-assignments-in-if-and-else' => [
+                '<?php
+                    /** @return void **/
+                    function takesInt(int $i) {}
+            
+                    $a = null;
+            
+                    foreach ([1, 2, 3] as $i) {
+                        if (is_int($a)) {
+                            $a = 6;
+                        } else {
+                            $a = $i;
+                        }
+                    }'
+            ],
+            'second-loop-with-int-check-and-loop-set' => [
+                '<?php
+                    /** @return void **/
+                    function takesInt(int $i) {}
+            
+                    $a = null;
+            
+                    foreach ([1, 2, 3] as $i) {
+                        if (is_int($a)) takesInt($a);
+            
+                        while (rand(0, 1)) {
+                            $a = $i;
+                        }
+                    }'
+            ],
+            'second-loop-with-return-in-elseif' => [
+                '<?php
+                    class A {}
+                    class B extends A {}
+                    class C extends A {}
+            
+                    $b = null;
+            
+                    foreach ([new A, new A] as $a) {
+                        if ($a instanceof B) {
+            
+                        } elseif (!$a instanceof C) {
+                            return "goodbye";
+                        }
+            
+                        if ($b instanceof C) {
+                            return "hello";
+                        }
+            
+                        $b = $a;
+                    }'
+            ],
+            'third-loop-with-int-check-and-loop-set' => [
+                '<?php
+                    /** @return void **/
+                    function takesInt(int $i) {}
+            
+                    $a = null;
+                    $b = null;
+            
+                    foreach ([1, 2, 3] as $i) {
+                        if ($b !== null) {
+                            takesInt($b);
+                        }
+            
+                        if ($a !== null) {
+                            takesInt($a);
+                            $b = $a;
+                        }
+            
+                        $a = $i;
+                    }'
+            ],
+            'implicit-fourth-loop' => [
+                '<?php
+                    function test(): int {
+                      $x = 0;
+                      $y = 1;
+                      $z = 2;
+                      for ($i = 0; $i < 3; $i++) {
+                        $x = $y;
+                        $y = $z;
+                        $z = 5;
+                      }
+                      return $x;
+                    }'
+            ],
+            'unset-in-loop' => [
+                '<?php
+                    $a = null;
+            
+                    foreach ([1, 2, 3] as $i) {
+                        $a = $i;
+                        unset($i);
+                    }'
+            ],
+            'assign-inside-foreach' => [
+                '<?php
+                    $b = false;
+            
+                    foreach ([1, 2, 3, 4] as $a) {
+                        if ($a === rand(0, 10)) {
+                            $b = true;
+                        }
+                    }',
+                'assertions' => [
+                    ['bool' => '$b']
+                ]
+            ],
+            'assign-inside-foreach-with-break' => [
+                '<?php
+                    $b = false;
+            
+                    foreach ([1, 2, 3, 4] as $a) {
+                        if ($a === rand(0, 10)) {
+                            $b = true;
+                            break;
+                        }
+                    }',
+                'assertions' => [
+                    ['bool' => '$b']
+                ]
+            ],
+            'null-check-inside-foreach-with-continue' => [
+                '<?php
+                    class A {
+                        /** @return array<A|null> */
+                        public static function loadMultiple()
+                        {
+                            return [new A, null];
+                        }
+            
+                        /** @return void */
+                        public function barBar() {
+            
+                        }
+                    }
+            
+                    foreach (A::loadMultiple() as $a) {
+                        if ($a === null) {
+                            continue;
+                        }
+            
+                        $a->barBar();
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testSwitchVariableWithFallthrough()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        foreach ([\'a\', \'b\', \'c\'] as $letter) {
-            switch ($letter) {
-                case \'a\':
-                case \'b\':
-                    $foo = 2;
-                    break;
-
-                default:
-                    $foo = 3;
-                    break;
-            }
-
-            $moo = $foo;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSwitchVariableWithFallthroughStatement()
-    {
-        $stmts = self::$parser->parse('<?php
-        foreach ([\'a\', \'b\', \'c\'] as $letter) {
-            switch ($letter) {
-                case \'a\':
-                    $bar = 1;
-
-                case \'b\':
-                    $foo = 2;
-                    break;
-
-                default:
-                    $foo = 3;
-                    break;
-            }
-
-            $moo = $foo;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testWhileVar()
-    {
-        $stmts = self::$parser->parse('<?php
-
-        $worked = false;
-
-        while (rand(0,100) === 10) {
-            $worked = true;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('bool', (string) $context->vars_in_scope['$worked']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testDoWhileVar()
-    {
-        $stmts = self::$parser->parse('<?php
-        $worked = false;
-
-        do {
-            $worked = true;
-        }
-        while (rand(0,100) === 10);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('bool', (string) $context->vars_in_scope['$worked']);
-    }
-
-     /**
-     * @return void
-     */
-    public function testDoWhileVarAndBreak()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void */
-        function foo(string $b) {}
-
-        do {
-            if (null === ($a = rand(0, 1) ? "hello" : null)) {
-                break;
-            }
-
-            foo($a);
-        }
-        while (rand(0,100) === 10);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyUndefinedVariable - somefile.php:9 - Possibly undefined variable $a, first seen on line 4
-     * @return                   void
-     */
-    public function testPossiblyUndefinedVariableInForeachAndIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        foreach ([1,2,3,4] as $i) {
-            if ($i === 1) {
-                $a = true;
-                break;
-            }
-        }
-
-        echo $a;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testObjectValue()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B {}
-        class A {
-            /** @var A|B */
-            public $child;
-
-            public function __construct() {
-                $this->child = rand(0, 1) ? new A() : new B();
-            }
-        }
-
-        function makeA() : A {
-            return new A();
-        }
-
-        $a = makeA();
-
-        while ($a instanceof A) {
-            $a = $a->child;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('B', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSecondLoopWithNotNullCheck()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void **/
-        function takesInt(int $i) {}
-
-        $a = null;
-
-        foreach ([1, 2, 3] as $i) {
-            if ($a !== null) takesInt($a);
-            $a = $i;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSecondLoopWithIntCheck()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void **/
-        function takesInt(int $i) {}
-
-        $a = null;
-
-        foreach ([1, 2, 3] as $i) {
-            if (is_int($a)) takesInt($a);
-            $a = $i;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSecondLoopWithIntCheckAndConditionalSet()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void **/
-        function takesInt(int $i) {}
-
-        $a = null;
-
-        foreach ([1, 2, 3] as $i) {
-            if (is_int($a)) takesInt($a);
-
-            if (rand(0, 1)) {
-                $a = $i;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSecondLoopWithIntCheckAndAssignmentsInIfAndElse()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void **/
-        function takesInt(int $i) {}
-
-        $a = null;
-
-        foreach ([1, 2, 3] as $i) {
-            if (is_int($a)) {
-                $a = 6;
-            } else {
-                $a = $i;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSecondLoopWithIntCheckAndLoopSet()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void **/
-        function takesInt(int $i) {}
-
-        $a = null;
-
-        foreach ([1, 2, 3] as $i) {
-            if (is_int($a)) takesInt($a);
-
-            while (rand(0, 1)) {
-                $a = $i;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSecondLoopWithReturnInElseif()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A {}
-        class C extends A {}
-
-        $b = null;
-
-        foreach ([new A, new A] as $a) {
-            if ($a instanceof B) {
-
-            } elseif (!$a instanceof C) {
-                return "goodbye";
-            }
-
-            if ($b instanceof C) {
-                return "hello";
-            }
-
-            $b = $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testThirdLoopWithIntCheckAndLoopSet()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void **/
-        function takesInt(int $i) {}
-
-        $a = null;
-        $b = null;
-
-        foreach ([1, 2, 3] as $i) {
-            if ($b !== null) {
-                takesInt($b);
-            }
-
-            if ($a !== null) {
-                takesInt($a);
-                $b = $a;
-            }
-
-            $a = $i;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testImplicitFourthLoop()
-    {
-        $stmts = self::$parser->parse('<?php
-        function test(): int {
-          $x = 0;
-          $y = 1;
-          $z = 2;
-          for ($i = 0; $i < 3; $i++) {
-            $x = $y;
-            $y = $z;
-            $z = 5;
-          }
-          return $x;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testImplicitFourthLoopWithBadReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        function test(): int {
-          $x = 0;
-          $y = 1;
-          $z = 2;
-          for ($i = 0; $i < 3; $i++) {
-            $x = $y;
-            $y = $z;
-            $z = "hello";
-          }
-          return $x;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testUnsetInLoop()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = null;
-
-        foreach ([1, 2, 3] as $i) {
-            $a = $i;
-            unset($i);
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAssignInsideForeach()
-    {
-        $stmts = self::$parser->parse('<?php
-        $b = false;
-
-        foreach ([1, 2, 3, 4] as $a) {
-            if ($a === rand(0, 10)) {
-                $b = true;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-
-        $this->assertSame('bool', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAssignInsideForeachWithBreak()
-    {
-        $stmts = self::$parser->parse('<?php
-        $b = false;
-
-        foreach ([1, 2, 3, 4] as $a) {
-            if ($a === rand(0, 10)) {
-                $b = true;
-                break;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-
-        $this->assertSame('bool', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyNullReference
-     * @return                   void
-     */
-    public function testPossiblyNullCheckInsideForeachWithNoLeaveStatement()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return array<A|null> */
-            public static function loadMultiple()
-            {
-                return [new A, null];
-            }
-
-            /** @return void */
-            public function barBar() {
-
-            }
-        }
-
-        foreach (A::loadMultiple() as $a) {
-            if ($a === null) {
-                // do nothing
-            }
-
-            $a->barBar();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullCheckInsideForeachWithContinue()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return array<A|null> */
-            public static function loadMultiple()
-            {
-                return [new A, null];
-            }
-
-            /** @return void */
-            public function barBar() {
-
-            }
-        }
-
-        foreach (A::loadMultiple() as $a) {
-            if ($a === null) {
-                continue;
-            }
-
-            $a->barBar();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
+        return [
+            'possibly-undefined-array-in-foreach' => [
+                '<?php
+                    foreach ([1, 2, 3, 4] as $b) {
+                        $array[] = "hello";
+                    }
+            
+                    echo $array;',
+                'error_message' => 'PossiblyUndefinedVariable - somefile.php:3 - Possibly undefined variable ' .
+                    '$array, first seen on line 3'
+            ],
+            'possibly-undefined-array-in-while-and-foreach' => [
+                '<?php
+                    for ($i = 0; $i < 4; $i++) {
+                        while (rand(0,10) === 5) {
+                            $array[] = "hello";
+                        }
+                    }
+            
+                    echo $array;',
+                'error_message' => 'PossiblyUndefinedVariable - somefile.php:4 - Possibly undefined variable ' .
+                    '$array, first seen on line 4'
+            ],
+            'possibly-undefined-variable-in-foreach' => [
+                '<?php
+                    foreach ([1, 2, 3, 4] as $b) {
+                        $car = "Volvo";
+                    }
+            
+                    echo $car;',
+                'error_message' => 'PossiblyUndefinedVariable - somefile.php:6 - Possibly undefined variable ' .
+                    '$car, first seen on line 3'
+            ],
+            'possible-undefined-variable-in-foreach-and-if' => [
+                '<?php
+                    foreach ([1,2,3,4] as $i) {
+                        if ($i === 1) {
+                            $a = true;
+                            break;
+                        }
+                    }
+            
+                    echo $a;',
+                'error_message' => 'PossiblyUndefinedVariable - somefile.php:9 - Possibly undefined variable $a, ' .
+                    'first seen on line 4'
+            ],
+            'implicit-fourth-loop-with-bad-return-type' => [
+                '<?php
+                    function test(): int {
+                      $x = 0;
+                      $y = 1;
+                      $z = 2;
+                      for ($i = 0; $i < 3; $i++) {
+                        $x = $y;
+                        $y = $z;
+                        $z = "hello";
+                      }
+                      return $x;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'possibly-null-check-inside-foreach-with-no-leave-statement' => [
+                '<?php
+                    class A {
+                        /** @return array<A|null> */
+                        public static function loadMultiple()
+                        {
+                            return [new A, null];
+                        }
+            
+                        /** @return void */
+                        public function barBar() {
+            
+                        }
+                    }
+            
+                    foreach (A::loadMultiple() as $a) {
+                        if ($a === null) {
+                            // do nothing
+                        }
+            
+                        $a->barBar();
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ]
+        ];
     }
 }

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -1,252 +1,145 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class MethodCallTest extends PHPUnit_Framework_TestCase
+class MethodCallTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        return [
+            'parent-static-call' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public static function foo(){}
+                    }
+            
+                    class B extends A {
+                        /** @return void */
+                        public static function bar(){
+                            parent::foo();
+                        }
+                    }'
+            ],
+            'non-static-invocation' => [
+                '<?php
+                    class Foo {
+                        public static function barBar() : void {}
+                    }
+            
+                    (new Foo())->barBar();'
+            ],
+            'static-invocation' => [
+                '<?php
+                    class A {
+                        public static function fooFoo() : void {}
+                    }
+            
+                    class B extends A {
+            
+                    }
+            
+                    B::fooFoo();'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
+        return [
+            'static-invocation' => [
+                '<?php
+                    class Foo {
+                        public function barBar() : void {}
+                    }
+            
+                    Foo::barBar();',
+                'error_message' => 'InvalidStaticInvocation'
+            ],
+            'parent-static-call' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function foo(){}
+                    }
+            
+                    class B extends A {
+                        /** @return void */
+                        public static function bar(){
+                            parent::foo();
+                        }
+                    }',
+                'error_message' => 'InvalidStaticInvocation'
+            ],
+            'mixed-method-call' => [
+                '<?php
+                    class Foo {
+                        public static function barBar() : void {}
+                    }
+            
+                    /** @var mixed */
+                    $a = (new Foo());
+            
+                    $a->barBar();',
+                'error_message' => 'MixedMethodCall',
+                'error_levels' => [
+                    'MissingPropertyType',
+                    'MixedAssignment'
+                ]
+            ],
+            'self-non-static-invocation' => [
+                '<?php
+                    class A {
+                        public function fooFoo() : void {}
+            
+                        public function barBar() : void {
+                            self::fooFoo();
+                        }
+                    }',
+                'error_message' => 'NonStaticSelfCall'
+            ],
+            'no-parent' => [
+                '<?php
+                    class Foo {
+                        public function barBar() : void {
+                            parent::barBar();
+                        }
+                    }',
+                'error_message' => 'ParentNotFound'
+            ],
+            'coerced-class' => [
+                '<?php
+                    class NullableClass {
+                    }
+            
+                    class NullableBug {
+                        /**
+                         * @param string $className
+                         * @return object|null
+                         */
+                        public static function mock($className) {
+                            if (!$className) { return null; }
+                            return new $className();
+                        }
+            
+                        /**
+                         * @return NullableClass
+                         */
+                        public function returns_nullable_class() {
+                            return self::mock("NullableClass");
+                        }
+                    }',
+                'error_message' => 'MoreSpecificReturnType',
+                'error_levels' => ['MixedInferredReturnType']
+            ]
+        ];
     }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidStaticInvocation
-     * @return                   void
-     */
-    public function testInvalidStaticInvocation()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            public function barBar() : void {}
-        }
-
-        Foo::barBar();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidStaticInvocation
-     * @return                   void
-     */
-    public function testInvalidParentStaticCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function foo(){}
-        }
-
-        class B extends A {
-            /** @return void */
-            public static function bar(){
-                parent::foo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testValidParentStaticCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public static function foo(){}
-        }
-
-        class B extends A {
-            /** @return void */
-            public static function bar(){
-                parent::foo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testValidNonStaticInvocation()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            public static function barBar() : void {}
-        }
-
-        (new Foo())->barBar();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MixedMethodCall
-     * @return                   void
-     */
-    public function testMixedMethodCall()
-    {
-        Config::getInstance()->setCustomErrorLevel('MissingPropertyType', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            public static function barBar() : void {}
-        }
-
-        /** @var mixed */
-        $a = (new Foo());
-
-        $a->barBar();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testValidStaticInvocation()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public static function fooFoo() : void {}
-        }
-
-        class B extends A {
-
-        }
-
-        B::fooFoo();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage NonStaticSelfCall
-     * @return                   void
-     */
-    public function testSelfNonStaticInvocation()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo() : void {}
-
-            public function barBar() : void {
-                self::fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ParentNotFound
-     * @return                   void
-     */
-    public function testNoParent()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            public function barBar() : void {
-                parent::barBar();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MoreSpecificReturnType
-     * @return                   void
-     */
-    public function testCoercedClass()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedInferredReturnType', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        class NullableClass {
-        }
-
-        class NullableBug {
-            /**
-             * @param string $className
-             * @return object|null
-             */
-            public static function mock($className) {
-                if (!$className) { return null; }
-                return new $className();
-            }
-
-            /**
-             * @return NullableClass
-             */
-            public function returns_nullable_class() {
-                return self::mock("NullableClass");
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-
 }

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -12,7 +12,7 @@ class MethodCallTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'parent-static-call' => [
+            'parentStaticCall' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -26,7 +26,7 @@ class MethodCallTest extends TestCase
                         }
                     }'
             ],
-            'non-static-invocation' => [
+            'nonStaticInvocation' => [
                 '<?php
                     class Foo {
                         public static function barBar() : void {}
@@ -34,7 +34,7 @@ class MethodCallTest extends TestCase
             
                     (new Foo())->barBar();'
             ],
-            'static-invocation' => [
+            'staticInvocation' => [
                 '<?php
                     class A {
                         public static function fooFoo() : void {}
@@ -55,7 +55,7 @@ class MethodCallTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'static-invocation' => [
+            'staticInvocation' => [
                 '<?php
                     class Foo {
                         public function barBar() : void {}
@@ -64,7 +64,7 @@ class MethodCallTest extends TestCase
                     Foo::barBar();',
                 'error_message' => 'InvalidStaticInvocation'
             ],
-            'parent-static-call' => [
+            'parentStaticCall' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -79,7 +79,7 @@ class MethodCallTest extends TestCase
                     }',
                 'error_message' => 'InvalidStaticInvocation'
             ],
-            'mixed-method-call' => [
+            'mixedMethodCall' => [
                 '<?php
                     class Foo {
                         public static function barBar() : void {}
@@ -95,7 +95,7 @@ class MethodCallTest extends TestCase
                     'MixedAssignment'
                 ]
             ],
-            'self-non-static-invocation' => [
+            'selfNonStaticInvocation' => [
                 '<?php
                     class A {
                         public function fooFoo() : void {}
@@ -106,7 +106,7 @@ class MethodCallTest extends TestCase
                     }',
                 'error_message' => 'NonStaticSelfCall'
             ],
-            'no-parent' => [
+            'noParent' => [
                 '<?php
                     class Foo {
                         public function barBar() : void {
@@ -115,7 +115,7 @@ class MethodCallTest extends TestCase
                     }',
                 'error_message' => 'ParentNotFound'
             ],
-            'coerced-class' => [
+            'coercedClass' => [
                 '<?php
                     class NullableClass {
                     }

--- a/tests/MethodMutationTest.php
+++ b/tests/MethodMutationTest.php
@@ -1,50 +1,18 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
-use Psalm\Checker\MethodChecker;
-use Psalm\Config;
 use Psalm\Context;
 
-class MethodMutationTest extends PHPUnit_Framework_TestCase
+class MethodMutationTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
     /**
      * @return void
      */
     public function testControllerMutation()
     {
         $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
+            'somefile.php',
             '<?php
         class User {
             /** @var string */
@@ -121,7 +89,7 @@ class MethodMutationTest extends PHPUnit_Framework_TestCase
         }'
         );
 
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
         $context = new Context();
         $file_checker->visit($context);
         $file_checker->analyze(false, true);

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -92,7 +92,7 @@ class MethodSignatureTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'more-arguments' => [
+            'moreArguments' => [
                 '<?php
                     class A {
                         public function fooFoo(int $a, bool $b) : void {
@@ -107,7 +107,7 @@ class MethodSignatureTest extends TestCase
                     }',
                 'error_message' => 'Method B::fooFoo has more arguments than parent method A::fooFoo'
             ],
-            'fewer-arguments' => [
+            'fewerArguments' => [
                 '<?php
                     class A {
                         public function fooFoo(int $a, bool $b) : void {
@@ -122,7 +122,7 @@ class MethodSignatureTest extends TestCase
                     }',
                 'error_message' => 'Method B::fooFoo has fewer arguments than parent method A::fooFoo'
             ],
-            'different-arguments' => [
+            'differentArguments' => [
                 '<?php
                     class A {
                         public function fooFoo(int $a, bool $b) : void {

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -1,119 +1,12 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
-use Psalm\Config;
 use Psalm\Context;
 
-class MethodSignatureTest extends PHPUnit_Framework_TestCase
+class MethodSignatureTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage Method B::fooFoo has more arguments than parent method A::fooFoo
-     * @return                   void
-     */
-    public function testMoreArguments()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo(int $a, bool $b) : void {
-
-            }
-        }
-
-        class B extends A {
-            public function fooFoo(int $a, bool $b, array $c) : void {
-
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage Method B::fooFoo has fewer arguments than parent method A::fooFoo
-     * @return                   void
-     */
-    public function testFewerArguments()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo(int $a, bool $b) : void {
-
-            }
-        }
-
-        class B extends A {
-            public function fooFoo(int $a) : void {
-
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage Argument 1 of B::fooFoo has wrong type 'bool', expecting 'int' as defined by A::foo
-     * @return                   void
-     */
-    public function testDifferentArguments()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo(int $a, bool $b) : void {
-
-            }
-        }
-
-        class B extends A {
-            public function fooFoo(bool $b, int $a) : void {
-
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
 
     /**
      * @return void
@@ -121,12 +14,10 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
     public function testExtendDocblockParamType()
     {
         if (class_exists('SoapClient') === false) {
-            $this->markTestSkipped(
-                'Cannot run test, base class "SoapClient" does not exist!'
-            );
-
+            $this->markTestSkipped('Cannot run test, base class "SoapClient" does not exist!');
             return;
         }
+
         $stmts = self::$parser->parse('<?php
         class A extends SoapClient
         {
@@ -163,12 +54,10 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
     public function testExtendDocblockParamTypeWithWrongParam()
     {
         if (class_exists('SoapClient') === false) {
-            $this->markTestSkipped(
-                'Cannot run test, base class "SoapClient" does not exist!'
-            );
-
+            $this->markTestSkipped('Cannot run test, base class "SoapClient" does not exist!');
             return;
         }
+
         $stmts = self::$parser->parse('<?php
         class A extends SoapClient
         {
@@ -195,5 +84,60 @@ class MethodSignatureTest extends PHPUnit_Framework_TestCase
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context();
         $file_checker->visitAndAnalyzeMethods($context);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerFileCheckerInvalidCodeParse()
+    {
+        return [
+            'more-arguments' => [
+                '<?php
+                    class A {
+                        public function fooFoo(int $a, bool $b) : void {
+            
+                        }
+                    }
+            
+                    class B extends A {
+                        public function fooFoo(int $a, bool $b, array $c) : void {
+            
+                        }
+                    }',
+                'error_message' => 'Method B::fooFoo has more arguments than parent method A::fooFoo'
+            ],
+            'fewer-arguments' => [
+                '<?php
+                    class A {
+                        public function fooFoo(int $a, bool $b) : void {
+            
+                        }
+                    }
+            
+                    class B extends A {
+                        public function fooFoo(int $a) : void {
+            
+                        }
+                    }',
+                'error_message' => 'Method B::fooFoo has fewer arguments than parent method A::fooFoo'
+            ],
+            'different-arguments' => [
+                '<?php
+                    class A {
+                        public function fooFoo(int $a, bool $b) : void {
+            
+                        }
+                    }
+            
+                    class B extends A {
+                        public function fooFoo(bool $b, int $a) : void {
+            
+                        }
+                    }',
+                'error_message' => 'Argument 1 of B::fooFoo has wrong type \'bool\', expecting \'int\' as defined ' .
+                    'by A::foo'
+            ]
+        ];
     }
 }

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -1,97 +1,54 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class NamespaceTest extends PHPUnit_Framework_TestCase
+class NamespaceTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testEmptyNamespace()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace A {
-            /** @return void */
-            function foo() {
-
-            }
-
-            class Bar {
-
-            }
-        }
-        namespace {
-            A\foo();
-            \A\foo();
-
-            (new A\Bar);
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstantReference()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Aye\Bee {
-            const HELLO = "hello";
-        }
-        namespace Aye\Bee {
-            /** @return void */
-            function foo() {
-                echo \Aye\Bee\HELLO;
-            }
-
-            class Bar {
-                /** @return void */
-                public function foo() {
-                    echo \Aye\Bee\HELLO;
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'empty-namespace' => [
+                '<?php
+                    namespace A {
+                        /** @return void */
+                        function foo() {
+            
+                        }
+            
+                        class Bar {
+            
+                        }
+                    }
+                    namespace {
+                        A\foo();
+                        \A\foo();
+            
+                        (new A\Bar);
+                    }'
+            ],
+            'constant-reference' => [
+                '<?php
+                    namespace Aye\Bee {
+                        const HELLO = "hello";
+                    }
+                    namespace Aye\Bee {
+                        /** @return void */
+                        function foo() {
+                            echo \Aye\Bee\HELLO;
+                        }
+            
+                        class Bar {
+                            /** @return void */
+                            public function foo() {
+                                echo \Aye\Bee\HELLO;
+                            }
+                        }
+                    }'
+            ]
+        ];
     }
 }

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -11,7 +11,7 @@ class NamespaceTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'empty-namespace' => [
+            'emptyNamespace' => [
                 '<?php
                     namespace A {
                         /** @return void */
@@ -30,7 +30,7 @@ class NamespaceTest extends TestCase
                         (new A\Bar);
                     }'
             ],
-            'constant-reference' => [
+            'constantReference' => [
                 '<?php
                     namespace Aye\Bee {
                         const HELLO = "hello";

--- a/tests/Php40Test.php
+++ b/tests/Php40Test.php
@@ -1,86 +1,42 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class Php40Test extends PHPUnit_Framework_TestCase
+class Php40Test extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
+        return [
+            'extend-old-style-constructor' => [
+                '<?php
+                    class A {
+                        /**
+                         * @return string
+                         */
+                        public function A() {
+                            return "hello";
+                        }
+                    }
+            
+                    class B extends A {
+                        public function __construct() {
+                            parent::__construct();
+                        }
+                    }'
+            ],
+            'same-name-method-with-new-style-constructor' => [
+                '<?php
+                    class A {
+                        public function __construct(string $s) { }
+                        /** @return void */
+                        public function a(int $i) { }
+                    }
+                    new A("hello");'
+            ]
+        ];
     }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testExtendOldStyleConstructor()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /**
-             * @return string
-             */
-            public function A() {
-                return "hello";
-            }
-        }
-
-        class B extends A {
-            public function __construct() {
-                parent::__construct();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSameNameMethodWithNewStyleConstructor()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function __construct(string $s) { }
-            /** @return void */
-            public function a(int $i) { }
-        }
-        new A("hello");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
 }

--- a/tests/Php40Test.php
+++ b/tests/Php40Test.php
@@ -11,7 +11,7 @@ class Php40Test extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'extend-old-style-constructor' => [
+            'extendOldStyleConstructor' => [
                 '<?php
                     class A {
                         /**
@@ -28,7 +28,7 @@ class Php40Test extends TestCase
                         }
                     }'
             ],
-            'same-name-method-with-new-style-constructor' => [
+            'sameNameMethodWithNewStyleConstructor' => [
                 '<?php
                     class A {
                         public function __construct(string $s) { }

--- a/tests/Php55Test.php
+++ b/tests/Php55Test.php
@@ -47,7 +47,7 @@ class Php55Test extends TestCase
                     finally {
                     }'
             ],
-            'foreach-list' => [
+            'foreachList' => [
                 '<?php
                     $array = [
                         [1, 2],
@@ -58,7 +58,7 @@ class Php55Test extends TestCase
                         echo "A: $a; B: $b\n";
                     }'
             ],
-            'array-string-dereferencing' => [
+            'arrayStringDereferencing' => [
                 '<?php
                     $a = [1, 2, 3][0];
                     $b = "PHP"[0];',
@@ -67,7 +67,7 @@ class Php55Test extends TestCase
                     ['string' => '$b']
                 ]
             ],
-            'class-string' => [
+            'classString' => [
                 '<?php
                     class ClassName {}
             

--- a/tests/Php55Test.php
+++ b/tests/Php55Test.php
@@ -1,150 +1,81 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class Php55Test extends PHPUnit_Framework_TestCase
+class Php55Test extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGenerator()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param  int  $start
-         * @param  int  $limit
-         * @param  int  $step
-         * @return Generator<int>
-         */
-        function xrange($start, $limit, $step = 1) {
-            for ($i = $start; $i <= $limit; $i += $step) {
-                yield $i;
-            }
-        }
-
-        $a = null;
-
-        /*
-         * Note that an array is never created or returned,
-         * which saves memory.
-         */
-        foreach (xrange(1, 9, 2) as $number) {
-            $a = $number;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('null|int', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testFinally()
-    {
-        $stmts = self::$parser->parse('<?php
-        try {
-        }
-        catch (\Exception $e) {
-        }
-        finally {
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testForeachList()
-    {
-        $stmts = self::$parser->parse('<?php
-        $array = [
-            [1, 2],
-            [3, 4],
+        return [
+            'generator' => [
+                '<?php
+                    /**
+                     * @param  int  $start
+                     * @param  int  $limit
+                     * @param  int  $step
+                     * @return Generator<int>
+                     */
+                    function xrange($start, $limit, $step = 1) {
+                        for ($i = $start; $i <= $limit; $i += $step) {
+                            yield $i;
+                        }
+                    }
+            
+                    $a = null;
+            
+                    /*
+                     * Note that an array is never created or returned,
+                     * which saves memory.
+                     */
+                    foreach (xrange(1, 9, 2) as $number) {
+                        $a = $number;
+                    }',
+                'assertions' => [
+                    ['null|int' => '$a']
+                ]
+            ],
+            'finally' => [
+                '<?php
+                    try {
+                    }
+                    catch (\Exception $e) {
+                    }
+                    finally {
+                    }'
+            ],
+            'foreach-list' => [
+                '<?php
+                    $array = [
+                        [1, 2],
+                        [3, 4],
+                    ];
+            
+                    foreach ($array as list($a, $b)) {
+                        echo "A: $a; B: $b\n";
+                    }'
+            ],
+            'array-string-dereferencing' => [
+                '<?php
+                    $a = [1, 2, 3][0];
+                    $b = "PHP"[0];',
+                'assertions' => [
+                    ['int' => '$a'],
+                    ['string' => '$b']
+                ]
+            ],
+            'class-string' => [
+                '<?php
+                    class ClassName {}
+            
+                    $a = ClassName::class;',
+                'assertions' => [
+                    ['string' => '$a']
+                ]
+            ]
         ];
-
-        foreach ($array as list($a, $b)) {
-            echo "A: $a; B: $b\n";
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayStringDereferencing()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = [1, 2, 3][0];
-        $b = "PHP"[0];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testClassString()
-    {
-        $stmts = self::$parser->parse('<?php
-        class ClassName {}
-
-        $a = ClassName::class;
-        ?>
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-
-        $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
     }
 }

--- a/tests/Php56Test.php
+++ b/tests/Php56Test.php
@@ -17,7 +17,7 @@ class Php56Test extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'const-array' => [
+            'constArray' => [
                 '<?php
                     const ARR = ["a", "b"];
                     $a = ARR[0];',
@@ -25,7 +25,7 @@ class Php56Test extends TestCase
                     ['string' =>'$a']
                 ]
             ],
-            'const-features' => [
+            'constFeatures' => [
                 '<?php
                     const ONE = 1;
                     const TWO = ONE * 2;
@@ -55,7 +55,7 @@ class Php56Test extends TestCase
                     ['float|int' => '$g']
                 ]
             ],
-            'argument-unpacking' => [
+            'argumentUnpacking' => [
                 '<?php
                     /**
                      * @return int
@@ -75,7 +75,7 @@ class Php56Test extends TestCase
                     $a = 2;
                     $a **= 3;'
             ],
-            'constant-alias-in-namespace' => [
+            'constantAliasInNamespace' => [
                 '<?php
                     namespace Name\Space {
                         const FOO = 42;
@@ -88,7 +88,7 @@ class Php56Test extends TestCase
                         echo \Name\Space\FOO;
                     }'
             ],
-            'constant-alias-in-class' => [
+            'constantAliasInClass' => [
                 '<?php
                     namespace Name\Space {
                         const FOO = 42;
@@ -106,7 +106,7 @@ class Php56Test extends TestCase
                         }
                     }'
             ],
-            'function-alias-in-namespace' => [
+            'functionAliasInNamespace' => [
                 '<?php
                     namespace Name\Space {
                         /**
@@ -122,7 +122,7 @@ class Php56Test extends TestCase
                         \Name\Space\f();
                     }'
             ],
-            'function-alias-in-class' => [
+            'functionAliasInClass' => [
                 '<?php
                     namespace Name\Space {
                         /**

--- a/tests/Php56Test.php
+++ b/tests/Php56Test.php
@@ -7,235 +7,142 @@ use Psalm\Checker\FileChecker;
 use Psalm\Config;
 use Psalm\Context;
 
-class Php56Test extends PHPUnit_Framework_TestCase
+class Php56Test extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstArray()
-    {
-        $stmts = self::$parser->parse('<?php
-        const ARR = ["a", "b"];
-        $a = ARR[0];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstFeatures()
-    {
-        $stmts = self::$parser->parse('<?php
-        const ONE = 1;
-        const TWO = ONE * 2;
-
-        class C {
-            const THREE = TWO + 1;
-            const ONE_THIRD = ONE / self::THREE;
-            const SENTENCE = "The value of THREE is " . self::THREE;
-
-            /**
-             * @param  int $a
-             * @return int
-             */
-            public function f($a = ONE + self::THREE) {
-                return $a;
-            }
-        }
-
-        $d = (new C)->f();
-        $e = C::SENTENCE;
-        $f = TWO;
-        $g = C::ONE_THIRD;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$d']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$e']);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$f']);
-        $this->assertEquals('float|int', (string) $context->vars_in_scope['$g']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArgumentUnpacking()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @return int
-         * @param int $a
-         * @param int $b
-         * @param int $c
-         */
-        function add($a, $b, $c) {
-            return $a + $b + $c;
-        }
-
-        $operators = [2, 3];
-        echo add(1, ...$operators);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testExponentiation()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = 2;
-        $a **= 3;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstantAliasInNamespace()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Name\Space {
-            const FOO = 42;
-        }
-
-        namespace Noom\Spice {
-            use const Name\Space\FOO;
-
-            echo FOO . "\n";
-            echo \Name\Space\FOO;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testConstantAliasInClass()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Name\Space {
-            const FOO = 42;
-        }
-
-        namespace Noom\Spice {
-            use const Name\Space\FOO;
-
-            class A {
-                /** @return void */
-                public function fooFoo() {
-                    echo FOO . "\n";
-                    echo \Name\Space\FOO;
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testFunctionAliasInNamespace()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Name\Space {
-            /**
-             * @return void
-             */
-            function f() { echo __FUNCTION__."\n"; }
-        }
-
-        namespace Noom\Spice {
-            use function Name\Space\f;
-
-            f();
-            \Name\Space\f();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testFunctionAliasInClass()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Name\Space {
-            /**
-             * @return void
-             */
-            function f() { echo __FUNCTION__."\n"; }
-        }
-
-        namespace Noom\Spice {
-            use function Name\Space\f;
-
-            class A {
-                /** @return void */
-                public function fooFoo() {
-                    f();
-                    \Name\Space\f();
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'const-array' => [
+                '<?php
+                    const ARR = ["a", "b"];
+                    $a = ARR[0];',
+                'assertions' => [
+                    ['string' =>'$a']
+                ]
+            ],
+            'const-features' => [
+                '<?php
+                    const ONE = 1;
+                    const TWO = ONE * 2;
+            
+                    class C {
+                        const THREE = TWO + 1;
+                        const ONE_THIRD = ONE / self::THREE;
+                        const SENTENCE = "The value of THREE is " . self::THREE;
+            
+                        /**
+                         * @param  int $a
+                         * @return int
+                         */
+                        public function f($a = ONE + self::THREE) {
+                            return $a;
+                        }
+                    }
+            
+                    $d = (new C)->f();
+                    $e = C::SENTENCE;
+                    $f = TWO;
+                    $g = C::ONE_THIRD;',
+                'assertions' => [
+                    ['int' => '$d'],
+                    ['string' => '$e'],
+                    ['int' => '$f'],
+                    ['float|int' => '$g']
+                ]
+            ],
+            'argument-unpacking' => [
+                '<?php
+                    /**
+                     * @return int
+                     * @param int $a
+                     * @param int $b
+                     * @param int $c
+                     */
+                    function add($a, $b, $c) {
+                        return $a + $b + $c;
+                    }
+            
+                    $operators = [2, 3];
+                    echo add(1, ...$operators);'
+            ],
+            'exponentiation' => [
+                '<?php
+                    $a = 2;
+                    $a **= 3;'
+            ],
+            'constant-alias-in-namespace' => [
+                '<?php
+                    namespace Name\Space {
+                        const FOO = 42;
+                    }
+            
+                    namespace Noom\Spice {
+                        use const Name\Space\FOO;
+            
+                        echo FOO . "\n";
+                        echo \Name\Space\FOO;
+                    }'
+            ],
+            'constant-alias-in-class' => [
+                '<?php
+                    namespace Name\Space {
+                        const FOO = 42;
+                    }
+            
+                    namespace Noom\Spice {
+                        use const Name\Space\FOO;
+            
+                        class A {
+                            /** @return void */
+                            public function fooFoo() {
+                                echo FOO . "\n";
+                                echo \Name\Space\FOO;
+                            }
+                        }
+                    }'
+            ],
+            'function-alias-in-namespace' => [
+                '<?php
+                    namespace Name\Space {
+                        /**
+                         * @return void
+                         */
+                        function f() { echo __FUNCTION__."\n"; }
+                    }
+            
+                    namespace Noom\Spice {
+                        use function Name\Space\f;
+            
+                        f();
+                        \Name\Space\f();
+                    }'
+            ],
+            'function-alias-in-class' => [
+                '<?php
+                    namespace Name\Space {
+                        /**
+                         * @return void
+                         */
+                        function f() { echo __FUNCTION__."\n"; }
+                    }
+            
+                    namespace Noom\Spice {
+                        use function Name\Space\f;
+            
+                        class A {
+                            /** @return void */
+                            public function fooFoo() {
+                                f();
+                                \Name\Space\f();
+                            }
+                        }
+                    }'
+            ]
+        ];
     }
 }

--- a/tests/Php70Test.php
+++ b/tests/Php70Test.php
@@ -12,7 +12,7 @@ class Php70Test extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'function-type-hints' => [
+            'functionTypeHints' => [
                 '<?php
                     function indexof(string $haystack, string $needle) : int
                     {
@@ -30,7 +30,7 @@ class Php70Test extends TestCase
                     ['int' => '$a']
                 ]
             ],
-            'method-type-hints' => [
+            'methodTypeHints' => [
                 '<?php
                     class Foo {
                         public static function indexof(string $haystack, string $needle) : int
@@ -50,7 +50,7 @@ class Php70Test extends TestCase
                     ['int' => '$a']
                 ]
             ],
-            'null-coalesce' => [
+            'nullCoalesce' => [
                 '<?php
                     $a = $_GET["bar"] ?? "nobody";',
                 'assertions' => [
@@ -65,7 +65,7 @@ class Php70Test extends TestCase
                     ['int' => '$a']
                 ]
             ],
-            'define-array' => [
+            'defineArray' => [
                 '<?php
                     define("ANIMALS", [
                         "dog",
@@ -78,7 +78,7 @@ class Php70Test extends TestCase
                     ['string' =>'$a']
                 ]
             ],
-            'anonymous-class-logger' => [
+            'anonymousClassLogger' => [
                 '<?php
                     interface Logger {
                         /** @return void */
@@ -102,7 +102,7 @@ class Php70Test extends TestCase
                         }
                     });'
             ],
-            'anonymous-class-function-return-type' => [
+            'anonymousClassFunctionReturnType' => [
                 '<?php
                     $class = new class {
                         public function f() : int {
@@ -116,7 +116,7 @@ class Php70Test extends TestCase
             
                     $x = g($class->f());'
             ],
-            'generator-with-return' => [
+            'generatorWithReturn' => [
                 '<?php
                     /**
                      * @return Generator<int,int>
@@ -130,7 +130,7 @@ class Php70Test extends TestCase
                         yield 1;
                     }'
             ],
-            'generator-delegation' => [
+            'generatorDelegation' => [
                 '<?php
                     /**
                      * @return Generator<int,int>
@@ -180,7 +180,7 @@ class Php70Test extends TestCase
                 ],
                 'error_levels' => ['MixedAssignment']
             ],
-            'multiple-use' => [
+            'multipleUse' => [
                 '<?php
                     namespace Name\Space {
                         class A {
@@ -211,7 +211,7 @@ class Php70Test extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'anonymous-class-with-bad-statement' => [
+            'anonymousClassWithBadStatement' => [
                 '<?php
                     $foo = new class {
                         public function a() {
@@ -220,7 +220,7 @@ class Php70Test extends TestCase
                     };',
                 'error_message' => 'UndefinedClass'
             ],
-            'anonymous-class-with-invalid-function-return-type' => [
+            'anonymousClassWithInvalidFunctionReturnType' => [
                 '<?php
                     $foo = new class {
                         public function a() : string {

--- a/tests/Php70Test.php
+++ b/tests/Php70Test.php
@@ -1,355 +1,234 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class Php70Test extends PHPUnit_Framework_TestCase
+class Php70Test extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        return [
+            'function-type-hints' => [
+                '<?php
+                    function indexof(string $haystack, string $needle) : int
+                    {
+                        $pos = strpos($haystack, $needle);
+            
+                        if ($pos === false) {
+                            return -1;
+                        }
+            
+                        return $pos;
+                    }
+            
+                    $a = indexof("arr", "a");',
+                'assertions' => [
+                    ['int' => '$a']
+                ]
+            ],
+            'method-type-hints' => [
+                '<?php
+                    class Foo {
+                        public static function indexof(string $haystack, string $needle) : int
+                        {
+                            $pos = strpos($haystack, $needle);
+            
+                            if ($pos === false) {
+                                return -1;
+                            }
+            
+                            return $pos;
+                        }
+                    }
+            
+                    $a = Foo::indexof("arr", "a");',
+                'assertions' => [
+                    ['int' => '$a']
+                ]
+            ],
+            'null-coalesce' => [
+                '<?php
+                    $a = $_GET["bar"] ?? "nobody";',
+                'assertions' => [
+                    ['mixed' => '$a']
+                ],
+                'error_levels' => ['MixedAssignment']
+            ],
+            'spaceship' => [
+                '<?php
+                    $a = 1 <=> 1;',
+                'assertions' => [
+                    ['int' => '$a']
+                ]
+            ],
+            'define-array' => [
+                '<?php
+                    define("ANIMALS", [
+                        "dog",
+                        "cat",
+                        "bird"
+                    ]);
+            
+                    $a = ANIMALS[1];',
+                'assertions' => [
+                    ['string' =>'$a']
+                ]
+            ],
+            'anonymous-class-logger' => [
+                '<?php
+                    interface Logger {
+                        /** @return void */
+                        public function log(string $msg);
+                    }
+            
+                    class Application {
+                        /** @var Logger|null */
+                        private $logger;
+            
+                        /** @return void */
+                        public function setLogger(Logger $logger) {
+                             $this->logger = $logger;
+                        }
+                    }
+            
+                    $app = new Application;
+                    $app->setLogger(new class implements Logger {
+                        public function log(string $msg) {
+                            echo $msg;
+                        }
+                    });'
+            ],
+            'anonymous-class-function-return-type' => [
+                '<?php
+                    $class = new class {
+                        public function f() : int {
+                            return 42;
+                        }
+                    };
+            
+                    function g(int $i) : int {
+                        return $i;
+                    }
+            
+                    $x = g($class->f());'
+            ],
+            'generator-with-return' => [
+                '<?php
+                    /**
+                     * @return Generator<int,int>
+                     * @psalm-generator-return string
+                     */
+                    function fooFoo(int $i) : Generator {
+                        if ($i === 1) {
+                            return "bash";
+                        }
+            
+                        yield 1;
+                    }'
+            ],
+            'generator-delegation' => [
+                '<?php
+                    /**
+                     * @return Generator<int,int>
+                     * @psalm-generator-return int
+                     */
+                    function count_to_ten() : Generator {
+                        yield 1;
+                        yield 2;
+                        yield from [3, 4];
+                        yield from new ArrayIterator([5, 6]);
+                        yield from seven_eight();
+                        return yield from nine_ten();
+                    }
+            
+                    /**
+                     * @return Generator<int,int>
+                     */
+                    function seven_eight() : Generator {
+                        yield 7;
+                        yield from eight();
+                    }
+            
+                    /**
+                     * @return Generator<int,int>
+                     */
+                    function eight() : Generator {
+                        yield 8;
+                    }
+            
+                    /**
+                     * @return Generator<int,int>
+                     * @psalm-generator-return int
+                     */
+                    function nine_ten() : Generator {
+                        yield 9;
+                        return 10;
+                    }
+            
+                    $gen = count_to_ten();
+                    foreach ($gen as $num) {
+                        echo "$num ";
+                    }
+                    $gen2 = $gen->getReturn();',
+                'assertions' => [
+                    ['Generator<int, int>' => '$gen'],
+                    ['mixed' => '$gen2']
+                ],
+                'error_levels' => ['MixedAssignment']
+            ],
+            'multiple-use' => [
+                '<?php
+                    namespace Name\Space {
+                        class A {
+            
+                        }
+            
+                        class B {
+            
+                        }
+                    }
+            
+                    namespace Noom\Spice {
+                        use Name\Space\{
+                            A,
+                            B
+                        };
+            
+                        new A();
+                        new B();
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testFunctionTypeHints()
-    {
-        $stmts = self::$parser->parse('<?php
-        function indexof(string $haystack, string $needle) : int
-        {
-            $pos = strpos($haystack, $needle);
-
-            if ($pos === false) {
-                return -1;
-            }
-
-            return $pos;
-        }
-
-        $a = indexof("arr", "a");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testMethodTypeHints()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            public static function indexof(string $haystack, string $needle) : int
-            {
-                $pos = strpos($haystack, $needle);
-
-                if ($pos === false) {
-                    return -1;
-                }
-
-                return $pos;
-            }
-        }
-
-        $a = Foo::indexof("arr", "a");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullCoalesce()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        $a = $_GET["bar"] ?? "nobody";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('mixed', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSpaceship()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = 1 <=> 1;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testDefineArray()
-    {
-        $stmts = self::$parser->parse('<?php
-        define("ANIMALS", [
-            "dog",
-            "cat",
-            "bird"
-        ]);
-
-        $a = ANIMALS[1];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAnonymousClassLogger()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface Logger {
-            /** @return void */
-            public function log(string $msg);
-        }
-
-        class Application {
-            /** @var Logger|null */
-            private $logger;
-
-            /** @return void */
-            public function setLogger(Logger $logger) {
-                 $this->logger = $logger;
-            }
-        }
-
-        $app = new Application;
-        $app->setLogger(new class implements Logger {
-            public function log(string $msg) {
-                echo $msg;
-            }
-        });
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedClass
-     * @return                   void
-     */
-    public function testAnonymousClassWithBadStatement()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = new class {
-            public function a() {
-                new B();
-            }
-        };
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testAnonymousClassWithInvalidFunctionReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = new class {
-            public function a() : string {
-                return 5;
-            }
-        };
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAnonymousClassFunctionReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        $class = new class {
-            public function f() : int {
-                return 42;
-            }
-        };
-
-        function g(int $i) : int {
-            return $i;
-        }
-
-        $x = g($class->f());
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGeneratorWithReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @return Generator<int,int>
-         * @psalm-generator-return string
-         */
-        function fooFoo(int $i) : Generator {
-            if ($i === 1) {
-                return "bash";
-            }
-
-            yield 1;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGeneratorDelegation()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @return Generator<int,int>
-         * @psalm-generator-return int
-         */
-        function count_to_ten() : Generator {
-            yield 1;
-            yield 2;
-            yield from [3, 4];
-            yield from new ArrayIterator([5, 6]);
-            yield from seven_eight();
-            return yield from nine_ten();
-        }
-
-        /**
-         * @return Generator<int,int>
-         */
-        function seven_eight() : Generator {
-            yield 7;
-            yield from eight();
-        }
-
-        /**
-         * @return Generator<int,int>
-         */
-        function eight() : Generator {
-            yield 8;
-        }
-
-        /**
-         * @return Generator<int,int>
-         * @psalm-generator-return int
-         */
-        function nine_ten() : Generator {
-            yield 9;
-            return 10;
-        }
-
-        $gen = count_to_ten();
-        foreach ($gen as $num) {
-            echo "$num ";
-        }
-        $gen2 = $gen->getReturn();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('Generator<int, int>', (string) $context->vars_in_scope['$gen']);
-        $this->assertEquals('mixed', (string) $context->vars_in_scope['$gen2']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testMultipleUse()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Name\Space {
-            class A {
-
-            }
-
-            class B {
-
-            }
-        }
-
-        namespace Noom\Spice {
-            use Name\Space\{
-                A,
-                B
-            };
-
-            new A();
-            new B();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'anonymous-class-with-bad-statement' => [
+                '<?php
+                    $foo = new class {
+                        public function a() {
+                            new B();
+                        }
+                    };',
+                'error_message' => 'UndefinedClass'
+            ],
+            'anonymous-class-with-invalid-function-return-type' => [
+                '<?php
+                    $foo = new class {
+                        public function a() : string {
+                            return 5;
+                        }
+                    };',
+                'error_message' => 'InvalidReturnType'
+            ]
+        ];
     }
 }

--- a/tests/Php71Test.php
+++ b/tests/Php71Test.php
@@ -12,7 +12,7 @@ class Php71Test extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'nullable-return-type' => [
+            'nullableReturnType' => [
                 '<?php
                     function a(): ?string
                     {
@@ -24,7 +24,7 @@ class Php71Test extends TestCase
                     ['string|null' => '$a']
                 ]
             ],
-            'nullable-return-type-in-docblock' => [
+            'nullableReturnTypeInDocblock' => [
                 '<?php
                     /** @return ?string */
                     function a() {
@@ -36,7 +36,7 @@ class Php71Test extends TestCase
                     ['null|string' =>'$a']
                 ]
             ],
-            'nullable-argument' => [
+            'nullableArgument' => [
                 '<?php
                     function test(?string $name) : ?string
                     {
@@ -46,7 +46,7 @@ class Php71Test extends TestCase
                     test("elePHPant");
                     test(null);'
             ],
-            'protected-class-const' => [
+            'protectedClassConst' => [
                 '<?php
                     class A
                     {
@@ -60,7 +60,7 @@ class Php71Test extends TestCase
                         }
                     }',
             ],
-            'private-class-const' => [
+            'privateClassConst' => [
                 '<?php
                     class A
                     {
@@ -71,7 +71,7 @@ class Php71Test extends TestCase
                         }
                     }'
             ],
-            'public-class-const-fetch' => [
+            'publicClassConstFetch' => [
                 '<?php
                     class A
                     {
@@ -90,7 +90,7 @@ class Php71Test extends TestCase
                     echo A::IS_PUBLIC;
                     echo A::IS_ALSO_PUBLIC;'
             ],
-            'array-destructuring' => [
+            'arrayDestructuring' => [
                 '<?php
                     $data = [
                         [1, "Tom"],
@@ -109,7 +109,7 @@ class Php71Test extends TestCase
                     ['string|int' => '$name2']
                 ]
             ],
-            'array-destructuring-in-foreach' => [
+            'arrayDestructuringInForeach' => [
                 '<?php
                     $data = [
                         [1, "Tom"],
@@ -122,7 +122,7 @@ class Php71Test extends TestCase
                         echo $name;
                     }'
             ],
-            'array-destructuring-with-keys' => [
+            'arrayDestructuringWithKeys' => [
                 '<?php
                     $data = [
                         ["id" => 1, "name" => "Tom"],
@@ -141,7 +141,7 @@ class Php71Test extends TestCase
                     ['string' => '$name2']
                 ]
             ],
-            'array-list-destructuring-in-foreach-with-keys' => [
+            'arrayListDestructuringInForeachWithKeys' => [
                 '<?php
                     $data = [
                         ["id" => 1, "name" => "Tom"],
@@ -161,7 +161,7 @@ class Php71Test extends TestCase
                     ['null|string' => '$last_name']
                 ]
             ],
-            'array-destructuring-in-foreach-with-keys' => [
+            'arrayDestructuringInForeachWithKeys' => [
                 '<?php
                     $data = [
                         ["id" => 1, "name" => "Tom"],
@@ -181,7 +181,7 @@ class Php71Test extends TestCase
                     ['null|string' => '$last_name']
                 ]
             ],
-            'iterable-arg' => [
+            'iterableArg' => [
                 '<?php
                     /**
                      * @param  iterable<int, int> $iter
@@ -196,7 +196,7 @@ class Php71Test extends TestCase
                     iterator([1, 2, 3, 4]);
                     iterator(new SplFixedArray(5));'
             ],
-            'traversable-object' => [
+            'traversableObject' => [
                 '<?php
                     class IteratorObj implements Iterator {
                         function rewind() : void {}
@@ -221,7 +221,7 @@ class Php71Test extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'invalid-private-class-const-fetch' => [
+            'invalidPrivateClassConstFetch' => [
                 '<?php
                     class A
                     {
@@ -231,7 +231,7 @@ class Php71Test extends TestCase
                     echo A::IS_PRIVATE;',
                 'error_message' => 'InaccessibleClassConstant'
             ],
-            'invalid-private-class-const-fetch-from-subclass' => [
+            'invalidPrivateClassConstFetchFromSubclass' => [
                 '<?php
                     class A
                     {
@@ -246,7 +246,7 @@ class Php71Test extends TestCase
                     }',
                 'error_message' => 'InaccessibleClassConstant'
             ],
-            'invalid-protected-class-const-fetch' => [
+            'invalidProtectedClassConstFetch' => [
                 '<?php
                     class A
                     {
@@ -256,7 +256,7 @@ class Php71Test extends TestCase
                     echo A::IS_PROTECTED;',
                 'error_message' => 'InaccessibleClassConstant'
             ],
-            'invalid-iterable-arg' => [
+            'invalidIterableArg' => [
                 '<?php
                     /**
                      * @param  iterable<string> $iter

--- a/tests/Php71Test.php
+++ b/tests/Php71Test.php
@@ -1,454 +1,279 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class Php71Test extends PHPUnit_Framework_TestCase
+class Php71Test extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        function a(): ?string
-        {
-            return rand(0, 10) ? "elePHPant" : null;
-        }
-
-        $a = a();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string|null', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableReturnTypeInDocblock()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return ?string */
-        function a() {
-            return rand(0, 10) ? "elePHPant" : null;
-        }
-
-        $a = a();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('null|string', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableArgument()
-    {
-        $stmts = self::$parser->parse('<?php
-        function test(?string $name) : ?string
-        {
-            return $name;
-        }
-
-        test("elePHPant");
-        test(null);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testPrivateClassConst()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A
-        {
-            private const IS_PRIVATE = 1;
-
-            function fooFoo() : int {
-                return A::IS_PRIVATE;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleClassConstant
-     * @return                   void
-     */
-    public function testInvalidPrivateClassConstFetch()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A
-        {
-            private const IS_PRIVATE = 1;
-        }
-
-        echo A::IS_PRIVATE;
-        ');
-
-        $file_checker = new FileChecker('/somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleClassConstant
-     * @return                   void
-     */
-    public function testInvalidPrivateClassConstFetchFromSubclass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A
-        {
-            private const IS_PRIVATE = 1;
-        }
-
-        class B extends A
-        {
-            function fooFoo() : int {
-                return A::IS_PRIVATE;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testProtectedClassConst()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A
-        {
-            protected const IS_PROTECTED = 1;
-        }
-
-        class B extends A
-        {
-            function fooFoo() : int {
-                return A::IS_PROTECTED;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleClassConstant
-     * @return                   void
-     */
-    public function testInvalidProtectedClassConstFetch()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A
-        {
-            protected const IS_PROTECTED = 1;
-        }
-
-        echo A::IS_PROTECTED;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testPublicClassConstFetch()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A
-        {
-            public const IS_PUBLIC = 1;
-            const IS_ALSO_PUBLIC = 2;
-        }
-
-        class B extends A
-        {
-            function fooFoo() : int {
-                echo A::IS_PUBLIC;
-                return A::IS_ALSO_PUBLIC;
-            }
-        }
-
-        echo A::IS_PUBLIC;
-        echo A::IS_ALSO_PUBLIC;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayDestructuring()
-    {
-        $stmts = self::$parser->parse('<?php
-        $data = [
-            [1, "Tom"],
-            [2, "Fred"],
+        return [
+            'nullable-return-type' => [
+                '<?php
+                    function a(): ?string
+                    {
+                        return rand(0, 10) ? "elePHPant" : null;
+                    }
+            
+                    $a = a();',
+                'assertions' => [
+                    ['string|null' => '$a']
+                ]
+            ],
+            'nullable-return-type-in-docblock' => [
+                '<?php
+                    /** @return ?string */
+                    function a() {
+                        return rand(0, 10) ? "elePHPant" : null;
+                    }
+            
+                    $a = a();',
+                'assertions' => [
+                    ['null|string' =>'$a']
+                ]
+            ],
+            'nullable-argument' => [
+                '<?php
+                    function test(?string $name) : ?string
+                    {
+                        return $name;
+                    }
+            
+                    test("elePHPant");
+                    test(null);'
+            ],
+            'protected-class-const' => [
+                '<?php
+                    class A
+                    {
+                        protected const IS_PROTECTED = 1;
+                    }
+            
+                    class B extends A
+                    {
+                        function fooFoo() : int {
+                            return A::IS_PROTECTED;
+                        }
+                    }',
+            ],
+            'private-class-const' => [
+                '<?php
+                    class A
+                    {
+                        private const IS_PRIVATE = 1;
+            
+                        function fooFoo() : int {
+                            return A::IS_PRIVATE;
+                        }
+                    }'
+            ],
+            'public-class-const-fetch' => [
+                '<?php
+                    class A
+                    {
+                        public const IS_PUBLIC = 1;
+                        const IS_ALSO_PUBLIC = 2;
+                    }
+            
+                    class B extends A
+                    {
+                        function fooFoo() : int {
+                            echo A::IS_PUBLIC;
+                            return A::IS_ALSO_PUBLIC;
+                        }
+                    }
+            
+                    echo A::IS_PUBLIC;
+                    echo A::IS_ALSO_PUBLIC;'
+            ],
+            'array-destructuring' => [
+                '<?php
+                    $data = [
+                        [1, "Tom"],
+                        [2, "Fred"],
+                    ];
+            
+                    // list() style
+                    list($id1, $name1) = $data[0];
+            
+                    // [] style
+                    [$id2, $name2] = $data[1];',
+                'assertions' => [
+                    ['string|int' => '$id1'],
+                    ['string|int' => '$name1'],
+                    ['string|int' => '$id2'],
+                    ['string|int' => '$name2']
+                ]
+            ],
+            'array-destructuring-in-foreach' => [
+                '<?php
+                    $data = [
+                        [1, "Tom"],
+                        [2, "Fred"],
+                    ];
+            
+                    // [] style
+                    foreach ($data as [$id, $name]) {
+                        echo $id;
+                        echo $name;
+                    }'
+            ],
+            'array-destructuring-with-keys' => [
+                '<?php
+                    $data = [
+                        ["id" => 1, "name" => "Tom"],
+                        ["id" => 2, "name" => "Fred"],
+                    ];
+            
+                    // list() style
+                    list("id" => $id1, "name" => $name1) = $data[0];
+            
+                    // [] style
+                    ["id" => $id2, "name" => $name2] = $data[1];',
+                'assertions' => [
+                    ['int' => '$id1'],
+                    ['string' => '$name1'],
+                    ['int' => '$id2'],
+                    ['string' => '$name2']
+                ]
+            ],
+            'array-list-destructuring-in-foreach-with-keys' => [
+                '<?php
+                    $data = [
+                        ["id" => 1, "name" => "Tom"],
+                        ["id" => 2, "name" => "Fred"],
+                    ];
+            
+                    $last_id = null;
+                    $last_name = null;
+            
+                    // list() style
+                    foreach ($data as list("id" => $id, "name" => $name)) {
+                        $last_id = $id;
+                        $last_name = $name;
+                    }',
+                'assertions' => [
+                    ['null|int' => '$last_id'],
+                    ['null|string' => '$last_name']
+                ]
+            ],
+            'array-destructuring-in-foreach-with-keys' => [
+                '<?php
+                    $data = [
+                        ["id" => 1, "name" => "Tom"],
+                        ["id" => 2, "name" => "Fred"],
+                    ];
+            
+                    $last_id = null;
+                    $last_name = null;
+            
+                    // [] style
+                    foreach ($data as ["id" => $id, "name" => $name]) {
+                        $last_id = $id;
+                        $last_name = $name;
+                    }',
+                'assertions' => [
+                    ['null|int' => '$last_id'],
+                    ['null|string' => '$last_name']
+                ]
+            ],
+            'iterable-arg' => [
+                '<?php
+                    /**
+                     * @param  iterable<int, int> $iter
+                     */
+                    function iterator(iterable $iter) : void
+                    {
+                        foreach ($iter as $val) {
+                            //
+                        }
+                    }
+            
+                    iterator([1, 2, 3, 4]);
+                    iterator(new SplFixedArray(5));'
+            ],
+            'traversable-object' => [
+                '<?php
+                    class IteratorObj implements Iterator {
+                        function rewind() : void {}
+                        /** @return mixed */
+                        function current() { return null; }
+                        function key() : int { return 0; }
+                        function next() : void {}
+                        function valid() : bool { return false; }
+                    }
+            
+                    function foo(\Traversable $t) : void {
+                    }
+            
+                    foo(new IteratorObj);'
+            ]
         ];
-
-        // list() style
-        list($id1, $name1) = $data[0];
-
-        // [] style
-        [$id2, $name2] = $data[1];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string|int', (string) $context->vars_in_scope['$id1']);
-        $this->assertEquals('string|int', (string) $context->vars_in_scope['$name1']);
-        $this->assertEquals('string|int', (string) $context->vars_in_scope['$id2']);
-        $this->assertEquals('string|int', (string) $context->vars_in_scope['$name2']);
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testArrayDestructuringInForeach()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        $data = [
-            [1, "Tom"],
-            [2, "Fred"],
+        return [
+            'invalid-private-class-const-fetch' => [
+                '<?php
+                    class A
+                    {
+                        private const IS_PRIVATE = 1;
+                    }
+            
+                    echo A::IS_PRIVATE;',
+                'error_message' => 'InaccessibleClassConstant'
+            ],
+            'invalid-private-class-const-fetch-from-subclass' => [
+                '<?php
+                    class A
+                    {
+                        private const IS_PRIVATE = 1;
+                    }
+            
+                    class B extends A
+                    {
+                        function fooFoo() : int {
+                            return A::IS_PRIVATE;
+                        }
+                    }',
+                'error_message' => 'InaccessibleClassConstant'
+            ],
+            'invalid-protected-class-const-fetch' => [
+                '<?php
+                    class A
+                    {
+                        protected const IS_PROTECTED = 1;
+                    }
+            
+                    echo A::IS_PROTECTED;',
+                'error_message' => 'InaccessibleClassConstant'
+            ],
+            'invalid-iterable-arg' => [
+                '<?php
+                    /**
+                     * @param  iterable<string> $iter
+                     */
+                    function iterator(iterable $iter) : void
+                    {
+                        foreach ($iter as $val) {
+                            //
+                        }
+                    }
+            
+                    class A {
+                    }
+            
+                    iterator(new A());',
+                'error_message' => 'InvalidArgument'
+            ]
         ];
-
-        // [] style
-        foreach ($data as [$id, $name]) {
-            echo $id;
-            echo $name;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayDestructuringWithKeys()
-    {
-        $stmts = self::$parser->parse('<?php
-        $data = [
-            ["id" => 1, "name" => "Tom"],
-            ["id" => 2, "name" => "Fred"],
-        ];
-
-        // list() style
-        list("id" => $id1, "name" => $name1) = $data[0];
-
-        // [] style
-        ["id" => $id2, "name" => $name2] = $data[1];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$id1']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$name1']);
-        $this->assertEquals('int', (string) $context->vars_in_scope['$id2']);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$name2']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayListDestructuringInForeachWithKeys()
-    {
-        $stmts = self::$parser->parse('<?php
-        $data = [
-            ["id" => 1, "name" => "Tom"],
-            ["id" => 2, "name" => "Fred"],
-        ];
-
-        $last_id = null;
-        $last_name = null;
-
-        // list() style
-        foreach ($data as list("id" => $id, "name" => $name)) {
-            $last_id = $id;
-            $last_name = $name;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('null|int', (string) $context->vars_in_scope['$last_id']);
-        $this->assertEquals('null|string', (string) $context->vars_in_scope['$last_name']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayDestructuringInForeachWithKeys()
-    {
-        $stmts = self::$parser->parse('<?php
-        $data = [
-            ["id" => 1, "name" => "Tom"],
-            ["id" => 2, "name" => "Fred"],
-        ];
-
-        $last_id = null;
-        $last_name = null;
-
-        // [] style
-        foreach ($data as ["id" => $id, "name" => $name]) {
-            $last_id = $id;
-            $last_name = $name;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('null|int', (string) $context->vars_in_scope['$last_id']);
-        $this->assertEquals('null|string', (string) $context->vars_in_scope['$last_name']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIterableArg()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param  iterable<int, int> $iter
-         */
-        function iterator(iterable $iter) : void
-        {
-            foreach ($iter as $val) {
-                //
-            }
-        }
-
-        iterator([1, 2, 3, 4]);
-        iterator(new SplFixedArray(5));
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidArgument
-     * @return                   void
-     */
-    public function testInvalidIterableArg()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param  iterable<string> $iter
-         */
-        function iterator(iterable $iter) : void
-        {
-            foreach ($iter as $val) {
-                //
-            }
-        }
-
-        class A {
-        }
-
-        iterator(new A());
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testTraversableObject()
-    {
-        $stmts = self::$parser->parse('<?php
-        class IteratorObj implements Iterator {
-            function rewind() : void {}
-            /** @return mixed */
-            function current() { return null; }
-            function key() : int { return 0; }
-            function next() : void {}
-            function valid() : bool { return false; }
-        }
-
-        function foo(\Traversable $t) : void {
-        }
-
-        foo(new IteratorObj);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
     }
 }

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -47,7 +47,7 @@ class PropertyTypeTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'new-var-in-if' => [
+            'newVarInIf' => [
                 '<?php
                     class A {
                         /**
@@ -68,7 +68,7 @@ class PropertyTypeTest extends TestCase
                         }
                     }'
             ],
-            'property-without-type-suppressing-issue' => [
+            'propertyWithoutTypeSuppressingIssue' => [
                 '<?php
                     class A {
                         public $foo;
@@ -81,7 +81,7 @@ class PropertyTypeTest extends TestCase
                     'MixedAssignment'
                 ]
             ],
-            'property-without-type-suppressing-issue-and-asserting-null' => [
+            'propertyWithoutTypeSuppressingIssueAndAssertingNull' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -99,7 +99,7 @@ class PropertyTypeTest extends TestCase
                     'MixedPropertyFetch'
                 ]
             ],
-            'shared-property-in-if' => [
+            'sharedPropertyInIf' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -120,7 +120,7 @@ class PropertyTypeTest extends TestCase
                     ['null|string|int' => '$b']
                 ]
             ],
-            'shared-property-in-else-if' => [
+            'sharedPropertyInElseIf' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -144,7 +144,7 @@ class PropertyTypeTest extends TestCase
                     ['null|string|int' => '$b']
                 ]
             ],
-            'nullable-property-check' => [
+            'nullablePropertyCheck' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -162,7 +162,7 @@ class PropertyTypeTest extends TestCase
                         echo $b->bb->aa;
                     }'
             ],
-            'nullable-property-after-guard' => [
+            'nullablePropertyAfterGuard' => [
                 '<?php
                     class A {
                         /** @var string|null */
@@ -177,7 +177,7 @@ class PropertyTypeTest extends TestCase
             
                     echo substr($a->aa, 1);'
             ],
-            'nullable-static-property-with-if-check' => [
+            'nullableStaticPropertyWithIfCheck' => [
                 '<?php
                     class A {
                         /** @var A|null */
@@ -192,7 +192,7 @@ class PropertyTypeTest extends TestCase
                         }
                     }'
             ],
-            'reflection-properties' => [
+            'reflectionProperties' => [
                 '<?php
                     class Foo {
                     }
@@ -201,7 +201,7 @@ class PropertyTypeTest extends TestCase
             
                     echo $a->name . " - " . $a->class;'
             ],
-            'grandparent-reflected-properties' => [
+            'grandparentReflectedProperties' => [
                 '<?php
                     $a = new DOMElement("foo");
                     $owner = $a->ownerDocument;',
@@ -209,7 +209,7 @@ class PropertyTypeTest extends TestCase
                     ['DOMDocument' => '$owner']
                 ]
             ],
-            'good-array-properties' => [
+            'goodArrayProperties' => [
                 '<?php
                     interface I1 {}
             
@@ -229,7 +229,7 @@ class PropertyTypeTest extends TestCase
                 'assertions' => [],
                 'error_levels' => ['MixedAssignment']
             ],
-            'isset-property-does-not-exist' => [
+            'issetPropertyDoesNotExist' => [
                 '<?php
                     class A {
                     }
@@ -240,7 +240,7 @@ class PropertyTypeTest extends TestCase
             
                     }'
             ],
-            'not-set-in-constructor-but-has-default' => [
+            'notSetInConstructorButHasDefault' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -249,7 +249,7 @@ class PropertyTypeTest extends TestCase
                         public function __construct() { }
                     }'
             ],
-            'property-set-in-private-method' => [
+            'propertySetInPrivateMethod' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -264,7 +264,7 @@ class PropertyTypeTest extends TestCase
                         }
                     }'
             ],
-            'defined-in-trait-set-in-constructor' => [
+            'definedInTraitSetInConstructor' => [
                 '<?php
                     trait A {
                         /** @var string **/
@@ -278,7 +278,7 @@ class PropertyTypeTest extends TestCase
                         }
                     }'
             ],
-            'property-set-in-nested-private-method' => [
+            'propertySetInNestedPrivateMethod' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -297,7 +297,7 @@ class PropertyTypeTest extends TestCase
                         }
                     }'
             ],
-            'property-array-isset-assertion' => [
+            'propertyArrayIssetAssertion' => [
                 '<?php
                     function bar(string $s) : void { }
         
@@ -312,7 +312,7 @@ class PropertyTypeTest extends TestCase
                         }
                     }'
             ],
-            'property-array-isset-assertion-with-variable-offset' => [
+            'propertyArrayIssetAssertionWithVariableOffset' => [
                 '<?php
                     function bar(string $s) : void { }
         
@@ -331,7 +331,7 @@ class PropertyTypeTest extends TestCase
                         }
                     }'
             ],
-            'static-property-array-isset-assertion-with-variable-offset' => [
+            'staticPropertyArrayIssetAssertionWithVariableOffset' => [
                 '<?php
                     function bar(string $s) : void { }
         
@@ -359,7 +359,7 @@ class PropertyTypeTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'undefined-property-assignment' => [
+            'undefinedPropertyAssignment' => [
                 '<?php
                     class A {
                     }
@@ -367,7 +367,7 @@ class PropertyTypeTest extends TestCase
                     (new A)->foo = "cool";',
                 'error_message' => 'UndefinedPropertyAssignment'
             ],
-            'undefined-property-fetch' => [
+            'undefinedPropertyFetch' => [
                 '<?php
                     class A {
                     }
@@ -375,7 +375,7 @@ class PropertyTypeTest extends TestCase
                     echo (new A)->foo;',
                 'error_message' => 'UndefinedPropertyFetch'
             ],
-            'undefined-this-property-assignment' => [
+            'undefinedThisPropertyAssignment' => [
                 '<?php
                     class A {
                         public function fooFoo() : void {
@@ -384,7 +384,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'UndefinedThisPropertyAssignment'
             ],
-            'undefined-this-property-fetch' => [
+            'undefinedThisPropertyFetch' => [
                 '<?php
                     class A {
                         public function fooFoo() : void {
@@ -393,7 +393,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'UndefinedThisPropertyFetch'
             ],
-            'missing-property-declaration' => [
+            'missingPropertyDeclaration' => [
                 '<?php
                     class A {
                     }
@@ -404,7 +404,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'MissingPropertyDeclaration'
             ],
-            'missing-property-type' => [
+            'missingPropertyType' => [
                 '<?php
                     class A {
                         public $foo;
@@ -416,7 +416,7 @@ class PropertyTypeTest extends TestCase
                 'error_message' => 'MissingPropertyType - somefile.php:3 - Property A::$foo does not have a ' .
                     'declared type - consider null|int'
             ],
-            'missing-property-type-with-constructor-init' => [
+            'missingPropertyTypeWithConstructorInit' => [
                 '<?php
                     class A {
                         public $foo;
@@ -428,7 +428,7 @@ class PropertyTypeTest extends TestCase
                 'error_message' => 'MissingPropertyType - somefile.php:3 - Property A::$foo does not have a ' .
                     'declared type - consider int'
             ],
-            'missing-property-type-with-constructor-init-and-null' => [
+            'missingPropertyTypeWithConstructorInitAndNull' => [
                 '<?php
                     class A {
                         public $foo;
@@ -445,7 +445,7 @@ class PropertyTypeTest extends TestCase
                     'declared type - consider null|int'
             ],
             // Skipped. Doesn't yet work.
-            'SKIPPED-missing-property-type-with-constructor-init-in-private-method' => [
+            'SKIPPED-missingPropertyTypeWithConstructorInitInPrivateMethod' => [
                 '<?php
                     class A {
                         public $foo;
@@ -461,7 +461,7 @@ class PropertyTypeTest extends TestCase
                 'error_message' => 'MissingPropertyType - somefile.php:3 - Property A::$foo does not have a ' .
                     'declared type - consider int'
             ],
-            'missing-property-type-with-constructor-init-and-null-default' => [
+            'missingPropertyTypeWithConstructorInitAndNullDefault' => [
                 '<?php
                     class A {
                         public $foo = null;
@@ -473,7 +473,7 @@ class PropertyTypeTest extends TestCase
                 'error_message' => 'MissingPropertyType - somefile.php:3 - Property A::$foo does not have a ' .
                     'declared type - consider int|null'
             ],
-            'bad-assignment' => [
+            'badAssignment' => [
                 '<?php
                     class A {
                         /** @var string */
@@ -486,19 +486,19 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'InvalidPropertyAssignment'
             ],
-            'bad-assignment-as-well' => [
+            'badAssignmentAsWell' => [
                 '<?php
                     $a = "hello";
                     $a->foo = "bar";',
                 'error_message' => 'InvalidPropertyAssignment'
             ],
-            'bad-fetch' => [
+            'badFetch' => [
                 '<?php
                     $a = "hello";
                     echo $a->foo;',
                 'error_message' => 'InvalidPropertyFetch'
             ],
-            'mixed-property-fetch' => [
+            'mixedPropertyFetch' => [
                 '<?php
                     class Foo {
                         /** @var string */
@@ -515,7 +515,7 @@ class PropertyTypeTest extends TestCase
                     'MixedAssignment'
                 ]
             ],
-            'mixed-property-assignment' => [
+            'mixedPropertyAssignment' => [
                 '<?php
                     class Foo {
                         /** @var string */
@@ -532,7 +532,7 @@ class PropertyTypeTest extends TestCase
                     'MixedAssignment'
                 ]
             ],
-            'possibly-nullable-property-assignment' => [
+            'possiblyNullablePropertyAssignment' => [
                 '<?php
                     class Foo {
                         /** @var string */
@@ -544,14 +544,14 @@ class PropertyTypeTest extends TestCase
                     $a->foo = "hello";',
                 'error_message' => 'PossiblyNullPropertyAssignment'
             ],
-            'nullable-property-assignment' => [
+            'nullablePropertyAssignment' => [
                 '<?php
                     $a = null;
             
                     $a->foo = "hello";',
                 'error_message' => 'NullPropertyAssignment'
             ],
-            'possibly-nullable-property-fetch' => [
+            'possiblyNullablePropertyFetch' => [
                 '<?php
                     class Foo {
                         /** @var string */
@@ -563,14 +563,14 @@ class PropertyTypeTest extends TestCase
                     echo $a->foo;',
                 'error_message' => 'PossiblyNullPropertyFetch'
             ],
-            'nullable-property-fetch' => [
+            'nullablePropertyFetch' => [
                 '<?php
                     $a = null;
             
                     echo $a->foo;',
                 'error_message' => 'NullPropertyFetch'
             ],
-            'bad-array-property' => [
+            'badArrayProperty' => [
                 '<?php
                     class A {}
             
@@ -586,7 +586,7 @@ class PropertyTypeTest extends TestCase
                 'error_message' => 'InvalidPropertyAssignment',
                 'error_levels' => ['MixedAssignment']
             ],
-            'not-set-in-empty-constructor' => [
+            'notSetInEmptyConstructor' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -596,7 +596,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'PropertyNotSetInConstructor'
             ],
-            'no-constructor' => [
+            'noConstructor' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -604,7 +604,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'MissingConstructor'
             ],
-            'not-set-in-all-branches-of-if' => [
+            'notSetInAllBranchesOfIf' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -618,7 +618,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'PropertyNotSetInConstructor'
             ],
-            'property-set-in-protected-method' => [
+            'propertySetInProtectedMethod' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -634,7 +634,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'PropertyNotSetInConstructor'
             ],
-            'defined-in-trait-not-set-in-empty-constructor' => [
+            'definedInTraitNotSetInEmptyConstructor' => [
                 '<?php
                     trait A {
                         /** @var string **/
@@ -648,7 +648,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'PropertyNotSetInConstructor'
             ],
-            'property-set-in-private-method-with-if' => [
+            'propertySetInPrivateMethodWithIf' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -666,7 +666,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'PropertyNotSetInConstructor'
             ],
-            'property-set-in-private-method-with-if-and-else' => [
+            'propertySetInPrivateMethodWithIfAndElse' => [
                 '<?php
                     class A {
                         /** @var int */
@@ -690,7 +690,7 @@ class PropertyTypeTest extends TestCase
                     }',
                 'error_message' => 'PropertyNotSetInConstructor'
             ],
-            'undefined-property-class' => [
+            'undefinedPropertyClass' => [
                 '<?php
                     class A {
                         /** @var B */

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -1,1174 +1,13 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
 use Psalm\Config;
-use Psalm\Context;
 
-class PropertyTypeTest extends PHPUnit_Framework_TestCase
+class PropertyTypeTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testNewVarInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /**
-             * @var mixed
-             */
-            public $foo;
-
-            /** @return void */
-            public function barBar()
-            {
-                if (rand(0,10) === 5) {
-                    $this->foo = [];
-                }
-
-                if (!is_array($this->foo)) {
-                    // do something
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testPropertyWithoutTypeSuppressingIssue()
-    {
-        Config::getInstance()->setCustomErrorLevel('MissingPropertyType', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public $foo;
-        }
-
-        $a = (new A)->foo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testPropertyWithoutTypeSuppressingIssueAndAssertingNull()
-    {
-        Config::getInstance()->setCustomErrorLevel('UndefinedThisPropertyFetch', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedMethodCall', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedPropertyFetch', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            function foo() {
-                $boop = $this->foo === null && rand(0,1);
-
-                echo $this->foo->baz;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedPropertyAssignment
-     * @return                   void
-     */
-    public function testUndefinedPropertyAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-        }
-
-        (new A)->foo = "cool";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedPropertyFetch
-     * @return                   void
-     */
-    public function testUndefinedPropertyFetch()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-        }
-
-        echo (new A)->foo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedThisPropertyAssignment
-     * @return                   void
-     */
-    public function testUndefinedThisPropertyAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo() : void {
-                $this->foo = "cool";
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedThisPropertyFetch
-     * @return                   void
-     */
-    public function testUndefinedThisPropertyFetch()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function fooFoo() : void {
-                echo $this->foo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyDeclaration
-     * @return                   void
-     */
-    public function testMissingPropertyDeclaration()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-        }
-
-        /** @psalm-suppress UndefinedPropertyAssignment */
-        function fooDo() : void {
-            (new A)->foo = "cool";
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyType - somefile.php:3 - Property A::$foo does not have a declared type - consider null|int
-     * @return                   void
-     */
-    public function testMissingPropertyType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public $foo;
-
-            public function assignToFoo() : void {
-                $this->foo = 5;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyType - somefile.php:3 - Property A::$foo does not have a declared type - consider int
-     * @return                   void
-     */
-    public function testMissingPropertyTypeWithConstructorInit()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public $foo;
-
-            public function __construct() : void {
-                $this->foo = 5;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyType - somefile.php:3 - Property A::$foo does not have a declared type - consider null|int
-     * @return                   void
-     */
-    public function testMissingPropertyTypeWithConstructorInitAndNull()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public $foo;
-
-            public function __construct() : void {
-                $this->foo = 5;
-            }
-
-            public function makeNull() : void {
-                $this->foo = null;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyType - somefile.php:3 - Property A::$foo does not have a declared type - consider int
-     * @return                   void
-     */
-    public function testMissingPropertyTypeWithConstructorInitInPrivateMethod()
-    {
-        $this->markTestSkipped('Doesn’t yet work');
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public $foo;
-
-            public function __construct() : void {
-                $this->makeValue();
-            }
-
-            private function makeValue() : void {
-                $this->foo = 5;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyType - somefile.php:3 - Property A::$foo does not have a declared type - consider int|null
-     * @return                   void
-     */
-    public function testMissingPropertyTypeWithConstructorInitAndNullDefault()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public $foo = null;
-
-            public function __construct() : void {
-                $this->foo = 5;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidPropertyAssignment
-     * @return                   void
-     */
-    public function testBadAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            public $foo;
-
-            public function barBar() : void
-            {
-                $this->foo = 5;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidPropertyAssignment
-     * @return                   void
-     */
-    public function testBadAssignmentAsWell()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = "hello";
-        $a->foo = "bar";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidPropertyFetch
-     * @return                   void
-     */
-    public function testBadFetch()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = "hello";
-        echo $a->foo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSharedPropertyInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var int */
-            public $foo = 0;
-        }
-        class B {
-            /** @var string */
-            public $foo = "";
-        }
-
-        $a = rand(0, 10) ? new A() : (rand(0, 10) ? new B() : null);
-        $b = null;
-
-        if ($a instanceof A || $a instanceof B) {
-            $b = $a->foo;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('null|string|int', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testSharedPropertyInElseIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var int */
-            public $foo = 0;
-        }
-        class B {
-            /** @var string */
-            public $foo = "";
-        }
-
-        $a = rand(0, 10) ? new A() : new B();
-        $b = null;
-
-        if (rand(0, 10) === 4) {
-            // do nothing
-        }
-        elseif ($a instanceof A || $a instanceof B) {
-            $b = $a->foo;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('null|string|int', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MixedPropertyFetch
-     * @return                   void
-     */
-    public function testMixedPropertyFetch()
-    {
-        Config::getInstance()->setCustomErrorLevel('MissingPropertyType', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            /** @var string */
-            public $foo = "";
-        }
-
-        /** @var mixed */
-        $a = (new Foo());
-
-        echo $a->foo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MixedPropertyAssignment
-     * @return                   void
-     */
-    public function testMixedPropertyAssignment()
-    {
-        Config::getInstance()->setCustomErrorLevel('MissingPropertyType', Config::REPORT_SUPPRESS);
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            /** @var string */
-            public $foo = "";
-        }
-
-        /** @var mixed */
-        $a = (new Foo());
-
-        $a->foo = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyNullPropertyAssignment
-     * @return                   void
-     */
-    public function testPossiblyNullablePropertyAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            /** @var string */
-            public $foo = "";
-        }
-
-        $a = rand(0, 10) ? new Foo() : null;
-
-        $a->foo = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage NullPropertyAssignment
-     * @return                   void
-     */
-    public function testNullablePropertyAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = null;
-
-        $a->foo = "hello";
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyNullPropertyFetch
-     * @return                   void
-     */
-    public function testPossiblyNullablePropertyFetch()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-            /** @var string */
-            public $foo = "";
-        }
-
-        $a = rand(0, 10) ? new Foo() : null;
-
-        echo $a->foo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage NullPropertyFetch
-     * @return                   void
-     */
-    public function testNullablePropertyFetch()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = null;
-
-        echo $a->foo;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullablePropertyCheck()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string */
-            public $aa = "";
-        }
-
-        class B {
-            /** @var A|null */
-            public $bb;
-        }
-
-        $b = rand(0, 10) ? new A() : new B();
-
-        if ($b instanceof B && isset($b->bb) && $b->bb->aa === "aa") {
-            echo $b->bb->aa;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullablePropertyAfterGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var string|null */
-            public $aa;
-        }
-
-        $a = new A();
-
-        if (!$a->aa) {
-            $a->aa = "hello";
-        }
-
-        echo substr($a->aa, 1);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableStaticPropertyWithIfCheck()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var A|null */
-            public static $fooFoo;
-
-            public static function getFoo() : A {
-                if (!self::$fooFoo) {
-                    self::$fooFoo = new A();
-                }
-
-                return self::$fooFoo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testReflectionProperties()
-    {
-        $stmts = self::$parser->parse('<?php
-        class Foo {
-        }
-
-        $a = new \ReflectionMethod("Foo", "__construct");
-
-        echo $a->name . " - " . $a->class;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGrandparentReflectedProperties()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = new DOMElement("foo");
-        $owner = $a->ownerDocument;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('DOMDocument', (string) $context->vars_in_scope['$owner']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGoodArrayProperties()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-
-        interface I1 {}
-
-        class A1 implements I1{}
-
-        class B1 implements I1 {}
-
-        class C1 {
-            /** @var array<I1> */
-            public $is = [];
-        }
-
-        $c = new C1;
-        $c->is = [new A1];
-        $c->is = [new A1, new A1];
-        $c->is = [new A1, new B1];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidPropertyAssignment
-     * @return                   void
-     */
-    public function testBadArrayProperty()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedAssignment', Config::REPORT_SUPPRESS);
-
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        class A {}
-
-        class B {}
-
-        class C {
-            /** @var array<B> */
-            public $bb;
-        }
-
-        $c = new C;
-        $c->bb = [new A, new B];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIssetPropertyDoesNotExist()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-        }
-
-        $a = new A();
-
-        if (isset($a->bar)) {
-
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PropertyNotSetInConstructor
-     * @return                   void
-     */
-    public function testNotSetInEmptyConstructor()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            class A {
-                /** @var int */
-                public $a;
-
-                public function __construct() { }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingConstructor
-     * @return                   void
-     */
-    public function testNoConstructor()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            class A {
-                /** @var int */
-                public $a;
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testNotSetInConstructorButHasDefault()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            class A {
-                /** @var int */
-                public $a = 0;
-
-                public function __construct() { }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PropertyNotSetInConstructor
-     * @return                   void
-     */
-    public function testNotSetInAllBranchesOfIf()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            class A {
-                /** @var int */
-                public $a;
-
-                public function __construct() {
-                    if (rand(0, 1)) {
-                        $this->a = 5;
-                    }
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testPropertySetInPrivateMethod()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            class A {
-                /** @var int */
-                public $a;
-
-                public function __construct() {
-                    $this->foo();
-                }
-
-                private function foo() : void {
-                    $this->a = 5;
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PropertyNotSetInConstructor
-     * @return                   void
-     */
-    public function testPropertySetInProtectedMethod()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            class A {
-                /** @var int */
-                public $a;
-
-                public function __construct() {
-                    $this->foo();
-                }
-
-                protected function foo() : void {
-                    $this->a = 5;
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PropertyNotSetInConstructor
-     * @return                   void
-     */
-    public function testDefinedInTraitNotSetInEmptyConstructor()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            trait A {
-                /** @var string **/
-                public $a;
-            }
-            class B {
-                use A;
-
-                public function __construct() {
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testDefinedInTraitSetInConstructor()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            trait A {
-                /** @var string **/
-                public $a;
-            }
-            class B {
-                use A;
-
-                public function __construct() {
-                    $this->a = "hello";
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testPropertySetInNestedPrivateMethod()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            class A {
-                /** @var int */
-                public $a;
-
-                public function __construct() {
-                    $this->foo();
-                }
-
-                private function foo() : void {
-                    $this->bar();
-                }
-
-                private function bar() : void {
-                    $this->a = 5;
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PropertyNotSetInConstructor
-     * @return                   void
-     */
-    public function testPropertySetInPrivateMethodWithIf()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            class A {
-                /** @var int */
-                public $a;
-
-                public function __construct() {
-                    if (rand(0, 1)) {
-                        $this->foo();
-                    }
-                }
-
-                private function foo() : void {
-                    $this->a = 5;
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PropertyNotSetInConstructor
-     * @return                   void
-     */
-    public function testPropertySetInPrivateMethodWithIfAndElse()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            class A {
-                /** @var int */
-                public $a;
-
-                public function __construct() {
-                    if (rand(0, 1)) {
-                        $this->foo();
-                    } else {
-                        $this->bar();
-                    }
-                }
-
-                private function foo() : void {
-                    $this->a = 5;
-                }
-
-                private function bar() : void {
-                    $this->a = 5;
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testPropertyArrayIssetAssertion()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            function bar(string $s) : void { }
-
-            class A {
-                /** @var array<string, string> */
-                public $a = [];
-
-                private function foo() : void {
-                    if (isset($this->a["hello"])) {
-                        bar($this->a["hello"]);
-                    }
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testPropertyArrayIssetAssertionWithVariableOffset()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            function bar(string $s) : void { }
-
-            class A {
-                /** @var array<string, string> */
-                public $a = [];
-
-                private function foo() : void {
-                    $b = "hello";
-
-                    if (!isset($this->a[$b])) {
-                        return;
-                    }
-
-                    bar($this->a[$b]);
-                }
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testStaticPropertyArrayIssetAssertionWithVariableOffset()
-    {
-        $this->project_checker->registerFile(
-            getcwd() . '/somefile.php',
-            '<?php
-            function bar(string $s) : void { }
-
-            class A {
-                /** @var array<string, string> */
-                public static $a = [];
-            }
-
-            function foo() : void {
-                $b = "hello";
-
-                if (!isset(A::$a[$b])) {
-                    return;
-                }
-
-                bar(A::$a[$b]);
-            }'
-        );
-
-        $file_checker = new FileChecker(getcwd() . '/somefile.php', $this->project_checker);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedClass
-     * @return                   void
-     */
-    public function testUndefinedPropertyClass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var B */
-            public $foo;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
      * @expectedException        \Psalm\Exception\CodeException
@@ -1202,5 +41,663 @@ class PropertyTypeTest extends PHPUnit_Framework_TestCase
         $file_checker->visitAndAnalyzeMethods();
     }
 
+    /**
+     * @return array
+     */
+    public function providerFileCheckerValidCodeParse()
+    {
+        return [
+            'new-var-in-if' => [
+                '<?php
+                    class A {
+                        /**
+                         * @var mixed
+                         */
+                        public $foo;
+            
+                        /** @return void */
+                        public function barBar()
+                        {
+                            if (rand(0,10) === 5) {
+                                $this->foo = [];
+                            }
+            
+                            if (!is_array($this->foo)) {
+                                // do something
+                            }
+                        }
+                    }'
+            ],
+            'property-without-type-suppressing-issue' => [
+                '<?php
+                    class A {
+                        public $foo;
+                    }
+            
+                    $a = (new A)->foo;',
+                'assertions' => [],
+                'error_levels' => [
+                    'MissingPropertyType',
+                    'MixedAssignment'
+                ]
+            ],
+            'property-without-type-suppressing-issue-and-asserting-null' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        function foo() {
+                            $boop = $this->foo === null && rand(0,1);
+            
+                            echo $this->foo->baz;
+                        }
+                    }',
+                'assertions' => [],
+                'error_levels' => [
+                    'UndefinedThisPropertyFetch',
+                    'MixedAssignment',
+                    'MixedMethodCall',
+                    'MixedPropertyFetch'
+                ]
+            ],
+            'shared-property-in-if' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $foo = 0;
+                    }
+                    class B {
+                        /** @var string */
+                        public $foo = "";
+                    }
+            
+                    $a = rand(0, 10) ? new A() : (rand(0, 10) ? new B() : null);
+                    $b = null;
+            
+                    if ($a instanceof A || $a instanceof B) {
+                        $b = $a->foo;
+                    }',
+                'assertions' => [
+                    ['null|string|int' => '$b']
+                ]
+            ],
+            'shared-property-in-else-if' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $foo = 0;
+                    }
+                    class B {
+                        /** @var string */
+                        public $foo = "";
+                    }
+            
+                    $a = rand(0, 10) ? new A() : new B();
+                    $b = null;
+            
+                    if (rand(0, 10) === 4) {
+                        // do nothing
+                    }
+                    elseif ($a instanceof A || $a instanceof B) {
+                        $b = $a->foo;
+                    }',
+                'assertions' => [
+                    ['null|string|int' => '$b']
+                ]
+            ],
+            'nullable-property-check' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        public $aa = "";
+                    }
+            
+                    class B {
+                        /** @var A|null */
+                        public $bb;
+                    }
+            
+                    $b = rand(0, 10) ? new A() : new B();
+            
+                    if ($b instanceof B && isset($b->bb) && $b->bb->aa === "aa") {
+                        echo $b->bb->aa;
+                    }'
+            ],
+            'nullable-property-after-guard' => [
+                '<?php
+                    class A {
+                        /** @var string|null */
+                        public $aa;
+                    }
+            
+                    $a = new A();
+            
+                    if (!$a->aa) {
+                        $a->aa = "hello";
+                    }
+            
+                    echo substr($a->aa, 1);'
+            ],
+            'nullable-static-property-with-if-check' => [
+                '<?php
+                    class A {
+                        /** @var A|null */
+                        public static $fooFoo;
+            
+                        public static function getFoo() : A {
+                            if (!self::$fooFoo) {
+                                self::$fooFoo = new A();
+                            }
+            
+                            return self::$fooFoo;
+                        }
+                    }'
+            ],
+            'reflection-properties' => [
+                '<?php
+                    class Foo {
+                    }
+            
+                    $a = new \ReflectionMethod("Foo", "__construct");
+            
+                    echo $a->name . " - " . $a->class;'
+            ],
+            'grandparent-reflected-properties' => [
+                '<?php
+                    $a = new DOMElement("foo");
+                    $owner = $a->ownerDocument;',
+                'assertions' => [
+                    ['DOMDocument' => '$owner']
+                ]
+            ],
+            'good-array-properties' => [
+                '<?php
+                    interface I1 {}
+            
+                    class A1 implements I1{}
+            
+                    class B1 implements I1 {}
+            
+                    class C1 {
+                        /** @var array<I1> */
+                        public $is = [];
+                    }
+            
+                    $c = new C1;
+                    $c->is = [new A1];
+                    $c->is = [new A1, new A1];
+                    $c->is = [new A1, new B1];',
+                'assertions' => [],
+                'error_levels' => ['MixedAssignment']
+            ],
+            'isset-property-does-not-exist' => [
+                '<?php
+                    class A {
+                    }
+            
+                    $a = new A();
+            
+                    if (isset($a->bar)) {
+            
+                    }'
+            ],
+            'not-set-in-constructor-but-has-default' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a = 0;
+        
+                        public function __construct() { }
+                    }'
+            ],
+            'property-set-in-private-method' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a;
+        
+                        public function __construct() {
+                            $this->foo();
+                        }
+        
+                        private function foo() : void {
+                            $this->a = 5;
+                        }
+                    }'
+            ],
+            'defined-in-trait-set-in-constructor' => [
+                '<?php
+                    trait A {
+                        /** @var string **/
+                        public $a;
+                    }
+                    class B {
+                        use A;
+        
+                        public function __construct() {
+                            $this->a = "hello";
+                        }
+                    }'
+            ],
+            'property-set-in-nested-private-method' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a;
+        
+                        public function __construct() {
+                            $this->foo();
+                        }
+        
+                        private function foo() : void {
+                            $this->bar();
+                        }
+        
+                        private function bar() : void {
+                            $this->a = 5;
+                        }
+                    }'
+            ],
+            'property-array-isset-assertion' => [
+                '<?php
+                    function bar(string $s) : void { }
+        
+                    class A {
+                        /** @var array<string, string> */
+                        public $a = [];
+        
+                        private function foo() : void {
+                            if (isset($this->a["hello"])) {
+                                bar($this->a["hello"]);
+                            }
+                        }
+                    }'
+            ],
+            'property-array-isset-assertion-with-variable-offset' => [
+                '<?php
+                    function bar(string $s) : void { }
+        
+                    class A {
+                        /** @var array<string, string> */
+                        public $a = [];
+        
+                        private function foo() : void {
+                            $b = "hello";
+        
+                            if (!isset($this->a[$b])) {
+                                return;
+                            }
+        
+                            bar($this->a[$b]);
+                        }
+                    }'
+            ],
+            'static-property-array-isset-assertion-with-variable-offset' => [
+                '<?php
+                    function bar(string $s) : void { }
+        
+                    class A {
+                        /** @var array<string, string> */
+                        public static $a = [];
+                    }
+        
+                    function foo() : void {
+                        $b = "hello";
+        
+                        if (!isset(A::$a[$b])) {
+                            return;
+                        }
+        
+                        bar(A::$a[$b]);
+                    }'
+            ]
+        ];
+    }
 
+    /**
+     * @return array
+     */
+    public function providerFileCheckerInvalidCodeParse()
+    {
+        return [
+            'undefined-property-assignment' => [
+                '<?php
+                    class A {
+                    }
+            
+                    (new A)->foo = "cool";',
+                'error_message' => 'UndefinedPropertyAssignment'
+            ],
+            'undefined-property-fetch' => [
+                '<?php
+                    class A {
+                    }
+            
+                    echo (new A)->foo;',
+                'error_message' => 'UndefinedPropertyFetch'
+            ],
+            'undefined-this-property-assignment' => [
+                '<?php
+                    class A {
+                        public function fooFoo() : void {
+                            $this->foo = "cool";
+                        }
+                    }',
+                'error_message' => 'UndefinedThisPropertyAssignment'
+            ],
+            'undefined-this-property-fetch' => [
+                '<?php
+                    class A {
+                        public function fooFoo() : void {
+                            echo $this->foo;
+                        }
+                    }',
+                'error_message' => 'UndefinedThisPropertyFetch'
+            ],
+            'missing-property-declaration' => [
+                '<?php
+                    class A {
+                    }
+            
+                    /** @psalm-suppress UndefinedPropertyAssignment */
+                    function fooDo() : void {
+                        (new A)->foo = "cool";
+                    }',
+                'error_message' => 'MissingPropertyDeclaration'
+            ],
+            'missing-property-type' => [
+                '<?php
+                    class A {
+                        public $foo;
+            
+                        public function assignToFoo() : void {
+                            $this->foo = 5;
+                        }
+                    }',
+                'error_message' => 'MissingPropertyType - somefile.php:3 - Property A::$foo does not have a ' .
+                    'declared type - consider null|int'
+            ],
+            'missing-property-type-with-constructor-init' => [
+                '<?php
+                    class A {
+                        public $foo;
+            
+                        public function __construct() : void {
+                            $this->foo = 5;
+                        }
+                    }',
+                'error_message' => 'MissingPropertyType - somefile.php:3 - Property A::$foo does not have a ' .
+                    'declared type - consider int'
+            ],
+            'missing-property-type-with-constructor-init-and-null' => [
+                '<?php
+                    class A {
+                        public $foo;
+            
+                        public function __construct() : void {
+                            $this->foo = 5;
+                        }
+            
+                        public function makeNull() : void {
+                            $this->foo = null;
+                        }
+                    }',
+                'error_message' => 'MissingPropertyType - somefile.php:3 - Property A::$foo does not have a ' .
+                    'declared type - consider null|int'
+            ],
+            // Skipped. Doesn't yet work.
+            'SKIPPED-missing-property-type-with-constructor-init-in-private-method' => [
+                '<?php
+                    class A {
+                        public $foo;
+            
+                        public function __construct() : void {
+                            $this->makeValue();
+                        }
+            
+                        private function makeValue() : void {
+                            $this->foo = 5;
+                        }
+                    }',
+                'error_message' => 'MissingPropertyType - somefile.php:3 - Property A::$foo does not have a ' .
+                    'declared type - consider int'
+            ],
+            'missing-property-type-with-constructor-init-and-null-default' => [
+                '<?php
+                    class A {
+                        public $foo = null;
+            
+                        public function __construct() : void {
+                            $this->foo = 5;
+                        }
+                    }',
+                'error_message' => 'MissingPropertyType - somefile.php:3 - Property A::$foo does not have a ' .
+                    'declared type - consider int|null'
+            ],
+            'bad-assignment' => [
+                '<?php
+                    class A {
+                        /** @var string */
+                        public $foo;
+                
+                        public function barBar() : void
+                        {
+                            $this->foo = 5;
+                        }
+                    }',
+                'error_message' => 'InvalidPropertyAssignment'
+            ],
+            'bad-assignment-as-well' => [
+                '<?php
+                    $a = "hello";
+                    $a->foo = "bar";',
+                'error_message' => 'InvalidPropertyAssignment'
+            ],
+            'bad-fetch' => [
+                '<?php
+                    $a = "hello";
+                    echo $a->foo;',
+                'error_message' => 'InvalidPropertyFetch'
+            ],
+            'mixed-property-fetch' => [
+                '<?php
+                    class Foo {
+                        /** @var string */
+                        public $foo = "";
+                    }
+            
+                    /** @var mixed */
+                    $a = (new Foo());
+            
+                    echo $a->foo;',
+                'error_message' => 'MixedPropertyFetch',
+                'error_levels' => [
+                    'MissingPropertyType',
+                    'MixedAssignment'
+                ]
+            ],
+            'mixed-property-assignment' => [
+                '<?php
+                    class Foo {
+                        /** @var string */
+                        public $foo = "";
+                    }
+            
+                    /** @var mixed */
+                    $a = (new Foo());
+            
+                    $a->foo = "hello";',
+                'error_message' => '',
+                'error_levels' => [
+                    'MissingPropertyType',
+                    'MixedAssignment'
+                ]
+            ],
+            'possibly-nullable-property-assignment' => [
+                '<?php
+                    class Foo {
+                        /** @var string */
+                        public $foo = "";
+                    }
+            
+                    $a = rand(0, 10) ? new Foo() : null;
+            
+                    $a->foo = "hello";',
+                'error_message' => 'PossiblyNullPropertyAssignment'
+            ],
+            'nullable-property-assignment' => [
+                '<?php
+                    $a = null;
+            
+                    $a->foo = "hello";',
+                'error_message' => 'NullPropertyAssignment'
+            ],
+            'possibly-nullable-property-fetch' => [
+                '<?php
+                    class Foo {
+                        /** @var string */
+                        public $foo = "";
+                    }
+            
+                    $a = rand(0, 10) ? new Foo() : null;
+            
+                    echo $a->foo;',
+                'error_message' => 'PossiblyNullPropertyFetch'
+            ],
+            'nullable-property-fetch' => [
+                '<?php
+                    $a = null;
+            
+                    echo $a->foo;',
+                'error_message' => 'NullPropertyFetch'
+            ],
+            'bad-array-property' => [
+                '<?php
+                    class A {}
+            
+                    class B {}
+            
+                    class C {
+                        /** @var array<B> */
+                        public $bb;
+                    }
+            
+                    $c = new C;
+                    $c->bb = [new A, new B];',
+                'error_message' => 'InvalidPropertyAssignment',
+                'error_levels' => ['MixedAssignment']
+            ],
+            'not-set-in-empty-constructor' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a;
+        
+                        public function __construct() { }
+                    }',
+                'error_message' => 'PropertyNotSetInConstructor'
+            ],
+            'no-constructor' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a;
+                    }',
+                'error_message' => 'MissingConstructor'
+            ],
+            'not-set-in-all-branches-of-if' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a;
+        
+                        public function __construct() {
+                            if (rand(0, 1)) {
+                                $this->a = 5;
+                            }
+                        }
+                    }',
+                'error_message' => 'PropertyNotSetInConstructor'
+            ],
+            'property-set-in-protected-method' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a;
+        
+                        public function __construct() {
+                            $this->foo();
+                        }
+        
+                        protected function foo() : void {
+                            $this->a = 5;
+                        }
+                    }',
+                'error_message' => 'PropertyNotSetInConstructor'
+            ],
+            'defined-in-trait-not-set-in-empty-constructor' => [
+                '<?php
+                    trait A {
+                        /** @var string **/
+                        public $a;
+                    }
+                    class B {
+                        use A;
+        
+                        public function __construct() {
+                        }
+                    }',
+                'error_message' => 'PropertyNotSetInConstructor'
+            ],
+            'property-set-in-private-method-with-if' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a;
+        
+                        public function __construct() {
+                            if (rand(0, 1)) {
+                                $this->foo();
+                            }
+                        }
+        
+                        private function foo() : void {
+                            $this->a = 5;
+                        }
+                    }',
+                'error_message' => 'PropertyNotSetInConstructor'
+            ],
+            'property-set-in-private-method-with-if-and-else' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $a;
+        
+                        public function __construct() {
+                            if (rand(0, 1)) {
+                                $this->foo();
+                            } else {
+                                $this->bar();
+                            }
+                        }
+        
+                        private function foo() : void {
+                            $this->a = 5;
+                        }
+        
+                        private function bar() : void {
+                            $this->a = 5;
+                        }
+                    }',
+                'error_message' => 'PropertyNotSetInConstructor'
+            ],
+            'undefined-property-class' => [
+                '<?php
+                    class A {
+                        /** @var B */
+                        public $foo;
+                    }',
+                'error_message' => 'UndefinedClass'
+            ]
+        ];
+    }
 }

--- a/tests/ReferenceConstraintTest.php
+++ b/tests/ReferenceConstraintTest.php
@@ -12,7 +12,7 @@ class ReferenceConstraintTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'function-parameter-no-violation' => [
+            'functionParameterNoViolation' => [
                 '<?php
                     /** @return void */
                     function changeInt(int &$a) {
@@ -28,7 +28,7 @@ class ReferenceConstraintTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'function-parameter-violation' => [
+            'functionParameterViolation' => [
                 '<?php
                     /** @return void */
                     function changeInt(int &$a) {
@@ -36,7 +36,7 @@ class ReferenceConstraintTest extends TestCase
                     }',
                 'error_message' => 'ReferenceConstraintViolation'
             ],
-            'class-method-parameter-violation' => [
+            'classMethodParameterViolation' => [
                 '<?php
                     class A {
                       /** @var int */
@@ -53,7 +53,7 @@ class ReferenceConstraintTest extends TestCase
                     $bar = null; // ReferenceConstraintViolation issue emitted',
                 'error_message' => 'ReferenceConstraintViolation'
             ],
-            'class-method-parameter-violation-in-post-assignment' => [
+            'classMethodParameterViolationInPostAssignment' => [
                 '<?php
                     class A {
                       /** @var int */
@@ -69,7 +69,7 @@ class ReferenceConstraintTest extends TestCase
                     $bar = null;',
                 'error_message' => 'ReferenceConstraintViolation'
             ],
-            'contradictory-reference-constraints' => [
+            'contradictoryReferenceConstraints' => [
                 '<?php
                     class A {
                         /** @var int */

--- a/tests/ReferenceConstraintTest.php
+++ b/tests/ReferenceConstraintTest.php
@@ -1,172 +1,105 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ReferenceConstraintTest extends PHPUnit_Framework_TestCase
+class ReferenceConstraintTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
+        return [
+            'function-parameter-no-violation' => [
+                '<?php
+                    /** @return void */
+                    function changeInt(int &$a) {
+                      $a = 5;
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ReferenceConstraintViolation
-     * @return                   void
-     */
-    public function testFunctionParameterViolation()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void */
-        function changeInt(int &$a) {
-          $a = "hello";
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testFunctionParameterNoViolation()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void */
-        function changeInt(int &$a) {
-          $a = 5;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ReferenceConstraintViolation
-     * @return                   void
-     */
-    public function testClassMethodParameterViolation()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-          /** @var int */
-          private $foo;
-
-            public function __construct(int &$foo) {
-                $this->foo = &$foo;
-                $foo = "hello";
-            }
-        }
-
-        $bar = 5;
-        $a = new A($bar); // $bar is constrained to an int
-        $bar = null; // ReferenceConstraintViolation issue emitted
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ReferenceConstraintViolation
-     * @return                   void
-     */
-    public function testClassMethodParameterViolationInPostAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-          /** @var int */
-          private $foo;
-
-            public function __construct(int &$foo) {
-                $this->foo = &$foo;
-            }
-        }
-
-        $bar = 5;
-        $a = new A($bar);
-        $bar = null;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ConflictingReferenceConstraint
-     * @return                   void
-     */
-    public function testContradictoryReferenceConstraints()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var int */
-            private $foo;
-
-            public function __construct(int &$foo) {
-                $this->foo = &$foo;
-            }
-        }
-
-        class B {
-            /** @var string */
-            private $bar;
-
-            public function __construct(string &$bar) {
-                $this->bar = &$bar;
-            }
-        }
-
-        if (rand(0, 1)) {
-            $v = 5;
-            $c = (new A($v)); // $v is constrained to an int
-        } else {
-            $v = "hello";
-            $c =  (new B($v)); // $v is constrained to a string
-        }
-
-        $v = 8;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'function-parameter-violation' => [
+                '<?php
+                    /** @return void */
+                    function changeInt(int &$a) {
+                      $a = "hello";
+                    }',
+                'error_message' => 'ReferenceConstraintViolation'
+            ],
+            'class-method-parameter-violation' => [
+                '<?php
+                    class A {
+                      /** @var int */
+                      private $foo;
+            
+                        public function __construct(int &$foo) {
+                            $this->foo = &$foo;
+                            $foo = "hello";
+                        }
+                    }
+            
+                    $bar = 5;
+                    $a = new A($bar); // $bar is constrained to an int
+                    $bar = null; // ReferenceConstraintViolation issue emitted',
+                'error_message' => 'ReferenceConstraintViolation'
+            ],
+            'class-method-parameter-violation-in-post-assignment' => [
+                '<?php
+                    class A {
+                      /** @var int */
+                      private $foo;
+            
+                        public function __construct(int &$foo) {
+                            $this->foo = &$foo;
+                        }
+                    }
+            
+                    $bar = 5;
+                    $a = new A($bar);
+                    $bar = null;',
+                'error_message' => 'ReferenceConstraintViolation'
+            ],
+            'contradictory-reference-constraints' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        private $foo;
+            
+                        public function __construct(int &$foo) {
+                            $this->foo = &$foo;
+                        }
+                    }
+            
+                    class B {
+                        /** @var string */
+                        private $bar;
+            
+                        public function __construct(string &$bar) {
+                            $this->bar = &$bar;
+                        }
+                    }
+            
+                    if (rand(0, 1)) {
+                        $v = 5;
+                        $c = (new A($v)); // $v is constrained to an int
+                    } else {
+                        $v = "hello";
+                        $c =  (new B($v)); // $v is constrained to a string
+                    }
+            
+                    $v = 8;',
+                'error_message' => 'ConflictingReferenceConstraint'
+            ]
+        ];
     }
 }

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -12,7 +12,7 @@ class ReturnTypeTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'return-type-after-useless-null-check' => [
+            'returnTypeAfterUselessNullCheck' => [
                 '<?php
                     class One {}
             
@@ -32,7 +32,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'return-type-not-empty-check' => [
+            'returnTypeNotEmptyCheck' => [
                 '<?php
                     class B {
                         /**
@@ -47,7 +47,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'return-type-not-empty-check-in-else-if' => [
+            'returnTypeNotEmptyCheckInElseIf' => [
                 '<?php
                     class B {
                         /**
@@ -65,7 +65,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'return-type-not-empty-check-in-else' => [
+            'returnTypeNotEmptyCheckInElse' => [
                 '<?php
                     class B {
                         /**
@@ -83,7 +83,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'return-type-after-if' => [
+            'returnTypeAfterIf' => [
                 '<?php
                     class B {
                         /**
@@ -99,7 +99,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'return-type-after-two-ifs-with-throw' => [
+            'returnTypeAfterTwoIfsWithThrow' => [
                 '<?php
                     class A1 {
                     }
@@ -120,7 +120,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'return-type-after-if-else-if-with-throw' => [
+            'returnTypeAfterIfElseIfWithThrow' => [
                 '<?php
                     class A1 {
                     }
@@ -141,7 +141,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'try-catch-return-type' => [
+            'tryCatchReturnType' => [
                 '<?php
                     class A {
                         /** @return bool */
@@ -156,7 +156,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'switch-return-type-with-fallthrough' => [
+            'switchReturnTypeWithFallthrough' => [
                 '<?php
                     class A {
                         /** @return bool */
@@ -169,7 +169,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'switch-return-type-with-fallthrough-and-statement' => [
+            'switchReturnTypeWithFallthroughAndStatement' => [
                 '<?php
                     class A {
                         /** @return bool */
@@ -183,7 +183,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'switch-return-type-with-default-exception' => [
+            'switchReturnTypeWithDefaultException' => [
                 '<?php
                     class A {
                         /**
@@ -202,7 +202,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'extends-static-call-return-type' => [
+            'extendsStaticCallReturnType' => [
                 '<?php
                     abstract class A {
                         /** @return static */
@@ -219,7 +219,7 @@ class ReturnTypeTest extends TestCase
                     ['B' => '$b']
                 ]
             ],
-            'extends-static-call-array-return-type' => [
+            'extendsStaticCallArrayReturnType' => [
                 '<?php
                     abstract class A {
                         /** @return array<int,static> */
@@ -236,7 +236,7 @@ class ReturnTypeTest extends TestCase
                     ['array<int, B>' => '$bees']
                 ]
             ],
-            'isset-return-type' => [
+            'issetReturnType' => [
                 '<?php
                     /**
                      * @param  mixed $foo
@@ -246,7 +246,7 @@ class ReturnTypeTest extends TestCase
                         return isset($foo);
                     }'
             ],
-            'this-return-type' => [
+            'thisReturnType' => [
                 '<?php
                     class A {
                         /** @return $this */
@@ -255,7 +255,7 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
-            'override-return-type' => [
+            'overrideReturnType' => [
                 '<?php
                     class A {
                         /** @return string|null */
@@ -276,7 +276,7 @@ class ReturnTypeTest extends TestCase
                     ['string' => '$blah']
                 ]
             ],
-            'interface-return-type' => [
+            'interfaceReturnType' => [
                 '<?php
                     interface A {
                         /** @return string|null */
@@ -294,7 +294,7 @@ class ReturnTypeTest extends TestCase
                     ['string|null' => '$blah']
                 ]
             ],
-            'override-return-type-in-grandparent' => [
+            'overrideReturnTypeInGrandparent' => [
                 '<?php
                     abstract class A {
                         /** @return string|null */
@@ -315,7 +315,7 @@ class ReturnTypeTest extends TestCase
                     ['string|null' => '$blah']
                 ]
             ],
-            'backwards-return-type' => [
+            'backwardsReturnType' => [
                 '<?php
                     class A {}
                     class B extends A {}
@@ -334,7 +334,7 @@ class ReturnTypeTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'switch-return-type-with-fallthrough-and-break' => [
+            'switchReturnTypeWithFallthroughAndBreak' => [
                 '<?php
                     class A {
                         /** @return bool */
@@ -349,7 +349,7 @@ class ReturnTypeTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'switch-return-type-with-fallthrough-and-conditional-break' => [
+            'switchReturnTypeWithFallthroughAndConditionalBreak' => [
                 '<?php
                     class A {
                         /** @return bool */
@@ -366,7 +366,7 @@ class ReturnTypeTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'switch-return-type-with-no-default' => [
+            'switchReturnTypeWithNoDefault' => [
                 '<?php
                     class A {
                         /** @return bool */
@@ -380,21 +380,21 @@ class ReturnTypeTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'wrong-return-type-1' => [
+            'wrongReturnType1' => [
                 '<?php
                     function fooFoo() : string {
                         return 5;
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'wrong-return-type-2' => [
+            'wrongReturnType2' => [
                 '<?php
                     function fooFoo() : string {
                         return rand(0, 5) ? "hello" : null;
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'wrong-return-type-in-namespace-1' => [
+            'wrongReturnTypeInNamespace1' => [
                 '<?php
                     namespace bar;
             
@@ -403,7 +403,7 @@ class ReturnTypeTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'wrong-return-type-in-namespace-2' => [
+            'wrongReturnTypeInNamespace2' => [
                 '<?php
                     namespace bar;
             
@@ -412,21 +412,21 @@ class ReturnTypeTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'missing-return-type' => [
+            'missingReturnType' => [
                 '<?php
                     function fooFoo() {
                         return rand(0, 5) ? "hello" : null;
                     }',
                 'error_message' => 'MissingReturnType'
             ],
-            'mixed-inferred-return-type' => [
+            'mixedInferredReturnType' => [
                 '<?php
                     function fooFoo() : string {
                         return array_pop([]);
                     }',
                 'error_message' => 'MixedInferredReturnType'
             ],
-            'invalid-return-type-class' => [
+            'invalidReturnTypeClass' => [
                 '<?php
                     function fooFoo() : A {
                         return array_pop([]);
@@ -434,7 +434,7 @@ class ReturnTypeTest extends TestCase
                 'error_message' => 'UndefinedClass',
                 'error_levels' => ['MixedInferredReturnType']
             ],
-            'invalid-class-on-call' => [
+            'invalidClassOnCall' => [
                 '<?php
                     /**
                      * @psalm-suppress UndefinedClass

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1,741 +1,452 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ReturnTypeTest extends PHPUnit_Framework_TestCase
+class ReturnTypeTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnTypeAfterUselessNullcheck()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {}
-
-        class B {
-            /**
-             * @return One|null
-             */
-            public function barBar() {
-                $baz = rand(0,100) > 50 ? new One() : null;
-
-                // should have no effect
-                if ($baz === null) {
-                    $baz = null;
-                }
-
-                return $baz;
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnTypeNotEmptyCheck()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B {
-            /**
-             * @param string|null $str
-             * @return string
-             */
-            public function barBar($str) {
-                if (empty($str)) {
-                    $str = "";
-                }
-                return $str;
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnTypeNotEmptyCheckInElseIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B {
-            /**
-             * @param string|null $str
-             * @return string
-             */
-            public function barBar($str) {
-                if ($str === "badger") {
-                    // do nothing
-                }
-                elseif (empty($str)) {
-                    $str = "";
-                }
-                return $str;
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnTypeNotEmptyCheckInElse()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B {
-            /**
-             * @param string|null $str
-             * @return string
-             */
-            public function barBar($str) {
-                if (!empty($str)) {
-                    // do nothing
-                }
-                else {
-                    $str = "";
-                }
-                return $str;
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnTypeAfterIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B {
-            /**
-             * @return string|null
-             */
-            public function barBar() {
-                $str = null;
-                $bar1 = rand(0, 100) > 40;
-                if ($bar1) {
-                    $str = "";
-                }
-                return $str;
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnTypeAfterTwoIfsWithThrow()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A1 {
-        }
-        class A2 {
-        }
-        class B {
-            /**
-             * @return A1
-             */
-            public function barBar(A1 $a1 = null, A2 $a2 = null) {
-                if (!$a1) {
-                    throw new \Exception();
-                }
-                if (!$a2) {
-                    throw new \Exception();
-                }
-                return $a1;
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testReturnTypeAfterIfElseIfWithThrow()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A1 {
-        }
-        class A2 {
-        }
-        class B {
-            /**
-             * @return A1
-             */
-            public function barBar(A1 $a1 = null, A2 $a2 = null) {
-                if (!$a1) {
-                    throw new \Exception();
-                }
-                elseif (!$a2) {
-                    throw new \Exception();
-                }
-                return $a1;
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testTryCatchReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return bool */
-            public function fooFoo() {
-                try {
-                    // do a thing
-                    return true;
-                }
-                catch (\Exception $e) {
-                    throw $e;
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSwitchReturnTypeWithFallthrough()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return bool */
-            public function fooFoo() {
-                switch (rand(0,10)) {
-                    case 1:
-                    default:
-                        return true;
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSwitchReturnTypeWithFallthroughAndStatement()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return bool */
-            public function fooFoo() {
-                switch (rand(0,10)) {
-                    case 1:
-                        $a = 5;
-                    default:
-                        return true;
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException \Psalm\Exception\CodeException
-     * @return            void
-     */
-    public function testSwitchReturnTypeWithFallthroughAndBreak()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return bool */
-            public function fooFoo() {
-                switch (rand(0,10)) {
-                    case 1:
-                        break;
-                    default:
-                        return true;
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException \Psalm\Exception\CodeException
-     * @return            void
-     */
-    public function testSwitchReturnTypeWithFallthroughAndConditionalBreak()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return bool */
-            public function fooFoo() {
-                switch (rand(0,10)) {
-                    case 1:
-                        if (rand(0,10) === 5) {
-                            break;
+        return [
+            'return-type-after-useless-null-check' => [
+                '<?php
+                    class One {}
+            
+                    class B {
+                        /**
+                         * @return One|null
+                         */
+                        public function barBar() {
+                            $baz = rand(0,100) > 50 ? new One() : null;
+            
+                            // should have no effect
+                            if ($baz === null) {
+                                $baz = null;
+                            }
+            
+                            return $baz;
                         }
-                    default:
-                        return true;
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
+                    }'
+            ],
+            'return-type-not-empty-check' => [
+                '<?php
+                    class B {
+                        /**
+                         * @param string|null $str
+                         * @return string
+                         */
+                        public function barBar($str) {
+                            if (empty($str)) {
+                                $str = "";
+                            }
+                            return $str;
+                        }
+                    }'
+            ],
+            'return-type-not-empty-check-in-else-if' => [
+                '<?php
+                    class B {
+                        /**
+                         * @param string|null $str
+                         * @return string
+                         */
+                        public function barBar($str) {
+                            if ($str === "badger") {
+                                // do nothing
+                            }
+                            elseif (empty($str)) {
+                                $str = "";
+                            }
+                            return $str;
+                        }
+                    }'
+            ],
+            'return-type-not-empty-check-in-else' => [
+                '<?php
+                    class B {
+                        /**
+                         * @param string|null $str
+                         * @return string
+                         */
+                        public function barBar($str) {
+                            if (!empty($str)) {
+                                // do nothing
+                            }
+                            else {
+                                $str = "";
+                            }
+                            return $str;
+                        }
+                    }'
+            ],
+            'return-type-after-if' => [
+                '<?php
+                    class B {
+                        /**
+                         * @return string|null
+                         */
+                        public function barBar() {
+                            $str = null;
+                            $bar1 = rand(0, 100) > 40;
+                            if ($bar1) {
+                                $str = "";
+                            }
+                            return $str;
+                        }
+                    }'
+            ],
+            'return-type-after-two-ifs-with-throw' => [
+                '<?php
+                    class A1 {
+                    }
+                    class A2 {
+                    }
+                    class B {
+                        /**
+                         * @return A1
+                         */
+                        public function barBar(A1 $a1 = null, A2 $a2 = null) {
+                            if (!$a1) {
+                                throw new \Exception();
+                            }
+                            if (!$a2) {
+                                throw new \Exception();
+                            }
+                            return $a1;
+                        }
+                    }'
+            ],
+            'return-type-after-if-else-if-with-throw' => [
+                '<?php
+                    class A1 {
+                    }
+                    class A2 {
+                    }
+                    class B {
+                        /**
+                         * @return A1
+                         */
+                        public function barBar(A1 $a1 = null, A2 $a2 = null) {
+                            if (!$a1) {
+                                throw new \Exception();
+                            }
+                            elseif (!$a2) {
+                                throw new \Exception();
+                            }
+                            return $a1;
+                        }
+                    }'
+            ],
+            'try-catch-return-type' => [
+                '<?php
+                    class A {
+                        /** @return bool */
+                        public function fooFoo() {
+                            try {
+                                // do a thing
+                                return true;
+                            }
+                            catch (\Exception $e) {
+                                throw $e;
+                            }
+                        }
+                    }'
+            ],
+            'switch-return-type-with-fallthrough' => [
+                '<?php
+                    class A {
+                        /** @return bool */
+                        public function fooFoo() {
+                            switch (rand(0,10)) {
+                                case 1:
+                                default:
+                                    return true;
+                            }
+                        }
+                    }'
+            ],
+            'switch-return-type-with-fallthrough-and-statement' => [
+                '<?php
+                    class A {
+                        /** @return bool */
+                        public function fooFoo() {
+                            switch (rand(0,10)) {
+                                case 1:
+                                    $a = 5;
+                                default:
+                                    return true;
+                            }
+                        }
+                    }'
+            ],
+            'switch-return-type-with-default-exception' => [
+                '<?php
+                    class A {
+                        /**
+                         * @psalm-suppress TooManyArguments
+                         * @return bool
+                         */
+                        public function fooFoo() {
+                            switch (rand(0,10)) {
+                                case 1:
+                                case 2:
+                                    return true;
+            
+                                default:
+                                    throw new \Exception("badness");
+                            }
+                        }
+                    }'
+            ],
+            'extends-static-call-return-type' => [
+                '<?php
+                    abstract class A {
+                        /** @return static */
+                        public static function load() {
+                            return new static();
+                        }
+                    }
+            
+                    class B extends A {
+                    }
+            
+                    $b = B::load();',
+                'assertions' => [
+                    ['B' => '$b']
+                ]
+            ],
+            'extends-static-call-array-return-type' => [
+                '<?php
+                    abstract class A {
+                        /** @return array<int,static> */
+                        public static function loadMultiple() {
+                            return [new static()];
+                        }
+                    }
+            
+                    class B extends A {
+                    }
+            
+                    $bees = B::loadMultiple();',
+                'assertions' => [
+                    ['array<int, B>' => '$bees']
+                ]
+            ],
+            'isset-return-type' => [
+                '<?php
+                    /**
+                     * @param  mixed $foo
+                     * @return bool
+                     */
+                    function a($foo = null) {
+                        return isset($foo);
+                    }'
+            ],
+            'this-return-type' => [
+                '<?php
+                    class A {
+                        /** @return $this */
+                        public function getThis() {
+                            return $this;
+                        }
+                    }'
+            ],
+            'override-return-type' => [
+                '<?php
+                    class A {
+                        /** @return string|null */
+                        public function blah() {
+                            return rand(0, 10) === 4 ? "blah" : null;
+                        }
+                    }
+            
+                    class B extends A {
+                        /** @return string */
+                        public function blah() {
+                            return "blah";
+                        }
+                    }
+            
+                    $blah = (new B())->blah();',
+                'assertions' => [
+                    ['string' => '$blah']
+                ]
+            ],
+            'interface-return-type' => [
+                '<?php
+                    interface A {
+                        /** @return string|null */
+                        public function blah();
+                    }
+            
+                    class B implements A {
+                        public function blah() {
+                            return rand(0, 10) === 4 ? "blah" : null;
+                        }
+                    }
+            
+                    $blah = (new B())->blah();',
+                'assertions' => [
+                    ['string|null' => '$blah']
+                ]
+            ],
+            'override-return-type-in-grandparent' => [
+                '<?php
+                    abstract class A {
+                        /** @return string|null */
+                        abstract public function blah();
+                    }
+            
+                    class B extends A {
+                    }
+            
+                    class C extends B {
+                        public function blah() {
+                            return rand(0, 10) === 4 ? "blahblah" : null;
+                        }
+                    }
+            
+                    $blah = (new C())->blah();',
+                'assertions' => [
+                    ['string|null' => '$blah']
+                ]
+            ],
+            'backwards-return-type' => [
+                '<?php
+                    class A {}
+                    class B extends A {}
+            
+                    /** @return B|A */
+                    function foo() {
+                      return rand(0, 1) ? new A : new B;
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @expectedException \Psalm\Exception\CodeException
-     * @return            void
+     * @return array
      */
-    public function testSwitchReturnTypeWithNoDefault()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return bool */
-            public function fooFoo() {
-                switch (rand(0,10)) {
-                    case 1:
-                    case 2:
-                        return true;
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testSwitchReturnTypeWitDefaultException()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /**
-             * @psalm-suppress TooManyArguments
-             * @return bool
-             */
-            public function fooFoo() {
-                switch (rand(0,10)) {
-                    case 1:
-                    case 2:
-                        return true;
-
-                    default:
-                        throw new \Exception("badness");
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testExtendsStaticCallReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        abstract class A {
-            /** @return static */
-            public static function load() {
-                return new static();
-            }
-        }
-
-        class B extends A {
-        }
-
-        $b = B::load();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-
-        $this->assertEquals('B', (string) $context->vars_in_scope['$b']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testExtendsStaticCallArrayReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        abstract class A {
-            /** @return array<int,static> */
-            public static function loadMultiple() {
-                return [new static()];
-            }
-        }
-
-        class B extends A {
-        }
-
-        $bees = B::loadMultiple();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-
-        $this->assertEquals('array<int, B>', (string) $context->vars_in_scope['$bees']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIssetReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param  mixed $foo
-         * @return bool
-         */
-        function a($foo = null) {
-            return isset($foo);
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testThisReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return $this */
-            public function getThis() {
-                return $this;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testOverrideReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return string|null */
-            public function blah() {
-                return rand(0, 10) === 4 ? "blah" : null;
-            }
-        }
-
-        class B extends A {
-            /** @return string */
-            public function blah() {
-                return "blah";
-            }
-        }
-
-        $blah = (new B())->blah();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string', (string) $context->vars_in_scope['$blah']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testInterfaceReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        interface A {
-            /** @return string|null */
-            public function blah();
-        }
-
-        class B implements A {
-            public function blah() {
-                return rand(0, 10) === 4 ? "blah" : null;
-            }
-        }
-
-        $blah = (new B())->blah();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string|null', (string) $context->vars_in_scope['$blah']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testOverrideReturnTypeInGrandparent()
-    {
-        $stmts = self::$parser->parse('<?php
-        abstract class A {
-            /** @return string|null */
-            abstract public function blah();
-        }
-
-        class B extends A {
-        }
-
-        class C extends B {
-            public function blah() {
-                return rand(0, 10) === 4 ? "blahblah" : null;
-            }
-        }
-
-        $blah = (new C())->blah();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string|null', (string) $context->vars_in_scope['$blah']);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testWrongReturnType1()
-    {
-        $stmts = self::$parser->parse('<?php
-        function fooFoo() : string {
-            return 5;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testWrongReturnType2()
-    {
-        $stmts = self::$parser->parse('<?php
-        function fooFoo() : string {
-            return rand(0, 5) ? "hello" : null;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testWrongReturnTypeInNamespace1()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace bar;
-
-        function fooFoo() : string {
-            return 5;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testWrongReturnTypeInNamespace2()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace bar;
-
-        function fooFoo() : string {
-            return rand(0, 5) ? "hello" : null;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingReturnType
-     * @return                   void
-     */
-    public function testMissingReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        function fooFoo() {
-            return rand(0, 5) ? "hello" : null;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MixedInferredReturnType
-     * @return                   void
-     */
-    public function testMixedInferredReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        function fooFoo() : string {
-            return array_pop([]);
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testBackwardsReturnType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A {}
-
-        /** @return B|A */
-        function foo() {
-          return rand(0, 1) ? new A : new B;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedClass
-     * @return                   void
-     */
-    public function testInvalidReturnTypeClass()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedInferredReturnType', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        function fooFoo() : A {
-            return array_pop([]);
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedClass
-     * @return                   void
-     */
-    public function testInvalidClassOnCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @psalm-suppress UndefinedClass
-         * @psalm-suppress MixedInferredReturnType
-         */
-        function fooFoo() : A {
-            return array_pop([]);
-        }
-
-        fooFoo()->bar();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'switch-return-type-with-fallthrough-and-break' => [
+                '<?php
+                    class A {
+                        /** @return bool */
+                        public function fooFoo() {
+                            switch (rand(0,10)) {
+                                case 1:
+                                    break;
+                                default:
+                                    return true;
+                            }
+                        }
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'switch-return-type-with-fallthrough-and-conditional-break' => [
+                '<?php
+                    class A {
+                        /** @return bool */
+                        public function fooFoo() {
+                            switch (rand(0,10)) {
+                                case 1:
+                                    if (rand(0,10) === 5) {
+                                        break;
+                                    }
+                                default:
+                                    return true;
+                            }
+                        }
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'switch-return-type-with-no-default' => [
+                '<?php
+                    class A {
+                        /** @return bool */
+                        public function fooFoo() {
+                            switch (rand(0,10)) {
+                                case 1:
+                                case 2:
+                                    return true;
+                            }
+                        }
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'wrong-return-type-1' => [
+                '<?php
+                    function fooFoo() : string {
+                        return 5;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'wrong-return-type-2' => [
+                '<?php
+                    function fooFoo() : string {
+                        return rand(0, 5) ? "hello" : null;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'wrong-return-type-in-namespace-1' => [
+                '<?php
+                    namespace bar;
+            
+                    function fooFoo() : string {
+                        return 5;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'wrong-return-type-in-namespace-2' => [
+                '<?php
+                    namespace bar;
+            
+                    function fooFoo() : string {
+                        return rand(0, 5) ? "hello" : null;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'missing-return-type' => [
+                '<?php
+                    function fooFoo() {
+                        return rand(0, 5) ? "hello" : null;
+                    }',
+                'error_message' => 'MissingReturnType'
+            ],
+            'mixed-inferred-return-type' => [
+                '<?php
+                    function fooFoo() : string {
+                        return array_pop([]);
+                    }',
+                'error_message' => 'MixedInferredReturnType'
+            ],
+            'invalid-return-type-class' => [
+                '<?php
+                    function fooFoo() : A {
+                        return array_pop([]);
+                    }',
+                'error_message' => 'UndefinedClass',
+                'error_levels' => ['MixedInferredReturnType']
+            ],
+            'invalid-class-on-call' => [
+                '<?php
+                    /**
+                     * @psalm-suppress UndefinedClass
+                     * @psalm-suppress MixedInferredReturnType
+                     */
+                    function fooFoo() : A {
+                        return array_pop([]);
+                    }
+            
+                    fooFoo()->bar();',
+                'error_message' => 'UndefinedClass'
+            ]
+        ];
     }
 }

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -12,7 +12,7 @@ class ScopeTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'new-var-in-if' => [
+            'newVarInIf' => [
                 '<?php
                     if (rand(0,100) === 10) {
                         $badge = "hello";
@@ -23,7 +23,7 @@ class ScopeTest extends TestCase
             
                     echo $badge;'
             ],
-            'new-var-in-if-with-else-return' => [
+            'newVarInIfWithElseReturn' => [
                 '<?php
                     if (rand(0,100) === 10) {
                         $badge = "hello";
@@ -34,7 +34,7 @@ class ScopeTest extends TestCase
             
                     echo $badge;'
             ],
-            'try-catch-var' => [
+            'tryCatchVar' => [
                 '<?php
                     try {
                         $worked = true;
@@ -46,13 +46,13 @@ class ScopeTest extends TestCase
                     ['bool' => '$worked']
                 ]
             ],
-            'assignment-in-if' => [
+            'assignmentInIf' => [
                 '<?php
                     if ($row = (rand(0, 10) ? [5] : null)) {
                         echo $row[0];
                     }'
             ],
-            'negated-assignment-in-if' => [
+            'negatedAssignmentInIf' => [
                 '<?php
                     if (!($row = (rand(0, 10) ? [5] : null))) {
                         // do nothing
@@ -61,7 +61,7 @@ class ScopeTest extends TestCase
                         echo $row[0];
                     }'
             ],
-            'assign-in-else-if' => [
+            'assignInElseIf' => [
                 '<?php
                     if (rand(0, 10) > 5) {
                         echo "hello";
@@ -69,25 +69,25 @@ class ScopeTest extends TestCase
                         echo $row[0];
                     }'
             ],
-            'if-not-equals-false' => [
+            'ifNotEqualsFalse' => [
                 '<?php
                     if (($row = rand(0,10) ? [1] : false) !== false) {
                        echo $row[0];
                     }'
             ],
-            'if-not-equals-null' => [
+            'ifNotEqualsNull' => [
                 '<?php
                     if (($row = rand(0,10) ? [1] : null) !== null) {
                        echo $row[0];
                     }'
             ],
-            'if-null-not-equals' => [
+            'ifNullNotEquals' => [
                 '<?php
                     if (null !== ($row = rand(0,10) ? [1] : null)) {
                        echo $row[0];
                     }'
             ],
-            'if-null-equals' => [
+            'ifNullEquals' => [
                 '<?php
                     if (null === ($row = rand(0,10) ? [1] : null)) {
             
@@ -95,40 +95,40 @@ class ScopeTest extends TestCase
                         echo $row[0];
                     }'
             ],
-            'passed-by-ref-in-if' => [
+            'passedByRefInIf' => [
                 '<?php
                     if (preg_match("/bad/", "badger", $matches)) {
                         echo (string)$matches[0];
                     }'
             ],
-            'pass-by-ref-in-if-check-after' => [
+            'passByRefInIfCheckAfter' => [
                 '<?php
                     if (!preg_match("/bad/", "badger", $matches)) {
                         exit();
                     }
                     echo (string)$matches[0];'
             ],
-            'pass-by-ref-in-if-with-boolean' => [
+            'passByRefInIfWithBoolean' => [
                 '<?php
                     $a = true;
                     if ($a && preg_match("/bad/", "badger", $matches)) {
                         echo (string)$matches[0];
                     }'
             ],
-            'pass-by-ref-in-var-with-boolean' => [
+            'passByRefInVarWithBoolean' => [
                 '<?php
                     $a = preg_match("/bad/", "badger", $matches) > 0;
                     if ($a) {
                         echo (string)$matches[1];
                     }'
             ],
-            'function-exists' => [
+            'functionExists' => [
                 '<?php
                     if (true && function_exists("flabble")) {
                         flabble();
                     }'
             ],
-            'nested-property-fetch-in-elseif' => [
+            'nestedPropertyFetchInElseif' => [
                 '<?php
                     class A {
                         /** @var A|null */
@@ -148,7 +148,7 @@ class ScopeTest extends TestCase
                         echo $a;
                     }'
             ],
-            'global-return' => [
+            'globalReturn' => [
                 '<?php
                     $foo = "foo";
             
@@ -158,7 +158,7 @@ class ScopeTest extends TestCase
                         return $foo;
                     }'
             ],
-            'negate-assertion-and-other' => [
+            'negateAssertionAndOther' => [
                 '<?php
                     $a = rand(0, 10) ? "hello" : null;
             
@@ -169,7 +169,7 @@ class ScopeTest extends TestCase
                     ['string|null' => '$a']
                 ]
             ],
-            'repeat-assertion-with-other' => [
+            'repeatAssertionWithOther' => [
                 '<?php
                     $a = rand(0, 10) ? "hello" : null;
             
@@ -182,7 +182,7 @@ class ScopeTest extends TestCase
                     ['string|null' => '$a']
                 ]
             ],
-            'refine-ored-type' => [
+            'refineOredType' => [
                 '<?php
                     class A {
                         public function doThing() : void
@@ -197,7 +197,7 @@ class ScopeTest extends TestCase
                     class B extends A {}
                     class C extends A {}'
             ],
-            'instance-of-subtraction' => [
+            'instanceOfSubtraction' => [
                 '<?php
                     class Foo {}
                     class FooBar extends Foo{}
@@ -212,7 +212,7 @@ class ScopeTest extends TestCase
             
                     }'
             ],
-            'static-null-ref' => [
+            'staticNullRef' => [
                 '<?php
                     /** @return void */
                     function foo() {
@@ -234,7 +234,7 @@ class ScopeTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'possibly-undefined-var-in-if' => [
+            'possiblyUndefinedVarInIf' => [
                 '<?php
                     if (rand(0,100) === 10) {
                         $b = "s";
@@ -244,7 +244,7 @@ class ScopeTest extends TestCase
                 'error_message' => 'PossiblyUndefinedVariable - somefile.php:6 - Possibly undefined variable $b, ' .
                     'first seen on line 3'
             ],
-            'possibly-undefined-array-in-if' => [
+            'possiblyUndefinedArrayInIf' => [
                 '<?php
                     if (rand(0,100) === 10) {
                         $array[] = "hello";
@@ -254,14 +254,14 @@ class ScopeTest extends TestCase
                 'error_message' => 'PossiblyUndefinedVariable - somefile.php:3 - Possibly undefined variable ' .
                     '$array, first seen on line 3'
             ],
-            'invalid-global' => [
+            'invalidGlobal' => [
                 '<?php
                     $a = "heli";
             
                     global $a;',
                 'error_message' => 'InvalidGlobal'
             ],
-            'this-in-static' => [
+            'thisInStatic' => [
                 '<?php
                     class A {
                         public static function fooFoo() {

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -1,545 +1,284 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class ScopeTest extends PHPUnit_Framework_TestCase
+class ScopeTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyUndefinedVariable - somefile.php:6 - Possibly undefined variable $b, first seen on line 3
-     * @return                   void
-     */
-    public function testPossiblyUndefinedVarInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (rand(0,100) === 10) {
-            $b = "s";
-        }
-
-        echo $b;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNewVarInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (rand(0,100) === 10) {
-            $badge = "hello";
-        }
-        else {
-            $badge = "goodbye";
-        }
-
-        echo $badge;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNewVarInIfWithElseReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (rand(0,100) === 10) {
-            $badge = "hello";
-        }
-        else {
-            throw new \Exception();
-        }
-
-        echo $badge;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyUndefinedVariable - somefile.php:3 - Possibly undefined variable $array, first seen on line 3
-     * @return                   void
-     */
-    public function testPossiblyUndefinedArrayInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (rand(0,100) === 10) {
-            $array[] = "hello";
-        }
-
-        echo $array;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-
-
-    /**
-     * @return void
-     */
-    public function testTryCatchVar()
-    {
-        $stmts = self::$parser->parse('<?php
-        try {
-            $worked = true;
-        }
-        catch (\Exception $e) {
-            $worked = false;
-        }
-
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('bool', (string) $context->vars_in_scope['$worked']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAssignmentInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        if ($row = (rand(0, 10) ? [5] : null)) {
-            echo $row[0];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNegatedAssignmentInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (!($row = (rand(0, 10) ? [5] : null))) {
-            // do nothing
-        }
-        else {
-            echo $row[0];
-        }
-
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAssignInElseIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (rand(0, 10) > 5) {
-            echo "hello";
-        } elseif ($row = (rand(0, 10) ? [5] : null)) {
-            echo $row[0];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testIfNotEqualsFalse()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (($row = rand(0,10) ? [1] : false) !== false) {
-           echo $row[0];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testIfNotEqualsNull()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (($row = rand(0,10) ? [1] : null) !== null) {
-           echo $row[0];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testIfNullNotEquals()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (null !== ($row = rand(0,10) ? [1] : null)) {
-           echo $row[0];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testIfNullEquals()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (null === ($row = rand(0,10) ? [1] : null)) {
-
-        } else {
-            echo $row[0];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testPassByRefInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (preg_match("/bad/", "badger", $matches)) {
-            echo (string)$matches[0];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testPassByRefInIfCheckAfter()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (!preg_match("/bad/", "badger", $matches)) {
-            exit();
-        }
-        echo (string)$matches[0];
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testPassByRefInIfWithBoolean()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = true;
-        if ($a && preg_match("/bad/", "badger", $matches)) {
-            echo (string)$matches[0];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testPassByRefInIVarWithBoolean()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = preg_match("/bad/", "badger", $matches) > 0;
-        if ($a) {
-            echo (string)$matches[1];
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testFunctionExists()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (true && function_exists("flabble")) {
-            flabble();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNestedPropertyFetchInElseif()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @var A|null */
-            public $foo;
-
-            public function __toString() : string {
-                return "boop";
-            }
-        }
-
-        $a = rand(0, 10) === 5 ? new A() : null;
-
-        if (false) {
-
-        }
-        elseif ($a && $a->foo) {
-            echo $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testGlobalReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        $foo = "foo";
-
-        function a() : string {
-            global $foo;
-
-            return $foo;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidGlobal
-     * @return                   void
-     */
-    public function testInvalidGlobal()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = "heli";
-
-        global $a;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidStaticVariable
-     * @return                   void
-     */
-    public function testThisInStatic()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public static function fooFoo() {
-                echo $this;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNegateAssertionAndOther()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = rand(0, 10) ? "hello" : null;
-
-        if (rand(0, 10) > 1 && is_string($a)) {
-            throw new \Exception("bad");
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string|null', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testRepeatAssertionWithOther()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = rand(0, 10) ? "hello" : null;
-
-        if (rand(0, 10) > 1 || is_string($a)) {
-            if (is_string($a)) {
-                echo strpos("e", $a);
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('string|null', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testRefineORedType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            public function doThing() : void
-            {
-                if ($this instanceof B || $this instanceof C) {
-                    if ($this instanceof B) {
-
+        return [
+            'new-var-in-if' => [
+                '<?php
+                    if (rand(0,100) === 10) {
+                        $badge = "hello";
                     }
-                }
-            }
-        }
-        class B extends A {}
-        class C extends A {}
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+                    else {
+                        $badge = "goodbye";
+                    }
+            
+                    echo $badge;'
+            ],
+            'new-var-in-if-with-else-return' => [
+                '<?php
+                    if (rand(0,100) === 10) {
+                        $badge = "hello";
+                    }
+                    else {
+                        throw new \Exception();
+                    }
+            
+                    echo $badge;'
+            ],
+            'try-catch-var' => [
+                '<?php
+                    try {
+                        $worked = true;
+                    }
+                    catch (\Exception $e) {
+                        $worked = false;
+                    }',
+                'assertions' => [
+                    ['bool' => '$worked']
+                ]
+            ],
+            'assignment-in-if' => [
+                '<?php
+                    if ($row = (rand(0, 10) ? [5] : null)) {
+                        echo $row[0];
+                    }'
+            ],
+            'negated-assignment-in-if' => [
+                '<?php
+                    if (!($row = (rand(0, 10) ? [5] : null))) {
+                        // do nothing
+                    }
+                    else {
+                        echo $row[0];
+                    }'
+            ],
+            'assign-in-else-if' => [
+                '<?php
+                    if (rand(0, 10) > 5) {
+                        echo "hello";
+                    } elseif ($row = (rand(0, 10) ? [5] : null)) {
+                        echo $row[0];
+                    }'
+            ],
+            'if-not-equals-false' => [
+                '<?php
+                    if (($row = rand(0,10) ? [1] : false) !== false) {
+                       echo $row[0];
+                    }'
+            ],
+            'if-not-equals-null' => [
+                '<?php
+                    if (($row = rand(0,10) ? [1] : null) !== null) {
+                       echo $row[0];
+                    }'
+            ],
+            'if-null-not-equals' => [
+                '<?php
+                    if (null !== ($row = rand(0,10) ? [1] : null)) {
+                       echo $row[0];
+                    }'
+            ],
+            'if-null-equals' => [
+                '<?php
+                    if (null === ($row = rand(0,10) ? [1] : null)) {
+            
+                    } else {
+                        echo $row[0];
+                    }'
+            ],
+            'passed-by-ref-in-if' => [
+                '<?php
+                    if (preg_match("/bad/", "badger", $matches)) {
+                        echo (string)$matches[0];
+                    }'
+            ],
+            'pass-by-ref-in-if-check-after' => [
+                '<?php
+                    if (!preg_match("/bad/", "badger", $matches)) {
+                        exit();
+                    }
+                    echo (string)$matches[0];'
+            ],
+            'pass-by-ref-in-if-with-boolean' => [
+                '<?php
+                    $a = true;
+                    if ($a && preg_match("/bad/", "badger", $matches)) {
+                        echo (string)$matches[0];
+                    }'
+            ],
+            'pass-by-ref-in-var-with-boolean' => [
+                '<?php
+                    $a = preg_match("/bad/", "badger", $matches) > 0;
+                    if ($a) {
+                        echo (string)$matches[1];
+                    }'
+            ],
+            'function-exists' => [
+                '<?php
+                    if (true && function_exists("flabble")) {
+                        flabble();
+                    }'
+            ],
+            'nested-property-fetch-in-elseif' => [
+                '<?php
+                    class A {
+                        /** @var A|null */
+                        public $foo;
+            
+                        public function __toString() : string {
+                            return "boop";
+                        }
+                    }
+            
+                    $a = rand(0, 10) === 5 ? new A() : null;
+            
+                    if (false) {
+            
+                    }
+                    elseif ($a && $a->foo) {
+                        echo $a;
+                    }'
+            ],
+            'global-return' => [
+                '<?php
+                    $foo = "foo";
+            
+                    function a() : string {
+                        global $foo;
+            
+                        return $foo;
+                    }'
+            ],
+            'negate-assertion-and-other' => [
+                '<?php
+                    $a = rand(0, 10) ? "hello" : null;
+            
+                    if (rand(0, 10) > 1 && is_string($a)) {
+                        throw new \Exception("bad");
+                    }',
+                'assertions' => [
+                    ['string|null' => '$a']
+                ]
+            ],
+            'repeat-assertion-with-other' => [
+                '<?php
+                    $a = rand(0, 10) ? "hello" : null;
+            
+                    if (rand(0, 10) > 1 || is_string($a)) {
+                        if (is_string($a)) {
+                            echo strpos("e", $a);
+                        }
+                    }',
+                'assertions' => [
+                    ['string|null' => '$a']
+                ]
+            ],
+            'refine-ored-type' => [
+                '<?php
+                    class A {
+                        public function doThing() : void
+                        {
+                            if ($this instanceof B || $this instanceof C) {
+                                if ($this instanceof B) {
+            
+                                }
+                            }
+                        }
+                    }
+                    class B extends A {}
+                    class C extends A {}'
+            ],
+            'instance-of-subtraction' => [
+                '<?php
+                    class Foo {}
+                    class FooBar extends Foo{}
+                    class FooBarBat extends FooBar{}
+                    class FooMoo extends Foo{}
+            
+                    $a = new Foo();
+            
+                    if ($a instanceof FooBar && !$a instanceof FooBarBat) {
+            
+                    } elseif ($a instanceof FooMoo) {
+            
+                    }'
+            ],
+            'static-null-ref' => [
+                '<?php
+                    /** @return void */
+                    function foo() {
+                        static $bar = null;
+            
+                        if ($bar !== null) {
+                            // do something
+                        }
+            
+                        $bar = 5;
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testIntstanceOfSubtraction()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        class Foo {}
-        class FooBar extends Foo{}
-        class FooBarBat extends FooBar{}
-        class FooMoo extends Foo{}
-
-        $a = new Foo();
-
-        if ($a instanceof FooBar && !$a instanceof FooBarBat) {
-
-        } elseif ($a instanceof FooMoo) {
-
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MixedInferredReturnType
-     * @return                   void
-     */
-    public function testStatic()
-    {
-        $stmts = self::$parser->parse('<?php
-        function a() : string {
-            static $foo = "foo";
-
-            return $foo;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testStaticNullRef()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return void */
-        function foo() {
-            static $bar = null;
-
-            if ($bar !== null) {
-                // do something
-            }
-
-            $bar = 5;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
+        return [
+            'possibly-undefined-var-in-if' => [
+                '<?php
+                    if (rand(0,100) === 10) {
+                        $b = "s";
+                    }
+            
+                    echo $b;',
+                'error_message' => 'PossiblyUndefinedVariable - somefile.php:6 - Possibly undefined variable $b, ' .
+                    'first seen on line 3'
+            ],
+            'possibly-undefined-array-in-if' => [
+                '<?php
+                    if (rand(0,100) === 10) {
+                        $array[] = "hello";
+                    }
+            
+                    echo $array;',
+                'error_message' => 'PossiblyUndefinedVariable - somefile.php:3 - Possibly undefined variable ' .
+                    '$array, first seen on line 3'
+            ],
+            'invalid-global' => [
+                '<?php
+                    $a = "heli";
+            
+                    global $a;',
+                'error_message' => 'InvalidGlobal'
+            ],
+            'this-in-static' => [
+                '<?php
+                    class A {
+                        public static function fooFoo() {
+                            echo $this;
+                        }
+                    }',
+                'error_message' => 'InvalidStaticVariable'
+            ],
+            'static' => [
+                '<?php
+                    function a() : string {
+                        static $foo = "foo";
+            
+                        return $foo;
+                    }',
+                'error_message' => 'MixedInferredReturnType'
+            ]
+        ];
     }
 }

--- a/tests/SwitchTypeTest.php
+++ b/tests/SwitchTypeTest.php
@@ -12,7 +12,7 @@ class SwitchTypeTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'get-class-arg' => [
+            'getClassArg' => [
                 '<?php
                     class A {
                         /**
@@ -44,7 +44,7 @@ class SwitchTypeTest extends TestCase
                             break;
                     }'
             ],
-            'get-type-arg' => [
+            'getTypeArg' => [
                 '<?php
                     function testInt(int $var) : void {
             
@@ -75,7 +75,7 @@ class SwitchTypeTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'get-class-arg-wrong-class' => [
+            'getClassArgWrongClass' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -100,7 +100,7 @@ class SwitchTypeTest extends TestCase
                     }',
                 'error_message' => 'UndefinedMethod'
             ],
-            'get-type-arg-wrong-args' => [
+            'getTypeArgWrongArgs' => [
                 '<?php
                     function testInt(int $var) : void {
             

--- a/tests/SwitchTypeTest.php
+++ b/tests/SwitchTypeTest.php
@@ -1,183 +1,126 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Checker\TypeChecker;
-use Psalm\Config;
-use Psalm\Context;
-use Psalm\Type;
-
-class SwitchTypeTest extends PHPUnit_Framework_TestCase
+class SwitchTypeTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
+        return [
+            'get-class-arg' => [
+                '<?php
+                    class A {
+                        /**
+                         * @return void
+                         */
+                        public function fooFoo() {
+            
+                        }
+                    }
+            
+                    class B {
+                        /**
+                         * @return void
+                         */
+                        public function barBar() {
+            
+                        }
+                    }
+            
+                    $a = rand(0, 10) ? new A() : new B();
+            
+                    switch (get_class($a)) {
+                        case "A":
+                            $a->fooFoo();
+                            break;
+            
+                        case "B":
+                            $a->barBar();
+                            break;
+                    }'
+            ],
+            'get-type-arg' => [
+                '<?php
+                    function testInt(int $var) : void {
+            
+                    }
+            
+                    function testString(string $var) : void {
+            
+                    }
+            
+                    $a = rand(0, 10) ? 1 : "two";
+            
+                    switch (gettype($a)) {
+                        case "string":
+                            testString($a);
+                            break;
+            
+                        case "int":
+                            testInt($a);
+                            break;
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGetClassArg()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /**
-             * @return void
-             */
-            public function fooFoo() {
-
-            }
-        }
-
-        class B {
-            /**
-             * @return void
-             */
-            public function barBar() {
-
-            }
-        }
-
-        $a = rand(0, 10) ? new A() : new B();
-
-        switch (get_class($a)) {
-            case "A":
-                $a->fooFoo();
-                break;
-
-            case "B":
-                $a->barBar();
-                break;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedMethod
-     * @return                   void
-     */
-    public function testGetClassArgWrongClass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {
-
-            }
-        }
-
-        class B {
-            /** @return void */
-            public function barBar() {
-
-            }
-        }
-
-        $a = rand(0, 10) ? new A() : new B();
-
-        switch (get_class($a)) {
-            case "A":
-                $a->barBar();
-                break;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGetTypeArg()
-    {
-        $stmts = self::$parser->parse('<?php
-        function testInt(int $var) : void {
-
-        }
-
-        function testString(string $var) : void {
-
-        }
-
-        $a = rand(0, 10) ? 1 : "two";
-
-        switch (gettype($a)) {
-            case "string":
-                testString($a);
-                break;
-
-            case "int":
-                testInt($a);
-                break;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScalarArgument
-     * @return                   void
-     */
-    public function testGetTypeArgWrongArgs()
-    {
-        $stmts = self::$parser->parse('<?php
-        function testInt(int $var) : void {
-
-        }
-
-        function testString(string $var) : void {
-
-        }
-
-        $a = rand(0, 10) ? 1 : "two";
-
-        switch (gettype($a)) {
-            case "string":
-                testInt($a);
-
-            case "int":
-                testString($a);
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'get-class-arg-wrong-class' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {
+            
+                        }
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar() {
+            
+                        }
+                    }
+            
+                    $a = rand(0, 10) ? new A() : new B();
+            
+                    switch (get_class($a)) {
+                        case "A":
+                            $a->barBar();
+                            break;
+                    }',
+                'error_message' => 'UndefinedMethod'
+            ],
+            'get-type-arg-wrong-args' => [
+                '<?php
+                    function testInt(int $var) : void {
+            
+                    }
+            
+                    function testString(string $var) : void {
+            
+                    }
+            
+                    $a = rand(0, 10) ? 1 : "two";
+            
+                    switch (gettype($a)) {
+                        case "string":
+                            testInt($a);
+            
+                        case "int":
+                            testString($a);
+                    }',
+                'error_message' => 'InvalidScalarArgument'
+            ]
+        ];
     }
 }

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -12,7 +12,7 @@ class TemplateTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'class-template' => [
+            'classTemplate' => [
                 '<?php
                     class A {}
                     class B {}
@@ -70,7 +70,7 @@ class TemplateTest extends TestCase
                     ['Foo<mixed>' => '$dfoo']
                 ]
             ],
-            'class-template-container' => [
+            'classTemplateContainer' => [
                 '<?php
                     class A {}
             
@@ -108,7 +108,7 @@ class TemplateTest extends TestCase
                 ],
                 'error_levels' => ['MixedOperand']
             ],
-            'phan-tuple' => [
+            'phanTuple' => [
                 '<?php
                     namespace Phan\Library;
             
@@ -233,7 +233,7 @@ class TemplateTest extends TestCase
                     takes_string($a->_0);
                     takes_int($a->_1);'
             ],
-            'valid-templated-type' => [
+            'validTemplatedType' => [
                 '<?php
                     /**
                      * @template T
@@ -248,7 +248,7 @@ class TemplateTest extends TestCase
             
                     bar(foo("string"));'
             ],
-            'valid-templated-static-method-type' => [
+            'validTemplatedStaticMethodType' => [
                 '<?php
                     class A {
                         /**
@@ -265,7 +265,7 @@ class TemplateTest extends TestCase
             
                     bar(A::foo("string"));'
             ],
-            'valid-templated-instance-method-type' => [
+            'validTemplatedInstanceMethodType' => [
                 '<?php
                     class A {
                         /**
@@ -282,7 +282,7 @@ class TemplateTest extends TestCase
             
                     bar((new A())->foo("string"));'
             ],
-            'generic-array-keys' => [
+            'genericArrayKeys' => [
                 '<?php
                     /**
                      * @template T
@@ -299,7 +299,7 @@ class TemplateTest extends TestCase
                     ['array<int, string>' => '$a']
                 ]
             ],
-            'generic-array-reverse' => [
+            'genericArrayReverse' => [
                 '<?php
                     /**
                      * @template TKey
@@ -326,7 +326,7 @@ class TemplateTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'invalid-templated-type' => [
+            'invalidTemplatedType' => [
                 '<?php
                     /**
                      * @template T
@@ -342,7 +342,7 @@ class TemplateTest extends TestCase
                     bar(foo(4));',
                 'error_message' => 'InvalidScalarArgument'
             ],
-            'invalid-templated-static-method-type' => [
+            'invalidTemplatedStaticMethodType' => [
                 '<?php
                     class A {
                         /**
@@ -360,7 +360,7 @@ class TemplateTest extends TestCase
                     bar(A::foo(4));',
                 'error_message' => 'InvalidScalarArgument'
             ],
-            'invalid-templated-instance-method-type' => [
+            'invalidTemplatedInstanceMethodType' => [
                 '<?php
                     class A {
                         /**

--- a/tests/TemplateTest.php
+++ b/tests/TemplateTest.php
@@ -1,498 +1,383 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class TemplateTest extends PHPUnit_Framework_TestCase
+class TemplateTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        return [
+            'class-template' => [
+                '<?php
+                    class A {}
+                    class B {}
+                    class C {}
+                    class D {}
+            
+                    /**
+                     * @template T as object
+                     */
+                    class Foo {
+                        /** @var string */
+                        public $T;
+            
+                        /**
+                         * @param string $T
+                         * @template-typeof T $T
+                         */
+                        public function __construct(string $T) {
+                            $this->T = $T;
+                        }
+            
+                        /**
+                         * @return T
+                         */
+                        public function bar() {
+                            $t = $this->T;
+                            return new $t();
+                        }
+                    }
+            
+                    $at = "A";
+            
+                    /** @var Foo<A> */
+                    $afoo = new Foo($at);
+                    $afoo_bar = $afoo->bar();
+            
+                    $bfoo = new Foo(B::class);
+                    $bfoo_bar = $bfoo->bar();
+            
+                    $cfoo = new Foo("C");
+                    $cfoo_bar = $cfoo->bar();
+            
+                    $dt = "D";
+                    $dfoo = new Foo($dt);',
+                'assertions' => [
+                    ['Foo<A>' => '$afoo'],
+                    ['A' => '$afoo_bar'],
+
+                    ['Foo<B>' =>'$bfoo'],
+                    ['B' => '$bfoo_bar'],
+
+                    ['Foo<C>' => '$cfoo'],
+                    ['C' => '$cfoo_bar'],
+
+                    ['Foo<mixed>' => '$dfoo']
+                ]
+            ],
+            'class-template-container' => [
+                '<?php
+                    class A {}
+            
+                    /**
+                     * @template T
+                     */
+                    class Foo {
+                        /** @var T */
+                        public $obj;
+            
+                        /**
+                         * @param T $obj
+                         */
+                        public function __construct($obj) {
+                            $this->obj = $obj;
+                        }
+            
+                        /**
+                         * @return T
+                         */
+                        public function bar() {
+                            return $this->obj;
+                        }
+            
+                        public function __toString() : string {
+                            return "hello " . $this->obj;
+                        }
+                    }
+            
+                    $afoo = new Foo(new A());
+                    $afoo_bar = $afoo->bar();',
+                'assertions' => [
+                    ['Foo<A>' => '$afoo'],
+                    ['A' => '$afoo_bar']
+                ],
+                'error_levels' => ['MixedOperand']
+            ],
+            'phan-tuple' => [
+                '<?php
+                    namespace Phan\Library;
+            
+                    /**
+                     * An abstract tuple.
+                     */
+                    abstract class Tuple
+                    {
+                        const ARITY = 0;
+            
+                        /**
+                         * @return int
+                         * The arity of this tuple
+                         */
+                        public function arity() : int
+                        {
+                            return (int)static::ARITY;
+                        }
+            
+                        /**
+                         * @return array
+                         * An array of all elements in this tuple.
+                         */
+                        abstract public function toArray() : array;
+                    }
+            
+                    /**
+                     * A tuple of 1 element.
+                     *
+                     * @template T0
+                     * The type of element zero
+                     */
+                    class Tuple1 extends Tuple
+                    {
+                        /** @var int */
+                        const ARITY = 1;
+            
+                        /** @var T0 */
+                        public $_0;
+            
+                        /**
+                         * @param T0 $_0
+                         * The 0th element
+                         */
+                        public function __construct($_0) {
+                            $this->_0 = $_0;
+                        }
+            
+                        /**
+                         * @return int
+                         * The arity of this tuple
+                         */
+                        public function arity() : int
+                        {
+                            return (int)static::ARITY;
+                        }
+            
+                        /**
+                         * @return array
+                         * An array of all elements in this tuple.
+                         */
+                        public function toArray() : array
+                        {
+                            return [
+                                $this->_0,
+                            ];
+                        }
+                    }
+            
+                    /**
+                     * A tuple of 2 elements.
+                     *
+                     * @template T0
+                     * The type of element zero
+                     *
+                     * @template T1
+                     * The type of element one
+                     *
+                     * @inherits Tuple1<T0>
+                     */
+                    class Tuple2 extends Tuple1
+                    {
+                        /** @var int */
+                        const ARITY = 2;
+            
+                        /** @var T1 */
+                        public $_1;
+            
+                        /**
+                         * @param T0 $_0
+                         * The 0th element
+                         *
+                         * @param T1 $_1
+                         * The 1st element
+                         */
+                        public function __construct($_0, $_1) {
+                            parent::__construct($_0);
+                            $this->_1 = $_1;
+                        }
+            
+                        /**
+                         * @return array
+                         * An array of all elements in this tuple.
+                         */
+                        public function toArray() : array
+                        {
+                            return [
+                                $this->_0,
+                                $this->_1,
+                            ];
+                        }
+                    }
+            
+                    $a = new Tuple2("cool", 5);
+            
+                    /** @return void */
+                    function takes_int(int $i) {}
+            
+                    /** @return void */
+                    function takes_string(string $s) {}
+            
+                    takes_string($a->_0);
+                    takes_int($a->_1);'
+            ],
+            'valid-templated-type' => [
+                '<?php
+                    /**
+                     * @template T
+                     * @param T $x
+                     * @return T
+                     */
+                    function foo($x) {
+                        return $x;
+                    }
+            
+                    function bar(string $a) : void { }
+            
+                    bar(foo("string"));'
+            ],
+            'valid-templated-static-method-type' => [
+                '<?php
+                    class A {
+                        /**
+                         * @template T
+                         * @param T $x
+                         * @return T
+                         */
+                        public static function foo($x) {
+                            return $x;
+                        }
+                    }
+            
+                    function bar(string $a) : void { }
+            
+                    bar(A::foo("string"));'
+            ],
+            'valid-templated-instance-method-type' => [
+                '<?php
+                    class A {
+                        /**
+                         * @template T
+                         * @param T $x
+                         * @return T
+                         */
+                        public function foo($x) {
+                            return $x;
+                        }
+                    }
+            
+                    function bar(string $a) : void { }
+            
+                    bar((new A())->foo("string"));'
+            ],
+            'generic-array-keys' => [
+                '<?php
+                    /**
+                     * @template T
+                     *
+                     * @param array<T, mixed> $arr
+                     * @return array<int, T>
+                     */
+                    function my_array_keys($arr) {
+                        return array_keys($arr);
+                    }
+            
+                    $a = my_array_keys(["hello" => 5, "goodbye" => new Exception()]);',
+                'assertions' => [
+                    ['array<int, string>' => '$a']
+                ]
+            ],
+            'generic-array-reverse' => [
+                '<?php
+                    /**
+                     * @template TKey
+                     * @template TValue
+                     *
+                     * @param array<TKey, TValue> $arr
+                     * @return array<TValue, TKey>
+                     */
+                    function my_array_reverse($arr) {
+                        return array_reverse($arr);
+                    }
+            
+                    $b = my_array_reverse(["hello" => 5, "goodbye" => 6]);',
+                'assertions' => [
+                    ['array<int, string>' => '$b']
+                ]
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testClassTemplate()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B {}
-        class C {}
-        class D {}
-
-        /**
-         * @template T as object
-         */
-        class Foo {
-            /** @var string */
-            public $T;
-
-            /**
-             * @param string $T
-             * @template-typeof T $T
-             */
-            public function __construct(string $T) {
-                $this->T = $T;
-            }
-
-            /**
-             * @return T
-             */
-            public function bar() {
-                $t = $this->T;
-                return new $t();
-            }
-        }
-
-        $at = "A";
-
-        /** @var Foo<A> */
-        $afoo = new Foo($at);
-        $afoo_bar = $afoo->bar();
-
-        $bfoo = new Foo(B::class);
-        $bfoo_bar = $bfoo->bar();
-
-        $cfoo = new Foo("C");
-        $cfoo_bar = $cfoo->bar();
-
-        $dt = "D";
-        $dfoo = new Foo($dt);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('Foo<A>', (string) $context->vars_in_scope['$afoo']);
-        $this->assertEquals('A', (string) $context->vars_in_scope['$afoo_bar']);
-
-        $this->assertEquals('Foo<B>', (string) $context->vars_in_scope['$bfoo']);
-        $this->assertEquals('B', (string) $context->vars_in_scope['$bfoo_bar']);
-
-        $this->assertEquals('Foo<C>', (string) $context->vars_in_scope['$cfoo']);
-        $this->assertEquals('C', (string) $context->vars_in_scope['$cfoo_bar']);
-
-        $this->assertEquals('Foo<mixed>', (string) $context->vars_in_scope['$dfoo']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testClassTemplateContainer()
-    {
-        Config::getInstance()->setCustomErrorLevel('MixedOperand', Config::REPORT_SUPPRESS);
-
-        $stmts = self::$parser->parse('<?php
-        class A {}
-
-        /**
-         * @template T
-         */
-        class Foo {
-            /** @var T */
-            public $obj;
-
-            /**
-             * @param T $obj
-             */
-            public function __construct($obj) {
-                $this->obj = $obj;
-            }
-
-            /**
-             * @return T
-             */
-            public function bar() {
-                return $this->obj;
-            }
-
-            public function __toString() : string {
-                return "hello " . $this->obj;
-            }
-        }
-
-        $afoo = new Foo(new A());
-        $afoo_bar = $afoo->bar();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('Foo<A>', (string) $context->vars_in_scope['$afoo']);
-        $this->assertEquals('A', (string) $context->vars_in_scope['$afoo_bar']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testPhanTuple()
-    {
-        $stmts = self::$parser->parse('<?php
-        namespace Phan\Library;
-
-        /**
-         * An abstract tuple.
-         */
-        abstract class Tuple
-        {
-            const ARITY = 0;
-
-            /**
-             * @return int
-             * The arity of this tuple
-             */
-            public function arity() : int
-            {
-                return (int)static::ARITY;
-            }
-
-            /**
-             * @return array
-             * An array of all elements in this tuple.
-             */
-            abstract public function toArray() : array;
-        }
-
-        /**
-         * A tuple of 1 element.
-         *
-         * @template T0
-         * The type of element zero
-         */
-        class Tuple1 extends Tuple
-        {
-            /** @var int */
-            const ARITY = 1;
-
-            /** @var T0 */
-            public $_0;
-
-            /**
-             * @param T0 $_0
-             * The 0th element
-             */
-            public function __construct($_0) {
-                $this->_0 = $_0;
-            }
-
-            /**
-             * @return int
-             * The arity of this tuple
-             */
-            public function arity() : int
-            {
-                return (int)static::ARITY;
-            }
-
-            /**
-             * @return array
-             * An array of all elements in this tuple.
-             */
-            public function toArray() : array
-            {
-                return [
-                    $this->_0,
-                ];
-            }
-        }
-
-        /**
-         * A tuple of 2 elements.
-         *
-         * @template T0
-         * The type of element zero
-         *
-         * @template T1
-         * The type of element one
-         *
-         * @inherits Tuple1<T0>
-         */
-        class Tuple2 extends Tuple1
-        {
-            /** @var int */
-            const ARITY = 2;
-
-            /** @var T1 */
-            public $_1;
-
-            /**
-             * @param T0 $_0
-             * The 0th element
-             *
-             * @param T1 $_1
-             * The 1st element
-             */
-            public function __construct($_0, $_1) {
-                parent::__construct($_0);
-                $this->_1 = $_1;
-            }
-
-            /**
-             * @return array
-             * An array of all elements in this tuple.
-             */
-            public function toArray() : array
-            {
-                return [
-                    $this->_0,
-                    $this->_1,
-                ];
-            }
-        }
-
-        $a = new Tuple2("cool", 5);
-
-        /** @return void */
-        function takes_int(int $i) {}
-
-        /** @return void */
-        function takes_string(string $s) {}
-
-        takes_string($a->_0);
-        takes_int($a->_1);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testValidTemplatedType()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @template T
-         * @param T $x
-         * @return T
-         */
-        function foo($x) {
-            return $x;
-        }
-
-        function bar(string $a) : void { }
-
-        bar(foo("string"));
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScalarArgument
-     * @return                   void
-     */
-    public function testInvalidTemplatedType()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @template T
-         * @param T $x
-         * @return T
-         */
-        function foo($x) {
-            return $x;
-        }
-
-        function bar(string $a) : void { }
-
-        bar(foo(4));
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testValidTemplatedStaticMethodType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /**
-             * @template T
-             * @param T $x
-             * @return T
-             */
-            public static function foo($x) {
-                return $x;
-            }
-        }
-
-        function bar(string $a) : void { }
-
-        bar(A::foo("string"));
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScalarArgument
-     * @return                   void
-     */
-    public function testInvalidTemplatedStaticMethodType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /**
-             * @template T
-             * @param T $x
-             * @return T
-             */
-            public static function foo($x) {
-                return $x;
-            }
-        }
-
-        function bar(string $a) : void { }
-
-        bar(A::foo(4));
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testValidTemplatedInstanceMethodType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /**
-             * @template T
-             * @param T $x
-             * @return T
-             */
-            public function foo($x) {
-                return $x;
-            }
-        }
-
-        function bar(string $a) : void { }
-
-        bar((new A())->foo("string"));
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidScalarArgument
-     * @return                   void
-     */
-    public function testInvalidTemplatedInstanceMethodType()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /**
-             * @template T
-             * @param T $x
-             * @return T
-             */
-            public function foo($x) {
-                return $x;
-            }
-        }
-
-        function bar(string $a) : void { }
-
-        bar((new A())->foo(4));
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGenericArrayKeys()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @template T
-         *
-         * @param array<T, mixed> $arr
-         * @return array<int, T>
-         */
-        function my_array_keys($arr) {
-            return array_keys($arr);
-        }
-
-        $a = my_array_keys(["hello" => 5, "goodbye" => new Exception()]);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testGenericArrayReverse()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @template TKey
-         * @template TValue
-         *
-         * @param array<TKey, TValue> $arr
-         * @return array<TValue, TKey>
-         */
-        function my_array_reverse($arr) {
-            return array_reverse($arr);
-        }
-
-        $b = my_array_reverse(["hello" => 5, "goodbye" => 6]);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<int, string>', (string) $context->vars_in_scope['$b']);
+        return [
+            'invalid-templated-type' => [
+                '<?php
+                    /**
+                     * @template T
+                     * @param T $x
+                     * @return T
+                     */
+                    function foo($x) {
+                        return $x;
+                    }
+            
+                    function bar(string $a) : void { }
+            
+                    bar(foo(4));',
+                'error_message' => 'InvalidScalarArgument'
+            ],
+            'invalid-templated-static-method-type' => [
+                '<?php
+                    class A {
+                        /**
+                         * @template T
+                         * @param T $x
+                         * @return T
+                         */
+                        public static function foo($x) {
+                            return $x;
+                        }
+                    }
+            
+                    function bar(string $a) : void { }
+            
+                    bar(A::foo(4));',
+                'error_message' => 'InvalidScalarArgument'
+            ],
+            'invalid-templated-instance-method-type' => [
+                '<?php
+                    class A {
+                        /**
+                         * @template T
+                         * @param T $x
+                         * @return T
+                         */
+                        public function foo($x) {
+                            return $x;
+                        }
+                    }
+            
+                    function bar(string $a) : void { }
+            
+                    bar((new A())->foo(4));',
+                'error_message' => 'InvalidScalarArgument'
+            ]
+        ];
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,39 @@
+<?php
+namespace Psalm\Tests;
+
+use PhpParser\ParserFactory;
+use PHPUnit_Framework_TestCase;
+use Psalm\Checker\FileChecker;
+
+class TestCase extends PHPUnit_Framework_TestCase
+{
+    /** @var \PhpParser\Parser */
+    protected static $parser;
+
+    /** @var TestConfig */
+    protected static $config;
+
+    /** @var \Psalm\Checker\ProjectChecker */
+    protected $project_checker;
+
+    /**
+     * @return void
+     */
+    public static function setUpBeforeClass()
+    {
+        parent::setUpBeforeClass();
+        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+    }
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        parent::setUp();
+
+        FileChecker::clearCache();
+        $this->project_checker = new \Psalm\Checker\ProjectChecker();
+        $this->project_checker->setConfig(new TestConfig());
+    }
+}

--- a/tests/ToStringTest.php
+++ b/tests/ToStringTest.php
@@ -1,12 +1,6 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
 class ToStringTest extends TestCase
 {
     use Traits\FileCheckerInvalidCodeParseTestTrait;
@@ -18,7 +12,7 @@ class ToStringTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'valid-to-string' => [
+            'validToString' => [
                 '<?php
                     class A {
                         function __toString() : string {
@@ -27,7 +21,7 @@ class ToStringTest extends TestCase
                     }
                     echo (new A);'
             ],
-            'valid-inferred-to-string-type' => [
+            'validInferredToStringType' => [
                 '<?php
                     class A {
                         /**
@@ -39,7 +33,7 @@ class ToStringTest extends TestCase
                     }
                     echo (new A);'
             ],
-            'good-cast' => [
+            'goodCast' => [
                 '<?php
                     class A {
                         public function __toString() : string
@@ -66,20 +60,20 @@ class ToStringTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'echo-class' => [
+            'echoClass' => [
                 '<?php
                     class A {}
                     echo (new A);',
                 'error_message' => 'InvalidArgument'
             ],
-            'invalid-to-string-return-type' => [
+            'invalidToStringReturnType' => [
                 '<?php
                     class A {
                         function __toString() : void { }
                     }',
                 'error_message' => 'InvalidToString'
             ],
-            'invalid-inferred-to-string-return-type' => [
+            'invalidInferredToStringReturnType' => [
                 '<?php
                     class A {
                         /**
@@ -89,7 +83,7 @@ class ToStringTest extends TestCase
                     }',
                 'error_message' => 'InvalidToString'
             ],
-            'implicit-cost' => [
+            'implicitCost' => [
                 '<?php
                     class A {
                         public function __toString() : string

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -12,7 +12,7 @@ class TraitTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'accessible-private-method-from-trait' => [
+            'accessiblePrivateMethodFromTrait' => [
                 '<?php
                     trait T {
                         private function fooFoo() : void {
@@ -27,7 +27,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'accessible-protected-method-from-trait' => [
+            'accessibleProtectedMethodFromTrait' => [
                 '<?php
                     trait T {
                         protected function fooFoo() : void {
@@ -42,7 +42,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'accessible-public-method-from-trait' => [
+            'accessiblePublicMethodFromTrait' => [
                 '<?php
                     trait T {
                         public function fooFoo() : void {
@@ -57,7 +57,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'accessible-private-property-from-trait' => [
+            'accessiblePrivatePropertyFromTrait' => [
                 '<?php
                     trait T {
                         /** @var string */
@@ -72,7 +72,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'accessible-protected-property-from-trait' => [
+            'accessibleProtectedPropertyFromTrait' => [
                 '<?php
                     trait T {
                         /** @var string */
@@ -87,7 +87,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'accessible-public-property-from-trait' => [
+            'accessiblePublicPropertyFromTrait' => [
                 '<?php
                     trait T {
                         /** @var string */
@@ -102,7 +102,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'accessible-protected-method-from-inherited-trait' => [
+            'accessibleProtectedMethodFromInheritedTrait' => [
                 '<?php
                     trait T {
                         protected function fooFoo() : void {
@@ -119,7 +119,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'accessible-public-method-from-inherited-trait' => [
+            'accessiblePublicMethodFromInheritedTrait' => [
                 '<?php
                     trait T {
                         public function fooFoo() : void {
@@ -136,7 +136,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'static-class-method-from-within-trait' => [
+            'staticClassMethodFromWithinTrait' => [
                 '<?php
                     trait T {
                         public function fooFoo() : void {
@@ -152,7 +152,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'redefined-trait-method-without-alias' => [
+            'redefinedTraitMethodWithoutAlias' => [
                 '<?php
                     trait T {
                         public function fooFoo() : void {
@@ -168,7 +168,7 @@ class TraitTest extends TestCase
             
                     (new B)->fooFoo("hello");'
             ],
-            'redefined-trait-method-with-alias' => [
+            'redefinedTraitMethodWithAlias' => [
                 '<?php
                     trait T {
                         public function fooFoo() : void {
@@ -185,7 +185,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'trait-self' => [
+            'traitSelf' => [
                 '<?php
                     trait T {
                         public function g(): self
@@ -203,7 +203,7 @@ class TraitTest extends TestCase
                     ['A' => '$a']
                 ]
             ],
-            'parent-trait-self' => [
+            'parentTraitSelf' => [
                 '<?php
                     trait T {
                         public function g(): self
@@ -228,7 +228,7 @@ class TraitTest extends TestCase
                     ['A' => '$a']
                 ]
             ],
-            'direct-static-call' => [
+            'directStaticCall' => [
                 '<?php
                     trait T {
                         /** @return void */
@@ -243,7 +243,7 @@ class TraitTest extends TestCase
                         }
                     }'
             ],
-            'abstract-trait-method' => [
+            'abstractTraitMethod' => [
                 '<?php
                     trait T {
                         /** @return void */
@@ -268,7 +268,7 @@ class TraitTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'inaccessible-private-method-from-inherited-trait' => [
+            'inaccessiblePrivateMethodFromInheritedTrait' => [
                 '<?php
                     trait T {
                         private function fooFoo() : void {
@@ -286,14 +286,14 @@ class TraitTest extends TestCase
                     }',
                 'error_message' => 'InaccessibleMethod'
             ],
-            'undefined-trait' => [
+            'undefinedTrait' => [
                 '<?php
                     class B {
                         use A;
                     }',
                 'error_message' => 'UndefinedTrait'
             ],
-            'missing-property-type' => [
+            'missingPropertyType' => [
                 '<?php
                     trait T {
                         public $foo;
@@ -308,7 +308,7 @@ class TraitTest extends TestCase
                 'error_message' => 'MissingPropertyType - somefile.php:3 - Property T::$foo does not have a ' .
                     'declared type - consider null|int'
             ],
-            'missing-property-type-with-constructor-init' => [
+            'missingPropertyTypeWithConstructorInit' => [
                 '<?php
                     trait T {
                         public $foo;
@@ -323,7 +323,7 @@ class TraitTest extends TestCase
                 'error_message' => 'MissingPropertyType - somefile.php:3 - Property T::$foo does not have a ' .
                     'declared type - consider int'
             ],
-            'missing-property-type-with-constructor-init-and-null' => [
+            'missingPropertyTypeWithConstructorInitAndNull' => [
                 '<?php
                     trait T {
                         public $foo;
@@ -342,7 +342,7 @@ class TraitTest extends TestCase
                 'error_message' => 'MissingPropertyType - somefile.php:3 - Property T::$foo does not have a ' .
                     'declared type - consider null|int'
             ],
-            'missing-property-type-with-constructor-init-and-null-default' => [
+            'missingPropertyTypeWithConstructorInitAndNullDefault' => [
                 '<?php
                     trait T {
                         public $foo = null;

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -1,566 +1,362 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class TraitTest extends PHPUnit_Framework_TestCase
+class TraitTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
+        return [
+            'accessible-private-method-from-trait' => [
+                '<?php
+                    trait T {
+                        private function fooFoo() : void {
+                        }
+                    }
+            
+                    class B {
+                        use T;
+            
+                        public function doFoo() : void {
+                            $this->fooFoo();
+                        }
+                    }'
+            ],
+            'accessible-protected-method-from-trait' => [
+                '<?php
+                    trait T {
+                        protected function fooFoo() : void {
+                        }
+                    }
+            
+                    class B {
+                        use T;
+            
+                        public function doFoo() : void {
+                            $this->fooFoo();
+                        }
+                    }'
+            ],
+            'accessible-public-method-from-trait' => [
+                '<?php
+                    trait T {
+                        public function fooFoo() : void {
+                        }
+                    }
+            
+                    class B {
+                        use T;
+            
+                        public function doFoo() : void {
+                            $this->fooFoo();
+                        }
+                    }'
+            ],
+            'accessible-private-property-from-trait' => [
+                '<?php
+                    trait T {
+                        /** @var string */
+                        private $fooFoo = "";
+                    }
+            
+                    class B {
+                        use T;
+            
+                        public function doFoo() : void {
+                            echo $this->fooFoo;
+                        }
+                    }'
+            ],
+            'accessible-protected-property-from-trait' => [
+                '<?php
+                    trait T {
+                        /** @var string */
+                        protected $fooFoo = "";
+                    }
+            
+                    class B {
+                        use T;
+            
+                        public function doFoo() : void {
+                            echo $this->fooFoo;
+                        }
+                    }'
+            ],
+            'accessible-public-property-from-trait' => [
+                '<?php
+                    trait T {
+                        /** @var string */
+                        public $fooFoo = "";
+                    }
+            
+                    class B {
+                        use T;
+            
+                        public function doFoo() : void {
+                            echo $this->fooFoo;
+                        }
+                    }'
+            ],
+            'accessible-protected-method-from-inherited-trait' => [
+                '<?php
+                    trait T {
+                        protected function fooFoo() : void {
+                        }
+                    }
+            
+                    class B {
+                        use T;
+                    }
+            
+                    class C extends B {
+                        public function doFoo() : void {
+                            $this->fooFoo();
+                        }
+                    }'
+            ],
+            'accessible-public-method-from-inherited-trait' => [
+                '<?php
+                    trait T {
+                        public function fooFoo() : void {
+                        }
+                    }
+            
+                    class B {
+                        use T;
+                    }
+            
+                    class C extends B {
+                        public function doFoo() : void {
+                            $this->fooFoo();
+                        }
+                    }'
+            ],
+            'static-class-method-from-within-trait' => [
+                '<?php
+                    trait T {
+                        public function fooFoo() : void {
+                            self::barBar();
+                        }
+                    }
+            
+                    class B {
+                        use T;
+            
+                        public static function barBar() : void {
+            
+                        }
+                    }'
+            ],
+            'redefined-trait-method-without-alias' => [
+                '<?php
+                    trait T {
+                        public function fooFoo() : void {
+                        }
+                    }
+            
+                    class B {
+                        use T;
+            
+                        public function fooFoo(string $a) : void {
+                        }
+                    }
+            
+                    (new B)->fooFoo("hello");'
+            ],
+            'redefined-trait-method-with-alias' => [
+                '<?php
+                    trait T {
+                        public function fooFoo() : void {
+                        }
+                    }
+            
+                    class B {
+                        use T {
+                            fooFoo as barBar;
+                        }
+            
+                        public function fooFoo() : void {
+                            $this->barBar();
+                        }
+                    }'
+            ],
+            'trait-self' => [
+                '<?php
+                    trait T {
+                        public function g(): self
+                        {
+                            return $this;
+                        }
+                    }
+            
+                    class A {
+                        use T;
+                    }
+            
+                    $a = (new A)->g();',
+                'assertions' => [
+                    ['A' => '$a']
+                ]
+            ],
+            'parent-trait-self' => [
+                '<?php
+                    trait T {
+                        public function g(): self
+                        {
+                            return $this;
+                        }
+                    }
+            
+                    class A {
+                        use T;
+                    }
+            
+                    class B extends A {
+                    }
+            
+                    class C {
+                        use T;
+                    }
+            
+                    $a = (new B)->g();',
+                'assertions' => [
+                    ['A' => '$a']
+                ]
+            ],
+            'direct-static-call' => [
+                '<?php
+                    trait T {
+                        /** @return void */
+                        public static function foo() {}
+                    }
+                    class A {
+                        use T;
+            
+                        /** @return void */
+                        public function bar() {
+                            T::foo();
+                        }
+                    }'
+            ],
+            'abstract-trait-method' => [
+                '<?php
+                    trait T {
+                        /** @return void */
+                        abstract public function foo();
+                    }
+            
+                    abstract class A {
+                        use T;
+            
+                        /** @return void */
+                        public function bar() {
+                            $this->foo();
+                        }
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessiblePrivateMethodFromTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            private function fooFoo() : void {
-            }
-        }
-
-        class B {
-            use T;
-
-            public function doFoo() : void {
-                $this->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessibleProtectedMethodFromTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            protected function fooFoo() : void {
-            }
-        }
-
-        class B {
-            use T;
-
-            public function doFoo() : void {
-                $this->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessiblePublicMethodFromTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public function fooFoo() : void {
-            }
-        }
-
-        class B {
-            use T;
-
-            public function doFoo() : void {
-                $this->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessiblePrivatePropertyFromTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            /** @var string */
-            private $fooFoo = "";
-        }
-
-        class B {
-            use T;
-
-            public function doFoo() : void {
-                echo $this->fooFoo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessibleProtectedPropertyFromTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            /** @var string */
-            protected $fooFoo = "";
-        }
-
-        class B {
-            use T;
-
-            public function doFoo() : void {
-                echo $this->fooFoo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessiblePublicPropertyFromTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            /** @var string */
-            public $fooFoo = "";
-        }
-
-        class B {
-            use T;
-
-            public function doFoo() : void {
-                echo $this->fooFoo;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InaccessibleMethod
-     * @return                   void
-     */
-    public function testInccessiblePrivateMethodFromInheritedTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            private function fooFoo() : void {
-            }
-        }
-
-        class B {
-            use T;
-        }
-
-        class C extends B {
-            public function doFoo() : void {
-                $this->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessibleProtectedMethodFromInheritedTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            protected function fooFoo() : void {
-            }
-        }
-
-        class B {
-            use T;
-        }
-
-        class C extends B {
-            public function doFoo() : void {
-                $this->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testAccessiblePublicMethodFromInheritedTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public function fooFoo() : void {
-            }
-        }
-
-        class B {
-            use T;
-        }
-
-        class C extends B {
-            public function doFoo() : void {
-                $this->fooFoo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testStaticClassMethodFromWithinTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public function fooFoo() : void {
-                self::barBar();
-            }
-        }
-
-        class B {
-            use T;
-
-            public static function barBar() : void {
-
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UndefinedTrait
-     * @return                   void
-     */
-    public function testUndefinedTrait()
-    {
-        $stmts = self::$parser->parse('<?php
-        class B {
-            use A;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testRedefinedTraitMethodWithoutAlias()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public function fooFoo() : void {
-            }
-        }
-
-        class B {
-            use T;
-
-            public function fooFoo(string $a) : void {
-            }
-        }
-
-        (new B)->fooFoo("hello");
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testRedefinedTraitMethodWithAlias()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public function fooFoo() : void {
-            }
-        }
-
-        class B {
-            use T {
-                fooFoo as barBar;
-            }
-
-            public function fooFoo() : void {
-                $this->barBar();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testTraitSelf()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public function g(): self
-            {
-                return $this;
-            }
-        }
-
-        class A {
-            use T;
-        }
-
-        $a = (new A)->g();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('A', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testParentTraitSelf()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public function g(): self
-            {
-                return $this;
-            }
-        }
-
-        class A {
-            use T;
-        }
-
-        class B extends A {
-        }
-
-        class C {
-            use T;
-        }
-
-        $a = (new B)->g();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('A', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testDirectStaticCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            /** @return void */
-            public static function foo() {}
-        }
-        class A {
-            use T;
-
-            /** @return void */
-            public function bar() {
-                T::foo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testAbstractTraitMethod()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            /** @return void */
-            abstract public function foo();
-        }
-
-        abstract class A {
-            use T;
-
-            /** @return void */
-            public function bar() {
-                $this->foo();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyType - somefile.php:3 - Property T::$foo does not have a declared type - consider null|int
-     * @return                   void
-     */
-    public function testMissingPropertyType()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public $foo;
-        }
-        class A {
-            use T;
-
-            public function assignToFoo() : void {
-                $this->foo = 5;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyType - somefile.php:3 - Property T::$foo does not have a declared type - consider int
-     * @return                   void
-     */
-    public function testMissingPropertyTypeWithConstructorInit()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public $foo;
-        }
-        class A {
-            use T;
-
-            public function __construct() : void {
-                $this->foo = 5;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyType - somefile.php:3 - Property T::$foo does not have a declared type - consider null|int
-     * @return                   void
-     */
-    public function testMissingPropertyTypeWithConstructorInitAndNull()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public $foo;
-        }
-        class A {
-            use T;
-
-            public function __construct() : void {
-                $this->foo = 5;
-            }
-
-            public function makeNull() : void {
-                $this->foo = null;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MissingPropertyType - somefile.php:3 - Property T::$foo does not have a declared type - consider int|null
-     * @return                   void
-     */
-    public function testMissingPropertyTypeWithConstructorInitAndNullDefault()
-    {
-        $stmts = self::$parser->parse('<?php
-        trait T {
-            public $foo = null;
-        }
-        class A {
-            use T;
-
-            public function __construct() : void {
-                $this->foo = 5;
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
+        return [
+            'inaccessible-private-method-from-inherited-trait' => [
+                '<?php
+                    trait T {
+                        private function fooFoo() : void {
+                        }
+                    }
+            
+                    class B {
+                        use T;
+                    }
+            
+                    class C extends B {
+                        public function doFoo() : void {
+                            $this->fooFoo();
+                        }
+                    }',
+                'error_message' => 'InaccessibleMethod'
+            ],
+            'undefined-trait' => [
+                '<?php
+                    class B {
+                        use A;
+                    }',
+                'error_message' => 'UndefinedTrait'
+            ],
+            'missing-property-type' => [
+                '<?php
+                    trait T {
+                        public $foo;
+                    }
+                    class A {
+                        use T;
+            
+                        public function assignToFoo() : void {
+                            $this->foo = 5;
+                        }
+                    }',
+                'error_message' => 'MissingPropertyType - somefile.php:3 - Property T::$foo does not have a ' .
+                    'declared type - consider null|int'
+            ],
+            'missing-property-type-with-constructor-init' => [
+                '<?php
+                    trait T {
+                        public $foo;
+                    }
+                    class A {
+                        use T;
+            
+                        public function __construct() : void {
+                            $this->foo = 5;
+                        }
+                    }',
+                'error_message' => 'MissingPropertyType - somefile.php:3 - Property T::$foo does not have a ' .
+                    'declared type - consider int'
+            ],
+            'missing-property-type-with-constructor-init-and-null' => [
+                '<?php
+                    trait T {
+                        public $foo;
+                    }
+                    class A {
+                        use T;
+            
+                        public function __construct() : void {
+                            $this->foo = 5;
+                        }
+            
+                        public function makeNull() : void {
+                            $this->foo = null;
+                        }
+                    }',
+                'error_message' => 'MissingPropertyType - somefile.php:3 - Property T::$foo does not have a ' .
+                    'declared type - consider null|int'
+            ],
+            'missing-property-type-with-constructor-init-and-null-default' => [
+                '<?php
+                    trait T {
+                        public $foo = null;
+                    }
+                    class A {
+                        use T;
+            
+                        public function __construct() : void {
+                            $this->foo = 5;
+                        }
+                    }',
+                'error_message' => 'MissingPropertyType - somefile.php:3 - Property T::$foo does not have a ' .
+                    'declared type - consider int|nul'
+            ]
+        ];
     }
 }

--- a/tests/Traits/FileCheckerInvalidCodeParseTestTrait.php
+++ b/tests/Traits/FileCheckerInvalidCodeParseTestTrait.php
@@ -1,0 +1,46 @@
+<?php
+namespace Psalm\Tests\Traits;
+
+use Psalm\Checker\FileChecker;
+use Psalm\Config;
+use Psalm\Context;
+
+trait FileCheckerInvalidCodeParseTestTrait
+{
+    /**
+     * @return array
+     */
+    abstract public function providerFileCheckerInvalidCodeParse();
+
+    /**
+     * @dataProvider providerFileCheckerInvalidCodeParse
+     * @param string $code
+     * @param string $error_message
+     * @param array<string> $error_levels
+     * @param boolean $strict_mode
+     * @return void
+     */
+    public function testInvalidCode($code, $error_message, $error_levels = [], $strict_mode = false)
+    {
+        if (strpos($this->getName(), 'SKIPPED-') !== false) {
+            $this->markTestSkipped();
+        }
+
+        if ($strict_mode) {
+            Config::getInstance()->strict_binary_operands = true;
+        }
+
+        foreach ($error_levels as $error_level) {
+            Config::getInstance()->setCustomErrorLevel($error_level, Config::REPORT_SUPPRESS);
+        }
+
+        $this->expectException('\Psalm\Exception\CodeException');
+        $this->expectExceptionMessage($error_message);
+
+        $stmts = self::$parser->parse($code);
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $context = new Context();
+        $file_checker->visitAndAnalyzeMethods($context);
+    }
+}

--- a/tests/Traits/FileCheckerValidCodeParseTestTrait.php
+++ b/tests/Traits/FileCheckerValidCodeParseTestTrait.php
@@ -1,0 +1,55 @@
+<?php
+namespace Psalm\Tests\Traits;
+
+use Psalm\Checker\FileChecker;
+use Psalm\Config;
+use Psalm\Context;
+
+trait FileCheckerValidCodeParseTestTrait
+{
+    /**
+     * @return array
+     */
+    abstract public function providerFileCheckerValidCodeParse();
+
+    /**
+     * @dataProvider providerFileCheckerValidCodeParse
+     * @param string $code
+     * @param array<array<string,string>> $assertions
+     * @param array<string> $error_levels
+     * @param array<string,\Psalm\Type\Union> $scope_vars
+     * @return void
+     */
+    public function testValidCode($code, $assertions = [], $error_levels = [], $scope_vars = [])
+    {
+        $test_name = $this->getName();
+        if (strpos($test_name, 'PHP7-') !== false) {
+            if (version_compare(PHP_VERSION, '7.0.0dev', '<')) {
+                $this->markTestSkipped('Test case requires PHP 7.');
+                return;
+            }
+        } elseif (strpos($test_name, 'SKIPPED-') !== false) {
+            $this->markTestSkipped('Skipped due to a bug.');
+        }
+
+        foreach ($error_levels as $error_level) {
+            Config::getInstance()->setCustomErrorLevel($error_level, Config::REPORT_SUPPRESS);
+        }
+
+        $stmts = self::$parser->parse($code);
+
+        $context = new Context();
+        foreach ($scope_vars as $var => $value) {
+            $context->vars_in_scope[$var] = $value;
+        }
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
+        $file_checker->visitAndAnalyzeMethods($context);
+
+        foreach ($assertions as $assertion) {
+            foreach ($assertion as $expected => $var) {
+                $this->assertEquals($expected, (string)$context->vars_in_scope[$var]);
+            }
+        }
+    }
+}

--- a/tests/TypeAlgebraTest.php
+++ b/tests/TypeAlgebraTest.php
@@ -1,687 +1,427 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
-use Psalm\Config;
-use Psalm\Context;
-
-class TypeAlgebraTest extends PHPUnit_Framework_TestCase
+class TypeAlgebraTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
+        return [
+            'two-var-logic' => [
+                '<?php
+                    function takesString(string $s) : void {}
+            
+                    function foo(?string $a, ?string $b) : void {
+                        if ($a !== null || $b !== null) {
+                            if ($a !== null) {
+                                $c = $a;
+                            } else {
+                                $c = $b;
+                            }
+            
+                            takesString($c);
+                        }
+                    }'
+            ],
+            'three-var-logic' => [
+                '<?php
+                    function takesString(string $s) : void {}
+            
+                    function foo(?string $a, ?string $b, ?string $c) : void {
+                        if ($a !== null || $b !== null || $c !== null) {
+                            if ($a !== null) {
+                                $d = $a;
+                            } elseif ($b !== null) {
+                                $d = $b;
+                            } else {
+                                $d = $c;
+                            }
+            
+                            takesString($d);
+                        }
+                    }'
+            ],
+            'two-var-logic-not-nested' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if (!$a && !$b) return "bad";
+                        if (!$a) return $b;
+                        return $a;
+                    }'
+            ],
+            'two-var-logic-not-nested-with-all-paths-returning' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if (!$a && !$b) {
+                            return "bad";
+                        } else {
+                            if (!$a) {
+                                return $b;
+                            } else {
+                                return $a;
+                            }
+                        }
+                    }'
+            ],
+            'two-var-logic-not-nested-with-assignment-before-return' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if (!$a && !$b) {
+                            $a = 5;
+                            return "bad";
+                        }
+            
+                        if (!$a) {
+                            $a = 7;
+                            return $b;
+                        }
+            
+                        return $a;
+                    }'
+            ],
+            'inverted-two-var-logic-not-nested' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if ($a || $b) {
+                            // do nothing
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a) return $b;
+                        return $a;
+                    }'
+            ],
+            'inverted-two-var-logic-not-nested-with-assignment-before-return' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if ($a || $b) {
+                            // do nothing
+                        } else {
+                            $a = 5;
+                            return "bad";
+                        }
+            
+                        if (!$a) return $b;
+                        return $a;
+                    }'
+            ],
+            'two-var-logic-not-nested-with-elseif' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if ($a) {
+                            // do nothing
+                        } elseif ($b) {
+                            // do nothing here
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a) return $b;
+                        return $a;
+                    }'
+            ],
+            'three-var-logic-not-nested' => [
+                '<?php
+                    function foo(?string $a, ?string $b, ?string $c) : string {
+                        if ($a) {
+                            // do nothing
+                        } elseif ($b) {
+                            // do nothing here
+                        } elseif ($c) {
+                            // do nothing here
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a && !$b) return $c;
+                        if (!$a) return $b;
+                        return $a;
+                    }'
+            ],
+            'three-var-logic-not-nested-and-or' => [
+                '<?php
+                    function foo(?string $a, ?string $b, ?string $c) : string {
+                        if ($a) {
+                            // do nothing
+                        } elseif ($b || $c) {
+                            // do nothing here
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a && !$b) return $c;
+                        if (!$a) return $b;
+                        return $a;
+                    }'
+            ],
+            'two-var-logic-not-nested-with-elseif-correctly-negated-in-else-if' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if ($a) {
+                            // do nothing here
+                        } elseif ($b) {
+                            $a = null;
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a) return $b;
+                        return $a;
+                    }'
+            ],
+            'nested-reassignment' => [
+                '<?php
+                    function foo(?string $a) : void {
+                        if ($a === null) {
+                            $a = "blah-blah";
+                        } else {
+                            $a = rand(0, 1) ? "blah" : null;
+            
+                            if ($a === null) {
+            
+                            }
+                        }
+                    }'
+            ],
+            'two-var-logic-not-nested-with-elseif-correctly-reinforced-in-if' => [
+                '<?php
+                    class A {}
+                    class B extends A {}
+            
+                    function foo(?A $a, ?A $b) : A {
+                        if ($a) {
+                            $a = new B;
+                        } elseif ($b) {
+                            // do nothing
+                        } else {
+                            return new A;
+                        }
+            
+                        if (!$a) return $b;
+                        return $a;
+                    }'
+            ],
+            'different-value-checks' => [
+                '<?php
+                    function foo(string $a) : void {
+                        if ($a === "foo") {
+                            // do something
+                        } elseif ($a === "bar") {
+                            // can never get here
+                        }
+                    }'
+            ],
+            'repeated-set' => [
+                '<?php
+                    function foo() : void {
+                        if ($a = rand(0, 1) ? "" : null) {
+                            return;
+                        }
+            
+                        if (rand(0, 1)) {
+                            $a = rand(0, 1) ? "hello" : null;
+            
+                            if ($a) {
+            
+                            }
+                        }
+                    }'
+            ],
+            'repeated-set-inside-while' => [
+                '<?php
+                    function foo() : void {
+                        if ($a = rand(0, 1) ? "" : null) {
+                            return;
+                        } else {
+                            while (rand(0, 1)) {
+                                $a = rand(0, 1) ? "hello" : null;
+                            }
+            
+                            if ($a) {
+            
+                            }
+                        }
+                    }'
+            ],
+            'by-ref-assignment' => [
+                '<?php
+                    function foo() : void {
+                        preg_match("/hello/", "hello molly", $matches);
+            
+                        if (!$matches) {
+                            return;
+                        }
+            
+                        preg_match("/hello/", "hello dolly", $matches);
+            
+                        if (!$matches) {
+            
+                        }
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @return void
-     */
-    public function testTwoVarLogic()
-    {
-        $stmts = self::$parser->parse('<?php
-        function takesString(string $s) : void {}
-
-        function foo(?string $a, ?string $b) : void {
-            if ($a !== null || $b !== null) {
-                if ($a !== null) {
-                    $c = $a;
-                } else {
-                    $c = $b;
-                }
-
-                takesString($c);
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testThreeVarLogic()
-    {
-        $stmts = self::$parser->parse('<?php
-        function takesString(string $s) : void {}
-
-        function foo(?string $a, ?string $b, ?string $c) : void {
-            if ($a !== null || $b !== null || $c !== null) {
-                if ($a !== null) {
-                    $d = $a;
-                } elseif ($b !== null) {
-                    $d = $b;
-                } else {
-                    $d = $c;
-                }
-
-                takesString($d);
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage NullArgument
-     * @return                   void
-     */
-    public function testThreeVarLogicWithChange()
-    {
-        $stmts = self::$parser->parse('<?php
-        function takesString(string $s) : void {}
-
-        function foo(?string $a, ?string $b, ?string $c) : void {
-            if ($a !== null || $b !== null || $c !== null) {
-                $c = null;
-
-                if ($a !== null) {
-                    $d = $a;
-                } elseif ($b !== null) {
-                    $d = $b;
-                } else {
-                    $d = $c;
-                }
-
-                takesString($d);
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage NullArgument
-     * @return                   void
-     */
-    public function testThreeVarLogicWithException()
-    {
-        $stmts = self::$parser->parse('<?php
-        function takesString(string $s) : void {}
-
-        function foo(?string $a, ?string $b, ?string $c) : void {
-            if ($a !== null || $b !== null || $c !== null) {
-                if ($c !== null) {
-                    throw new \Exception("bad");
-                }
-
-                if ($a !== null) {
-                    $d = $a;
-                } elseif ($b !== null) {
-                    $d = $b;
-                } else {
-                    $d = $c;
-                }
-
-                takesString($d);
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testTwoVarLogicNotNested()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if (!$a && !$b) return "bad";
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testTwoVarLogicNotNestedWithAllPathsReturning()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if (!$a && !$b) {
-                return "bad";
-            } else {
-                if (!$a) {
-                    return $b;
-                } else {
-                    return $a;
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testTwoVarLogicNotNestedWithAssignmentBeforeReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if (!$a && !$b) {
-                $a = 5;
-                return "bad";
-            }
-
-            if (!$a) {
-                $a = 7;
-                return $b;
-            }
-
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testInvertedTwoVarLogicNotNested()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if ($a || $b) {
-                // do nothing
-            } else {
-                return "bad";
-            }
-
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testInvertedTwoVarLogicNotNestedWithAssignmentBeforeReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if ($a || $b) {
-                // do nothing
-            } else {
-                $a = 5;
-                return "bad";
-            }
-
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testInvertedTwoVarLogicNotNestedWithVarChange()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if ($a || $b) {
-                $b = null;
-            } else {
-                return "bad";
-            }
-
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testInvertedTwoVarLogicNotNestedWithElseif()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if (rand(0, 1)) {
-                // do nothing
-            } elseif ($a || $b) {
-                // do nothing here
-            } else {
-                return "bad";
-            }
-
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testTwoVarLogicNotNestedWithElseif()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if ($a) {
-                // do nothing
-            } elseif ($b) {
-                // do nothing here
-            } else {
-                return "bad";
-            }
-
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testThreeVarLogicNotNested()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b, ?string $c) : string {
-            if ($a) {
-                // do nothing
-            } elseif ($b) {
-                // do nothing here
-            } elseif ($c) {
-                // do nothing here
-            } else {
-                return "bad";
-            }
-
-            if (!$a && !$b) return $c;
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testThreeVarLogicNotNestedAndOr()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b, ?string $c) : string {
-            if ($a) {
-                // do nothing
-            } elseif ($b || $c) {
-                // do nothing here
-            } else {
-                return "bad";
-            }
-
-            if (!$a && !$b) return $c;
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testThreeVarLogicWithElseifAndAnd()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b, ?string $c) : string {
-            if ($a) {
-                // do nothing
-            } elseif ($b && $c) {
-                // do nothing here
-            } else {
-                return "bad";
-            }
-
-            if (!$a && !$b) return $c;
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testTwoVarLogicNotNestedWithElseifNegatedInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if ($a) {
-                $a = null;
-            } elseif ($b) {
-                // do nothing here
-            } else {
-                return "bad";
-            }
-
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testTwoVarLogicNotNestedWithElseifCorrectlyNegatedInElseIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if ($a) {
-                // do nothing here
-            } elseif ($b) {
-                $a = null;
-            } else {
-                return "bad";
-            }
-
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage InvalidReturnType
-     * @return                   void
-     */
-    public function testTwoVarLogicNotNestedWithElseifIncorrectlyReinforcedInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a, ?string $b) : string {
-            if ($a) {
-                $a = "";
-            } elseif ($b) {
-                // do nothing
-            } else {
-                return "bad";
-            }
-
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNestedReassignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a) : void {
-            if ($a === null) {
-                $a = "blah-blah";
-            } else {
-                $a = rand(0, 1) ? "blah" : null;
-
-                if ($a === null) {
-
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testTwoVarLogicNotNestedWithElseifCorrectlyReinforcedInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A {}
-
-        function foo(?A $a, ?A $b) : A {
-            if ($a) {
-                $a = new B;
-            } elseif ($b) {
-                // do nothing
-            } else {
-                return new A;
-            }
-
-            if (!$a) return $b;
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ParadoxicalCondition
-     * @return                   void
-     */
-    public function testRepeatedIfStatements()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return string|null */
-        function foo(?string $a) {
-            if ($a) {
-                return $a;
-            }
-
-            if ($a) {
-
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage ParadoxicalCondition
-     * @return                   void
-     */
-    public function testRepeatedConditionals()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(?string $a) : void {
-            if ($a) {
-                // do something
-            } elseif ($a) {
-                // can never get here
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * This shouldn't throw an error
-     *
-     * @return void
-     */
-    public function testDifferentValueChecks()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo(string $a) : void {
-            if ($a === "foo") {
-                // do something
-            } elseif ($a === "bar") {
-                // can never get here
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * This shouldn't throw an error
-     *
-     * @return void
-     */
-    public function testRepeatedSet()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo() : void {
-            if ($a = rand(0, 1) ? "" : null) {
-                return;
-            }
-
-            if (rand(0, 1)) {
-                $a = rand(0, 1) ? "hello" : null;
-
-                if ($a) {
-
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testRepeatedSetInsideWhile()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo() : void {
-            if ($a = rand(0, 1) ? "" : null) {
-                return;
-            } else {
-                while (rand(0, 1)) {
-                    $a = rand(0, 1) ? "hello" : null;
-                }
-
-                if ($a) {
-
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testByRefAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        function foo() : void {
-            preg_match("/hello/", "hello molly", $matches);
-
-            if (!$matches) {
-                return;
-            }
-
-            preg_match("/hello/", "hello dolly", $matches);
-
-            if (!$matches) {
-
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
+        return [
+            'three-var-logic-with-change' => [
+                '<?php
+                    function takesString(string $s) : void {}
+            
+                    function foo(?string $a, ?string $b, ?string $c) : void {
+                        if ($a !== null || $b !== null || $c !== null) {
+                            $c = null;
+            
+                            if ($a !== null) {
+                                $d = $a;
+                            } elseif ($b !== null) {
+                                $d = $b;
+                            } else {
+                                $d = $c;
+                            }
+            
+                            takesString($d);
+                        }
+                    }',
+                'error_message' => 'NullArgument'
+            ],
+            'three-var-logic-with-exception' => [
+                '<?php
+                    function takesString(string $s) : void {}
+            
+                    function foo(?string $a, ?string $b, ?string $c) : void {
+                        if ($a !== null || $b !== null || $c !== null) {
+                            if ($c !== null) {
+                                throw new \Exception("bad");
+                            }
+            
+                            if ($a !== null) {
+                                $d = $a;
+                            } elseif ($b !== null) {
+                                $d = $b;
+                            } else {
+                                $d = $c;
+                            }
+            
+                            takesString($d);
+                        }
+                    }',
+                'error_message' => 'NullArgument'
+            ],
+            'inverted-two-var-logic-not-nested-with-var-change' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if ($a || $b) {
+                            $b = null;
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a) return $b;
+                        return $a;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'inverted-two-var-logic-not-nested-with-elseif' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if (rand(0, 1)) {
+                            // do nothing
+                        } elseif ($a || $b) {
+                            // do nothing here
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a) return $b;
+                        return $a;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'three-var-logic-with-elseif-and-and' => [
+                '<?php
+                    function foo(?string $a, ?string $b, ?string $c) : string {
+                        if ($a) {
+                            // do nothing
+                        } elseif ($b && $c) {
+                            // do nothing here
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a && !$b) return $c;
+                        if (!$a) return $b;
+                        return $a;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'two-var-logic-not-nested-with-elseif-negated-in-if' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if ($a) {
+                            $a = null;
+                        } elseif ($b) {
+                            // do nothing here
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a) return $b;
+                        return $a;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'two-var-logic-not-nested-with-elseif-incorrectly-reinforced-in-if' => [
+                '<?php
+                    function foo(?string $a, ?string $b) : string {
+                        if ($a) {
+                            $a = "";
+                        } elseif ($b) {
+                            // do nothing
+                        } else {
+                            return "bad";
+                        }
+            
+                        if (!$a) return $b;
+                        return $a;
+                    }',
+                'error_message' => 'InvalidReturnType'
+            ],
+            'repeated-if-statements' => [
+                '<?php
+                    /** @return string|null */
+                    function foo(?string $a) {
+                        if ($a) {
+                            return $a;
+                        }
+            
+                        if ($a) {
+            
+                        }
+                    }',
+                'error_message' => 'ParadoxicalCondition'
+            ],
+            'repeated-conditionals' => [
+                '<?php
+                    function foo(?string $a) : void {
+                        if ($a) {
+                            // do something
+                        } elseif ($a) {
+                            // can never get here
+                        }
+                    }',
+                'error_message' => 'ParadoxicalCondition'
+            ]
+        ];
     }
 }

--- a/tests/TypeAlgebraTest.php
+++ b/tests/TypeAlgebraTest.php
@@ -12,7 +12,7 @@ class TypeAlgebraTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'two-var-logic' => [
+            'twoVarLogic' => [
                 '<?php
                     function takesString(string $s) : void {}
             
@@ -28,7 +28,7 @@ class TypeAlgebraTest extends TestCase
                         }
                     }'
             ],
-            'three-var-logic' => [
+            'threeVarLogic' => [
                 '<?php
                     function takesString(string $s) : void {}
             
@@ -46,7 +46,7 @@ class TypeAlgebraTest extends TestCase
                         }
                     }'
             ],
-            'two-var-logic-not-nested' => [
+            'twoVarLogicNotNested' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if (!$a && !$b) return "bad";
@@ -54,7 +54,7 @@ class TypeAlgebraTest extends TestCase
                         return $a;
                     }'
             ],
-            'two-var-logic-not-nested-with-all-paths-returning' => [
+            'twoVarLogicNotNestedWithAllPathsReturning' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if (!$a && !$b) {
@@ -68,7 +68,7 @@ class TypeAlgebraTest extends TestCase
                         }
                     }'
             ],
-            'two-var-logic-not-nested-with-assignment-before-return' => [
+            'twoVarLogicNotNestedWithAssignmentBeforeReturn' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if (!$a && !$b) {
@@ -84,7 +84,7 @@ class TypeAlgebraTest extends TestCase
                         return $a;
                     }'
             ],
-            'inverted-two-var-logic-not-nested' => [
+            'invertedTwoVarLogicNotNested' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if ($a || $b) {
@@ -97,7 +97,7 @@ class TypeAlgebraTest extends TestCase
                         return $a;
                     }'
             ],
-            'inverted-two-var-logic-not-nested-with-assignment-before-return' => [
+            'invertedTwoVarLogicNotNestedWithAssignmentBeforeReturn' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if ($a || $b) {
@@ -111,7 +111,7 @@ class TypeAlgebraTest extends TestCase
                         return $a;
                     }'
             ],
-            'two-var-logic-not-nested-with-elseif' => [
+            'twoVarLogicNotNestedWithElseif' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if ($a) {
@@ -126,7 +126,7 @@ class TypeAlgebraTest extends TestCase
                         return $a;
                     }'
             ],
-            'three-var-logic-not-nested' => [
+            'threeVarLogicNotNested' => [
                 '<?php
                     function foo(?string $a, ?string $b, ?string $c) : string {
                         if ($a) {
@@ -144,7 +144,7 @@ class TypeAlgebraTest extends TestCase
                         return $a;
                     }'
             ],
-            'three-var-logic-not-nested-and-or' => [
+            'threeVarLogicNotNestedAndOr' => [
                 '<?php
                     function foo(?string $a, ?string $b, ?string $c) : string {
                         if ($a) {
@@ -160,7 +160,7 @@ class TypeAlgebraTest extends TestCase
                         return $a;
                     }'
             ],
-            'two-var-logic-not-nested-with-elseif-correctly-negated-in-else-if' => [
+            'twoVarLogicNotNestedWithElseifCorrectlyNegatedInElseIf' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if ($a) {
@@ -175,7 +175,7 @@ class TypeAlgebraTest extends TestCase
                         return $a;
                     }'
             ],
-            'nested-reassignment' => [
+            'nestedReassignment' => [
                 '<?php
                     function foo(?string $a) : void {
                         if ($a === null) {
@@ -189,7 +189,7 @@ class TypeAlgebraTest extends TestCase
                         }
                     }'
             ],
-            'two-var-logic-not-nested-with-elseif-correctly-reinforced-in-if' => [
+            'twoVarLogicNotNestedWithElseifCorrectlyReinforcedInIf' => [
                 '<?php
                     class A {}
                     class B extends A {}
@@ -207,7 +207,7 @@ class TypeAlgebraTest extends TestCase
                         return $a;
                     }'
             ],
-            'different-value-checks' => [
+            'differentValueChecks' => [
                 '<?php
                     function foo(string $a) : void {
                         if ($a === "foo") {
@@ -217,7 +217,7 @@ class TypeAlgebraTest extends TestCase
                         }
                     }'
             ],
-            'repeated-set' => [
+            'repeatedSet' => [
                 '<?php
                     function foo() : void {
                         if ($a = rand(0, 1) ? "" : null) {
@@ -233,7 +233,7 @@ class TypeAlgebraTest extends TestCase
                         }
                     }'
             ],
-            'repeated-set-inside-while' => [
+            'repeatedSetInsideWhile' => [
                 '<?php
                     function foo() : void {
                         if ($a = rand(0, 1) ? "" : null) {
@@ -249,7 +249,7 @@ class TypeAlgebraTest extends TestCase
                         }
                     }'
             ],
-            'by-ref-assignment' => [
+            'byRefAssignment' => [
                 '<?php
                     function foo() : void {
                         preg_match("/hello/", "hello molly", $matches);
@@ -274,7 +274,7 @@ class TypeAlgebraTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'three-var-logic-with-change' => [
+            'threeVarLogicWithChange' => [
                 '<?php
                     function takesString(string $s) : void {}
             
@@ -295,7 +295,7 @@ class TypeAlgebraTest extends TestCase
                     }',
                 'error_message' => 'NullArgument'
             ],
-            'three-var-logic-with-exception' => [
+            'threeVarLogicWithException' => [
                 '<?php
                     function takesString(string $s) : void {}
             
@@ -318,7 +318,7 @@ class TypeAlgebraTest extends TestCase
                     }',
                 'error_message' => 'NullArgument'
             ],
-            'inverted-two-var-logic-not-nested-with-var-change' => [
+            'invertedTwoVarLogicNotNestedWithVarChange' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if ($a || $b) {
@@ -332,7 +332,7 @@ class TypeAlgebraTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'inverted-two-var-logic-not-nested-with-elseif' => [
+            'invertedTwoVarLogicNotNestedWithElseif' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if (rand(0, 1)) {
@@ -348,7 +348,7 @@ class TypeAlgebraTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'three-var-logic-with-elseif-and-and' => [
+            'threeVarLogicWithElseifAndAnd' => [
                 '<?php
                     function foo(?string $a, ?string $b, ?string $c) : string {
                         if ($a) {
@@ -365,7 +365,7 @@ class TypeAlgebraTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'two-var-logic-not-nested-with-elseif-negated-in-if' => [
+            'twoVarLogicNotNestedWithElseifNegatedInIf' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if ($a) {
@@ -381,7 +381,7 @@ class TypeAlgebraTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'two-var-logic-not-nested-with-elseif-incorrectly-reinforced-in-if' => [
+            'twoVarLogicNotNestedWithElseifIncorrectlyReinforcedInIf' => [
                 '<?php
                     function foo(?string $a, ?string $b) : string {
                         if ($a) {
@@ -397,7 +397,7 @@ class TypeAlgebraTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType'
             ],
-            'repeated-if-statements' => [
+            'repeatedIfStatements' => [
                 '<?php
                     /** @return string|null */
                     function foo(?string $a) {
@@ -411,7 +411,7 @@ class TypeAlgebraTest extends TestCase
                     }',
                 'error_message' => 'ParadoxicalCondition'
             ],
-            'repeated-conditionals' => [
+            'repeatedConditionals' => [
                 '<?php
                     function foo(?string $a) : void {
                         if ($a) {

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -31,7 +31,7 @@ class TypeCombinationTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'multiple-valued-array' => [
+            'multipleValuedArray' => [
                 '<?php
                     class A {}
                     class B {}
@@ -48,104 +48,104 @@ class TypeCombinationTest extends TestCase
     public function providerTestValidTypeCombination()
     {
         return [
-            'int-or-string' => [
+            'intOrString' => [
                 'int|string',
                 [
                     'int',
                     'string'
                 ]
             ],
-            'array-of-int-or-string' => [
+            'arrayOfIntOrString' => [
                 'array<mixed, int|string>',
                 [
                     'array<int>',
                     'array<string>'
                 ]
             ],
-            'array-of-int-or-also-string' => [
+            'arrayOfIntOrAlsoString' => [
                 'array<mixed, int>|string',
                 [
                     'array<int>',
                     'string'
                 ]
             ],
-            'empty-arrays' => [
+            'emptyArrays' => [
                 'array<empty, empty>',
                 [
                     'array<empty,empty>',
                     'array<empty,empty>'
                 ]
             ],
-            'array-string-or-empty-array' => [
+            'arrayStringOrEmptyArray' => [
                 'array<mixed, string>',
                 [
                     'array<empty>',
                     'array<string>'
                 ]
             ],
-            'array-mixed-or-string' => [
+            'arrayMixedOrString' => [
                 'array<mixed, mixed>',
                 [
                     'array<mixed>',
                     'array<string>'
                 ]
             ],
-            'array-mixed-or-string-keys' => [
+            'arrayMixedOrStringKeys' => [
                 'array<mixed, string>',
                 [
                     'array<int|string,string>',
                     'array<mixed,string>'
                 ]
             ],
-            'array-mixed-or-empty' => [
+            'arrayMixedOrEmpty' => [
                 'array<mixed, mixed>',
                 [
                     'array<empty>',
                     'array<mixed>'
                 ]
             ],
-            'array-big-combination' => [
+            'arrayBigCombination' => [
                 'array<mixed, int|float|string>',
                 [
                     'array<int|float>',
                     'array<string>'
                 ]
             ],
-            'false-destruction' => [
+            'falseDestruction' => [
                 'bool',
                 [
                     'false',
                     'bool'
                 ]
             ],
-            'only-false' => [
+            'onlyFalse' => [
                 'bool',
                 [
                     'false'
                 ]
             ],
-            'false-false-destruction' => [
+            'falseFalseDestruction' => [
                 'bool',
                 [
                     'false',
                     'false'
                 ]
             ],
-            'a-and-a-of-b' => [
+            'aAndAOfB' => [
                 'A<mixed>',
                 [
                     'A',
                     'A<B>'
                 ]
             ],
-            'combine-object-type-1' => [
+            'combineObjectType1' => [
                 'array{a:int, b:string}',
                 [
                     'array{a:int}',
                     'array{b:string}'
                 ]
             ],
-            'combine-object-type-2' => [
+            'combineObjectType2' => [
                 'array{a:int|string, b:string}',
                 [
                     'array{a:int}',

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -1,39 +1,158 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
-use Psalm\Checker\FileChecker;
 use Psalm\Type;
 
-class TypeCombinationTest extends PHPUnit_Framework_TestCase
+class TypeCombinationTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
+     * @dataProvider providerTestValidTypeCombination
+     * @param string $expected
+     * @param array<string> $types
      * @return void
      */
-    public static function setUpBeforeClass()
+    public function testValidTypeCombination($expected, $types)
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
+        foreach ($types as $k => $type) {
+            $types[$k] = self::getAtomic($type);
+        }
+
+        $this->assertEquals(
+            $expected,
+            (string) Type::combineTypes($types)
+        );
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function setUp()
+    public function providerFileCheckerValidCodeParse()
     {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
+        return [
+            'multiple-valued-array' => [
+                '<?php
+                    class A {}
+                    class B {}
+                    $var = [];
+                    $var[] = new A();
+                    $var[] = new B();'
+            ]
+        ];
+    }
+
+    /**
+     * @return array
+     */
+    public function providerTestValidTypeCombination()
+    {
+        return [
+            'int-or-string' => [
+                'int|string',
+                [
+                    'int',
+                    'string'
+                ]
+            ],
+            'array-of-int-or-string' => [
+                'array<mixed, int|string>',
+                [
+                    'array<int>',
+                    'array<string>'
+                ]
+            ],
+            'array-of-int-or-also-string' => [
+                'array<mixed, int>|string',
+                [
+                    'array<int>',
+                    'string'
+                ]
+            ],
+            'empty-arrays' => [
+                'array<empty, empty>',
+                [
+                    'array<empty,empty>',
+                    'array<empty,empty>'
+                ]
+            ],
+            'array-string-or-empty-array' => [
+                'array<mixed, string>',
+                [
+                    'array<empty>',
+                    'array<string>'
+                ]
+            ],
+            'array-mixed-or-string' => [
+                'array<mixed, mixed>',
+                [
+                    'array<mixed>',
+                    'array<string>'
+                ]
+            ],
+            'array-mixed-or-string-keys' => [
+                'array<mixed, string>',
+                [
+                    'array<int|string,string>',
+                    'array<mixed,string>'
+                ]
+            ],
+            'array-mixed-or-empty' => [
+                'array<mixed, mixed>',
+                [
+                    'array<empty>',
+                    'array<mixed>'
+                ]
+            ],
+            'array-big-combination' => [
+                'array<mixed, int|float|string>',
+                [
+                    'array<int|float>',
+                    'array<string>'
+                ]
+            ],
+            'false-destruction' => [
+                'bool',
+                [
+                    'false',
+                    'bool'
+                ]
+            ],
+            'only-false' => [
+                'bool',
+                [
+                    'false'
+                ]
+            ],
+            'false-false-destruction' => [
+                'bool',
+                [
+                    'false',
+                    'false'
+                ]
+            ],
+            'a-and-a-of-b' => [
+                'A<mixed>',
+                [
+                    'A',
+                    'A<B>'
+                ]
+            ],
+            'combine-object-type-1' => [
+                'array{a:int, b:string}',
+                [
+                    'array{a:int}',
+                    'array{b:string}'
+                ]
+            ],
+            'combine-object-type-2' => [
+                'array{a:int|string, b:string}',
+                [
+                    'array{a:int}',
+                    'array{a:string,b:string}'
+                ]
+            ]
+        ];
     }
 
     /**
@@ -43,225 +162,5 @@ class TypeCombinationTest extends PHPUnit_Framework_TestCase
     private static function getAtomic($string)
     {
         return array_values(Type::parseString($string)->types)[0];
-    }
-
-    /**
-     * @return void
-     */
-    public function testIntOrString()
-    {
-        $this->assertEquals(
-            'int|string',
-            (string) Type::combineTypes([
-                self::getAtomic('int'),
-                self::getAtomic('string')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayOfIntOrString()
-    {
-        $this->assertEquals(
-            'array<mixed, int|string>',
-            (string) Type::combineTypes([
-                self::getAtomic('array<int>'),
-                self::getAtomic('array<string>')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayOfIntOrAlsoString()
-    {
-        $this->assertEquals(
-            'array<mixed, int>|string',
-            (string) Type::combineTypes([
-                self::getAtomic('array<int>'),
-                self::getAtomic('string')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testEmptyArrays()
-    {
-        $this->assertEquals(
-            'array<empty, empty>',
-            (string) Type::combineTypes([
-                self::getAtomic('array<empty,empty>'),
-                self::getAtomic('array<empty,empty>')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayStringOrEmptyArray()
-    {
-        $this->assertEquals(
-            'array<mixed, string>',
-            (string) Type::combineTypes([
-                self::getAtomic('array<empty>'),
-                self::getAtomic('array<string>')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayMixedOrString()
-    {
-        $this->assertEquals(
-            'array<mixed, mixed>',
-            (string) Type::combineTypes([
-                self::getAtomic('array<mixed>'),
-                self::getAtomic('array<string>')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayMixedOrStringKeys()
-    {
-        $this->assertEquals(
-            'array<mixed, string>',
-            (string) Type::combineTypes([
-                self::getAtomic('array<int|string,string>'),
-                self::getAtomic('array<mixed,string>')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayMixedOrEmpty()
-    {
-        $this->assertEquals(
-            'array<mixed, mixed>',
-            (string) Type::combineTypes([
-                self::getAtomic('array<empty>'),
-                self::getAtomic('array<mixed>')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayBigCombination()
-    {
-        $this->assertEquals(
-            'array<mixed, int|float|string>',
-            (string) Type::combineTypes([
-                self::getAtomic('array<int|float>'),
-                self::getAtomic('array<string>')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testFalseDestruction()
-    {
-        $this->assertEquals(
-            'bool',
-            (string) Type::combineTypes([
-                self::getAtomic('false'),
-                self::getAtomic('bool')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testOnlyFalse()
-    {
-        $this->assertEquals(
-            'bool',
-            (string) Type::combineTypes([
-                self::getAtomic('false')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testFalseFalseDestruction()
-    {
-        $this->assertEquals(
-            'bool',
-            (string) Type::combineTypes([
-                self::getAtomic('false'),
-                self::getAtomic('false')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testAAndAOfB()
-    {
-        $this->assertEquals(
-            'A<mixed>',
-            (string) Type::combineTypes([
-                self::getAtomic('A'),
-                self::getAtomic('A<B>')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testCombineObjectType()
-    {
-        $this->assertEquals(
-            'array{a:int, b:string}',
-            (string) Type::combineTypes([
-                self::getAtomic('array{a:int}'),
-                self::getAtomic('array{b:string}')
-            ])
-        );
-
-        $this->assertEquals(
-            'array{a:int|string, b:string}',
-            (string) Type::combineTypes([
-                self::getAtomic('array{a:int}'),
-                self::getAtomic('array{a:string,b:string}')
-            ])
-        );
-    }
-
-    /**
-     * @return void
-     */
-    public function testMultipleValuedArray()
-    {
-        $stmts = self::$parser->parse('<?php
-            class A {}
-            class B {}
-            $var = [];
-            $var[] = new A();
-            $var[] = new B();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
     }
 }

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -1,38 +1,10 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Type;
 
-class TypeParseTest extends PHPUnit_Framework_TestCase
+class TypeParseTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
-    /**
-     * @return void
-     */
-    public static function setUpBeforeClass()
-    {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return \Psalm\Type\Atomic
-     */
-    private static function getAtomic($string)
-    {
-        return array_values(Type::parseString($string)->types)[0];
-    }
-
     /**
      * @return void
      */

--- a/tests/TypeReconciliationTest.php
+++ b/tests/TypeReconciliationTest.php
@@ -177,38 +177,37 @@ class TypeReconciliationTest extends TestCase
     public function providerTestReconcilation()
     {
         return [
-            'not-null.MyObject' => ['MyObject', '!null', 'MyObject'],
-            'not-null.MyObject|null' => ['MyObject', '!null', 'MyObject|null'],
-            'not-null.MyObject|false' => ['MyObject|false', '!null', 'MyObject|false'],
-            'not-null.mixed' => ['mixed', '!null', 'mixed'],
+            'notNullWithObject' => ['MyObject', '!null', 'MyObject'],
+            'notNullWithObjectPipeNull' => ['MyObject', '!null', 'MyObject|null'],
+            'notNullWithMyObjectPipeFalse' => ['MyObject|false', '!null', 'MyObject|false'],
+            'notNullWithMixed' => ['mixed', '!null', 'mixed'],
 
-            'not-empty.MyObject' => ['MyObject', '!empty', 'MyObject'],
-            'not-empty.MyObject|null' => ['MyObject', '!empty', 'MyObject|null'],
-            'not-empty.MyObject|false' => ['MyObject', '!empty', 'MyObject|false'],
-            'not-empty.mixed' => ['mixed', '!empty', 'mixed'],
+            'notEmptyWithMyObject' => ['MyObject', '!empty', 'MyObject'],
+            'notEmptyWithMyObjectPipeNull' => ['MyObject', '!empty', 'MyObject|null'],
+            'notEmptyWithMyObjectPipeFalse' => ['MyObject', '!empty', 'MyObject|false'],
+            'notEmptyWithMixed' => ['mixed', '!empty', 'mixed'],
             // @todo in the future this should also work
-            //'not-empty.MyObject|true' => ['MyObject|true', '!empty', 'MyObject|bool'],
+            //'notEmptyWithMyObjectFalseTrue' => ['MyObject|true', '!empty', 'MyObject|bool'],
 
-            'not-empty.MyObject|null' => ['null', 'null', 'MyObject|null'],
-            'not-empty.MyObject|null' => ['null', 'null', 'mixed'],
+            'notEmptyWithMyObjectPipeNull' => ['null', 'null', 'MyObject|null'],
+            'notEmptyWithMixed' => ['null', 'null', 'mixed'],
 
-            'empty.MyObject' => ['null', 'empty', 'MyObject'],
-            'empty.MyObject|false' => ['false', 'empty', 'MyObject|false'],
-            'empty.MyObject|false' => ['false', 'empty', 'MyObject|false'],
-            'empty.MyObject|bool' => ['false', 'empty', 'MyObject|bool'],
-            'empty.mixed' => ['mixed', 'empty', 'mixed'],
-            'empty.bool' => ['false', 'empty', 'bool'],
+            'emptyWithMyObject' => ['null', 'empty', 'MyObject'],
+            'emptyWithMyObjectPipeFalse' => ['false', 'empty', 'MyObject|false'],
+            'emptyWithMyObjectPipeBool' => ['false', 'empty', 'MyObject|bool'],
+            'emptyWithMixed' => ['mixed', 'empty', 'mixed'],
+            'emptyWithBool' => ['false', 'empty', 'bool'],
 
-            'not-my-object.MyObject|bool' => ['bool', '!MyObject', 'MyObject|bool'],
-            'not-my-object.MyObject|null' => ['null', '!MyObject', 'MyObject|null'],
-            'not-my-object.MyObjectA|MyObjectB' => ['MyObjectB', '!MyObjectA', 'MyObjectA|MyObjectB'],
+            'notMyObjectWithMyObjectPipeBool' => ['bool', '!MyObject', 'MyObject|bool'],
+            'notMyObjectWithMyObjectPipeNull' => ['null', '!MyObject', 'MyObject|null'],
+            'notMyObjectWithMyObjectAPipeMyObjectB' => ['MyObjectB', '!MyObjectA', 'MyObjectA|MyObjectB'],
 
-            'my-object.MyObject|bool' => ['MyObject', 'MyObject', 'MyObject|bool'],
-            'my-object.MyObjectA|MyObjectB' => ['MyObjectA', 'MyObjectA', 'MyObjectA|MyObjectB'],
+            'myObjectWithMyObjectPipeBool' => ['MyObject', 'MyObject', 'MyObject|bool'],
+            'myObjectWithMyObjectAPipeMyObjectB' => ['MyObjectA', 'MyObjectA', 'MyObjectA|MyObjectB'],
 
             'array' => ['array<mixed, mixed>', 'array', 'array|null'],
 
-            '2d-array' => ['array<mixed, array<mixed, string>>', 'array', 'array<array<string>>|null'],
+            '2dArray' => ['array<mixed, array<mixed, string>>', 'array', 'array<array<string>>|null'],
 
             'numeric' => ['string', 'numeric', 'string']
         ];
@@ -220,11 +219,11 @@ class TypeReconciliationTest extends TestCase
     public function providerTestTypeIsContainedBy()
     {
         return [
-            'array-contains.array<string>' => ['array<string>', 'array'],
-            'array-contains.array<Exception>' => ['array<Exception>', 'array'],
+            'arrayContainsWithArrayOfStrings' => ['array<string>', 'array'],
+            'arrayContainsWithArrayOfExceptions' => ['array<Exception>', 'array'],
 
-            'union-contains.string' => ['string', 'string|false'],
-            'union-contains.false' => ['false', 'string|false']
+            'unionContainsWithstring' => ['string', 'string|false'],
+            'unionContainsWithFalse' => ['false', 'string|false']
         ];
     }
 
@@ -234,7 +233,7 @@ class TypeReconciliationTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'int-is-mixed' => [
+            'intIsMixed' => [
                 '<?php
                     function foo($a) : void {
                         $b = 5;
@@ -242,7 +241,7 @@ class TypeReconciliationTest extends TestCase
                         if ($b === $a) { }
                     }'
             ],
-            'type-resolution-from-docblock' => [
+            'typeResolutionFromDocblock' => [
                 '<?php
                     class A { }
             
@@ -255,7 +254,7 @@ class TypeReconciliationTest extends TestCase
                         }
                     }'
             ],
-            'array-type-resolution-from-docblock' => [
+            'arrayTypeResolutionFromDocblock' => [
                 '<?php
                     /**
                      * @param string[] $strs
@@ -267,7 +266,7 @@ class TypeReconciliationTest extends TestCase
                         }
                     }'
             ],
-            'type-resolution-from-docblock-inside' => [
+            'typeResolutionFromDocblockInside' => [
                 '<?php
                     /**
                      * @param int $length
@@ -280,7 +279,7 @@ class TypeReconciliationTest extends TestCase
                         }
                     }'
             ],
-            'not-instanceof' => [
+            'notInstanceof' => [
                 '<?php
                     class A { }
             
@@ -302,7 +301,7 @@ class TypeReconciliationTest extends TestCase
                     '$a' => Type::parseString('A')
                 ]
             ],
-            'not-instance-of-property' => [
+            'notInstanceOfProperty' => [
                 '<?php
                     class B { }
             
@@ -335,7 +334,7 @@ class TypeReconciliationTest extends TestCase
                     '$a' => Type::parseString('A')
                 ]
             ],
-            'not-instance-of-property-elseif' => [
+            'notInstanceOfPropertyElseif' => [
                 '<?php
                     class B { }
             
@@ -365,7 +364,7 @@ class TypeReconciliationTest extends TestCase
                     '$a' => Type::parseString('A')
                 ]
             ],
-            'type-arguments' => [
+            'typeArguments' => [
                 '<?php
                     $a = min(0, 1);
                     $b = min([0, 1]);
@@ -382,7 +381,7 @@ class TypeReconciliationTest extends TestCase
                     ['string' => '$seconds']
                 ]
             ],
-            'type-refinement-with-is-numeric' => [
+            'typeRefinementWithIsNumeric' => [
                 '<?php
                     /** @return void */
                     function fooFoo(string $a) {
@@ -392,7 +391,7 @@ class TypeReconciliationTest extends TestCase
                     $b = rand(0, 1) ? 5 : false;
                     if (is_numeric($b)) { }'
             ],
-            'type-refinement-with-is-numeric-and-is-string' => [
+            'typeRefinementWithIsNumericAndIsString' => [
                 '<?php
                     /**
                      * @param mixed $a
@@ -405,7 +404,7 @@ class TypeReconciliationTest extends TestCase
                         }
                     }'
             ],
-            'update-multiple-isset-vars' => [
+            'updateMultipleIssetVars' => [
                 '<?php
                     /** @return void **/
                     function foo(string $s) {}
@@ -415,7 +414,7 @@ class TypeReconciliationTest extends TestCase
                         foo($a[0]);
                     }'
             ],
-            'update-multiple-isset-vars-with-variable-offset' => [
+            'updateMultipleIssetVarsWithVariableOffset' => [
                 '<?php
                     /** @return void **/
                     function foo(string $s) {}
@@ -426,7 +425,7 @@ class TypeReconciliationTest extends TestCase
                         foo($a[$b]);
                     }'
             ],
-            'remove-empty-array' => [
+            'removeEmptyArray' => [
                 '<?php
                     $arr_or_string = [];
             
@@ -441,7 +440,7 @@ class TypeReconciliationTest extends TestCase
                         foo($arr_or_string);
                     }'
             ],
-            'instance-of-subtypes' => [
+            'instanceOfSubtypes' => [
                 '<?php
                     abstract class A {}
                     class B extends A {}
@@ -461,7 +460,7 @@ class TypeReconciliationTest extends TestCase
             
                     if ($a instanceof B || $a instanceof D) { }'
             ],
-            'empty-array-reconciliation-then-if' => [
+            'emptyArrayReconciliationThenIf' => [
                 '<?php
                     /**
                      * @param string|string[] $a
@@ -480,7 +479,7 @@ class TypeReconciliationTest extends TestCase
                         return "not found";
                     }'
             ],
-            'empty-string-reconciliation-then-if' => [
+            'emptyStringReconciliationThenIf' => [
                 '<?php
                     /**
                      * @param Exception|string|string[] $a
@@ -499,7 +498,7 @@ class TypeReconciliationTest extends TestCase
                         return "an exception";
                     }'
             ],
-            'empty-exception-reconciliation-after-if' => [
+            'emptyExceptionReconciliationAfterIf' => [
                 '<?php
                     /**
                      * @param Exception|null $a
@@ -514,7 +513,7 @@ class TypeReconciliationTest extends TestCase
                         return $a->getMessage();
                     }'
             ],
-            'type-reconciliation-after-if-and-return' => [
+            'typeReconciliationAfterIfAndReturn' => [
                 '<?php
                     /**
                      * @param string|int $a
@@ -530,7 +529,7 @@ class TypeReconciliationTest extends TestCase
                         throw new \LogicException("Runtime error");
                     }'
             ],
-            'ignore-null-check-and-maintain-null-value' => [
+            'ignoreNullCheckAndMaintainNullValue' => [
                 '<?php
                     $a = null;
                     if ($a !== null) { }
@@ -540,7 +539,7 @@ class TypeReconciliationTest extends TestCase
                 ],
                 'error_levels' => ['FailedTypeResolution']
             ],
-            'ignore-null-check-and-maintain-nullable-value' => [
+            'ignoreNullCheckAndMaintainNullableValue' => [
                 '<?php
                     $a = rand(0, 1) ? 5 : null;
                     if ($a !== null) { }
@@ -549,7 +548,7 @@ class TypeReconciliationTest extends TestCase
                     ['int|null' => '$b']
                 ]
             ],
-            'ternary-by-ref-var' => [
+            'ternaryByRefVar' => [
                 '<?php
                     function foo() : void {
                         $b = null;
@@ -560,7 +559,7 @@ class TypeReconciliationTest extends TestCase
                         $a = 5;
                     }'
             ],
-            'ternary-by-ref-var-in-conditional' => [
+            'ternaryByRefVarInConditional' => [
                 '<?php
                     function foo() : void {
                         $b = null;
@@ -572,7 +571,7 @@ class TypeReconciliationTest extends TestCase
                         $a = 5;
                     }'
             ],
-            'possible-instanceof' => [
+            'possibleInstanceof' => [
                 '<?php
                     interface I1 {}
                     interface I2 {}
@@ -620,7 +619,7 @@ class TypeReconciliationTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'make-non-nullable-null' => [
+            'makeNonNullableNull' => [
                 '<?php
                     class A { }
                     $a = new A();
@@ -628,7 +627,7 @@ class TypeReconciliationTest extends TestCase
                     }',
                 'error_message' => 'TypeDoesNotContainNull'
             ],
-            'make-instance-of-thing-in-elseif' => [
+            'makeInstanceOfThingInElseif' => [
                 '<?php
                     class A { }
                     class B { }
@@ -639,27 +638,27 @@ class TypeReconciliationTest extends TestCase
                     }',
                 'error_message' => 'TypeDoesNotContainType'
             ],
-            'function-value-is-not-type' => [
+            'functionValueIsNotType' => [
                 '<?php
                     if (json_last_error() === "5") { }',
                 'error_message' => 'TypeDoesNotContainType'
             ],
-            'string-is-not-int' => [
+            'stringIsNotTnt' => [
                 '<?php
                     if (5 === "5") { }',
                 'error_message' => 'TypeDoesNotContainType'
             ],
-            'string-is-not-null' => [
+            'stringIsNotNull' => [
                 '<?php
                     if (5 === null) { }',
                 'error_message' => 'TypeDoesNotContainNull'
             ],
-            'string-is-not-false' => [
+            'stringIsNotFalse' => [
                 '<?php
                     if (5 === false) { }',
                 'error_message' => 'TypeDoesNotContainType'
             ],
-            'failed-type-resolution' => [
+            'failedTypeResolution' => [
                 '<?php
                     class A { }
             
@@ -672,7 +671,7 @@ class TypeReconciliationTest extends TestCase
                     }',
                 'error_message' => 'FailedTypeResolution'
             ],
-            'failed-type-resolution-with-docblock' => [
+            'failedTypeResolutionWithDocblock' => [
                 '<?php
                     class A { }
             
@@ -686,7 +685,7 @@ class TypeReconciliationTest extends TestCase
                     }',
                 'error_message' => 'FailedTypeResolution'
             ],
-            'type-resolution-from-docblock-and-instanceof' => [
+            'typeResolutionFromDocblockAndInstanceof' => [
                 '<?php
                     class A { }
             
@@ -702,7 +701,7 @@ class TypeReconciliationTest extends TestCase
                     }',
                 'error_message' => 'FailedTypeResolution'
             ],
-            'type-transformation' => [
+            'typeTransformation' => [
                 '<?php
                     $a = "5";
             

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -1,9 +1,6 @@
 <?php
 namespace Psalm\Tests;
 
-use Psalm\Checker\FileChecker;
-use Psalm\Context;
-
 class TypeTest extends TestCase
 {
     use Traits\FileCheckerInvalidCodeParseTestTrait;
@@ -15,7 +12,7 @@ class TypeTest extends TestCase
     public function providerFileCheckerValidCodeParse()
     {
         return [
-            'nullable-method-with-ternary-guard' => [
+            'nullableMethodWithTernaryGuard' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -29,7 +26,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-ternary-if-null-guard' => [
+            'nullableMethodWithTernaryIfNullGuard' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -43,7 +40,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-ternary-empty-guard' => [
+            'nullableMethodWithTernaryEmptyGuard' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -57,7 +54,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-ternary-is-null-guard' => [
+            'nullableMethodWithTernaryIsNullGuard' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -71,7 +68,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-if-guard' => [
+            'nullableMethodWithIfGuard' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -87,7 +84,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-ternary-guard-with-this' => [
+            'nullableMethodWithTernaryGuardWithThis' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -105,7 +102,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-ternary-if-null-guard-with-this' => [
+            'nullableMethodWithTernaryIfNullGuardWithThis' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -123,7 +120,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-if-guard-with-this' => [
+            'nullableMethodWithIfGuardWithThis' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -144,7 +141,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-exception-thrown' => [
+            'nullableMethodWithExceptionThrown' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -162,7 +159,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-redefinition-and-else' => [
+            'nullableMethodWithRedefinitionAndElse' => [
                 '<?php
                     class One {
                         /** @var int|null */
@@ -186,7 +183,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-boolean-if-guard' => [
+            'nullableMethodWithBooleanIfGuard' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -207,7 +204,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-non-null-boolean-if-guard' => [
+            'nullableMethodWithNonNullBooleanIfGuard' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -228,7 +225,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-non-null-boolean-if-guard-and-boolean-and' => [
+            'nullableMethodWithNonNullBooleanIfGuardAndBooleanAnd' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -249,7 +246,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-in-condition-with-if-guard-before' => [
+            'nullableMethodInConditionWithIfGuardBefore' => [
                 '<?php
                     class One {
                         /** @var string */
@@ -277,7 +274,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-boolean-if-guard-before' => [
+            'nullableMethodWithBooleanIfGuardBefore' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -300,7 +297,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-redefinition' => [
+            'nullableMethodWithGuardedRedefinition' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -318,7 +315,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-redefinition-in-else' => [
+            'nullableMethodWithGuardedRedefinitionInElse' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -339,7 +336,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-nested-redefinition' => [
+            'nullableMethodWithGuardedNestedRedefinition' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -369,7 +366,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-switch-redefinition' => [
+            'nullableMethodWithGuardedSwitchRedefinition' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -397,7 +394,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-switch-redefinition-due-to-exception' => [
+            'nullableMethodWithGuardedSwitchRedefinitionDueToException' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -426,7 +423,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-switch-that-always-returns' => [
+            'nullableMethodWithGuardedSwitchThatAlwaysReturns' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -452,7 +449,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-nested-redefinition-with-return' => [
+            'nullableMethodWithGuardedNestedRedefinitionWithReturn' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -478,7 +475,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-nested-redefinition-with-else-return' => [
+            'nullableMethodWithGuardedNestedRedefinitionWithElseReturn' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -504,7 +501,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-nested-redefinition-with-elseif-return' => [
+            'nullableMethodWithGuardedNestedRedefinitionWithElseifReturn' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -533,7 +530,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-switch-break' => [
+            'nullableMethodWithGuardedSwitchBreak' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -557,7 +554,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'nullable-method-with-guarded-redefinition-on-this' => [
+            'nullableMethodWithGuardedRedefinitionOnThis' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -580,7 +577,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'array-union-type-assertion' => [
+            'arrayUnionTypeAssertion' => [
                 '<?php
                     /** @var array|null */
                     $ids = (1 + 1 === 2) ? [] : null;
@@ -592,7 +589,7 @@ class TypeTest extends TestCase
                     ['array<empty, empty>' => '$ids']
                 ]
             ],
-            'array-union-type-assertion-with-is-array' => [
+            'arrayUnionTypeAssertionWithIsArray' => [
                 '<?php
                     /** @var array|null */
                     $ids = (1 + 1 === 2) ? [] : null;
@@ -604,7 +601,7 @@ class TypeTest extends TestCase
                     ['array<empty, empty>' => '$ids']
                 ]
             ],
-            '2d-array-union-type-assertion-with-is-array' => [
+            '2dArrayUnionTypeAssertionWithIsArray' => [
                 '<?php
                     /** @return array<array<string>>|null */
                     function foo() {
@@ -617,7 +614,7 @@ class TypeTest extends TestCase
                         return null;
                     }'
             ],
-            'variable-reassignment' => [
+            'variableReassignment' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -635,7 +632,7 @@ class TypeTest extends TestCase
             
                     $one->barBar();'
             ],
-            'variable-reassignment-in-if' => [
+            'variableReassignmentInIf' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -655,7 +652,7 @@ class TypeTest extends TestCase
                         $one->barBar();
                     }'
             ],
-            'union-type-flow' => [
+            'unionTypeFlow' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -687,7 +684,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'union-type-flow-with-throw' => [
+            'unionTypeFlowWithThrow' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -704,7 +701,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'union-type-flow-with-elseif' => [
+            'unionTypeFlowWithElseif' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -724,7 +721,7 @@ class TypeTest extends TestCase
                         $var->fooFoo();
                     }'
             ],
-            'typed-adjustment' => [
+            'typedAdjustment' => [
                 '<?php
                     $var = 0;
             
@@ -737,7 +734,7 @@ class TypeTest extends TestCase
                     ['int|string' => '$var']
                 ]
             ],
-            'type-mixed-adjustment' => [
+            'typeMixedAdjustment' => [
                 '<?php
                     $var = 0;
             
@@ -752,7 +749,7 @@ class TypeTest extends TestCase
                     ['int|string' => '$var']
                 ]
             ],
-            'type-adjustment-if-null' => [
+            'typeAdjustmentIfNull' => [
                 '<?php
                     class A {}
                     class B {}
@@ -766,7 +763,7 @@ class TypeTest extends TestCase
                     ['A|B' => '$var']
                 ]
             ],
-            'while-true' => [
+            'whileTrue' => [
                 '<?php
                     class One {
                         /**
@@ -784,7 +781,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'passing-param' => [
+            'passingParam' => [
                 '<?php
                     class A {}
             
@@ -796,7 +793,7 @@ class TypeTest extends TestCase
                     $b = new B();
                     $b->barBar(new A);'
             ],
-            'null-to-nullable-param' => [
+            'nullToNullableParam' => [
                 '<?php
                     class A {}
             
@@ -808,7 +805,7 @@ class TypeTest extends TestCase
                     $b = new B();
                     $b->barBar(null);'
             ],
-            'object-to-nullable-object-param' => [
+            'objectToNullableObjectParam' => [
                 '<?php
                     class A {}
             
@@ -820,7 +817,7 @@ class TypeTest extends TestCase
                     $b = new B();
                     $b->barBar(new A);'
             ],
-            'param-coercion' => [
+            'paramCoercion' => [
                 '<?php
                     class A {}
                     class B extends A {
@@ -837,7 +834,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'param-elseif-coercion' => [
+            'paramElseifCoercion' => [
                 '<?php
                     class A {}
                     class B extends A {
@@ -861,7 +858,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'plus-plus' => [
+            'plusPlus' => [
                 '<?php
                     $a = 0;
                     $b = $a++;',
@@ -869,7 +866,7 @@ class TypeTest extends TestCase
                     ['int' => '$a']
                 ]
             ],
-            'typed-value-assertion' => [
+            'typedValueAssertion' => [
                 '<?php
                     /**
                      * @param array|string $a
@@ -882,7 +879,7 @@ class TypeTest extends TestCase
                         }
                     }'
             ],
-            'isset-with-simple-assignment' => [
+            'issetWithSimpleAssignment' => [
                 '<?php
                     $array = [];
             
@@ -892,7 +889,7 @@ class TypeTest extends TestCase
             
                     print $a;'
             ],
-            'isset-with-multiple-assignments' => [
+            'issetWithMultipleAssignments' => [
                 '<?php
                     if (rand(0, 4) > 2) {
                         $arr = [5 => [3 => "hello"]];
@@ -905,7 +902,7 @@ class TypeTest extends TestCase
                     echo $a;
                     echo $b;'
             ],
-            'is-int-on-unary-plus' => [
+            'isIntOnUnaryPlus' => [
                 '<?php
                     $a = +"5";
                     if (!is_int($a)) {
@@ -920,7 +917,7 @@ class TypeTest extends TestCase
     public function providerFileCheckerInvalidCodeParse()
     {
         return [
-            'nullable-method-call' => [
+            'nullableMethodCall' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -935,7 +932,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'nullable-method-call-with-this' => [
+            'nullableMethodCallWithThis' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -954,7 +951,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'nullable-method-with-if-guard' => [
+            'nullableMethodWithIfGuard' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -976,7 +973,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'nullable-method-with-wrong-boolean-if-guard' => [
+            'nullableMethodWithWrongBooleanIfGuard' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -998,7 +995,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'nullable-method-with-wrong-if-guarded-before' => [
+            'nullableMethodWithWrongIfGuardedBefore' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -1022,7 +1019,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'nullable-method-with-wrong-boolean-if-guard-before' => [
+            'nullableMethodWithWrongBooleanIfGuardBefore' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -1046,7 +1043,7 @@ class TypeTest extends TestCase
                     }',
                 'error_mesage' => 'PossiblyNullReference'
             ],
-            'method-with-meaningless-check' => [
+            'methodWithMeaninglessCheck' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -1065,7 +1062,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'nullable-method-with-guarded-nested-incomplete-redefinition' => [
+            'nullableMethodWithGuardedNestedIncompleteRedefinition' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -1093,7 +1090,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'nullable-method-with-guarded-switch-redefinition-no-default' => [
+            'nullableMethodWithGuardedSwitchRedefinitionNoDefault' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -1118,7 +1115,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'nullable-method-with-guarded-switch-redefinition-empty-default' => [
+            'nullableMethodWithGuardedSwitchRedefinitionEmptyDefault' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -1146,7 +1143,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'nullable-method-with-guarded-nested-redefinition-with-useless-else-return' => [
+            'nullableMethodWithGuardedNestedRedefinitionWithUselessElseReturn' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -1176,7 +1173,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'PossiblyNullReference'
             ],
-            'variable-reassignment-in-if-with-outside-call' => [
+            'variableReassignmentInIfWithOutsideCall' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -1199,7 +1196,7 @@ class TypeTest extends TestCase
                     $one->barBar();',
                 'error_message' => 'UndefinedMethod'
             ],
-            'unnecessary-instanceof' => [
+            'unnecessaryInstanceof' => [
                 '<?php
                     class One {
                         public function fooFoo() {}
@@ -1212,7 +1209,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'FailedTypeResolution'
             ],
-            'un-negatable-instanceof' => [
+            'unNegatableInstanceof' => [
                 '<?php
                     class One {
                         /** @return void */
@@ -1229,7 +1226,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'FailedTypeResolution'
             ],
-            'wrong-param' => [
+            'wrongParam' => [
                 '<?php
                     class A {}
             
@@ -1242,7 +1239,7 @@ class TypeTest extends TestCase
                     $b->barBar(5);',
                 'error_message' => 'InvalidArgument'
             ],
-            'int-to-nullable-object-param' => [
+            'intToNullableObjectParam' => [
                 '<?php
                     class A {}
             
@@ -1255,7 +1252,7 @@ class TypeTest extends TestCase
                     $b->barBar(5);',
                 'error_message' => 'InvalidArgument'
             ],
-            'param-coercion-with-bad-arg' => [
+            'paramCoercionWithBadArg' => [
                 '<?php
                     class A {}
                     class B extends A {
@@ -1273,7 +1270,7 @@ class TypeTest extends TestCase
                     }',
                 'error_message' => 'UndefinedMethod'
             ],
-            'null-check-inside-foreach-with-no-leave-statement' => [
+            'nullCheckInsideForeachWithNoLeaveStatement' => [
                 '<?php
                     $a = null;
             

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -1,1870 +1,1285 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
-use Psalm\Config;
 use Psalm\Context;
 
-class TypeTest extends PHPUnit_Framework_TestCase
+class TypeTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /**
-     * @return void
+     * @return array
      */
-    public static function setUpBeforeClass()
+    public function providerFileCheckerValidCodeParse()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-        self::$config = new TestConfig();
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(self::$config);
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(A $a = null) {
-                $a->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithTernaryGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(A $a = null) {
-                $b = $a ? $a->fooFoo() : null;
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithTernaryIfNullGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(A $a = null) {
-                $b = $a === null ? null : $a->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithTernaryEmptyGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(A $a = null) {
-                $b = empty($a) ? null : $a->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithTernaryIsNullGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(A $a = null) {
-                $b = is_null($a) ? null : $a->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithIfGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(A $a = null) {
-                if ($a) {
-                    $a->fooFoo();
-                }
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodCallWithThis()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @var A|null */
-            protected $a;
-
-            /** @return void */
-            public function barBar(A $a = null) {
-                $this->a = $a;
-                $this->a->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithTernaryGuardWithThis()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @var A|null */
-            public $a;
-
-            /** @return void */
-            public function barBar(A $a = null) {
-                $this->a = $a;
-                $b = $this->a ? $this->a->fooFoo() : null;
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithTernaryIfNullGuardWithThis()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @var A|null */
-            public $a;
-
-            /** @return void */
-            public function barBar(A $a = null) {
-                $this->a = $a;
-                $b = $this->a === null ? null : $this->a->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithIfGuardWithThis()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @var A|null */
-            public $a;
-
-            /** @return void */
-            public function barBar(A $a = null) {
-                $this->a = $a;
-
-                if ($this->a) {
-                    $this->a->fooFoo();
-                }
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodWithWrongIfGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                if ($one) {
-                    $two->fooFoo();
-                }
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithExceptionThrown()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                if (!$one) {
-                    throw new Exception();
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithRedefinitionAndElse()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @var int|null */
-            public $two;
-
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                if (!$one) {
-                    $one = new One();
-                }
-                else {
-                    $one->two = 3;
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodWithWrongBooleanIfGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                if ($one || $two) {
-                    $two->fooFoo();
-                }
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithBooleanIfGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                if ($one && $two) {
-                    $two->fooFoo();
-                }
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithNonNullBooleanIfGuard()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                if ($one !== null && $two) {
-                    $one->fooFoo();
-                }
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithNonNullBooleanIfGuardAndBooleanAnd()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                if ($one !== null && ($two || 1 + 1 === 3)) {
-                    $one->fooFoo();
-                }
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodInConditionWithIfGuardBefore()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @var string */
-            public $a = "";
-
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                if ($one === null) {
-                    return;
-                }
-
-                if (!$one->a && $one->fooFoo()) {
-                    // do something
-                }
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodWithWrongIfGuardBefore()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                if ($two === null) {
-                    return;
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithBooleanIfGuardBefore()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                if ($one === null || $two === null) {
-                    return;
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodWithWrongBooleanIfGuardBefore()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                if ($one === null && $two === null) {
-                    return;
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedRedefinition()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                if ($one === null) {
-                    $one = new One();
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedRedefinitionInElse()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                if ($one) {
-                    // do nothing
-                }
-                else {
-                    $one = new One();
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testMethodWithMeaninglessCheck()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one) {
-                if (!$one) {
-                    // do nothing
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodWithGuardedNestedIncompleteRedefinition()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null, Two $two = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    if ($a === 4) {
-                        $one = new One();
+        return [
+            'nullable-method-with-ternary-guard' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
                     }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedNestedRedefinition()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    if ($a === 4) {
-                        $one = new One();
-                    }
-                    else {
-                        $one = new One();
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedSwitchRedefinition()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    switch ($a) {
-                        case 4:
-                            $one = new One();
-                            break;
-
-                        default:
-                            $one = new One();
-                            break;
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodWithGuardedSwitchRedefinitionNoDefault()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    switch ($a) {
-                        case 4:
-                            $one = new One();
-                            break;
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodWithGuardedSwitchRedefinitionEmptyDefault()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    switch ($a) {
-                        case 4:
-                            $one = new One();
-                            break;
-
-                        default:
-                            break;
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedSwitchRedefinitionDueToException()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /**
-             * @return void
-             */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    switch ($a) {
-                        case 4:
-                            $one = new One();
-                            break;
-
-                        default:
-                            throw new \Exception("bad");
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedSwitchThatAlwaysReturns()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    switch ($a) {
-                        case 4:
-                            return;
-
-                        default:
-                            return;
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedNestedRedefinitionWithReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    if ($a === 4) {
-                        $one = new One();
-                        return;
-                    }
-                    else {
-                        $one = new One();
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedNestedRedefinitionWithElseReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    if ($a === 4) {
-                        $one = new One();
-                    }
-                    else {
-                        $one = new One();
-                        return;
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    PossiblyNullReference
-     * @return            void
-     */
-    public function testNullableMethodWithGuardedNestedRedefinitionWithUselessElseReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    if ($a === 4) {
-                        $one = new One();
-                    }
-                    else if ($a === 3) {
-                        // do nothing
-                    }
-                    else {
-                        $one = new One();
-                        return;
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedNestedRedefinitionWithElseifReturn()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                if ($one === null) {
-                    if ($a === 4) {
-                        $one = new One();
-                    }
-                    else if ($a === 3) {
-                        // do nothing
-                        return;
-                    }
-                    else {
-                        $one = new One();
-                    }
-                }
-
-                $one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullableMethodWithGuardedSwitchBreak()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @return void */
-            public function barBar(One $one = null) {
-                $a = 4;
-
-                switch ($a) {
-                    case 4:
-                        if ($one === null) {
-                            break;
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            $b = $a ? $a->fooFoo() : null;
                         }
-
-                        $one->fooFoo();
-                        break;
-                }
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
+                    }'
+            ],
+            'nullable-method-with-ternary-if-null-guard' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            $b = $a === null ? null : $a->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-ternary-empty-guard' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            $b = empty($a) ? null : $a->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-ternary-is-null-guard' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            $b = is_null($a) ? null : $a->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-if-guard' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            if ($a) {
+                                $a->fooFoo();
+                            }
+                        }
+                    }'
+            ],
+            'nullable-method-with-ternary-guard-with-this' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @var A|null */
+                        public $a;
+            
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            $this->a = $a;
+                            $b = $this->a ? $this->a->fooFoo() : null;
+                        }
+                    }'
+            ],
+            'nullable-method-with-ternary-if-null-guard-with-this' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @var A|null */
+                        public $a;
+            
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            $this->a = $a;
+                            $b = $this->a === null ? null : $this->a->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-if-guard-with-this' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @var A|null */
+                        public $a;
+            
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            $this->a = $a;
+            
+                            if ($this->a) {
+                                $this->a->fooFoo();
+                            }
+                        }
+                    }'
+            ],
+            'nullable-method-with-exception-thrown' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            if (!$one) {
+                                throw new Exception();
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-redefinition-and-else' => [
+                '<?php
+                    class One {
+                        /** @var int|null */
+                        public $two;
+            
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            if (!$one) {
+                                $one = new One();
+                            }
+                            else {
+                                $one->two = 3;
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-boolean-if-guard' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            if ($one && $two) {
+                                $two->fooFoo();
+                            }
+                        }
+                    }'
+            ],
+            'nullable-method-with-non-null-boolean-if-guard' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            if ($one !== null && $two) {
+                                $one->fooFoo();
+                            }
+                        }
+                    }'
+            ],
+            'nullable-method-with-non-null-boolean-if-guard-and-boolean-and' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            if ($one !== null && ($two || 1 + 1 === 3)) {
+                                $one->fooFoo();
+                            }
+                        }
+                    }'
+            ],
+            'nullable-method-in-condition-with-if-guard-before' => [
+                '<?php
+                    class One {
+                        /** @var string */
+                        public $a = "";
+            
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            if ($one === null) {
+                                return;
+                            }
+            
+                            if (!$one->a && $one->fooFoo()) {
+                                // do something
+                            }
+                        }
+                    }'
+            ],
+            'nullable-method-with-boolean-if-guard-before' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            if ($one === null || $two === null) {
+                                return;
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-redefinition' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            if ($one === null) {
+                                $one = new One();
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-redefinition-in-else' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            if ($one) {
+                                // do nothing
+                            }
+                            else {
+                                $one = new One();
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-nested-redefinition' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                if ($a === 4) {
+                                    $one = new One();
+                                }
+                                else {
+                                    $one = new One();
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-switch-redefinition' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                switch ($a) {
+                                    case 4:
+                                        $one = new One();
+                                        break;
+            
+                                    default:
+                                        $one = new One();
+                                        break;
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-switch-redefinition-due-to-exception' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /**
+                         * @return void
+                         */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                switch ($a) {
+                                    case 4:
+                                        $one = new One();
+                                        break;
+            
+                                    default:
+                                        throw new \Exception("bad");
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-switch-that-always-returns' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                switch ($a) {
+                                    case 4:
+                                        return;
+            
+                                    default:
+                                        return;
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-nested-redefinition-with-return' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                if ($a === 4) {
+                                    $one = new One();
+                                    return;
+                                }
+                                else {
+                                    $one = new One();
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-nested-redefinition-with-else-return' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                if ($a === 4) {
+                                    $one = new One();
+                                }
+                                else {
+                                    $one = new One();
+                                    return;
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-nested-redefinition-with-elseif-return' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                if ($a === 4) {
+                                    $one = new One();
+                                }
+                                else if ($a === 3) {
+                                    // do nothing
+                                    return;
+                                }
+                                else {
+                                    $one = new One();
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-switch-break' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            switch ($a) {
+                                case 4:
+                                    if ($one === null) {
+                                        break;
+                                    }
+            
+                                    $one->fooFoo();
+                                    break;
+                            }
+                        }
+                    }'
+            ],
+            'nullable-method-with-guarded-redefinition-on-this' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @var One|null */
+                        public $one;
+            
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $this->one = $one;
+            
+                            if ($this->one === null) {
+                                $this->one = new One();
+                            }
+            
+                            $this->one->fooFoo();
+                        }
+                    }'
+            ],
+            'array-union-type-assertion' => [
+                '<?php
+                    /** @var array|null */
+                    $ids = (1 + 1 === 2) ? [] : null;
+        
+                    if ($ids === null) {
+                        $ids = [];
+                    }',
+                'assertions' => [
+                    ['array<empty, empty>' => '$ids']
+                ]
+            ],
+            'array-union-type-assertion-with-is-array' => [
+                '<?php
+                    /** @var array|null */
+                    $ids = (1 + 1 === 2) ? [] : null;
+        
+                    if (!is_array($ids)) {
+                        $ids = [];
+                    }',
+                'assertions' => [
+                    ['array<empty, empty>' => '$ids']
+                ]
+            ],
+            '2d-array-union-type-assertion-with-is-array' => [
+                '<?php
+                    /** @return array<array<string>>|null */
+                    function foo() {
+                        $ids = rand(0, 1) ? [["hello"]] : null;
+            
+                        if (is_array($ids)) {
+                            return $ids;
+                        }
+            
+                        return null;
+                    }'
+            ],
+            'variable-reassignment' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function barBar() {}
+                    }
+            
+                    $one = new One();
+            
+                    $one = new Two();
+            
+                    $one->barBar();'
+            ],
+            'variable-reassignment-in-if' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function barBar() {}
+                    }
+            
+                    $one = new One();
+            
+                    if (1 + 1 === 2) {
+                        $one = new Two();
+            
+                        $one->barBar();
+                    }'
+            ],
+            'union-type-flow' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function barBar() {}
+                    }
+            
+                    class Three {
+                        /** @return void */
+                        public function baz() {}
+                    }
+            
+                    /** @var One|Two|Three|null */
+                    $var = null;
+            
+                    if ($var instanceof One) {
+                        $var->fooFoo();
+                    }
+                    else {
+                        if ($var instanceof Two) {
+                            $var->barBar();
+                        }
+                        else if ($var) {
+                            $var->baz();
+                        }
+                    }'
+            ],
+            'union-type-flow-with-throw' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    /** @return void */
+                    function a(One $var = null) {
+                        if (!$var) {
+                            throw new \Exception("some exception");
+                        }
+                        else {
+                            $var->fooFoo();
+                        }
+                    }'
+            ],
+            'union-type-flow-with-elseif' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    /** @var One|null */
+                    $var = null;
+            
+                    if (rand(0,100) === 5) {
+            
+                    }
+                    elseif (!$var) {
+            
+                    }
+                    else {
+                        $var->fooFoo();
+                    }'
+            ],
+            'typed-adjustment' => [
+                '<?php
+                    $var = 0;
+            
+                    if (5 + 3 === 8) {
+                        $var = "hello";
+                    }
+            
+                    echo $var;',
+                'assertions' => [
+                    ['int|string' => '$var']
+                ]
+            ],
+            'type-mixed-adjustment' => [
+                '<?php
+                    $var = 0;
+            
+                    $arr = ["hello"];
+            
+                    if (5 + 3 === 8) {
+                        $var = $arr[0];
+                    }
+            
+                    echo $var;',
+                'assertions' => [
+                    ['int|string' => '$var']
+                ]
+            ],
+            'type-adjustment-if-null' => [
+                '<?php
+                    class A {}
+                    class B {}
+            
+                    $var = rand(0,10) > 5 ? new A : null;
+            
+                    if ($var === null) {
+                        $var = new B;
+                    }',
+                'assertions' => [
+                    ['A|B' => '$var']
+                ]
+            ],
+            'while-true' => [
+                '<?php
+                    class One {
+                        /**
+                         * @return array|false
+                         */
+                        public function fooFoo(){
+                            return rand(0,100) ? ["hello"] : false;
+                        }
+            
+                        /** @return void */
+                        public function barBar(){
+                            while ($row = $this->fooFoo()) {
+                                $row[0] = "bad";
+                            }
+                        }
+                    }'
+            ],
+            'passing-param' => [
+                '<?php
+                    class A {}
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a) {}
+                    }
+            
+                    $b = new B();
+                    $b->barBar(new A);'
+            ],
+            'null-to-nullable-param' => [
+                '<?php
+                    class A {}
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a = null) {}
+                    }
+            
+                    $b = new B();
+                    $b->barBar(null);'
+            ],
+            'object-to-nullable-object-param' => [
+                '<?php
+                    class A {}
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a = null) {}
+                    }
+            
+                    $b = new B();
+                    $b->barBar(new A);'
+            ],
+            'param-coercion' => [
+                '<?php
+                    class A {}
+                    class B extends A {
+                        /** @return void */
+                        public function barBar() {}
+                    }
+            
+                    class C {
+                        /** @return void */
+                        function fooFoo(A $a) {
+                            if ($a instanceof B) {
+                                $a->barBar();
+                            }
+                        }
+                    }'
+            ],
+            'param-elseif-coercion' => [
+                '<?php
+                    class A {}
+                    class B extends A {
+                        /** @return void */
+                        public function barBar() {}
+                    }
+                    class C extends A {
+                        /** @return void */
+                        public function baz() {}
+                    }
+            
+                    class D {
+                        /** @return void */
+                        function fooFoo(A $a) {
+                            if ($a instanceof B) {
+                                $a->barBar();
+                            }
+                            elseif ($a instanceof C) {
+                                $a->baz();
+                            }
+                        }
+                    }'
+            ],
+            'plus-plus' => [
+                '<?php
+                    $a = 0;
+                    $b = $a++;',
+                'assertions' => [
+                    ['int' => '$a']
+                ]
+            ],
+            'typed-value-assertion' => [
+                '<?php
+                    /**
+                     * @param array|string $a
+                     */
+                    function fooFoo($a) : void {
+                        $b = "aadad";
+            
+                        if ($a === $b) {
+                            echo substr($a, 1);
+                        }
+                    }'
+            ],
+            'isset-with-simple-assignment' => [
+                '<?php
+                    $array = [];
+            
+                    if (isset($array[$a = 5])) {
+                        print "hello";
+                    }
+            
+                    print $a;'
+            ],
+            'isset-with-multiple-assignments' => [
+                '<?php
+                    if (rand(0, 4) > 2) {
+                        $arr = [5 => [3 => "hello"]];
+                    }
+            
+                    if (isset($arr[$a = 5][$b = 3])) {
+            
+                    }
+            
+                    echo $a;
+                    echo $b;'
+            ],
+            'is-int-on-unary-plus' => [
+                '<?php
+                    $a = +"5";
+                    if (!is_int($a)) {
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @return void
+     * @return array
      */
-    public function testNullableMethodWithGuardedRedefinitionOnThis()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class B {
-            /** @var One|null */
-            public $one;
-
-            /** @return void */
-            public function barBar(One $one = null) {
-                $this->one = $one;
-
-                if ($this->one === null) {
-                    $this->one = new One();
-                }
-
-                $this->one->fooFoo();
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayUnionTypeAssertion()
-    {
-        $stmts = self::$parser->parse('<?php
-            /** @var array|null */
-            $ids = (1 + 1 === 2) ? [] : null;
-
-            if ($ids === null) {
-                $ids = [];
-            }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<empty, empty>', (string) $context->vars_in_scope['$ids']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testArrayUnionTypeAssertionWithIsArray()
-    {
-        $stmts = self::$parser->parse('<?php
-            /** @var array|null */
-            $ids = (1 + 1 === 2) ? [] : null;
-
-            if (!is_array($ids)) {
-                $ids = [];
-            }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('array<empty, empty>', (string) $context->vars_in_scope['$ids']);
-    }
-
-    /**
-     * @return void
-     */
-    public function test2DArrayUnionTypeAssertionWithIsArray()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return array<array<string>>|null */
-        function foo() {
-            $ids = rand(0, 1) ? [["hello"]] : null;
-
-            if (is_array($ids)) {
-                return $ids;
-            }
-
-            return null;
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testVariableReassignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function barBar() {}
-        }
-
-        $one = new One();
-
-        $one = new Two();
-
-        $one->barBar();
-
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testVariableReassignmentInIf()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function barBar() {}
-        }
-
-        $one = new One();
-
-        if (1 + 1 === 2) {
-            $one = new Two();
-
-            $one->barBar();
-        }
-
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    UndefinedMethod
-     * @return                      void
-     */
-    public function testVariableReassignmentInIfWithOutsideCall()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function barBar() {}
-        }
-
-        $one = new One();
-
-        if (1 + 1 === 2) {
-            $one = new Two();
-
-            $one->barBar();
-        }
-
-        $one->barBar();
-
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testUnionTypeFlow()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        class Two {
-            /** @return void */
-            public function barBar() {}
-        }
-
-        class Three {
-            /** @return void */
-            public function baz() {}
-        }
-
-        /** @var One|Two|Three|null */
-        $var = null;
-
-        if ($var instanceof One) {
-            $var->fooFoo();
-        }
-        else {
-            if ($var instanceof Two) {
-                $var->barBar();
-            }
-            else if ($var) {
-                $var->baz();
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testUnionTypeFlowWithThrow()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        /** @return void */
-        function a(One $var = null) {
-            if (!$var) {
-                throw new \Exception("some exception");
-            }
-            else {
-                $var->fooFoo();
-            }
-        }
-
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testUnionTypeFlowWithElseif()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        /** @var One|null */
-        $var = null;
-
-        if (rand(0,100) === 5) {
-
-        }
-        elseif (!$var) {
-
-        }
-        else {
-            $var->fooFoo();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    FailedTypeResolution
-     * @return                      void
-     */
-    public function testUnnecessaryInstanceof()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            public function fooFoo() {}
-        }
-
-        $var = new One();
-
-        if ($var instanceof One) {
-            $var->fooFoo();
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException \Psalm\Exception\CodeException
-     * @return            void
-     */
-    public function testUnNegatableInstanceof()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /** @return void */
-            public function fooFoo() {}
-        }
-
-        $var = new One();
-
-        if ($var instanceof One) {
-            $var->fooFoo();
-        }
-        else {
-            // do something
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testTypeAdjustment()
-    {
-        $stmts = self::$parser->parse('<?php
-        $var = 0;
-
-        if (5 + 3 === 8) {
-            $var = "hello";
-        }
-
-        echo $var;
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int|string', (string) $context->vars_in_scope['$var']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testTypeMixedAdjustment()
-    {
-        $stmts = self::$parser->parse('<?php
-        $var = 0;
-
-        $arr = ["hello"];
-
-        if (5 + 3 === 8) {
-            $var = $arr[0];
-        }
-
-        echo $var;
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('int|string', (string) $context->vars_in_scope['$var']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testTypeAdjustmentIfNull()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B {}
-
-        $var = rand(0,10) > 5 ? new A : null;
-
-        if ($var === null) {
-            $var = new B;
-        }
-        ');
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->assertEquals('A|B', (string) $context->vars_in_scope['$var']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testWhileTrue()
-    {
-        $stmts = self::$parser->parse('<?php
-        class One {
-            /**
-             * @return array|false
-             */
-            public function fooFoo(){
-                return rand(0,100) ? ["hello"] : false;
-            }
-
-            /** @return void */
-            public function barBar(){
-                while ($row = $this->fooFoo()) {
-                    $row[0] = "bad";
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    InvalidArgument
-     * @return                      void
-     */
-    public function testWrongParam()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-
-        class B {
-            /** @return void */
-            public function barBar(A $a) {}
-        }
-
-        $b = new B();
-        $b->barBar(5);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testPassingParam()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-
-        class B {
-            /** @return void */
-            public function barBar(A $a) {}
-        }
-
-        $b = new B();
-        $b->barBar(new A);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testNullToNullableParam()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-
-        class B {
-            /** @return void */
-            public function barBar(A $a = null) {}
-        }
-
-        $b = new B();
-        $b->barBar(null);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    InvalidArgument
-     * @return                      void
-     */
-    public function testIntToNullableObjectParam()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-
-        class B {
-            /** @return void */
-            public function barBar(A $a = null) {}
-        }
-
-        $b = new B();
-        $b->barBar(5);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testObjectToNullableObjectParam()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-
-        class B {
-            /** @return void */
-            public function barBar(A $a = null) {}
-        }
-
-        $b = new B();
-        $b->barBar(new A);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException           \Psalm\Exception\CodeException
-     * @expectedExceptionMessage    UndefinedMethod
-     * @return                      void
-     */
-    public function testParamCoercionWithBadArg()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A {
-            /** @return void */
-            public function blab() {}
-        }
-
-        class C {
-            /** @return void */
-            function fooFoo(A $a) {
-                if ($a instanceof B) {
-                    $a->barBar();
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testParamCoercion()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A {
-            /** @return void */
-            public function barBar() {}
-        }
-
-        class C {
-            /** @return void */
-            function fooFoo(A $a) {
-                if ($a instanceof B) {
-                    $a->barBar();
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testParamElseifCoercion()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A {}
-        class B extends A {
-            /** @return void */
-            public function barBar() {}
-        }
-        class C extends A {
-            /** @return void */
-            public function baz() {}
-        }
-
-        class D {
-            /** @return void */
-            function fooFoo(A $a) {
-                if ($a instanceof B) {
-                    $a->barBar();
-                }
-                elseif ($a instanceof C) {
-                    $a->baz();
-                }
-            }
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage NullReference
-     * @return                   void
-     */
-    public function testNullCheckInsideForeachWithNoLeaveStatement()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = null;
-
-        $a->fooBar();
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods();
-    }
-
-    /**
-     * @return void
-     */
-    public function testPlusPlus()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = 0;
-        $b = $a++;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-
-        $this->assertSame('int', (string) $context->vars_in_scope['$a']);
-    }
-
-    /**
-     * @return void
-     */
-    public function testTypedValueAssertion()
-    {
-        $context = new Context();
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param array|string $a
-         */
-        function fooFoo($a) : void {
-            $b = "aadad";
-
-            if ($a === $b) {
-                echo substr($a, 1);
-            }
-        }');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIssetWithSimpleAssignment()
-    {
-        $stmts = self::$parser->parse('<?php
-        $array = [];
-
-        if (isset($array[$a = 5])) {
-            print "hello";
-        }
-
-        print $a;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIssetWithMultipleAssignments()
-    {
-        $stmts = self::$parser->parse('<?php
-        if (rand(0, 4) > 2) {
-            $arr = [5 => [3 => "hello"]];
-        }
-
-        if (isset($arr[$a = 5][$b = 3])) {
-
-        }
-
-        echo $a;
-        echo $b;
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testIsIntOnUnaryPlus()
-    {
-        $stmts = self::$parser->parse('<?php
-        $a = +"5";
-        if (!is_int($a)) {
-        }
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
+        return [
+            'nullable-method-call' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            $a->fooFoo();
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'nullable-method-call-with-this' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @var A|null */
+                        protected $a;
+            
+                        /** @return void */
+                        public function barBar(A $a = null) {
+                            $this->a = $a;
+                            $this->a->fooFoo();
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'nullable-method-with-if-guard' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            if ($one) {
+                                $two->fooFoo();
+                            }
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'nullable-method-with-wrong-boolean-if-guard' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            if ($one || $two) {
+                                $two->fooFoo();
+                            }
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'nullable-method-with-wrong-if-guarded-before' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            if ($two === null) {
+                                return;
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'nullable-method-with-wrong-boolean-if-guard-before' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            if ($one === null && $two === null) {
+                                return;
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }',
+                'error_mesage' => 'PossiblyNullReference'
+            ],
+            'method-with-meaningless-check' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one) {
+                            if (!$one) {
+                                // do nothing
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'nullable-method-with-guarded-nested-incomplete-redefinition' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null, Two $two = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                if ($a === 4) {
+                                    $one = new One();
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'nullable-method-with-guarded-switch-redefinition-no-default' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                switch ($a) {
+                                    case 4:
+                                        $one = new One();
+                                        break;
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'nullable-method-with-guarded-switch-redefinition-empty-default' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                switch ($a) {
+                                    case 4:
+                                        $one = new One();
+                                        break;
+            
+                                    default:
+                                        break;
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'nullable-method-with-guarded-nested-redefinition-with-useless-else-return' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(One $one = null) {
+                            $a = 4;
+            
+                            if ($one === null) {
+                                if ($a === 4) {
+                                    $one = new One();
+                                }
+                                else if ($a === 3) {
+                                    // do nothing
+                                }
+                                else {
+                                    $one = new One();
+                                    return;
+                                }
+                            }
+            
+                            $one->fooFoo();
+                        }
+                    }',
+                'error_message' => 'PossiblyNullReference'
+            ],
+            'variable-reassignment-in-if-with-outside-call' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    class Two {
+                        /** @return void */
+                        public function barBar() {}
+                    }
+            
+                    $one = new One();
+            
+                    if (1 + 1 === 2) {
+                        $one = new Two();
+            
+                        $one->barBar();
+                    }
+            
+                    $one->barBar();',
+                'error_message' => 'UndefinedMethod'
+            ],
+            'unnecessary-instanceof' => [
+                '<?php
+                    class One {
+                        public function fooFoo() {}
+                    }
+            
+                    $var = new One();
+            
+                    if ($var instanceof One) {
+                        $var->fooFoo();
+                    }',
+                'error_message' => 'FailedTypeResolution'
+            ],
+            'un-negatable-instanceof' => [
+                '<?php
+                    class One {
+                        /** @return void */
+                        public function fooFoo() {}
+                    }
+            
+                    $var = new One();
+            
+                    if ($var instanceof One) {
+                        $var->fooFoo();
+                    }
+                    else {
+                        // do something
+                    }',
+                'error_message' => 'FailedTypeResolution'
+            ],
+            'wrong-param' => [
+                '<?php
+                    class A {}
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a) {}
+                    }
+            
+                    $b = new B();
+                    $b->barBar(5);',
+                'error_message' => 'InvalidArgument'
+            ],
+            'int-to-nullable-object-param' => [
+                '<?php
+                    class A {}
+            
+                    class B {
+                        /** @return void */
+                        public function barBar(A $a = null) {}
+                    }
+            
+                    $b = new B();
+                    $b->barBar(5);',
+                'error_message' => 'InvalidArgument'
+            ],
+            'param-coercion-with-bad-arg' => [
+                '<?php
+                    class A {}
+                    class B extends A {
+                        /** @return void */
+                        public function blab() {}
+                    }
+            
+                    class C {
+                        /** @return void */
+                        function fooFoo(A $a) {
+                            if ($a instanceof B) {
+                                $a->barBar();
+                            }
+                        }
+                    }',
+                'error_message' => 'UndefinedMethod'
+            ],
+            'null-check-inside-foreach-with-no-leave-statement' => [
+                '<?php
+                    $a = null;
+            
+                    $a->fooBar();',
+                'error_message' => 'NullReference'
+            ]
+        ];
     }
 }

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -104,7 +104,7 @@ class UnusedCodeTest extends TestCase
                     }',
                 'error_message' => 'UnusedVariable'
             ],
-            'if-in-function' => [
+            'ifInFunction' => [
                 '<?php
                     /** @return int */
                     function foo() {
@@ -127,12 +127,12 @@ class UnusedCodeTest extends TestCase
     public function providerTestUnusedCodeWithClassReferences()
     {
         return [
-            'unused-class' => [
+            'unusedClass' => [
                 '<?php
                     class A { }',
                 'error_message' => 'UnusedClass'
             ],
-            'public-unused-method' => [
+            'publicUnusedMethod' => [
                 '<?php
                     class A {
                         /** @return void */
@@ -142,7 +142,7 @@ class UnusedCodeTest extends TestCase
                     new A();',
                 'error_message' => 'PossiblyUnusedMethod'
             ],
-            'private-unused-method' => [
+            'privateUnusedMethod' => [
                 '<?php
                     class A {
                         /** @return void */

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1,16 +1,14 @@
 <?php
 namespace Psalm\Tests;
 
-use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
 use Psalm\Config;
 use Psalm\Context;
 
-class UnusedCodeTest extends PHPUnit_Framework_TestCase
+class UnusedCodeTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
+    use Traits\FileCheckerInvalidCodeParseTestTrait;
+    use Traits\FileCheckerValidCodeParseTestTrait;
 
     /** @var string */
     protected static $project_dir;
@@ -23,7 +21,7 @@ class UnusedCodeTest extends PHPUnit_Framework_TestCase
      */
     public static function setUpBeforeClass()
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
+        parent::setUpBeforeClass();
         self::$project_dir = getcwd() . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
     }
 
@@ -47,87 +45,22 @@ class UnusedCodeTest extends PHPUnit_Framework_TestCase
                 </projectFiles>
             </psalm>'
         ));
+
         $this->project_checker->collect_references = true;
     }
 
     /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UnusedVariable
-     * @return                   void
-     */
-    public function testFunction()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return int */
-        function foo() {
-            $a = 5;
-            $b = [];
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker(self::$project_dir . 'somefile.php', $this->project_checker, $stmts);
-
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UnusedVariable
-     * @return                   void
-     */
-    public function testIfInFunction()
-    {
-        $stmts = self::$parser->parse('<?php
-        /** @return int */
-        function foo() {
-            $a = 5;
-            if (rand(0, 1)) {
-                $b = "hello";
-            } else {
-                $b = "goodbye";
-            }
-            return $a;
-        }
-        ');
-
-        $file_checker = new FileChecker(self::$project_dir . 'somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
+     * @dataProvider providerTestUnusedCodeWithClassReferences
+     * @param string $code
+     * @param string $error_message
      * @return void
      */
-    public function testUnset()
+    public function testUnusedCodeWithClassReferences($code, $error_message)
     {
-        $stmts = self::$parser->parse('<?php
-        /** @return void */
-        function foo() {
-            $a = 0;
+        $this->expectException('\Psalm\Exception\CodeException');
+        $this->expectExceptionMessage($error_message);
 
-            $arr = ["hello"];
-
-            unset($arr[$a]);
-        }
-        ');
-
-        $file_checker = new FileChecker(self::$project_dir . 'somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UnusedClass
-     * @return                   void
-     */
-    public function testUnusedClass()
-    {
-        $stmts = self::$parser->parse('<?php
-        class A { }
-        ');
+        $stmts = self::$parser->parse($code);
 
         $file_checker = new FileChecker(self::$project_dir . 'somefile.php', $this->project_checker, $stmts);
         $context = new Context();
@@ -136,46 +69,89 @@ class UnusedCodeTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage PossiblyUnusedMethod
-     * @return                   void
+     * @return array
      */
-    public function testPublicUnusedMethod()
+    public function providerFileCheckerValidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            public function foo() {}
-        }
-
-        new A();
-        ');
-
-        $file_checker = new FileChecker(self::$project_dir . 'somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->project_checker->checkClassReferences();
+        return [
+            'unset' => [
+                '<?php
+                    /** @return void */
+                    function foo() {
+                        $a = 0;
+            
+                        $arr = ["hello"];
+            
+                        unset($arr[$a]);
+                    }'
+            ]
+        ];
     }
 
     /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage UnusedMethod
-     * @return                   void
+     * @return array
      */
-    public function testPrivateUnusedMethod()
+    public function providerFileCheckerInvalidCodeParse()
     {
-        $stmts = self::$parser->parse('<?php
-        class A {
-            /** @return void */
-            private function foo() {}
-        }
+        return [
+            'function' => [
+                '<?php
+                    /** @return int */
+                    function foo() {
+                        $a = 5;
+                        $b = [];
+                        return $a;
+                    }',
+                'error_message' => 'UnusedVariable'
+            ],
+            'if-in-function' => [
+                '<?php
+                    /** @return int */
+                    function foo() {
+                        $a = 5;
+                        if (rand(0, 1)) {
+                            $b = "hello";
+                        } else {
+                            $b = "goodbye";
+                        }
+                        return $a;
+                    }',
+                'error_message' => 'UnusedVariable'
+            ]
+        ];
+    }
 
-        new A();
-        ');
-
-        $file_checker = new FileChecker(self::$project_dir . 'somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-        $this->project_checker->checkClassReferences();
+    /**
+     * @return array
+     */
+    public function providerTestUnusedCodeWithClassReferences()
+    {
+        return [
+            'unused-class' => [
+                '<?php
+                    class A { }',
+                'error_message' => 'UnusedClass'
+            ],
+            'public-unused-method' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        public function foo() {}
+                    }
+            
+                    new A();',
+                'error_message' => 'PossiblyUnusedMethod'
+            ],
+            'private-unused-method' => [
+                '<?php
+                    class A {
+                        /** @return void */
+                        private function foo() {}
+                    }
+            
+                    new A();',
+                'error_message' => 'UnusedMethod'
+            ]
+        ];
     }
 }

--- a/tests/VariadicTest.php
+++ b/tests/VariadicTest.php
@@ -64,7 +64,7 @@ class VariadicTest extends TestCase
                 f(1, 2, 3, 4);
                 f(1, 2, 3, 4, 5);'
             ],
-            'variadic-array' => [
+            'variadicArray' => [
                 '<?php
                     /**
                      * @param array<int, int> $a_list

--- a/tests/VariadicTest.php
+++ b/tests/VariadicTest.php
@@ -2,98 +2,19 @@
 namespace Psalm\Tests;
 
 use PhpParser\ParserFactory;
-use PHPUnit_Framework_TestCase;
 use Psalm\Checker\FileChecker;
-use Psalm\Config;
 use Psalm\Context;
 
-class VariadicTest extends PHPUnit_Framework_TestCase
+class VariadicTest extends TestCase
 {
-    /** @var \PhpParser\Parser */
-    protected static $parser;
-
-    /** @var TestConfig */
-    protected static $config;
-
-    /** @var \Psalm\Checker\ProjectChecker */
-    protected $project_checker;
-
     /**
+     * @dataProvider providerTestValidVariadic
+     * @param string $code
      * @return void
      */
-    public static function setUpBeforeClass()
+    public function testVariadic($code)
     {
-        self::$parser = (new ParserFactory)->create(ParserFactory::PREFER_PHP7);
-    }
-
-    /**
-     * @return void
-     */
-    public function setUp()
-    {
-        FileChecker::clearCache();
-        $this->project_checker = new \Psalm\Checker\ProjectChecker();
-        $this->project_checker->setConfig(new TestConfig());
-    }
-
-    /**
-     * @return void
-     */
-    public function testVariadic()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @return array<mixed>
-         */
-        function f($req, $opt = null, ...$params) {
-            return $params;
-        }
-
-        f(1);
-        f(1, 2);
-        f(1, 2, 3);
-        f(1, 2, 3, 4);
-        f(1, 2, 3, 4, 5);
-        ');
-
-        $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
-        $context = new Context();
-        $file_checker->visitAndAnalyzeMethods($context);
-    }
-
-    /**
-     * @return void
-     */
-    public function testVariadicArray()
-    {
-        $stmts = self::$parser->parse('<?php
-        /**
-         * @param array<int, int> $a_list
-         * @return array<int, int>
-         */
-        function f(int ...$a_list) {
-            return array_map(
-                /**
-                 * @return int
-                 */
-                function (int $a) {
-                    return $a + 1;
-                },
-                $a_list
-            );
-        }
-
-        f(1);
-        f(1, 2);
-        f(1, 2, 3);
-
-        /**
-         * @param string ...$a_list
-         * @return void
-         */
-        function g(string ...$a_list) {
-        }
-        ');
+        $stmts = self::$parser->parse($code);
 
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context();
@@ -120,5 +41,58 @@ class VariadicTest extends PHPUnit_Framework_TestCase
         $file_checker = new FileChecker('somefile.php', $this->project_checker, $stmts);
         $context = new Context();
         $file_checker->visitAndAnalyzeMethods($context);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerTestValidVariadic()
+    {
+        return [
+            'variadic' => [
+                '<?php
+                /**
+                 * @return array<mixed>
+                 */
+                function f($req, $opt = null, ...$params) {
+                    return $params;
+                }
+        
+                f(1);
+                f(1, 2);
+                f(1, 2, 3);
+                f(1, 2, 3, 4);
+                f(1, 2, 3, 4, 5);'
+            ],
+            'variadic-array' => [
+                '<?php
+                    /**
+                     * @param array<int, int> $a_list
+                     * @return array<int, int>
+                     */
+                    function f(int ...$a_list) {
+                        return array_map(
+                            /**
+                             * @return int
+                             */
+                            function (int $a) {
+                                return $a + 1;
+                            },
+                            $a_list
+                        );
+                    }
+            
+                    f(1);
+                    f(1, 2);
+                    f(1, 2, 3);
+            
+                    /**
+                     * @param string ...$a_list
+                     * @return void
+                     */
+                    function g(string ...$a_list) {
+                    }'
+            ]
+        ];
     }
 }


### PR DESCRIPTION
*This is a massive PR. I'm sorry.*

### Summary
I've gone through every unit test to rewrite, and streamline them with a consistent PHPUnit dataProvider framework.

### Why
The main problem that I found with the existing test suite was that every test was full of the same basic test case:

1. Take a piece of code.
2. Pass it into `$stmts = self::$parser->parse($code);`
3. Run `(new FileChecker('somefile.php', $this->project_checker, $stmts))->visitAndAnalyzeMethods();`
4. If we are looking for failures, verify that a `\Psalm\Exception\CodeException` exception was thrown.

With this, it didn't make any sense to not do this as the maintainability gains are immediately apparent. When you need to change a use case, you only need to change it once instead of messing with IDE refactoring. 

Having a common framework in place for tests also makes it easier for new people to come in and add/fix/update tests for new features and bug fixes.

Frankly, before this, it was incredibly daunting.

And less important to maintainability and overall friendliness, doing this also removed a **lot** of repeated test code that added upwards of 100KB+.

### Details
Since the majority of the unit test suite was doing a code parse and `FileChecker->visitAndAnalyzeMethods` analysis, I've pulled these into a `FileCheckerInvalidCodeParseTestTrait` and `FileCheckerValidCodeParseTestTrait` trait. These do as they're named. Given a piece of code and some options, they either check that it's valid, or invalid (throws exceptions).

#### Framework
Since these tests are now utilizing a common framework for validation and invalidation of code, there needed to be some special cases written in to support PHP 7 and skipped tests with the data providers.

* For test cases that require >= PHP7, you can prefix the data provider name with `PHP7-`. If the test is not run on PHP 7, it is marked as skipped with the following message: "Test case requires PHP 7."
* For tests that need to be skipped, you can do the same, but with `SKIPPED-`. They will then be marked as skipped with the following message: "Skipped due to a bug."