### PR TITLE
Allow suppressing UnusedClass on specific classes

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -664,8 +664,10 @@ class ClassLikes
                     if (IssueBuffer::accepts(
                         new UnusedClass(
                             'Class ' . $classlike_storage->name . ' is never used',
-                            $classlike_storage->location
-                        )
+                            $classlike_storage->location,
+                            $classlike_storage->name
+                        ),
+                        $classlike_storage->suppressed_issues
                     )) {
                         // fall through
                     }

--- a/src/Psalm/Issue/UnusedClass.php
+++ b/src/Psalm/Issue/UnusedClass.php
@@ -1,6 +1,6 @@
 <?php
 namespace Psalm\Issue;
 
-class UnusedClass extends CodeIssue
+class UnusedClass extends ClassIssue
 {
 }


### PR DESCRIPTION
This allows suppressing UnusedClass with either `referencedMethod` or`@psalm-suppress`

Fixes vimeo/psalm#1353