### PR TITLE
Isolate where we load static storage objects

### DIFF
--- a/examples/StringChecker.php
+++ b/examples/StringChecker.php
@@ -39,10 +39,10 @@ class StringChecker extends \Psalm\Plugin
             if (preg_match($class_or_class_method, $stmt->value)) {
                 $fq_class_name = preg_split('/[:]/', $stmt->value)[0];
 
-                $file_checker = $statements_checker->getFileChecker();
+                $project_checker = $statements_checker->getFileChecker()->project_checker;
                 if (Checker\ClassChecker::checkFullyQualifiedClassLikeName(
+                    $project_checker,
                     $fq_class_name,
-                    $file_checker,
                     $code_location,
                     $suppressed_issues
                 ) === false
@@ -52,8 +52,8 @@ class StringChecker extends \Psalm\Plugin
 
                 if ($fq_class_name !== $stmt->value) {
                     if (Checker\MethodChecker::checkMethodExists(
+                        $project_checker,
                         $stmt->value,
-                        $file_checker,
                         $code_location,
                         $suppressed_issues
                     )

--- a/src/Psalm/Checker/ClassChecker.php
+++ b/src/Psalm/Checker/ClassChecker.php
@@ -50,7 +50,7 @@ class ClassChecker extends ClassLikeChecker
      *
      * @return bool
      */
-    public static function classExists($fq_class_name, FileChecker $file_checker)
+    public static function classExists(ProjectChecker $project_checker, $fq_class_name)
     {
         if (isset(self::$SPECIAL_TYPES[$fq_class_name])) {
             return false;
@@ -60,24 +60,23 @@ class ClassChecker extends ClassLikeChecker
             return true;
         }
 
-        return $file_checker->project_checker->hasFullyQualifiedClassName($fq_class_name);
+        return $project_checker->hasFullyQualifiedClassName($fq_class_name);
     }
 
     /**
      * Determine whether or not a class has the correct casing
      *
      * @param  string       $fq_class_name
-     * @param  FileChecker  $file_checker
      *
      * @return bool
      */
-    public static function hasCorrectCasing($fq_class_name, FileChecker $file_checker)
+    public static function hasCorrectCasing(ProjectChecker $project_checker, $fq_class_name)
     {
         if ($fq_class_name === 'Generator') {
             return true;
         }
 
-        return isset($file_checker->project_checker->existing_classes[$fq_class_name]);
+        return isset($project_checker->existing_classes[$fq_class_name]);
     }
 
     /**
@@ -88,7 +87,7 @@ class ClassChecker extends ClassLikeChecker
      *
      * @return bool
      */
-    public static function classExtends($fq_class_name, $possible_parent)
+    public static function classExtends(ProjectChecker $project_checker, $fq_class_name, $possible_parent)
     {
         $fq_class_name = strtolower($fq_class_name);
 
@@ -96,23 +95,9 @@ class ClassChecker extends ClassLikeChecker
             return false;
         }
 
-        if (!isset(self::$storage[$fq_class_name])) {
-            throw new \UnexpectedValueException('$storage should not be null for ' . $fq_class_name);
-        }
+        $class_storage = $project_checker->classlike_storage_provider->get($fq_class_name);
 
-        return in_array(strtolower($possible_parent), self::$storage[$fq_class_name]->parent_classes, true);
-    }
-
-    /**
-     * Get all the interfaces a given class implements
-     *
-     * @param  string $fq_class_name
-     *
-     * @return array<string>
-     */
-    public static function getInterfacesForClass($fq_class_name)
-    {
-        return self::$storage[strtolower($fq_class_name)]->class_implements;
+        return in_array(strtolower($possible_parent), $class_storage->parent_classes, true);
     }
 
     /**
@@ -123,7 +108,7 @@ class ClassChecker extends ClassLikeChecker
      *
      * @return bool
      */
-    public static function classImplements($fq_class_name, $interface)
+    public static function classImplements(ProjectChecker $project_checker, $fq_class_name, $interface)
     {
         $interface_id = strtolower($interface);
 
@@ -141,8 +126,8 @@ class ClassChecker extends ClassLikeChecker
             return false;
         }
 
-        $storage = self::$storage[$fq_class_name];
+        $class_storage = $project_checker->classlike_storage_provider->get($fq_class_name);
 
-        return isset($storage->class_implements[$interface_id]);
+        return isset($class_storage->class_implements[$interface_id]);
     }
 }

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -123,9 +123,6 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
     /** @var ClassLikeStorage */
     protected $storage;
 
-    /** @var array<string, ClassLikeStorage> */
-    public static $all_storage;
-
     /**
      * @param PhpParser\Node\Stmt\ClassLike $class
      * @param StatementsSource              $source
@@ -1736,7 +1733,5 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
         self::$trait_checkers = [];
 
         self::$class_checkers = [];
-
-        self::$all_storage = [];
     }
 }

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -61,6 +61,9 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
      */
     protected $source;
 
+    /** @var FileChecker */
+    public $file_checker;
+
     /**
      * @var string
      */
@@ -1633,11 +1636,13 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
      *
      * @return  array<string>
      */
-    public static function getClassesForFile($file_path)
+    public static function getClassesForFile(ProjectChecker $project_checker, $file_path)
     {
-        return isset(FileChecker::$storage[strtolower($file_path)])
-            ? array_unique(FileChecker::$storage[strtolower($file_path)]->classes_in_file)
-            : [];
+        try {
+            return $project_checker->file_storage_provider->get($file_path)->classes_in_file;
+        } catch (\InvalidArgumentException $e) {
+            return [];
+        }
     }
 
     /**
@@ -1684,6 +1689,11 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
     public static function inPropertyMap($class_name)
     {
         return isset(self::getPropertyMap()[strtolower($class_name)]);
+    }
+
+    public function getFileChecker()
+    {
+        return $this->file_checker;
     }
 
     /**

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -6,7 +6,6 @@ use Psalm\Config;
 use Psalm\Context;
 use Psalm\IssueBuffer;
 use Psalm\StatementsSource;
-use Psalm\Storage\FileStorage;
 use Psalm\Type;
 
 class FileChecker extends SourceChecker implements StatementsSource
@@ -57,13 +56,6 @@ class FileChecker extends SourceChecker implements StatementsSource
      * @var bool
      */
     public static $show_notices = true;
-
-    /**
-     * A list of data useful to analyse files
-     *
-     * @var array<string, FileStorage>
-     */
-    public static $storage = [];
 
     /**
      * @var array<string, ClassLikeChecker>
@@ -433,8 +425,6 @@ class FileChecker extends SourceChecker implements StatementsSource
      */
     public static function clearCache()
     {
-        self::$storage = [];
-
         ClassLikeChecker::clearCache();
         FunctionChecker::clearCache();
         StatementsChecker::clearCache();

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -219,7 +219,11 @@ class FileChecker extends SourceChecker implements StatementsSource
                 /** @var string */
                 $method_id = $function_checker->getMethodId();
 
-                $function_storage = FunctionChecker::getStorage($method_id, $this->file_path);
+                $function_storage = FunctionChecker::getStorage(
+                    $this->project_checker,
+                    $method_id,
+                    $this->file_path
+                );
 
                 if (!$function_storage->has_template_return_type) {
                     $return_type = $function_storage->return_type;

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -121,11 +121,6 @@ class FileChecker extends SourceChecker implements StatementsSource
         $this->file_name = Config::getInstance()->shortenFileName($this->file_path);
         $this->project_checker = $project_checker;
         $this->will_analyze = $will_analyze;
-
-        if (!isset(self::$storage[strtolower($file_path)])) {
-            self::$storage[strtolower($file_path)] = new FileStorage();
-            self::$storage[strtolower($file_path)]->file_path = $file_path;
-        }
     }
 
     /**

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -62,6 +62,9 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
      */
     protected $source;
 
+    /** @var FileChecker */
+    public $file_checker;
+
     /**
      * @var array<string, array<string, Type\Union>>
      */
@@ -114,6 +117,8 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
                 }
             }
         }
