### PR TITLE
Add support for forking at the scanning step

### DIFF
--- a/src/Psalm/Checker/ProjectChecker.php
+++ b/src/Psalm/Checker/ProjectChecker.php
@@ -289,7 +289,7 @@ class ProjectChecker
 
             $this->config->initializePlugins($this);
 
-            $this->codebase->scanFiles();
+            $this->codebase->scanFiles($this->threads);
         } else {
             if ($this->debug_output) {
                 echo count($diff_files) . ' changed files: ' . "\n";
@@ -306,7 +306,7 @@ class ProjectChecker
 
                 $this->config->initializePlugins($this);
 
-                $this->codebase->scanFiles();
+                $this->codebase->scanFiles($this->threads);
             }
         }
 
@@ -401,7 +401,7 @@ class ProjectChecker
 
         $this->config->initializePlugins($this);
 
-        $this->codebase->scanFiles();
+        $this->codebase->scanFiles($this->threads);
 
         $this->config->visitStubFiles($this->codebase, $this->debug_output);
 
@@ -571,7 +571,7 @@ class ProjectChecker
 
         $this->config->initializePlugins($this);
 
-        $this->codebase->scanFiles();
+        $this->codebase->scanFiles($this->threads);
 
         $this->config->visitStubFiles($this->codebase, $this->debug_output);
 
@@ -609,7 +609,7 @@ class ProjectChecker
 
         $this->config->initializePlugins($this);
 
-        $this->codebase->scanFiles();
+        $this->codebase->scanFiles($this->threads);
 
         $this->config->visitStubFiles($this->codebase, $this->debug_output);
 

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -292,9 +292,9 @@ class Codebase
      *
      * @return void
      */
-    public function scanFiles()
+    public function scanFiles(int $threads = 1)
     {
-        $has_changes = $this->scanner->scanFiles($this->classlikes);
+        $has_changes = $this->scanner->scanFiles($this->classlikes, $threads);
 
         if ($has_changes) {
             $this->populator->populateCodebase($this);

--- a/src/Psalm/Codebase/ClassLikes.php
+++ b/src/Psalm/Codebase/ClassLikes.php
@@ -877,11 +877,86 @@ class ClassLikes
             $this->existing_classlikes_lc[$fq_class_name_lc],
             $this->existing_classes_lc[$fq_class_name_lc],
             $this->existing_traits_lc[$fq_class_name_lc],
+            $this->existing_traits[$fq_class_name],
             $this->existing_interfaces_lc[$fq_class_name_lc],
+            $this->existing_interfaces[$fq_class_name],
             $this->existing_classes[$fq_class_name],
             $this->trait_nodes[$fq_class_name_lc],
             $this->trait_aliases[$fq_class_name_lc],
             $this->classlike_references[$fq_class_name_lc]
         );
+    }
+
+    /**
+     * @return array{
+     *     0: array<string, bool>,
+     *     1: array<string, bool>,
+     *     2: array<string, bool>,
+     *     3: array<string, bool>,
+     *     4: array<string, bool>,
+     *     5: array<string, bool>,
+     *     6: array<string, bool>,
+     *     7: array<string, \PhpParser\Node\Stmt\Trait_>,
+     *     8: array<string, \Psalm\Aliases>,
+     *     9: array<string, int>
+     * }
+     */
+    public function getThreadData()
+    {
+        return [
+            $this->existing_classlikes_lc,
+            $this->existing_classes_lc,
+            $this->existing_traits_lc,
+            $this->existing_traits,
+            $this->existing_interfaces_lc,
+            $this->existing_interfaces,
+            $this->existing_classes,
+            $this->trait_nodes,
+            $this->trait_aliases,
+            $this->classlike_references
+        ];
+    }
+
+    /**
+     * @param array{
+     *     0: array<string, bool>,
+     *     1: array<string, bool>,
+     *     2: array<string, bool>,
+     *     3: array<string, bool>,
+     *     4: array<string, bool>,
+     *     5: array<string, bool>,
+     *     6: array<string, bool>,
+     *     7: array<string, \PhpParser\Node\Stmt\Trait_>,
+     *     8: array<string, \Psalm\Aliases>,
+     *     9: array<string, int>
+     * } $thread_data
+     *
+     * @return void
+     */
+    public function addThreadData(array $thread_data)
+    {
+        list (
+            $existing_classlikes_lc,
+            $existing_classes_lc,
+            $existing_traits_lc,
+            $existing_traits,
+            $existing_interfaces_lc,
+            $existing_interfaces,
+            $existing_classes,
+            $trait_nodes,
+            $trait_aliases,
+            $classlike_references
+        ) = $thread_data;
+
+        $this->existing_classlikes_lc = array_merge($existing_classlikes_lc, $this->existing_classlikes_lc);
+        $this->existing_classes_lc = array_merge($existing_classes_lc, $this->existing_classes_lc);
+        $this->existing_traits_lc = array_merge($existing_traits_lc, $this->existing_traits_lc);
+        $this->existing_traits = array_merge($existing_traits, $this->existing_traits);
+        $this->existing_interfaces_lc = array_merge($existing_interfaces_lc, $this->existing_interfaces_lc);
+        $this->existing_interfaces = array_merge($existing_interfaces, $this->existing_interfaces);
+        $this->existing_classes = array_merge($existing_classes, $this->existing_classes);
+        $this->trait_nodes = array_merge($trait_nodes, $this->trait_nodes);
+        $this->trait_aliases = array_merge($trait_aliases, $this->trait_aliases);
+        $this->classlike_references = array_merge($classlike_references, $this->classlike_references);
     }
 }

