### PR TITLE
Support the pylint output format

### DIFF
--- a/bin/travis-php-cs-fixer.sh
+++ b/bin/travis-php-cs-fixer.sh
@@ -1,9 +1,2 @@
-set -e
-if [[ $(git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.php_cs.dist$') != ".php_cs.dist" ]];
-then
-  echo ".php_cs.dist has not changed";
-  ./vendor/bin/php-cs-fixer fix --verbose --allow-risky=yes --dry-run --config ./.php_cs.dist -- $(git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.php$') .php_cs.dist;
-else
-  echo ".php_cs.dist has changed";
-  ./vendor/bin/php-cs-fixer fix --verbose --allow-risky=yes --dry-run --config ./.php_cs.dist;
-fi
+#!/usr/bin/env bash
+./vendor/bin/php-cs-fixer fix --verbose --config ./.php_cs.dist -- $(git diff --name-only $TRAVIS_COMMIT_RANGE | grep '\.php$') .php_cs.dist;

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -129,9 +129,18 @@ class ProjectChecker
     private $cache = false;
 
     const TYPE_CONSOLE = 'console';
+    const TYPE_PYLINT = 'pylint';
     const TYPE_JSON = 'json';
     const TYPE_EMACS = 'emacs';
     const TYPE_XML = 'xml';
+
+    const SUPPORTED_OUTPUT_TYPES = [
+        self::TYPE_CONSOLE,
+        self::TYPE_PYLINT,
+        self::TYPE_JSON,
+        self::TYPE_EMACS,
+        self::TYPE_XML,
+    ];
 
     /**
      * @param FileProvider  $file_provider
@@ -181,7 +190,7 @@ class ProjectChecker
             $debug_output
         );
 
-        if (!in_array($output_format, [self::TYPE_CONSOLE, self::TYPE_JSON, self::TYPE_EMACS, self::TYPE_XML], true)) {
+        if (!in_array($output_format, self::SUPPORTED_OUTPUT_TYPES, true)) {
             throw new \UnexpectedValueException('Unrecognised output format ' . $output_format);
         }
 
@@ -194,6 +203,7 @@ class ProjectChecker
                 '.json' => self::TYPE_JSON,
                 '.txt' => self::TYPE_EMACS,
                 '.emacs' => self::TYPE_EMACS,
+                '.pylint' => self::TYPE_PYLINT,
             ];
             foreach ($mapping as $extension => $type) {
                 if (substr($reports, -strlen($extension)) === $extension) {

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -126,9 +126,43 @@ class IssueBuffer
     }
 
     /**
-     * @param  array{severity: string, line_from: int, type: string, message: string, file_name: string,
-     *  file_path: string, snippet: string, from: int, to: int, snippet_from: int, snippet_to: int,
-     *  column_from: int, column_to: int} $issue_data
+     * @param  array{severity: string, line_from: int, line_to: int, type: string, message: string,
+     *  file_name: string, file_path: string, snippet: string, from: int, to: int,
+     *  snippet_from: int, snippet_to: int, column_from: int, column_to: int} $issue_data
+     *
+     * @return string
+     */
+    protected static function getPylintOutput(array $issue_data)
+    {
+        $message = sprintf(
+            '%s: %s',
+            $issue_data['type'],
+            $issue_data['message']
+        );
+        if ($issue_data['severity'] === Config::REPORT_ERROR) {
+            $code = 'E0001';
+        } else {
+            $code = 'W0001';
+        }
+
+        // https://docs.pylint.org/en/1.6.0/output.html doesn't mention what to do about 'column',
+        // but it's still useful for users.
+        // E.g. jenkins can't parse %s:%d:%d.
+        $message = sprintf('%s (column %d)', $message, $issue_data['column_from']);
+        $issue_string = sprintf(
+            '%s:%d: [%s] %s',
+            $issue_data['file_name'],
+            $issue_data['line_from'],
+            $code,
+            $message
+        );
+        return $issue_string;
+    }
+
+    /**
+     * @param  array{severity: string, line_from: int, line_to: int, type: string, message: string,
+     *  file_name: string, file_path: string, snippet: string, from: int, to: int,
+     *  snippet_from: int, snippet_to: int, column_from: int, column_to: int} $issue_data
      * @param  bool  $use_color
      *
      * @return string
@@ -286,6 +320,13 @@ class IssueBuffer
             $output = '';
             foreach (self::$issues_data as $issue_data) {
                 $output .= self::getEmacsOutput($issue_data) . PHP_EOL;
+            }
+
+            return $output;
+        } elseif ($format === ProjectChecker::TYPE_PYLINT) {
+            $output = '';
+            foreach (self::$issues_data as $issue_data) {
+                $output .= self::getPylintOutput($issue_data) . PHP_EOL;
             }
 
             return $output;

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -84,7 +84,7 @@ Options:
         Psalm checks itself
 
     --output-format=console
-        Changes the output format. Possible values: console, json, xml
+        Changes the output format. Possible values: console, emacs, json, pylint, xml
 
     --find-dead-code
         Look for dead code


### PR DESCRIPTION
This is a compact output format that is easy to write scripts that parse.
(And errors fit on a single line)

- E.g. jenkins violation plugin works reliably with pylint.

The multi-line details are deliberately omitted. (same as emacs)
An application can output 'console' to stdout and to
a pylint file at the same time.

Files with the extension .pylint will use this format.

Document the emacs and pylint output formats in `psalm --help`

An optional followup task would be to create unique issue codes,
I don't have any use cases for that.