### PR TITLE
Update PHPUnit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,11 @@ cache:
 
 before_install:
     # determine INI file
-    - export INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+    - export INI_DIR=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d
+    - export INI=$INI_DIR/travis.ini
     # disable default memory limit
     - echo memory_limit = 2G >> $INI
-    - if [[ $COVERALLS = "" ]]; then phpenv config-rm xdebug.ini; fi
+    - if [[ $COVERALLS = "" && -f $INI_DIR/xdebug.ini ]]; then phpenv config-rm xdebug.ini; fi
 
 install:
   - composer --prefer-source $DEPS update

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,26 @@
 language: php
 
 matrix:
-  include:
+  exclude:
     - php: 7.0
+      env: DEPS="" COVERALLS=true
     - php: 7.1
+      env: DEPS="" COVERALLS=true
     - php: 7.2
-      env: COVERALLS=true
+      env: DEPS="" COVERALLS=""
     - php: nightly
+      env: DEPS="" COVERALLS=true
   allow_failures:
     - php: nightly
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+
+env:
+  - DEPS="--prefer-lowest --prefer-stable" COVERALLS=""
+  - DEPS="" COVERALLS=""
+  - DEPS="" COVERALLS=true
 
 cache:
   directories:
@@ -22,7 +34,7 @@ before_install:
     - if [[ $COVERALLS = "" ]]; then phpenv config-rm xdebug.ini; fi
 
 install:
-  - composer --prefer-source install
+  - composer --prefer-source $DEPS update
 
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - nightly
 
 env:
   - DEPS="--prefer-lowest --prefer-stable" COVERALLS=""

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ matrix:
       env: DEPS="" COVERALLS=true
   allow_failures:
     - php: nightly
