### PR TITLE
Tweak error message

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -507,7 +507,7 @@ class Config
             $autoloader_path = $config->base_dir . DIRECTORY_SEPARATOR . $config_xml['autoloader'];
 
             if (!file_exists($autoloader_path)) {
-                throw new ConfigException('Cannot locate config schema');
+                throw new ConfigException('Cannot locate autoloader');
             }
 
             $config->autoloader = realpath($autoloader_path);


### PR DESCRIPTION
got this error, looked at

https://github.com/vimeo/psalm/blob/90dc39c29651a7cc20bc8ff594ce1ea5d10a5f8b/src/Psalm/Config.php#L441-L445

ended up debugging a global PHAR to see if its config.xsd was missing, etc.

finally installed psalm locally, and figured out my autoloader path was wrong :joy: 