### PR TITLE
Few fixes to make tests pass on windows

### DIFF
--- a/src/Psalm/Checker/CommentChecker.php
+++ b/src/Psalm/Checker/CommentChecker.php
@@ -567,22 +567,22 @@ class CommentChecker
      */
     public static function renderDocComment(array $parsed_doc_comment, $left_padding)
     {
-        $doc_comment_text = '/**' . PHP_EOL;
+        $doc_comment_text = '/**' . "\n";
 
         $description_lines = null;
 
         $trimmed_description = trim($parsed_doc_comment['description']);
 
         if (!empty($trimmed_description)) {
-            $description_lines = explode(PHP_EOL, $parsed_doc_comment['description']);
+            $description_lines = explode("\n", $parsed_doc_comment['description']);
 
             foreach ($description_lines as $line) {
-                $doc_comment_text .= $left_padding . ' *' . (trim($line) ? ' ' . $line : '') . PHP_EOL;
+                $doc_comment_text .= $left_padding . ' *' . (trim($line) ? ' ' . $line : '') . "\n";
             }
         }
 
         if ($description_lines && $parsed_doc_comment['specials']) {
-            $doc_comment_text .= $left_padding . ' *' . PHP_EOL;
+            $doc_comment_text .= $left_padding . ' *' . "\n";
         }
 
         if ($parsed_doc_comment['specials']) {
@@ -590,19 +590,19 @@ class CommentChecker
 
             foreach ($parsed_doc_comment['specials'] as $type => $lines) {
                 if ($last_type !== null && ($last_type !== 'return' || $last_type !== 'psalm-return')) {
-                    $doc_comment_text .= $left_padding . ' *' . PHP_EOL;
+                    $doc_comment_text .= $left_padding . ' *' . "\n";
                 }
 
                 foreach ($lines as $line) {
                     $doc_comment_text .= $left_padding . ' * @' . $type . ' '
-                        . str_replace("\n", "\n" . $left_padding . ' *', $line) . PHP_EOL;
+                        . str_replace("\n", "\n" . $left_padding . ' *', $line) . "\n";
                 }
 
                 $last_type = $type;
             }
         }
 
-        $doc_comment_text .= $left_padding . ' */' . PHP_EOL . $left_padding;
+        $doc_comment_text .= $left_padding . ' */' . "\n" . $left_padding;
 
         return $doc_comment_text;
     }

--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -271,7 +271,7 @@ class ProjectChecker
         }
 
         if ($this->output_format === self::TYPE_CONSOLE) {
-            echo 'Scanning files...' . PHP_EOL;
+            echo 'Scanning files...' . "\n";
         }
 
         if ($diff_files === null || $deleted_files === null || count($diff_files) > 200) {
@@ -282,7 +282,7 @@ class ProjectChecker
             $this->codebase->scanFiles();
         } else {
             if ($this->debug_output) {
-                echo count($diff_files) . ' changed files' . PHP_EOL;
+                echo count($diff_files) . ' changed files' . "\n";
             }
 
             if ($diff_files) {
@@ -298,7 +298,7 @@ class ProjectChecker
         }
 
         if ($this->output_format === self::TYPE_CONSOLE) {
-            echo 'Analyzing files...' . PHP_EOL;
+            echo 'Analyzing files...' . "\n";
         }
 
         $this->codebase->analyzer->analyzeFiles($this, $this->threads, $this->alter_code);
@@ -308,7 +308,7 @@ class ProjectChecker
         );
 
         if ($this->debug_output && $removed_parser_files) {
-            echo 'Removed ' . $removed_parser_files . ' old parser caches' . PHP_EOL;
+            echo 'Removed ' . $removed_parser_files . ' old parser caches' . "\n";
         }
 
         if ($is_diff) {
@@ -355,14 +355,14 @@ class ProjectChecker
                 $selection_start = $selection_bounds[0] - $snippet_bounds[0];
                 $selection_length = $selection_bounds[1] - $selection_bounds[0];
 
-                echo $location->file_name . ':' . $location->getLineNumber() . PHP_EOL .
+                echo $location->file_name . ':' . $location->getLineNumber() . "\n" .
                     (
                         $this->use_color
                         ? substr($snippet, 0, $selection_start) .
                         "\e[97;42m" . substr($snippet, $selection_start, $selection_length) .
                         "\e[0m" . substr($snippet, $selection_length + $selection_start)
                         : $snippet
-                    ) . PHP_EOL . PHP_EOL;
+                    ) . "\n" . "\n";
             }
         }
     }
@@ -379,13 +379,13 @@ class ProjectChecker
         $this->checkDirWithConfig($dir_name, $this->config, true);
 
         if ($this->output_format === self::TYPE_CONSOLE) {
-            echo 'Scanning files...' . PHP_EOL;
+            echo 'Scanning files...' . "\n";
         }
 
         $this->codebase->scanFiles();
 
         if ($this->output_format === self::TYPE_CONSOLE) {
-            echo 'Analyzing files...' . PHP_EOL;
+            echo 'Analyzing files...' . "\n";
         }
 
         $this->codebase->analyzer->analyzeFiles($this, $this->threads, $this->alter_code);
