### PR TITLE
Attempt to fix builds on scrutinizer-ci

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,13 +1,13 @@
 build:
+  environment:
+    postgresql: false
+    redis: false
   nodes:
     analysis:
       project_setup:
         override: true
       tests:
         override: [php-scrutinizer-run]
-    php56:
-      environment:
-        php: 5.6
     php70:
       environment:
         php: 7.0


### PR DESCRIPTION
- Dropped php56 (this branch is not compatible with php5 anymore due to nikic/php-parser:^4 dependency)
- Dropped postgresql and redis from environment (they don't seem to be used)