### PR TITLE
Fix incorrect strpos argument order

### DIFF
--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -1738,7 +1738,7 @@ class CallChecker
                         $arg->value,
                         $by_ref_type,
                         $context,
-                        $method_id && (strpos('::', $method_id) !== false || !FunctionChecker::inCallMap($method_id))
+                        $method_id && (strpos($method_id, '::') !== false || !FunctionChecker::inCallMap($method_id))
                     );
                 } else {
                     if ($arg->value instanceof PhpParser\Node\Expr\Variable) {


### PR DESCRIPTION
Detected via static analysis heuristic

https://secure.php.net/strpos documents it as `mixed strpos ( string $haystack , mixed $needle [, int $offset = 0 ] )`