@@ -510,7 +510,7 @@ class ProjectChecker
 
             if (!$config->isInProjectDirs($file_path)) {
                 if ($this->debug_output) {
-                    echo 'skipping ' . $file_path . PHP_EOL;
+                    echo 'skipping ' . $file_path . "\n";
                 }
 
                 continue;
@@ -530,7 +530,7 @@ class ProjectChecker
     public function checkFile($file_path)
     {
         if ($this->debug_output) {
-            echo 'Checking ' . $file_path . PHP_EOL;
+            echo 'Checking ' . $file_path . "\n";
         }
 
         $this->config->hide_external_errors = $this->config->isInProjectDirs($file_path);
@@ -540,13 +540,13 @@ class ProjectChecker
         FileReferenceProvider::loadReferenceCache();
 
         if ($this->output_format === self::TYPE_CONSOLE) {
-            echo 'Scanning files...' . PHP_EOL;
+            echo 'Scanning files...' . "\n";
         }
 
         $this->codebase->scanFiles();
 
         if ($this->output_format === self::TYPE_CONSOLE) {
-            echo 'Analyzing files...' . PHP_EOL;
+            echo 'Analyzing files...' . "\n";
         }
 
         $this->codebase->analyzer->analyzeFiles($this, $this->threads, $this->alter_code);

--- a/src/Psalm/Checker/StatementsChecker.php
+++ b/src/Psalm/Checker/StatementsChecker.php
@@ -138,7 +138,7 @@ class StatementsChecker extends SourceChecker implements StatementsSource
             }
 
             if ($project_checker->debug_lines) {
-                echo $this->getFilePath() . ':' . $stmt->getLine() . PHP_EOL;
+                echo $this->getFilePath() . ':' . $stmt->getLine() . "\n";
             }
 
             /*
@@ -556,7 +556,7 @@ class StatementsChecker extends SourceChecker implements StatementsSource
                 $newline_pos = (int)strrpos($file_contents, "\n", $branch_point - strlen($file_contents)) + 1;
                 $indentation = substr($file_contents, $newline_pos, $branch_point - $newline_pos);
                 FileManipulationBuffer::add($this->getFilePath(), [
-                    new FileManipulation($branch_point, $branch_point, $var_id . ' = null;' . PHP_EOL . $indentation),
+                    new FileManipulation($branch_point, $branch_point, $var_id . ' = null;' . "\n" . $indentation),
                 ]);
             }
         }

--- a/src/Psalm/Codebase/Analyzer.php
+++ b/src/Psalm/Codebase/Analyzer.php
@@ -104,7 +104,7 @@ class Analyzer
         }
 
         if ($this->debug_output) {
-            echo 'Getting ' . $file_path . PHP_EOL;
+            echo 'Getting ' . $file_path . "\n";
         }
 
         return $file_checker;
@@ -132,7 +132,7 @@ class Analyzer
                 $file_checker = $this->getFileChecker($project_checker, $file_path, $filetype_checkers);
 
                 if ($this->debug_output) {
-                    echo 'Analyzing ' . $file_checker->getFilePath() . PHP_EOL;
+                    echo 'Analyzing ' . $file_checker->getFilePath() . "\n";
                 }
 
                 $file_checker->analyze(null);
@@ -288,7 +288,7 @@ class Analyzer
                 list($path_mixed_count, $path_nonmixed_count) = $this->mixed_counts[$file_path];
                 $stats .= number_format(100 * $path_nonmixed_count / ($path_mixed_count + $path_nonmixed_count), 0)
                     . '% ' . $this->config->shortenFileName($file_path)
-                    . ' (' . $path_mixed_count . ' mixed)' . PHP_EOL;
+                    . ' (' . $path_mixed_count . ' mixed)' . "\n";
             }
         }
 
@@ -357,7 +357,7 @@ class Analyzer
 
         if ($docblock_update_count) {
             if ($dry_run) {
-                echo $file_path . ':' . PHP_EOL;
+                echo $file_path . ':' . "\n";
 
                 $differ = new \PhpCsFixer\Diff\v2_0\Differ(
                     new \PhpCsFixer\Diff\GeckoPackages\DiffOutputBuilder\UnifiedDiffOutputBuilder([
@@ -372,7 +372,7 @@ class Analyzer
             }
 
             if ($output_changes) {
-                echo 'Altering ' . $file_path . PHP_EOL;
+                echo 'Altering ' . $file_path . "\n";
             }
 
             $this->file_provider->setContents($file_path, $existing_contents);

--- a/src/Psalm/Codebase/ClassLikes.php
+++ b/src/Psalm/Codebase/ClassLikes.php
@@ -259,7 +259,7 @@ class ClassLikes
                 && !$this->classlike_storage_provider->has($fq_class_name_lc)
             ) {
                 if ($this->debug_output) {
-                    echo 'Last-chance attempt to hydrate ' . $fq_class_name . PHP_EOL;
+                    echo 'Last-chance attempt to hydrate ' . $fq_class_name . "\n";
                 }
                 // attempt to load in the class
                 $this->scanner->queueClassLikeForScanning($fq_class_name);
@@ -308,7 +308,7 @@ class ClassLikes
                 && !$this->classlike_storage_provider->has($fq_class_name_lc)
             ) {
                 if ($this->debug_output) {
-                    echo 'Last-chance attempt to hydrate ' . $fq_class_name . PHP_EOL;
+                    echo 'Last-chance attempt to hydrate ' . $fq_class_name . "\n";
                 }
 
                 // attempt to load in the class

--- a/src/Psalm/Codebase/Populator.php
+++ b/src/Psalm/Codebase/Populator.php
@@ -67,7 +67,7 @@ class Populator
     public function populateCodebase()
     {
         if ($this->debug_output) {
-            echo 'ClassLikeStorage is populating' . PHP_EOL;
+            echo 'ClassLikeStorage is populating' . "\n";
         }
 
         foreach ($this->classlike_storage_provider->getAll() as $class_storage) {
@@ -79,11 +79,11 @@ class Populator
         }
 
         if ($this->debug_output) {
-            echo 'ClassLikeStorage is populated' . PHP_EOL;
+            echo 'ClassLikeStorage is populated' . "\n";
         }
 
         if ($this->debug_output) {
-            echo 'FileStorage is populating' . PHP_EOL;
+            echo 'FileStorage is populating' . "\n";
         }
 
         $all_file_storage = $this->file_storage_provider->getAll();
@@ -129,7 +129,7 @@ class Populator
         }
 
         if ($this->debug_output) {
-            echo 'FileStorage is populated' . PHP_EOL;
+            echo 'FileStorage is populated' . "\n";
         }
     }
 
@@ -195,7 +195,7 @@ class Populator
         }
 
         if ($this->debug_output) {
-            echo 'Have populated ' . $storage->name . PHP_EOL;
+            echo 'Have populated ' . $storage->name . "\n";
         }
 
         $storage->populated = true;

--- a/src/Psalm/Codebase/Scanner.php
+++ b/src/Psalm/Codebase/Scanner.php
@@ -224,7 +224,7 @@ class Scanner
                 if (!isset($this->classlike_files[$fq_classlike_name_lc])) {
                     if ($classlikes->doesClassLikeExist($fq_classlike_name_lc)) {
                         if ($this->debug_output) {
-                            echo 'Using reflection to get metadata for ' . $fq_classlike_name . PHP_EOL;
+                            echo 'Using reflection to get metadata for ' . $fq_classlike_name . "\n";
                         }
 
                         $reflected_class = new \ReflectionClass($fq_classlike_name);
@@ -385,7 +385,7 @@ class Scanner
 
         if ($composer_file_path && file_exists($composer_file_path)) {
             if ($this->debug_output) {
-                echo 'Using composer to locate file for ' . $fq_class_name . PHP_EOL;
+                echo 'Using composer to locate file for ' . $fq_class_name . "\n";
             }
 
             $classlikes->addFullyQualifiedClassLikeName(
@@ -404,7 +404,7 @@ class Scanner
 
         try {
             if ($this->debug_output) {
-                echo 'Using reflection to locate file for ' . $fq_class_name . PHP_EOL;
+                echo 'Using reflection to locate file for ' . $fq_class_name . "\n";
             }
 
             $reflected_class = new \ReflectionClass($fq_class_name);

--- a/src/Psalm/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/FileManipulation/FunctionDocblockManipulator.php
@@ -141,7 +141,7 @@ class FunctionDocblockManipulator
             $char = $chars[$i];
 
             switch ($char) {
-                case PHP_EOL:
+                case "\n":
                     $in_single_line_comment = false;
                     continue;
 
@@ -215,7 +215,7 @@ class FunctionDocblockManipulator
             }
         }
 
-        $preceding_newline_pos = strrpos($file_contents, PHP_EOL, $this->docblock_end - strlen($file_contents));
+        $preceding_newline_pos = strrpos($file_contents, "\n", $this->docblock_end - strlen($file_contents));
 
         if ($preceding_newline_pos === false) {
             $this->indentation = '';

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -240,7 +240,7 @@ class IssueBuffer
         }
 
         $issue_string .= ': ' . $issue_data['type'] . ' - ' . $issue_data['file_name'] . ':' .
-            $issue_data['line_from'] . ':' . $issue_data['column_from'] . ' - ' . $issue_data['message'] . PHP_EOL;
+            $issue_data['line_from'] . ':' . $issue_data['column_from'] . ' - ' . $issue_data['message'] . "\n";
 
         $snippet = $issue_data['snippet'];
 
@@ -252,7 +252,7 @@ class IssueBuffer
 
             $issue_string .= substr($snippet, 0, $selection_start) .
                 ($is_error ? "\e[97;41m" : "\e[30;47m") . substr($snippet, $selection_start, $selection_length) .
-                "\e[0m" . substr($snippet, $selection_length + $selection_start) . PHP_EOL;
+                "\e[0m" . substr($snippet, $selection_length + $selection_start) . "\n";
         }
 
         return $issue_string;
@@ -297,7 +297,7 @@ class IssueBuffer
         $scanned_files = $project_checker->codebase->scanner->getScannedFiles();
         Provider\FileReferenceProvider::updateReferenceCache($project_checker, $scanned_files);
 
-        echo PHP_EOL;
+        echo "\n";
 
         $error_count = 0;
         $info_count = 0;
@@ -341,42 +341,42 @@ class IssueBuffer
             );
         }
 
-        echo str_repeat('-', 30) . PHP_EOL;
+        echo str_repeat('-', 30) . "\n";
 
         if ($error_count) {
             echo ($project_checker->use_color
                 ? "\e[0;31m" . $error_count . " errors\e[0m"
                 : $error_count . ' errors'
-            ) . ' found' . PHP_EOL;
+            ) . ' found' . "\n";
         } else {
-            echo 'No errors found!' . PHP_EOL;
+            echo 'No errors found!' . "\n";
         }
 
         if ($info_count) {
-            echo str_repeat('-', 30) . PHP_EOL;
+            echo str_repeat('-', 30) . "\n";
 
-            echo $info_count . ' other issues found.' . PHP_EOL
+            echo $info_count . ' other issues found.' . "\n"
                 . 'You can hide them with ' .
-                ($project_checker->use_color ? "\e[30;48;5;195m--show-info=false\e[0m" : '--show-info=false') . PHP_EOL;
+                ($project_checker->use_color ? "\e[30;48;5;195m--show-info=false\e[0m" : '--show-info=false') . "\n";
         }
 
-        echo str_repeat('-', 30) . PHP_EOL . PHP_EOL;
+        echo str_repeat('-', 30) . "\n" . "\n";
 
         if ($start_time) {
             echo 'Checks took ' . number_format((float)microtime(true) - $start_time, 2) . ' seconds';
-            echo ' and used ' . number_format(memory_get_peak_usage() / (1024 * 1024), 3) . 'MB of memory' . PHP_EOL;
+            echo ' and used ' . number_format(memory_get_peak_usage() / (1024 * 1024), 3) . 'MB of memory' . "\n";
 
             $nonmixed_percentage = $project_checker->codebase->analyzer->getNonMixedPercentage();
 
             if ($is_full) {
                 echo 'Psalm was able to infer types for ' . number_format($nonmixed_percentage, 3) . '%'
-                    . ' of the codebase' . PHP_EOL;
+                    . ' of the codebase' . "\n";
             }
 
             if ($add_stats) {
-                echo '-----------------' . PHP_EOL;
+                echo '-----------------' . "\n";
                 echo $project_checker->codebase->analyzer->getNonMixedStats();
-                echo PHP_EOL;
+                echo "\n";
             }
         }
 
@@ -398,7 +398,7 @@ class IssueBuffer
     public static function getOutput($format, $useColor)
     {
         if ($format === ProjectChecker::TYPE_JSON) {
-            return json_encode(self::$issues_data) . PHP_EOL;
+            return json_encode(self::$issues_data) . "\n";
         } elseif ($format === ProjectChecker::TYPE_XML) {
             $xml = Array2XML::createXML('report', ['item' => self::$issues_data]);
 
@@ -406,14 +406,14 @@ class IssueBuffer
         } elseif ($format === ProjectChecker::TYPE_EMACS) {
             $output = '';
             foreach (self::$issues_data as $issue_data) {
-                $output .= self::getEmacsOutput($issue_data) . PHP_EOL;
+                $output .= self::getEmacsOutput($issue_data) . "\n";
             }
 
             return $output;
         } elseif ($format === ProjectChecker::TYPE_PYLINT) {
             $output = '';
             foreach (self::$issues_data as $issue_data) {
-                $output .= self::getPylintOutput($issue_data) . PHP_EOL;
+                $output .= self::getPylintOutput($issue_data) . "\n";
             }
 
             return $output;
@@ -421,7 +421,7 @@ class IssueBuffer
 
         $output = '';
         foreach (self::$issues_data as $issue_data) {
-            $output .= self::getConsoleOutput($issue_data, $useColor) . PHP_EOL . PHP_EOL;
+            $output .= self::getConsoleOutput($issue_data, $useColor) . "\n" . "\n";
         }
 
         return $output;

--- a/src/Psalm/Provider/StatementsProvider.php
+++ b/src/Psalm/Provider/StatementsProvider.php
@@ -67,7 +67,7 @@ class StatementsProvider
 
         if ($stmts === null) {
             if ($debug_output) {
-                echo 'Parsing ' . $file_path . PHP_EOL;
+                echo 'Parsing ' . $file_path . "\n";
             }
 
             $stmts = self::parseStatementsInFile($file_contents);

--- a/src/Psalm/Scanner/FileScanner.php
+++ b/src/Psalm/Scanner/FileScanner.php
@@ -64,9 +64,9 @@ class FileScanner implements FileSource
 
         if ($debug_output) {
             if ($this->will_analyze) {
-                echo 'Deep scanning ' . $file_storage->file_path . PHP_EOL;
+                echo 'Deep scanning ' . $file_storage->file_path . "\n";
             } else {
-                echo 'Scanning ' . $file_storage->file_path . PHP_EOL;
+                echo 'Scanning ' . $file_storage->file_path . "\n";
             }
         }
 

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -911,7 +911,7 @@ class AnnotationTest extends TestCase
                     }
 
                     fooBar("hello");',
-                'error_message' => 'TooManyArguments - src/somefile.php:8 - Too many arguments for method fooBar '
+                'error_message' => 'TooManyArguments - src' . DIRECTORY_SEPARATOR . 'somefile.php:8 - Too many arguments for method fooBar '
                     . '- expecting 0 but saw 1',
             ],
             'missingParamVar' => [
@@ -921,7 +921,7 @@ class AnnotationTest extends TestCase
                      */
                     function fooBar(): void {
                     }',
-                'error_message' => 'InvalidDocblock - src/somefile.php:5 - Badly-formatted @param',
+                'error_message' => 'InvalidDocblock - src' . DIRECTORY_SEPARATOR . 'somefile.php:5 - Badly-formatted @param',
             ],
             'invalidDocblockReturn' => [
                 '<?php
@@ -982,7 +982,7 @@ class AnnotationTest extends TestCase
 
                     $a = new A();
                     $a->foo = new SomeOtherPropertyType();',
-                'error_message' => 'InvalidPropertyAssignmentValue - src/somefile.php:27 - $a->foo with declared type'
+                'error_message' => 'InvalidPropertyAssignmentValue - src' . DIRECTORY_SEPARATOR . 'somefile.php:27 - $a->foo with declared type'
                     . ' \'Bar\PropertyType\' cannot',
             ],
             'propertyWriteDocblockInvalidAssignment' => [
@@ -1095,7 +1095,7 @@ class AnnotationTest extends TestCase
                     function fooFoo($a): void {
                         echo substr($a, 4, 2);
                     }',
-                'error_message' => 'MissingParamType - src/somefile.php:2 - Parameter $a has no provided type,'
+                'error_message' => 'MissingParamType - src' . DIRECTORY_SEPARATOR . 'somefile.php:2 - Parameter $a has no provided type,'
                     . ' should be string',
                 'error_levels' => ['MixedArgument'],
             ],
