### PR TITLE
Look for dead code in every Psalm build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ install:
 
 script:
   - vendor/bin/phpunit
-  - ./psalm
+  - ./psalm --find-dead-code
   - vendor/bin/phpcs
 
 after_success:

--- a/examples/StringChecker.php
+++ b/examples/StringChecker.php
@@ -1,10 +1,12 @@
 <?php
 namespace Psalm\Example\Plugin;
 
+use PhpParser;
 use Psalm\Checker;
 use Psalm\Checker\StatementsChecker;
 use Psalm\Context;
 use Psalm\CodeLocation;
+use Psalm\FileManipulation\FileManipulation;
 
 /**
  * Checks all strings to see if they contain references to classes
@@ -16,21 +18,24 @@ use Psalm\CodeLocation;
 class StringChecker extends \Psalm\Plugin
 {
     /**
-     * Checks an expression
+     * Called after an expression has been checked
      *
-     * @param  StatementsChecker     $statements_checker
-     * @param  \PhpParser\Node\Expr  $stmt
-     * @param  Context               $context
-     * @param  CodeLocation          $code_location
-     * @param  array<string>         $suppressed_issues
+     * @param  StatementsChecker    $statements_checker
+     * @param  PhpParser\Node\Expr  $stmt
+     * @param  Context              $context
+     * @param  CodeLocation         $code_location
+     * @param  string[]             $suppressed_issues
+     * @param  FileManipulation[]   $file_replacements
+     *
      * @return null|false
      */
-    public function checkExpression(
+    public function afterExpressionCheck(
         StatementsChecker $statements_checker,
-        \PhpParser\Node\Expr $stmt,
+        PhpParser\Node\Expr $stmt,
         Context $context,
         CodeLocation $code_location,
-        array $suppressed_issues
+        array $suppressed_issues,
+        array &$file_replacements = []
     ) {
         if ($stmt instanceof \PhpParser\Node\Scalar\String_) {
             // Replace "Psalm" with your namespace

--- a/examples/TemplateChecker.php
+++ b/examples/TemplateChecker.php
@@ -27,8 +27,6 @@ class TemplateChecker extends Psalm\Checker\FileChecker
 
         $first_stmt = $stmts[0];
 
-        $this_params = null;
-
         if (($first_stmt instanceof PhpParser\Node\Stmt\Nop) && ($doc_comment = $first_stmt->getDocComment())) {
 
             $comment_block = CommentChecker::parseDocComment(trim($doc_comment->getText()));

--- a/psalm.xml
+++ b/psalm.xml
@@ -39,19 +39,6 @@
             </errorLevel>
         </PossiblyUnusedParam>
 
-        <UnusedVariable>
-            <errorLevel type="suppress">
-                <directory name="examples" />
-            </errorLevel>
-        </UnusedVariable>
-
-        <UnusedMethod>
-            <errorLevel type="suppress">
-                <directory name="tests" />
-                <directory name="examples" />
-            </errorLevel>
-        </UnusedMethod>
-
         <UnusedClass>
             <errorLevel type="suppress">
                 <directory name="tests" />
@@ -61,9 +48,7 @@
         <PossiblyUnusedMethod>
             <errorLevel type="suppress">
                 <directory name="tests" />
-                <directory name="examples" />
                 <file name="src/Psalm/Type/Atomic/GenericTrait.php" />
-                <file name="src/Psalm/TraitSource.php" />
                 <file name="src/Psalm/FileManipulation/FileManipulationBuffer.php" />
             </errorLevel>
         </PossiblyUnusedMethod>

--- a/src/Psalm/Fork/Pool.php
+++ b/src/Psalm/Fork/Pool.php
@@ -280,6 +280,8 @@ class Pool
      * Returns true if this had an error, e.g. due to memory limits or due to a child process crashing.
      *
      * @return  bool
+     *
+     * @psalm-suppress PossiblyUnusedMethod because we may in the future
      */
     public function didHaveError()
     {


### PR DESCRIPTION
Dead code detection is now good enough to be run on every Psalm build, to prevent dead code seeping into Psalm's codebase.

There's one remaining false positive when analysing Psalm's codebase, ticketed with https://github.com/vimeo/psalm/issues/416, but it's minor enough that we can suppress for now.