### PR TITLE
Code style: Bring phpdoc `@param` up to date

### DIFF
--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -398,7 +398,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
      * Gets the fully-qualified class name from a Name object
      *
      * @param  PhpParser\Node\Name      $class_name
-     * @param  StatementsSource         $source
+     * @param  Aliases                  $aliases
      *
      * @return string
      */
@@ -420,7 +420,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
 
     /**
      * @param  string                   $class
-     * @param  StatementsSource         $source
+     * @param  Aliases                  $aliases
      *
      * @return string
      */

--- a/src/Psalm/Checker/InterfaceChecker.php
+++ b/src/Psalm/Checker/InterfaceChecker.php
@@ -19,9 +19,6 @@ class InterfaceChecker extends ClassLikeChecker
     }
 
     /**
-     * @param Context|null  $class_context
-     * @param Context|null  $global_context
-     *
      * @return void
      */
     public function analyze()

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -473,8 +473,6 @@ class MethodChecker extends FunctionLikeChecker
      * @param  string           $method_id
      * @param  string|null      $calling_context
      * @param  StatementsSource $source
-     * @param  CodeLocation     $code_location
-     * @param  array            $suppressed_issues
      *
      * @return bool
      */

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -295,7 +295,6 @@ class Config
 
         if (@mkdir($config->cache_directory, 0777, true) === false && is_dir($config->cache_directory) === false) {
             trigger_error('Could not create cache directory: ' . $config->cache_directory, E_USER_ERROR);
-            exit(255);
         }
 
         if (isset($config_xml['allowFileIncludes'])) {

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -189,9 +189,9 @@ class IssueBuffer
     }
 
     /**
+     * @param  ProjectChecker       $project_checker
      * @param  bool                 $is_full
      * @param  float                $start_time
-     * @param  array<string, bool>  $scanned_files
      *
      * @return void
      */


### PR DESCRIPTION
Maybe a limited subset of PHP_CodeSniffer rules (or other linter) can be used to check for this in Jenkins (For third party PRs), and a larger subset can be used to check locally (Whitespace, etc.)