@@ -1104,7 +1104,7 @@ class AnnotationTest extends TestCase
                     function fooFoo($a): void {
                         echo $a . "foo";
                     }',
-                'error_message' => 'MissingParamType - src/somefile.php:2 - Parameter $a has no provided type,'
+                'error_message' => 'MissingParamType - src' . DIRECTORY_SEPARATOR . 'somefile.php:2 - Parameter $a has no provided type,'
                     . ' should be string',
                 'error_levels' => ['MixedOperand'],
             ],
@@ -1113,7 +1113,7 @@ class AnnotationTest extends TestCase
                     function fooFoo($a): void {
                         echo $a + 5;
                     }',
-                'error_message' => 'MissingParamType - src/somefile.php:2 - Parameter $a has no provided type,'
+                'error_message' => 'MissingParamType - src' . DIRECTORY_SEPARATOR . 'somefile.php:2 - Parameter $a has no provided type,'
                     . ' should be int|float',
                 'error_levels' => ['MixedOperand', 'MixedArgument'],
             ],
@@ -1122,7 +1122,7 @@ class AnnotationTest extends TestCase
                     function fooFoo($a): void {
                         echo $a / 5;
                     }',
-                'error_message' => 'MissingParamType - src/somefile.php:2 - Parameter $a has no provided type,'
+                'error_message' => 'MissingParamType - src' . DIRECTORY_SEPARATOR . 'somefile.php:2 - Parameter $a has no provided type,'
                     . ' should be int|float',
                 'error_levels' => ['MixedOperand', 'MixedArgument'],
             ],
