### PR TITLE
fix: add preserve_keys on array_reverse function

### DIFF
--- a/src/Psalm/Stubs/CoreGenericFunctions.php
+++ b/src/Psalm/Stubs/CoreGenericFunctions.php
@@ -108,9 +108,10 @@ function array_pop(array &$arr) {}
  * @template TValue
  *
  * @param array<TKey, TValue> $arr
+ * @param bool            $preserve_keys
  * @return array<TKey, TValue>
  */
-function array_reverse(array $arr) {}
+function array_reverse(array $arr, bool $preserve_keys = false) {}
 
 /**
  * @template TKey

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -211,6 +211,20 @@ class FunctionCallTest extends TestCase
                     '$d' => 'array{0:string, 1:string, 2:string, 3:int, 4:int, 5:int}',
                 ],
             ],
+            'arrayReverse' => [
+                '<?php
+                    $d = array_reverse(["a", "b", 1]);',
+                'assertions' => [
+                    '$d' => 'array<int, int|string>',
+                ],
+            ],
+            'arrayReversePreserveKey' => [
+                '<?php
+                    $d = array_reverse(["a", "b", 1], true);',
+                'assertions' => [
+                    '$d' => 'array<int, int|string>',
+                ],
+            ],
             'arrayDiff' => [
                 '<?php
                     $d = array_diff(["a" => 5, "b" => 12], [5]);',


### PR DESCRIPTION
An omission was made on the function array_reverse (the second parameter, optional).