### PR TITLE
Fix usage of substr_count($haystack, $needle)

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1075,7 +1075,7 @@ class Codebase
     {
         $file_contents = substr($file_contents, 0, $offset);
         return new Position(
-            substr_count("\n", $file_contents),
+            substr_count($file_contents, "\n"),
             $offset - (int)strrpos($file_contents, "\n", strlen($file_contents))
         );
     }


### PR DESCRIPTION
Detected via a check that literals and variables occur in the most
typical order for a global function.

See http://php.net/manual/en/function.substr-count.php#refsect1-function.substr-count-examples