@@ -1131,7 +1131,7 @@ class AnnotationTest extends TestCase
                     function fooFoo($a): void {
                         echo "$a";
                     }',
-                'error_message' => 'MissingParamType - src/somefile.php:2 - Parameter $a has no provided type,'
+                'error_message' => 'MissingParamType - src' . DIRECTORY_SEPARATOR . 'somefile.php:2 - Parameter $a has no provided type,'
                     . ' should be string',
                 'error_levels' => ['MixedOperand'],
             ],
@@ -1144,7 +1144,7 @@ class AnnotationTest extends TestCase
                             echo substr("hello", $a, 2);
                         }
                     }',
-                'error_message' => 'MissingParamType - src/somefile.php:2 - Parameter $a has no provided type,'
+                'error_message' => 'MissingParamType - src' . DIRECTORY_SEPARATOR . 'somefile.php:2 - Parameter $a has no provided type,'
                     . ' should be int|string',
                 'error_levels' => ['MixedArgument'],
             ],
@@ -1167,7 +1167,7 @@ class AnnotationTest extends TestCase
                     function shouldTakeString($s): void {
                       if (is_string($s)) takesString($s);
                     }',
-                'error_message' => 'MissingParamType - src/somefile.php:4 - Parameter $s has no provided type,'
+                'error_message' => 'MissingParamType - src' . DIRECTORY_SEPARATOR . 'somefile.php:4 - Parameter $s has no provided type,'
                     . ' could not infer',
                 'error_levels' => ['MixedArgument'],
             ],
