### PR TITLE
Allow Psalm to be run outside of the directory it's installed in

### DIFF
--- a/bin/psalm
+++ b/bin/psalm
@@ -61,7 +61,7 @@ Options:
         Enable monochrome output
 
     -r, --root
-        If running as a global
+        If running Psalm globally you'll need to specify a project root. Defaults to cwd
 
     --show-info[=BOOLEAN]
         Show non-exception parser findings

--- a/bin/psalm
+++ b/bin/psalm
@@ -98,7 +98,7 @@ if (isset($options['root'])) {
     $options['r'] = $options['root'];
 }
 
-$root_dir = dirname(__DIR__);
+$root_dir = (string)getcwd();
 
 if (isset($options['r'])) {
     $root_path = realpath($options['r']);
@@ -121,7 +121,13 @@ foreach ([$root_dir . '/../../autoload.php', $root_dir . '/vendor/autoload.php']
 }
 
 if (!$autoloader_found) {
-    die('Could not find any composer autoloaders in ' . $root_dir . PHP_EOL);
+    $error_message = 'Could not find any composer autoloaders in ' . $root_dir;
+
+    if (!isset($options['r'])) {
+        $error_message .= PHP_EOL . 'Add a --root=[your/project/directory] flag to specify a particular project to run Psalm on.';
+    }
+
+    die($error_message . PHP_EOL);
 }
 
 if (isset($options['r'])) {

--- a/bin/psalm
+++ b/bin/psalm
@@ -1,16 +1,6 @@
 #!/usr/bin/env php
 <?php
 
-foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php'] as $file) {
-    if (file_exists($file)) {
-        require $file;
-        break;
-    }
-}
-
-use Psalm\Checker\FileChecker;
-use Psalm\Checker\ProjectChecker;
-
 // show all errors
 error_reporting(-1);
 ini_set('display_errors', 1);
@@ -20,11 +10,11 @@ ini_set('xdebug.max_nesting_level', 512);
 
 // get options from command line
 $options = getopt(
-    'f:mhc:i',
+    'f:mhc:ir:',
     [
         'help', 'debug', 'config:', 'monochrome', 'show-info:', 'diff',
         'file:', 'self-check', 'update-docblocks', 'output-format:',
-        'find-dead-code', 'init', 'find-references-to:',
+        'find-dead-code', 'init', 'find-references-to:', 'root:',
     ]
 );
 
@@ -70,6 +60,9 @@ Options:
     -m, --monochrome
         Enable monochrome output
 
+    -r, --root
+        If running as a global
+
     --show-info[=BOOLEAN]
         Show non-exception parser findings
 
@@ -99,6 +92,40 @@ HELP;
 
 if (getcwd() === false) {
     die('Cannot get current working directory');
+}
+
+if (isset($options['root'])) {
+    $options['r'] = $options['root'];
+}
+
+$root_dir = dirname(__DIR__);
+
+if (isset($options['r'])) {
+    $root_path = realpath($options['r']);
+
+    if (!$root_path) {
+        die('Could not locate root directory ' . getcwd() . DIRECTORY_SEPARATOR . $options['r'] . PHP_EOL);
+    }
+
+    $root_dir = $root_path;
+}
+
+$autoloader_found = false;
+
+foreach ([$root_dir . '/../../autoload.php', $root_dir . '/vendor/autoload.php'] as $file) {
+    if (file_exists($file)) {
+        require $file;
+        $autoloader_found = true;
+        break;
+    }
+}
+
+if (!$autoloader_found) {
+    die('Could not find any composer autoloaders in ' . $root_dir . PHP_EOL);
+}
+
+if (isset($options['r'])) {
+    $options['r'] = $options['root'];
 }
 
 if (isset($options['i'])) {
@@ -137,7 +164,7 @@ if (isset($options['i'])) {
         die('The given path "' . $bad_dir_path . '" does not appear to be a directory' . PHP_EOL);
     }
 
-    $template_file_name = dirname(__DIR__) . '/assets/config_levels/' . $level . '.xml';
+    $template_file_name = dirname($root_dir) . '/assets/config_levels/' . $level . '.xml';
 
     if (!file_exists($template_file_name)) {
         die('Could not open config template' . PHP_EOL);
@@ -157,6 +184,9 @@ if (isset($options['i'])) {
 
     exit('Config file created successfully. Please re-run psalm.' . PHP_EOL);
 }
+
+use Psalm\Checker\FileChecker;
+use Psalm\Checker\ProjectChecker;
 
 // get vars from options
 $debug = array_key_exists('debug', $options);
@@ -256,7 +286,7 @@ $project_checker = new ProjectChecker(
 
 // initialise custom config, if passed
 if ($path_to_config) {
-    $project_checker->setConfigXML($path_to_config);
+    $project_checker->setConfigXML($path_to_config, $root_dir);
 }
 
 // If XDebug is enabled, restart without it
@@ -267,13 +297,13 @@ if ($path_to_config) {
 if (array_key_exists('self-check', $options)) {
     $project_checker->checkDir(dirname(__DIR__) . '/src');
 } elseif ($paths_to_check === null) {
-    $project_checker->check($is_diff);
+    $project_checker->check($root_dir, $is_diff);
 } elseif ($paths_to_check) {
     foreach ($paths_to_check as $path_to_check) {
         if (is_dir($path_to_check)) {
-            $project_checker->checkDir($path_to_check);
+            $project_checker->checkDir($path_to_check, $root_dir);
         } else {
-            $project_checker->checkFile($path_to_check);
+            $project_checker->checkFile($path_to_check, $root_dir);
         }
     }
 }

--- a/bin/psalm
+++ b/bin/psalm
@@ -98,40 +98,58 @@ if (isset($options['root'])) {
     $options['r'] = $options['root'];
 }
 
-$root_dir = (string)getcwd();
+$current_dir = (string)getcwd() . DIRECTORY_SEPARATOR;
 
 if (isset($options['r'])) {
     $root_path = realpath($options['r']);
 
     if (!$root_path) {
-        die('Could not locate root directory ' . getcwd() . DIRECTORY_SEPARATOR . $options['r'] . PHP_EOL);
+        die('Could not locate root directory ' . $current_dir . DIRECTORY_SEPARATOR . $options['r'] . PHP_EOL);
     }
 
-    $root_dir = $root_path;
+    $current_dir = $root_path . DIRECTORY_SEPARATOR;
 }
 
-$autoloader_found = false;
+$autoload_roots = [$current_dir];
 
-foreach ([$root_dir . '/../../autoload.php', $root_dir . '/vendor/autoload.php'] as $file) {
-    if (file_exists($file)) {
-        require $file;
-        $autoloader_found = true;
-        break;
+$psalm_dir = dirname(__DIR__);
+
+if (realpath($psalm_dir) !== realpath($current_dir)) {
+    $autoload_roots[] = $psalm_dir;
+}
+
+$autoload_files = [];
+
+foreach ($autoload_roots as $autoload_root) {
+    $has_autoloader = false;
+
+    $nested_autoload_file = dirname(dirname($autoload_root)) . DIRECTORY_SEPARATOR . 'autoload.php';
+
+    if (file_exists($nested_autoload_file)) {
+        $autoload_files[] = realpath($nested_autoload_file);
+        $has_autoloader = true;
+    }
+
+    $vendor_autoload_file = $autoload_root . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'autoload.php';
+
+    if (file_exists($vendor_autoload_file)) {
+        $autoload_files[] = realpath($vendor_autoload_file);
+        $has_autoloader = true;
+    }
+
+    if (!$has_autoloader) {
+        $error_message = 'Could not find any composer autoloaders in ' . $autoload_root;
+
+        if (!isset($options['r'])) {
+            $error_message .= PHP_EOL . 'Add a --root=[your/project/directory] flag to specify a particular project to run Psalm on.';
+        }
+
+        die($error_message . PHP_EOL);
     }
 }
 
-if (!$autoloader_found) {
-    $error_message = 'Could not find any composer autoloaders in ' . $root_dir;
-
-    if (!isset($options['r'])) {
-        $error_message .= PHP_EOL . 'Add a --root=[your/project/directory] flag to specify a particular project to run Psalm on.';
-    }
-
-    die($error_message . PHP_EOL);
-}
-
-if (isset($options['r'])) {
-    $options['r'] = $options['root'];
+foreach ($autoload_files as $file) {
+    require_once $file;
 }
 
 if (isset($options['i'])) {
@@ -170,7 +188,7 @@ if (isset($options['i'])) {
         die('The given path "' . $bad_dir_path . '" does not appear to be a directory' . PHP_EOL);
     }
 
-    $template_file_name = dirname($root_dir) . '/assets/config_levels/' . $level . '.xml';
+    $template_file_name = dirname($current_dir) . '/assets/config_levels/' . $level . '.xml';
 
     if (!file_exists($template_file_name)) {
         die('Could not open config template' . PHP_EOL);
@@ -292,7 +310,7 @@ $project_checker = new ProjectChecker(
 
 // initialise custom config, if passed
 if ($path_to_config) {
-    $project_checker->setConfigXML($path_to_config, $root_dir);
+    $project_checker->setConfigXML($path_to_config, $current_dir);
 }
 
 // If XDebug is enabled, restart without it
@@ -303,13 +321,13 @@ if ($path_to_config) {
 if (array_key_exists('self-check', $options)) {
     $project_checker->checkDir(dirname(__DIR__) . '/src');
 } elseif ($paths_to_check === null) {
-    $project_checker->check($root_dir, $is_diff);
+    $project_checker->check($current_dir, $is_diff);
 } elseif ($paths_to_check) {
     foreach ($paths_to_check as $path_to_check) {
         if (is_dir($path_to_check)) {
-            $project_checker->checkDir($path_to_check, $root_dir);
+            $project_checker->checkDir($path_to_check, $current_dir);
         } else {
-            $project_checker->checkFile($path_to_check, $root_dir);
+            $project_checker->checkFile($path_to_check, $current_dir);
         }
     }
 }

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -233,21 +233,20 @@ class ProjectChecker
     }
 
     /**
+     * @param  string  $base_dir
      * @param  boolean $is_diff
      * @return void
      */
-    public function check($is_diff = false)
+    public function check($base_dir, $is_diff = false)
     {
-        $cwd = getcwd();
-
         $start_checks = (int)microtime(true);
 
-        if (!$cwd) {
-            throw new \InvalidArgumentException('Cannot work with empty cwd');
+        if (!$base_dir) {
+            throw new \InvalidArgumentException('Cannot work with empty base_dir');
         }
 
         if (!$this->config) {
-            $this->config = $this->getConfigForPath($cwd);
+            $this->config = $this->getConfigForPath($base_dir, $base_dir);
         }
 
         $diff_files = null;
@@ -515,12 +514,13 @@ class ProjectChecker
 
     /**
      * @param  string  $dir_name
+     * @param  string  $base_dir
      * @return void
      */
-    public function checkDir($dir_name)
+    public function checkDir($dir_name, $base_dir)
     {
         if (!$this->config) {
-            $this->config = $this->getConfigForPath($dir_name);
+            $this->config = $this->getConfigForPath($dir_name, $base_dir);
             $this->config->hide_external_errors = $this->config->isInProjectDirs($dir_name . DIRECTORY_SEPARATOR);
         }
 
@@ -657,16 +657,17 @@ class ProjectChecker
 
     /**
      * @param  string  $file_path
+     * @param  string  $base_dir
      * @return void
      */
-    public function checkFile($file_path)
+    public function checkFile($file_path, $base_dir)
     {
         if ($this->debug_output) {
             echo 'Checking ' . $file_path . PHP_EOL;
         }
 
         if (!$this->config) {
-            $this->config = $this->getConfigForPath($file_path);
+            $this->config = $this->getConfigForPath($file_path, $base_dir);
         }
 
         $start_checks = (int)microtime(true);
@@ -956,10 +957,11 @@ class ProjectChecker
      * Searches up a folder hierarchy for the most immediate config.
      *
      * @param  string $path
+     * @param  string $base_dir
      * @return Config
      * @throws Exception\ConfigException If a config path is not found.
      */
-    private function getConfigForPath($path)
+    private function getConfigForPath($path, $base_dir)
     {
         $dir_path = realpath($path);
 
@@ -973,7 +975,7 @@ class ProjectChecker
             $maybe_path = $dir_path . DIRECTORY_SEPARATOR . Config::DEFAULT_FILE_NAME;
 
             if (file_exists($maybe_path)) {
-                $config = Config::loadFromXMLFile($maybe_path);
+                $config = Config::loadFromXMLFile($maybe_path, $base_dir);
 
                 break;
             }
@@ -1014,16 +1016,17 @@ class ProjectChecker
 
     /**
      * @param string $path_to_config
+     * @param string $base_dir
      * @return void
      * @throws Exception\ConfigException If a config file is not found in the given location.
      */
-    public function setConfigXML($path_to_config)
+    public function setConfigXML($path_to_config, $base_dir)
     {
         if (!file_exists($path_to_config)) {
             throw new Exception\ConfigException('Config not found at location ' . $path_to_config);
         }
 
-        $this->config = Config::loadFromXMLFile($path_to_config);
+        $this->config = Config::loadFromXMLFile($path_to_config, $base_dir);
 
         $this->config->visitStubFiles($this);
         $this->config->initializePlugins($this);

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -200,9 +200,10 @@ class Config
      * Creates a new config object from the file
      *
      * @param  string           $file_path
+     * @param  string           $base_dir
      * @return self
      */
-    public static function loadFromXMLFile($file_path)
+    public static function loadFromXMLFile($file_path, $base_dir)
     {
         $file_contents = file_get_contents($file_path);
 
@@ -210,13 +211,14 @@ class Config
             throw new \InvalidArgumentException('Cannot open ' . $file_path);
         }
 
-        return self::loadFromXML($file_path, $file_contents);
+        return self::loadFromXML($file_path, $base_dir, $file_contents);
     }
 
     /**
      * Creates a new config object from an XML string
      *
      * @param  string           $file_path
+     * @param  string           $base_dir
      * @param  string           $file_contents
      * @return self
      * @psalm-suppress MixedArgument
@@ -226,13 +228,13 @@ class Config
      * @psalm-suppress MixedOperand
      * @psalm-suppress MixedPropertyAssignment
      */
-    public static function loadFromXML($file_path, $file_contents)
+    public static function loadFromXML($file_path, $base_dir, $file_contents)
     {
         $config = new static();
 
         $config->file_path = $file_path;
 
-        $config->base_dir = (string)getcwd() . DIRECTORY_SEPARATOR;
+        $config->base_dir = $base_dir;
 
         $schema_path = dirname(dirname(__DIR__)) . '/config.xsd';
 
@@ -336,7 +338,7 @@ class Config
         }
 
         if (isset($config_xml->projectFiles)) {
-            $config->project_files = ProjectFileFilter::loadFromXMLElement($config_xml->projectFiles, true);
+            $config->project_files = ProjectFileFilter::loadFromXMLElement($config_xml->projectFiles, $base_dir, true);
         }
 
         if (isset($config_xml->fileExtensions)) {
@@ -404,7 +406,7 @@ class Config
             /** @var \SimpleXMLElement $issue_handler */
             foreach ($config_xml->issueHandlers->children() as $key => $issue_handler) {
                 /** @var string $key */
-                $config->issue_handlers[$key] = IssueHandler::loadFromXMLElement($issue_handler);
+                $config->issue_handlers[$key] = IssueHandler::loadFromXMLElement($issue_handler, $base_dir);
             }
         }
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -411,7 +411,7 @@ class Config
         }
 
         if ($config->autoloader) {
-            require_once(getcwd() . DIRECTORY_SEPARATOR . $config->autoloader);
+            require_once($base_dir . DIRECTORY_SEPARATOR . $config->autoloader);
         }
 
         $config->collectPredefinedConstants();

--- a/src/Psalm/Config/ErrorLevelFileFilter.php
+++ b/src/Psalm/Config/ErrorLevelFileFilter.php
@@ -14,13 +14,15 @@ class ErrorLevelFileFilter extends FileFilter
     /**
      * @param  SimpleXMLElement $e
      * @param  bool             $inclusive
+     * @param  string           $base_dir
      * @return self
      */
     public static function loadFromXMLElement(
         SimpleXMLElement $e,
+        $base_dir,
         $inclusive
     ) {
-        $filter = parent::loadFromXMLElement($e, $inclusive);
+        $filter = parent::loadFromXMLElement($e, $base_dir, $inclusive);
 
         if (isset($e['type'])) {
             $filter->error_level = (string) $e['type'];

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -47,11 +47,13 @@ class FileFilter
 
     /**
      * @param  SimpleXMLElement $e
+     * @param  string           $base_dir
      * @param  bool             $inclusive
      * @return static
      */
     public static function loadFromXMLElement(
         SimpleXMLElement $e,
+        $base_dir,
         $inclusive
     ) {
         $filter = new static($inclusive);
@@ -59,7 +61,7 @@ class FileFilter
         if ($e->directory) {
             /** @var \SimpleXMLElement $directory */
             foreach ($e->directory as $directory) {
-                $prospective_directory_path = (getcwd() . DIRECTORY_SEPARATOR . (string)$directory['name']);
+                $prospective_directory_path = ($base_dir . DIRECTORY_SEPARATOR . (string)$directory['name']);
                 if (strpos($prospective_directory_path, '*') !== false) {
                     $globs = array_map(
                         'realpath',
@@ -70,7 +72,7 @@ class FileFilter
                     );
                     foreach ($globs as $glob_index => $directory_path) {
                         if (!$directory_path) {
-                            die('Could not resolve config path to ' . getcwd() . DIRECTORY_SEPARATOR .
+                            die('Could not resolve config path to ' . $base_dir . DIRECTORY_SEPARATOR .
                                 (string)$directory['name']. ':' . $glob_index);
                         }
                         $filter->addDirectory($directory_path);
@@ -80,7 +82,7 @@ class FileFilter
                 $directory_path = realpath($prospective_directory_path);
 
                 if (!$directory_path) {
-                    die('Could not resolve config path to ' . getcwd() . DIRECTORY_SEPARATOR .
+                    die('Could not resolve config path to ' . $base_dir . DIRECTORY_SEPARATOR .
                         (string)$directory['name'] . PHP_EOL);
                 }
 
@@ -91,10 +93,10 @@ class FileFilter
         if ($e->file) {
             /** @var \SimpleXMLElement $file */
             foreach ($e->file as $file) {
-                $file_path = realpath(getcwd() . DIRECTORY_SEPARATOR . (string)$file['name']);
+                $file_path = realpath($base_dir . DIRECTORY_SEPARATOR . (string)$file['name']);
 
                 if (!$file_path) {
-                    die('Could not resolve config path to ' . getcwd() . DIRECTORY_SEPARATOR .
+                    die('Could not resolve config path to ' . $base_dir . DIRECTORY_SEPARATOR .
                         (string)$file['name'] . PHP_EOL);
                 }
 

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -18,9 +18,10 @@ class IssueHandler
 
     /**
      * @param  SimpleXMLElement $e
+     * @param  string           $base_dir
      * @return self
      */
-    public static function loadFromXMLElement(SimpleXMLElement $e)
+    public static function loadFromXMLElement(SimpleXMLElement $e, $base_dir)
     {
         $handler = new self();
 
@@ -34,7 +35,7 @@ class IssueHandler
 
         /** @var \SimpleXMLElement $error_level */
         foreach ($e->errorLevel as $error_level) {
-            $handler->custom_levels[] = ErrorLevelFileFilter::loadFromXMLElement($error_level, true);
+            $handler->custom_levels[] = ErrorLevelFileFilter::loadFromXMLElement($error_level, $base_dir, true);
         }
 
         return $handler;

--- a/src/Psalm/Config/ProjectFileFilter.php
+++ b/src/Psalm/Config/ProjectFileFilter.php
@@ -13,14 +13,16 @@ class ProjectFileFilter extends FileFilter
 
     /**
      * @param  SimpleXMLElement $e
+     * @param  string           $base_dir
      * @param  bool             $inclusive
      * @return static
      */
     public static function loadFromXMLElement(
         SimpleXMLElement $e,
+        $base_dir,
         $inclusive
     ) {
-        $filter = parent::loadFromXMLElement($e, $inclusive);
+        $filter = parent::loadFromXMLElement($e, $base_dir, $inclusive);
 
         if (isset($e->ignoreFiles)) {
             if (!$inclusive) {
@@ -28,7 +30,7 @@ class ProjectFileFilter extends FileFilter
             }
 
             /** @var \SimpleXMLElement $e->ignoreFiles */
-            $filter->file_filter = static::loadFromXMLElement($e->ignoreFiles, false);
+            $filter->file_filter = static::loadFromXMLElement($e->ignoreFiles, $base_dir, false);
         }
 
         return $filter;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -70,6 +70,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     {
         $config = Config::loadFromXML(
             'psalm.xml',
+            (string)getcwd(),
             '<?xml version="1.0"?>
             <psalm>
                 <projectFiles>
@@ -89,6 +90,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     {
         $config = Config::loadFromXML(
             'psalm.xml',
+            dirname(__DIR__),
             '<?xml version="1.0"?>
             <psalm>
                 <projectFiles>
@@ -112,6 +114,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     {
         $config = Config::loadFromXML(
             'psalm.xml',
+            dirname(__DIR__),
             '<?xml version="1.0"?>
             <psalm>
                 <projectFiles>
@@ -136,6 +139,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     {
         $config = Config::loadFromXML(
             'psalm.xml',
+            dirname(__DIR__),
             '<?xml version="1.0"?>
             <psalm>
                 <projectFiles>
@@ -194,6 +198,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
         Config::loadFromXML(
             'psalm.xml',
+            dirname(__DIR__),
             '<?xml version="1.0"?>
             <psalm>
                 <projectFiles>
@@ -216,6 +221,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     {
         Config::loadFromXML(
             'psalm.xml',
+            dirname(__DIR__),
             '<?xml version="1.0"?>
             <psalm>
                 <projectFiles>
@@ -238,6 +244,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     {
         Config::loadFromXML(
             'psalm.xml',
+            dirname(__DIR__),
             '<?xml version="1.0"?>
             <psalm>
                 <projectFiles>
@@ -259,6 +266,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->project_checker->setConfig(
             TestConfig::loadFromXML(
                 'psalm.xml',
+                dirname(__DIR__),
                 '<?xml version="1.0"?>
                 <psalm>
                     <projectFiles>
@@ -293,6 +301,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->project_checker->setConfig(
             TestConfig::loadFromXML(
                 'psalm.xml',
+                dirname(__DIR__),
                 '<?xml version="1.0"?>
                 <psalm>
                     <projectFiles>
@@ -327,6 +336,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->project_checker->setConfig(
             TestConfig::loadFromXML(
                 'psalm.xml',
+                dirname(__DIR__),
                 '<?xml version="1.0"?>
                 <psalm>
                     <projectFiles>
@@ -357,6 +367,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->project_checker->setConfig(
             TestConfig::loadFromXML(
                 'psalm.xml',
+                dirname(__DIR__),
                 '<?xml version="1.0"?>
                 <psalm>
                     <projectFiles>
@@ -387,6 +398,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->project_checker->setConfig(
             TestConfig::loadFromXML(
                 'psalm.xml',
+                dirname(__DIR__),
                 '<?xml version="1.0"?>
                 <psalm>
                     <projectFiles>
@@ -417,6 +429,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->project_checker->setConfig(
             TestConfig::loadFromXML(
                 'psalm.xml',
+                dirname(__DIR__),
                 '<?xml version="1.0"?>
                 <psalm>
                     <projectFiles>
@@ -449,6 +462,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->project_checker->setConfig(
             TestConfig::loadFromXML(
                 'psalm.xml',
+                dirname(__DIR__),
                 '<?xml version="1.0"?>
                 <psalm
                     requireVoidReturnType="true">
@@ -476,6 +490,7 @@ class ConfigTest extends PHPUnit_Framework_TestCase
         $this->project_checker->setConfig(
             TestConfig::loadFromXML(
                 'psalm.xml',
+                dirname(__DIR__),
                 '<?xml version="1.0"?>
                 <psalm
                     requireVoidReturnType="false">
@@ -501,7 +516,10 @@ class ConfigTest extends PHPUnit_Framework_TestCase
     public function testTemplatedFiles()
     {
         foreach (['1.xml', '2.xml', '3.xml', '4.xml', '5.xml'] as $file_name) {
-            Config::loadFromXMLFile(realpath(dirname(__DIR__) . '/assets/config_levels/' . $file_name));
+            Config::loadFromXMLFile(
+                realpath(dirname(__DIR__) . '/assets/config_levels/' . $file_name),
+                dirname(__DIR__)
+            );
         }
     }
 }

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -34,6 +34,7 @@ class UnusedCodeTest extends TestCase
         $this->project_checker = new \Psalm\Checker\ProjectChecker();
         $this->project_checker->setConfig(Config::loadFromXML(
             'psalm.xml',
+            dirname(__DIR__),
             '<?xml version="1.0"?>
             <psalm
                 throwExceptionOnError="true"
@@ -79,9 +80,9 @@ class UnusedCodeTest extends TestCase
                     /** @return void */
                     function foo() {
                         $a = 0;
-            
+
                         $arr = ["hello"];
-            
+
                         unset($arr[$a]);
                     }'
             ]
@@ -138,7 +139,7 @@ class UnusedCodeTest extends TestCase
                         /** @return void */
                         public function foo() {}
                     }
-            
+
                     new A();',
                 'error_message' => 'PossiblyUnusedMethod'
             ],
@@ -148,7 +149,7 @@ class UnusedCodeTest extends TestCase
                         /** @return void */
                         private function foo() {}
                     }
-            
+
                     new A();',
                 'error_message' => 'UnusedMethod'
             ]


### PR DESCRIPTION
Fixes #132

Running Psalm with `--root` will change the directory it runs on. This allows you to install Psalm globally and run it anywhere, as long as the target directory uses the composer autoloader.