### PR TITLE
Multi-stage builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,25 @@
 language: php
 
-matrix:
-  include:
-    - php: 7.0
-      env: DEPS="--prefer-lowest --prefer-stable" COVERALLS=""
-    - php: 7.0
-      env: DEPS="" COVERALLS=""
-    - php: 7.1
-      env: DEPS="--prefer-lowest --prefer-stable" COVERALLS=""
-    - php: 7.1
-      env: DEPS="" COVERALLS=""
-    - php: 7.2
-      env: DEPS="--prefer-lowest --prefer-stable" COVERALLS=""
-    - php: 7.2
-      env: DEPS="" COVERALLS=true
-    - php: nightly
-      env: DEPS="" COVERALLS=""
-  allow_failures:
-    - php: nightly
-      env: DEPS="" COVERALLS=""
-    - php: 7.1
-      env: DEPS="--prefer-lowest --prefer-stable" COVERALLS=""
+stages:
+  - Code style analysis
+  - test
+  - Code coverage analysis
+  - Phar build
+
+php:
+  - 7.0
+  - 7.1
+  - 7.2
+  - nightly
+
+env: 
+  matrix:
+    - DEPS="high"
+    - DEPS="low"
+  global:
+    - DEFAULT_COMPOSER_FLAGS="--no-interaction --no-suggest --prefer-source"
+    - XDEBUG="false"
+
 
 cache:
   directories:
@@ -32,15 +31,53 @@ before_install:
     - export INI=$INI_DIR/travis.ini
     # disable default memory limit
     - echo memory_limit = 2G >> $INI
-    - if [[ $COVERALLS = "" && -f $INI_DIR/xdebug.ini ]]; then phpenv config-rm xdebug.ini; fi
+    - if [[ "$XDEBUG" = 'false' && -f $INI_DIR/xdebug.ini ]]; then phpenv config-rm xdebug.ini; fi
+    - composer clear-cache
 
 install:
-  - composer --prefer-source $DEPS update
+  - if [[ "$DEPS" = 'high' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS update; fi
+  - if [[ "$DEPS" = 'low' ]]; then travis_retry composer $DEFAULT_COMPOSER_FLAGS --prefer-lowest --prefer-stable update; fi
 
 script:
   - vendor/bin/phpunit
   - ./psalm --find-dead-code
-  - vendor/bin/phpcs
 
-after_success:
-  - travis_retry php vendor/bin/php-coveralls -v
+# Base test matrix (php/env)
+matrix:
+  fast_finish: true
+  allow_failures:
+    - php: nightly
+  exclude: # covered in Code coverage stage
+    - php: 7.2
+      env: DEPS="high"
+
+# Additional stages
+jobs:
+  include:
+    - stage: Code coverage analysis
+      php: 7.2
+      # don't disable xdebug here
+      env: DEPS="high" XDEBUG="true"
+      after_success:
+        - travis_retry php vendor/bin/php-coveralls -v
+
+    - stage: Code style analysis
+      php: 7.2
+      env: DEPS="high"
+      script:
+        - vendor/bin/phpcs
+
+      # always build phar, but only deploy on tag builds
+    - stage: Phar build
+      php: 7.1
+      env: DEPS="low"
+      script:
+        - bin/build-phar.sh
+      deploy:
+        skip_cleanup: true
+        on:
+          tags: true
+        provider: releases
+        api_key:
+          secure: "E7aVJXRLY0s9m5AA9ozbJUtSvo7Ov/2kusjRWKreLHcjXl5y0dElZYwvv/Zl0/4/5KwNl36hdsOj+UMqiHdZYxgsDhwKhQ5pC59xUEmPl3gtu8kRfkFXesYrm5A0KMh3fU4vzLD7qbv2lY6ax1m5OP0PP6YjTwOsRQMiVbP3TEpnNsDrhEOzQQvmG0NzW1NK/xnaWjzghzsiEBn+oLrKO1x3ykg9iE3gEglg8clQMWN74pRTyIkEJUE93cLdqocpwx3L/SCqZaK2zIy7U1vQ4U5x7WvN22UCdGbuAcqvG+0cTVit8pzfIq93JOk09i19lStSA0+vHVeAOY32icH01q6dlcIxHf66z9ypHnTaRcreUVYMYFHsqbQOy+Sy4zXBdRnF8N2IqWHENT1ib/qI46t7CrknSOmsMlLeyMBRCzdxYaPZFMH0pbHzR9EfrzI0Do5KVUU2ZNxdhJoVh38+6zuaIQOECkoKNY7ijA8QezpjwtxEsEUn2ESCtnAQ5mcDLZqhRbXN4wZ7S63ntIl+zqEltV4PTOujg48MwrBUhgjVhPuUqH9y3crVj+rX4b9G9YEiNoV8kmpD2u2nOc6NLRlDoHHL1eNRs3XPv9bNlzMPF+6h31c0zqGWS5wsT3WB/2Z+huLt4kQFF4cVbhVJqg0zb+thltnM/ANywhRiUnk="
+        file: build/psalm.phar

--- a/bin/build-phar.sh
+++ b/bin/build-phar.sh
@@ -3,4 +3,4 @@ composer bin box install
 
 vendor/bin/box compile
 
-build/psalm.phar --config=bin/phar.psalm.xml
+# build/psalm.phar --config=bin/phar.psalm.xml


### PR DESCRIPTION
- Run phpcs once, not on every row of build matrix
- Start coverage builds only when regular test builds succeed
- Always build phar (to see if it builds)
- Automatically deploy psalm.phar on tag builds (no more missing phars)

![image](https://user-images.githubusercontent.com/57403/43558922-687d4130-9614-11e8-9ad8-c02612d7c7ff.png)

Branch build: https://travis-ci.com/weirdan/psalm/builds/80694173
Tag build: https://travis-ci.com/weirdan/psalm/builds/80696128
Allowed failures build: https://travis-ci.com/weirdan/psalm/builds/80690283
Release that was created automatically with the above tag build: https://github.com/weirdan/psalm/releases/tag/v10-dev

api_key.secure entry needs to be replaced by github token with public_repo scope, encrypted with
```console
$ travis encrypt -r vimeo/psalm --org # use --pro instead of --org if running from travis-ci.com
```

Supersedes vimeo/psalm#923
Fixes vimeo/psalm#921