--- a/src/Psalm/Codebase/Scanner.php
+++ b/src/Psalm/Codebase/Scanner.php
@@ -335,6 +335,10 @@ class Scanner
 
         $this->files_to_scan = [];
 
+        if (!$files_to_scan) {
+            return false;
+        }
+
         $files_to_deep_scan = $this->files_to_deep_scan;
 
         $scanner_worker =
@@ -439,7 +443,7 @@ class Scanner
             }
         }
 
-        return (bool) $files_to_scan;
+        return true;
     }
 
     /**

--- a/src/Psalm/Codebase/Scanner.php
+++ b/src/Psalm/Codebase/Scanner.php
@@ -9,6 +9,57 @@ use Psalm\Provider\FileStorageProvider;
 use Psalm\Scanner\FileScanner;
 
 /**
+ * @psalm-type  IssueData = array{
+ *     severity: string,
+ *     line_from: int,
+ *     line_to: int,
+ *     type: string,
+ *     message: string,
+ *     file_name: string,
+ *     file_path: string,
+ *     snippet: string,
+ *     from: int,
+ *     to: int,
+ *     snippet_from: int,
+ *     snippet_to: int,
+ *     column_from: int,
+ *     column_to: int
+ * }
+ *
+ * @psalm-type  PoolData = array{
+ *     classlikes_data:array{
+ *         0:array<string, bool>,
+ *         1:array<string, bool>,
+ *         2:array<string, bool>,
+ *         3:array<string, bool>,
+ *         4:array<string, bool>,
+ *         5:array<string, bool>,
+ *         6:array<string, bool>,
+ *         7:array<string, \PhpParser\Node\Stmt\Trait_>,
+ *         8:array<string, \Psalm\Aliases>,
+ *         9:array<string, int>
+ *     },
+ *     scanner_data:array{
+ *         0:array<string, string>,
+ *         1:array<string, string>,
+ *         2:array<string, string>,
+ *         3:array<string, bool>,
+ *         4:array<string, bool>,
+ *         5:array<string, string>,
+ *         6:array<string, bool>,
+ *         7:array<string, bool>,
+ *         8:array<string, bool>
+ *     },
+ *     issues:array<int, IssueData>,
+ *     changed_members:array<string, array<string, bool>>,
+ *     unchanged_signature_members:array<string, array<string, bool>>,
+ *     diff_map:array<string, array<int, array{0:int, 1:int, 2:int, 3:int}>>,
+ *     classlike_storage:array<string, \Psalm\Storage\ClassLikeStorage>,
+ *     file_storage:array<string, \Psalm\Storage\FileStorage>
+ * }
+ */
+
+/**
  * @internal
  *
  * Contains methods that aid in the scanning of Psalm's codebase
@@ -94,6 +145,11 @@ class Scanner
      * @var FileReferenceProvider
      */
     private $file_reference_provider;