+
+        $file_storage_provider = $this->file_checker->project_checker->file_storage_provider;
 
         if ($this->function instanceof ClassMethod) {
             $real_method_id = (string)$this->getMethodId();
@@ -287,13 +292,13 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
                 }
             }
         } elseif ($this->function instanceof Function_) {
-            $file_storage = FileChecker::$storage[strtolower($this->source->getFilePath())];
+            $file_storage = $file_storage_provider->get($this->source->getFilePath());
 
             $storage = $file_storage->functions[(string)$this->getMethodId()];
 
             $cased_method_id = $this->function->name;
         } else { // Closure
-            $file_storage = FileChecker::$storage[strtolower($this->source->getFilePath())];
+            $file_storage = $file_storage_provider->get($this->source->getFilePath());
 
             $function_id = $cased_function_id =
                 $this->getFilePath() . ':' . $this->function->getLine() . ':' . 'closure';
@@ -1220,5 +1225,10 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
     public static function clearCache()
     {
         self::$no_effects_hashes = [];
+    }
+
+    public function getFileChecker()
+    {
+        return $this->file_checker;
     }
 }

--- a/src/Psalm/Checker/InterfaceChecker.php
+++ b/src/Psalm/Checker/InterfaceChecker.php
@@ -22,13 +22,13 @@ class InterfaceChecker extends ClassLikeChecker
      *
      * @return bool
      */
-    public static function interfaceExists($fq_interface_name, FileChecker $file_checker)
+    public static function interfaceExists(ProjectChecker $project_checker, $fq_interface_name)
     {
         if (isset(self::$SPECIAL_TYPES[strtolower($fq_interface_name)])) {
             return false;
         }
 
-        return $file_checker->project_checker->hasFullyQualifiedInterfaceName($fq_interface_name);
+        return $project_checker->hasFullyQualifiedInterfaceName($fq_interface_name);
     }
 
     /**
@@ -37,9 +37,9 @@ class InterfaceChecker extends ClassLikeChecker
      *
      * @return bool
      */
-    public static function hasCorrectCasing($fq_interface_name, FileChecker $file_checker)
+    public static function hasCorrectCasing(ProjectChecker $project_checker, $fq_interface_name)
     {
-        return isset($file_checker->project_checker->existing_interfaces[$fq_interface_name]);
+        return isset($project_checker->existing_interfaces[$fq_interface_name]);
     }
 
     /**
@@ -49,9 +49,9 @@ class InterfaceChecker extends ClassLikeChecker
      *
      * @return bool
      */
-    public static function interfaceExtends($interface_name, $possible_parent, FileChecker $file_checker)
+    public static function interfaceExtends(ProjectChecker $project_checker, $interface_name, $possible_parent)
     {
-        return in_array($possible_parent, self::getParentInterfaces($interface_name, $file_checker), true);
+        return in_array($possible_parent, self::getParentInterfaces($project_checker, $interface_name), true);
     }
 
     /**
@@ -60,31 +60,14 @@ class InterfaceChecker extends ClassLikeChecker
      *
      * @return array<string>   all interfaces extended by $interface_name
      */
-    public static function getParentInterfaces($fq_interface_name, FileChecker $file_checker)
+    public static function getParentInterfaces(ProjectChecker $project_checker, $fq_interface_name)
     {
         $fq_interface_name = strtolower($fq_interface_name);
 
-        if (!isset(self::$storage[$fq_interface_name])) {
-            throw new \UnexpectedValueException('Invalid storage for ' . $fq_interface_name);
-        }
-
         $extended_interfaces = [];
 
-        $storage = self::$storage[$fq_interface_name];
+        $storage = $project_checker->classlike_storage_provider->get($fq_interface_name);
 
-        foreach ($storage->parent_interfaces as $extended_interface_name) {
-            $extended_interfaces[] = $extended_interface_name;
-
-            if (!self::interfaceExists($extended_interface_name, $file_checker)) {
-                continue;
-            }
-
-            $extended_interfaces = array_merge(
-                self::getParentInterfaces($extended_interface_name, $file_checker),
-                $extended_interfaces
-            );
-        }
-
-        return $extended_interfaces;
+        return $storage->parent_interfaces;
     }
 }

--- a/src/Psalm/Checker/NamespaceChecker.php
+++ b/src/Psalm/Checker/NamespaceChecker.php
@@ -55,7 +55,6 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
     public function __construct(Namespace_ $namespace, FileChecker $source)
     {
         $this->source = $source;
-        $this->file_checker = $source;
         $this->namespace = $namespace;
         $this->namespace_name = $this->namespace->name ? implode('\\', $this->namespace->name->parts) : '';
     }
@@ -181,5 +180,10 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
         }
 
         throw new \InvalidArgumentException('Given $visibility not supported');
+    }
+
+    public function getFileChecker()
+    {
+        return $this->source;
     }
 }

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -10,6 +10,7 @@ use Psalm\Issue\UnusedClass;
 use Psalm\Issue\UnusedMethod;
 use Psalm\IssueBuffer;
 use Psalm\Provider\CacheProvider;
+use Psalm\Provider\ClassLikeStorageProvider;
 use Psalm\Provider\FileProvider;
 use Psalm\Provider\FileReferenceProvider;
 use Psalm\Provider\FileStorageProvider;
@@ -39,6 +40,9 @@ class ProjectChecker
 
     /** @var FileStorageProvider */
     public $file_storage_provider;
+
+    /** @var ClassLikeStorageProvider */
+    public $classlike_storage_provider;
 
     /** @var CacheProvider */
     public $cache_provider;
@@ -271,6 +275,7 @@ class ProjectChecker
         $this->collectPredefinedClassLikes();
 
         $this->file_storage_provider = new FileStorageProvider();
+        $this->classlike_storage_provider = new ClassLikeStorageProvider();
     }
 
     /**
@@ -1279,6 +1284,8 @@ class ProjectChecker
         if (isset($this->scanned_files[$file_path])) {
             throw new \UnexpectedValueException('Should not be rescanning ' . $file_path);
         }
+
+        $this->file_storage_provider->create($file_path);
 
         if ($this->debug_output) {
             if (isset($this->files_to_deep_scan[$file_path])) {

--- a/src/Psalm/Checker/SourceChecker.php
+++ b/src/Psalm/Checker/SourceChecker.php
@@ -12,11 +12,6 @@ abstract class SourceChecker implements StatementsSource
     protected $source = null;
 
     /**
-     * @var FileChecker|null
-     */
-    protected $file_checker;
-
-    /**
      * @return Aliases
      */
     public function getAliases()
@@ -66,12 +61,8 @@ abstract class SourceChecker implements StatementsSource
 
     /**
      * @return FileChecker
-     * @psalm-suppress InvalidReturnType because it basically always returns a file checker
      */