+    - php: 7.0
+      env: DEPS="" COVERALLS=""
 php:
   - 7.0
   - 7.1

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "optimize-autoloader": true
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7.4",
+        "phpunit/phpunit": "^6.0 || ^7.0",
         "squizlabs/php_codesniffer": "^3.0",
         "php-coveralls/php-coveralls": "^2.0",
         "bamarni/composer-bin-plugin": "^1.2"

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -110,7 +110,7 @@ class DocumentationTest extends TestCase
      */
     public function testInvalidCode($code, $error_message, $error_levels = [], $check_references = false)
     {
-        if (strpos($this->getName(), 'SKIPPED-') !== false) {
+        if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
         }
 

--- a/tests/FileManipulationTest.php
+++ b/tests/FileManipulationTest.php
@@ -33,7 +33,7 @@ class FileManipulationTest extends TestCase
      */
     public function testValidCode($input_code, $output_code, $php_version, array $issues_to_fix, $safe_types)
     {
-        $test_name = $this->getName();
+        $test_name = $this->getTestName();
         if (strpos($test_name, 'PHP7-') !== false) {
             if (version_compare(PHP_VERSION, '7.0.0dev', '<')) {
                 $this->markTestSkipped('Test case requires PHP 7.');

--- a/tests/FileReferenceTest.php
+++ b/tests/FileReferenceTest.php
@@ -41,7 +41,7 @@ class FileReferenceTest extends TestCase
      */
     public function testValidCode($input_code, $symbol, $expected_locations)
     {
-        $test_name = $this->getName();
+        $test_name = $this->getTestName();
         if (strpos($test_name, 'PHP7-') !== false) {
             if (version_compare(PHP_VERSION, '7.0.0dev', '<')) {
                 $this->markTestSkipped('Test case requires PHP 7.');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Psalm\Tests;
 use PHPUnit\Framework\TestCase as BaseTestCase;
 use Psalm\Checker\FileChecker;
 use Psalm\Checker\ProjectChecker;
+use RuntimeException;
 
 class TestCase extends BaseTestCase
 {
@@ -98,5 +99,14 @@ class TestCase extends BaseTestCase
             $codebase->config->shortenFileName($file_path)
         );
         $file_checker->analyze($context);
+    }
+    public function getName($withDataSet = true): string
+    {
+        $name = parent::getName($withDataSet);
+        /** @psalm-suppress DocblockTypeContradiction PHPUnit 7 introduced nullable name */
+        if (null === $name) {
+            throw new RuntimeException('anonymous test - shouldn\'t happen');
+        }
+        return $name;
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -100,7 +100,7 @@ class TestCase extends BaseTestCase
         );
         $file_checker->analyze($context);
     }
-    public function getName($withDataSet = true): string
+    protected function getTestName(bool $withDataSet = true): string
     {
         $name = parent::getName($withDataSet);
         /** @psalm-suppress DocblockTypeContradiction PHPUnit 7 introduced nullable name */

--- a/tests/Traits/FileCheckerInvalidCodeParseTestTrait.php
+++ b/tests/Traits/FileCheckerInvalidCodeParseTestTrait.php
@@ -24,7 +24,7 @@ trait FileCheckerInvalidCodeParseTestTrait
      */
     public function testInvalidCode($code, $error_message, $error_levels = [], $strict_mode = false)
     {
-        if (strpos($this->getName(), 'SKIPPED-') !== false) {
+        if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
         }
 

--- a/tests/Traits/FileCheckerValidCodeParseTestTrait.php
+++ b/tests/Traits/FileCheckerValidCodeParseTestTrait.php
@@ -26,7 +26,7 @@ trait FileCheckerValidCodeParseTestTrait
      */
     public function testValidCode($code, $assertions = [], $error_levels = [], $scope_vars = [])
     {
-        $test_name = $this->getName();
+        $test_name = $this->getTestName();
         if (strpos($test_name, 'PHP7-') !== false) {
             if (version_compare(PHP_VERSION, '7.0.0dev', '<')) {
                 $this->markTestSkipped('Test case requires PHP 7.');

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -40,7 +40,7 @@ class UnusedCodeTest extends TestCase
      */
     public function testValidCode($code, array $error_levels = [])
     {
-        $test_name = $this->getName();
+        $test_name = $this->getTestName();
         if (strpos($test_name, 'PHP7-') !== false) {
             if (version_compare(PHP_VERSION, '7.0.0dev', '<')) {
                 $this->markTestSkipped('Test case requires PHP 7.');
@@ -81,7 +81,7 @@ class UnusedCodeTest extends TestCase
      */
     public function testInvalidCode($code, $error_message, $error_levels = [])
     {
-        if (strpos($this->getName(), 'SKIPPED-') !== false) {
+        if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
         }
 

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -40,7 +40,7 @@ class UnusedVariableTest extends TestCase
      */
     public function testValidCode($code, array $error_levels = [])
     {
-        $test_name = $this->getName();
+        $test_name = $this->getTestName();
         if (strpos($test_name, 'PHP7-') !== false) {
             if (version_compare(PHP_VERSION, '7.0.0dev', '<')) {
                 $this->markTestSkipped('Test case requires PHP 7.');
@@ -81,7 +81,7 @@ class UnusedVariableTest extends TestCase
      */
     public function testInvalidCode($code, $error_message, $error_levels = [])
     {
-        if (strpos($this->getName(), 'SKIPPED-') !== false) {
+        if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
         }
 


### PR DESCRIPTION
This updates to PHPUnit 6/7, including the minor tweaks to the tests that were needed to satisfy Psalm and PHP for various PHP/PHPUnit combinations.

One Psalm failure is still there (PHP 7.0 / low-deps, https://travis-ci.com/weirdan/psalm/jobs/134301736#L855), but I hope it'll be fixed in phpunit (reported here: sebastianbergmann/phpunit#3209)

Nightly fails for unrelated reason (phpcs has some ugly switch/continue code).

Also it adds another variable into build matrix, causing travis to run with both lowest possible and highest possible dependencies. That's useful to see if your dependency version constraints actually make sense.