### PR TITLE
Fix unused imports in psalm, wrong param order doc comments

### DIFF
--- a/src/Psalm/Checker/ClassChecker.php
+++ b/src/Psalm/Checker/ClassChecker.php
@@ -9,7 +9,6 @@ use Psalm\Context;
 use Psalm\Issue\DeprecatedClass;
 use Psalm\Issue\DeprecatedInterface;
 use Psalm\Issue\InaccessibleMethod;
-use Psalm\Issue\InvalidReturnType;
 use Psalm\Issue\MissingConstructor;
 use Psalm\Issue\MissingPropertyType;
 use Psalm\Issue\PropertyNotSetInConstructor;

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -73,9 +73,9 @@ class FileChecker extends SourceChecker implements StatementsSource
     public $project_checker;
 
     /**
+     * @param ProjectChecker  $project_checker
      * @param string  $file_path
      * @param string  $file_name
-     * @param ProjectChecker  $project_checker
      */
     public function __construct(ProjectChecker $project_checker, $file_path, $file_name)
     {

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -4,7 +4,6 @@ namespace Psalm\Checker;
 use Psalm\Codebase;
 use Psalm\Config;
 use Psalm\Context;
-use Psalm\Issue\PossiblyUnusedMethod;
 use Psalm\Provider\ClassLikeStorageProvider;
 use Psalm\Provider\FileProvider;
 use Psalm\Provider\FileReferenceProvider;

--- a/src/Psalm/Checker/Statements/Block/TryChecker.php
+++ b/src/Psalm/Checker/Statements/Block/TryChecker.php
@@ -170,7 +170,7 @@ class TryChecker
 
             $catch_var_id = '$' . $catch->var;
 
-            $catch_context->vars_in_scope[$catch_var_id] = new Type\Union(
+            $catch_context->vars_in_scope[$catch_var_id] = new Union(
                 array_map(
                     /**
                      * @param string $fq_catch_class

--- a/src/Psalm/Checker/Statements/Expression/Call/FunctionCallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/Call/FunctionCallChecker.php
@@ -10,7 +10,6 @@ use Psalm\Checker\Statements\ExpressionChecker;
 use Psalm\Checker\StatementsChecker;
 use Psalm\Codebase\CallMap;
 use Psalm\CodeLocation;
-use Psalm\Config;
 use Psalm\Context;
 use Psalm\Issue\ForbiddenCode;
 use Psalm\Issue\InvalidFunctionCall;

--- a/src/Psalm/Checker/Statements/Expression/Fetch/ArrayFetchChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/Fetch/ArrayFetchChecker.php
@@ -140,8 +140,8 @@ class ArrayFetchChecker
     /**
      * @param  Type\Union $array_type
      * @param  Type\Union $offset_type
-     * @param  null|string    $array_var_id
      * @param  bool       $in_assignment
+     * @param  null|string    $array_var_id
      * @param  bool       $inside_isset
      *
      * @return Type\Union

--- a/src/Psalm/Checker/Statements/ExpressionChecker.php
+++ b/src/Psalm/Checker/Statements/ExpressionChecker.php
@@ -501,8 +501,8 @@ class ExpressionChecker
      * @param  StatementsChecker    $statements_checker
      * @param  PhpParser\Node\Expr  $stmt
      * @param  Type\Union           $by_ref_type
-     * @param  bool                 $constrain_type
      * @param  Context              $context
+     * @param  bool                 $constrain_type
      *
      * @return void
      */

--- a/src/Psalm/Checker/TypeChecker.php
+++ b/src/Psalm/Checker/TypeChecker.php
@@ -254,9 +254,9 @@ class TypeChecker
     /**
      * Does the input param atomic type match the given param atomic type
      *
+     * @param  Codebase     $codebase
      * @param  Type\Atomic  $input_type_part
      * @param  Type\Atomic  $container_type_part
-     * @param  Codebase     $codebase
      * @param  bool         &$has_scalar_match
      * @param  bool         &$type_coerced    whether or not there was type coercion involved
      * @param  bool         &$type_coerced_from_mixed

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -69,8 +69,8 @@ class CodeLocation
 
     /**
      * @param bool                 $single_line
-     * @param null|int             $regex_type
      * @param null|CodeLocation    $previous_location
+     * @param null|int             $regex_type
      * @param null|string          $selected_text
      */
     public function __construct(

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -121,7 +121,6 @@ class Codebase
     public $populator;
 
     /**
-     * @param bool $collect_references
      * @param bool $debug_output
      */
     public function __construct(

--- a/src/Psalm/Codebase/Analyzer.php
+++ b/src/Psalm/Codebase/Analyzer.php
@@ -85,7 +85,6 @@ class Analyzer
     /**
      * @param  string $file_path
      * @param  array<string, string> $filetype_checkers
-     * @param  bool   $will_analyze
      *
      * @return FileChecker
      *

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -778,8 +778,6 @@ class Config
     }
 
     /**
-     * @param  ProjectChecker $project_checker
-     *
      * @return void
      */
     public function visitStubFiles(Codebase $codebase)

--- a/src/Psalm/Config/ErrorLevelFileFilter.php
+++ b/src/Psalm/Config/ErrorLevelFileFilter.php
@@ -12,8 +12,8 @@ class ErrorLevelFileFilter extends FileFilter
 
     /**
      * @param  SimpleXMLElement $e
-     * @param  bool             $inclusive
      * @param  string           $base_dir
+     * @param  bool             $inclusive
      *
      * @return static
      */

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -1,7 +1,6 @@
 <?php
 namespace Psalm\Config;
 
-use Psalm\Config;
 use SimpleXMLElement;
 
 class FileFilter

--- a/src/Psalm/Plugin.php
+++ b/src/Psalm/Plugin.php
@@ -86,7 +86,6 @@ abstract class Plugin
 
     /**
      * @param  string $method_id - the method id being checked
-     * @param  string $appearing_method_id - the method id of the class that contains the method
      * @param  string $declaring_method_id - the method id of the class or trait that declares the method
      * @param  PhpParser\Node\Arg[] $args
      * @param  FileManipulation[] $file_replacements

--- a/src/Psalm/Provider/Cache/NoParserCacheProvider.php
+++ b/src/Psalm/Provider/Cache/NoParserCacheProvider.php
@@ -6,9 +6,9 @@ use PhpParser;
 class NoParserCacheProvider extends \Psalm\Provider\ParserCacheProvider
 {
     /**
+     * @param  int      $file_modified_time
      * @param  string   $file_content_hash
      * @param  string   $file_cache_key
-     * @param mixed $file_modified_time
      *
      * @return array<int, PhpParser\Node\Stmt>|null
      */

--- a/src/Psalm/Provider/ParserCacheProvider.php
+++ b/src/Psalm/Provider/ParserCacheProvider.php
@@ -26,9 +26,9 @@ class ParserCacheProvider
     public $use_igbinary = false;
 
     /**
+     * @param  int      $file_modified_time
      * @param  string   $file_content_hash
      * @param  string   $file_cache_key
-     * @param mixed $file_modified_time
      *
      * @return array<int, PhpParser\Node\Stmt>|null
      *

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -9,7 +9,6 @@ use Psalm\IssueBuffer;
 use Psalm\StatementsSource;
 use Psalm\Type;
 use Psalm\Type\Atomic\ObjectLike;
-use Psalm\Type\Atomic\Scalar;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TBool;
 use Psalm\Type\Atomic\TCallable;

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -905,9 +905,9 @@ class Reconciler
     /**
      * Gets the type for a given (non-existent key) based on the passed keys
      *
+     * @param  ProjectChecker            $project_checker
      * @param  string                    $key
      * @param  array<string,Type\Union>  $existing_keys
-     * @param  ProjectChecker            $project_checker
      *
      * @return Type\Union|null
      */

--- a/src/Psalm/Visitor/DependencyFinderVisitor.php
+++ b/src/Psalm/Visitor/DependencyFinderVisitor.php
@@ -1019,8 +1019,8 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
     }
 
     /**
-     * @param  array<int, array{type:string,name:string,line_number:int}>  $docblock_params
      * @param  FunctionLikeStorage          $storage
+     * @param  array<int, array{type:string,name:string,line_number:int}>  $docblock_params
      * @param  PhpParser\Node\FunctionLike  $function
      *
      * @return void


### PR DESCRIPTION
(Some of the imports appear as strings elsewhere in the same file, but not as phpdoc tags)