-    public function getFileChecker()
-    {
-        return $this->file_checker;
-    }
+    abstract public function getFileChecker();
 
     /**
      * @return string|null

--- a/src/Psalm/Checker/Statements/Block/ForeachChecker.php
+++ b/src/Psalm/Checker/Statements/Block/ForeachChecker.php
@@ -79,6 +79,8 @@ class ForeachChecker
                 }
             }
 
+            $project_checker = $statements_checker->getFileChecker()->project_checker;
+
             foreach ($iterator_type->types as $iterator_type) {
                 // if it's an empty array, we cannot iterate over it
                 if ((string) $iterator_type === 'array<empty, empty>') {
@@ -131,8 +133,8 @@ class ForeachChecker
                         $iterator_type->value !== $statements_checker->getClassName()
                     ) {
                         if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
+                            $project_checker,
                             $iterator_type->value,
-                            $statements_checker->getFileChecker(),
                             new CodeLocation($statements_checker->getSource(), $stmt->expr),
                             $statements_checker->getSuppressedIssues()
                         ) === false) {
@@ -144,6 +146,7 @@ class ForeachChecker
                         (strtolower($iterator_type->value) === 'iterable' ||
                             strtolower($iterator_type->value) === 'traversable' ||
                             ClassChecker::classImplements(
+                                $project_checker,
                                 $iterator_type->value,
                                 'Traversable'
                             ))
@@ -170,15 +173,17 @@ class ForeachChecker
                     }
 
                     if (ClassChecker::classImplements(
+                        $project_checker,
                         $iterator_type->value,
                         'Iterator'
                     )) {
                         $iterator_method = $iterator_type->value . '::current';
-                        $iterator_class_type = MethodChecker::getMethodReturnType($iterator_method);
+                        $iterator_class_type = MethodChecker::getMethodReturnType($project_checker, $iterator_method);
 
                         if ($iterator_class_type) {
-                            $value_type_part = ExpressionChecker::fleshOutTypes(
-                                clone $iterator_class_type,
+                            $value_type_part = ExpressionChecker::fleshOutType(
+                                $project_checker,
+                                $iterator_class_type,
                                 $iterator_type->value,
                                 $iterator_method
                             );

--- a/src/Psalm/Checker/Statements/Block/IfChecker.php
+++ b/src/Psalm/Checker/Statements/Block/IfChecker.php
@@ -295,13 +295,15 @@ class IfChecker
         }
 
         if ($if_context->byref_constraints !== null) {
+            $project_checker = $statements_checker->getFileChecker()->project_checker;
+
             foreach ($if_context->byref_constraints as $var_id => $byref_constraint) {
                 if ($outer_context->byref_constraints !== null &&
                     isset($outer_context->byref_constraints[$var_id]) &&
                     !TypeChecker::isContainedBy(
+                        $project_checker,
                         $byref_constraint->type,
-                        $outer_context->byref_constraints[$var_id]->type,
-                        $statements_checker->getFileChecker()
+                        $outer_context->byref_constraints[$var_id]->type
                     )
                 ) {
                     if (IssueBuffer::accepts(
@@ -535,13 +537,15 @@ class IfChecker
         }
 
         if ($elseif_context->byref_constraints !== null) {
+            $project_checker = $statements_checker->getFileChecker()->project_checker;
+
             foreach ($elseif_context->byref_constraints as $var_id => $byref_constraint) {
                 if ($outer_context->byref_constraints !== null &&
                     isset($outer_context->byref_constraints[$var_id]) &&
                     !TypeChecker::isContainedBy(
+                        $project_checker,
                         $byref_constraint->type,
-                        $outer_context->byref_constraints[$var_id]->type,
-                        $statements_checker->getFileChecker()
+                        $outer_context->byref_constraints[$var_id]->type
                     )
                 ) {
                     if (IssueBuffer::accepts(
@@ -776,13 +780,15 @@ class IfChecker
         }
 
         if ($else_context->byref_constraints !== null) {
+            $project_checker = $statements_checker->getFileChecker()->project_checker;
+
             foreach ($else_context->byref_constraints as $var_id => $byref_constraint) {
                 if ($outer_context->byref_constraints !== null &&
                     isset($outer_context->byref_constraints[$var_id]) &&
                     !TypeChecker::isContainedBy(
+                        $project_checker,
                         $byref_constraint->type,
-                        $outer_context->byref_constraints[$var_id]->type,
-                        $statements_checker->getFileChecker()
+                        $outer_context->byref_constraints[$var_id]->type
                     )
                 ) {
                     if (IssueBuffer::accepts(

--- a/src/Psalm/Checker/Statements/Block/TryChecker.php
+++ b/src/Psalm/Checker/Statements/Block/TryChecker.php
@@ -45,8 +45,8 @@ class TryChecker
 
                 if ($context->check_classes) {
                     if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
+                        $statements_checker->getFileChecker()->project_checker,
                         $fq_catch_class,
-                        $statements_checker->getFileChecker(),
                         new CodeLocation($statements_checker->getSource(), $catch_type, $context->include_location),
                         $statements_checker->getSuppressedIssues()
                     ) === false) {

--- a/src/Psalm/Checker/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Checker/Statements/Expression/AssertionFinder.php
@@ -34,6 +34,8 @@ class AssertionFinder
     ) {
         $if_types = [];
 
+        $project_checker = $source->getFileChecker()->project_checker;
+
         if ($conditional instanceof PhpParser\Node\Expr\Instanceof_) {
             $instanceof_type = self::getInstanceOfTypes($conditional, $this_class_name, $source);
 
@@ -126,13 +128,13 @@ class AssertionFinder
                     $null_type = Type::getNull();
 
                     if (!TypeChecker::isContainedBy(
+                        $project_checker,
                         $var_type,
-                        $null_type,
-                        $source->getFileChecker()
+                        $null_type
                     ) && !TypeChecker::isContainedBy(
+                        $project_checker,
                         $null_type,
-                        $var_type,
-                        $source->getFileChecker()
+                        $var_type
                     )) {
                         if (IssueBuffer::accepts(
                             new TypeDoesNotContainNull(
@@ -198,13 +200,13 @@ class AssertionFinder
                     $false_type = Type::getFalse();
 
                     if (!TypeChecker::isContainedBy(
+                        $project_checker,
                         $var_type,
-                        $false_type,
-                        $source->getFileChecker()
+                        $false_type
                     ) && !TypeChecker::isContainedBy(
+                        $project_checker,
                         $false_type,
-                        $var_type,
-                        $source->getFileChecker()
+                        $var_type
                     )) {
                         if (IssueBuffer::accepts(
                             new TypeDoesNotContainType(
@@ -284,14 +286,14 @@ class AssertionFinder
                         $if_types[$var_name] = '^' . $var_type;
                     } elseif ($other_type && $conditional instanceof PhpParser\Node\Expr\BinaryOp\Identical) {
                         if (!TypeChecker::isContainedBy(
+                            $project_checker,
                             $var_type,
                             $other_type,
-                            $source->getFileChecker(),
                             true
                         ) && !TypeChecker::isContainedBy(
+                            $project_checker,
                             $other_type,
                             $var_type,
-                            $source->getFileChecker(),
                             true
                         )) {
                             if (IssueBuffer::accepts(
@@ -314,7 +316,7 @@ class AssertionFinder
             $other_type = isset($conditional->right->inferredType) ? $conditional->right->inferredType : null;
 
             if ($var_type && $other_type && $conditional instanceof PhpParser\Node\Expr\BinaryOp\Identical) {
-                if (!TypeChecker::canBeIdenticalTo($var_type, $other_type, $source->getFileChecker())) {
+                if (!TypeChecker::canBeIdenticalTo($project_checker, $var_type, $other_type)) {
                     if (IssueBuffer::accepts(
                         new TypeDoesNotContainType(
                             $var_type . ' does not contain ' . $other_type,

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -186,12 +186,12 @@ class CallChecker
                         // handled above
                     } elseif (!$var_type_part instanceof TNamedObject ||
                         !ClassLikeChecker::classOrInterfaceExists(
-                            $var_type_part->value,
-                            $statements_checker->getFileChecker()
+                            $project_checker,
+                            $var_type_part->value
                         ) ||
                         !MethodChecker::methodExists(
-                            $var_type_part->value . '::__invoke',
-                            $statements_checker->getFileChecker()
+                            $project_checker,
+                            $var_type_part->value . '::__invoke'
                         )
                     ) {
                         $var_id = ExpressionChecker::getVarId(
@@ -272,9 +272,9 @@ class CallChecker
 
                 if ($in_call_map && !$is_stubbed) {
                     $function_params = FunctionLikeChecker::getFunctionParamsFromCallMapById(
+                        $statements_checker->getFileChecker()->project_checker,
                         $method_id,
-                        $stmt->args,
-                        $statements_checker->getFileChecker()
+                        $stmt->args
                     );
                 }
             }
@@ -297,9 +297,9 @@ class CallChecker
             if ($stmt->name instanceof PhpParser\Node\Name && $method_id) {
                 if (!$is_stubbed && $in_call_map) {
                     $function_params = FunctionLikeChecker::getFunctionParamsFromCallMapById(
+                        $statements_checker->getFileChecker()->project_checker,
                         $method_id,
-                        $stmt->args,
-                        $statements_checker->getFileChecker()
+                        $stmt->args
                     );
                 }
             }
@@ -450,7 +450,7 @@ class CallChecker
     ) {
         $fq_class_name = null;
 
-        $file_checker = $statements_checker->getFileChecker();
+        $project_checker = $statements_checker->getFileChecker()->project_checker;
 
         $late_static = false;
 
@@ -467,8 +467,8 @@ class CallChecker
                     }
 
                     if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
+                        $project_checker,
                         $fq_class_name,
-                        $file_checker,
                         new CodeLocation($statements_checker->getSource(), $stmt->class),
                         $statements_checker->getSuppressedIssues()
                     ) === false) {
@@ -504,9 +504,9 @@ class CallChecker
 
             if (strtolower($fq_class_name) !== 'stdclass' &&
                 $context->check_classes &&
-                ClassChecker::classExists($fq_class_name, $file_checker)
+                ClassChecker::classExists($project_checker, $fq_class_name)
             ) {
-                $storage = ClassLikeChecker::$storage[strtolower($fq_class_name)];
+                $storage = $project_checker->classlike_storage_provider->get($fq_class_name);
 
                 // if we're not calling this constructor via new static()
                 if ($storage->abstract && !$late_static) {
@@ -534,8 +534,8 @@ class CallChecker
                 }
 
                 if (MethodChecker::methodExists(
+                    $project_checker,
                     $fq_class_name . '::__construct',
-                    $file_checker,
                     $context->collect_references ? new CodeLocation($statements_checker->getSource(), $stmt) : null
                 )) {
                     $method_id = $fq_class_name . '::__construct';
@@ -736,7 +736,7 @@ class CallChecker
         }
 
         $config = Config::getInstance();
-        $file_checker = $statements_checker->getFileChecker();
+        $project_checker = $statements_checker->getFileChecker()->project_checker;
 
         if ($class_type && is_string($stmt->name)) {
             $return_type = null;
@@ -805,8 +805,8 @@ class CallChecker
                     $does_class_exist = true;
                 } else {
                     $does_class_exist = ClassLikeChecker::checkFullyQualifiedClassLikeName(
+                        $project_checker,
                         $fq_class_name,
-                        $file_checker,
                         new CodeLocation($statements_checker->getSource(), $stmt),
                         $statements_checker->getSuppressedIssues()
                     );
@@ -816,7 +816,11 @@ class CallChecker
                     return $does_class_exist;
                 }
 
-                if (MethodChecker::methodExists($fq_class_name . '::__call', $statements_checker->getFileChecker())) {
+                if (MethodChecker::methodExists(
+                    $project_checker,
+                    $fq_class_name . '::__call'
+                )
+                ) {
                     $return_type = Type::getMixed();
                     continue;
                 }
@@ -826,18 +830,18 @@ class CallChecker
                 if ($var_id === '$this' &&
                     $context->self &&
                     $fq_class_name !== $context->self &&
-                    MethodChecker::methodExists($context->self . '::' . strtolower($stmt->name), $file_checker)
+                    MethodChecker::methodExists($project_checker, $context->self . '::' . strtolower($stmt->name))
                 ) {
                     $method_id = $context->self . '::' . strtolower($stmt->name);
                     $fq_class_name = $context->self;
                 }
 
-                if ($intersection_types && !MethodChecker::methodExists($method_id, $file_checker)) {
+                if ($intersection_types && !MethodChecker::methodExists($project_checker, $method_id)) {
                     foreach ($intersection_types as $intersection_type) {
                         $method_id = $intersection_type->value . '::' . strtolower($stmt->name);
                         $fq_class_name = $intersection_type->value;
 
-                        if (MethodChecker::methodExists($method_id, $file_checker)) {
+                        if (MethodChecker::methodExists($project_checker, $method_id)) {
                             break;
                         }
                     }
@@ -846,8 +850,8 @@ class CallChecker
                 $cased_method_id = $fq_class_name . '::' . $stmt->name;
 
                 $does_method_exist = MethodChecker::checkMethodExists(
+                    $project_checker,
                     $cased_method_id,
-                    $statements_checker->getFileChecker(),
                     new CodeLocation($statements_checker->getSource(), $stmt),
                     $statements_checker->getSuppressedIssues()
                 );
@@ -867,7 +871,7 @@ class CallChecker
                     self::collectSpecialInformation($source, $stmt->name, $context);
                 }
 
-                $class_storage = ClassLikeChecker::$storage[strtolower($fq_class_name)];
+                $class_storage = $project_checker->classlike_storage_provider->get($fq_class_name);
 
                 if ($class_storage->template_types) {
                     $class_template_params = [];
@@ -904,7 +908,7 @@ class CallChecker
                 }
 
                 $return_type_location = null;
-                $file_checker = $source->getFileChecker();
+                $project_checker = $source->getFileChecker()->project_checker;
 
                 if (FunctionChecker::inCallMap($cased_method_id)) {
                     $return_type_candidate = FunctionChecker::getReturnTypeFromCallMap($method_id);
@@ -920,6 +924,7 @@ class CallChecker
                     }
 
                     if (MethodChecker::checkMethodNotDeprecated(
+                        $project_checker,
                         $method_id,
                         new CodeLocation($source, $stmt),
                         $statements_checker->getSuppressedIssues()
@@ -927,7 +932,7 @@ class CallChecker
                         return false;
                     }
 
-                    $return_type_candidate = MethodChecker::getMethodReturnType($method_id);
+                    $return_type_candidate = MethodChecker::getMethodReturnType($project_checker, $method_id);
 
                     if ($return_type_candidate) {
                         if ($class_template_params) {
@@ -939,13 +944,15 @@ class CallChecker
                             $return_type_candidate = clone $return_type_candidate;
                         }
 
-                        $return_type_candidate = ExpressionChecker::fleshOutTypes(
+                        $return_type_candidate = ExpressionChecker::fleshOutType(
+                            $project_checker,
                             $return_type_candidate,
                             $fq_class_name,
                             $method_id
                         );
 
                         $return_type_location = MethodChecker::getMethodReturnTypeLocation(
+                            $project_checker,
                             $method_id,
                             $secondary_return_type_location
                         );
@@ -1010,26 +1017,28 @@ class CallChecker
     ) {
         $fq_class_name = (string)$source->getFQCLN();
 
+        $project_checker = $source->getFileChecker()->project_checker;
+
         if ($context->collect_mutations &&
             $context->self &&
             (
                 $context->self === $fq_class_name ||
                 ClassChecker::classExtends(
+                    $project_checker,
                     $context->self,
                     $fq_class_name
                 )
             )
         ) {
-            $file_checker = $source->getFileChecker();
-
             $method_id = $fq_class_name . '::' . strtolower($method_name);
 
-            $file_checker->project_checker->getMethodMutations($method_id, $context);
+            $project_checker->getMethodMutations($method_id, $context);
         } elseif ($context->collect_initializations &&
             $context->self &&
             (
                 $context->self === $fq_class_name ||
                 ClassChecker::classExtends(
+                    $project_checker,
                     $context->self,
                     $fq_class_name
                 )
@@ -1038,9 +1047,9 @@ class CallChecker
         ) {
             $method_id = $fq_class_name . '::' . strtolower($method_name);
 
-            $declaring_method_id = MethodChecker::getDeclaringMethodId($method_id);
+            $declaring_method_id = MethodChecker::getDeclaringMethodId($project_checker, $method_id);
 
-            $method_storage = MethodChecker::getStorage((string)$declaring_method_id);
+            $method_storage = MethodChecker::getStorage($project_checker, (string)$declaring_method_id);
 
             $class_checker = $source->getSource();
 
@@ -1101,6 +1110,7 @@ class CallChecker
         $lhs_type = null;
 
         $file_checker = $statements_checker->getFileChecker();
+        $project_checker = $file_checker->project_checker;
         $source = $statements_checker->getSource();
 
         if ($stmt->class instanceof PhpParser\Node\Name) {
@@ -1126,7 +1136,7 @@ class CallChecker
                         return;
                     }
 
-                    $class_storage = ClassLikeChecker::$storage[strtolower($fq_class_name)];
+                    $class_storage = $project_checker->classlike_storage_provider->get($fq_class_name);
 
                     if (is_string($stmt->name) && $class_storage->user_defined) {
                         $method_id = $fq_class_name . '::' . strtolower($stmt->name);
@@ -1192,9 +1202,9 @@ class CallChecker
                 $does_class_exist = false;
 
                 if ($context->self) {
-                    if (isset(
-                        ClassLikeChecker::$storage[strtolower($context->self)]->used_traits[strtolower($fq_class_name)]
-                    )) {
+                    $self_storage = $project_checker->classlike_storage_provider->get($context->self);
+
+                    if (isset($self_storage->used_traits[strtolower($fq_class_name)])) {
                         $fq_class_name = $context->self;
                         $does_class_exist = true;
                     }
@@ -1202,8 +1212,8 @@ class CallChecker
 
                 if (!$does_class_exist) {
                     $does_class_exist = ClassLikeChecker::checkFullyQualifiedClassLikeName(
+                        $project_checker,
                         $fq_class_name,
-                        $file_checker,
                         new CodeLocation($source, $stmt->class),
                         $statements_checker->getSuppressedIssues(),
                         false
@@ -1248,15 +1258,15 @@ class CallChecker
             $method_id = null;
 
             if (is_string($stmt->name) &&
-                !MethodChecker::methodExists($fq_class_name . '::__callStatic', $file_checker) &&
+                !MethodChecker::methodExists($project_checker, $fq_class_name . '::__callStatic') &&
                 !$is_mock
             ) {
                 $method_id = $fq_class_name . '::' . strtolower($stmt->name);
                 $cased_method_id = $fq_class_name . '::' . $stmt->name;
 
                 $does_method_exist = MethodChecker::checkMethodExists(
+                    $project_checker,
                     $cased_method_id,
-                    $file_checker,
                     new CodeLocation($source, $stmt),
                     $statements_checker->getSuppressedIssues()
                 );
@@ -1265,7 +1275,7 @@ class CallChecker
                     return $does_method_exist;
                 }
 
-                $class_storage = ClassLikeChecker::$storage[strtolower($fq_class_name)];
+                $class_storage = $project_checker->classlike_storage_provider->get($fq_class_name);
 
                 if ($class_storage->deprecated) {
                     if (IssueBuffer::accepts(
@@ -1293,12 +1303,13 @@ class CallChecker
                     && ($stmt->class->parts[0] !== 'parent' || $statements_checker->isStatic())
                     && (!$context->self
                         || $statements_checker->isStatic()
-                        || !ClassChecker::classExtends($context->self, $fq_class_name)
+                        || !ClassChecker::classExtends($project_checker, $context->self, $fq_class_name)
                     )
                 ) {
                     if (MethodChecker::checkStatic(
                         $method_id,
                         $stmt->class instanceof PhpParser\Node\Name && $stmt->class->parts[0] === 'self',
+                        $project_checker,
                         new CodeLocation($source, $stmt),
                         $statements_checker->getSuppressedIssues()
                     ) === false) {
@@ -1307,6 +1318,7 @@ class CallChecker
                 }
 
                 if (MethodChecker::checkMethodNotDeprecated(
+                    $project_checker,
                     $method_id,
                     new CodeLocation($statements_checker->getSource(), $stmt),
                     $statements_checker->getSuppressedIssues()
@@ -1331,7 +1343,7 @@ class CallChecker
 
                 $class_template_params = [];
 
-                $return_type_candidate = MethodChecker::getMethodReturnType($method_id);
+                $return_type_candidate = MethodChecker::getMethodReturnType($project_checker, $method_id);
 
                 if ($return_type_candidate) {
                     if ($found_generic_params) {
@@ -1343,13 +1355,15 @@ class CallChecker
                         $return_type_candidate = clone $return_type_candidate;
                     }
 
-                    $return_type_candidate = ExpressionChecker::fleshOutTypes(
+                    $return_type_candidate = ExpressionChecker::fleshOutType(
+                        $project_checker,
                         $return_type_candidate,
                         $fq_class_name,
                         $method_id
                     );
 
                     $return_type_location = MethodChecker::getMethodReturnTypeLocation(
+                        $project_checker,
                         $method_id,
                         $secondary_return_type_location
                     );
@@ -1413,10 +1427,10 @@ class CallChecker
         CodeLocation $code_location,
         StatementsChecker $statements_checker
     ) {
-        $file_checker = $statements_checker->getFileChecker();
+        $project_checker = $statements_checker->getFileChecker()->project_checker;
 
         $method_params = $method_id
-            ? FunctionLikeChecker::getMethodParamsById($method_id, $args, $file_checker)
+            ? FunctionLikeChecker::getMethodParamsById($project_checker, $method_id, $args)
             : null;
 
         if (self::checkFunctionArguments(
@@ -1434,7 +1448,7 @@ class CallChecker
 
         list($fq_class_name, $method_name) = explode('::', $method_id);
 
-        $class_storage = ClassLikeChecker::$storage[strtolower($fq_class_name)];
+        $class_storage = $project_checker->classlike_storage_provider->get($fq_class_name);
         $method_storage = isset($class_storage->methods[strtolower($method_name)])
             ? $class_storage->methods[strtolower($method_name)]
             : null;
@@ -1442,9 +1456,9 @@ class CallChecker
         if (!$class_storage->user_defined) {
             // check again after we've processed args
             $method_params = FunctionLikeChecker::getMethodParamsById(
+                $project_checker,
                 $method_id,
-                $args,
-                $file_checker
+                $args
             );
         }
 
@@ -1608,9 +1622,10 @@ class CallChecker
 
         $fq_class_name = null;
 
+        $project_checker = $statements_checker->getFileChecker()->project_checker;
+
         if ($method_id) {
             if ($in_call_map || !strpos($method_id, '::')) {
-                $project_checker = $statements_checker->getFileChecker()->project_checker;
                 $is_variadic = FunctionChecker::isVariadic(
                     $project_checker,
                     strtolower($method_id),
@@ -1618,12 +1633,12 @@ class CallChecker
                 );
             } else {
                 $fq_class_name = explode('::', $method_id)[0];
-                $is_variadic = MethodChecker::isVariadic($method_id);
+                $is_variadic = MethodChecker::isVariadic($project_checker, $method_id);
             }
         }
 
         if ($method_id && strpos($method_id, '::') && !$in_call_map) {
-            $cased_method_id = MethodChecker::getCasedMethodId($method_id);
+            $cased_method_id = MethodChecker::getCasedMethodId($project_checker, $method_id);
         }
 
         if ($function_params) {
@@ -1698,8 +1713,8 @@ class CallChecker
                                     // register class if the class exists
                                     if ($offset_value_type_part instanceof TNamedObject) {
                                         ClassLikeChecker::checkFullyQualifiedClassLikeName(
+                                            $project_checker,
                                             $offset_value_type_part->value,
-                                            $statements_checker->getFileChecker(),
                                             new CodeLocation($statements_checker->getSource(), $arg->value),
                                             $statements_checker->getSuppressedIssues()
                                         );
@@ -1730,7 +1745,8 @@ class CallChecker
                         break;
                     }
 
-                    $fleshed_out_type = ExpressionChecker::fleshOutTypes(
+                    $fleshed_out_type = ExpressionChecker::fleshOutType(
+                        $project_checker,
                         $param_type,
                         $fq_class_name,
                         $method_id
@@ -1893,6 +1909,8 @@ class CallChecker
 
                 $i = 0;
 
+                $project_checker = $statements_checker->getFileChecker()->project_checker;
+
                 foreach ($closure_params as $closure_param) {
                     if (!isset($array_arg_types[$i])) {
                         ++$i;
@@ -1912,9 +1930,9 @@ class CallChecker
                     $closure_param_type = $closure_param->type;
 
                     $type_match_found = TypeChecker::isContainedBy(
+                        $project_checker,
                         $input_type,
                         $closure_param_type,
-                        $statements_checker->getFileChecker(),
                         false,
                         $scalar_type_match_found,
                         $coerced_type
@@ -1935,9 +1953,9 @@ class CallChecker
 
                     if (!$type_match_found) {
                         $types_can_be_identical = TypeChecker::canBeIdenticalTo(
+                            $project_checker,
                             $input_type,
-                            $closure_param_type,
-                            $statements_checker->getFileChecker()
+                            $closure_param_type
                         );
 
                         if ($scalar_type_match_found) {
@@ -2049,12 +2067,17 @@ class CallChecker
             }
         }
 
-        $param_type = TypeChecker::simplifyUnionType($param_type, $statements_checker->getFileChecker());
+        $param_type = TypeChecker::simplifyUnionType(
+            $statements_checker->getFileChecker()->project_checker,
+            $param_type
+        );
+
+        $project_checker = $statements_checker->getFileChecker()->project_checker;
 
         $type_match_found = TypeChecker::isContainedBy(
+            $project_checker,
             $input_type,
             $param_type,
-            $statements_checker->getFileChecker(),
             true,
             $scalar_type_match_found,
             $coerced_type,
@@ -2089,9 +2112,9 @@ class CallChecker
 
         if (!$type_match_found && !$coerced_type) {
             $types_can_be_identical = TypeChecker::canBeIdenticalTo(
+                $project_checker,
                 $param_type,
-                $input_type,
-                $statements_checker->getFileChecker()
+                $input_type
             );
 
             if ($scalar_type_match_found) {

--- a/src/Psalm/Checker/Statements/ExpressionChecker.php
+++ b/src/Psalm/Checker/Statements/ExpressionChecker.php
@@ -8,6 +8,7 @@ use Psalm\Checker\ClassLikeChecker;
 use Psalm\Checker\ClosureChecker;
 use Psalm\Checker\CommentChecker;
 use Psalm\Checker\MethodChecker;
+use Psalm\Checker\ProjectChecker;
 use Psalm\Checker\Statements\Expression\AssignmentChecker;
 use Psalm\Checker\Statements\Expression\CallChecker;
 use Psalm\Checker\Statements\Expression\FetchChecker;
@@ -232,6 +233,7 @@ class ExpressionChecker
                 if ($context->collect_mutations &&
                     $context->self &&
                     ClassChecker::classExtends(
+                        $statements_checker->getFileChecker()->project_checker,
                         $context->self,
                         (string)$statements_checker->getFQCLN()
                     )
@@ -368,8 +370,8 @@ class ExpressionChecker
                     );
 
                     if (ClassLikeChecker::checkFullyQualifiedClassLikeName(
+                        $statements_checker->getFileChecker()->project_checker,
                         $fq_class_name,
-                        $statements_checker->getFileChecker(),
                         new CodeLocation($statements_checker->getSource(), $stmt->class),
                         $statements_checker->getSuppressedIssues()
                     ) === false) {
@@ -1389,18 +1391,20 @@ class ExpressionChecker
                 }
             }
 
+            $project_checker = $statements_checker->getFileChecker()->project_checker;
+
             $left_type_match = TypeChecker::isContainedBy(
+                $project_checker,
                 $left_type,
                 Type::getString(),
-                $statements_checker->getFileChecker(),
                 true,
                 $left_has_scalar_match
             );
 
             $right_type_match = TypeChecker::isContainedBy(
+                $project_checker,
                 $right_type,
                 Type::getString(),
-                $statements_checker->getFileChecker(),
                 true,
                 $right_has_scalar_match
             );
@@ -1530,14 +1534,23 @@ class ExpressionChecker
      *
      * @return Type\Union
      */
