### PR TITLE
[wip] replace composer/composer with composer/xdebug-handler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "nikic/PHP-Parser": "^3.1.2",
-        "composer/composer": "^1.3|^1.4|^1.5",
         "openlss/lib-array2xml": "^0.0.10||^0.5.1",
         "muglug/package-versions-56": "1.2.3",
-        "php-cs-fixer/diff": "^1.2"
+        "php-cs-fixer/diff": "^1.2",
+        "composer/xdebug-handler": "dev-master"
     },
     "bin": ["psalm", "psalter"],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "openlss/lib-array2xml": "^0.0.10||^0.5.1",
         "muglug/package-versions-56": "1.2.3",
         "php-cs-fixer/diff": "^1.2",
-        "composer/xdebug-handler": "dev-master"
+        "composer/xdebug-handler": "^1.0"
     },
     "bin": ["psalm", "psalter"],
     "autoload": {

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -47,7 +47,7 @@ if (isset($options['c']) && is_array($options['c'])) {
 }
 
 if (array_key_exists('h', $options)) {
-    echo <<< HELP
+    echo <<<HELP
 Usage:
     psalm [options] [file...]
 
@@ -147,7 +147,7 @@ if (array_key_exists('v', $options)) {
 }
 
 // If XDebug is enabled, restart without it
-(new \Composer\XdebugHandler(\Composer\Factory::createOutput()))->check();
+(new \Composer\XdebugHandler\XdebugHandler())->check();
 
 setlocale(LC_CTYPE, 'C');
 

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -147,7 +147,7 @@ if (array_key_exists('v', $options)) {
 }
 
 // If XDebug is enabled, restart without it
-(new \Composer\XdebugHandler\XdebugHandler())->check();
+(new \Composer\XdebugHandler\XdebugHandler('PSALM'))->check();
 
 setlocale(LC_CTYPE, 'C');
 


### PR DESCRIPTION
Fixes vimeo/psalm#349

Note: there's no stable release at the moment, so it's using dev-master for now. For this reason you may want to not merge it right away and wait for stable release.