### PR TITLE
CI improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,12 @@ jobs:
       install:
         - composer $DEFAULT_COMPOSER_FLAGS update
         - composer require --dev php-coveralls/php-coveralls
+        - mkdir -p build
+      before_script:
+        - vendor/bin/phpunit --dump-xdebug-filter build/xdebug-filter.php
+      script:
+        - vendor/bin/phpunit --prepend build/xdebug-filter.php
+        - ./psalm --find-dead-code
       after_success:
         - travis_retry php vendor/bin/php-coveralls -v
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
   - nightly
 
 env:
@@ -50,14 +51,14 @@ matrix:
   allow_failures:
     - php: nightly
   exclude: # covered in Code coverage stage
-    - php: 7.2
+    - php: 7.3
       env: DEPS="high"
 
 # Additional stages
 jobs:
   include:
     - stage: Code coverage analysis
-      php: 7.2
+      php: 7.3
       # don't disable xdebug here
       env: XDEBUG="true"
       install:
@@ -67,7 +68,7 @@ jobs:
         - travis_retry php vendor/bin/php-coveralls -v
 
     - stage: Code style analysis
-      php: 7.2
+      php: 7.3
       env: DEPS="high"
       script:
         - vendor/bin/phpcs


### PR DESCRIPTION
## Enable PHP 7.3 builds
Now that PHP 7.3 is released `nightly` points to `7.4-dev`, so Psalm was lacking proper 7.3 builds

## Speed up code coverage job runs
Using technique from [article by Sebastian Bergmann and Sebastian Heuer](https://thephp.cc/news/2019/01/faster-code-coverage) code coverage job runs are now ~30% faster (compare https://travis-ci.com/weirdan/psalm/builds/97308745 vs https://travis-ci.org/vimeo/psalm/builds/479228801) 