### PR TITLE
Addition of a new "compact" output format

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -133,6 +133,7 @@ class ProjectAnalyzer
      */
     public $onchange_line_limit;
 
+    const TYPE_COMPACT = 'compact';
     const TYPE_CONSOLE = 'console';
     const TYPE_PYLINT = 'pylint';
     const TYPE_JSON = 'json';
@@ -140,6 +141,7 @@ class ProjectAnalyzer
     const TYPE_XML = 'xml';
 
     const SUPPORTED_OUTPUT_TYPES = [
+        self::TYPE_COMPACT,
         self::TYPE_CONSOLE,
         self::TYPE_PYLINT,
         self::TYPE_JSON,

--- a/src/Psalm/Output.php
+++ b/src/Psalm/Output.php
@@ -1,0 +1,42 @@
+<?php
+namespace Psalm;
+
+abstract class Output
+{
+    /**
+     * @var array<int, array{severity: string, line_from: int, line_to: int, type: string, message: string,
+     * file_name: string, file_path: string, snippet: string, from: int, to: int,
+     * snippet_from: int, snippet_to: int, column_from: int, column_to: int, selected_text: string}>
+     */
+    protected $issues_data;
+
+    /** @var bool */
+    protected $use_color;
+
+    /** @var bool */
+    protected $show_snippet;
+
+    /** @var bool */
+    protected $show_info;
+
+    /**
+     * @param array<int, array{severity: string, line_from: int, line_to: int, type: string, message: string,
+     *  file_name: string, file_path: string, snippet: string, from: int, to: int,
+     *  snippet_from: int, snippet_to: int, column_from: int, column_to: int, selected_text: string}> $issues_data
+     * @param bool $use_color
+     * @param bool $show_snippet
+     * @param bool $show_info
+     */
+    public function __construct(array $issues_data, bool $use_color, bool $show_snippet = true, bool $show_info = true)
+    {
+        $this->issues_data = $issues_data;
+        $this->use_color = $use_color;
+        $this->show_snippet = $show_snippet;
+        $this->show_info = $show_info;
+    }
+
+    /**
+     * @return string
+     */
+    abstract public function create(): string;
+}

--- a/src/Psalm/Output/Compact.php
+++ b/src/Psalm/Output/Compact.php
@@ -38,7 +38,6 @@ class Compact extends Output
 
                 $buffer = new BufferedOutput();
                 $table = new Table($buffer);
-                $table->setColumnMaxWidth(3, 70);
                 $table->setHeaders(['SEVERITY', 'LINE', 'ISSUE', 'DESCRIPTION']);
             }
 
@@ -49,11 +48,18 @@ class Compact extends Output
                 $severity = strtoupper($issue_data['severity']);
             }
 
+            // Since `Table::setColumnMaxWidth` is only available in symfony/console 4.2+ we need do something similar
+            // so we have clean tables.
+            $message = $issue_data['message'];
+            if (strlen($message) > 70) {
+                $message = implode("\n", str_split($message, 70));
+            }
+
             $table->addRow([
                 $severity,
                 $issue_data['line_from'],
                 $issue_data['type'],
-                $issue_data['message']
+                $message
             ]);
 
             $current_file = $issue_data['file_name'];

--- a/src/Psalm/Output/Compact.php
+++ b/src/Psalm/Output/Compact.php
@@ -1,0 +1,70 @@
+<?php
+namespace Psalm\Output;
+
+use Psalm\Config;
+use Psalm\Output;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class Compact extends Output
+{
+    /**
+     * {{@inheritdoc}}
+     * @psalm-suppress PossiblyNullReference
+     */
+    public function create(): string
+    {
+        /** @var BufferedOutput|null $buffer */
+        $buffer = null;
+
+        /** @var Table|null $table */
+        $table = null;
+
+        /** @var string|null $current_file */
+        $current_file = null;
+
+        $output = [];
+        foreach ($this->issues_data as $i => $issue_data) {
+            if (!$this->show_info && $issue_data['severity'] === Config::REPORT_INFO) {
+                continue;
+            } elseif (is_null($current_file) || $current_file !== $issue_data['file_name']) {
+                // If we're processing a new file, then wrap up the last table and render it out.
+                if ($buffer !== null) {
+                    $table->render();
+                    $output[] = $buffer->fetch();
+                }
+
+                $output[] = 'FILE: ' . $issue_data['file_name'] . "\n";
+
+                $buffer = new BufferedOutput();
+                $table = new Table($buffer);
+                $table->setColumnMaxWidth(3, 70);
+                $table->setHeaders(['SEVERITY', 'LINE', 'ISSUE', 'DESCRIPTION']);
+            }
+
+            $is_error = $issue_data['severity'] === Config::REPORT_ERROR;
+            if ($is_error) {
+                $severity = ($this->use_color ? "\e[0;31mERROR\e[0m" : 'ERROR');
+            } else {
+                $severity = strtoupper($issue_data['severity']);
+            }
+
+            $table->addRow([
+                $severity,
+                $issue_data['line_from'],
+                $issue_data['type'],
+                $issue_data['message']
+            ]);
+
+            $current_file = $issue_data['file_name'];
+
+            // If we're at the end of the issue sets, then wrap up the last table and render it out.
+            if ($i === count($this->issues_data) - 1) {
+                $table->render();
+                $output[] = $buffer->fetch();
+            }
+        }
+
+        return implode("\n", $output);
+    }
+}

