### PR TITLE
Add better understanding of arrays with keyed integer offsets

### DIFF
--- a/src/Psalm/Checker/FunctionChecker.php
+++ b/src/Psalm/Checker/FunctionChecker.php
@@ -569,7 +569,7 @@ class FunctionChecker extends FunctionLikeChecker
             if ($first_arg_array instanceof Type\Atomic\TArray) {
                 $key_type = clone $first_arg_array->type_params[0];
             } else {
-                $key_type = Type::getString();
+                $key_type = $first_arg_array->getGenericKeyType();
             }
 
             if (!$second_arg

--- a/src/Psalm/Checker/FunctionChecker.php
+++ b/src/Psalm/Checker/FunctionChecker.php
@@ -407,7 +407,7 @@ class FunctionChecker extends FunctionLikeChecker
                         if ($first_arg->inferredType->hasArray()) {
                             $array_type = $first_arg->inferredType->types['array'];
                             if ($array_type instanceof Type\Atomic\ObjectLike) {
-                                return $array_type->getGenericTypeParam();
+                                return $array_type->getGenericValueType();
                             }
 
                             if ($array_type instanceof Type\Atomic\TArray) {
@@ -475,13 +475,10 @@ class FunctionChecker extends FunctionLikeChecker
                     if (!$type_part instanceof Type\Atomic\TArray) {
                         if ($type_part instanceof Type\Atomic\ObjectLike) {
                             if ($generic_properties !== null) {
-                                $generic_properties = array_merge($type_part->properties, $generic_properties);
+                                $generic_properties = array_merge($generic_properties, $type_part->properties);
                             }
 
-                            $type_part = new Type\Atomic\TArray([
-                                Type::getString(),
-                                $type_part->getGenericTypeParam(),
-                            ]);
+                            $type_part = $type_part->getGenericArrayType();
                         } else {
                             return Type::getArray();
                         }
@@ -493,10 +490,13 @@ class FunctionChecker extends FunctionLikeChecker
                         continue;
                     }
 
-                    $inner_key_types = array_merge(array_values($type_part->type_params[0]->types), $inner_key_types);
+                    $inner_key_types = array_merge(
+                        $inner_key_types,
+                        array_values($type_part->type_params[0]->types)
+                    );
                     $inner_value_types = array_merge(
-                        array_values($type_part->type_params[1]->types),
-                        $inner_value_types
+                        $inner_value_types,
+                        array_values($type_part->type_params[1]->types)
                     );
                 }
             }
@@ -536,8 +536,8 @@ class FunctionChecker extends FunctionLikeChecker
                 $inner_type = $first_arg_array->type_params[1];
                 $key_type = clone $first_arg_array->type_params[0];
             } else {
-                $inner_type = $first_arg_array->getGenericTypeParam();
-                $key_type = Type::getString();
+                $inner_type = $first_arg_array->getGenericValueType();
+                $key_type = $first_arg_array->getGenericKeyType();
             }
 
             if (!$second_arg) {

--- a/src/Psalm/Checker/Statements/Block/ForeachChecker.php
+++ b/src/Psalm/Checker/Statements/Block/ForeachChecker.php
@@ -98,7 +98,13 @@ class ForeachChecker
                     continue;
                 }
 
