### PR TITLE
Add code replacement api

### DIFF
--- a/examples/ClassUnqualifier.php
+++ b/examples/ClassUnqualifier.php
@@ -1,0 +1,54 @@
+<?php
+namespace Psalm\Example\Plugin;
+
+use PhpParser;
+use Psalm\Checker;
+use Psalm\Context;
+use Psalm\CodeLocation;
+use Psalm\FileManipulation\FileManipulation;
+use Psalm\StatementsSource;
+use Psalm\Type;
+
+class ClassUnqualifier extends \Psalm\Plugin
+{
+    /**
+     * @param  string             $fq_class_name
+     * @param  FileManipulation[] $file_replacements
+     *
+     * @return void
+     */
+    public function afterClassLikeExistsCheck(
+        StatementsSource $statements_source,
+        $fq_class_name,
+        CodeLocation $code_location,
+        array &$file_replacements = []
+    ) {
+        $candidate_type = $code_location->getSelectedText();
+        $aliases = $statements_source->getAliasedClassesFlipped();
+
+        if ($statements_source->getFileChecker()->getFilePath() !== $code_location->file_path) {
+            return;
+        }
+
+        if (strpos($candidate_type, '\\' . $fq_class_name) !== false) {
+            $type_tokens = Type::tokenize($candidate_type, false);
+
+            foreach ($type_tokens as &$type_token) {
+                if ($type_token === ('\\' . $fq_class_name)
+                    && isset($aliases[strtolower($fq_class_name)])
+                ) {
+                    $type_token = $aliases[strtolower($fq_class_name)];
+                }
+            }
+
+            $new_candidate_type = implode('', $type_tokens);
+
+            if ($new_candidate_type !== $candidate_type) {
+                $bounds = $code_location->getSelectionBounds();
+                $file_replacements[] = new FileManipulation($bounds[0], $bounds[1], $new_candidate_type);
+            }
+        }
+    }
+}
+
+return new ClassUnqualifier;

--- a/psalm.xml
+++ b/psalm.xml
@@ -49,7 +49,6 @@
             <errorLevel type="suppress">
                 <directory name="tests" />
                 <file name="src/Psalm/Type/Atomic/GenericTrait.php" />
-                <file name="src/Psalm/FileManipulation/FileManipulationBuffer.php" />
             </errorLevel>
         </PossiblyUnusedMethod>
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -822,7 +822,7 @@ class Config
          * @var Plugin
          * @psalm-suppress UnresolvableInclude
          */
-        $loaded_plugin = require($path);
+        $loaded_plugin = require_once($path);
 
         if (!$loaded_plugin) {
             throw new \InvalidArgumentException(
@@ -833,7 +833,7 @@ class Config
 
         if (!($loaded_plugin instanceof Plugin)) {
             throw new \InvalidArgumentException(
-                'Plugins must extend \Psalm\Plugin - ' . $plugin_file_name . ' does not'
+                'Plugins must extend \Psalm\Plugin - ' . $path . ' does not'
             );
         }
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -435,7 +435,7 @@ class Config
     }
 
     /**
-     * @param  array<\SimpleXMLElement> $extensions
+     * @param  array<SimpleXMLElement> $extensions
      *
      * @throws ConfigException if a Config file could not be found
      *

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -387,27 +387,7 @@ class Config
 
                 $path = $config->base_dir . $plugin_file_name;
 
-                if (!file_exists($path)) {
-                    throw new \InvalidArgumentException('Cannot find file ' . $path);
-                }
-
-                /** @psalm-suppress UnresolvableInclude */
-                $loaded_plugin = require($path);
-
-                if (!$loaded_plugin) {
-                    throw new \InvalidArgumentException(
-                        'Plugins must return an instance of that plugin at the end of the file - ' .
-                            $plugin_file_name . ' does not'
-                    );
-                }
-
-                if (!($loaded_plugin instanceof Plugin)) {
-                    throw new \InvalidArgumentException(
-                        'Plugins must extend \Psalm\Plugin - ' . $plugin_file_name . ' does not'
-                    );
-                }
-
-                $config->plugins[] = $loaded_plugin;
+                $config->addPluginPath($path);
             }
         }
 
