### PR TITLE
Add a script to run the same tests as jenkins locally

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,12 +41,15 @@
         "ext-igbinary": "^2.0.5"
     },
     "scripts": {
-        "psalm": "./psalm",
-        "standards": "php ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --allow-risky=yes",
+        "psalm": "./psalm --find-dead-code",
+        "standards": "phpcs",
         "tests": [
-            "php ./vendor/squizlabs/php_codesniffer/bin/phpcs",
-            "php ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --allow-risky=yes --dry-run .php_cs.dist",
-            "php ./vendor/friendsofphp/php-cs-fixer/php-cs-fixer fix --verbose --allow-risky=yes --dry-run",
+            "phpcs",
+            "phpunit"
+        ],
+        "all-tests": [
+            "phpcs",
+            "./psalm --find-dead-code",
             "phpunit"
         ]
     }


### PR DESCRIPTION
Make `composer tests` use only phpcs

Also add `composer all-tests`, which also runs the self-check.

php-cs-fixer was removed from .travis.yml earlier.
I'm guessing that composer was overlooked?

The goal is to make it easy to create PRs passing travis checks.