-                if ($iterator_type instanceof Type\Atomic\TArray) {
+                if ($iterator_type instanceof Type\Atomic\TArray
+                    || $iterator_type instanceof Type\Atomic\ObjectLike
+                ) {
+                    if ($iterator_type instanceof Type\Atomic\ObjectLike) {
+                        $iterator_type = $iterator_type->getGenericArrayType();
+                    }
+
                     if (!$value_type) {
                         $value_type = $iterator_type->type_params[1];
                     } else {

--- a/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
@@ -1321,8 +1321,10 @@ class AssignmentChecker
 
         $root_is_string = array_keys($root_type->types) === ['string'];
 
-        if ($current_dim instanceof PhpParser\Node\Scalar\String_
-            || ($current_dim instanceof PhpParser\Node\Scalar\LNumber && !$root_is_string)
+        if (($current_dim instanceof PhpParser\Node\Scalar\String_
+                || $current_dim instanceof PhpParser\Node\Scalar\LNumber)
+            && ($current_dim instanceof PhpParser\Node\Scalar\String_
+                || !$root_is_string)
         ) {
             $key_value = $current_dim->value;
 

--- a/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
@@ -301,7 +301,8 @@ class AssignmentChecker
                             $new_assign_type = clone $assign_value_type->types['array']->type_params[1];
                         } elseif ($assign_value_type->types['array'] instanceof Type\Atomic\ObjectLike) {
                             if ($assign_var_item->key
-                                && $assign_var_item->key instanceof PhpParser\Node\Scalar\String_
+                                && ($assign_var_item->key instanceof PhpParser\Node\Scalar\String_
+                                    || $assign_var_item->key instanceof PhpParser\Node\Scalar\LNumber)
                                 && isset($assign_value_type->types['array']->properties[$assign_var_item->key->value])
                             ) {
                                 $new_assign_type =
@@ -1258,24 +1259,26 @@ class AssignmentChecker
                 throw new \InvalidArgumentException('Should never get here');
             }
 
-            if ($current_dim instanceof PhpParser\Node\Scalar\String_) {
-                $string_key_value = $current_dim->value;
+            if ($current_dim instanceof PhpParser\Node\Scalar\String_
+                || $current_dim instanceof PhpParser\Node\Scalar\LNumber
+            ) {
+                $key_value = $current_dim->value;
 
                 $has_matching_objectlike_property = false;
 
                 foreach ($child_stmt->inferredType->types as $type) {
                     if ($type instanceof ObjectLike) {
-                        if (isset($type->properties[$string_key_value])) {
+                        if (isset($type->properties[$key_value])) {
                             $has_matching_objectlike_property = true;
 
-                            $type->properties[$string_key_value] = clone $current_type;
+                            $type->properties[$key_value] = clone $current_type;
                         }
                     }
                 }
 
                 if (!$has_matching_objectlike_property) {
                     $array_assignment_type = new Type\Union([
-                        new ObjectLike([$string_key_value => $current_type]),
+                        new ObjectLike([$key_value => $current_type]),
                     ]);
 
                     $new_child_type = Type::combineUnionTypes(
@@ -1316,24 +1319,26 @@ class AssignmentChecker
             }
         }
 
-        if ($current_dim instanceof PhpParser\Node\Scalar\String_) {
-            $string_key_value = $current_dim->value;
+        if ($current_dim instanceof PhpParser\Node\Scalar\String_
+            || $current_dim instanceof PhpParser\Node\Scalar\LNumber
+        ) {
+            $key_value = $current_dim->value;
 
             $has_matching_objectlike_property = false;
 
             foreach ($root_type->types as $type) {
                 if ($type instanceof ObjectLike) {
-                    if (isset($type->properties[$string_key_value])) {
+                    if (isset($type->properties[$key_value])) {
                         $has_matching_objectlike_property = true;
 
-                        $type->properties[$string_key_value] = clone $current_type;
+                        $type->properties[$key_value] = clone $current_type;
                     }
                 }
             }
 
             if (!$has_matching_objectlike_property) {
                 $array_assignment_type = new Type\Union([
-                    new ObjectLike([$string_key_value => $current_type]),
+                    new ObjectLike([$key_value => $current_type]),
                 ]);
 
                 $new_child_type = Type::combineUnionTypes(

--- a/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
@@ -1319,8 +1319,10 @@ class AssignmentChecker
             }
         }
 
+        $root_is_string = array_keys($root_type->types) === ['string'];
+
         if ($current_dim instanceof PhpParser\Node\Scalar\String_
-            || $current_dim instanceof PhpParser\Node\Scalar\LNumber
+            || ($current_dim instanceof PhpParser\Node\Scalar\LNumber && !$root_is_string)
         ) {
             $key_value = $current_dim->value;
 
@@ -1348,7 +1350,7 @@ class AssignmentChecker
             } else {
                 $new_child_type = $root_type; // noop
             }
-        } elseif (array_keys($root_type->types) !== ['string']) {
+        } elseif (!$root_is_string) {
             $array_assignment_type = new Type\Union([
                 new TArray([
                     isset($current_dim->inferredType) ? $current_dim->inferredType : Type::getInt(),

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -1664,7 +1664,7 @@ class CallChecker
                 $array_type = $array_arg->inferredType->types['array'];
 
                 if ($array_type instanceof ObjectLike) {
-                    $array_type = new TArray([Type::getString(), $array_type->getGenericTypeParam()]);
+                    $array_type = $array_type->getGenericArrayType();
                 }
 
                 $by_ref_type = new Type\Union([clone $array_type]);
@@ -1777,7 +1777,7 @@ class CallChecker
                             $array_type = $arg->value->inferredType->types['array'];
 
                             if ($array_type instanceof ObjectLike) {
-                                $array_type = new TArray([Type::getString(), $array_type->getGenericTypeParam()]);
+                                $array_type = $array_type->getGenericArrayType();
                             }
 
                             if (in_array($method_id, ['shuffle', 'sort', 'rsort', 'usort'], true)) {
@@ -2215,7 +2215,7 @@ class CallChecker
                 : null;
 
             if ($array_arg_type instanceof ObjectLike) {
-                $array_arg_type = new TArray([Type::getString(), $array_arg_type->getGenericTypeParam()]);
+                $array_arg_type = $array_arg_type->getGenericArrayType();
             }
 
             $array_arg_types[] = $array_arg_type;

--- a/src/Psalm/Checker/Statements/Expression/FetchChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/FetchChecker.php
@@ -978,15 +978,21 @@ class FetchChecker
                         $offset_type,
                         $type->getGenericKeyType(),
                         true
-                    )) {
+                    ) || $in_assignment
+                    ) {
                         if ($replacement_type) {
                             $generic_params = Type::combineUnionTypes(
                                 $type->getGenericValueType(),
                                 $replacement_type
                             );
 
-                            $type = new TArray([
+                            $new_key_type = Type::combineUnionTypes(
                                 $type->getGenericKeyType(),
+                                $offset_type
+                            );
+
+                            $type = new TArray([
+                                $new_key_type,
                                 $generic_params,
                             ]);
 

--- a/src/Psalm/Checker/Statements/ExpressionChecker.php
+++ b/src/Psalm/Checker/Statements/ExpressionChecker.php
@@ -1386,8 +1386,9 @@ class ExpressionChecker
                         || $left_type_part instanceof ObjectLike
                         || $right_type_part instanceof ObjectLike
                     ) {
-                        if ((!$right_type_part instanceof TArray && !$right_type_part instanceof ObjectLike) ||
-                            (!$left_type_part instanceof TArray && !$left_type_part instanceof ObjectLike)) {
+                        if ((!$right_type_part instanceof TArray && !$right_type_part instanceof ObjectLike)
+                            || (!$left_type_part instanceof TArray && !$left_type_part instanceof ObjectLike)
+                        ) {
                             if (!$left_type_part instanceof TArray && !$left_type_part instanceof ObjectLike) {
                                 if (IssueBuffer::accepts(
                                     new InvalidOperand(
@@ -1415,7 +1416,13 @@ class ExpressionChecker
                             return;
                         }
 
-                        $result_type_member = Type::combineTypes([$left_type_part, $right_type_part]);
+                        if ($left_type_part instanceof ObjectLike && $right_type_part instanceof ObjectLike) {
+                            $properties = $left_type_part->properties + $right_type_part->properties;
+
+                            $result_type_member = new Type\Union([new ObjectLike($properties)]);
+                        } else {
+                            $result_type_member = Type::combineTypes([$left_type_part, $right_type_part]);
+                        }
 
                         if (!$result_type) {
                             $result_type = $result_type_member;

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -1213,6 +1213,7 @@ class TypeChecker
             strtolower($container_type_part->value) === 'iterable' &&
             (
                 $input_type_part instanceof TArray ||
+                $input_type_part instanceof ObjectLike ||
                 (
                     $input_type_part instanceof TNamedObject &&
                     (
@@ -1257,6 +1258,7 @@ class TypeChecker
             (
                 $input_type_part instanceof TString ||
                 $input_type_part instanceof TArray ||
+                $input_type_part instanceof ObjectLike ||
                 (
                     $input_type_part instanceof TNamedObject &&
                     ClassChecker::classExists($project_checker, $input_type_part->value) &&
@@ -1272,6 +1274,7 @@ class TypeChecker
             (
                 $container_type_part instanceof TString ||
                 $container_type_part instanceof TArray ||
+                $container_type_part instanceof ObjectLike ||
                 (
                     $container_type_part instanceof TNamedObject &&
                     ClassChecker::classExists($project_checker, $container_type_part->value) &&

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -1092,17 +1092,11 @@ class TypeChecker
                 && ($container_type_part instanceof TArray || $container_type_part instanceof ObjectLike)
             ) {
                 if ($container_type_part instanceof ObjectLike) {
-                    $container_type_part = new TArray([
-                        Type::getString(),
-                        $container_type_part->getGenericTypeParam(),
-                    ]);
+                    $container_type_part = $container_type_part->getGenericArrayType();
                 }
 
                 if ($input_type_part instanceof ObjectLike) {
-                    $input_type_part = new TArray([
-                        Type::getString(),
-                        $input_type_part->getGenericTypeParam(),
-                    ]);
+                    $input_type_part = $input_type_part->getGenericArrayType();
                 }
 
                 foreach ($input_type_part->type_params as $i => $input_param) {

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -582,7 +582,9 @@ abstract class Type
                 if ($combination->objectlike_entries) {
                     $object_like_generic_type = null;
 
-                    foreach ($combination->objectlike_entries as $property_type) {
+                    $objectlike_keys = [];
+
+                    foreach ($combination->objectlike_entries as $property_name => $property_type) {
                         if ($object_like_generic_type) {
                             $object_like_generic_type = Type::combineUnionTypes(
                                 $property_type,
@@ -591,15 +593,27 @@ abstract class Type
                         } else {
                             $object_like_generic_type = $property_type;
                         }
+
+                        if (is_int($property_name)) {
+                            if (!isset($objectlike_keys['int'])) {
+                                $objectlike_keys['int'] = new TInt;
+                            }
+                        } else {
+                            if (!isset($objectlike_keys['string'])) {
+                                $objectlike_keys['string'] = new TString;
+                            }
+                        }
                     }
 
                     if (!$object_like_generic_type) {
                         throw new \InvalidArgumentException('Cannot be null');
                     }
 
+                    $objectlike_key_type = new Type\Union(array_values($objectlike_keys));
+
                     $generic_type_params[0] = Type::combineUnionTypes(
                         $generic_type_params[0],
-                        Type::getString()
+                        $objectlike_key_type
                     );
                     $generic_type_params[1] = Type::combineUnionTypes(
                         $generic_type_params[1],

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -105,9 +105,9 @@ trait GenericTrait
                 $input_type_param = $input_type->type_params[$offset];
             } elseif ($input_type instanceof Atomic\ObjectLike) {
                 if ($offset === 0) {
-                    $input_type_param = new Union([new Atomic\TString()]);
+                    $input_type_param = $input_type->getGenericKeyType();
                 } elseif ($offset === 1) {
-                    $input_type_param = $input_type->getGenericTypeParam();
+                    $input_type_param = $input_type->getGenericValueType();
                 } else {
                     throw new \UnexpectedValueException('Not expecting offset of ' . $offset);
                 }

--- a/src/Psalm/Type/Atomic/ObjectLike.php
+++ b/src/Psalm/Type/Atomic/ObjectLike.php
@@ -53,7 +53,7 @@ class ObjectLike extends \Psalm\Type\Atomic
     public function toNamespacedString(array $aliased_classes, $this_class, $use_phpdoc_format)
     {
         if ($use_phpdoc_format) {
-            return 'array';
+            return $this->getGenericArrayType()->toNamespacedString($aliased_classes, $this_class, $use_phpdoc_format);
         }
 
         return 'array{' .

--- a/src/Psalm/Type/TypeCombination.php
+++ b/src/Psalm/Type/TypeCombination.php
@@ -9,6 +9,6 @@ class TypeCombination
     /** @var array<string, array<int, Union>> */
     public $type_params = [];
 
-    /** @var array<string, Union> */
+    /** @var array<string|int, Union> */
     public $objectlike_entries = [];
 }

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -56,7 +56,7 @@ class ArrayAssignmentTest extends TestCase
                         $out[] = [4];
                     }',
                 'assertions' => [
-                    '$out' => 'array<int, array<int, int>>',
+                    '$out' => 'array<int, array{0:int}>',
                 ],
             ],
             'generic2dArrayCreationAddedInIf' => [
@@ -194,8 +194,8 @@ class ArrayAssignmentTest extends TestCase
                         $bat[$text] = $bar[$i];
                     }',
                 'assertions' => [
-                    '$foo' => 'array<int, string>',
-                    '$bar' => 'array<int, int>',
+                    '$foo' => 'array{0:string, 1:string, 2:string}',
+                    '$bar' => 'array{0:int, 1:int, 2:int}',
                     '$bat' => 'array<string, int>',
                 ],
             ],
@@ -259,7 +259,7 @@ class ArrayAssignmentTest extends TestCase
                         "baz" => [1]
                     ];',
                 'assertions' => [
-                    '$foo' => 'array{bar:array{a:string}, baz:array<int, int>}',
+                    '$foo' => 'array{bar:array{a:string}, baz:array{0:int}}',
                 ],
             ],
             'implicitObjectLikeCreation' => [
@@ -280,7 +280,7 @@ class ArrayAssignmentTest extends TestCase
                     ];
                     $foo["bar"]["bam"]["baz"] = "hello";',
                 'assertions' => [
-                    '$foo' => 'array{bar:array{a:string, bam:array{baz:string}}, baz:array<int, int>}',
+                    '$foo' => 'array{bar:array{a:string, bam:array{baz:string}}, baz:array{0:int}}',
                 ],
             ],
             'conflictingTypesWithAssignment2' => [
@@ -382,8 +382,8 @@ class ArrayAssignmentTest extends TestCase
 
                     $b = [] + ["bar"];',
                 'assertions' => [
-                    '$a' => 'array<int, string>',
-                    '$b' => 'array<int, string>',
+                    '$a' => 'array{0:string}',
+                    '$b' => 'array{0:string}',
                 ],
             ],
             'additionDifferentType' => [
@@ -393,8 +393,8 @@ class ArrayAssignmentTest extends TestCase
 
                     $b = ["bar"] + [1];',
                 'assertions' => [
-                    '$a' => 'array<int, string|int>',
-                    '$b' => 'array<int, string|int>',
+                    '$a' => 'array{0:string}',
+                    '$b' => 'array{0:string}',
                 ],
             ],
             'present1dArrayTypeWithVarKeys' => [
@@ -438,7 +438,7 @@ class ArrayAssignmentTest extends TestCase
                     $foo["a"] = 1;
                     $foo += ["b" => [2, 3]];',
                 'assertions' => [
-                    '$foo' => 'array{a:int, b:array<int, int>}',
+                    '$foo' => 'array{a:int, b:array{0:int, 1:int}}',
                 ],
             ],
             'nestedObjectLikeArrayAddition' => [
@@ -447,7 +447,7 @@ class ArrayAssignmentTest extends TestCase
                     $foo["root"]["a"] = 1;
                     $foo["root"] += ["b" => [2, 3]];',
                 'assertions' => [
-                    '$foo' => 'array{root:array{a:int, b:array<int, int>}}',
+                    '$foo' => 'array{root:array{a:int, b:array{0:int, 1:int}}}',
                 ],
             ],
             'updateStringIntKey' => [
@@ -480,7 +480,7 @@ class ArrayAssignmentTest extends TestCase
                     $e[$int] = 3;
                     $e[$string] = 5;',
                 'assertions' => [
-                    '$a' => 'array<int|string, int>',
+                    '$a' => 'array{a:int, 0:int}',
                     '$b' => 'array<string|int, int>',
                     '$c' => 'array<int|string, int>',
                     '$d' => 'array<int|string, int>',
@@ -497,7 +497,7 @@ class ArrayAssignmentTest extends TestCase
                     $a[0]["a"] = 5;
                     $a[0][0] = 3;',
                 'assertions' => [
-                    '$a' => 'array<int, array<int|string, int>>',
+                    '$a' => 'array{0:array{a:int, 0:int}}',
                 ],
             ],
             'updateStringIntKeyWithIntRoot' => [
@@ -525,10 +525,10 @@ class ArrayAssignmentTest extends TestCase
                     $e[0][$int] = 3;
                     $e[0][$string] = 5;',
                 'assertions' => [
-                    '$b' => 'array<int, array<string|int, int>>',
-                    '$c' => 'array<int, array<int|string, int>>',
-                    '$d' => 'array<int, array<int|string, int>>',
-                    '$e' => 'array<int, array<int|string, int>>',
+                    '$b' => 'array{0:array<string|int, int>}',
+                    '$c' => 'array{0:array<int|string, int>}',
+                    '$d' => 'array{0:array<int|string, int>}',
+                    '$e' => 'array{0:array<int|string, int>}',
                 ],
             ],
             'updateStringIntKeyWithObjectLikeRootAndNumberOffset' => [
@@ -541,7 +541,7 @@ class ArrayAssignmentTest extends TestCase
                     $a["root"]["a"] = 5;
                     $a["root"][0] = 3;',
                 'assertions' => [
-                    '$a' => 'array{root:array<int|string, int>}',
+                    '$a' => 'array{root:array{a:int, 0:int}}',
                 ],
             ],
             'updateStringIntKeyWithObjectLikeRoot' => [
@@ -691,7 +691,7 @@ class ArrayAssignmentTest extends TestCase
                     $a = null;
                     $a[0][] = 1;',
                 'assertions' => [
-                    '$a' => 'array<int, array<int, int>>',
+                    '$a' => 'array{0:array<int, int>}',
                 ],
                 'error_levels' => ['PossiblyNullArrayAssignment'],
             ],
@@ -719,6 +719,52 @@ class ArrayAssignmentTest extends TestCase
                         $a["b"]["d"] += $a["b"][$i];
                     }',
                 'assertions' => [],
+            ],
+            'keyedIntOffsetArrayValues' => [
+                '<?php
+                    $a = ["hello", 5];
+                    $a_values = array_values($a);
+                    $a_keys = array_keys($a);',
+                'assertions' => [
+                    '$a' => 'array{0:string, 1:int}',
+                    '$a_values' => 'array<int, int|string>',
+                    '$a_keys' => 'array<int, int>',
+                ],
+            ],
+            'changeIntOffsetKeyValuesWithDirectAssignment' => [
+                '<?php
+                    $b = ["hello", 5];
+                    $b[0] = 3;',
+                'assertions' => [
+                    '$b' => 'array{0:int, 1:int}',
+                ],
+            ],
+            'changeIntOffsetKeyValuesAfterCopy' => [
+                '<?php
+                    $b = ["hello", 5];
+                    $c = $b;
+                    $c[0] = 3;',
+                'assertions' => [
+                    '$b' => 'array{0:string, 1:int}',
+                    '$c' => 'array{0:int, 1:int}',
+                ],
+            ],
+            'mergeIntOffsetValues' => [
+                '<?php
+                    $d = array_merge(["hello", 5], []);
+                    $e = array_merge(["hello", 5], ["hello again"]);',
+                'assertions' => [
+                    '$d' => 'array{0:string, 1:int}',
+                    '$e' => 'array{0:string, 1:int, 2:string}',
+                ],
+            ],
+            'addIntOffsetToEmptyArray' => [
+                '<?php
+                    $f = [];
+                    $f[0] = "hello";',
+                'assertions' => [
+                    '$f' => 'array{0:string}',
+                ],
             ],
         ];
     }

--- a/tests/FileManipulationTest.php
+++ b/tests/FileManipulationTest.php
@@ -117,7 +117,7 @@ class FileManipulationTest extends TestCase
                 '<?php
                     /**
                      * @return       string[]
-                     * @psalm-return array<int, string>
+                     * @psalm-return array{0:string}
                      */
                     function foo() {
                         return ["hello"];

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -310,12 +310,16 @@ class FunctionCallTest extends TestCase
                 '<?php
                     $vars = ["x" => "a", "y" => "b"];
                     $c = array_rand($vars);
-                    $d = $vars[$c];',
+                    $d = $vars[$c];
+                    $more_vars = ["a", "b"];
+                    $e = array_rand($more_vars);',
 
                 'assertions' => [
                     '$vars' => 'array{x:string, y:string}',
                     '$c' => 'string',
                     '$d' => 'string',
+                    '$more_vars' => 'array{0:string, 1:string}',
+                    '$e' => 'int',
                 ],
             ],
             'arrayRandMultiple' => [

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -208,7 +208,7 @@ class FunctionCallTest extends TestCase
                 '<?php
                     $d = array_merge(["a", "b", "c"], [1, 2, 3]);',
                 'assertions' => [
-                    '$d' => 'array<int, int|string>',
+                    '$d' => 'array{0:string, 1:string, 2:string, 3:int, 4:int, 5:int}',
                 ],
             ],
             'arrayDiff' => [
@@ -288,7 +288,7 @@ class FunctionCallTest extends TestCase
 
                   foo($a3);',
                 'assertions' => [
-                    '$a3' => 'array{bye:int, hi:int}',
+                    '$a3' => 'array{hi:int, bye:int}',
                 ],
             ],
             'goodByRef' => [

--- a/tests/IssetTest.php
+++ b/tests/IssetTest.php
@@ -99,6 +99,22 @@ class IssetTest extends TestCase
                         unset($foo, $bar);
                     }',
             ],
+            'issetObjectLike' => [
+                '<?php
+                    $arr = [
+                        "profile" => [
+                            "foo" => "bar",
+                        ],
+                        "groups" => [
+                            "foo" => "bar",
+                            "hide"  => rand() % 2 > 0,
+                        ],
+                    ];
+
+                    foreach ($arr as $item) {
+                        if (!isset($item["hide"]) || !$item["hide"]) {}
+                    }',
+            ],
         ];
     }
 }

--- a/tests/ListTest.php
+++ b/tests/ListTest.php
@@ -33,8 +33,8 @@ class ListTest extends TestCase
                     $bar = ["a", 2];
                     list($a, $b) = $bar;',
                 'assertions' => [
-                    '$a' => 'int|string',
-                    '$b' => 'int|string',
+                    '$a' => 'string',
+                    '$b' => 'int',
                 ],
             ],
             'thisVar' => [

--- a/tests/Php71Test.php
+++ b/tests/Php71Test.php
@@ -103,10 +103,10 @@ class Php71Test extends TestCase
                     // [] style
                     [$id2, $name2] = $data[1];',
                 'assertions' => [
-                    '$id1' => 'string|int',
-                    '$name1' => 'string|int',
-                    '$id2' => 'string|int',
-                    '$name2' => 'string|int',
+                    '$id1' => 'int',
+                    '$name1' => 'string',
+                    '$id2' => 'int',
+                    '$name2' => 'string',
                 ],
             ],
             'arrayDestructuringInForeach' => [


### PR DESCRIPTION
Fixes #398 and also fixes #335 

This PR is designed to extend the power of `ObjectLike` arrays to expressions like

```php
$a = ["foo", 50];
$b = [];
$b[0] = "bar";
$b[1] = 70;
```

Where before these would be typed as `array<int, string|int>` we now treat them as `ObjectLike`s with integer keys – `array{0:string, 1:int}`

cc @TysonAndre @weirdan 