### PR TITLE
Make Psalm compatible with PHP Parser 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: php
 
 matrix:
   include:
-    - php: 5.6
     - php: 7.0
     - php: 7.1
     - php: 7.2

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
         }
     ],
     "require": {
-        "php": "^5.6 || ^7.0",
-        "nikic/PHP-Parser": "^3.1.2",
+        "php": "^7.0",
+        "nikic/PHP-Parser": "^4.0",
         "openlss/lib-array2xml": "^0.0.10||^0.5.1",
         "muglug/package-versions-56": "1.2.4",
         "php-cs-fixer/diff": "^1.2",

--- a/src/Psalm/Checker/CanAlias.php
+++ b/src/Psalm/Checker/CanAlias.php
@@ -41,14 +41,15 @@ trait CanAlias
     {
         foreach ($stmt->uses as $use) {
             $use_path = implode('\\', $use->name->parts);
+            $use_alias = $use->alias ? $use->alias->name : $use->name->getLast();
 
             switch ($use->type !== PhpParser\Node\Stmt\Use_::TYPE_UNKNOWN ? $use->type : $stmt->type) {
                 case PhpParser\Node\Stmt\Use_::TYPE_FUNCTION:
-                    $this->aliased_functions[strtolower($use->alias)] = $use_path;
+                    $this->aliased_functions[strtolower($use_alias)] = $use_path;
                     break;
 
                 case PhpParser\Node\Stmt\Use_::TYPE_CONSTANT:
-                    $this->aliased_constants[$use->alias] = $use_path;
+                    $this->aliased_constants[$use_alias] = $use_path;
                     break;
 
                 case PhpParser\Node\Stmt\Use_::TYPE_NORMAL:
@@ -62,9 +63,9 @@ trait CanAlias
                         $codebase->use_referencing_files[$this->getFilePath()][strtolower($use_path)] = true;
                     }
 
-                    $this->aliased_classes[strtolower($use->alias)] = $use_path;
-                    $this->aliased_class_locations[strtolower($use->alias)] = new CodeLocation($this, $stmt);
-                    $this->aliased_classes_flipped[strtolower($use_path)] = $use->alias;
+                    $this->aliased_classes[strtolower($use_alias)] = $use_path;
+                    $this->aliased_class_locations[strtolower($use_alias)] = new CodeLocation($this, $stmt);
+                    $this->aliased_classes_flipped[strtolower($use_path)] = $use_alias;
                     break;
             }
         }
@@ -81,14 +82,15 @@ trait CanAlias
 
         foreach ($stmt->uses as $use) {
             $use_path = $use_prefix . '\\' . implode('\\', $use->name->parts);
+            $use_alias = $use->alias ? $use->alias->name : $use->name->getLast();
 
             switch ($use->type !== PhpParser\Node\Stmt\Use_::TYPE_UNKNOWN ? $use->type : $stmt->type) {
                 case PhpParser\Node\Stmt\Use_::TYPE_FUNCTION:
-                    $this->aliased_functions[strtolower($use->alias)] = $use_path;
+                    $this->aliased_functions[strtolower($use_alias)] = $use_path;
                     break;
 
                 case PhpParser\Node\Stmt\Use_::TYPE_CONSTANT:
-                    $this->aliased_constants[$use->alias] = $use_path;
+                    $this->aliased_constants[$use_alias] = $use_path;
                     break;
 
                 case PhpParser\Node\Stmt\Use_::TYPE_NORMAL:
@@ -100,8 +102,8 @@ trait CanAlias
                             new \Psalm\CodeLocation($this, $use);
                     }
 
-                    $this->aliased_classes[strtolower($use->alias)] = $use_path;
-                    $this->aliased_classes_flipped[strtolower($use_path)] = $use->alias;
+                    $this->aliased_classes[strtolower($use_alias)] = $use_path;
+                    $this->aliased_classes_flipped[strtolower($use_path)] = $use_alias;
                     break;
             }
         }

--- a/src/Psalm/Checker/ClassChecker.php
+++ b/src/Psalm/Checker/ClassChecker.php
@@ -81,11 +81,10 @@ class ClassChecker extends ClassLikeChecker
 
         $storage = $this->storage;
 
