### PR TITLE
Fix/array chunk type hinting

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
@@ -146,3 +146,11 @@ function usort(array &$arr, callable $callback): bool {}
  */
 function array_change_key_case(array $arr, int $case = CASE_LOWER) {}
 
+/**
+ * @psalm-template T
+ *
+ * @param array<array-key, T> $arr
+ *
+ * @return array<int, array<array-key, T>>
+ */
+function array_chunk(array $arr, int $size, bool $preserve_keys = false) {}

--- a/tests/Loop/ForeachTest.php
+++ b/tests/Loop/ForeachTest.php
@@ -831,6 +831,21 @@ class ForeachTest extends \Psalm\Tests\TestCase
                         foreach ($list as $item) {}
                     }'
             ],
+            'loopOverArrayChunk' => [
+                '<?php
+                    /**
+                    * @return array<int, array{0:int, 1:int}>
+                    */
+                    function Foo(int $a, int $b, int ...$ints) : array {
+                      array_unshift($ints, $a, $b);
+
+                      return array_chunk($ints, 2);
+                    }
+
+                    foreach(Foo(1, 2, 3, 4, 5) as $ints) {
+                      echo $ints[0], ", ", ($ints[1] ?? "n/a"), "\n";
+                    }'
+            ],
         ];
     }
 

--- a/tests/Loop/ForeachTest.php
+++ b/tests/Loop/ForeachTest.php
@@ -834,7 +834,7 @@ class ForeachTest extends \Psalm\Tests\TestCase
             'loopOverArrayChunk' => [
                 '<?php
                     /**
-                    * @return array<int, array{0:int, 1:int}>
+                    * @return array<int, array<array-key, int>>
                     */
                     function Foo(int $a, int $b, int ...$ints) : array {
                       array_unshift($ints, $a, $b);


### PR DESCRIPTION
had to change the type-hinting in d5f2e06 because I'm unsure how to type-hint that the size of the inner `array<array-key, T>` is dependant upon param `$size` :s