@@ -1182,7 +1182,7 @@ class AnnotationTest extends TestCase
                       $s = returnsMixed();
                       takesString($s);
                     }',
-                'error_message' => 'MissingParamType - src/somefile.php:7 - Parameter $s has no provided type,'
+                'error_message' => 'MissingParamType - src' . DIRECTORY_SEPARATOR . 'somefile.php:7 - Parameter $s has no provided type,'
                     . ' could not infer',
                 'error_levels' => ['MixedArgument', 'InvalidReturnType', 'MixedAssignment'],
             ],

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -211,7 +211,7 @@ class ArrayAccessTest extends TestCase
                 '<?php
                     $params = ["key" => "value"];
                     echo $params["fieldName"];',
-                'error_message' => 'InvalidArrayOffset - src/somefile.php:3 - Cannot access '
+                'error_message' => 'InvalidArrayOffset - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Cannot access '
                     . 'value on variable $params using offset value of',
             ],
         ];

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -260,7 +260,7 @@ class ConfigTest extends TestCase
                  * @return string
                  */
                 function ($issue_name) {
-                    return '<' . $issue_name . ' errorLevel="suppress" />' . PHP_EOL;
+                    return '<' . $issue_name . ' errorLevel="suppress" />' . "\n";
                 },
                 self::getAllIssues()
             )

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -27,7 +27,7 @@ class DocumentationTest extends TestCase
             throw new \UnexpectedValueException('Docs are empty');
         }
 
