### PR TITLE
Fix misuse of preg_quote

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -811,7 +811,7 @@ class Config
      */
     public function shortenFileName($file_name)
     {
-        return preg_replace('/^' . preg_quote($this->base_dir, DIRECTORY_SEPARATOR) . '/', '', $file_name);
+        return preg_replace('/^' . preg_quote($this->base_dir, '/') . '/', '', $file_name);
     }
 
     /**

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -477,7 +477,7 @@ class Context
             $quoted_remove_var_id = preg_quote($remove_var_id);
 
             foreach ($clause->possibilities as $var_id => $_) {
-                if (preg_match('/' . $quoted_remove_var_id . '[\]\[\-]/', $var_id)) {
+                if (preg_match('/' . preg_quote($quoted_remove_var_id, '/') . '[\]\[\-]/', $var_id)) {
                     break 2;
                 }
             }
@@ -583,7 +583,7 @@ class Context
         $vars_to_remove = [];
 
         foreach ($this->vars_in_scope as $var_id => $_) {
-            if (preg_match('/' . preg_quote($remove_var_id, DIRECTORY_SEPARATOR) . '[\]\[\-]/', $var_id)) {
+            if (preg_match('/' . preg_quote($remove_var_id, '/') . '[\]\[\-]/', $var_id)) {
                 $vars_to_remove[] = $var_id;
             }
         }


### PR DESCRIPTION
1. Variable ids can contain slashes or dots, e.g. for `${'my/var'} = 2`
   or psalm's local representation of properties or array indexes
   (I forget which)
2. preg_quote's escape character should **always** be the same as the
   pattern starting character.
   Using DIRECTORY_SEPARATOR will fail to escape '/' on windows.

See https://secure.php.net/manual/en/function.preg-quote.php#refsect1-function.preg-quote-parameters and https://secure.php.net/manual/en/function.preg-quote.php#refsect1-function.preg-quote-examples