### PR TITLE
Fix password_hash() return type

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -8972,7 +8972,7 @@ return [
 'parsekit_func_arginfo' => ['array', 'function'=>'mixed'],
 'passthru' => ['void', 'command'=>'string', '&w_return_value='=>'int'],
 'password_get_info' => ['array', 'hash'=>'string'],
-'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'int', 'options='=>'array'],
+'password_hash' => ['string|null', 'password'=>'string', 'algo'=>'int', 'options='=>'array'],
 'password_make_salt' => ['bool', 'password'=>'string', 'hash'=>'string'],
 'password_needs_rehash' => ['bool', 'hash'=>'string', 'algo'=>'int', 'options='=>'array'],
 'password_verify' => ['bool', 'password'=>'string', 'hash'=>'string'],


### PR DESCRIPTION
Revert #1189.

password_hash() returns null on failure: https://bugs.php.net/bug.php?id=77218