### PR TITLE
Add find all references command

### DIFF
--- a/src/Psalm/CallGraphNode.php
+++ b/src/Psalm/CallGraphNode.php
@@ -1,0 +1,45 @@
+<?php
+namespace Psalm;
+
+class location {
+    public $start_line;
+    public $end_line;
+    public $start_offset;
+    public $end_offset;
+    public $start_column;
+    public $end_column;
+
+    public $file_path;
+    public $file_name;
+
+    public function __construct($internalLocation) {
+        $this->start_line = $internalLocation->getLineNumber();
+        $this->end_line = $internalLocation->getEndLineNumber();
+        $this->start_column = $internalLocation->getColumn();
+        $this->end_column = $internalLocation->getEndColumn();
+
+        list($this->start_offset, $this->end_offset) = $internalLocation->getSelectionBounds();
+
+        $this->file_path = $internalLocation->file_path;
+        $this->file_name = $internalLocation->file_name;
+    }
+}
+
+class CallGraphNode {
+    public $definitionLocation;
+    public $referenceLocations = [];
+
+    public function __construct($def, $refs) {
+        $this->definitionLocation = new location($def);
+        foreach ($refs as $refset) {
+            foreach ($refset as $ref) {
+                $this->referenceLocations[] = new location($ref);
+            }
+        }
+    }
+
+    public function print() {
+        $json = json_encode($this, JSON_PRETTY_PRINT);
+        print $json . "\r\n";
+    }
+}

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -329,13 +329,13 @@ class Codebase
         $method_name_lc = strtolower($method_name);
 
         if (!isset($class_storage->methods[$method_name_lc])) {
-            die('Method ' . $method_id . ' cannot be found' . PHP_EOL);
+            throw new \InvalidArgumentException('Method ' . $method_id . ' cannot be found' . PHP_EOL);
         }
 
         $method_storage = $class_storage->methods[$method_name_lc];
 
         if ($method_storage->referencing_locations === null) {
-            die('No references found for ' . $method_id . PHP_EOL);
+            throw new \InvalidArgumentException('No references found for ' . $method_id . PHP_EOL);
         }
 
         return $method_storage->referencing_locations;


### PR DESCRIPTION
Output all references to functions as a JSON dump of the call graph when  `--find-references-to="all"` is set. 

This may not be generally useful, but it solves my own [issue](https://github.com/vimeo/psalm/issues/815).