### PR TITLE
Fix define() with a namespace

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -366,14 +366,6 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     }
 
     /**
-     * @return null|string
-     */
-    public function getNamespace()
-    {
-        return $this->source->getNamespace();
-    }
-
-    /**
      * @return array<string, string>
      */
     public function getAliasedClassesFlipped()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -607,10 +607,11 @@ class FunctionCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expressio
                     return false;
                 }
             } elseif ($function->parts === ['define']) {
-                if ($first_arg && $first_arg->value instanceof PhpParser\Node\Scalar\String_) {
+                $const_name = StatementsAnalyzer::getConstName($first_arg->value);
+
+                if ($const_name !== null) {
                     $second_arg = $stmt->args[1];
                     ExpressionAnalyzer::analyze($statements_analyzer, $second_arg->value, $context);
-                    $const_name = $first_arg->value->value;
 
                     $statements_analyzer->setConstType(
                         $const_name,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -607,17 +607,21 @@ class FunctionCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expressio
                     return false;
                 }
             } elseif ($function->parts === ['define']) {
-                $const_name = StatementsAnalyzer::getConstName($first_arg->value);
+                if ($first_arg) {
+                    $const_name = StatementsAnalyzer::getConstName($first_arg->value);
 
-                if ($const_name !== null) {
-                    $second_arg = $stmt->args[1];
-                    ExpressionAnalyzer::analyze($statements_analyzer, $second_arg->value, $context);
+                    if ($const_name !== null) {
+                        $second_arg = $stmt->args[1];
+                        ExpressionAnalyzer::analyze($statements_analyzer, $second_arg->value, $context);
 
-                    $statements_analyzer->setConstType(
-                        $const_name,
-                        isset($second_arg->value->inferredType) ? $second_arg->value->inferredType : Type::getMixed(),
-                        $context
-                    );
+                        $statements_analyzer->setConstType(
+                            $const_name,
+                            isset($second_arg->value->inferredType) ?
+                                $second_arg->value->inferredType :
+                                Type::getMixed(),
+                            $context
+                        );
+                    }
                 } else {
                     $context->check_consts = false;
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -147,12 +147,27 @@ class ExpressionAnalyzer
                     $stmt->inferredType = Type::getLiteralClassString($context->self);
                     break;
 
+                case '__namespace__':
+                    $namespace = $statements_analyzer->getNamespace();
+                    if ($namespace === null &&
+                    IssueBuffer::accepts(
+                        new UndefinedConstant(
+                            'Cannot get __namespace__ outside a namespace',
+                            new CodeLocation($statements_analyzer->getSource(), $stmt)
+                        ),
+                        $statements_analyzer->getSuppressedIssues()
+                    )) {
+                        // fall through
+                    }
+
+                    $stmt->inferredType = Type::getString($namespace);
+                    break;
+
                 case '__file__':
                 case '__dir__':
                 case '__function__':
                 case '__trait__':
                 case '__method__':
-                case '__namespace__':
                     $stmt->inferredType = Type::getString();
                     break;
             }

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -1477,13 +1477,8 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
         if ($first_arg_value instanceof PhpParser\Node\Scalar\String_) {
             $const_name = $first_arg_value->value;
         } elseif (isset($first_arg_value->inferredType)) {
-            $possible_value_types = $first_arg_value->inferredType->getTypes();
-            if (count($possible_value_types) === 1) {
-                reset($possible_value_types);
-                $possible_value_type = current($possible_value_types);
-                if ($possible_value_type instanceof Type\Atomic\TLiteralString) {
-                    $const_name = $possible_value_type->value;
-                }
+            if ($first_arg_value->inferredType->isSingleStringLiteral()) {
+                $const_name = $first_arg_value->inferredType->getSingleStringLiteral()->value;
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -143,7 +143,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
                     && $stmt->expr->name instanceof PhpParser\Node\Name
                     && $stmt->expr->name->parts === ['define']
                     && isset($stmt->expr->args[1])
-                    && $stmt->expr->args[0]->value instanceof PhpParser\Node\Scalar\String_
                 ) {
                     $const_name = static::getConstName($stmt->expr->args[0]->value);
                     if ($const_name !== null) {

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -1467,7 +1467,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     }
 
     /**
-     * @param  mixed $first_arg_value
+     * @param  PhpParser\Node\Expr $first_arg_value
      *
      * @return null|string
      */

--- a/src/Psalm/Internal/Visitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/Visitor/ReflectorVisitor.php
@@ -588,14 +588,13 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         if ($function_id === 'define') {
             $first_arg_value = isset($node->args[0]) ? $node->args[0]->value : null;
             $second_arg_value = isset($node->args[1]) ? $node->args[1]->value : null;
-            if ($first_arg_value instanceof PhpParser\Node\Scalar\String_ && $second_arg_value) {
+            $const_name = StatementsAnalyzer::getConstName($first_arg_value);
+            if ($const_name !== null && $second_arg_value) {
                 $const_type = StatementsAnalyzer::getSimpleType(
                     $this->codebase,
                     $second_arg_value,
                     $this->aliases
                 ) ?: Type::getMixed();
-                $const_name = $first_arg_value->value;
-
                 if ($this->functionlike_storages && !$this->config->hoist_constants) {
                     $functionlike_storage =
                         $this->functionlike_storages[count($this->functionlike_storages) - 1];

--- a/src/Psalm/Internal/Visitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/Visitor/ReflectorVisitor.php
@@ -588,20 +588,22 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         if ($function_id === 'define') {
             $first_arg_value = isset($node->args[0]) ? $node->args[0]->value : null;
             $second_arg_value = isset($node->args[1]) ? $node->args[1]->value : null;
-            $const_name = StatementsAnalyzer::getConstName($first_arg_value);
-            if ($const_name !== null && $second_arg_value) {
-                $const_type = StatementsAnalyzer::getSimpleType(
-                    $this->codebase,
-                    $second_arg_value,
-                    $this->aliases
-                ) ?: Type::getMixed();
-                if ($this->functionlike_storages && !$this->config->hoist_constants) {
-                    $functionlike_storage =
-                        $this->functionlike_storages[count($this->functionlike_storages) - 1];
-                    $functionlike_storage->defined_constants[$const_name] = $const_type;
-                } else {
-                    $this->file_storage->constants[$const_name] = $const_type;
-                    $this->file_storage->declaring_constants[$const_name] = $this->file_path;
+            if ($first_arg_value && $second_arg_value) {
+                $const_name = StatementsAnalyzer::getConstName($first_arg_value);
+                if ($const_name !== null) {
+                    $const_type = StatementsAnalyzer::getSimpleType(
+                        $this->codebase,
+                        $second_arg_value,
+                        $this->aliases
+                    ) ?: Type::getMixed();
+                    if ($this->functionlike_storages && !$this->config->hoist_constants) {
+                        $functionlike_storage =
+                            $this->functionlike_storages[count($this->functionlike_storages) - 1];
+                        $functionlike_storage->defined_constants[$const_name] = $const_type;
+                    } else {
+                        $this->file_storage->constants[$const_name] = $const_type;
+                        $this->file_storage->declaring_constants[$const_name] = $this->file_path;
+                    }
                 }
             }
         }

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -327,6 +327,29 @@ class ConstantTest extends TestCase
                     namespace Foo;
                     echo DIRECTORY_SEPARATOR;',
             ],
+            'constantDefinedInNamespace' => [
+                '<?php
+                    namespace {
+                    define("ns1\\cons1", 0);
+
+                    echo \ns1\cons1;
+                    echo ns1\cons1;
+                    }
+                    namespace ns2 {
+                    define(__NAMESPACE__."\\cons2", 0);
+
+                    echo \ns2\cons2;
+                    echo cons2;
+                    }
+                    namespace ns2 {
+                    echo \ns2\cons2;
+                    echo cons2;
+                    }
+                    namespace {
+                    echo \ns2\cons2;
+                    echo ns2\cons2;
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #1301

The namespace is ignored for now. Psalm can't find the constant when it has a namespace. I'll open another issue for that.