-        $file_lines = explode(PHP_EOL, $file_contents);
+        $file_lines = explode("\n", $file_contents);
 
         $issue_code = [];
 
@@ -47,7 +47,7 @@ class DocumentationTest extends TestCase
                 ++$i;
 
                 do {
-                    $current_block .= $file_lines[$i] . PHP_EOL;
+                    $current_block .= $file_lines[$i] . "\n";
                     ++$i;
                 } while (substr($file_lines[$i], 0, 3) !== '```' && $i < $j);
 
@@ -94,7 +94,7 @@ class DocumentationTest extends TestCase
         $documented_issues = array_keys($code_blocks);
         sort($documented_issues);
 
-        $this->assertSame(implode(PHP_EOL, $all_issues), implode(PHP_EOL, $documented_issues));
+        $this->assertSame(implode("\n", $all_issues), implode("\n", $documented_issues));
     }
 
     /**
@@ -181,7 +181,7 @@ class DocumentationTest extends TestCase
             }
 
             $invalid_code_data[$issue_name] = [
-                '<?php' . PHP_EOL . $blocks[0],
+                '<?php' . "\n" . $blocks[0],
                 $issue_name,
                 $ignored_issues,
                 strpos($issue_name, 'Unused') !== false || strpos($issue_name, 'Unevaluated') !== false,

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -659,7 +659,7 @@ class FunctionCallTest extends TestCase
                 '<?php
                     function fooFoo(int $a): void {}
                     fooFoo(5, "dfd");',
-                'error_message' => 'TooManyArguments - src/somefile.php:3 - Too many arguments for method fooFoo '
+                'error_message' => 'TooManyArguments - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Too many arguments for method fooFoo '
                     . '- expecting 1 but saw 2',
             ],
             'tooManyArgumentsForConstructor' => [

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -69,7 +69,7 @@ class IssueSuppressionTest extends TestCase
                             new C();
                         }
                     }',
-                'error_message' => 'UndefinedClass - src/somefile.php:8 - Class or interface C',
+                'error_message' => 'UndefinedClass - src' . DIRECTORY_SEPARATOR . 'somefile.php:8 - Class or interface C',
             ],
             'undefinedClassOneLineInFileAfter' => [
                 '<?php
@@ -78,7 +78,7 @@ class IssueSuppressionTest extends TestCase
                      */
                     new B();
                     new C();',
-                'error_message' => 'UndefinedClass - src/somefile.php:6 - Class or interface C',
+                'error_message' => 'UndefinedClass - src' . DIRECTORY_SEPARATOR . 'somefile.php:6 - Class or interface C',
             ],
         ];
     }

--- a/tests/ListTest.php
+++ b/tests/ListTest.php
@@ -92,7 +92,7 @@ class ListTest extends TestCase
                             return $this->a;
                         }
                     }',
-                'error_message' => 'InvalidPropertyAssignmentValue - src/somefile.php:11',
+                'error_message' => 'InvalidPropertyAssignmentValue - src' . DIRECTORY_SEPARATOR . 'somefile.php:11',
             ],
         ];
     }

