### PR TITLE
Fix not generated report

### DIFF
--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -209,12 +209,12 @@ class IssueBuffer
             }
 
             echo self::getOutput($project_checker->output_format, $project_checker->use_color);
-            foreach ($project_checker->reports as $format => $path) {
-                file_put_contents(
-                    $path,
-                    self::getOutput($format, $project_checker->use_color)
-                );
-            }
+        }
+        foreach ($project_checker->reports as $format => $path) {
+            file_put_contents(
+                $path,
+                self::getOutput($format, $project_checker->use_color)
+            );
         }
 
         if ($start_time) {

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -183,4 +183,35 @@ somefile.php:2:43:error - Could not verify return type \'string|null\' for psalm
         //    XML2Array::createArray(IssueBuffer::getOutput(ProjectChecker::TYPE_XML, false), LIBXML_NOCDATA)
         //);
     }
+
+    /**
+     * @return void
+     */
+    public function testEmptyReportIfNotError()
+    {
+        $this->addFile(
+            'somefile.php',
+            '<?php ?>'
+        );
+
+        $file_checker = new FileChecker('somefile.php', $this->project_checker);
+        $file_checker->visitAndAnalyzeMethods();
+        $this->assertSame(
+            '[]
+',
+            IssueBuffer::getOutput(ProjectChecker::TYPE_JSON, false)
+        );
+        $this->assertSame(
+            '',
+            IssueBuffer::getOutput(ProjectChecker::TYPE_EMACS, false)
+        );
+        $this->assertSame(
+            '<?xml version="1.0" encoding="UTF-8"?>
+<report>
+  <item/>
+</report>
+',
+            IssueBuffer::getOutput(ProjectChecker::TYPE_XML, false)
+        );
+    }
 }

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -214,7 +214,7 @@ somefile.php:2:43:error - Could not verify return type \'string|null\' for psalm
             IssueBuffer::getOutput(ProjectChecker::TYPE_XML, false)
         );
 
-        IssueBuffer::finish($this->project_checker, true, null, ['somefile.php']);
+        IssueBuffer::finish($this->project_checker, true, null, ['somefile.php' => true]);
         $this->assertFileExists(__DIR__ . '/test-report.json');
         $this->assertSame('[]
 ', file_get_contents(__DIR__ . '/test-report.json'));

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -213,5 +213,11 @@ somefile.php:2:43:error - Could not verify return type \'string|null\' for psalm
 ',
             IssueBuffer::getOutput(ProjectChecker::TYPE_XML, false)
         );
+
+        IssueBuffer::finish($this->project_checker, true, null, ['somefile.php']);
+        $this->assertFileExists(__DIR__ . '/test-report.json');
+        $this->assertSame('[]
+', file_get_contents(__DIR__ . '/test-report.json'));
+        unlink(__DIR__ . '/test-report.json');
     }
 }


### PR DESCRIPTION
The previous code don't generate report file if there are no errors nor warnings.

Which:
 - can lead to false positive if the previous file is not removed (because last file always contains at least one issue)
 - can break CI because the report file don't exist if the previous file is purge at each run