-        if (preg_match(
+        if ($class->name && preg_match(
             '/(^|\\\)(int|float|bool|string|void|null|false|true|resource|object|numeric|mixed)$/i',
             $fq_class_name
-        )
-        ) {
+        )) {
             $class_name_parts = explode('\\', $fq_class_name);
             $class_name = array_pop($class_name_parts);
 
@@ -94,7 +93,7 @@ class ClassChecker extends ClassLikeChecker
                     $class_name . ' is a reserved word',
                     new CodeLocation(
                         $this,
-                        $class,
+                        $class->name,
                         null,
                         true
                     ),
@@ -138,7 +137,7 @@ class ClassChecker extends ClassLikeChecker
                 if ($parent_class_storage->deprecated) {
                     $code_location = new CodeLocation(
                         $this,
-                        $class,
+                        $class->extends,
                         $class_context ? $class_context->include_location : null,
                         true
                     );
@@ -191,7 +190,7 @@ class ClassChecker extends ClassLikeChecker
 
                 $code_location = new CodeLocation(
                     $this,
-                    $class,
+                    $class->name ? $class->name : $class,
                     $class_context ? $class_context->include_location : null,
                     true
                 );
@@ -296,7 +295,7 @@ class ClassChecker extends ClassLikeChecker
                             $this->fq_class_name . ', defined abstract in ' . $declaring_class_name,
                             new CodeLocation(
                                 $this,
-                                $class,
+                                $class->name ? $class->name : $class,
                                 $class_context->include_location,
                                 true
                             )
@@ -398,7 +397,7 @@ class ClassChecker extends ClassLikeChecker
                     $global_context
                 );
 
-                if ($stmt->name === '__construct') {
+                if ($stmt->name->name === '__construct') {
                     $constructor_checker = $method_checker;
                 }
             } elseif ($stmt instanceof PhpParser\Node\Stmt\TraitUse) {
@@ -456,7 +455,7 @@ class ClassChecker extends ClassLikeChecker
                                     $global_context
                                 );
 
-                                if ($trait_stmt->name === '__construct') {
+                                if ($trait_stmt->name->name === '__construct') {
                                     $constructor_checker = $trait_method_checker;
                                 }
                             }
@@ -531,7 +530,6 @@ class ClassChecker extends ClassLikeChecker
                     && isset($storage->declaring_method_ids['__construct'])
                     && $class->extends
                 ) {
-                    $class_parent = $class->extends;
                     list($construct_fqcln) = explode('::', $storage->declaring_method_ids['__construct']);
 
                     $constructor_class_storage = $classlike_storage_provider->get($construct_fqcln);
@@ -562,20 +560,22 @@ class ClassChecker extends ClassLikeChecker
                         );
 
                         $fake_constructor_stmts = [
-                            new PhpParser\Node\Expr\StaticCall(
-                                new PhpParser\Node\Name(['parent']),
-                                '__construct',
-                                $fake_constructor_stmt_args,
-                                [
-                                    'line' => $class_parent->getLine(),
-                                    'startFilePos' => $class_parent->getAttribute('startFilePos'),
-                                    'endFilePos' => $class_parent->getAttribute('endFilePos'),
-                                ]
+                            new PhpParser\Node\Stmt\Expression(
+                                new PhpParser\Node\Expr\StaticCall(
+                                    new PhpParser\Node\Name(['parent']),
+                                    new PhpParser\Node\Identifier('__construct'),
+                                    $fake_constructor_stmt_args,
+                                    [
+                                        'line' => $class->extends->getLine(),
+                                        'startFilePos' => $class->extends->getAttribute('startFilePos'),
+                                        'endFilePos' => $class->extends->getAttribute('endFilePos'),
+                                    ]
+                                )
                             ),
                         ];
 
                         $fake_stmt = new PhpParser\Node\Stmt\ClassMethod(
-                            '__construct',
+                            new PhpParser\Node\Identifier('__construct'),
                             [
                                 'type' => PhpParser\Node\Stmt\Class_::MODIFIER_PUBLIC,
                                 'params' => $fake_constructor_params,
@@ -708,7 +708,7 @@ class ClassChecker extends ClassLikeChecker
 
         if (!$comment || !$comment->getText()) {
             $fq_class_name = $source->getFQCLN();
-            $property_name = $stmt->props[0]->name;
+            $property_name = $stmt->props[0]->name->name;
 
             $codebase = $project_checker->codebase;
 
@@ -817,7 +817,7 @@ class ClassChecker extends ClassLikeChecker
             $global_context ? clone $global_context : null
         );
 
-        if ($stmt->name !== '__construct'
+        if ($stmt->name->name !== '__construct'
             && $config->reportIssueInFile('InvalidReturnType', $source->getFilePath())
         ) {
             $return_type_location = null;
@@ -837,16 +837,18 @@ class ClassChecker extends ClassLikeChecker
 
                 $return_type = $codebase->methods->getMethodReturnType($analyzed_method_id, $self_class);
 
-                $overridden_method_ids = isset($class_storage->overridden_method_ids[strtolower($stmt->name)])
-                    ? $class_storage->overridden_method_ids[strtolower($stmt->name)]
+                $overridden_method_ids = isset($class_storage->overridden_method_ids[strtolower($stmt->name->name)])
+                    ? $class_storage->overridden_method_ids[strtolower($stmt->name->name)]
                     : [];
 
                 if ($actual_method_storage->overridden_downstream) {
                     $overridden_method_ids[] = 'overridden::downstream';
                 }
 
-                if (!$return_type && isset($class_storage->interface_method_ids[strtolower($stmt->name)])) {
-                    foreach ($class_storage->interface_method_ids[strtolower($stmt->name)] as $interface_method_id) {
+                if (!$return_type && isset($class_storage->interface_method_ids[strtolower($stmt->name->name)])) {
+                    $interface_method_ids = $class_storage->interface_method_ids[strtolower($stmt->name->name)];
+
+                    foreach ($interface_method_ids as $interface_method_id) {
                         list($interface_class) = explode('::', $interface_method_id);
 
                         $interface_return_type = $codebase->methods->getMethodReturnType(

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -131,9 +131,9 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
 
         foreach ($this->class->stmts as $stmt) {
             if ($stmt instanceof PhpParser\Node\Stmt\ClassMethod &&
-                strtolower($stmt->name) === strtolower($method_name)
+                strtolower($stmt->name->name) === strtolower($method_name)
             ) {
-                $method_id = $this->fq_class_name . '::' . $stmt->name;
+                $method_id = $this->fq_class_name . '::' . $stmt->name->name;
 
                 if ($project_checker->canCacheCheckers()) {
                     $method_checker = $codebase->methods->getCachedChecker($method_id);
@@ -166,7 +166,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
 
                     foreach ($trait_node->stmts as $trait_stmt) {
                         if ($trait_stmt instanceof PhpParser\Node\Stmt\ClassMethod &&
-                            strtolower($trait_stmt->name) === strtolower($method_name)
+                            strtolower($trait_stmt->name->name) === strtolower($method_name)
                         ) {
                             $method_checker = new MethodChecker($trait_stmt, $trait_checker);
 
@@ -394,7 +394,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
      */
     public function getClassName()
     {
-        return $this->class->name;
+        return $this->class->name ? $this->class->name->name : null;
     }
 
     /**

--- a/src/Psalm/Checker/FileChecker.php
+++ b/src/Psalm/Checker/FileChecker.php
@@ -133,9 +133,9 @@ class FileChecker extends SourceChecker implements StatementsSource
     }
 
     /**
-     * @param  array<int, PhpParser\Node\Expr|PhpParser\Node\Stmt>  $stmts
+     * @param  array<int, PhpParser\Node\Stmt>  $stmts
      *
-     * @return array<int, PhpParser\Node\Expr|PhpParser\Node\Stmt>
+     * @return array<int, PhpParser\Node\Stmt>
      */
     public function populateCheckers(array $stmts)
     {
@@ -183,13 +183,13 @@ class FileChecker extends SourceChecker implements StatementsSource
         }
 
         if ($stmt instanceof PhpParser\Node\Stmt\Class_) {
-            $class_checker = new ClassChecker($stmt, $this, $stmt->name);
+            $class_checker = new ClassChecker($stmt, $this, $stmt->name->name);
 
             $fq_class_name = $class_checker->getFQCLN();
 
             $this->class_checkers_to_analyze[strtolower($fq_class_name)] = $class_checker;
         } elseif ($stmt instanceof PhpParser\Node\Stmt\Interface_) {
-            $class_checker = new InterfaceChecker($stmt, $this, $stmt->name);
+            $class_checker = new InterfaceChecker($stmt, $this, $stmt->name->name);
 
             $fq_class_name = $class_checker->getFQCLN();
 

--- a/src/Psalm/Checker/FunctionChecker.php
+++ b/src/Psalm/Checker/FunctionChecker.php
@@ -639,23 +639,22 @@ class FunctionChecker extends FunctionLikeChecker
                     return Type::getArray();
                 }
 
-                if (count($function_call_arg->value->stmts) === 1
-                    && count($function_call_arg->value->params)
-                ) {
+                if (count($function_call_arg->value->stmts) === 1 && count($function_call_arg->value->params)) {
                     $first_param = $function_call_arg->value->params[0];
                     $stmt = $function_call_arg->value->stmts[0];
 
                     if ($first_param->variadic === false
+                        && is_string($first_param->var->name)
                         && $stmt instanceof PhpParser\Node\Stmt\Return_
                         && $stmt->expr
                     ) {
                         $assertions = AssertionFinder::getAssertions($stmt->expr, null, $statements_checker);
 
-                        if (isset($assertions['$' . $first_param->name])) {
+                        if (isset($assertions['$' . $first_param->var->name])) {
                             $changed_var_ids = [];
 
                             $reconciled_types = Reconciler::reconcileKeyedTypes(
-                                ['$inner_type' => $assertions['$' . $first_param->name]],
+                                ['$inner_type' => $assertions['$' . $first_param->var->name]],
                                 ['$inner_type' => $inner_type],
                                 $changed_var_ids,
                                 ['$inner_type' => true],
@@ -671,6 +670,13 @@ class FunctionChecker extends FunctionLikeChecker
                     }
                 }
             }
+
+            return new Type\Union([
+                new Type\Atomic\TArray([
+                    $key_type,
+                    $inner_type,
+                ]),
+            ]);
         }
 
         return new Type\Union([

--- a/src/Psalm/Checker/FunctionLike/ReturnTypeChecker.php
+++ b/src/Psalm/Checker/FunctionLike/ReturnTypeChecker.php
@@ -64,10 +64,10 @@ class ReturnTypeChecker
             return null;
         }
 
-        $is_to_string = $function instanceof ClassMethod && strtolower($function->name) === '__tostring';
+        $is_to_string = $function instanceof ClassMethod && strtolower($function->name->name) === '__tostring';
 
         if ($function instanceof ClassMethod &&
-            substr($function->name, 0, 2) === '__' &&
+            substr($function->name->name, 0, 2) === '__' &&
             !$is_to_string
         ) {
             // do not check __construct, __set, __get, __call etc.
@@ -77,7 +77,10 @@ class ReturnTypeChecker
         $cased_method_id = $function_like_checker->getCorrectlyCasedMethodId();
 
         if (!$return_type_location) {
-            $return_type_location = new CodeLocation($function_like_checker, $function, null, true);
+            $return_type_location = new CodeLocation(
+                $function_like_checker,
+                $function instanceof Closure ? $function : $function->name
+            );
         }
 
         $inferred_yield_types = [];

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -171,12 +171,12 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
 
             $overridden_method_ids = $codebase->methods->getOverriddenMethodIds($method_id);
 
-            if ($this->function->name === '__construct') {
+            if ($this->function->name->name === '__construct') {
                 $context->inside_constructor = true;
             }
 
             if ($overridden_method_ids
-                && $this->function->name !== '__construct'
+                && $this->function->name->name !== '__construct'
                 && !$context->collect_initializations
                 && !$context->collect_mutations
             ) {
@@ -756,7 +756,7 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
         if ($this->function instanceof Function_) {
             $namespace = $this->source->getNamespace();
 
-            return ($namespace ? strtolower($namespace) . '\\' : '') . strtolower($this->function->name);
+            return ($namespace ? strtolower($namespace) . '\\' : '') . strtolower($this->function->name->name);
         }
 
         return $this->getFilePath() . ':' . $this->function->getLine() . ':-:closure';

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -493,7 +493,7 @@ class MethodChecker extends FunctionLikeChecker
                             . '\' for ' . $cased_guide_method_id . ' is more specific than the implemented '
                             . 'return type for ' . $implementer_declaring_method_id . ' \''
                             . $implementer_method_storage->return_type . '\'',
-                            $implementer_method_storage->location ?: $code_location
+                            $implementer_method_storage->return_type_location ?: $code_location
                         ),
                         $suppressed_issues
                     )) {
@@ -506,7 +506,7 @@ class MethodChecker extends FunctionLikeChecker
                             . '\' for ' . $cased_guide_method_id . ' is different to the implemented '
                             . 'return type for ' . $implementer_declaring_method_id . ' \''
                             . $implementer_method_storage->return_type . '\'',
-                            $implementer_method_storage->location ?: $code_location
+                            $implementer_method_storage->return_type_location ?: $code_location
                         ),
                         $suppressed_issues
                     )) {

--- a/src/Psalm/Checker/NamespaceChecker.php
+++ b/src/Psalm/Checker/NamespaceChecker.php
@@ -69,7 +69,7 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
                 $this->visitGroupUse($stmt);
             } elseif ($stmt instanceof PhpParser\Node\Stmt\Const_) {
                 foreach ($stmt->consts as $const) {
-                    self::$public_namespace_constants[$this->namespace_name][$const->name] = Type::getMixed();
+                    self::$public_namespace_constants[$this->namespace_name][$const->name->name] = Type::getMixed();
                 }
 
                 $leftover_stmts[] = $stmt;
@@ -98,7 +98,7 @@ class NamespaceChecker extends SourceChecker implements StatementsSource
             throw new \UnexpectedValueException('Did not expect anonymous class here');
         }
 
-        $fq_class_name = Type::getFQCLNFromString($stmt->name, $this->getAliases());
+        $fq_class_name = Type::getFQCLNFromString($stmt->name->name, $this->getAliases());
 
         if ($stmt instanceof PhpParser\Node\Stmt\Class_) {
             $this->source->addNamespacedClassChecker(

--- a/src/Psalm/Checker/ScopeChecker.php
+++ b/src/Psalm/Checker/ScopeChecker.php
@@ -12,7 +12,7 @@ class ScopeChecker
     const ACTION_RETURN = 'RETURN';
 
     /**
-     * @param   array<PhpParser\Node>   $stmts
+     * @param   array<PhpParser\Node\Stmt>   $stmts
      *
      * @return  bool
      */
@@ -72,7 +72,7 @@ class ScopeChecker
 
             if ($stmt instanceof PhpParser\Node\Stmt\Return_ ||
                 $stmt instanceof PhpParser\Node\Stmt\Throw_ ||
-                $stmt instanceof PhpParser\Node\Expr\Exit_
+                ($stmt instanceof PhpParser\Node\Stmt\Expression && $stmt->expr instanceof PhpParser\Node\Expr\Exit_)
             ) {
                 if (!$return_is_exit && $stmt instanceof PhpParser\Node\Stmt\Return_) {
                     return [self::ACTION_RETURN];

--- a/src/Psalm/Checker/Statements/Block/LoopChecker.php
+++ b/src/Psalm/Checker/Statements/Block/LoopChecker.php
@@ -19,12 +19,12 @@ class LoopChecker
     /**
      * Checks an array of statements in a loop
      *
-     * @param  array<PhpParser\Node\Stmt|PhpParser\Node\Expr>   $stmts
-     * @param  PhpParser\Node\Expr[]                            $pre_conditions
-     * @param  PhpParser\Node\Expr[]                            $post_expressions
-     * @param  Context                                          $loop_scope->loop_context
-     * @param  Context                                          $loop_scope->loop_parent_context
-     * @param  bool                                             $is_do
+     * @param  array<PhpParser\Node\Stmt>   $stmts
+     * @param  PhpParser\Node\Expr[]        $pre_conditions
+     * @param  PhpParser\Node\Expr[]        $post_expressions
+     * @param  Context                      loop_scope->loop_context
+     * @param  Context                      $loop_scope->loop_parent_context
+     * @param  bool                         $is_do
      *
      * @return false|null
      */

--- a/src/Psalm/Checker/Statements/Block/TryChecker.php
+++ b/src/Psalm/Checker/Statements/Block/TryChecker.php
@@ -134,6 +134,12 @@ class TryChecker
 
             $fq_catch_classes = [];
 
+            $catch_var_name = $catch->var->name;
+
+            if (!is_string($catch_var_name)) {
+                throw new \UnexpectedValueException('Catch var name must be a string');
+            }
+
             foreach ($catch->types as $catch_type) {
                 $fq_catch_class = ClassLikeChecker::getFQCLNFromNameObject(
                     $catch_type,
@@ -174,7 +180,7 @@ class TryChecker
                 $fq_catch_classes[] = $fq_catch_class;
             }
 
-            $catch_var_id = '$' . $catch->var;
+            $catch_var_id = '$' . $catch_var_name;
 
             $catch_context->vars_in_scope[$catch_var_id] = new Union(
                 array_map(
@@ -207,10 +213,8 @@ class TryChecker
             if (!$statements_checker->hasVariable($catch_var_id)) {
                 $location = new CodeLocation(
                     $statements_checker,
-                    $catch,
-                    $context->include_location,
-                    true,
-                    CodeLocation::CATCH_VAR
+                    $catch->var,
+                    $context->include_location
                 );
                 $statements_checker->registerVariable(
                     $catch_var_id,

--- a/src/Psalm/Checker/Statements/Expression/ArrayChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/ArrayChecker.php
@@ -43,6 +43,7 @@ class ArrayChecker
 
         $array_keys = [];
 
+        /** @var int $int_offset */
         foreach ($stmt->items as $int_offset => $item) {
             if ($item === null) {
                 continue;

--- a/src/Psalm/Checker/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Checker/Statements/Expression/AssertionFinder.php
@@ -832,8 +832,8 @@ class AssertionFinder
                     $if_types[$first_var_name] = $prefix . $is_a_prefix . $first_arg->value;
                 } elseif ($first_arg instanceof PhpParser\Node\Expr\ClassConstFetch
                     && $first_arg->class instanceof PhpParser\Node\Name
-                    && is_string($first_arg->name)
-                    && strtolower($first_arg->name) === 'class'
+                    && $first_arg->name instanceof PhpParser\Node\Identifier
+                    && strtolower($first_arg->name->name) === 'class'
                 ) {
                     $class_node = $first_arg->class;
 
@@ -1054,8 +1054,8 @@ class AssertionFinder
                 $conditional->left instanceof PhpParser\Node\Scalar\String_
                 || ($conditional->left instanceof PhpParser\Node\Expr\ClassConstFetch
                     && $conditional->left->class instanceof PhpParser\Node\Name
-                    && is_string($conditional->left->name)
-                    && strtolower($conditional->left->name) === 'class')
+                    && $conditional->left->name instanceof PhpParser\Node\Identifier
+                    && strtolower($conditional->left->name->name) === 'class')
             )
         ) {
             return self::ASSIGNMENT_TO_RIGHT;
@@ -1068,8 +1068,8 @@ class AssertionFinder
                 $conditional->right instanceof PhpParser\Node\Scalar\String_
                 || ($conditional->right instanceof PhpParser\Node\Expr\ClassConstFetch
                     && $conditional->right->class instanceof PhpParser\Node\Name
-                    && is_string($conditional->right->name)
-                    && strtolower($conditional->right->name) === 'class')
+                    && $conditional->right->name instanceof PhpParser\Node\Identifier
+                    && strtolower($conditional->right->name->name) === 'class')
             )
         ) {
             return self::ASSIGNMENT_TO_LEFT;
@@ -1135,8 +1135,8 @@ class AssertionFinder
                 || (
                     $second_arg instanceof PhpParser\Node\Expr\ClassConstFetch
                     && $second_arg->class instanceof PhpParser\Node\Name
-                    && is_string($second_arg->name)
-                    && strtolower($second_arg->name) === 'class'
+                    && $second_arg->name instanceof PhpParser\Node\Identifier
+                    && strtolower($second_arg->name->name) === 'class'
                 )
             ) {
                 return true;

--- a/src/Psalm/Checker/Statements/Expression/Assignment/ArrayAssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/Assignment/ArrayAssignmentChecker.php
@@ -315,11 +315,11 @@ class ArrayAssignmentChecker
         $root_array_expr->inferredType = $root_type;
 
         if ($root_array_expr instanceof PhpParser\Node\Expr\PropertyFetch) {
-            if (is_string($root_array_expr->name)) {
+            if ($root_array_expr->name instanceof PhpParser\Node\Identifier) {
                 PropertyAssignmentChecker::analyzeInstance(
                     $statements_checker,
                     $root_array_expr,
-                    $root_array_expr->name,
+                    $root_array_expr->name->name,
                     null,
                     $root_type,
                     $context,

--- a/src/Psalm/Checker/Statements/Expression/Assignment/PropertyAssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/Assignment/PropertyAssignmentChecker.php
@@ -651,7 +651,7 @@ class PropertyAssignmentChecker
 
         $prop_name = $stmt->name;
 
-        if (!is_string($prop_name)) {
+        if (!$prop_name instanceof PhpParser\Node\Identifier) {
             return;
         }
 
@@ -694,12 +694,12 @@ class PropertyAssignmentChecker
         }
 
         $declaring_property_class = $codebase->properties->getDeclaringClassForProperty(
-            $fq_class_name . '::$' . $prop_name
+            $fq_class_name . '::$' . $prop_name->name
         );
 
         $class_storage = $project_checker->classlike_storage_provider->get((string)$declaring_property_class);
 
-        $property_storage = $class_storage->properties[$prop_name];
+        $property_storage = $class_storage->properties[$prop_name->name];
 
         if ($var_id) {
             $context->vars_in_scope[$var_id] = $assignment_value_type;

--- a/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/AssignmentChecker.php
@@ -403,11 +403,11 @@ class AssignmentChecker
                 $assign_value_type
             );
         } elseif ($assign_var instanceof PhpParser\Node\Expr\PropertyFetch) {
-            if (is_string($assign_var->name)) {
+            if ($assign_var->name instanceof PhpParser\Node\Identifier) {
                 PropertyAssignmentChecker::analyzeInstance(
                     $statements_checker,
                     $assign_var,
-                    $assign_var->name,
+                    $assign_var->name->name,
                     $assign_value,
                     $assign_value_type,
                     $context
@@ -426,8 +426,7 @@ class AssignmentChecker
                 $context->vars_possibly_in_scope[$var_id] = true;
             }
         } elseif ($assign_var instanceof PhpParser\Node\Expr\StaticPropertyFetch &&
-            $assign_var->class instanceof PhpParser\Node\Name &&
-            is_string($assign_var->name)
+            $assign_var->class instanceof PhpParser\Node\Name
         ) {
             if (ExpressionChecker::analyze($statements_checker, $assign_var, $context) === false) {
                 return false;

--- a/src/Psalm/Checker/Statements/Expression/Call/StaticCallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/Call/StaticCallChecker.php
@@ -78,8 +78,8 @@ class StaticCallChecker extends \Psalm\Checker\Statements\Expression\CallChecker
 
                     $fq_class_name = $class_storage->name;
 
-                    if (is_string($stmt->name) && $class_storage->user_defined) {
-                        $method_id = $fq_class_name . '::' . strtolower($stmt->name);
+                    if ($stmt->name instanceof PhpParser\Node\Identifier && $class_storage->user_defined) {
+                        $method_id = $fq_class_name . '::' . strtolower($stmt->name->name);
 
                         $old_context_include_location = $context->include_location;
                         $old_self = $context->self;
@@ -250,12 +250,12 @@ class StaticCallChecker extends \Psalm\Checker\Statements\Expression\CallChecker
 
             $method_id = null;
 
-            if (is_string($stmt->name) &&
-                !$codebase->methodExists($fq_class_name . '::__callStatic') &&
-                !$is_mock
+            if ($stmt->name instanceof PhpParser\Node\Identifier
+                && !$codebase->methodExists($fq_class_name . '::__callStatic')
+                && !$is_mock
             ) {
-                $method_id = $fq_class_name . '::' . strtolower($stmt->name);
-                $cased_method_id = $fq_class_name . '::' . $stmt->name;
+                $method_id = $fq_class_name . '::' . strtolower($stmt->name->name);
+                $cased_method_id = $fq_class_name . '::' . $stmt->name->name;
 
                 $does_method_exist = MethodChecker::checkMethodExists(
                     $project_checker,

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -424,8 +424,10 @@ class CallChecker
                     }
                 }
             } else {
-                if ($arg->value instanceof PhpParser\Node\Expr\PropertyFetch && is_string($arg->value->name)) {
-                    $var_id = '$' . $arg->value->name;
+                if ($arg->value instanceof PhpParser\Node\Expr\PropertyFetch
+                    && $arg->value->name instanceof PhpParser\Node\Identifier
+                ) {
+                    $var_id = '$' . $arg->value->name->name;
                 } else {
                     $var_id = ExpressionChecker::getVarId(
                         $arg->value,
@@ -674,10 +676,10 @@ class CallChecker
 
                             $offset_value_type = null;
 
-                            if ($arg->value instanceof PhpParser\Node\Expr\ClassConstFetch &&
-                                $arg->value->class instanceof PhpParser\Node\Name &&
-                                is_string($arg->value->name) &&
-                                strtolower($arg->value->name) === 'class'
+                            if ($arg->value instanceof PhpParser\Node\Expr\ClassConstFetch
+                                && $arg->value->class instanceof PhpParser\Node\Name
+                                && $arg->value->name instanceof PhpParser\Node\Identifier
+                                && strtolower($arg->value->name->name) === 'class'
                             ) {
                                 $offset_value_type = Type::parseString(
                                     ClassLikeChecker::getFQCLNFromNameObject(
@@ -1640,8 +1642,8 @@ class CallChecker
         }
 
         if ($class_arg instanceof PhpParser\Node\Expr\ClassConstFetch
-            && is_string($class_arg->name)
-            && strtolower($class_arg->name) === 'class'
+            && $class_arg->name instanceof PhpParser\Node\Identifier
+            && strtolower($class_arg->name->name) === 'class'
             && $class_arg->class instanceof PhpParser\Node\Name
         ) {
             $fq_class_name = ClassLikeChecker::getFQCLNFromNameObject(

--- a/src/Psalm/Checker/Statements/Expression/Fetch/ConstFetchChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/Fetch/ConstFetchChecker.php
@@ -83,9 +83,9 @@ class ConstFetchChecker
         PhpParser\Node\Expr\ClassConstFetch $stmt,
         Context $context
     ) {
-        if ($context->check_consts &&
-            $stmt->class instanceof PhpParser\Node\Name &&
-            is_string($stmt->name)
+        if ($context->check_consts
+            && $stmt->class instanceof PhpParser\Node\Name
+            && $stmt->name instanceof PhpParser\Node\Identifier
         ) {
             $first_part_lc = strtolower($stmt->class->parts[0]);
 
@@ -128,7 +128,7 @@ class ConstFetchChecker
                 }
             }
 
-            if ($stmt->name === 'class') {
+            if ($stmt->name->name === 'class') {
                 $stmt->inferredType = Type::getClassString($fq_class_name);
 
                 return null;
@@ -166,7 +166,7 @@ class ConstFetchChecker
                 $class_visibility
             );
 
-            if (!isset($class_constants[$stmt->name]) && $first_part_lc !== 'static') {
+            if (!isset($class_constants[$stmt->name->name]) && $first_part_lc !== 'static') {
                 $all_class_constants = [];
 
                 if ($fq_class_name !== $context->self) {
@@ -176,7 +176,7 @@ class ConstFetchChecker
                     );
                 }
 
-                if ($all_class_constants && isset($all_class_constants[$stmt->name])) {
+                if ($all_class_constants && isset($all_class_constants[$stmt->name->name])) {
                     IssueBuffer::add(
                         new InaccessibleClassConstant(
                             'Constant ' . $const_id . ' is not visible in this context',
@@ -194,9 +194,9 @@ class ConstFetchChecker
 
                 return false;
             }
-            $stmt->inferredType = isset($class_constants[$stmt->name])
+            $stmt->inferredType = isset($class_constants[$stmt->name->name])
                 && $first_part_lc !== 'static'
-                ? $class_constants[$stmt->name]
+                ? $class_constants[$stmt->name->name]
                 : Type::getMixed();
 
             return null;

--- a/src/Psalm/Checker/Statements/ExpressionChecker.php
+++ b/src/Psalm/Checker/Statements/ExpressionChecker.php
@@ -273,18 +273,23 @@ class ExpressionChecker
             }
 
             foreach ($stmt->uses as $use) {
-                // insert the ref into the current context if passed by ref, as whatever we're passing
-                // the closure to could execute it straight away.
-                if (!$context->hasVariable('$' . $use->var, $statements_checker) && $use->byRef) {
-                    $context->vars_in_scope['$' . $use->var] = Type::getMixed();
+                if (!is_string($use->var->name)) {
+                    continue;
                 }
 
-                $use_context->vars_in_scope['$' . $use->var] =
-                    $context->hasVariable('$' . $use->var, $statements_checker) && !$use->byRef
-                    ? clone $context->vars_in_scope['$' . $use->var]
+                $use_var_id = '$' . $use->var->name;
+                // insert the ref into the current context if passed by ref, as whatever we're passing
+                // the closure to could execute it straight away.
+                if (!$context->hasVariable($use_var_id, $statements_checker) && $use->byRef) {
+                    $context->vars_in_scope[$use_var_id] = Type::getMixed();
+                }
+
+                $use_context->vars_in_scope[$use_var_id] =
+                    $context->hasVariable($use_var_id, $statements_checker) && !$use->byRef
+                    ? clone $context->vars_in_scope[$use_var_id]
                     : Type::getMixed();
 
-                $use_context->vars_possibly_in_scope['$' . $use->var] = true;
+                $use_context->vars_possibly_in_scope[$use_var_id] = true;
             }
 
             $closure_checker->analyze($use_context, $context);
@@ -587,7 +592,7 @@ class ExpressionChecker
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\StaticPropertyFetch
-            && is_string($stmt->name)
+            && $stmt->name instanceof PhpParser\Node\Identifier
             && $stmt->class instanceof PhpParser\Node\Name
         ) {
             if (count($stmt->class->parts) === 1
@@ -607,17 +612,17 @@ class ExpressionChecker
                     : implode('\\', $stmt->class->parts);
             }
 
-            return $fq_class_name . '::$' . $stmt->name;
+            return $fq_class_name . '::$' . $stmt->name->name;
         }
 
-        if ($stmt instanceof PhpParser\Node\Expr\PropertyFetch && is_string($stmt->name)) {
+        if ($stmt instanceof PhpParser\Node\Expr\PropertyFetch && $stmt->name instanceof PhpParser\Node\Identifier) {
             $object_id = self::getVarId($stmt->var, $this_class_name, $source);
 
             if (!$object_id) {
                 return null;
             }
 
-            return $object_id . '->' . $stmt->name;
+            return $object_id . '->' . $stmt->name->name;
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\ArrayDimFetch && $nesting !== null) {
@@ -647,11 +652,11 @@ class ExpressionChecker
             return self::getVarId($stmt, $this_class_name, $source);
         }
 
-        if ($stmt instanceof PhpParser\Node\Expr\PropertyFetch && is_string($stmt->name)) {
+        if ($stmt instanceof PhpParser\Node\Expr\PropertyFetch && $stmt->name instanceof PhpParser\Node\Identifier) {
             $property_root = self::getRootVarId($stmt->var, $this_class_name, $source);
 
             if ($property_root) {
-                return $property_root . '->' . $stmt->name;
+                return $property_root . '->' . $stmt->name->name;
             }
         }
 
@@ -700,7 +705,7 @@ class ExpressionChecker
             }
         }
 
-        if ($stmt instanceof PhpParser\Node\Expr\PropertyFetch && is_string($stmt->name)) {
+        if ($stmt instanceof PhpParser\Node\Expr\PropertyFetch && $stmt->name instanceof PhpParser\Node\Identifier) {
             $object_id = self::getArrayVarId($stmt->var, $this_class_name, $source);
 
             if (!$object_id) {
@@ -821,10 +826,13 @@ class ExpressionChecker
         Context $context
     ) {
         foreach ($stmt->uses as $use) {
-            $use_var_id = '$' . $use->var;
-            if (!$context->hasVariable($use_var_id, $statements_checker)
-                && (!$context->is_global || !in_array($use_var_id, ['$argv', '$argc'], true))
-            ) {
+            if (!$use->var->name instanceof PhpParser\Node\Identifier) {
+                continue;
+            }
+
+            $use_var_id = '$' . $use->var->name;
+
+            if (!$context->hasVariable($use_var_id, $statements_checker)) {
                 if ($use->byRef) {
                     $context->vars_in_scope[$use_var_id] = Type::getMixed();
                     $context->vars_possibly_in_scope[$use_var_id] = true;
@@ -832,7 +840,7 @@ class ExpressionChecker
                     if (!$statements_checker->hasVariable($use_var_id)) {
                         $statements_checker->registerVariable(
                             $use_var_id,
-                            new CodeLocation($statements_checker, $use),
+                            new CodeLocation($statements_checker, $use->var),
                             null
                         );
                     }
@@ -845,7 +853,7 @@ class ExpressionChecker
                         if (IssueBuffer::accepts(
                             new UndefinedVariable(
                                 'Cannot find referenced variable ' . $use_var_id,
-                                new CodeLocation($statements_checker->getSource(), $use)
+                                new CodeLocation($statements_checker->getSource(), $use->var)
                             ),
                             $statements_checker->getSuppressedIssues()
                         )) {
@@ -863,7 +871,7 @@ class ExpressionChecker
                         new PossiblyUndefinedVariable(
                             'Possibly undefined variable ' . $use_var_id . ', first seen on line ' .
                                 $first_appearance->getLineNumber(),
-                            new CodeLocation($statements_checker->getSource(), $use)
+                            new CodeLocation($statements_checker->getSource(), $use->var)
                         ),
                         $statements_checker->getSuppressedIssues()
                     )) {
@@ -877,7 +885,7 @@ class ExpressionChecker
                     if (IssueBuffer::accepts(
                         new UndefinedVariable(
                             'Cannot find referenced variable ' . $use_var_id,
-                            new CodeLocation($statements_checker->getSource(), $use)
+                            new CodeLocation($statements_checker->getSource(), $use->var)
                         ),
                         $statements_checker->getSuppressedIssues()
                     )) {
@@ -1081,12 +1089,12 @@ class ExpressionChecker
         Context $context
     ) {
         foreach ($stmt->vars as $isset_var) {
-            if ($isset_var instanceof PhpParser\Node\Expr\PropertyFetch &&
-                $isset_var->var instanceof PhpParser\Node\Expr\Variable &&
-                $isset_var->var->name === 'this' &&
-                is_string($isset_var->name)
+            if ($isset_var instanceof PhpParser\Node\Expr\PropertyFetch
+                && $isset_var->var instanceof PhpParser\Node\Expr\Variable
+                && $isset_var->var->name === 'this'
+                && $isset_var->name instanceof PhpParser\Node\Identifier
             ) {
-                $var_id = '$this->' . $isset_var->name;
+                $var_id = '$this->' . $isset_var->name->name;
 
                 if (!isset($context->vars_in_scope[$var_id])) {
                     $context->vars_in_scope[$var_id] = Type::getMixed();

--- a/src/Psalm/EffectsAnalyser.php
+++ b/src/Psalm/EffectsAnalyser.php
@@ -51,13 +51,22 @@ class EffectsAnalyser
                         $return_types[] = new Atomic\TMixed();
                     }
                 }
-            } elseif ($stmt instanceof PhpParser\Node\Expr\Yield_ || $stmt instanceof PhpParser\Node\Expr\YieldFrom) {
+            } elseif ($stmt instanceof PhpParser\Node\Stmt\Expression
+                && ($stmt->expr instanceof PhpParser\Node\Expr\Yield_
+                    || $stmt->expr instanceof PhpParser\Node\Expr\YieldFrom)
+            ) {
+                $yield_types = array_merge($yield_types, self::getYieldTypeFromExpression($stmt->expr));
+            } elseif ($stmt instanceof PhpParser\Node\Expr\Yield_
+                || $stmt instanceof PhpParser\Node\Expr\YieldFrom
+            ) {
                 $yield_types = array_merge($yield_types, self::getYieldTypeFromExpression($stmt));
-            } elseif ($stmt instanceof PhpParser\Node\Expr\Assign) {
+            } elseif ($stmt instanceof PhpParser\Node\Stmt\Expression
+                && $stmt->expr instanceof PhpParser\Node\Expr\Assign
+            ) {
                 $return_types = array_merge(
                     $return_types,
                     self::getReturnTypes(
-                        [$stmt->expr],
+                        [$stmt->expr->expr],
                         $yield_types,
                         $ignore_nullable_issues,
                         $ignore_falsable_issues
@@ -232,7 +241,7 @@ class EffectsAnalyser
      *
      * @return  array<int, Atomic>
      */
-    protected static function getYieldTypeFromExpression($stmt)
+    protected static function getYieldTypeFromExpression(PhpParser\Node\Expr $stmt)
     {
         if ($stmt instanceof PhpParser\Node\Expr\Yield_) {
             $key_type = null;

--- a/src/Psalm/Visitor/DependencyFinderVisitor.php
+++ b/src/Psalm/Visitor/DependencyFinderVisitor.php
@@ -117,17 +117,19 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
             foreach ($node->uses as $use) {
                 $use_path = implode('\\', $use->name->parts);
 
+                $use_alias = $use->alias ? $use->alias->name : $use->name->getLast();
+
                 switch ($use->type !== PhpParser\Node\Stmt\Use_::TYPE_UNKNOWN ? $use->type : $node->type) {
                     case PhpParser\Node\Stmt\Use_::TYPE_FUNCTION:
-                        $this->aliases->functions[strtolower($use->alias)] = $use_path;
+                        $this->aliases->functions[strtolower($use_alias)] = $use_path;
                         break;
 
                     case PhpParser\Node\Stmt\Use_::TYPE_CONSTANT:
-                        $this->aliases->constants[$use->alias] = $use_path;
+                        $this->aliases->constants[$use_alias] = $use_path;
                         break;
 
                     case PhpParser\Node\Stmt\Use_::TYPE_NORMAL:
-                        $this->aliases->uses[strtolower($use->alias)] = $use_path;
+                        $this->aliases->uses[strtolower($use_alias)] = $use_path;
                         break;
                 }
             }
@@ -136,18 +138,19 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
 
             foreach ($node->uses as $use) {
                 $use_path = $use_prefix . '\\' . implode('\\', $use->name->parts);
+                $use_alias = $use->alias ? $use->alias->name : $use->name->getLast();
 
                 switch ($use->type !== PhpParser\Node\Stmt\Use_::TYPE_UNKNOWN ? $use->type : $node->type) {
                     case PhpParser\Node\Stmt\Use_::TYPE_FUNCTION:
-                        $this->aliases->functions[strtolower($use->alias)] = $use_path;
+                        $this->aliases->functions[strtolower($use_alias)] = $use_path;
                         break;
 
                     case PhpParser\Node\Stmt\Use_::TYPE_CONSTANT:
-                        $this->aliases->constants[$use->alias] = $use_path;
+                        $this->aliases->constants[$use_alias] = $use_path;
                         break;
 
                     case PhpParser\Node\Stmt\Use_::TYPE_NORMAL:
-                        $this->aliases->uses[strtolower($use->alias)] = $use_path;
+                        $this->aliases->uses[strtolower($use_alias)] = $use_path;
                         break;
                 }
             }
@@ -159,7 +162,8 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
 
                 $fq_classlike_name = ClassChecker::getAnonymousClassName($node, $this->file_path);
             } else {
-                $fq_classlike_name = ($this->aliases->namespace ? $this->aliases->namespace . '\\' : '') . $node->name;
+                $fq_classlike_name =
+                    ($this->aliases->namespace ? $this->aliases->namespace . '\\' : '') . $node->name->name;
 
                 if ($this->codebase->classlike_storage_provider->has($fq_classlike_name)
                     && !$this->codebase->register_global_functions
@@ -449,8 +453,8 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
 
             foreach ($node->adaptations as $adaptation) {
                 if ($adaptation instanceof PhpParser\Node\Stmt\TraitUseAdaptation\Alias) {
-                    if ($adaptation->method && $adaptation->newName) {
-                        $method_map[strtolower($adaptation->method)] = strtolower($adaptation->newName);
+                    if ($adaptation->newName) {
+                        $method_map[strtolower($adaptation->method->name)] = strtolower($adaptation->newName->name);
                     }
                 }
             }
@@ -498,18 +502,16 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
                 $const_type = StatementsChecker::getSimpleType($const->value) ?: Type::getMixed();
 
                 if ($this->codebase->register_global_functions) {
-                    $this->codebase->addStubbedConstantType($const->name, $const_type);
+                    $this->codebase->addStubbedConstantType($const->name->name, $const_type);
                 } else {
-                    $this->file_storage->constants[$const->name] = $const_type;
-                    $this->file_storage->declaring_constants[$const->name] = $this->file_path;
+                    $this->file_storage->constants[$const->name->name] = $const_type;
+                    $this->file_storage->declaring_constants[$const->name->name] = $this->file_path;
                 }
             }
         }
     }
 
     /**
-     * @param  PhpParser\Node $node
-     *
      * @return null
      */
     public function leaveNode(PhpParser\Node $node)
@@ -593,7 +595,8 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
         $class_storage = null;
 
         if ($stmt instanceof PhpParser\Node\Stmt\Function_) {
-            $cased_function_id = ($this->aliases->namespace ? $this->aliases->namespace . '\\' : '') . $stmt->name;
+            $cased_function_id =
+                ($this->aliases->namespace ? $this->aliases->namespace . '\\' : '') . $stmt->name->name;
             $function_id = strtolower($cased_function_id);
 
             if ($this->codebase->register_global_functions) {
@@ -614,8 +617,8 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
 
             $fq_classlike_name = $this->fq_classlike_names[count($this->fq_classlike_names) - 1];
 
-            $function_id = $fq_classlike_name . '::' . strtolower($stmt->name);
-            $cased_function_id = $fq_classlike_name . '::' . $stmt->name;
+            $function_id = $fq_classlike_name . '::' . strtolower($stmt->name->name);
+            $cased_function_id = $fq_classlike_name . '::' . $stmt->name->name;
 
             if (!$this->classlike_storages) {
                 throw new \UnexpectedValueException('$class_storages cannot be empty for ' . $function_id);
@@ -623,16 +626,16 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
 
             $class_storage = $this->classlike_storages[count($this->classlike_storages) - 1];
 
-            if (isset($class_storage->methods[strtolower($stmt->name)])) {
+            if (isset($class_storage->methods[strtolower($stmt->name->name)])) {
                 throw new \InvalidArgumentException('Cannot re-register ' . $function_id);
             }
 
-            $storage = $class_storage->methods[strtolower($stmt->name)] = new MethodStorage();
+            $storage = $class_storage->methods[strtolower($stmt->name->name)] = new MethodStorage();
 
             $class_name_parts = explode('\\', $fq_classlike_name);
             $class_name = array_pop($class_name_parts);
 
-            if (strtolower((string)$stmt->name) === strtolower($class_name) &&
+            if (strtolower($stmt->name->name) === strtolower($class_name) &&
                 !isset($class_storage->methods['__construct']) &&
                 strpos($fq_classlike_name, '\\') === false
             ) {
@@ -646,15 +649,15 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
                 );
             }
 
-            $class_storage->declaring_method_ids[strtolower($stmt->name)] = $function_id;
-            $class_storage->appearing_method_ids[strtolower($stmt->name)] = $function_id;
+            $class_storage->declaring_method_ids[strtolower($stmt->name->name)] = $function_id;
+            $class_storage->appearing_method_ids[strtolower($stmt->name->name)] = $function_id;
 
-            if (!$stmt->isPrivate() || $stmt->name === '__construct' || $class_storage->is_trait) {
-                $class_storage->inheritable_method_ids[strtolower($stmt->name)] = $function_id;
+            if (!$stmt->isPrivate() || $stmt->name->name === '__construct' || $class_storage->is_trait) {
+                $class_storage->inheritable_method_ids[strtolower($stmt->name->name)] = $function_id;
             }
 
-            if (!isset($class_storage->overridden_method_ids[strtolower($stmt->name)])) {
-                $class_storage->overridden_method_ids[strtolower($stmt->name)] = [];
+            if (!isset($class_storage->overridden_method_ids[strtolower($stmt->name->name)])) {
+                $class_storage->overridden_method_ids[strtolower($stmt->name->name)] = [];
             }
 
             $storage->is_static = (bool) $stmt->isStatic();
@@ -678,7 +681,7 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
         $this->functionlike_storages[] = $storage;
 
         if ($stmt instanceof PhpParser\Node\Stmt\ClassMethod || $stmt instanceof PhpParser\Node\Stmt\Function_) {
-            $storage->cased_name = $stmt->name;
+            $storage->cased_name = $stmt->name->name;
         }
 
         $storage->location = new CodeLocation($this->file_scanner, $stmt, null, true);
@@ -696,7 +699,7 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
             if (isset($existing_params['$' . $param_array->name])) {
                 if (IssueBuffer::accepts(
                     new DuplicateParam(
-                        'Duplicate param $' . $param->name . ' in docblock for ' . $cased_function_id,
+                        'Duplicate param $' . $param_array->name . ' in docblock for ' . $cased_function_id,
                         new CodeLocation($this->file_scanner, $param, null, true)
                     )
                 )) {
@@ -711,10 +714,10 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
             if (!$param_array->is_optional) {
                 $required_param_count = $i + 1;
 
-                if (!$param->variadic && $has_optional_param) {
+                if (!$param->variadic && $has_optional_param && is_string($param->var->name)) {
                     if (IssueBuffer::accepts(
                         new MisplacedRequiredParam(
-                            'Required param $' . $param->name . ' should come before any optional params in ' .
+                            'Required param $' . $param->var->name . ' should come before any optional params in ' .
                             $cased_function_id,
                             new CodeLocation($this->file_scanner, $param, null, true)
                         )
@@ -733,7 +736,7 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
 
         if (($stmt instanceof PhpParser\Node\Stmt\Function_
                 || $stmt instanceof PhpParser\Node\Stmt\ClassMethod)
-            && strpos($stmt->name, 'assert') === 0
+            && strpos($stmt->name->name, 'assert') === 0
             && $stmt->stmts
         ) {
             $var_assertions = [];
@@ -795,11 +798,12 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
         ) {
             // pick up func_get_args that would otherwise be missed
             foreach ($stmt->stmts as $function_stmt) {
-                if ($function_stmt instanceof PhpParser\Node\Expr\Assign
-                    && ($function_stmt->expr instanceof PhpParser\Node\Expr\FuncCall)
-                    && ($function_stmt->expr->name instanceof PhpParser\Node\Name)
+                if ($function_stmt instanceof PhpParser\Node\Stmt\Expression
+                    && $function_stmt->expr instanceof PhpParser\Node\Expr\Assign
+                    && ($function_stmt->expr->expr instanceof PhpParser\Node\Expr\FuncCall)
+                    && ($function_stmt->expr->expr->name instanceof PhpParser\Node\Name)
                 ) {
-                    $function_id = implode('\\', $function_stmt->expr->name->parts);
+                    $function_id = implode('\\', $function_stmt->expr->expr->name->parts);
 
                     if ($function_id === 'func_get_arg'
                         || $function_id === 'func_get_args'
@@ -811,11 +815,6 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
             }
         }
 
-        /**
-         * @psalm-suppress MixedAssignment
-         *
-         * @var null|string|PhpParser\Node\Name|PhpParser\Node\NullableType
-         */
         $parser_return_type = $stmt->getReturnType();
 
         if ($parser_return_type) {
@@ -826,8 +825,8 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
                 $parser_return_type = $parser_return_type->type;
             }
 
-            if (is_string($parser_return_type)) {
-                $return_type_string = $parser_return_type . $suffix;
+            if ($parser_return_type instanceof PhpParser\Node\Identifier) {
+                $return_type_string = $parser_return_type->name . $suffix;
             } else {
                 $return_type_fq_classlike_name = ClassLikeChecker::getFQCLNFromNameObject(
                     $parser_return_type,
@@ -1072,8 +1071,8 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
         }
 
         if ($param_typehint) {
-            if (is_string($param_typehint)) {
-                $param_type_string = $param_typehint;
+            if ($param_typehint instanceof PhpParser\Node\Identifier) {
+                $param_type_string = $param_typehint->name;
             } elseif ($param_typehint instanceof PhpParser\Node\Name\FullyQualified) {
                 $param_type_string = (string)$param_typehint;
                 $this->codebase->scanner->queueClassLikeForScanning($param_type_string, $this->file_path);
@@ -1081,6 +1080,7 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
                 $param_type_string = $this->fq_classlike_names[count($this->fq_classlike_names) - 1];
             } else {
                 $param_type_string = ClassLikeChecker::getFQCLNFromNameObject($param_typehint, $this->aliases);
+
                 if (!in_array(strtolower($param_type_string), ['self', 'static', 'parent'], true)) {
                     $this->codebase->scanner->queueClassLikeForScanning($param_type_string, $this->file_path);
                     $this->file_storage->referenced_classlikes[strtolower($param_type_string)] = $param_type_string;
@@ -1114,8 +1114,12 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
 
         $is_optional = $param->default !== null;
 
+        if (!is_string($param->var->name)) {
+            throw new \UnexpectedValueException('Not expecting param name to be non-string');
+        }
+
         return new FunctionLikeParameter(
-            $param->name,
+            $param->var->name,
             $param->byRef,
             $param_type,
             new CodeLocation($this->file_scanner, $param, null, false, CodeLocation::FUNCTION_PARAM_VAR),
@@ -1360,10 +1364,10 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
                 $property_type = count($stmt->props) === 1 ? $property_group_type : clone $property_group_type;
             }
 
-            $property_storage = $storage->properties[$property->name] = new PropertyStorage();
+            $property_storage = $storage->properties[$property->name->name] = new PropertyStorage();
             $property_storage->is_static = (bool)$stmt->isStatic();
             $property_storage->type = $property_type;
-            $property_storage->location = new CodeLocation($this->file_scanner, $property);
+            $property_storage->location = new CodeLocation($this->file_scanner, $property->name);
             $property_storage->type_location = $property_type_location;
             $property_storage->has_default = $property->default ? true : false;
             $property_storage->suggested_type = $property_group_type ? null : $default_type;
@@ -1379,17 +1383,17 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
 
             $fq_classlike_name = $this->fq_classlike_names[count($this->fq_classlike_names) - 1];
 
-            $property_id = $fq_classlike_name . '::$' . $property->name;
+            $property_id = $fq_classlike_name . '::$' . $property->name->name;
 
-            $storage->declaring_property_ids[$property->name] = $property_id;
-            $storage->appearing_property_ids[$property->name] = $property_id;
+            $storage->declaring_property_ids[$property->name->name] = $property_id;
+            $storage->appearing_property_ids[$property->name->name] = $property_id;
 
             if ($property_is_initialized) {
-                $storage->initialized_properties[$property->name] = true;
+                $storage->initialized_properties[$property->name->name] = true;
             }
 
             if (!$stmt->isPrivate()) {
-                $storage->inheritable_property_ids[$property->name] = $property_id;
+                $storage->inheritable_property_ids[$property->name->name] = $property_id;
             }
         }
     }
@@ -1412,14 +1416,14 @@ class DependencyFinderVisitor extends PhpParser\NodeVisitorAbstract implements P
                 $existing_constants
             ) ?: Type::getMixed();
 
-            $existing_constants[$const->name] = $const_type;
+            $existing_constants[$const->name->name] = $const_type;
 
             if ($stmt->isProtected()) {
-                $storage->protected_class_constants[$const->name] = $const_type;
+                $storage->protected_class_constants[$const->name->name] = $const_type;
             } elseif ($stmt->isPrivate()) {
-                $storage->private_class_constants[$const->name] = $const_type;
+                $storage->private_class_constants[$const->name->name] = $const_type;
             } else {
-                $storage->public_class_constants[$const->name] = $const_type;
+                $storage->public_class_constants[$const->name->name] = $const_type;
             }
         }
     }

--- a/tests/ClassScopeTest.php
+++ b/tests/ClassScopeTest.php
@@ -266,7 +266,7 @@ class ClassScopeTest extends TestCase
                     }',
                 'error_message' => 'InaccessibleProperty',
             ],
-            'privateConstructorInheritance' => [
+            'privateConstructorInheritanceNoCall' => [
                 '<?php
                     class A {
                         private function __construct() { }

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -702,8 +702,12 @@ class PropertyTypeTest extends TestCase
                             $this->stmts = $stmts;
                         }
 
-                        public function getSubNodeNames() {
+                        public function getSubNodeNames() : array {
                             return array("stmts");
+                        }
+
+                        public function getType() : string {
+                            return "Stmt_Finally";
                         }
                     }',
                 'assertions' => [],


### PR DESCRIPTION
Fixes https://github.com/vimeo/psalm/issues/598

This PR does two big things:
 - upgrades to PHP Parser v4, which means it can be used alongside other tools that also require PHP Parser 4.
 - bumps the PHP version requirement to PHP 7 (required by PHP Parser)

Since this is a major breaking change, it'll land in a v2 release.
