### PR TITLE
Fix signature of "gmp_import"

### DIFF
--- a/src/Psalm/CallMap.php
+++ b/src/Psalm/CallMap.php
@@ -2703,7 +2703,7 @@ return [
 'gmp_gcdext' => ['array', 'a'=>'', 'b'=>''],
 'gmp_gcd' => ['GMP', 'a'=>'', 'b'=>''],
 'gmp_hamdist' => ['int', 'a'=>'', 'b'=>''],
-'gmp_import' => ['GMP', 'data'=>'string', 'word_size'=>'int', 'options'=>'int'],
+'gmp_import' => ['GMP', 'data'=>'string', 'word_size='=>'int', 'options='=>'int'],
 'gmp_init' => ['GMP', 'number'=>'', 'base='=>'int'],
 'gmp_intval' => ['int', 'gmpnumber'=>''],
 'gmp_invert' => ['GMP', 'a'=>'', 'b'=>''],


### PR DESCRIPTION
According to the PHP manual, the second and third argument of "gmp_import" have default values and are therefore optional.

https://php.net/gmp_import

Fixes https://github.com/vimeo/psalm/issues/260