@@ -825,5 +805,38 @@ class Config
             reset($objects);
             rmdir($dir);
         }
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return void
+     */
+    public function addPluginPath($path)
+    {
+        if (!file_exists($path)) {
+            throw new \InvalidArgumentException('Cannot find file ' . $path);
+        }
+
+        /**
+         * @var Plugin
+         * @psalm-suppress UnresolvableInclude
+         */
+        $loaded_plugin = require($path);
+
+        if (!$loaded_plugin) {
+            throw new \InvalidArgumentException(
+                'Plugins must return an instance of that plugin at the end of the file - ' .
+                    $plugin_file_name . ' does not'
+            );
+        }
+
+        if (!($loaded_plugin instanceof Plugin)) {
+            throw new \InvalidArgumentException(
+                'Plugins must extend \Psalm\Plugin - ' . $plugin_file_name . ' does not'
+            );
+        }
+
+        $this->plugins[] = $loaded_plugin;
     }
 }

--- a/src/Psalm/FileManipulation/FileManipulationBuffer.php
+++ b/src/Psalm/FileManipulation/FileManipulationBuffer.php
@@ -26,16 +26,16 @@ class FileManipulationBuffer
      */
     public static function getForFile($file_path)
     {
-        return isset(self::$file_manipulations[$file_path])
-            ? self::$file_manipulations[$file_path]
-            : [];
-    }
+        if (!isset(self::$file_manipulations[$file_path])) {
+            return [];
+        }
 
-    /**
-     * @return array<string, FileManipulation[]>
-     */
-    public static function getAll()
-    {
-        return self::$file_manipulations;
+        $file_manipulations = [];
+
+        foreach (self::$file_manipulations[$file_path] as $file_manipulation) {
+            $file_manipulations[$file_manipulation->start] = $file_manipulation;
+        }
+
+        return $file_manipulations;
     }
 }

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -68,4 +68,18 @@ abstract class Plugin
         array &$file_replacements = []
     ) {
     }
+
+    /**
+     * @param  string             $fq_class_name
+     * @param  FileManipulation[] $file_replacements
+     *
+     * @return void
+     */
+    public function afterClassLikeExistsCheck(
+        StatementsSource $statements_source,
+        $fq_class_name,
+        CodeLocation $code_location,
+        array &$file_replacements = []
+    ) {
+    }
 }

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -219,14 +219,18 @@ abstract class Type
 
     /**
      * @param  string $return_type
+     * @param  bool   $ignore_space
      *
      * @return array<int,string>
      */
-    public static function tokenize($return_type)
+    public static function tokenize($return_type, $ignore_space = true)
     {
         $return_type_tokens = [''];
         $was_char = false;
-        $return_type = str_replace(' ', '', $return_type);
+
+        if ($ignore_space) {
+            $return_type = str_replace(' ', '', $return_type);
+        }
 
         foreach (str_split($return_type) as $char) {
             if ($was_char) {
@@ -240,6 +244,9 @@ abstract class Type
                 $char === ',' ||
                 $char === '{' ||
                 $char === '}' ||
+                $char === '[' ||
+                $char === ']' ||
+                $char === ' ' ||
                 $char === ':'
             ) {
                 if ($return_type_tokens[count($return_type_tokens) - 1] === '') {

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -16,7 +16,7 @@ $options = getopt(
         'help', 'debug', 'config:', 'monochrome', 'show-info:', 'diff',
         'file:', 'self-check', 'update-docblocks', 'output-format:',
         'find-dead-code', 'init', 'find-references-to:', 'root:', 'threads:',
-        'report:', 'clear-cache', 'no-cache', 'version', 'plugin:',
+        'report:', 'clear-cache', 'no-cache', 'version', 'plugin:', 'replace-code',
     ]
 );
 
@@ -106,6 +106,12 @@ Options:
 
     --no-cache
         Runs Psalm without using cache
+
+    --plugin=PATH
+        Executes a plugin, an alternative to using the Psalm config
+
+    --replace-code
+        Processes any plugin code replacements and updates the code accordingly
 
 HELP;
 
@@ -406,6 +412,10 @@ if (!$config) {
 /** @var string $plugin_path */
 foreach ($plugins as $plugin_path) {
     Config::getInstance()->addPluginPath($current_dir . DIRECTORY_SEPARATOR . $plugin_path);
+}
+
+if (isset($options['replace-code'])) {
+    $project_checker->replaceCodeAfterCompletion();
 }
 
 /** @psalm-suppress MixedArgument */

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -326,6 +326,16 @@ if ($input_paths) {
     }
 }
 
+$plugins = [];
+
+if (isset($options['plugin'])) {
+    $plugins = $options['plugin'];
+
+    if (!is_array($plugins)) {
+        $plugins = [$plugins];
+    }
+}
+
 $path_to_config = isset($options['c']) && is_string($options['c']) ? realpath($options['c']) : null;
 
 if ($path_to_config === false) {
@@ -391,6 +401,11 @@ $config = $project_checker->getConfig();
 
 if (!$config) {
     $project_checker->getConfigForPath($current_dir, $current_dir);
+}
+
+/** @var string $plugin_path */
+foreach ($plugins as $plugin_path) {
+    Config::getInstance()->addPluginPath($current_dir . DIRECTORY_SEPARATOR . $plugin_path);
 }
 
 /** @psalm-suppress MixedArgument */

--- a/tests/FileManipulationTest.php
+++ b/tests/FileManipulationTest.php
@@ -24,7 +24,12 @@ class FileManipulationTest extends TestCase
             new Provider\FakeParserCacheProvider()
         );
 
-        $this->project_checker->setConfig(new TestConfig());
+        if (!self::$config) {
+            self::$config = new TestConfig();
+            self::$config->addPluginPath('examples/ClassUnqualifier.php');
+        }
+
+        $this->project_checker->setConfig(self::$config);
 
         $this->project_checker->update_docblocks = true;
     }
@@ -121,6 +126,26 @@ class FileManipulationTest extends TestCase
                      */
                     function foo() {
                         return ["hello"];
+                    }',
+            ],
+            'useUnqualifierPlugin' => [
+                '<?php
+                    namespace A\B\C {
+                        class D {}
+                    }
+                    namespace Foo\Bar {
+                        use A\B\C\D;
+
+                        new \A\B\C\D();
+                    }',
+                '<?php
+                    namespace A\B\C {
+                        class D {}
+                    }
+                    namespace Foo\Bar {
+                        use A\B\C\D;
+
+                        new D();
                     }',
             ],
         ];

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -17,7 +17,7 @@ class JsonOutputTest extends TestCase
         FileChecker::clearCache();
         $this->file_provider = new Provider\FakeFileProvider();
 
