### PR TITLE
adding editorconfig that seems to match the php files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.php]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -3,7 +3,7 @@ $finder = array_reduce(
     [
         __DIR__ . '/src/',
         __DIR__ . '/bin/',
-        __DIR__ . '/tests/'
+        __DIR__ . '/tests/',
     ],
     function (PhpCsFixer\Finder $finder, $dir) {
         return $finder->in($dir);

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "standards": "php ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --allow-risky=yes",
         "tests": [
             "php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
+            "php ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --allow-risky=yes --dry-run .php_cs.dist",
             "php ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --allow-risky=yes --dry-run",
             "phpunit"
         ]


### PR DESCRIPTION
just a teensy little touch, stops supporting editors from accidentally messing with the desired indentation etc. (i.e. in my setup, the default indentation in Atom is 2, but the PHP indentation is definitely 4) :D