### PR TITLE
Get rid of unused variables in psalm's codebase

### DIFF
--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -151,8 +151,6 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
         $this->file_checker = $source->getFileChecker();
         $this->fq_class_name = $fq_class_name;
 
-        $fq_class_name_lower = strtolower($fq_class_name);
-
         $this->storage = $this->file_checker->project_checker->classlike_storage_provider->get($fq_class_name);
 
         if ($this->storage->location) {
@@ -857,8 +855,6 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
     private function checkForMissingPropertyType(ProjectChecker $project_checker, PhpParser\Node\Stmt\Property $stmt)
     {
         $comment = $stmt->getDocComment();
-        $property_type_line_number = null;
-        $storage = $this->storage;
 
         if (!$comment || !$comment->getText()) {
             $fq_class_name = $this->fq_class_name;
@@ -1323,8 +1319,6 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
 
         // register where they appear (can never be in a trait)
         foreach ($parent_storage->appearing_method_ids as $method_name => $appearing_method_id) {
-            $parent_method_id = $parent_class . '::' . $method_name;
-
             $implemented_method_id = $fq_class_name . '::' . $method_name;
 
             $storage->appearing_method_ids[$method_name] = $appearing_method_id;
@@ -1332,8 +1326,6 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
 
         // register where they're declared
         foreach ($parent_storage->inheritable_method_ids as $method_name => $declaring_method_id) {
-            $parent_method_id = $parent_class . '::' . $method_name;
-
             $implemented_method_id = $fq_class_name . '::' . $method_name;
 
             $storage->declaring_method_ids[$method_name] = $declaring_method_id;

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -654,15 +654,6 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
                     $first_uninitialized_property = array_shift($uninitialized_properties);
 
                     if ($first_uninitialized_property->location) {
-                        if (!$config->reportIssueInFile(
-                            'PropertyNotSetInConstructor',
-                            $first_uninitialized_property->location->file_path
-                        ) && $this->class->extends) {
-                            $error_location = new CodeLocation($this, $this->class->extends);
-                        } else {
-                            $error_location = $first_uninitialized_property->location;
-                        }
-
                         if (IssueBuffer::accepts(
                             new MissingConstructor(
                                 $fq_class_name . ' has an uninitialized variable ' . $uninitialized_variables[0] .

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -122,8 +122,6 @@ class FileChecker extends SourceChecker implements StatementsSource
      */
     public function scan()
     {
-        $config = Config::getInstance();
-
         $stmts = $this->getStatements();
 
         $traverser = new PhpParser\NodeTraverser();

--- a/src/Psalm/Checker/FunctionChecker.php
+++ b/src/Psalm/Checker/FunctionChecker.php
@@ -484,7 +484,7 @@ class FunctionChecker extends FunctionLikeChecker
             $inner_value_types = [];
             $inner_key_types = [];
 
-            foreach ($call_args as $offset => $call_arg) {
+            foreach ($call_args as $call_arg) {
                 if (!isset($call_arg->value->inferredType)) {
                     return Type::getArray();
                 }

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -433,8 +433,6 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
                         $param_type
                     )
                 ) {
-                    $method_id = $this->getMethodId();
-
                     if (IssueBuffer::accepts(
                         new InvalidParamDefault(
                             'Default value for argument ' . ($offset + 1) . ' of method ' . $cased_method_id .

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -378,7 +378,6 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
 
         foreach ($storage->params as $offset => $function_param) {
             $signature_type = $function_param->signature_type;
-
             if ($function_param->type) {
                 $param_type = clone $function_param->type;
 
@@ -845,10 +844,7 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
         $inferred_return_type = $inferred_return_types ? Type::combineTypes($inferred_return_types) : Type::getVoid();
         $inferred_yield_type = $inferred_yield_types ? Type::combineTypes($inferred_yield_types) : null;
 
-        $inferred_generator_return_type = null;
-
         if ($inferred_yield_type) {
-            $inferred_generator_return_type = $inferred_return_type;
             $inferred_return_type = $inferred_yield_type;
         }
 

--- a/src/Psalm/Checker/InterfaceChecker.php
+++ b/src/Psalm/Checker/InterfaceChecker.php
@@ -64,8 +64,6 @@ class InterfaceChecker extends ClassLikeChecker
     {
         $fq_interface_name = strtolower($fq_interface_name);
 
-        $extended_interfaces = [];
-
         $storage = $project_checker->classlike_storage_provider->get($fq_interface_name);
 
         return $storage->parent_interfaces;

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -468,7 +468,7 @@ class MethodChecker extends FunctionLikeChecker
         $declaring_method_id = self::getDeclaringMethodId($project_checker, $method_id);
 
         if (!$declaring_method_id) {
-            list($method_class, $method_name) = explode('::', $method_id);
+            $method_name = explode('::', $method_id)[1];
 
             if ($method_name === '__construct') {
                 return null;

--- a/src/Psalm/Checker/NamespaceChecker.php
+++ b/src/Psalm/Checker/NamespaceChecker.php
@@ -94,8 +94,6 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
             }
         }
 
-        $function_checkers = [];
-
         // hoist functions to the top
         foreach ($function_stmts as $stmt) {
             $function_checker = new FunctionChecker($stmt, $this);

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -745,8 +745,6 @@ class ProjectChecker
                 continue;
             }
 
-            $parent_method_id = $parent_class . '::' . $method_name;
-
             $implemented_method_id = $fq_class_name . '::' . $aliased_method_name;
 
             $storage->appearing_method_ids[$aliased_method_name] =
@@ -782,8 +780,6 @@ class ProjectChecker
                     continue;
                 }
             }
-
-            $parent_method_id = $parent_class . '::' . $method_name;
 
             $storage->declaring_method_ids[$aliased_method_name] = $declaring_method_id;
             $storage->inheritable_method_ids[$aliased_method_name] = $declaring_method_id;
@@ -963,7 +959,8 @@ class ProjectChecker
                 FileReferenceProvider::addFileReferences($pool_data['file_references']);
             }
 
-            $did_fork_pool_have_error = $pool->didHaveError();
+            // TODO: Tell the caller that the fork pool encountered an error in another PR?
+            // $did_fork_pool_have_error = $pool->didHaveError();
         } else {
             $i = 0;
 
@@ -1241,7 +1238,6 @@ class ProjectChecker
     protected function getDiffFilesInDir($dir_name, Config $config)
     {
         $file_extensions = $config->getFileExtensions();
-        $filetype_handlers = $config->getFiletypeHandlers();
 
         /** @var RecursiveDirectoryIterator */
         $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir_name));
@@ -1320,8 +1316,6 @@ class ProjectChecker
         $this->files_to_deep_scan[$file_path] = $file_path;
         $this->files_to_scan[$file_path] = $file_path;
         $this->files_to_report[$file_path] = $file_path;
-
-        $filetype_handlers = $this->config->getFiletypeHandlers();
 
         FileReferenceProvider::loadReferenceCache();
 

--- a/src/Psalm/Checker/Statements/Block/IfChecker.php
+++ b/src/Psalm/Checker/Statements/Block/IfChecker.php
@@ -700,8 +700,6 @@ class IfChecker
                         $if_scope->updated_vars
                     );
                 } else {
-                    $negated_keys = [];
-
                     $outer_context->update(
                         $old_elseif_context,
                         $elseif_context,

--- a/src/Psalm/Checker/Statements/Block/SwitchChecker.php
+++ b/src/Psalm/Checker/Statements/Block/SwitchChecker.php
@@ -29,8 +29,6 @@ class SwitchChecker
         Context $context,
         Context $loop_context = null
     ) {
-        $type_candidate_var = null;
-
         if (ExpressionChecker::analyze($statements_checker, $stmt->cond, $context) === false) {
             return false;
         }
@@ -42,8 +40,6 @@ class SwitchChecker
         ) {
             /** @var Type\Atomic\T */
             $type_type = array_values($stmt->cond->inferredType->types)[0];
-
-            $type_candidate_var = $type_type->typeof;
         }
 
         $original_context = clone $context;
@@ -141,7 +137,6 @@ class SwitchChecker
 
             if (!$case_stmts || (!$has_ending_statements && !$has_leaving_statements)) {
                 $case_stmts = array_merge($case_stmts, $leftover_statements);
-                $has_ending_statements = ScopeChecker::doesAlwaysReturnOrThrow($case_stmts);
             } else {
                 $leftover_statements = [];
             }
@@ -154,9 +149,6 @@ class SwitchChecker
                     $case_context->referenced_vars
                 );
             }
-
-            // has a return/throw at end
-            $has_ending_statements = ScopeChecker::doesAlwaysReturnOrThrow($case_stmts);
 
             if ($case_exit_type !== 'return_throw') {
                 $vars = array_diff_key(

--- a/src/Psalm/Checker/Statements/Block/SwitchChecker.php
+++ b/src/Psalm/Checker/Statements/Block/SwitchChecker.php
@@ -33,15 +33,6 @@ class SwitchChecker
             return false;
         }
 
-        $type_type = null;
-
-        if (isset($stmt->cond->inferredType) &&
-            array_values($stmt->cond->inferredType->types)[0] instanceof Type\Atomic\T
-        ) {
-            /** @var Type\Atomic\T */
-            $type_type = array_values($stmt->cond->inferredType->types)[0];
-        }
-
         $original_context = clone $context;
 
         $new_vars_in_scope = null;

--- a/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
@@ -661,18 +661,6 @@ class AssignmentChecker
 
                 $has_regular_setter = true;
 
-                if (($stmt->var instanceof PhpParser\Node\Expr\Variable && $stmt->var->name === 'this')
-                    || $lhs_type_part->value === $context->self
-                ) {
-                    $class_visibility = \ReflectionProperty::IS_PRIVATE;
-                } elseif ($context->self &&
-                    ClassChecker::classExtends($project_checker, $lhs_type_part->value, $context->self)
-                ) {
-                    $class_visibility = \ReflectionProperty::IS_PROTECTED;
-                } else {
-                    $class_visibility = \ReflectionProperty::IS_PUBLIC;
-                }
-
                 $property_id = $lhs_type_part->value . '::$' . $prop_name;
 
                 if (!ClassLikeChecker::propertyExists($project_checker, $property_id)) {
@@ -851,18 +839,6 @@ class AssignmentChecker
         $fq_class_name = (string)$stmt->class->inferredType;
 
         $project_checker = $statements_checker->getFileChecker()->project_checker;
-
-        if (($stmt->class instanceof PhpParser\Node\Name && $stmt->class->parts[0] === 'this') ||
-            $fq_class_name === $context->self
-        ) {
-            $class_visibility = \ReflectionProperty::IS_PRIVATE;
-        } elseif ($context->self &&
-            ClassChecker::classExtends($project_checker, $fq_class_name, $context->self)
-        ) {
-            $class_visibility = \ReflectionProperty::IS_PROTECTED;
-        } else {
-            $class_visibility = \ReflectionProperty::IS_PUBLIC;
-        }
 
         $prop_name = $stmt->name;
 

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -1374,8 +1374,6 @@ class CallChecker
                     ? $statements_checker->getFQCLN()
                     : $fq_class_name;
 
-                $class_template_params = [];
-
                 $return_type_candidate = MethodChecker::getMethodReturnType($project_checker, $method_id);
 
                 if ($return_type_candidate) {
@@ -1670,7 +1668,7 @@ class CallChecker
                             }
 
                             if (in_array($method_id, ['shuffle', 'sort', 'rsort', 'usort'], true)) {
-                                list($tkey, $tvalue) = $array_type->type_params;
+                                $tvalue = $array_type->type_params[1];
                                 $by_ref_type = new Type\Union([new TArray([Type::getInt(), clone $tvalue])]);
                             } else {
                                 $by_ref_type = new Type\Union([clone $array_type]);

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -90,8 +90,6 @@ class StatementsChecker extends SourceChecker implements StatementsSource
 
         $project_checker = $this->getFileChecker()->project_checker;
 
-        $file_replacements = [];
-
         $plugins = Config::getInstance()->getPlugins();
 
         foreach ($stmts as $stmt) {

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -607,8 +607,6 @@ class TypeChecker
             return true;
         }
 
-        $type_match_found = false;
-
         foreach ($type1->types as $type1_part) {
             if ($type1_part instanceof TNull) {
                 continue;
@@ -995,7 +993,6 @@ class TypeChecker
                     }
                 }
 
-                $base_type = $existing_keys[$new_base_key];
                 $base_key = $new_base_key;
             } else {
                 throw new \InvalidArgumentException('Unexpected divider ' . $divider);

--- a/src/Psalm/EffectsAnalyser.php
+++ b/src/Psalm/EffectsAnalyser.php
@@ -202,8 +202,6 @@ class EffectsAnalyser
 
             return [new Atomic\TMixed()];
         } elseif ($stmt instanceof PhpParser\Node\Expr\YieldFrom) {
-            $key_type = null;
-
             if (isset($stmt->inferredType)) {
                 return array_values($stmt->inferredType->types);
             }

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -563,7 +563,7 @@ abstract class Type
             }
         }
 
-        foreach ($combination->value_types as $generic_type => $type) {
+        foreach ($combination->value_types as $type) {
             if (!($type instanceof TEmpty)
                 || (count($combination->value_types) === 1
                     && !count($new_types))

--- a/src/Psalm/Visitor/DependencyFinderVisitor.php
+++ b/src/Psalm/Visitor/DependencyFinderVisitor.php
@@ -509,8 +509,6 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
             $function_id = $fq_classlike_name . '::' . strtolower($stmt->name);
             $cased_function_id = $fq_classlike_name . '::' . $stmt->name;
 
-            $fq_classlike_name_lc = strtolower($fq_classlike_name);
-
             if (!$this->classlike_storages) {
                 throw new \UnexpectedValueException('$class_storages cannot be empty for ' . $function_id);
             }
@@ -940,19 +938,14 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
         $function,
         CodeLocation $code_location
     ) {
-        $docblock_param_vars = [];
-
         $base = $this->fq_classlike_names
             ? $this->fq_classlike_names[count($this->fq_classlike_names) - 1] . '::'
             : '';
 
         $cased_method_id = $base . $storage->cased_name;
 
-        $file_checker = $this->file_checker;
-
         foreach ($docblock_params as $docblock_param) {
             $param_name = $docblock_param['name'];
-            $line_number = $docblock_param['line_number'];
             $docblock_param_variadic = false;
 
             if (substr($param_name, 0, 3) === '...') {
@@ -974,8 +967,6 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
             if ($storage_param === null) {
                 continue;
             }
-
-            $docblock_param_vars[$param_name] = true;
 
             try {
                 $new_param_type = Type::parseString(


### PR DESCRIPTION
Unit tests and psalm self-checks pass after this change.

Remaining detected unused variables were false positives.
I'm not fully familiar with coding conventions for this repo, feel free to make changes. (e.g. change to $_ or $unused_var_name or add TODO to mark things to use later)