### PR TITLE
Fix typos detected by `misspell`

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -647,7 +647,7 @@ class B extends A {
 
 ### MethodSignatureMustOmitReturnType
 
-Emmitted when a `__clone`, `__construct`, or `__destruct` method is defined with a return type.
+Emitted when a `__clone`, `__construct`, or `__destruct` method is defined with a return type.
 
 ```php
 class A {
@@ -728,7 +728,7 @@ function foo(int $i = 5, string $j) : void {}
 
 ### MissingClosureParamType
 
-Emitted when a closure paramter has no type information associated with it
+Emitted when a closure parameter has no type information associated with it
 
 ```php
 $a = function($a): string {
@@ -789,7 +789,7 @@ require("nonexistent.php");
 
 ### MissingParamType
 
-Emitted when a function paramter has no type information associated with it
+Emitted when a function parameter has no type information associated with it
 
 ```php
 function foo($a) : void {}

--- a/src/Psalm/Checker/Statements/Expression/Assignment/PropertyAssignmentChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/Assignment/PropertyAssignmentChecker.php
@@ -45,7 +45,7 @@ class PropertyAssignmentChecker
      * @param   PhpParser\Node\Expr|null        $assignment_value
      * @param   Type\Union                      $assignment_value_type
      * @param   Context                         $context
-     * @param   bool                            $direct_assignment whether the variable is assigned explictly
+     * @param   bool                            $direct_assignment whether the variable is assigned explicitly
      *
      * @return  false|null
      */

--- a/src/Psalm/Checker/Statements/Expression/Call/StaticCallChecker.php
+++ b/src/Psalm/Checker/Statements/Expression/Call/StaticCallChecker.php
@@ -113,7 +113,7 @@ class StaticCallChecker extends \Psalm\Checker\Statements\Expression\CallChecker
                         if ($context->collect_mutations) {
                             $file_checker->getMethodMutations($method_id, $context);
                         } else {
-                            // collecting initalisations
+                            // collecting initializations
                             $local_vars_in_scope = [];
                             $local_vars_possibly_in_scope = [];
 


### PR DESCRIPTION
Both of initiali[sz]e were used, z was more common.