### PR TITLE
Don't choke on non-existing composer.lock

### DIFF
--- a/src/Psalm/PluginManager/PluginListFactory.php
+++ b/src/Psalm/PluginManager/PluginListFactory.php
@@ -5,8 +5,17 @@ class PluginListFactory
 {
     public function __invoke(string $current_dir, string $config_file_path = null): PluginList
     {
+        $stub_composer_lock = (object)[
+            "packages" => [],
+            "packages-dev" => [],
+        ];
+
         $config_file = new ConfigFile($current_dir, $config_file_path);
-        $composer_lock = new ComposerLock('composer.lock');
+        $lock_file = is_readable('composer.lock') ?
+            'composer.lock' :
+            'data:application/json,' . urlencode(json_encode($stub_composer_lock));
+
+        $composer_lock = new ComposerLock($lock_file);
         return new PluginList($config_file, $composer_lock);
     }
 }


### PR DESCRIPTION
It's useful to see enabled plugins and be able to disable them even if no composer files are found.