### PR TITLE
Fix bug in array key type checks

### DIFF
--- a/src/Psalm/Checker/FunctionChecker.php
+++ b/src/Psalm/Checker/FunctionChecker.php
@@ -787,7 +787,7 @@ class FunctionChecker extends FunctionLikeChecker
     /**
      * Gets the method/function call map
      *
-     * @return array<string, array<string, string>>
+     * @return array<string, array<int, string>>
      * @psalm-suppress MixedInferredReturnType as the use of require buggers things up
      * @psalm-suppress MixedAssignment
      * @psalm-suppress MoreSpecificReturnType

--- a/src/Psalm/Checker/Statements/Expression/FetchChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/FetchChecker.php
@@ -903,7 +903,6 @@ class FetchChecker
         ) === false) {
             return false;
         }
-
         $inferred_key_type = null;
 
         $project_checker = $statements_checker->getFileChecker()->project_checker;
@@ -972,6 +971,7 @@ class FetchChecker
                                     $type->type_params[0] = $key_type;
                                 }
                             } else {
+                                // TODO: What are inferred_key_type and key_type meant to be?
                                 if ($key_type) {
                                     $key_type = Type::combineUnionTypes($key_type, $type->type_params[0]);
                                 } else {
@@ -1253,7 +1253,7 @@ class FetchChecker
         }
 
         if ($stmt->dim) {
-            if (isset($stmt->dim->inferredType) && $key_type && !$key_type->isEmpty()) {
+            if (isset($stmt->dim->inferredType) && $inferred_key_type && !$inferred_key_type->isEmpty()) {
                 foreach ($stmt->dim->inferredType->types as $at) {
                     if (($at instanceof TMixed || $at instanceof TEmpty) &&
                         $inferred_key_type &&
@@ -1270,11 +1270,11 @@ class FetchChecker
                         )) {
                             return false;
                         }
-                    } elseif (!$at->isIn($project_checker, $key_type)) {
+                    } elseif (!$at->isIn($project_checker, $inferred_key_type)) {
                         if (IssueBuffer::accepts(
                             new InvalidArrayAccess(
                                 'Cannot access value on variable ' . $var_id . ' using ' . $at . ' offset - ' .
-                                    'expecting ' . $key_type,
+                                    'expecting ' . $inferred_key_type,
                                 new CodeLocation($statements_checker->getSource(), $stmt)
                             ),
                             $statements_checker->getSuppressedIssues()

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -366,7 +366,7 @@ class ArrayAssignmentTest extends TestCase
 
                     $c = ["a" => "foo", "b"=> "bar"];
                     $d = "a";
-                    $e = $a[$d];',
+                    $e = $c[$d];',
                 'assertions' => [
                     '$b' => 'string',
                     '$e' => 'string',


### PR DESCRIPTION
Fixes https://github.com/vimeo/psalm/issues/309.
The test case(s) mentioned in #309 still needs to be added.

Fix a test failure, should be accessing $c, not $a

**After this change, Psalm self-checks fail.**
I haven't gotten around to investigating all of the failing self-checks.
Feel free to add fixes.