### PR TITLE
scrutinizer-ci part 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Packagist](https://img.shields.io/packagist/v/vimeo/psalm.svg)](https://packagist.org/packages/vimeo/psalm)
 [![Travis CI](https://img.shields.io/travis/vimeo/psalm/master.svg)](https://travis-ci.org/vimeo/psalm/branches)
+[![Scrutinizer](https://img.shields.io/scrutinizer/g/vimeo/psalm/master.svg)](https://scrutinizer-ci.com/g/vimeo/psalm/?branch=master)
 
 Psalm is a static analysis tool for finding errors in PHP applications.
 
@@ -30,7 +31,7 @@ Then run Psalm:
 ./vendor/bin/psalm
 ```
 
-The config created above will show you all issues in your code, but will emit `INFO` issues (as opposed to `ERROR`) for certain common trivial code problems. If you want a more lenient config you can specify the level with 
+The config created above will show you all issues in your code, but will emit `INFO` issues (as opposed to `ERROR`) for certain common trivial code problems. If you want a more lenient config you can specify the level with
 
 ```bash
 ./vendor/bin/psalm --init [source_dir] [level]

--- a/src/Psalm/Checker/AlgebraChecker.php
+++ b/src/Psalm/Checker/AlgebraChecker.php
@@ -370,7 +370,9 @@ class AlgebraChecker
                         }
                     );
 
-                    if (!empty($things_that_can_be_said) && count($things_that_can_be_said) === count($possible_types)) {
+                    if (!empty($things_that_can_be_said)
+                        && count($things_that_can_be_said) === count($possible_types)
+                    ) {
                         $things_that_can_be_said = array_unique($things_that_can_be_said);
                         $truths[$var] = implode('|', array_unique($things_that_can_be_said));
                     }

--- a/src/Psalm/Checker/AlgebraChecker.php
+++ b/src/Psalm/Checker/AlgebraChecker.php
@@ -82,7 +82,7 @@ class AlgebraChecker
             $source
         );
 
-        if ($assertions) {
+        if (!empty($assertions)) {
             $clauses = [];
 
             foreach ($assertions as $var => $type) {
@@ -173,7 +173,7 @@ class AlgebraChecker
                 }
             }
 
-            if ($impossibility) {
+            if (!empty($impossibility)) {
                 $impossibilities[$var_id] = $impossibility;
             }
         }

--- a/src/Psalm/Checker/AlgebraChecker.php
+++ b/src/Psalm/Checker/AlgebraChecker.php
@@ -265,7 +265,7 @@ class AlgebraChecker
 
             $clause_var = array_keys($clause_a->possibilities)[0];
             $only_type = array_pop(array_values($clause_a->possibilities)[0]);
-            $negated_clause_type = TypeChecker::negateType($only_type);
+            $negated_clause_type = TypeChecker::negateType((string)$only_type);
 
             foreach ($cloned_clauses as $clause_b) {
                 if ($clause_a === $clause_b || !$clause_b->reconcilable || $clause_b->wedge) {

--- a/src/Psalm/Checker/AlgebraChecker.php
+++ b/src/Psalm/Checker/AlgebraChecker.php
@@ -370,7 +370,7 @@ class AlgebraChecker
                         }
                     );
 
-                    if ($things_that_can_be_said && count($things_that_can_be_said) === count($possible_types)) {
+                    if (!empty($things_that_can_be_said) && count($things_that_can_be_said) === count($possible_types)) {
                         $things_that_can_be_said = array_unique($things_that_can_be_said);
                         $truths[$var] = implode('|', array_unique($things_that_can_be_said));
                     }

--- a/src/Psalm/Checker/CanAlias.php
+++ b/src/Psalm/Checker/CanAlias.php
@@ -32,6 +32,16 @@ trait CanAlias
     private $aliased_constants = [];
 
     /**
+     * @return FileChecker
+     */
+    abstract public function getFileChecker();
+
+    /**
+     * @return string
+     */
+    abstract public function getFilePath();
+
+    /**
      * @param  PhpParser\Node\Stmt\Use_ $stmt
      *
      * @return void

--- a/src/Psalm/Checker/CanAlias.php
+++ b/src/Psalm/Checker/CanAlias.php
@@ -49,7 +49,7 @@ trait CanAlias
     public function visitUse(PhpParser\Node\Stmt\Use_ $stmt)
     {
         foreach ($stmt->uses as $use) {
-            $use_path = implode('\\', $use->name->parts);
+            $use_path = $use->name->toString();
 
             switch ($use->type !== PhpParser\Node\Stmt\Use_::TYPE_UNKNOWN ? $use->type : $stmt->type) {
                 case PhpParser\Node\Stmt\Use_::TYPE_FUNCTION:
@@ -86,7 +86,7 @@ trait CanAlias
      */
     public function visitGroupUse(PhpParser\Node\Stmt\GroupUse $stmt)
     {
-        $use_prefix = implode('\\', $stmt->prefix->parts);
+        $use_prefix = $stmt->prefix->toString();
 
         foreach ($stmt->uses as $use) {
             $use_path = $use_prefix . '\\' . implode('\\', $use->name->parts);

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -1357,16 +1357,16 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
         PhpParser\Node\Name $class_name,
         StatementsSource $source
     ) {
-        if ($class_name->parts == ['self']) {
+        if ($class_name->toString() == 'self') {
             return 'self';
         }
 
         if ($class_name instanceof PhpParser\Node\Name\FullyQualified) {
-            return implode('\\', $class_name->parts);
+            return $class_name->toString();
         }
 
         return self::getFQCLNFromString(
-            implode('\\', $class_name->parts),
+            $class_name->toString(),
             $source
         );
     }

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -199,7 +199,7 @@ class FileChecker extends SourceChecker implements StatementsSource
                     new TraitChecker($stmt, $this, $stmt->name);
                 }
             } elseif ($stmt instanceof PhpParser\Node\Stmt\Namespace_) {
-                $namespace_name = $stmt->name ? implode('\\', $stmt->name->parts) : '';
+                $namespace_name = $stmt->name ? $stmt->name->toString() : '';
 
                 $namespace_checker = new NamespaceChecker($stmt, $this);
                 $namespace_checker->visit();

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -644,7 +644,7 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
             foreach ($function->stmts as $stmt) {
                 if ($stmt instanceof PhpParser\Node\Expr\FuncCall &&
                     $stmt->name instanceof PhpParser\Node\Name &&
-                    $stmt->name->parts === ['define']
+                    $stmt->name->toString() === 'define'
                 ) {
                     $first_arg_value = isset($stmt->args[0]) ? $stmt->args[0]->value : null;
                     $second_arg_value = isset($stmt->args[1]) ? $stmt->args[1]->value : null;
@@ -1398,7 +1398,7 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
         $is_nullable = $param->default !== null &&
             $param->default instanceof \PhpParser\Node\Expr\ConstFetch &&
             $param->default->name instanceof PhpParser\Node\Name &&
-            strtolower($param->default->name->parts[0]) === 'null';
+            strtolower($param->default->name->getFirst()) === 'null';
 
         $param_typehint = $param->type;
 
@@ -1411,12 +1411,12 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
             if (is_string($param_typehint)) {
                 $param_type_string = $param_typehint;
             } elseif ($param_typehint instanceof PhpParser\Node\Name\FullyQualified) {
-                $param_type_string = implode('\\', $param_typehint->parts);
-            } elseif ($param_typehint->parts === ['self']) {
+                $param_type_string = $param_typehint->toString();
+            } elseif ($param_typehint->toString() === 'self') {
                 $param_type_string = $source->getFQCLN();
             } else {
                 $param_type_string = ClassLikeChecker::getFQCLNFromString(
-                    implode('\\', $param_typehint->parts),
+                    $param_typehint->toString(),
                     $source
                 );
             }

--- a/src/Psalm/Checker/NamespaceChecker.php
+++ b/src/Psalm/Checker/NamespaceChecker.php
@@ -59,7 +59,7 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
         $this->source = $source;
         $this->file_checker = $source;
         $this->namespace = $namespace;
-        $this->namespace_name = $this->namespace->name ? implode('\\', $this->namespace->name->parts) : '';
+        $this->namespace_name = $this->namespace->name ? $this->namespace->name->toString() : '';
     }
 
     /**

--- a/src/Psalm/Checker/ScopeChecker.php
+++ b/src/Psalm/Checker/ScopeChecker.php
@@ -57,8 +57,8 @@ class ScopeChecker
                 $has_default_leaver = false;
 
                 // iterate backwards in a case statement
-                for ($i = count($stmt->cases) - 1; $i >= 0; --$i) {
-                    $case = $stmt->cases[$i];
+                for ($j = count($stmt->cases) - 1; $j >= 0; --$j) {
+                    $case = $stmt->cases[$j];
 
                     $case_does_leave = self::doesEverBreakOrContinue($case->stmts, true);
 
@@ -166,8 +166,8 @@ class ScopeChecker
             if ($stmt instanceof PhpParser\Node\Stmt\Switch_) {
                 // iterate backwards
                 // in switch statements we only care here about continue
-                for ($i = count($stmt->cases) - 1; $i >= 0; --$i) {
-                    $case = $stmt->cases[$i];
+                for ($j = count($stmt->cases) - 1; $j >= 0; --$j) {
+                    $case = $stmt->cases[$j];
 
                     if (self::doesEverBreakOrContinue($case->stmts, true)) {
                         return true;
@@ -225,8 +225,8 @@ class ScopeChecker
             if ($stmt instanceof PhpParser\Node\Stmt\Switch_) {
                 // iterate backwards
                 // in switch statements we only care here about continue
-                for ($i = count($stmt->cases) - 1; $i >= 0; --$i) {
-                    $case = $stmt->cases[$i];
+                for ($j = count($stmt->cases) - 1; $j >= 0; --$j) {
+                    $case = $stmt->cases[$j];
 
                     if (!self::doesAlwaysBreakOrContinue($case->stmts, true)) {
                         return false;
@@ -289,8 +289,8 @@ class ScopeChecker
                 $has_default_terminator = false;
 
                 // iterate backwards in a case statement
-                for ($i = count($stmt->cases) - 1; $i >= 0; --$i) {
-                    $case = $stmt->cases[$i];
+                for ($j = count($stmt->cases) - 1; $j >= 0; --$j) {
+                    $case = $stmt->cases[$j];
 
                     if (self::doesEverBreakOrContinue($case->stmts)) {
                         return false;

--- a/src/Psalm/Checker/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Checker/Statements/Expression/AssertionFinder.php
@@ -603,14 +603,14 @@ class AssertionFinder
         StatementsSource $source
     ) {
         if ($stmt->class instanceof PhpParser\Node\Name) {
-            if (!in_array($stmt->class->parts[0], ['self', 'static', 'parent'], true)) {
+            if (!in_array($stmt->class->getFirst(), ['self', 'static', 'parent'], true)) {
                 $instanceof_class = ClassLikeChecker::getFQCLNFromNameObject(
                     $stmt->class,
                     $source
                 );
 
                 return $instanceof_class;
-            } elseif ($stmt->class->parts === ['self'] && $this_class_name) {
+            } elseif ($stmt->class->toString() === 'self' && $this_class_name) {
                 return $this_class_name;
             }
         }
@@ -627,13 +627,13 @@ class AssertionFinder
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\ConstFetch &&
             $conditional->right->name instanceof PhpParser\Node\Name &&
-            strtolower($conditional->right->name->parts[0]) === 'null') {
+            strtolower($conditional->right->name->getFirst()) === 'null') {
             return self::ASSIGNMENT_TO_RIGHT;
         }
 
         if ($conditional->left instanceof PhpParser\Node\Expr\ConstFetch &&
             $conditional->left->name instanceof PhpParser\Node\Name &&
-            strtolower($conditional->left->name->parts[0]) === 'null') {
+            strtolower($conditional->left->name->getFirst()) === 'null') {
             return self::ASSIGNMENT_TO_LEFT;
         }
 
@@ -649,13 +649,13 @@ class AssertionFinder
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\ConstFetch &&
             $conditional->right->name instanceof PhpParser\Node\Name &&
-            strtolower($conditional->right->name->parts[0]) === 'false') {
+            strtolower($conditional->right->name->getFirst()) === 'false') {
             return self::ASSIGNMENT_TO_RIGHT;
         }
 
         if ($conditional->left instanceof PhpParser\Node\Expr\ConstFetch &&
             $conditional->left->name instanceof PhpParser\Node\Name &&
-            strtolower($conditional->left->name->parts[0]) === 'false') {
+            strtolower($conditional->left->name->getFirst()) === 'false') {
             return self::ASSIGNMENT_TO_LEFT;
         }
 
@@ -671,13 +671,13 @@ class AssertionFinder
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\ConstFetch &&
             $conditional->right->name instanceof PhpParser\Node\Name &&
-            strtolower($conditional->right->name->parts[0]) === 'true') {
+            strtolower($conditional->right->name->getFirst()) === 'true') {
             return self::ASSIGNMENT_TO_RIGHT;
         }
 
         if ($conditional->left instanceof PhpParser\Node\Expr\ConstFetch &&
             $conditional->left->name instanceof PhpParser\Node\Name &&
-            strtolower($conditional->left->name->parts[0]) === 'true') {
+            strtolower($conditional->left->name->getFirst()) === 'true') {
             return self::ASSIGNMENT_TO_LEFT;
         }
 
@@ -693,14 +693,14 @@ class AssertionFinder
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\FuncCall &&
             $conditional->right->name instanceof PhpParser\Node\Name &&
-            strtolower($conditional->right->name->parts[0]) === 'gettype' &&
+            strtolower($conditional->right->name->getFirst()) === 'gettype' &&
             $conditional->left instanceof PhpParser\Node\Scalar\String_) {
             return self::ASSIGNMENT_TO_RIGHT;
         }
 
         if ($conditional->left instanceof PhpParser\Node\Expr\FuncCall &&
             $conditional->left->name instanceof PhpParser\Node\Name &&
-            strtolower($conditional->left->name->parts[0]) === 'gettype' &&
+            strtolower($conditional->left->name->getFirst()) === 'gettype' &&
             $conditional->right instanceof PhpParser\Node\Scalar\String_) {
             return self::ASSIGNMENT_TO_LEFT;
         }
@@ -737,7 +737,7 @@ class AssertionFinder
      */
     protected static function hasNullCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_null') {
+        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->getFirst()) === 'is_null') {
             return true;
         }
 
@@ -751,7 +751,7 @@ class AssertionFinder
      */
     protected static function hasIsACheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_a' &&
+        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->getFirst()) === 'is_a' &&
             $stmt->args[1]->value instanceof PhpParser\Node\Scalar\String_) {
             return true;
         }
@@ -766,7 +766,7 @@ class AssertionFinder
      */
     protected static function hasArrayCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_array') {
+        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->getFirst()) === 'is_array') {
             return true;
         }
 
@@ -780,7 +780,7 @@ class AssertionFinder
      */
     protected static function hasStringCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_string') {
+        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->getFirst()) === 'is_string') {
             return true;
         }
 
