### PR TITLE
Fix false UndefinedClass for resource used in namespace

### DIFF
--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -1282,6 +1282,10 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
             return true;
         }
 
+        if (strrpos($fq_class_name, '\resource') === strlen($fq_class_name) - strlen('\resource')) {
+            return true;
+        }
+
         $class_exists = ClassChecker::classExists($fq_class_name, $file_checker);
         $interface_exists = InterfaceChecker::interfaceExists($fq_class_name, $file_checker);
 

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -339,6 +339,14 @@ class ReturnTypeTest extends TestCase
                             return null;
                         }
                     }'
+            ],
+            'resourceReturnType' => [
+                '<?php
+                    namespace bar;
+
+                    function fooFoo() : ?resource {
+                        return null;
+                    }'
             ]
         ];
     }


### PR DESCRIPTION
Using `resource` as return type of a function or a class method withing a custom namespace will cause a UndefinedClass error. I have added a testcase for this issue and also tried to find a solution. Feel free to improve my solution.

My Setup: PHP 7.1.4 via docker php:7-alpine