### PR TITLE
Fix password_hash change between versions

### DIFF
--- a/src/Psalm/Internal/CallMap_74_delta.php
+++ b/src/Psalm/Internal/CallMap_74_delta.php
@@ -1,0 +1,23 @@
+<?php // phpcs:ignoreFile
+
+/**
+ * This contains the information needed to convert the function signatures for php 7.4 to php 7.3 (and vice versa)
+ *
+ * This has two sections.
+ * The 'new' section contains function/method names from FunctionSignatureMap (And alternates, if applicable) that do not exist in php7.3 or have different signatures in php 7.4.
+ *   If they were just updated, the function/method will be present in the 'added' signatures.
+ * The 'old' signatures contains the signatures that are different in php 7.3.
+ *   Functions are expected to be removed only in major releases of php. (e.g. php 7.0 removed various functions that were deprecated in 5.6)
+ *
+ * @see FunctionSignatureMap.php
+ *
+ * @phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
+ */
+return [
+'new' => [
+    'password_hash' => ['string|null', 'password'=>'string', 'algo'=>'int', 'options='=>'array'],
+],
+'old' => [
+    'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'int', 'options='=>'array'],
+]
+];


### PR DESCRIPTION
The bug given in #1341 was updated. The return type of `password_hash` was changed in 7.4: https://github.com/vimeo/psalm/pull/1341#issuecomment-464414032

Since PHP 7.4 isn't stable yet, you may prefer to close this and change the return type back.