### PR TITLE
UPDATE add issue type to text output

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -139,6 +139,7 @@ class ProjectAnalyzer
     const TYPE_JSON = 'json';
     const TYPE_EMACS = 'emacs';
     const TYPE_XML = 'xml';
+    const TYPE_TEXT = 'text';
 
     const SUPPORTED_OUTPUT_TYPES = [
         self::TYPE_COMPACT,
@@ -147,6 +148,7 @@ class ProjectAnalyzer
         self::TYPE_JSON,
         self::TYPE_EMACS,
         self::TYPE_XML,
+        self::TYPE_TEXT,
     ];
 
     /**
@@ -200,7 +202,7 @@ class ProjectAnalyzer
             $mapping = [
                 '.xml' => self::TYPE_XML,
                 '.json' => self::TYPE_JSON,
-                '.txt' => self::TYPE_EMACS,
+                '.txt' => self::TYPE_TEXT,
                 '.emacs' => self::TYPE_EMACS,
                 '.pylint' => self::TYPE_PYLINT,
             ];

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -11,6 +11,7 @@ use Psalm\Output\Console;
 use Psalm\Output\Emacs;
 use Psalm\Output\Json;
 use Psalm\Output\Pylint;
+use Psalm\Output\Text;
 use Psalm\Output\Xml;
 
 class IssueBuffer
@@ -389,6 +390,10 @@ class IssueBuffer
 
             case ProjectAnalyzer::TYPE_EMACS:
                 $output = new Emacs(self::$issues_data, $use_color, $show_snippet, $show_info);
+                break;
+
+            case ProjectAnalyzer::TYPE_TEXT:
+                $output = new Text(self::$issues_data, $use_color, $show_snippet, $show_info);
                 break;
 
             case ProjectAnalyzer::TYPE_JSON:

--- a/src/Psalm/Output/Text.php
+++ b/src/Psalm/Output/Text.php
@@ -1,0 +1,29 @@
+<?php
+namespace Psalm\Output;
+
+use Psalm\Config;
+use Psalm\Output;
+
+class Text extends Output
+{
+    /**
+     * {{@inheritdoc}}
+     */
+    public function create(): string
+    {
+        $output = null;
+        foreach ($this->issues_data as $issue_data) {
+            $output .= sprintf(
+                '%s:%s:%s:%s - %s: %s',
+                $issue_data['file_path'],
+                $issue_data['line_from'],
+                $issue_data['column_from'],
+                ($issue_data['severity'] === Config::REPORT_ERROR ? 'error' : 'warning'),
+                $issue_data['type'],
+                $issue_data['message']
+            ) . "\n";
+        }
+
+        return $output;
+    }
+}


### PR DESCRIPTION
Adds issue type to text output. Leaves .emacs output as before.

Possible solution to issue https://github.com/vimeo/psalm/issues/1138