-    public static function fleshOutTypes(Type\Union $return_type, $calling_class = null, $method_id = null)
-    {
+    public static function fleshOutType(
+        ProjectChecker $project_checker,
+        Type\Union $return_type,
+        $calling_class = null,
+        $method_id = null
+    ) {
         $return_type = clone $return_type;
 
         $new_return_type_parts = [];
 
         foreach ($return_type->types as $return_type_part) {
-            $new_return_type_parts[] = self::fleshOutAtomicType($return_type_part, $calling_class, $method_id);
+            $new_return_type_parts[] = self::fleshOutAtomicType(
+                $project_checker,
+                $return_type_part,
+                $calling_class,
+                $method_id
+            );
         }
 
         $fleshed_out_type = new Type\Union($new_return_type_parts);
@@ -1555,8 +1568,12 @@ class ExpressionChecker
      *
      * @return Type\Atomic
      */
-    protected static function fleshOutAtomicType(Type\Atomic $return_type, $calling_class, $method_id)
-    {
+    protected static function fleshOutAtomicType(
+        ProjectChecker $project_checker,
+        Type\Atomic $return_type,
+        $calling_class,
+        $method_id
+    ) {
         if ($return_type instanceof TNamedObject) {
             if ($return_type->value === '$this' ||
                 $return_type->value === 'static' ||
@@ -1573,7 +1590,10 @@ class ExpressionChecker
                 } else {
                     list(, $method_name) = explode('::', $method_id);
 
-                    $appearing_method_id = MethodChecker::getAppearingMethodId($calling_class . '::' . $method_name);
+                    $appearing_method_id = MethodChecker::getAppearingMethodId(
+                        $project_checker,
+                        $calling_class . '::' . $method_name
+                    );
 
                     $return_type->value = explode('::', (string)$appearing_method_id)[0];
                 }
@@ -1582,7 +1602,7 @@ class ExpressionChecker
 
         if ($return_type instanceof Type\Atomic\TArray || $return_type instanceof Type\Atomic\TGenericObject) {
             foreach ($return_type->type_params as &$type_param) {
-                $type_param = self::fleshOutTypes($type_param, $calling_class, $method_id);
+                $type_param = self::fleshOutType($project_checker, $type_param, $calling_class, $method_id);
             }
         }
 

--- a/src/Psalm/Checker/Statements/ExpressionChecker.php
+++ b/src/Psalm/Checker/Statements/ExpressionChecker.php
@@ -195,7 +195,14 @@ class ExpressionChecker
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\FuncCall) {
-            if (CallChecker::analyzeFunctionCall($statements_checker, $stmt, $context) === false) {
+            $project_checker = $statements_checker->getFileChecker()->project_checker;
+            if (CallChecker::analyzeFunctionCall(
+                $project_checker,
+                $statements_checker,
+                $stmt,
+                $context
+            ) === false
+            ) {
                 return false;
             }
         } elseif ($stmt instanceof PhpParser\Node\Expr\Ternary) {

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -82,6 +82,8 @@ class StatementsChecker extends SourceChecker implements StatementsSource
             }
         }
 
+        $project_checker = $this->getFileChecker()->project_checker;
+
         foreach ($stmts as $stmt) {
             $plugins = Config::getInstance()->getPlugins();
 
@@ -196,8 +198,6 @@ class StatementsChecker extends SourceChecker implements StatementsSource
                     }
                 }
             } elseif ($stmt instanceof PhpParser\Node\Stmt\Function_) {
-                $project_checker = $this->getFileChecker()->project_checker;
-
                 if (!$project_checker->register_global_functions) {
                     $function_context = new Context($context->self);
                     $function_context->collect_references = $project_checker->collect_references;
@@ -296,6 +296,7 @@ class StatementsChecker extends SourceChecker implements StatementsSource
 
                     if (isset($const->value->inferredType) && !$const->value->inferredType->isMixed()) {
                         ClassLikeChecker::setConstantType(
+                            $project_checker,
                             (string)$this->getFQCLN(),
                             $const->name,
                             $const->value->inferredType,

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -31,6 +31,11 @@ class StatementsChecker extends SourceChecker implements StatementsSource
     protected $source;
 
     /**
+     * @var FileChecker
+     */
+    protected $file_checker;
+
+    /**
      * @var array<string, CodeLocation>
      */
     private $all_vars = [];
@@ -204,7 +209,11 @@ class StatementsChecker extends SourceChecker implements StatementsSource
                         /** @var string */
                         $method_id = $function_checkers[$stmt->name]->getMethodId();
 
-                        $function_storage = FunctionChecker::getStorage($method_id, $this->getFilePath());
+                        $function_storage = FunctionChecker::getStorage(
+                            $project_checker,
+                            $method_id,
+                            $this->getFilePath()
+                        );
 
                         $return_type = $function_storage->return_type;
                         $return_type_location = $function_storage->return_type_location;
@@ -770,12 +779,14 @@ class StatementsChecker extends SourceChecker implements StatementsSource
 
         $file_path = $statements_checker->getFilePath();
 
-        $file_storage = FileChecker::$storage[strtolower($file_path)];
+        $file_storage_provider = $statements_checker->getFileChecker()->project_checker->file_storage_provider;
+
+        $file_storage = $file_storage_provider->get($file_path);
 
         if (isset($file_storage->declaring_constants[$const_name])) {
             $constant_file_path = $file_storage->declaring_constants[$const_name];
 
-            return FileChecker::$storage[strtolower($constant_file_path)]->constants[$const_name];
+            return $file_storage_provider->get($constant_file_path)->constants[$const_name];
         }
 
         $predefined_constants = Config::getInstance()->getPredefinedConstants();
@@ -1060,6 +1071,11 @@ class StatementsChecker extends SourceChecker implements StatementsSource
     public function getFirstAppearance($var_name)
     {
         return isset($this->all_vars[$var_name]) ? $this->all_vars[$var_name] : null;
+    }
+
+    public function getFileChecker()
+    {
+        return $this->file_checker;
     }
 
     /**

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -492,7 +492,12 @@ class Config
 
             require_once($path);
 
-            if (!\Psalm\Checker\ClassChecker::classExtends($declared_classes[0], 'Psalm\\Checker\\FileChecker')) {
+            if (!\Psalm\Checker\ClassChecker::classExtends(
+                $project_checker,
+                $declared_classes[0],
+                'Psalm\\Checker\\FileChecker'
+            )
+            ) {
                 throw new \InvalidArgumentException(
                     'Filetype handlers must extend \Psalm\Checker\FileChecker - ' . $path . ' does not'
                 );

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -481,7 +481,7 @@ class Config
             $plugin_file_checker = new FileChecker($path, $project_checker);
             $plugin_file_checker->scan();
 
-            $declared_classes = ClassLikeChecker::getClassesForFile($path);
+            $declared_classes = ClassLikeChecker::getClassesForFile($project_checker, $path);
 
             if (count($declared_classes) !== 1) {
                 throw new \InvalidArgumentException(

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -616,6 +616,7 @@ class Config
                 $generic_stubs,
                 $project_checker
             );
+            $project_checker->file_storage_provider->create($generic_stubs);
             $generic_stub_checker->scan();
         } else {
             throw new \UnexpectedValueException('Cannot locate core generic stubs');
@@ -623,6 +624,7 @@ class Config
 
         foreach ($this->stub_files as $stub_file) {
             $stub_checker = new FileChecker($stub_file, $project_checker);
+            $project_checker->file_storage_provider->create($stub_file);
             $stub_checker->scan();
         }
 

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -192,9 +192,9 @@ class IssueBuffer
      *
      * @return void
      */
-    public static function finish($is_full, $start_time, array $visited_files)
+    public static function finish(ProjectChecker $project_checker, $is_full, $start_time, array $visited_files)
     {
-        Provider\FileReferenceProvider::updateReferenceCache($visited_files);
+        Provider\FileReferenceProvider::updateReferenceCache($project_checker, $visited_files);
 
         $has_error = false;
 

--- a/src/Psalm/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Provider/ClassLikeStorageProvider.php
@@ -1,11 +1,13 @@
 <?php
 namespace Psalm\Provider;
 
-use Psalm\Checker\ClassLikeChecker;
 use Psalm\Storage\ClassLikeStorage;
 
 class ClassLikeStorageProvider
 {
+    /** @var array<string, ClassLikeStorage> */
+    private static $storage = [];
+
     /**
      * @param  string $fq_classlike_name
      *
@@ -15,11 +17,11 @@ class ClassLikeStorageProvider
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
 
-        if (!isset(ClassLikeChecker::$all_storage[$fq_classlike_name_lc])) {
+        if (!isset(self::$storage[$fq_classlike_name_lc])) {
             throw new \InvalidArgumentException('Could not get class storage for ' . $fq_classlike_name);
         }
 
-        return ClassLikeChecker::$all_storage[$fq_classlike_name_lc];
+        return self::$storage[$fq_classlike_name_lc];
     }
 
     /**
@@ -29,7 +31,7 @@ class ClassLikeStorageProvider
      */
     public function has($fq_classlike_name)
     {
-        return isset(ClassLikeChecker::$all_storage[strtolower($fq_classlike_name)]);
+        return isset(self::$storage[strtolower($fq_classlike_name)]);
     }
 
     /**
@@ -37,7 +39,7 @@ class ClassLikeStorageProvider
      */
     public function getAll()
     {
-        return ClassLikeChecker::$all_storage;
+        return self::$storage;
     }
 
     /**
@@ -49,10 +51,18 @@ class ClassLikeStorageProvider
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
 
-        ClassLikeChecker::$all_storage[$fq_classlike_name_lc] = $storage = new ClassLikeStorage();
+        self::$storage[$fq_classlike_name_lc] = $storage = new ClassLikeStorage();
 
         $storage->name = $fq_classlike_name;
 
         return $storage;
+    }
+
+    /**
+     * @return void
+     */
+    public function deleteAll()
+    {
+        self::$storage = [];
     }
 }

--- a/src/Psalm/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Provider/ClassLikeStorageProvider.php
@@ -15,11 +15,21 @@ class ClassLikeStorageProvider
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
 
-        if (!isset(ClassLikeChecker::$storage[$fq_classlike_name_lc])) {
+        if (!isset(ClassLikeChecker::$all_storage[$fq_classlike_name_lc])) {
             throw new \InvalidArgumentException('Could not get class storage for ' . $fq_classlike_name);
         }
 
-        return ClassLikeChecker::$storage[$fq_classlike_name_lc];
+        return ClassLikeChecker::$all_storage[$fq_classlike_name_lc];
+    }
+
+    /**
+     * @param  string  $fq_classlike_name
+     *
+     * @return bool
+     */
+    public function has($fq_classlike_name)
+    {
+        return isset(ClassLikeChecker::$all_storage[strtolower($fq_classlike_name)]);
     }
 
     /**
@@ -27,7 +37,7 @@ class ClassLikeStorageProvider
      */
     public function getAll()
     {
-        return ClassLikeChecker::$storage;
+        return ClassLikeChecker::$all_storage;
     }
 
     /**
@@ -39,7 +49,7 @@ class ClassLikeStorageProvider
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
 
-        ClassLikeChecker::$storage[$fq_classlike_name_lc] = $storage = new ClassLikeStorage();
+        ClassLikeChecker::$all_storage[$fq_classlike_name_lc] = $storage = new ClassLikeStorage();
 
         $storage->name = $fq_classlike_name;
 

--- a/src/Psalm/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Provider/ClassLikeStorageProvider.php
@@ -1,0 +1,48 @@
+<?php
+namespace Psalm\Provider;
+
+use Psalm\Checker\ClassLikeChecker;
+use Psalm\Storage\ClassLikeStorage;
+
+class ClassLikeStorageProvider
+{
+    /**
+     * @param  string $fq_classlike_name
+     *
+     * @return ClassLikeStorage
+     */
+    public function get($fq_classlike_name)
+    {
+        $fq_classlike_name_lc = strtolower($fq_classlike_name);
+
+        if (!isset(ClassLikeChecker::$storage[$fq_classlike_name_lc])) {
+            throw new \InvalidArgumentException('Could not get class storage for ' . $fq_classlike_name);
+        }
+
+        return ClassLikeChecker::$storage[$fq_classlike_name_lc];
+    }
+
+    /**
+     * @return array<string, ClassLikeStorage>
+     */
+    public function getAll()
+    {
+        return ClassLikeChecker::$storage;
+    }
+
+    /**
+     * @param  string $fq_classlike_name
+     *
+     * @return ClassLikeStorage
+     */
+    public function create($fq_classlike_name)
+    {
+        $fq_classlike_name_lc = strtolower($fq_classlike_name);
+
+        ClassLikeChecker::$storage[$fq_classlike_name_lc] = $storage = new ClassLikeStorage();
+
+        $storage->name = $fq_classlike_name;
+
+        return $storage;
+    }
+}

--- a/src/Psalm/Provider/FileReferenceProvider.php
+++ b/src/Psalm/Provider/FileReferenceProvider.php
@@ -2,6 +2,7 @@
 namespace Psalm\Provider;
 
 use Psalm\Checker\ClassLikeChecker;
+use Psalm\Checker\ProjectChecker;
 use Psalm\Config;
 
 /**
@@ -95,11 +96,11 @@ class FileReferenceProvider
      *
      * @return  array
      */
-    public static function calculateFilesReferencingFile($file)
+    public static function calculateFilesReferencingFile(ProjectChecker $project_checker, $file)
     {
         $referenced_files = [];
 
-        $file_classes = ClassLikeChecker::getClassesForFile($file);
+        $file_classes = ClassLikeChecker::getClassesForFile($project_checker, $file);
 
         foreach ($file_classes as $file_class) {
             if (isset(self::$file_references_to_class[$file_class])) {
@@ -118,11 +119,11 @@ class FileReferenceProvider
      *
      * @return  array
      */
-    public static function calculateFilesInheritingFile($file)
+    public static function calculateFilesInheritingFile(ProjectChecker $project_checker, $file)
     {
         $referenced_files = [];
 
-        $file_classes = ClassLikeChecker::getClassesForFile($file);
+        $file_classes = ClassLikeChecker::getClassesForFile($project_checker, $file);
 
         foreach ($file_classes as $file_class) {
             if (isset(self::$files_inheriting_classes[$file_class])) {
@@ -210,7 +211,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public static function updateReferenceCache(array $visited_files)
+    public static function updateReferenceCache(ProjectChecker $project_checker, array $visited_files)
     {
         $cache_directory = Config::getInstance()->getCacheDirectory();
 
@@ -221,14 +222,14 @@ class FileReferenceProvider
                 $all_file_references = array_unique(
                     array_merge(
                         isset(self::$file_references[$file]['a']) ? self::$file_references[$file]['a'] : [],
-                        FileReferenceProvider::calculateFilesReferencingFile($file)
+                        FileReferenceProvider::calculateFilesReferencingFile($project_checker, $file)
                     )
                 );
 
                 $inheritance_references = array_unique(
                     array_merge(
                         isset(self::$file_references[$file]['i']) ? self::$file_references[$file]['i'] : [],
-                        FileReferenceProvider::calculateFilesInheritingFile($file)
+                        FileReferenceProvider::calculateFilesInheritingFile($project_checker, $file)
                     )
                 );
 

--- a/src/Psalm/Provider/FileStorageProvider.php
+++ b/src/Psalm/Provider/FileStorageProvider.php
@@ -1,11 +1,17 @@
 <?php
 namespace Psalm\Provider;
 
-use Psalm\Checker\FileChecker;
 use Psalm\Storage\FileStorage;
 
 class FileStorageProvider
 {
+    /**
+     * A list of data useful to analyse files
+     *
+     * @var array<string, FileStorage>
+     */
+    private static $storage = [];
+
     /**
      * @param  string $file_path
      *
@@ -15,11 +21,11 @@ class FileStorageProvider
     {
         $file_path = strtolower($file_path);
 
-        if (!isset(FileChecker::$storage[$file_path])) {
+        if (!isset(self::$storage[$file_path])) {
             throw new \InvalidArgumentException('Could not get file storage for ' . $file_path);
         }
 
-        return FileChecker::$storage[$file_path];
+        return self::$storage[$file_path];
     }
 
     /**
@@ -27,7 +33,7 @@ class FileStorageProvider
      */
     public function getAll()
     {
-        return FileChecker::$storage;
+        return self::$storage;
     }
 
     /**
@@ -39,10 +45,18 @@ class FileStorageProvider
     {
         $file_path = strtolower($file_path);
 
-        FileChecker::$storage[$file_path] = $storage = new FileStorage();
+        self::$storage[$file_path] = $storage = new FileStorage();
 
         $storage->file_path = $file_path;
 
         return $storage;
+    }
+
+    /**
+     * @return void
+     */
+    public function deleteAll()
+    {
+        self::$storage = [];
     }
 }

--- a/src/Psalm/Provider/FileStorageProvider.php
+++ b/src/Psalm/Provider/FileStorageProvider.php
@@ -16,7 +16,7 @@ class FileStorageProvider
         $file_path = strtolower($file_path);
 
         if (!isset(FileChecker::$storage[$file_path])) {
-            throw new \InvalidArgumentException('Could not get storage for ' . $file_path);
+            throw new \InvalidArgumentException('Could not get file storage for ' . $file_path);
         }
 
         return FileChecker::$storage[$file_path];

--- a/src/Psalm/Provider/FileStorageProvider.php
+++ b/src/Psalm/Provider/FileStorageProvider.php
@@ -1,0 +1,48 @@
+<?php
+namespace Psalm\Provider;
+
+use Psalm\Checker\FileChecker;
+use Psalm\Storage\FileStorage;
+
+class FileStorageProvider
+{
+    /**
+     * @param  string $file_path
+     *
+     * @return FileStorage
+     */
+    public function get($file_path)
+    {
+        $file_path = strtolower($file_path);
+
+        if (!isset(FileChecker::$storage[$file_path])) {
+            throw new \InvalidArgumentException('Could not get storage for ' . $file_path);
+        }
+
+        return FileChecker::$storage[$file_path];
+    }
+
+    /**
+     * @return array<string, FileStorage>
+     */
+    public function getAll()
+    {
+        return FileChecker::$storage;
+    }
+
+    /**
+     * @param  string $file_path
+     *
+     * @return FileStorage
+     */
+    public function create($file_path)
+    {
+        $file_path = strtolower($file_path);
+
+        FileChecker::$storage[$file_path] = $storage = new FileStorage();
+
+        $storage->file_path = $file_path;
+
+        return $storage;
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -49,6 +49,15 @@ class TestCase extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @return void
+     */
+    public function tearDown()
+    {
+        $this->project_checker->classlike_storage_provider->deleteAll();
+        $this->project_checker->file_storage_provider->deleteAll();
+    }
+
+    /**
      * @param string $file_path
      * @param string $contents
      *

--- a/tests/TypeReconciliationTest.php
+++ b/tests/TypeReconciliationTest.php
@@ -74,9 +74,9 @@ class TypeReconciliationTest extends TestCase
     {
         $this->assertTrue(
             TypeChecker::isContainedBy(
+                $this->project_checker,
                 Type::parseString($input),
-                Type::parseString($container),
-                $this->file_checker
+                Type::parseString($container)
             )
         );
     }


### PR DESCRIPTION
Ref #193

The codebase had a lot of `ClassLikeChecker::$storage[...]` and `FileChecker::$storage[...]` array read/writes.

This PR moves that data access into `ClassStorageProvider` and `FileStorageProvider`, so that we can (at a later date) cache those to save time.