### PR TITLE
Simplify installation of a development version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,5 +53,11 @@
             "./psalm --find-dead-code",
             "phpunit"
         ]
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.x-dev",
+            "dev-1.x": "1.x-dev"
+        }
     }
 }


### PR DESCRIPTION
Simplify installation of a development version from Composer.

https://getcomposer.org/doc/articles/aliases.md#branch-alias

(This probably needs backporting to 1.x to work.)