### PR TITLE
HashContext is only implemented in `php:>=7.2`

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
@@ -154,3 +154,9 @@ function array_change_key_case(array $arr, int $case = CASE_LOWER) {}
  * @return array<int, array<array-key, T>>
  */
 function array_chunk(array $arr, int $size, bool $preserve_keys = false) {}
+
+
+/**
+* @param resource|HashContext
+*/
+function hash_update($hash, string $data) : bool {}


### PR DESCRIPTION
hash_init() is detected as returning `resource|HashContext`, but `hash_update()` is currently detected as only accepting `HashContext`.

* https://getpsalm.org/r/a27717736e
* using 69d4407

```php
<?php
$hash = hash_init('sha256');

hash_update($hash, 'foo');
```