### PR TITLE
Fix case of ZipArchive properties

### DIFF
--- a/src/Psalm/PropertyMap.php
+++ b/src/Psalm/PropertyMap.php
@@ -73,8 +73,8 @@ return [
     ],
     'ziparchive' => [
         'status' => 'int',
-        'statussys' => 'int',
-        'numfiles' => 'int',
+        'statusSys' => 'int',
+        'numFiles' => 'int',
         'filename' => 'string',
         'comment' => 'string',
     ],


### PR DESCRIPTION
The properties "numFiles" and "statusSys" use camelCase.

https://secure.php.net/manual/en/class.ziparchive.php