### PR TITLE
Enable PHP 7.4snapshot on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
 
 env:
   matrix:


### PR DESCRIPTION
Now that nightly is 8.x, Psalm can continue to be tested with 7.4 branch.