### PR TITLE
Remove unused variables

### DIFF
--- a/src/Psalm/Checker/ClassChecker.php
+++ b/src/Psalm/Checker/ClassChecker.php
@@ -285,7 +285,7 @@ class ClassChecker extends ClassLikeChecker
         }
 
         if (!$storage->abstract) {
-            foreach ($storage->declaring_method_ids as $method_name => $declaring_method_id) {
+            foreach ($storage->declaring_method_ids as $declaring_method_id) {
                 $method_storage = $codebase->methods->getStorage($declaring_method_id);
 
                 list($declaring_class_name, $method_name) = explode('::', $declaring_method_id);

--- a/src/Psalm/Checker/ClassLikeChecker.php
+++ b/src/Psalm/Checker/ClassLikeChecker.php
@@ -110,6 +110,7 @@ abstract class ClassLikeChecker extends SourceChecker implements StatementsSourc
             $source_file_path = $this->source->getCheckedFilePath();
 
             if (!Config::getInstance()->use_case_sensitive_file_names) {
+                // TODO: Use these variables
                 $storage_file_path = strtolower($storage_file_path);
                 $source_file_path = strtolower($source_file_path);
             }

--- a/src/Psalm/Checker/Statements/Expression/CallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/CallChecker.php
@@ -535,7 +535,7 @@ class CallChecker
                             $statements_checker
                         );
 
-                        foreach ($context->vars_in_scope[$var_id]->getTypes() as $key => &$type) {
+                        foreach ($context->vars_in_scope[$var_id]->getTypes() as $type) {
                             if ($type instanceof TArray && $type->type_params[1]->isEmpty()) {
                                 $context->vars_in_scope[$var_id]->removeType('array');
                                 $context->vars_in_scope[$var_id]->addType(

--- a/src/Psalm/Codebase/Reflection.php
+++ b/src/Psalm/Codebase/Reflection.php
@@ -367,8 +367,6 @@ class Reflection
 
             $storage->cased_name = $reflection_function->getName();
 
-            $config = \Psalm\Config::getInstance();
-
             if (version_compare(PHP_VERSION, '7.0.0dev', '>=')
                 && $reflection_return_type = $reflection_function->getReturnType()
             ) {


### PR DESCRIPTION
$method_name is overwritten 3 lines below in `explode('::', $declaring_method_id);`

use_case_sensitive_file_names seems to be a WIP