### PR TITLE
Return an empty string on magic __toString method

### DIFF
--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -94,6 +94,9 @@ class Union
 
     public function __toString()
     {
+        if (empty($this->types)) {
+            return '';
+        }
         $s = '';
         foreach ($this->types as $type) {
             $s .= $type . '|';


### PR DESCRIPTION
We can't throw exceptions here, due to engine constraints.