@@ -794,7 +794,7 @@ class AssertionFinder
      */
     protected static function hasBoolCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_bool') {
+        if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->getFirst()) === 'is_bool') {
             return true;
         }
 
@@ -808,7 +808,7 @@ class AssertionFinder
      */
     protected static function hasObjectCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_object']) {
+        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->toString() === 'is_object') {
             return true;
         }
 
@@ -822,7 +822,7 @@ class AssertionFinder
      */
     protected static function hasNumericCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_numeric']) {
+        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->toString() === 'is_numeric') {
             return true;
         }
 
@@ -837,9 +837,9 @@ class AssertionFinder
     protected static function hasIntCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
         if ($stmt->name instanceof PhpParser\Node\Name &&
-            ($stmt->name->parts === ['is_int'] ||
-                $stmt->name->parts === ['is_integer'] ||
-                $stmt->name->parts === ['is_long'])
+            ($stmt->name->toString() === 'is_int' ||
+                $stmt->name->toString() === 'is_integer' ||
+                $stmt->name->toString() === 'is_long')
         ) {
             return true;
         }
@@ -855,9 +855,9 @@ class AssertionFinder
     protected static function hasFloatCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
         if ($stmt->name instanceof PhpParser\Node\Name &&
-            ($stmt->name->parts === ['is_float'] ||
-                $stmt->name->parts === ['is_real'] ||
-                $stmt->name->parts === ['is_double'])
+            ($stmt->name->toString() === 'is_float' ||
+                $stmt->name->toString() === 'is_real' ||
+                $stmt->name->toString() === 'is_double')
         ) {
             return true;
         }
