### PR TITLE
Build psalm.phar on travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
   - vendor/bin/phpunit
   - ./psalm --find-dead-code
   - vendor/bin/phpcs
-  - bin/build-phar.sh
+  - bin/build-phar.sh || true
 
 after_success:
   - travis_retry php vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,18 @@ script:
   - vendor/bin/phpunit
   - ./psalm --find-dead-code
   - vendor/bin/phpcs
+  - bin/build-phar.sh
 
 after_success:
   - travis_retry php vendor/bin/php-coveralls -v
+
+deploy: # on tag builds with lowest php version (that box supports) and lowest deps
+  skip_cleanup: true
+  on:
+    tags: true
+    php: 7.1
+    condition: "$DEPS"
+  provider: releases
+  api_key:
+    secure: "E7aVJXRLY0s9m5AA9ozbJUtSvo7Ov/2kusjRWKreLHcjXl5y0dElZYwvv/Zl0/4/5KwNl36hdsOj+UMqiHdZYxgsDhwKhQ5pC59xUEmPl3gtu8kRfkFXesYrm5A0KMh3fU4vzLD7qbv2lY6ax1m5OP0PP6YjTwOsRQMiVbP3TEpnNsDrhEOzQQvmG0NzW1NK/xnaWjzghzsiEBn+oLrKO1x3ykg9iE3gEglg8clQMWN74pRTyIkEJUE93cLdqocpwx3L/SCqZaK2zIy7U1vQ4U5x7WvN22UCdGbuAcqvG+0cTVit8pzfIq93JOk09i19lStSA0+vHVeAOY32icH01q6dlcIxHf66z9ypHnTaRcreUVYMYFHsqbQOy+Sy4zXBdRnF8N2IqWHENT1ib/qI46t7CrknSOmsMlLeyMBRCzdxYaPZFMH0pbHzR9EfrzI0Do5KVUU2ZNxdhJoVh38+6zuaIQOECkoKNY7ijA8QezpjwtxEsEUn2ESCtnAQ5mcDLZqhRbXN4wZ7S63ntIl+zqEltV4PTOujg48MwrBUhgjVhPuUqH9y3crVj+rX4b9G9YEiNoV8kmpD2u2nOc6NLRlDoHHL1eNRs3XPv9bNlzMPF+6h31c0zqGWS5wsT3WB/2Z+huLt4kQFF4cVbhVJqg0zb+thltnM/ANywhRiUnk="
+  file: build/psalm.phar

--- a/bin/build-phar.sh
+++ b/bin/build-phar.sh
@@ -3,4 +3,4 @@ composer bin box install
 
 vendor/bin/box compile
 
-build/psalm.phar --config=bin/phar.psalm.xml
+#build/psalm.phar --config=bin/phar.psalm.xml


### PR DESCRIPTION
And upload it to GitHub releases automatically when tag is created.

api_key.secure entry needs to be replaced by github token with public_repo scope, encrypted with
```console
$ travis encrypt -r vimeo/psalm --org # use --pro instead of --org if running from travis-ci.com
```

Demo release: https://github.com/weirdan/psalm/releases/tag/v8-dev

PS: travis config is getting unwieldy, gotta redo it using build stages (like phpcs first, then test and psalm run on various versions, then deploy if it's a tag). That's for another day though.