### PR TITLE
Fix for not suppressing MethodSignatureMismatch and InvalidReturnType

### DIFF
--- a/src/Psalm/Checker/FunctionLike/ReturnTypeChecker.php
+++ b/src/Psalm/Checker/FunctionLike/ReturnTypeChecker.php
@@ -318,7 +318,8 @@ class ReturnTypeChecker
                         'No return statements were found for method ' . $cased_method_id .
                             ' but return type \'' . $declared_return_type . '\' was expected',
                         $return_type_location
-                    )
+                    ),
+                    $suppressed_issues
                 )) {
                     return false;
                 }

--- a/src/Psalm/Checker/MethodChecker.php
+++ b/src/Psalm/Checker/MethodChecker.php
@@ -454,7 +454,8 @@ class MethodChecker extends FunctionLikeChecker
                             . $implementer_signature_return_type . '\' is different to return type \''
                             . $guide_signature_return_type . '\' of inherited method ' . $cased_guide_method_id,
                         $code_location
-                    )
+                    ),
+                    $suppressed_issues
                 )) {
                     return false;
                 }


### PR DESCRIPTION
If you have an inherited class that overrides a method with a different return type, you can now suppress it with
@psalm-suppress MethodSignatureMismatch

Example code:

```
<?php
declare(strict_types=1);

class Animal
{
	public function getId(): string
	{
		return "Animal";
	}
}

class Dog extends Animal
{
	/**
	 * @psalm-suppress MethodSignatureMismatch
	 */
	public function getId(): int
	{
		return 1;
	}
}
```

Also related to the last line in issue #192 