--- a/tests/LoopScopeTest.php
+++ b/tests/LoopScopeTest.php
@@ -1032,7 +1032,7 @@ class LoopScopeTest extends TestCase
                     }
 
                     echo $array;',
-                'error_message' => 'PossiblyUndefinedGlobalVariable - src/somefile.php:3 - Possibly undefined ' .
+                'error_message' => 'PossiblyUndefinedGlobalVariable - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Possibly undefined ' .
                     'global variable $array, first seen on line 3',
             ],
             'possiblyUndefinedArrayInWhileAndForeach' => [
@@ -1044,7 +1044,7 @@ class LoopScopeTest extends TestCase
                     }
 
                     echo $array;',
-                'error_message' => 'PossiblyUndefinedGlobalVariable - src/somefile.php:4 - Possibly undefined ' .
+                'error_message' => 'PossiblyUndefinedGlobalVariable - src' . DIRECTORY_SEPARATOR . 'somefile.php:4 - Possibly undefined ' .
                     'global variable $array, first seen on line 4',
             ],
             'possiblyUndefinedVariableInForeach' => [
@@ -1054,7 +1054,7 @@ class LoopScopeTest extends TestCase
                     }
 
                     echo $car;',
-                'error_message' => 'PossiblyUndefinedGlobalVariable - src/somefile.php:6 - Possibly undefined ' .
+                'error_message' => 'PossiblyUndefinedGlobalVariable - src' . DIRECTORY_SEPARATOR . 'somefile.php:6 - Possibly undefined ' .
                     'global variable $car, first seen on line 3',
             ],
             'possibleUndefinedVariableInForeachAndIfWithBreak' => [
@@ -1067,7 +1067,7 @@ class LoopScopeTest extends TestCase
                     }
 
                     echo $a;',
-                'error_message' => 'PossiblyUndefinedGlobalVariable - src/somefile.php:9 - Possibly undefined ' .
+                'error_message' => 'PossiblyUndefinedGlobalVariable - src' . DIRECTORY_SEPARATOR . 'somefile.php:9 - Possibly undefined ' .
                     'global variable $a, first seen on line 4',
             ],
             'possibleUndefinedVariableInForeachAndIf' => [
@@ -1079,7 +1079,7 @@ class LoopScopeTest extends TestCase
 
                         echo $a;
                     }',
-                'error_message' => 'PossiblyUndefinedGlobalVariable - src/somefile.php:7 - Possibly undefined ' .
+                'error_message' => 'PossiblyUndefinedGlobalVariable - src' . DIRECTORY_SEPARATOR . 'somefile.php:7 - Possibly undefined ' .
                     'global variable $a, first seen on line 4',
             ],
             'implicitFourthLoopWithBadReturnType' => [

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -267,7 +267,7 @@ class MethodCallTest extends TestCase
                     class B extends A {}
 
                     $b = new B();',
-                'error_message' => 'MissingDependency - src/somefile.php:7',
+                'error_message' => 'MissingDependency - src' . DIRECTORY_SEPARATOR . 'somefile.php:7',
             ],
             'variableMethodCallOnArray' => [
                 '<?php

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -897,7 +897,7 @@ class PropertyTypeTest extends TestCase
                             $this->foo = 5;
                         }
                     }',
-                'error_message' => 'MissingPropertyType - src/somefile.php:3 - Property A::$foo does not have a ' .
+                'error_message' => 'MissingPropertyType - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Property A::$foo does not have a ' .
                     'declared type - consider null|int',
             ],
             'missingPropertyTypeWithConstructorInit' => [
@@ -909,7 +909,7 @@ class PropertyTypeTest extends TestCase
                             $this->foo = 5;
                         }
                     }',
-                'error_message' => 'MissingPropertyType - src/somefile.php:3 - Property A::$foo does not have a ' .
+                'error_message' => 'MissingPropertyType - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Property A::$foo does not have a ' .
                     'declared type - consider int',
             ],
             'missingPropertyTypeWithConstructorInitAndNull' => [
@@ -925,7 +925,7 @@ class PropertyTypeTest extends TestCase
                             $this->foo = null;
                         }
                     }',
-                'error_message' => 'MissingPropertyType - src/somefile.php:3 - Property A::$foo does not have a ' .
+                'error_message' => 'MissingPropertyType - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Property A::$foo does not have a ' .
                     'declared type - consider null|int',
             ],
             'missingPropertyTypeWithConstructorInitAndNullDefault' => [
@@ -937,7 +937,7 @@ class PropertyTypeTest extends TestCase
                             $this->foo = 5;
                         }
                     }',
-                'error_message' => 'MissingPropertyType - src/somefile.php:3 - Property A::$foo does not have a ' .
+                'error_message' => 'MissingPropertyType - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Property A::$foo does not have a ' .
                     'declared type - consider int|null',
             ],
             'badAssignment' => [

--- a/tests/RedundantConditionTest.php
+++ b/tests/RedundantConditionTest.php
@@ -505,7 +505,7 @@ class RedundantConditionTest extends TestCase
                     /** @psalm-suppress PossiblyNullArgument */
                     takesA($a);
                     if ($a instanceof A) {}',
-                'error_message' => 'RedundantCondition - src/somefile.php:15',
+                'error_message' => 'RedundantCondition - src' . DIRECTORY_SEPARATOR . 'somefile.php:15',
             ],
             'replaceFalseType' => [
                 '<?php
@@ -527,7 +527,7 @@ class RedundantConditionTest extends TestCase
 
                       if ($b) {}
                     }',
