### PR TITLE
Allow @psalm-template for classes

### DIFF
--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -535,8 +535,11 @@ class CommentAnalyzer
 
         $info = new ClassLikeDocblockComment();
 
-        if (isset($comments['specials']['template'])) {
-            foreach ($comments['specials']['template'] as $template_line) {
+        if (isset($comments['specials']['template']) || isset($comments['specials']['psalm-template'])) {
+            $all_templates = (isset($comments['specials']['template']) ? $comments['specials']['template'] : [])
+                + (isset($comments['specials']['psalm-template']) ? $comments['specials']['psalm-template'] : []);
+
+            foreach ($all_templates as $template_line) {
                 $template_type = preg_split('/[\s]+/', $template_line);
 
                 if (count($template_type) > 2

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -251,7 +251,7 @@ class TemplateTest extends TestCase
 
                     bar(foo("string"));',
             ],
-            'validPsalmTemplatedType' => [
+            'validPsalmTemplatedFunctionType' => [
                 '<?php
                     namespace FooFoo;
 
@@ -267,6 +267,23 @@ class TemplateTest extends TestCase
                     function bar(string $a): void { }
 
                     bar(foo("string"));',
+            ],
+            'validPsalmTemplatedClassType' => [
+                '<?php
+                    class A {}
+
+                    /**
+                     * @psalm-template T
+                     */
+                    class Foo {
+                        /**
+                         * @param T $x
+                         */
+                        public function bar($x): void { }
+                    }
+
+                    $afoo = new Foo();
+                    $afoo->bar(new A());',
             ],
             'validTemplatedStaticMethodType' => [
                 '<?php


### PR DESCRIPTION
`@psalm-template` can be used on functions but not classes.