--- a/src/Psalm/Output/Console.php
+++ b/src/Psalm/Output/Console.php
@@ -1,0 +1,65 @@
+<?php
+namespace Psalm\Output;
+
+use Psalm\Config;
+use Psalm\Output;
+
+class Console extends Output
+{
+    /**
+     * {{@inheritdoc}}
+     */
+    public function create(): string
+    {
+        $output = '';
+        foreach ($this->issues_data as $issue_data) {
+            if (!$this->show_info && $issue_data['severity'] === Config::REPORT_INFO) {
+                continue;
+            }
+
+            $output .= $this->format($issue_data) . "\n" . "\n";
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param  array{severity: string, line_from: int, line_to: int, type: string, message: string,
+     *  file_name: string, file_path: string, snippet: string, from: int, to: int,
+     *  snippet_from: int, snippet_to: int, column_from: int, column_to: int} $issue_data
+     *
+     * @return string
+     */
+    private function format(array $issue_data): string
+    {
+        $issue_string = '';
+
+        $is_error = $issue_data['severity'] === Config::REPORT_ERROR;
+
+        if ($is_error) {
+            $issue_string .= ($this->use_color ? "\e[0;31mERROR\e[0m" : 'ERROR');
+        } else {
+            $issue_string .= 'INFO';
+        }
+
+        $issue_string .= ': ' . $issue_data['type'] . ' - ' . $issue_data['file_name'] . ':' .
+            $issue_data['line_from'] . ':' . $issue_data['column_from'] . ' - ' . $issue_data['message'] . "\n";
+
+        if ($this->show_snippet) {
+            $snippet = $issue_data['snippet'];
+
+            if (!$this->use_color) {
+                $issue_string .= $snippet;
+            } else {
+                $selection_start = $issue_data['from'] - $issue_data['snippet_from'];
+                $selection_length = $issue_data['to'] - $issue_data['from'];
+
+                $issue_string .= substr($snippet, 0, $selection_start)
+                    . ($is_error ? "\e[97;41m" : "\e[30;47m") . substr($snippet, $selection_start, $selection_length)
+                    . "\e[0m" . substr($snippet, $selection_length + $selection_start) . "\n";
+            }
+        }
+
+        return $issue_string;
+    }
+}

--- a/src/Psalm/Output/Emacs.php
+++ b/src/Psalm/Output/Emacs.php
@@ -1,0 +1,28 @@
+<?php
+namespace Psalm\Output;
+
+use Psalm\Config;
+use Psalm\Output;
+
+class Emacs extends Output
+{
+    /**
+     * {{@inheritdoc}}
+     */
+    public function create(): string
+    {
+        $output = '';
+        foreach ($this->issues_data as $issue_data) {
+            $output .= sprintf(
+                '%s:%s:%s:%s - %s',
+                $issue_data['file_path'],
+                $issue_data['line_from'],
+                $issue_data['column_from'],
+                ($issue_data['severity'] === Config::REPORT_ERROR ? 'error' : 'warning'),
+                $issue_data['message']
+            ) . "\n";
+        }
+
+        return $output;
+    }
+}

--- a/src/Psalm/Output/Json.php
+++ b/src/Psalm/Output/Json.php
@@ -1,0 +1,15 @@
+<?php
+namespace Psalm\Output;
+
+use Psalm\Output;
+
+class Json extends Output
+{
+    /**
+     * {{@inheritdoc}}
+     */
+    public function create(): string
+    {
+        return json_encode($this->issues_data) . "\n";
+    }
+}

--- a/src/Psalm/Output/Pylint.php
+++ b/src/Psalm/Output/Pylint.php
@@ -1,0 +1,57 @@
+<?php
+namespace Psalm\Output;
+
+use Psalm\Config;
+use Psalm\Output;
+
+class Pylint extends Output
+{
+    /**
+     * {{@inheritdoc}}
+     */
+    public function create(): string
+    {
+        $output = '';
+        foreach ($this->issues_data as $issue_data) {
+            $output .= $this->format($issue_data) . "\n";
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param  array{severity: string, line_from: int, line_to: int, type: string, message: string,
+     *  file_name: string, file_path: string, snippet: string, from: int, to: int,
+     *  snippet_from: int, snippet_to: int, column_from: int, column_to: int} $issue_data
+     *
+     * @return string
+     */
+    private function format(array $issue_data): string
+    {
+        $message = sprintf(
+            '%s: %s',
+            $issue_data['type'],
+            $issue_data['message']
+        );
+
+        if ($issue_data['severity'] === Config::REPORT_ERROR) {
+            $code = 'E0001';
+        } else {
+            $code = 'W0001';
+        }
+
+        // https://docs.pylint.org/en/1.6.0/output.html doesn't mention what to do about 'column',
+        // but it's still useful for users.
+        // E.g. jenkins can't parse %s:%d:%d.
+        $message = sprintf('%s (column %d)', $message, $issue_data['column_from']);
+        $issue_string = sprintf(
+            '%s:%d: [%s] %s',
+            $issue_data['file_name'],
+            $issue_data['line_from'],
+            $code,
+            $message
+        );
+
+        return $issue_string;
+    }
+}

--- a/src/Psalm/Output/Xml.php
+++ b/src/Psalm/Output/Xml.php
@@ -1,0 +1,18 @@
+<?php
+namespace Psalm\Output;
+
+use LSS\Array2XML;
+use Psalm\Output;
+
+class Xml extends Output
+{
+    /**
+     * {{@inheritdoc}}
+     */
+    public function create(): string
+    {
+        $xml = Array2XML::createXML('report', ['item' => $this->issues_data]);
+
+        return $xml->saveXML();
+    }
+}

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -162,7 +162,7 @@ Options:
         Only checks methods that have changed (and their dependents)
 
     --output-format=console
-        Changes the output format. Possible values: console, emacs, json, pylint, xml
+        Changes the output format. Possible values: compact, console, emacs, json, pylint, xml
 
     --find-dead-code
         Look for dead code

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -85,7 +85,10 @@ class ReportOutputTest extends TestCase
         );
     }
 
-    public function testGetOutputForGetPsalmDotOrg(): void
+    /**
+     * @return void
+     */
+    public function testGetOutputForGetPsalmDotOrg()
     {
         $file_contents = '<?php
 function psalmCanVerify(int $your_code): ?string {


### PR DESCRIPTION
I've slightly refactored the output formatting system so that it's easier to add new formats, or maintain existing ones, while also adding a new `compact` format. This new format returns your report within a table structure similar to PHPCS.

Example:

```
$ ./psalm --find-dead-code --output-format=compact
FILE: src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php

+----------+------+----------------+------------------------------------------------------------------------+
| SEVERITY | LINE | ISSUE          | DESCRIPTION                                                            |
+----------+------+----------------+------------------------------------------------------------------------+
| INFO     | 63   | UnusedProperty | Property Psalm\Internal\FileManipulation\FunctionDocblockManipulator:: |
|          |      |                | $param_typehint_area_starts is never used                              |
| INFO     | 66   | UnusedProperty | Property Psalm\Internal\FileManipulation\FunctionDocblockManipulator:: |
|          |      |                | $param_typehint_starts is never used                                   |
| INFO     | 69   | UnusedProperty | Property Psalm\Internal\FileManipulation\FunctionDocblockManipulator:: |
|          |      |                | $param_typehint_ends is never used                                     |
+----------+------+----------------+------------------------------------------------------------------------+

FILE: src/Psalm/Type/Atomic/TNonEmptyArray.php

+----------+------+------------------------+------------------------------------------------------------------------+
| SEVERITY | LINE | ISSUE                  | DESCRIPTION                                                            |
+----------+------+------------------------+------------------------------------------------------------------------+
| INFO     | 20   | PossiblyUnusedProperty | Cannot find uses of public property Psalm\Type\Atomic\TNonEmptyArray:: |
|          |      |                        | $value                                                                 |
+----------+------+------------------------+------------------------------------------------------------------------+
```

It also, like the default `console` format, supports colors if errors are present:

![screen shot 2018-12-09 at 3 54 11 pm](https://user-images.githubusercontent.com/33762/49702803-b5fca880-fbca-11e8-9812-2c3ccabbdf4e.png)

Resolves #967