### PR TITLE
Check that __clone, __construct, __destruct signatures omit return types

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -645,6 +645,16 @@ class B extends A {
 }
 ```
 
+### MethodSignatureMustOmitReturnType
+
+Emmitted when a `__clone`, `__construct`, or `__destruct` method is defined with a return type.
+
+```php
+class A {
+    public function __clone() : void {}
+}
+```
+
 ### MismatchingDocblockParamType
 
 Emitted when an `@param` entry in a function’s docblock doesn’t match the param typehint,
@@ -1918,4 +1928,3 @@ function foo() : void {
     echo $b;
 }
 ```
-

--- a/src/Psalm/Checker/FunctionLikeChecker.php
+++ b/src/Psalm/Checker/FunctionLikeChecker.php
@@ -175,6 +175,13 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
                 $context->inside_constructor = true;
             }
 
+            $codeLocation = new CodeLocation(
+                $this,
+                $this->function,
+                null,
+                true
+            );
+
             if ($overridden_method_ids
                 && $this->function->name->name !== '__construct'
                 && !$context->collect_initializations
@@ -193,12 +200,7 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
                         $parent_storage,
                         $storage,
                         $parent_method_storage,
-                        new CodeLocation(
-                            $this,
-                            $this->function,
-                            null,
-                            true
-                        ),
+                        $codeLocation,
                         $storage->suppressed_issues
                     );
 
@@ -209,6 +211,8 @@ abstract class FunctionLikeChecker extends SourceChecker implements StatementsSo
                     }
                 }
             }
+
+            MethodChecker::checkMethodSignatureMustOmitReturnType($storage, $codeLocation);
         } elseif ($this->function instanceof Function_) {
             $file_storage = $file_storage_provider->get($this->source->getFilePath());
 

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -9,6 +9,7 @@ use Psalm\Issue\ImplementedReturnTypeMismatch;
 use Psalm\Issue\InaccessibleMethod;
 use Psalm\Issue\InvalidStaticInvocation;
 use Psalm\Issue\MethodSignatureMismatch;
+use Psalm\Issue\MethodSignatureMustOmitReturnType;
 use Psalm\Issue\MoreSpecificImplementedParamType;
 use Psalm\Issue\LessSpecificImplementedReturnType;
 use Psalm\Issue\NonStaticSelfCall;
@@ -651,6 +652,37 @@ class MethodChecker extends FunctionLikeChecker
                 new MethodSignatureMismatch(
                     'Method ' . $cased_implementer_method_id . ' has more arguments than parent method ' .
                         $cased_guide_method_id,
+                    $code_location
+                )
+            )) {
+                return false;
+            }
+
+            return null;
+        }
+    }
+
+    /**
+     * @param  MethodStorage $method_storage
+     * @param  CodeLocation  $code_location
+     * @return false|null
+     */
+    public static function checkMethodSignatureMustOmitReturnType(
+        MethodStorage $method_storage,
+        CodeLocation $code_location
+    ) {
+        if ($method_storage->signature_return_type === null) {
+            return null;
+        }
+
+        $cased_method_name = $method_storage->cased_name;
+        switch ($cased_method_name) {
+        case '__clone':
+        case '__construct':
+        case '__destruct':
+            if (IssueBuffer::accepts(
+                new MethodSignatureMustOmitReturnType(
+                    'Method ' . $cased_method_name . ' must not declare a return type',
                     $code_location
                 )
             )) {

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -663,6 +663,9 @@ class MethodChecker extends FunctionLikeChecker
     }
 
     /**
+     * Check that __clone, __construct, and __destruct do not have a return type
+     * hint in their signature.
+     *
      * @param  MethodStorage $method_storage
      * @param  CodeLocation  $code_location
      * @return false|null
@@ -676,10 +679,8 @@ class MethodChecker extends FunctionLikeChecker
         }
 
         $cased_method_name = $method_storage->cased_name;
-        switch ($cased_method_name) {
-        case '__clone':
-        case '__construct':
-        case '__destruct':
+        $methodsOfInterest = ['__clone', '__construct', '__destruct'];
+        if (in_array($cased_method_name, $methodsOfInterest)) {
             if (IssueBuffer::accepts(
                 new MethodSignatureMustOmitReturnType(
                     'Method ' . $cased_method_name . ' must not declare a return type',
@@ -688,8 +689,8 @@ class MethodChecker extends FunctionLikeChecker
             )) {
                 return false;
             }
-
-            return null;
         }
+
+        return null;
     }
 }

--- a/src/Psalm/Issue/MethodSignatureMustOmitReturnType.php
+++ b/src/Psalm/Issue/MethodSignatureMustOmitReturnType.php
@@ -1,0 +1,6 @@
+<?php
+namespace Psalm\Issue;
+
+class MethodSignatureMustOmitReturnType extends CodeIssue
+{
+}

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -470,28 +470,17 @@ class MethodSignatureTest extends TestCase
                     }',
                 'error_message' => 'MethodSignatureMismatch',
             ],
+            'mustOmitReturnType' => [
+                '<?php
+                    class A
+                    {
+                        public function __construct(): void
+                        {
+                        }
+                    }',
+                'error_message' => 'MethodSignatureMustOmitReturnType',
+            ],
         ];
     }
 
-    /**
-     * @expectedException        \Psalm\Exception\CodeException
-     * @expectedExceptionMessage MethodSignatureMustOmitReturnType
-     *
-     * @return                   void
-     */
-    public function testMustOmitReturnType()
-    {
-        $this->addFile(
-            'somefile.php',
-            '<?php
-                class A
-                {
-                    public function __construct(): void
-                    {
-                    }
-                }'
-        );
-
-        $this->analyzeFile('somefile.php', new Context());
-    }
 }

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -472,4 +472,26 @@ class MethodSignatureTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @expectedException        \Psalm\Exception\CodeException
+     * @expectedExceptionMessage MethodSignatureMustOmitReturnType
+     *
+     * @return                   void
+     */
+    public function testMustOmitReturnType()
+    {
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                class A
+                {
+                    public function __construct(): void
+                    {
+                    }
+                }'
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
 }


### PR DESCRIPTION
PHP complains when you have a return type declared for these three methods.