-                'error_message' => 'TypeDoesNotContainType - src/somefile.php:7',
+                'error_message' => 'TypeDoesNotContainType - src' . DIRECTORY_SEPARATOR . 'somefile.php:7',
             ],
         ];
     }

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -234,7 +234,9 @@ somefile.php:15:6:error - Possibly undefined global variable $a, first seen on l
             IssueBuffer::getOutput(ProjectChecker::TYPE_XML, false)
         );
 
+        ob_start();
         IssueBuffer::finish($this->project_checker, true, 0);
+        ob_end_clean();
         $this->assertFileExists(__DIR__ . '/test-report.json');
         $this->assertSame('[]
 ', file_get_contents(__DIR__ . '/test-report.json'));

--- a/tests/ScopeTest.php
+++ b/tests/ScopeTest.php
@@ -230,7 +230,7 @@ class ScopeTest extends TestCase
                     }
 
                     echo $b;',
-                'error_message' => 'PossiblyUndefinedGlobalVariable - src/somefile.php:6 - Possibly undefined global '
+                'error_message' => 'PossiblyUndefinedGlobalVariable - src' . DIRECTORY_SEPARATOR . 'somefile.php:6 - Possibly undefined global '
                     . 'variable $b, first seen on line 3',
             ],
             'possiblyUndefinedArrayInIf' => [
@@ -240,7 +240,7 @@ class ScopeTest extends TestCase
                     }
 
                     echo $array;',
-                'error_message' => 'PossiblyUndefinedGlobalVariable - src/somefile.php:3 - Possibly undefined global '
+                'error_message' => 'PossiblyUndefinedGlobalVariable - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Possibly undefined global '
                     . 'variable $array, first seen on line 3',
             ],
             'invalidGlobal' => [

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -568,7 +568,7 @@ class TraitTest extends TestCase
                             $this->foo = 5;
                         }
                     }',
-                'error_message' => 'MissingPropertyType - src/somefile.php:3 - Property T::$foo does not have a ' .
+                'error_message' => 'MissingPropertyType - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Property T::$foo does not have a ' .
                     'declared type - consider null|int',
             ],
             'missingPropertyTypeWithConstructorInit' => [
@@ -583,7 +583,7 @@ class TraitTest extends TestCase
                             $this->foo = 5;
                         }
                     }',
-                'error_message' => 'MissingPropertyType - src/somefile.php:3 - Property T::$foo does not have a ' .
+                'error_message' => 'MissingPropertyType - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Property T::$foo does not have a ' .
                     'declared type - consider int',
             ],
             'missingPropertyTypeWithConstructorInitAndNull' => [
@@ -602,7 +602,7 @@ class TraitTest extends TestCase
                             $this->foo = null;
                         }
                     }',
-                'error_message' => 'MissingPropertyType - src/somefile.php:3 - Property T::$foo does not have a ' .
+                'error_message' => 'MissingPropertyType - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Property T::$foo does not have a ' .
                     'declared type - consider null|int',
             ],
             'missingPropertyTypeWithConstructorInitAndNullDefault' => [
@@ -617,7 +617,7 @@ class TraitTest extends TestCase
                             $this->foo = 5;
                         }
                     }',
-                'error_message' => 'MissingPropertyType - src/somefile.php:3 - Property T::$foo does not have a ' .
+                'error_message' => 'MissingPropertyType - src' . DIRECTORY_SEPARATOR . 'somefile.php:3 - Property T::$foo does not have a ' .
                     'declared type - consider int|null',
             ],
             'redefinedTraitMethodInSubclass' => [

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -1368,7 +1368,7 @@ class TypeTest extends TestCase
                     class C extends A {}
 
                     function takesB(B $i): void {}',
-                'error_message' => 'TypeCoercion - src/somefile.php:11 - Argument 1 of takesB expects B,'
+                'error_message' => 'TypeCoercion - src' . DIRECTORY_SEPARATOR . 'somefile.php:11 - Argument 1 of takesB expects B,'
                     . ' parent type A provided',
             ],
             'intersectionTypeInterfaceCheckAfterInstanceof' => [
@@ -1387,7 +1387,7 @@ class TypeTest extends TestCase
                     interface I {}
 
                     function takesI(I $i): void {}',
-                'error_message' => 'InvalidArgument - src/somefile.php:9 - Argument 1 of takesI expects I, A provided',
+                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:9 - Argument 1 of takesI expects I, A provided',
             ],
         ];
     }


### PR DESCRIPTION
* changed / to DIRECTORY_SEPARATOR in expected messages
* changed most occurrences of PHP_EOL to "\n" in tests/ and src/
* added output buffering in test to avoid marking test as risky