### PR TITLE
Fix build failure - MixedPropertyAssignment should be expected in test.

### DIFF
--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -637,7 +637,7 @@ final class B extends A {}',
                     $a = (new Foo());
 
                     $a->foo = "hello";',
-                'error_message' => '',
+                'error_message' => 'MixedPropertyAssignment',
                 'error_levels' => [
                     'MissingPropertyType',
                     'MixedAssignment',


### PR DESCRIPTION
My understanding: This is assigning to a property of type mixed, and should warn?