### PR TITLE
Show total fixed errors when updating baseline

### DIFF
--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -6,6 +6,27 @@ use Psalm\Internal\Provider\FileProvider;
 class ErrorBaseline
 {
     /**
+     * @param array<string,array<string,array{o:int, s:array<int, string>}>> $existingIssues
+     * @return int
+     */
+    public static function countTotalIssues(array $existingIssues)
+    {
+        $totalIssues = 0;
+
+        foreach ($existingIssues as $existingIssue) {
+            $totalIssues += array_reduce(
+                $existingIssue,
+                function (int $carry, array $existingIssue): int {
+                    return $carry + (int)$existingIssue['o'];
+                },
+                0
+            );
+        }
+
+        return $totalIssues;
+    }
+
+    /**
      * @param FileProvider $fileProvider
      * @param string $baselineFile
      * @param array<array{file_name: string, type: string, severity: string, selected_text: string}> $issues

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -573,11 +573,25 @@ if (isset($options['update-baseline'])) {
     }
 
     try {
+        $issue_current_baseline = ErrorBaseline::read(
+            new \Psalm\Internal\Provider\FileProvider,
+            (string)Config::getInstance()->error_baseline
+        );
+        $total_issues_current_baseline = ErrorBaseline::countTotalIssues($issue_current_baseline);
+
         $issue_baseline = ErrorBaseline::update(
             new \Psalm\Internal\Provider\FileProvider,
             $baselineFile,
             IssueBuffer::getIssuesData()
         );
+        $total_issues_updated_baseline = ErrorBaseline::countTotalIssues($issue_baseline);
+
+        $total_fixed_issues = $total_issues_current_baseline - $total_issues_updated_baseline;
+
+        if ($total_fixed_issues > 0) {
+            echo str_repeat('-', 30) . "\n";
+            echo $total_fixed_issues . ' errors fixed' . "\n";
+        }
     } catch (\Psalm\Exception\ConfigException $exception) {
         die('Could not update baseline file: ' . $exception->getMessage());
     }

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -575,7 +575,7 @@ if (isset($options['update-baseline'])) {
     try {
         $issue_current_baseline = ErrorBaseline::read(
             new \Psalm\Internal\Provider\FileProvider,
-            (string)Config::getInstance()->error_baseline
+            $baselineFile
         );
         $total_issues_current_baseline = ErrorBaseline::countTotalIssues($issue_current_baseline);
 

--- a/tests/ErrorBaselineTest.php
+++ b/tests/ErrorBaselineTest.php
@@ -100,6 +100,26 @@ class ErrorBaselineTest extends TestCase
     /**
      * @return void
      */
+    public function testCountTotalIssuesShouldReturnCorrectNumber()
+    {
+        $existingIssues = [
+            'sample/sample-file.php' => [
+                'MixedAssignment' => ['o' => 2, 's' => ['bar']],
+                'MixedOperand' => ['o' => 2, 's' => []],
+            ],
+            'sample/sample-file2.php' => [
+                'TypeCoercion' => ['o' => 1, 's' => []],
+            ],
+        ];
+
+        $totalIssues = ErrorBaseline::countTotalIssues($existingIssues);
+
+        $this->assertEquals($totalIssues, 5);
+    }
+
+    /**
+     * @return void
+     */
     public function testCreateShouldAggregateIssuesPerFile()
     {
         $baselineFile = 'baseline.xml';


### PR DESCRIPTION
This PR adds a "total errors fixed" in the output report, every time Psalm runs with the flag --update-baseline, so then it's possible to check the number of errors that were removed from the codebase, comparing the current baseline against the updated one. 

We use Psalm in one of our projects at work, and we are having sessions every two weeks in order to reduce and eventually, fix **all** the errors Psalm found in our codebase, for this reason, it would be great (and motivating) to easily see the amount of errors removed by our changes, whenever we update our baseline. 

Feedback is very welcome :) 