@@ -872,7 +872,7 @@ class AssertionFinder
      */
     protected static function hasResourceCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_resource']) {
+        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->toString() === 'is_resource') {
             return true;
         }
 
@@ -886,7 +886,7 @@ class AssertionFinder
      */
     protected static function hasScalarCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_scalar']) {
+        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->toString() === 'is_scalar') {
             return true;
         }
 
@@ -900,7 +900,7 @@ class AssertionFinder
      */
     protected static function hasCallableCheck(PhpParser\Node\Expr\FuncCall $stmt)
     {
-        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_callable']) {
+        if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->toString() === 'is_callable') {
             return true;
         }
 

--- a/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
@@ -806,7 +806,7 @@ class AssignmentChecker
 
         $fq_class_name = (string)$stmt->class->inferredType;
 
-        if (($stmt->class instanceof PhpParser\Node\Name && $stmt->class->parts[0] === 'this') ||
+        if (($stmt->class instanceof PhpParser\Node\Name && $stmt->class->getFirst() === 'this') ||
             $fq_class_name === $context->self
         ) {
             $class_visibility = \ReflectionProperty::IS_PRIVATE;
@@ -827,7 +827,7 @@ class AssignmentChecker
         $property_id = $fq_class_name . '::$' . $prop_name;
 
         if (!ClassLikeChecker::propertyExists($property_id)) {
-            if ($stmt->class instanceof PhpParser\Node\Name && $stmt->class->parts[0] === 'this') {
+            if ($stmt->class instanceof PhpParser\Node\Name && $stmt->class->getFirst() === 'this') {
                 if (IssueBuffer::accepts(
                     new UndefinedThisPropertyAssignment(
                         'Static property ' . $property_id . ' is not defined',

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -1736,7 +1736,8 @@ class CallChecker
         }
 
         if (!$has_packed_var && count($args) < count($function_params)) {
-            for ($i = count($args); $i < count($function_params); ++$i) {
+            $j = count($function_params);
+            for ($i = count($args); $i < $j; ++$i) {
                 $param = $function_params[$i];
 
                 if (!$param->is_optional && !$param->is_variadic) {

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -69,34 +69,34 @@ class CallChecker
         if ($method instanceof PhpParser\Node\Name) {
             $first_arg = isset($stmt->args[0]) ? $stmt->args[0] : null;
 
-            if ($method->parts === ['method_exists']) {
+            if ($method->toString() === 'method_exists') {
                 $context->check_methods = false;
-            } elseif ($method->parts === ['class_exists']) {
+            } elseif ($method->toString() === 'class_exists') {
                 if ($first_arg && $first_arg->value instanceof PhpParser\Node\Scalar\String_) {
                     $context->addPhantomClass($first_arg->value->value);
                 } else {
                     $context->check_classes = false;
                 }
-            } elseif ($method->parts === ['function_exists']) {
+            } elseif ($method->toString() === 'function_exists') {
                 $context->check_functions = false;
-            } elseif ($method->parts === ['is_callable']) {
+            } elseif ($method->toString() === 'is_callable') {
                 $context->check_methods = false;
                 $context->check_functions = false;
-            } elseif ($method->parts === ['defined']) {
+            } elseif ($method->toString() === 'defined') {
                 $context->check_consts = false;
-            } elseif ($method->parts === ['extract']) {
+            } elseif ($method->toString() === 'extract') {
                 $context->check_variables = false;
-            } elseif ($method->parts === ['var_dump'] || $method->parts === ['shell_exec']) {
+            } elseif ($method->toString() === 'var_dump' || $method->toString() === 'shell_exec') {
                 if (IssueBuffer::accepts(
                     new ForbiddenCode(
-                        'Unsafe ' . implode('', $method->parts),
+                        'Unsafe ' . $method->toString(),
                         new CodeLocation($statements_checker->getSource(), $stmt)
                     ),
                     $statements_checker->getSuppressedIssues()
                 )) {
                     return false;
                 }
-            } elseif ($method->parts === ['define']) {
+            } elseif ($method->toString() === 'define') {
                 if ($first_arg && $first_arg->value instanceof PhpParser\Node\Scalar\String_) {
                     $second_arg = $stmt->args[1];
                     ExpressionChecker::analyze($statements_checker, $second_arg->value, $context);
@@ -215,7 +215,7 @@ class CallChecker
                 $stmt->inferredType = Type::getMixed();
             }
         } else {
-            $method_id = implode('\\', $stmt->name->parts);
+            $method_id = $stmt->name->toString();
 
             $in_call_map = FunctionChecker::inCallMap($method_id);
             $is_stubbed = isset(FunctionChecker::$stubbed_functions[strtolower($method_id)]);
@@ -375,7 +375,7 @@ class CallChecker
 
             if (Config::getInstance()->use_assert_for_type &&
                 $method instanceof PhpParser\Node\Name &&
-                $method->parts === ['assert'] &&
+                $method->toString() === 'assert' &&
                 isset($stmt->args[0])
             ) {
                 $assert_clauses = AlgebraChecker::getFormula(
@@ -420,7 +420,7 @@ class CallChecker
         }
 
         if ($stmt->name instanceof PhpParser\Node\Name &&
-            ($stmt->name->parts === ['get_class'] || $stmt->name->parts === ['gettype']) &&
+            ($stmt->name->toString() === 'get_class' || $stmt->name->toString() === 'gettype') &&
             $stmt->args
         ) {
             $var = $stmt->args[0]->value;
@@ -452,7 +452,7 @@ class CallChecker
         $late_static = false;
 
         if ($stmt->class instanceof PhpParser\Node\Name) {
-            if (!in_array($stmt->class->parts[0], ['self', 'static', 'parent'], true)) {
+            if (!in_array($stmt->class->getFirst(), ['self', 'static', 'parent'], true)) {
                 $fq_class_name = ClassLikeChecker::getFQCLNFromNameObject(
                     $stmt->class,
                     $statements_checker
@@ -473,7 +473,7 @@ class CallChecker
                     }
                 }
             } else {
-                switch ($stmt->class->parts[0]) {
+                switch ($stmt->class->getFirst()) {
                     case 'self':
                         $fq_class_name = $context->self;
                         break;
@@ -1103,10 +1103,10 @@ class CallChecker
         if ($stmt->class instanceof PhpParser\Node\Name) {
             $fq_class_name = null;
 
-            if (count($stmt->class->parts) === 1
-                && in_array($stmt->class->parts[0], ['self', 'static', 'parent'], true)
+            if ($stmt->class->isUnqualified()
+                && in_array($stmt->class->getFirst(), ['self', 'static', 'parent'], true)
             ) {
-                if ($stmt->class->parts[0] === 'parent') {
+                if ($stmt->class->getFirst() === 'parent') {
                     $fq_class_name = $statements_checker->getParentFQCLN();
 
                     if ($fq_class_name === null) {
@@ -1250,7 +1250,7 @@ class CallChecker
                 }
 
                 if ($stmt->class instanceof PhpParser\Node\Name
-                    && ($stmt->class->parts[0] !== 'parent' || $statements_checker->isStatic())
+                    && ($stmt->class->getFirst() !== 'parent' || $statements_checker->isStatic())
                     && (!$context->self
                         || $statements_checker->isStatic()
                         || !ClassChecker::classExtends($context->self, $fq_class_name)
@@ -1258,7 +1258,7 @@ class CallChecker
                 ) {
                     if (MethodChecker::checkStatic(
                         $method_id,
-                        $stmt->class instanceof PhpParser\Node\Name && $stmt->class->parts[0] === 'self',
+                        $stmt->class instanceof PhpParser\Node\Name && $stmt->class->getFirst() === 'self',
                         new CodeLocation($source, $stmt),
                         $statements_checker->getSuppressedIssues()
                     ) === false) {
@@ -1285,7 +1285,7 @@ class CallChecker
                     return false;
                 }
 
-                $fq_class_name = $stmt->class instanceof PhpParser\Node\Name && $stmt->class->parts === ['parent']
+                $fq_class_name = $stmt->class instanceof PhpParser\Node\Name && $stmt->class->toString() === 'parent'
                     ? $statements_checker->getFQCLN()
                     : $fq_class_name;
 

--- a/src/Psalm/Checker/Statements/Expression/FetchChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/FetchChecker.php
@@ -374,7 +374,7 @@ class FetchChecker
         PhpParser\Node\Expr\ConstFetch $stmt,
         Context $context
     ) {
-        $const_name = implode('\\', $stmt->name->parts);
+        $const_name = $stmt->name->toString();
         switch (strtolower($const_name)) {
             case 'null':
                 $stmt->inferredType = Type::getNull();
@@ -428,16 +428,16 @@ class FetchChecker
     ) {
         if ($context->check_consts &&
             $stmt->class instanceof PhpParser\Node\Name &&
-            $stmt->class->parts !== ['static'] &&
+            $stmt->class->toString() !== 'static' &&
             is_string($stmt->name)
         ) {
-            if ($stmt->class->parts === ['self']) {
+            if ($stmt->class->toString() === 'self') {
                 if (!$context->self) {
                     throw new \UnexpectedValueException('$context->self cannot be null');
                 }
 
                 $fq_class_name = (string)$context->self;
-            } elseif ($stmt->class->parts[0] === 'parent') {
+            } elseif ($stmt->class->getFirst() === 'parent') {
                 $fq_class_name = $statements_checker->getParentFQCLN();
 
                 if ($fq_class_name === null) {
@@ -574,10 +574,10 @@ class FetchChecker
         $fq_class_name = null;
 
         if ($stmt->class instanceof PhpParser\Node\Name) {
-            if (count($stmt->class->parts) === 1
-                && in_array($stmt->class->parts[0], ['self', 'static', 'parent'], true)
+            if ($stmt->class->isUnqualified()
+                && in_array($stmt->class->getFirst(), ['self', 'static', 'parent'], true)
             ) {
-                if ($stmt->class->parts[0] === 'parent') {
+                if ($stmt->class->getFirst() === 'parent') {
                     $fq_class_name = $statements_checker->getParentFQCLN();
 
                     if ($fq_class_name === null) {

--- a/src/Psalm/Checker/Statements/ExpressionChecker.php
+++ b/src/Psalm/Checker/Statements/ExpressionChecker.php
@@ -352,7 +352,7 @@ class ExpressionChecker
             }
 
             if ($stmt->class instanceof PhpParser\Node\Name &&
-                !in_array($stmt->class->parts[0], ['self', 'static', 'parent'], true)
+                !in_array($stmt->class->getFirst(), ['self', 'static', 'parent'], true)
             ) {
                 if ($context->check_classes) {
                     $fq_class_name = ClassLikeChecker::getFQCLNFromNameObject(
@@ -1416,11 +1416,11 @@ class ExpressionChecker
             && is_string($stmt->name)
             && $stmt->class instanceof PhpParser\Node\Name
         ) {
-            if (count($stmt->class->parts) === 1
-                && in_array($stmt->class->parts[0], ['self', 'static', 'parent'], true)
+            if ($stmt->class->isUnqualified()
+                && in_array($stmt->class->getFirst(), ['self', 'static', 'parent'], true)
             ) {
                 if (!$this_class_name) {
-                    $fq_class_name = $stmt->class->parts[0];
+                    $fq_class_name = $stmt->class->getFirst();
                 } else {
                     $fq_class_name = $this_class_name;
                 }
@@ -1430,7 +1430,7 @@ class ExpressionChecker
                         $stmt->class,
                         $source
                     )
-                    : implode('\\', $stmt->class->parts);
+                    : $stmt->class->toString();
             }
 
             return $fq_class_name . '::$' . $stmt->name;

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -502,11 +502,11 @@ class StatementsChecker extends SourceChecker implements StatementsSource
     public static function getSimpleType(PhpParser\Node\Expr $stmt)
     {
         if ($stmt instanceof PhpParser\Node\Expr\ConstFetch) {
-            if (strtolower($stmt->name->parts[0]) === 'false') {
+            if (strtolower($stmt->name->getFirst()) === 'false') {
                 return Type::getFalse();
-            } elseif (strtolower($stmt->name->parts[0]) === 'true') {
+            } elseif (strtolower($stmt->name->getFirst()) === 'true') {
                 return Type::getBool();
-            } elseif (strtolower($stmt->name->parts[0]) === 'null') {
+            } elseif (strtolower($stmt->name->getFirst()) === 'null') {
                 return Type::getNull();
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\ClassConstFetch) {
@@ -860,7 +860,7 @@ class StatementsChecker extends SourceChecker implements StatementsSource
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\FuncCall &&
             $stmt->name instanceof PhpParser\Node\Name &&
-            $stmt->name->parts === ['dirname']
+            $stmt->name->toString() === 'dirname'
         ) {
             if ($stmt->args) {
                 $evaled_path = self::getPathTo($stmt->args[0]->value, $file_name);
@@ -872,7 +872,7 @@ class StatementsChecker extends SourceChecker implements StatementsSource
                 return dirname($evaled_path);
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\ConstFetch && $stmt->name instanceof PhpParser\Node\Name) {
-            $const_name = implode('', $stmt->name->parts);
+            $const_name = implode('', explode('\\', $stmt->name->toString()));
 
             if (defined($const_name)) {
                 $constant_value = constant($const_name);

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -840,7 +840,8 @@ class TypeChecker
         $base_key = $key_parts[0];
 
         // for an expression like $obj->key1->key2
-        for ($i = 1; $i < count($key_parts); ++$i) {
+        $j = count($key_parts);
+        for ($i = 1; $i < $j; ++$i) {
             $new_base_key = $base_key . '->' . $key_parts[$i];
 
             if (!isset($existing_keys[$new_base_key])) {
@@ -921,7 +922,8 @@ class TypeChecker
         $base_key = $key_parts[0];
 
         // for an expression like $obj->key1->key2
-        for ($i = 1; $i < count($key_parts); ++$i) {
+        $j = count($key_parts);
+        for ($i = 1; $i < $j; ++$i) {
             $new_base_key = $base_key . '[' . $key_parts[$i] . ']';
 
             if (!isset($existing_keys[$new_base_key])) {

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -34,7 +34,6 @@ class FileFilter
     /**
      * @param  bool             $inclusive
      *
-     * @return self
      * @psalm-suppress FailedTypeResolution
      */
     public function __construct($inclusive)


### PR DESCRIPTION
There's a bit of an issue with the coverage generation; [phpunit tests will fail with xdebug enabled](https://travis-ci.org/SignpostMarv/psalm/jobs/236660470)

So while we can't have the funky coverage badge & auto coverage report generation, [it's about 76%](https://coveralls.io/builds/11715588) as of around 0e34941

Regarding the code quality, [there's a bunch of issues I'm not sure how to fix](https://scrutinizer-ci.com/g/SignpostMarv/psalm/issues/scrutinizer-ci/bug-fixes) mostly where scrutinizer is picking up type safety issues that psalm isn't.

If this pull request is accepted, you'll possibly want to flip the switches over at [scrutinizer-ci](https://scrutinizer-ci.com/) *first*, so the merge triggers an inspection.