-        $this->project_checker = new \Psalm\Checker\ProjectChecker(
+        $this->project_checker = new ProjectChecker(
             $this->file_provider,
             new Provider\FakeParserCacheProvider(),
             false,

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -18,7 +18,7 @@ class ReportOutputTest extends TestCase
         FileChecker::clearCache();
         $this->file_provider = new Provider\FakeFileProvider();
 
-        $this->project_checker = new \Psalm\Checker\ProjectChecker(
+        $this->project_checker = new ProjectChecker(
             $this->file_provider,
             new Provider\FakeParserCacheProvider(),
             false
@@ -38,12 +38,12 @@ class ReportOutputTest extends TestCase
     {
         // No exception
         foreach (['.xml', '.txt', '.json', '.emacs'] as $extension) {
-            new \Psalm\Checker\ProjectChecker(
+            new ProjectChecker(
                 $this->file_provider,
                 new Provider\FakeParserCacheProvider(),
                 false,
                 true,
-                \Psalm\Checker\ProjectChecker::TYPE_CONSOLE,
+                ProjectChecker::TYPE_CONSOLE,
                 1,
                 false,
                 false,
@@ -61,12 +61,12 @@ class ReportOutputTest extends TestCase
      */
     public function testReportFormatException()
     {
-        new \Psalm\Checker\ProjectChecker(
+        new ProjectChecker(
             $this->file_provider,
             new Provider\FakeParserCacheProvider(),
             false,
             true,
-            \Psalm\Checker\ProjectChecker::TYPE_CONSOLE,
+            ProjectChecker::TYPE_CONSOLE,
             1,
             false,
             false,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,6 +3,7 @@ namespace Psalm\Tests;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Psalm\Checker\FileChecker;
+use Psalm\Checker\ProjectChecker;
 
 class TestCase extends BaseTestCase
 {
@@ -15,7 +16,7 @@ class TestCase extends BaseTestCase
     /** @var string */
     protected static $src_dir_path;
 
-    /** @var \Psalm\Checker\ProjectChecker */
+    /** @var ProjectChecker */
     protected $project_checker;
 
     /** @var Provider\FakeFileProvider */
@@ -41,7 +42,7 @@ class TestCase extends BaseTestCase
 
         $this->file_provider = new Provider\FakeFileProvider();
 
-        $this->project_checker = new \Psalm\Checker\ProjectChecker(
+        $this->project_checker = new ProjectChecker(
             $this->file_provider,
             new Provider\FakeParserCacheProvider()
         );


### PR DESCRIPTION
Fixes #264

This PR gives Psalm the power to update code via plugins

For example, running
```
vendor/bin/psalm --plugin=vendor/vimeo/psalm/examples/ClassUnqualifier.php --replace-code
```

will change all unnecessarily-qualified classnames in comments and symbols to aliased equivalents.