### PR TITLE
 Make the string concatenation of two known values into a known value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,6 @@ phpunit.xml
 composer.lock
 .php_cs.cache
 .php_cs
+.*.swp
+.*.swo
 /build/logs/

--- a/src/Psalm/Checker/Statements/Expression/BinaryOpChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/BinaryOpChecker.php
@@ -29,11 +29,13 @@ use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TGenericParam;
 use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TNumeric;
 use Psalm\Type\Reconciler;
+use Psalm\Type\Union;
 
 class BinaryOpChecker
 {
@@ -1362,6 +1364,15 @@ class BinaryOpChecker
                         // fall through
                     }
                 }
+            }
+        }
+        // When concatenating two known string literals (with only one possibility),
+        // put the concatenated string into $result_type
+        if ($left_type && $right_type && $left_type->isSingleStringLiteral() && $right_type->isSingleStringLiteral()) {
+            $literal = $left_type->getSingleStringLiteral() . $right_type->getSingleStringLiteral();
+            if (strlen($literal) <= 10000) {
+                // Limit these to 10000 bytes to avoid extremely large union types from repeated concatenations, etc
+                $result_type = new Union([new TLiteralString([$literal => true])]);
             }
         }
     }

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -6,6 +6,7 @@ use Psalm\CodeLocation;
 use Psalm\StatementsSource;
 use Psalm\Storage\FileStorage;
 use Psalm\Type;
+use Psalm\Type\Atomic\TLiteralString;
 
 class Union
 {
@@ -676,6 +677,42 @@ class Union
         }
 
         return $type->type_params[count($type->type_params) - 1]->isSingle();
+    }
+
+    /**
+     * @return bool true if this is a string literal with only one possible value
+     * TODO: Is there a better place for this?
+     */
+    public function isSingleStringLiteral()
+    {
+        if (count($this->types) !== 1) {
+            return false;
+        }
+        $string_type = $this->types['string'] ?? null;
+        if (!($string_type instanceof TLiteralString)) {
+            return false;
+        }
+        return count($string_type->getValues()) === 1;
+    }
+
+    /**
+     * @return string the only string literal represented by this union type
+     * @throws \InvalidArgumentException if isSingleStringLiteral is false
+     */
+    public function getSingleStringLiteral()
+    {
+        if (count($this->types) !== 1) {
+            throw new \InvalidArgumentException("Not a string literal");
+        }
+        $string_type = $this->types['string'] ?? null;
+        if (!($string_type instanceof TLiteralString)) {
+            throw new \InvalidArgumentException("Not a string literal");
+        }
+        $values = $string_type->getValues();
+        if (count($values) !== 1) {
+            throw new \InvalidArgumentException("Not a string literal");
+        }
+        return (string)key($values);
     }
 
     /**

--- a/tests/TypeAlgebraTest.php
+++ b/tests/TypeAlgebraTest.php
@@ -831,6 +831,13 @@ class TypeAlgebraTest extends TestCase
                         echo $a === false ? "a" : "b";
                     }',
             ],
+            'stringConcatenationTrackedValid' => [
+                '<?php
+                    $x = "a";
+                    $x = "_" . $x;
+                    $array = [$x => 2];
+                    echo $array["_a"];',
+            ],
         ];
     }
 
@@ -1011,6 +1018,14 @@ class TypeAlgebraTest extends TestCase
                     $b = 5;
                     if ($a !== $b) {}',
                 'error_message' => 'RedundantCondition',
+            ],
+            'stringConcatenationTrackedInvalid' => [
+                '<?php
+                    $x = "a";
+                    $x = "_" . $x;
+                    $array = [$x => 2];
+                    echo $array["other"];',
+                'error_message' => 'InvalidArrayOffset',
             ],
         ];
     }


### PR DESCRIPTION
Add a hardcoded limit in case of analyzing code such as `$x = 'long'; $x = $x . $x; $x = $x . $x;`, etc (or code in the global scope). (I don't have strong preferences on the exact value of that limit)

This is useful for analyzing dynamic property accesses, multi-line strings `'my' . 'Method'`,  etc.

Added a helper method to check if a union type is a single string literal. This may be useful in the long run, for plugins (and property/method/call_user_func checks). I'm not very familiar with the project layout or naming conventions, suggestions are welcome.