### PR TITLE
Expose more internal methods through Codebase

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1179,7 +1179,7 @@ class Codebase
      * If you consider `Type\Union` as a set of types, this will tell you if intersection
      * of `$input_type` with `$container_type` is not empty.
      *
-     * $input_type ∩ $container_type ≠ ∅ , e.g. they are not dijoint.
+     * $input_type ∩ $container_type ≠ ∅ , e.g. they are not disjoint.
      *
      * Useful for emitting issues like PossiblyInvalidArgument, where argument at the call
      * site should be a subtype of the function parameter type, but it's has some types that are

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1162,8 +1162,6 @@ class Codebase
      *
      * Useful for emitting issues like InvalidArgument, where argument at the call site
      * should be a subset of the function parameter type.
-     *
-     * @psalm-suppress PossiblyUnusedMethod
      */
     public function isTypeContainedByType(
         Type\Union $input_type,
@@ -1184,8 +1182,6 @@ class Codebase
      * Useful for emitting issues like PossiblyInvalidArgument, where argument at the call
      * site should be a subtype of the function parameter type, but it's has some types that are
      * not a subtype of the required type.
-     *
-     * @psalm-suppress PossiblyUnusedMethod
      */
     public function canTypeBeContainedByType(
         Type\Union $input_type,
@@ -1207,7 +1203,6 @@ class Codebase
      * ```
      *
      * @return array{Type\Union,Type\Union}
-     * @psalm-suppress PossiblyUnusedMethod
      */
     public function getKeyValueParamsForTraversableObject(Type\Atomic $type): array
     {

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1152,6 +1152,17 @@ class Codebase
     }
 
     /**
+     * Checks if type is a subtype of other
+     *
+     * Given two types, checks if `$input_type` is a subtype of `$container_type`.
+     * If you consider `Type\Union` as a set of types, this will tell you
+     * if `$input_type` is fully contained in `$container_type`,
+     *
+     * $input_type ⊆ $container_type
+     *
+     * Useful for emitting issues like InvalidArgument, where argument at the call site
+     * should be a subset of the function parameter type.
+     *
      * @psalm-suppress PossiblyUnusedMethod
      */
     public function isTypeContainedByType(
@@ -1162,6 +1173,18 @@ class Codebase
     }
 
     /**
+     * Checks if type has any part that is a subtype of other
+     *
+     * Given two types, checks if *any part* of `$input_type` is a subtype of `$container_type`.
+     * If you consider `Type\Union` as a set of types, this will tell you if intersection
+     * of `$input_type` with `$container_type` is not empty.
+     *
+     * $input_type ∩ $container_type ≠ ∅ , e.g. they are not dijoint.
+     *
+     * Useful for emitting issues like PossiblyInvalidArgument, where argument at the call
+     * site should be a subtype of the function parameter type, but it's has some types that are
+     * not a subtype of the required type.
+     *
      * @psalm-suppress PossiblyUnusedMethod
      */
     public function canTypeBeContainedByType(
@@ -1172,6 +1195,17 @@ class Codebase
     }
 
     /**
+     * Extracts key and value types from a traversable object (or iterable)
+     *
+     * Given an iterable type (*but not TArray*) returns a tuple of it's key/value types.
+     * First element of the tuple holds key type, second has the value type.
+     *
+     * Example:
+     * ```php
+     * $codebase->getKeyValueParamsForTraversableObject(Type::parseString('iterable<int,string>'))
+     * //  returns [Union(TInt), Union(TString)]
+     * ```
+     *
      * @return array{Type\Union,Type\Union}
      * @psalm-suppress PossiblyUnusedMethod
      */

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -3,6 +3,7 @@ namespace Psalm;
 
 use LanguageServerProtocol\{Position, Range};
 use PhpParser;
+use Psalm\Internal\Analyzer\Statements\Block\ForeachAnalyzer;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Analyzer\TypeAnalyzer;
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
@@ -1149,7 +1150,7 @@ class Codebase
     {
         $this->file_provider->removeTemporaryFileChanges($file_path);
     }
-    
+
     /**
      * @psalm-suppress PossiblyUnusedMethod
      */
@@ -1158,5 +1159,32 @@ class Codebase
         Type\Union $container_type
     ): bool {
         return TypeAnalyzer::isContainedBy($this, $input_type, $container_type);
+    }
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function canTypeBeContainedByType(
+        Type\Union $input_type,
+        Type\Union $container_type
+    ): bool {
+        return TypeAnalyzer::canBeContainedBy($this, $input_type, $container_type);
+    }
+
+    /**
+     * @return array{Type\Union,Type\Union}
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function getKeyValueParamsForTraversableObject(Type\Atomic $type): array
+    {
+        $key_type = null;
+        $value_type = null;
+
+        ForeachAnalyzer::getKeyValueParamsForTraversableObject($type, $this, $key_type, $value_type);
+
+        return [
+            $key_type ?? Type::getMixed(),
+            $value_type ?? Type::getMixed(),
+        ];
     }
 }

--- a/tests/CodebaseTest.php
+++ b/tests/CodebaseTest.php
@@ -1,0 +1,114 @@
+<?php
+namespace Psalm\Tests;
+
+use Generator;
+use Psalm\Codebase;
+use Psalm\Context;
+use Psalm\Type;
+
+class CodebaseTest extends TestCase
+{
+    /** @var Codebase */
+    private $codebase;
+
+    /** @return void */
+    public function setUp()
+    {
+        parent::setUp();
+        $this->codebase = $this->project_analyzer->getCodebase();
+    }
+
+    /**
+     * @test
+     * @dataProvider typeContainments
+     * @return void
+     */
+    public function isTypeContainedByType(string $input, string $container, bool $expected)
+    {
+        $input = Type::parseString($input);
+        $container = Type::parseString($container);
+
+        $this->assertEquals(
+            $expected,
+            $this->codebase->isTypeContainedByType($input, $container),
+            'Expected ' . $input->getId() . ($expected ? ' ' : ' not ')
+            . 'to be contained in ' . $container->getId()
+        );
+    }
+
+
+    /** @return iterable<int,array{string,string,bool} */
+    public function typeContainments()
+    {
+        yield ['int', 'int|string', true];
+        yield ['int|string', 'int', false];
+
+        // This fails with 'could not get class storage' :(
+
+        // yield ['RuntimeException', 'Exception', true];
+        // yield ['Exception', 'RuntimeException', false];
+    }
+
+    /**
+     * @test
+     * @dataProvider typeIntersections
+     * @return void
+     */
+    public function canTypeBeContainedByType(string $input, string $container, bool $expected)
+    {
+        $input = Type::parseString($input);
+        $container = Type::parseString($container);
+
+        $this->assertEquals(
+            $expected,
+            $this->codebase->canTypeBeContainedByType($input, $container),
+            'Expected ' . $input->getId() . ($expected ? ' ' : ' not ')
+            . 'to be contained in ' . $container->getId()
+        );
+    }
+
+    /** @return iterable<int,array{string,string,bool} */
+    public function typeIntersections()
+    {
+        yield ['int', 'int|string', true];
+        yield ['int|string', 'int', true];
+        yield ['int|string', 'string|float', true];
+        yield ['int', 'string', false];
+        yield ['int|string', 'array|float', false];
+    }
+
+    /**
+     * @test
+     * @dataProvider iterableParams
+     * @param array{string,string} $expected
+     * @return void
+     */
+    public function getKeyValueParamsForTraversableObject(string $input, array $expected)
+    {
+        list($input) = array_values(Type::parseString($input)->getTypes());
+
+        $expected_key_type = Type::parseString($expected[0]);
+        $expected_value_type = Type::parseString($expected[1]);
+
+        $actual = $this->codebase->getKeyValueParamsForTraversableObject($input);
+
+        $this->assertTrue(
+            $expected_key_type->equals($actual[0]),
+            'Expected ' . $input->getId() . ' to have ' . $expected_key_type
+            . ' but got ' . $actual[0]->getId()
+        );
+
+        $this->assertTrue(
+            $expected_value_type->equals($actual[1]),
+            'Expected ' . $input->getId() . ' to have ' . $expected_value_type
+            . ' but got ' . $actual[1]->getId()
+        );
+    }
+
+    /** @return iterable<int,array{string,array{string,string}} */
+    public function iterableParams()
+    {
+        yield ['iterable<int,string>', ['int', 'string']];
+        yield ['iterable<int|string,bool|float', ['int|string', 'bool|float']];
+    }
+}


### PR DESCRIPTION
- `bool Codebase::canTypeBeContainedByType(Union $input, Union $container)`
- `array{Union,Union} Codebase::getKeyValueParamsForTraversableObject(Atomic $type)`

For usage, see psalm/phpunit-psalm-plugin#15