### PR TITLE
docs index tweaks

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -5,8 +5,9 @@
 - [Introduction](#introduction)
 - [Installation](installation.md)
 - [Configuration](configuration.md)
-- [Running Psalm via command line](running_psalm.md)
-- [Running Psalm in your IDE](language_server.md)
+- Using Psalm
+  - [Running Psalm via command line](running_psalm.md)
+  - [Running Psalm in your IDE](language_server.md)
 - [Using Psalter](fixing_code.md)
 - [Supported Annotations](supported_annotations.md)
 - [Dealing with code issues](dealing_with_code_issues.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,11 +7,15 @@
 - [Configuration](configuration.md)
 - [Running Psalm via command line](running_psalm.md)
 - [Running Psalm in your IDE](language_server.md)
+- [Using Psalter](fixing_code.md)
 - [Supported Annotations](supported_annotations.md)
 - [Dealing with code issues](dealing_with_code_issues.md)
+  - [Issue types](issues.md)
 - [Typing in Psalm](typing_in_psalm.md)
 - [Plugins](plugins.md)
 - [Checking non-PHP files](checking_non_php_files.md)
+- [How Psalm works](how_psalm_works.md)
+  - [Things that make developing Psalm complicated](what_makes_psalm_complicated.md)
 
 ## Introduction
 


### PR DESCRIPTION
There's an additional tweak I didn't want to make on the web interface that possibly merits a little discussion beforehand;

* Templates are a sufficiently useful topic that they'd deserve their own doc file to make them easier to find.
* Are supported annotation types a sub-topic of the topic "Typing in psalm"?
* If there isn't already one, should there be a script to auto-generate the [Builtin templated classes and interfaces](https://github.com/vimeo/psalm/blob/master/docs/supported_annotations.md#builtin-templated-classes-and-interfaces) section?

re:sub-topic:
```markdown
- [Typing in Psalm](typing_in_psalm.md)
  - [Supported Annotations](supported_annotations.md)
```