### PR TITLE
Moved dependencies friendsofphp/php-cs-fixer and squizlabs/php_codesniffer to "require-dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "nikic/PHP-Parser": "^3.0.4",
-        "composer/composer": "^1.3",
-        "friendsofphp/php-cs-fixer": "^2.3",
-        "squizlabs/php_codesniffer": "^3.0"
+        "composer/composer": "^1.3"
     },
     "bin": ["bin/psalm"],
     "autoload": {
@@ -28,7 +26,9 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.4"
+        "phpunit/phpunit": "^5.7.4",
+        "friendsofphp/php-cs-fixer": "^2.3",
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "scripts": {
         "psalm": "./bin/psalm",


### PR DESCRIPTION
It's currently impossible to [install](https://travis-ci.org/morozov/kih/jobs/244242449) a project with a dev-dependency on vimeo/psalm using PHP 7.2 because friendsofphp/php-cs-fixer doesn't support it:
```
Your requirements could not be resolved to an installable set of packages.
  Problem 1
    - Installation request for friendsofphp/php-cs-fixer v2.3.2 -> satisfiable by friendsofphp/php-cs-fixer[v2.3.2].
    - friendsofphp/php-cs-fixer v2.3.2 requires php ^5.6 || >=7.0 <7.2 -> your PHP version (7.2.0-dev) does not satisfy that requirement.
```
In fact, vimeo/psalm doesn't have a runtime dependency on the code standard checking tools, they are only needed for development.

Besides fixing the issue above, it will also reduce the package footprint when it's installed as a dependency.