### PR TITLE
Allow empty default of `0` for optional parameter in magic method

### DIFF
--- a/src/Psalm/Checker/CommentChecker.php
+++ b/src/Psalm/Checker/CommentChecker.php
@@ -467,7 +467,7 @@ class CommentChecker
                     $args[] = ($method_tree_child->byref ? '&' : '')
                         . ($method_tree_child->variadic ? '...' : '')
                         . $method_tree_child->name
-                        . ($method_tree_child->default ? ' = ' . $method_tree_child->default : '');
+                        . ($method_tree_child->default != '' ? ' = ' . $method_tree_child->default : '');
 
 
                     if ($method_tree_child->children) {


### PR DESCRIPTION
Fixes #879

`!= ''` will reject both null and '', but not `0`