### PR TITLE
Use lowercase nikic/php-parser for composer 2.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "nikic/PHP-Parser": "^4.0.2 || ^4.1",
+        "nikic/php-parser": "^4.0.2 || ^4.1",
         "openlss/lib-array2xml": "^0.0.10||^0.5.1",
         "muglug/package-versions-56": "1.2.4",
         "php-cs-fixer/diff": "^1.2",


### PR DESCRIPTION
Seen in composer 1.8.3:

> Deprecation warning: require.nikic/PHP-Parser is invalid, it should not
> contain uppercase characters. Please use nikic/php-parser instead. Make
> sure you fix this as Composer 2.0 will error.