+
+    /**
+     * @var bool
+     */
+    private $is_forked = false;
 
     /**
      * @param bool $debug_output
@@ -249,13 +305,13 @@ class Scanner
     /**
      * @return bool
      */
-    public function scanFiles(ClassLikes $classlikes)
+    public function scanFiles(ClassLikes $classlikes, int $pool_size = 1)
     {
         $has_changes = false;
 
         while ($this->files_to_scan || $this->classes_to_scan) {
             if ($this->files_to_scan) {
-                if ($this->scanFilePaths()) {
+                if ($this->scanFilePaths($pool_size)) {
                     $has_changes = true;
                 }
             } else {
@@ -266,7 +322,7 @@ class Scanner
         return $has_changes;
     }
 
-    private function scanFilePaths() : bool
+    private function scanFilePaths(int $pool_size) : bool
     {
         $filetype_scanners = $this->config->getFiletypeScanners();
         $files_to_scan = array_filter(
@@ -279,12 +335,108 @@ class Scanner
 
         $this->files_to_scan = [];
 
-        foreach ($files_to_scan as $file_path) {
-            $this->scanFile(
-                $file_path,
-                $filetype_scanners,
-                isset($this->files_to_deep_scan[$file_path])
+        $files_to_deep_scan = $this->files_to_deep_scan;
+
+        $scanner_worker =
+            /**
+             * @param int $_
+             * @param string $file_path
+             *
+             * @return void
+             */
+            function ($_, $file_path) use ($filetype_scanners, $files_to_deep_scan) {
+                $this->scanFile(
+                    $file_path,
+                    $filetype_scanners,
+                    isset($files_to_deep_scan[$file_path])
+                );
+            };
+
+        if (!$this->is_forked && $pool_size > 1 && count($files_to_scan) > 512) {
+            $pool_size = ceil(min($pool_size, count($files_to_scan) / 256));
+        } else {
+            $pool_size = 1;
+        }
+
+        if ($pool_size > 1) {
+            $process_file_paths = [];
+
+            $i = 0;
+
+            foreach ($files_to_scan as $file_path) {
+                $process_file_paths[$i % $pool_size][] = $file_path;
+                ++$i;
+            }
+
+            // Run scanning one file at a time, splitting the set of
+            // files up among a given number of child processes.
+            $pool = new \Psalm\Fork\Pool(
+                $process_file_paths,
+                /** @return void */
+                function () {
+                    $project_checker = \Psalm\Checker\ProjectChecker::getInstance();
+                    $statements_provider = $project_checker->codebase->statements_provider;
+
+                    $project_checker->codebase->scanner->isForked();
+                    $project_checker->codebase->file_storage_provider->deleteAll();
+                    $project_checker->codebase->classlike_storage_provider->deleteAll();
+
+                    $statements_provider->resetDiffs();
+                },
+                $scanner_worker,
+                /**
+                 * @return PoolData
+                */
+                function () {
+                    $project_checker = \Psalm\Checker\ProjectChecker::getInstance();
+                    $statements_provider = $project_checker->codebase->statements_provider;
+
+                    return [
+                        'classlikes_data' => $project_checker->codebase->classlikes->getThreadData(),
+                        'scanner_data' => $project_checker->codebase->scanner->getThreadData(),
+                        'issues' => \Psalm\IssueBuffer::getIssuesData(),
+                        'changed_members' => $statements_provider->getChangedMembers(),
+                        'unchanged_signature_members' => $statements_provider->getUnchangedSignatureMembers(),
+                        'diff_map' => $statements_provider->getDiffMap(),
+                        'classlike_storage' => $project_checker->classlike_storage_provider->getAll(),
+                        'file_storage' => $project_checker->file_storage_provider->getAll(),
+                    ];
+                }
             );
+
+            // Wait for all tasks to complete and collect the results.
+            /**
+             * @var array<int, PoolData>
+             */
+            $forked_pool_data = $pool->wait();
+
+            foreach ($forked_pool_data as $pool_data) {
+                \Psalm\IssueBuffer::addIssues($pool_data['issues']);
+
+                $this->codebase->statements_provider->addChangedMembers(
+                    $pool_data['changed_members']
+                );
+                $this->codebase->statements_provider->addUnchangedSignatureMembers(
+                    $pool_data['unchanged_signature_members']
+                );
+                $this->codebase->statements_provider->addDiffMap(
+                    $pool_data['diff_map']
+                );
+
+                $this->codebase->file_storage_provider->addMore($pool_data['file_storage']);
+                $this->codebase->classlike_storage_provider->addMore($pool_data['classlike_storage']);
+
+                $this->codebase->classlikes->addThreadData($pool_data['classlikes_data']);
+
+                $this->addThreadData($pool_data['scanner_data']);
+            }
+        } else {
+            $i = 0;
+
+            foreach ($files_to_scan as $file_path => $_) {
+                $scanner_worker($i, $file_path);
+                ++$i;
+            }
         }
 
         return (bool) $files_to_scan;
@@ -542,5 +694,84 @@ class Scanner
         }
 
         return true;
+    }
+
+    /**
+     * @return array{
+     *     0: array<string, string>,
+     *     1: array<string, string>,
+     *     2: array<string, string>,
+     *     3: array<string, bool>,
+     *     4: array<string, bool>,
+     *     5: array<string, string>,
+     *     6: array<string, bool>,
+     *     7: array<string, bool>,
+     *     8: array<string, bool>
+     * }
+     */
+    public function getThreadData()
+    {
+        return [
+            $this->files_to_scan,
+            $this->files_to_deep_scan,
+            $this->classes_to_scan,
+            $this->classes_to_deep_scan,
+            $this->store_scan_failure,
+            $this->classlike_files,
+            $this->deep_scanned_classlike_files,
+            $this->scanned_files,
+            $this->reflected_classlikes_lc
+        ];
+    }
+
+    /**
+     * @param array{
+     *     0: array<string, string>,
+     *     1: array<string, string>,
+     *     2: array<string, string>,
+     *     3: array<string, bool>,
+     *     4: array<string, bool>,
+     *     5: array<string, string>,
+     *     6: array<string, bool>,
+     *     7: array<string, bool>,
+     *     8: array<string, bool>
+     * } $thread_data
+     *
+     * @return void
+     */
+    public function addThreadData(array $thread_data)
+    {
+        list(
+            $files_to_scan,
+            $files_to_deep_scan,
+            $classes_to_scan,
+            $classes_to_deep_scan,
+            $store_scan_failure,
+            $classlike_files,
+            $deep_scanned_classlike_files,
+            $scanned_files,
+            $reflected_classlikes_lc
+        ) = $thread_data;
+
+        $this->files_to_scan = array_merge($files_to_scan, $this->files_to_scan);
+        $this->files_to_deep_scan = array_merge($files_to_deep_scan, $this->files_to_deep_scan);
+        $this->classes_to_scan = array_merge($classes_to_scan, $this->classes_to_scan);
+        $this->classes_to_deep_scan = array_merge($classes_to_deep_scan, $this->classes_to_deep_scan);
+        $this->store_scan_failure = array_merge($store_scan_failure, $this->store_scan_failure);
+        $this->classlike_files = array_merge($classlike_files, $this->classlike_files);
+        $this->deep_scanned_classlike_files = array_merge(
+            $deep_scanned_classlike_files,
+            $this->deep_scanned_classlike_files
+        );
+        $this->scanned_files = array_merge($scanned_files, $this->scanned_files);
+        $this->reflected_classlikes_lc = array_merge($reflected_classlikes_lc, $this->reflected_classlikes_lc);
+    }
+
+    /**
+     * @return void
+     */
+    public function isForked()
+    {
+        $this->is_forked = true;
     }
 }

--- a/src/Psalm/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Provider/ClassLikeStorageProvider.php
@@ -85,6 +85,15 @@ class ClassLikeStorageProvider
     }
 
     /**
+     * @param array<string, ClassLikeStorage> $more
+     * @return void
+     */
+    public function addMore(array $more)
+    {
+        self::$storage = array_merge($more, self::$storage);
+    }
+
+    /**
      * @param  string $fq_classlike_name
      *
      * @return ClassLikeStorage

--- a/src/Psalm/Provider/FileStorageProvider.php
+++ b/src/Psalm/Provider/FileStorageProvider.php
@@ -87,6 +87,15 @@ class FileStorageProvider
     }
 
     /**
+     * @param array<string, FileStorage> $more
+     * @return void
+     */
+    public function addMore(array $more)
+    {
+        self::$storage = array_merge($more, self::$storage);
+    }
+
+    /**
      * @param  string $file_path
      *
      * @return FileStorage

--- a/src/Psalm/Provider/StatementsProvider.php
+++ b/src/Psalm/Provider/StatementsProvider.php
@@ -214,11 +214,29 @@ class StatementsProvider
     }
 
     /**
+     * @param array<string, array<string, bool>> $more_changed_members
+     * @return void
+     */
+    public function addChangedMembers(array $more_changed_members)
+    {
+        $this->changed_members = array_merge($more_changed_members, $this->changed_members);
+    }
+
+    /**
      * @return array<string, array<string, bool>>
      */
     public function getUnchangedSignatureMembers()
     {
         return $this->unchanged_signature_members;
+    }
+
+    /**
+     * @param array<string, array<string, bool>> $more_unchanged_members
+     * @return void
+     */
+    public function addUnchangedSignatureMembers(array $more_unchanged_members)
+    {
+        $this->unchanged_signature_members = array_merge($more_unchanged_members, $this->unchanged_signature_members);
     }
 
     /**
@@ -238,6 +256,15 @@ class StatementsProvider
     public function getDiffMap()
     {
         return $this->diff_map;
+    }
+
+    /**
+     * @param array<string, array<int, array{0: int, 1: int, 2: int, 3: int}>> $diff_map
+     * @return void
+     */
+    public function addDiffMap(array $diff_map)
+    {
+        $this->diff_map = array_merge($diff_map, $this->diff_map);
     }
 
     /**

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -63,6 +63,10 @@ class IncludeTest extends TestCase
         array $files_to_check,
         $error_message
     ) {
+        if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
+            $this->markTestSkipped();
+        }
+
         $codebase = $this->project_checker->getCodebase();
 
         foreach ($files as $file_path => $contents) {
@@ -680,7 +684,7 @@ class IncludeTest extends TestCase
                 ],
                 'error_message' => 'InvalidReturnType',
             ],
-            'noHoistConstants' => [
+            'SKIPPED-noHoistConstants' => [
                 'files' => [
                     getcwd() . DIRECTORY_SEPARATOR . 'file1.php' => '<?php
                         require_once("file2.php");',


### PR DESCRIPTION
This makes Psalm's scanning step faster by scanning files (parsing if necessary and crawling the AST to find relevant info) in separate processes.

The main aim is to reduce cold-start times when running a language server (coming soon), but it also benefits cold start times and from-cache start times when running Psalm with the `--threads=X` option.

It'll use threads to scan if the number of files in any single batch exceeds 512. I did this to cut down on the number of forks, as each fork incurs a cost both at the creation of the thread and then aggregating the information afterwards.

Scanning Vimeo's codebase with 10 threads (analysis time not included)
 - Before: **144s** cold, **28s** from cache
 - After: **53s** cold, **19s** from cache