### PR TITLE
Fixes #1222 - incorrect config value used for `allowStringToStandInForClass`

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -570,7 +570,7 @@ class Config
         }
 
         if (isset($config_xml['allowStringToStandInForClass'])) {
-            $attribute_text = (string) $config_xml['allowCoercionFromStringToClassConst'];
+            $attribute_text = (string) $config_xml['allowStringToStandInForClass'];
             $config->allow_string_standin_for_class = $attribute_text === 'true' || $attribute_text === '1';
         }
 


### PR DESCRIPTION
Fixes #1222

Please make attention, that `allowCoercionFromStringToClassConst` are mentioned in docs, but not used now in config