### PR TITLE
Be strict about matching word boundaries for expected messages in tests

### DIFF
--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -450,7 +450,7 @@ class AnnotationTest extends TestCase
 
                     $a = new A();
                     $a->foo = 5;',
-                'error_message' => 'InvalidPropertyAssignment',
+                'error_message' => 'InvalidPropertyAssignmentValue',
             ],
             'propertyWriteDocblockInvalidAssignment' => [
                 '<?php
@@ -471,7 +471,7 @@ class AnnotationTest extends TestCase
 
                     $a = new A();
                     $a->foo = 5;',
-                'error_message' => 'InvalidPropertyAssignment',
+                'error_message' => 'InvalidPropertyAssignmentValue',
             ],
             'propertySealedDocblockUndefinedPropertyAssignment' => [
                 '<?php
@@ -515,7 +515,7 @@ class AnnotationTest extends TestCase
 
                     $a = new A();
                     $a->foo = 5;',
-                'error_message' => 'InvalidPropertyAssignment',
+                'error_message' => 'InvalidPropertyAssignmentValue',
             ],
             'propertyReadInvalidFetch' => [
                 '<?php
@@ -664,7 +664,7 @@ class AnnotationTest extends TestCase
                             $this->foo["boof"] = "hello";
                         }
                     }',
-                'error_message' => 'InvalidPropertyAssignment',
+                'error_message' => 'InvalidPropertyAssignmentValue',
             ],
             'incorrectDocblockOrder' => [
                 '<?php

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -819,7 +819,7 @@ class ArrayAssignmentTest extends TestCase
                             $this->strs = [new stdClass()]; // no issue emitted
                         }
                     }',
-                'error_message' => 'InvalidPropertyAssignment',
+                'error_message' => 'InvalidPropertyAssignmentValue',
             ],
             'incrementalArrayPropertyAssignment' => [
                 '<?php
@@ -832,7 +832,7 @@ class ArrayAssignmentTest extends TestCase
                             $this->strs[] = new stdClass(); // no issue emitted
                         }
                     }',
-                'error_message' => 'InvalidPropertyAssignment',
+                'error_message' => 'InvalidPropertyAssignmentValue',
             ],
         ];
     }

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -221,7 +221,7 @@ class MethodSignatureTest extends TestCase
                         }
                     }',
                 'error_message' => 'Argument 1 of B::fooFoo has wrong type \'bool\', expecting \'int\' as defined ' .
-                    'by A::foo',
+                    'by A::fooFoo',
             ],
             'nonNullableSubclassParam' => [
                 '<?php
@@ -236,7 +236,7 @@ class MethodSignatureTest extends TestCase
                             return $s;
                         }
                     }',
-                'error_message' => 'Argument 1 of B::foo has wrong type \'string\', expecting \'string|null\'',
+                'error_message' => 'Argument 1 of B::foo has wrong type \'string\', expecting \'string|null\' as',
             ],
             'mismatchingCovariantReturn' => [
                 '<?php

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -462,7 +462,7 @@ class TraitTest extends TestCase
                         }
                     }',
                 'error_message' => 'MissingPropertyType - src/somefile.php:3 - Property T::$foo does not have a ' .
-                    'declared type - consider int|nul',
+                    'declared type - consider int|null',
             ],
             'redefinedTraitMethodInSubclass' => [
                 '<?php

--- a/tests/Traits/FileCheckerInvalidCodeParseTestTrait.php
+++ b/tests/Traits/FileCheckerInvalidCodeParseTestTrait.php
@@ -38,7 +38,7 @@ trait FileCheckerInvalidCodeParseTestTrait
         }
 
         $this->expectException('\Psalm\Exception\CodeException');
-        $this->expectExceptionMessageRegexp('/\b' . preg_quote($error_message, '/') . '/');
+        $this->expectExceptionMessageRegexp('/\b' . preg_quote($error_message, '/') . '\b/');
 
         $this->addFile(
             self::$src_dir_path . 'somefile.php',

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -77,7 +77,7 @@ class UnusedCodeTest extends TestCase
         }
 
         $this->expectException('\Psalm\Exception\CodeException');
-        $this->expectExceptionMessageRegexp('/\b' . preg_quote($error_message, '/') . '/');
+        $this->expectExceptionMessageRegexp('/\b' . preg_quote($error_message, '/') . '\b/');
 
         $this->addFile(
             self::$src_dir_path . 'somefile.php',


### PR DESCRIPTION
This helps when some issue types are prefixes of different issue types.

Consistently require matching word boundaries both at the beginning and the end of expected fragments in unit tests (Possibly<issue>, <issue>Suffix)