### PR TITLE
Update PHPUnit configuration to follow best practices

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,50 +1,36 @@
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/4.5/phpunit.xsd"
-    backupGlobals="true"
-    backupStaticAttributes="false"
-    bootstrap="tests/bootstrap.php"
-    colors="false"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    forceCoversAnnotation="false"
-    mapTestClassNameToCoveredClassName="false"
-    printerClass="PHPUnit_TextUI_ResultPrinter"
-    processIsolation="false"
-    stopOnError="false"
-    stopOnFailure="false"
-    stopOnIncomplete="false"
-    stopOnSkipped="false"
-    stopOnRisky="false"
-    testSuiteLoaderClass="PHPUnit_Runner_StandardTestSuiteLoader"
-    timeoutForSmallTests="1"
-    timeoutForMediumTests="10"
-    timeoutForLargeTests="60"
-    verbose="false">
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/5.7/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         backupGlobals="false"
+         beStrictAboutCoversAnnotation="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutTodoAnnotatedTests="true"
+         verbose="true">
+    <testsuite name="default">
+        <directory>tests</directory>
+    </testsuite>
 
-    <testsuites>
-        <testsuite name="Psalm suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <logging>
-        <log type="coverage-html" target="./build/logs/phpunit-html/"/>
-        <log type="coverage-clover" target="./build/logs/clover.xml"/>
-    </logging>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-        <directory suffix=".php">./src/</directory>
-        <exclude>
-            <directory suffix=".php">./src/Psalm/Stubs/</directory>
-            <file>./src/Psalm/CallMap.php</file>
-            <file>./src/psalm.php</file>
-            <file>./src/psalter.php</file>
-            <file>./src/Psalm/Provider/Cache/NoParserCacheProvider.php</file>
-            <file>./src/Psalm/Provider/ParserCacheProvider.php</file>
-            <file>./src/Psalm/PropertyMap.php</file>
-            <directory suffix=".php">./src/Psalm/Issue/</directory>
-        </exclude>
+            <directory suffix=".php">src</directory>
+            <exclude>
+                <directory suffix=".php">src/Psalm/Issue/</directory>
+                <directory suffix=".php">src/Psalm/Stubs/</directory>
+                <file>src/psalm.php</file>
+                <file>src/psalter.php</file>
+                <file>src/Psalm/CallMap.php</file>
+                <file>src/Psalm/PropertyMap.php</file>
+                <file>src/Psalm/Provider/Cache/NoParserCacheProvider.php</file>
+                <file>src/Psalm/Provider/ParserCacheProvider.php</file>
+            </exclude>
         </whitelist>
     </filter>
+
+    <logging>
+        <log type="coverage-clover" target="build/logs/clover.xml"/>
+        <log type="coverage-html" target="build/logs/phpunit-html/"/>
+    </logging>
 </phpunit>
+


### PR DESCRIPTION
I saw that your `phpunit.xml.dist` appears to be based on a copy from an example in the documentation that shows all attributes for the `<phpunit>` element with their default values.

* Regenerated `phpunit.xml.dist` using `./vendor/bin/phpunit --generate-configuration`
* Restored `<filter>` and `<logging>` sections

Should you decide not to fix the risky tests that are now reported then simply set `beStrictAboutTestsThatDoNotTestAnything="false"` instead of `beStrictAboutTestsThatDoNotTestAnything="true"`.

Here is a list of the tests that are reported as risky:

