### PR TITLE
Update documentation of void types in CallMap

### DIFF
--- a/src/Psalm/CallMap.php
+++ b/src/Psalm/CallMap.php
@@ -49,7 +49,7 @@ namespace Psalm;
  *
  * Constructors have the class they belong to as a return type.
  *
- * Void types are declared as 'void' or ''.
+ * Void types are always declared as 'void'.
  */
 
 return [


### PR DESCRIPTION
The empty string is treated more like mixed