### PR TITLE
Add barriers between caches

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -32,7 +32,6 @@
         <xs:attribute name="strictBinaryOperands" type="xs:string" />
         <xs:attribute name="requireVoidReturnType" type="xs:string" />
         <xs:attribute name="useAssertForType" type="xs:string" />
-        <xs:attribute name="cacheFileContentHashes" type="xs:string" />
         <xs:attribute name="rememberPropertyAssignmentsAfterCall" type="xs:string" />
         <xs:attribute name="serializer" type="xs:string" />
         <xs:attribute name="allowPhpStormGenerics" type="xs:string" />

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -81,6 +81,13 @@ class Config
     public $cache_directory;
 
     /**
+     * The directory to store all Psalm project caches
+     *
+     * @var string
+     */
+    public $global_cache_directory;
+
+    /**
      * Path to the autoader
      *
      * @var string|null
@@ -138,11 +145,6 @@ class Config
      * @var array<int, string>
      */
     private $stub_files = [];
-
-    /**
-     * @var bool
-     */
-    public $cache_file_hashes_during_run = true;
 
     /**
      * @var bool
@@ -481,6 +483,10 @@ class Config
             $config->cache_directory = sys_get_temp_dir() . '/psalm';
         }
 
+        $config->global_cache_directory = $config->cache_directory;
+
+        $config->cache_directory .= DIRECTORY_SEPARATOR . sha1($base_dir);
+
         if (@mkdir($config->cache_directory, 0777, true) === false && is_dir($config->cache_directory) === false) {
             trigger_error('Could not create cache directory: ' . $config->cache_directory, E_USER_ERROR);
         }
@@ -508,11 +514,6 @@ class Config
         if (isset($config_xml['useAssertForType'])) {
             $attribute_text = (string) $config_xml['useAssertForType'];
             $config->use_assert_for_type = $attribute_text === 'true' || $attribute_text === '1';
-        }
-
-        if (isset($config_xml['cacheFileContentHashes'])) {
-            $attribute_text = (string) $config_xml['cacheFileContentHashes'];
-            $config->cache_file_hashes_during_run = $attribute_text === 'true' || $attribute_text === '1';
         }
 
         if (isset($config_xml['rememberPropertyAssignmentsAfterCall'])) {
@@ -1109,6 +1110,14 @@ class Config
     public function getCacheDirectory()
     {
         return $this->cache_directory;
+    }
+
+    /**
+     * @return string
+     */
+    public function getGlobalCacheDirectory()
+    {
+        return $this->global_cache_directory;
     }
 
     /**

--- a/src/Psalm/Provider/StatementsProvider.php
+++ b/src/Psalm/Provider/StatementsProvider.php
@@ -13,7 +13,7 @@ class StatementsProvider
     /**
      * @var ?ParserCacheProvider
      */
-    private $parser_cache_provider;
+    public $parser_cache_provider;
 
     /**
      * @var int

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -20,6 +20,7 @@ $valid_short_options = [
 
 $valid_long_options = [
     'clear-cache',
+    'clear-global-cache',
     'config:',
     'debug',
     'debug-by-line',
@@ -169,7 +170,10 @@ Options:
         (Currently supported format: ".json", ".xml", ".txt")
 
     --clear-cache
-        Clears all cache files that Psalm uses
+        Clears all cache files that Psalm uses for this specific project
+
+    --clear-global-cache
+        Clears all cache files that Psalm uses for all projects
 
     --no-cache
         Runs Psalm without using cache
@@ -383,6 +387,14 @@ if (isset($options['clear-cache'])) {
 
     Config::removeCacheDirectory($cache_directory);
     echo 'Cache directory deleted' . PHP_EOL;
+    exit;
+}
+
+if (isset($options['clear-global-cache'])) {
+    $cache_directory = $config->getGlobalCacheDirectory();
+
+    Config::removeCacheDirectory($cache_directory);
+    echo 'Global cache directory deleted' . PHP_EOL;
     exit;
 }
 


### PR DESCRIPTION
In https://github.com/vimeo/psalm/pull/1019 I gave these metrics for scanning Vimeo's codebase before and after adding threading to the scanning stage:
> Before: 144s cold, 28s from cache
> After: 53s cold, 19s from cache

In those above tests we used a specific config flag that forces Psalm to read from file a dictionary every time it scans a file, and to rewrite that dictionary to cache to avoid conflicts when running Psalm simultaneously on the same machine, analysing two different versions of Vimeo's codebase.

That config flag (`cacheFileContentHashes`) was a bit of a hack.

This PR introduces a more robust system that partitions the cache Psalm uses into different folders that change depending the project being scanned, so a Psalm run will never pollute another project's cache.

It also speeds up running Psalm on Vimeo's codebase:

Before: **53s** cold, **19s** from cache
After: **34s** cold, **12s** from cache