### PR TITLE
:bug: Fix --plugin option handling for psalter

### DIFF
--- a/src/psalter.php
+++ b/src/psalter.php
@@ -183,7 +183,7 @@ if (isset($options['plugin'])) {
 
 /** @var string $plugin_path */
 foreach ($plugins as $plugin_path) {
-    Config::getInstance()->addPluginPath($current_dir . DIRECTORY_SEPARATOR . $plugin_path);
+    Config::getInstance()->addPluginPath($current_dir . $plugin_path);
 }
 
 $project_analyzer->alterCodeAfterCompletion(


### PR DESCRIPTION
`$current_dir` already followed by `DIRECTORY_SEPARATOR`