```
1) Psalm\Tests\BadFormatTest::testMissingSemicolon
This test did not perform any assertions

2) Psalm\Tests\ConfigTest::testAllPossibleIssues
This test did not perform any assertions

3) Psalm\Tests\ConfigTest::testStubFile
This test did not perform any assertions

4) Psalm\Tests\ConfigTest::testNamespacedStubClass
This test did not perform any assertions

5) Psalm\Tests\ConfigTest::testStubFunction
This test did not perform any assertions

6) Psalm\Tests\ConfigTest::testNamespacedStubFunction
This test did not perform any assertions

7) Psalm\Tests\ConfigTest::testConditionalNamespacedStubFunction
This test did not perform any assertions

8) Psalm\Tests\ConfigTest::testStubFileWithExistingClassDefinition
This test did not perform any assertions

9) Psalm\Tests\ConfigTest::testDoNotRequireVoidReturnTypeExists
This test did not perform any assertions

10) Psalm\Tests\ConfigTest::testTemplatedFiles
This test did not perform any assertions

11) Psalm\Tests\FunctionCallTest::testArrayFilterUseKey
This test did not perform any assertions

12) Psalm\Tests\IncludeTest::testValidInclude with data set "basicRequire" (array('<?php\n                       ...     }', '<?php\n                       ...     }'), array('/usr/local/src/psalm/file2.php'))
This test did not perform any assertions

13) Psalm\Tests\IncludeTest::testValidInclude with data set "nestedRequire" (array('<?php\n                       ...     }', '<?php\n                       ...     }', '<?php\n                       ...     }'), array('/usr/local/src/psalm/file3.php'))
This test did not perform any assertions

14) Psalm\Tests\IncludeTest::testValidInclude with data set "requireNamespace" (array('<?php\n                       ...     }', '<?php\n                       ...     }'), array('/usr/local/src/psalm/file2.php'))
This test did not perform any assertions

15) Psalm\Tests\IncludeTest::testValidInclude with data set "requireFunction" (array('<?php\n                       ...     }', '<?php\n                       ...Foo();'), array('/usr/local/src/psalm/file2.php'))
This test did not perform any assertions

16) Psalm\Tests\IncludeTest::testValidInclude with data set "requireConstant" (array('<?php\n                       ...bat");', '<?php\n                       ...o BAR;'), array('/usr/local/src/psalm/file2.php'))
This test did not perform any assertions

17) Psalm\Tests\IncludeTest::testValidInclude with data set "requireNamespacedWithUse" (array('<?php\n                       ...     }', '<?php\n                       ...     }'), array('/usr/local/src/psalm/file2.php'))
This test did not perform any assertions

18) Psalm\Tests\IncludeTest::testValidInclude with data set "noInfiniteRequireLoop" (array('<?php\n                       ...w D();', '<?php\n                       ...w C();', '<?php\n                       ...w C();'), array('/usr/local/src/psalm/file1.php', '/usr/local/src/psalm/file2.php', '/usr/local/src/psalm/file3.php'))
This test did not perform any assertions

19) Psalm\Tests\IncludeTest::testValidInclude with data set "analyzeAllClasses" (array('<?php\n                       ...     }', '<?php\n                       ...     }'), array('/usr/local/src/psalm/file1.php', '/usr/local/src/psalm/file2.php'))
This test did not perform any assertions

20) Psalm\Tests\IncludeTest::testValidInclude with data set "loopWithInterdependencies" (array('<?php\n                       ...w B();', '<?php\n                       ...w D();'), array('/usr/local/src/psalm/file1.php', '/usr/local/src/psalm/file2.php'))
This test did not perform any assertions

21) Psalm\Tests\MethodSignatureTest::testExtendDocblockParamType
This test did not perform any assertions

22) Psalm\Tests\ReportOutputTest::testReportFormatValid
This test did not perform any assertions

23) Psalm\Tests\UnusedCodeTest::testValidCode with data set "unset" ('<?php\n                    /**...     }')
This test did not perform any assertions

24) Psalm\Tests\UnusedCodeTest::testValidCode with data set "usedVariables" ('<?php\n                    /**...     }')
This test did not perform any assertions

25) Psalm\Tests\UnusedCodeTest::testValidCode with data set "ifInFunction" ('<?php\n                    /**...     }')
This test did not perform any assertions

26) Psalm\Tests\UnusedCodeTest::testValidCode with data set "booleanOr" ('<?php\n                    fun...     }')
This test did not perform any assertions

27) Psalm\Tests\UnusedCodeTest::testValidCode with data set "magicCall" ('<?php\n                    cla...ue2");')
This test did not perform any assertions

28) Psalm\Tests\UnusedCodeTest::testValidCode with data set "usedTraitMethod" ('<?php\n                    cla...foo();')
This test did not perform any assertions

29) Psalm\Tests\UnusedCodeTest::testValidCode with data set "usedInterfaceMethod" ('<?php\n                    int...foo();')
This test did not perform any assertions

30) Psalm\Tests\UnusedCodeTest::testValidCode with data set "dummyByRefVar" ('<?php\n                    fun...bar();')
This test did not perform any assertions

31) Psalm\Tests\VariadicTest::testVariadic with data set "variadic" ('<?php\n                /**\n   ...4, 5);')
This test did not perform any assertions

32) Psalm\Tests\VariadicTest::testVariadic with data set "funcNumArgsVariadic" ('<?php\n                    fun...t(2));')
This test did not perform any assertions

33) Psalm\Tests\VariadicTest::testVariadic with data set "variadicArray" ('<?php\n                    /**...     }')
This test did not perform any assertions
```

I suggest to remove the `<logging>` section and to only generate code coverage reports when you need them (using the `--coverage-*` commandline options).