### PR TITLE
Allow @psalm-property and @psalm-method

### DIFF
--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -128,6 +128,7 @@ class DocComment
                     $special_key,
                     [
                         'return', 'param', 'template', 'var', 'type',
+                        'property', 'method',
                         'assert', 'assert-if-true', 'assert-if-false', 'suppress',
                         'ignore-nullable-return', 'override-property-visibility',
                         'override-method-visibility', 'seal-properties', 'seal-methods',

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -613,8 +613,11 @@ class CommentAnalyzer
             }
         }
 
-        if (isset($comments['specials']['method'])) {
-            foreach ($comments['specials']['method'] as $method_entry) {
+        if (isset($comments['specials']['method']) || isset($comments['specials']['psalm-method'])) {
+            $all_methods = (isset($comments['specials']['method']) ? $comments['specials']['method'] : [])
+                + (isset($comments['specials']['psalm-method']) ? $comments['specials']['psalm-method'] : []);
+
+            foreach ($all_methods as $method_entry) {
                 $method_entry = preg_replace('/[ \t]+/', ' ', trim($method_entry));
 
                 $docblock_lines = [];
@@ -714,6 +717,7 @@ class CommentAnalyzer
         }
 
         self::addMagicPropertyToInfo($info, $comments['specials'], 'property');
+        self::addMagicPropertyToInfo($info, $comments['specials'], 'psalm-property');
         self::addMagicPropertyToInfo($info, $comments['specials'], 'property-read');
         self::addMagicPropertyToInfo($info, $comments['specials'], 'property-write');
 
@@ -723,7 +727,7 @@ class CommentAnalyzer
     /**
      * @param ClassLikeDocblockComment $info
      * @param array<string, array<int, string>> $specials
-     * @param string $property_tag ('property', 'property-read', or 'property-write')
+     * @param string $property_tag ('property', 'psalm-property', 'property-read', or 'property-write')
      *
      * @throws DocblockParseException
      *

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -406,6 +406,28 @@ class MagicMethodAnnotationTest extends TestCase
                     '$a' => 'string',
                 ],
             ],
+            'overrideMethodAnnotations' => [
+                '<?php
+                    class ParentClass {
+                        public function __call(string $name, array $args) {}
+                    }
+
+                    /**
+                     * @method int getString() dsa sada
+                     * @method  void setInteger(string $integer) dsa sada
+                     * @psalm-method string getString() dsa sada
+                     * @psalm-method  void setInteger(int $integer) dsa sada
+                     */
+                    class Child extends ParentClass {}
+
+                    $child = new Child();
+
+                    $a = $child->getString();
+                    $child->setInteger(4);',
+                'assertions' => [
+                    '$a' => 'string',
+                ],
+            ],
         ];
     }
 

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -386,6 +386,26 @@ class MagicMethodAnnotationTest extends TestCase
                     '$d' => 'D',
                 ]
             ],
+            'validSimplePsalmAnnotations' => [
+                '<?php
+                    class ParentClass {
+                        public function __call(string $name, array $args) {}
+                    }
+
+                    /**
+                     * @psalm-method string getString() dsa sada
+                     * @psalm-method  void setInteger(int $integer) dsa sada
+                     */
+                    class Child extends ParentClass {}
+
+                    $child = new Child();
+
+                    $a = $child->getString();
+                    $child->setInteger(4);',
+                'assertions' => [
+                    '$a' => 'string',
+                ],
+            ],
         ];
     }
 

--- a/tests/MagicPropertyTest.php
+++ b/tests/MagicPropertyTest.php
@@ -434,6 +434,71 @@ class MagicPropertyTest extends TestCase
                     $a->foo = "hello";
                     $a->bar = "hello"; // not a property',
             ],
+            'overridePropertyAnnotations' => [
+                '<?php
+                    namespace Bar;
+
+                    /**
+                     * @property int $foo
+                     * @psalm-property string $foo
+                     */
+                    class A {
+                        /** @param string $name */
+                        public function __get($name): ?string {
+                            if ($name === "foo") {
+                                return "hello";
+                            }
+
+                            return null;
+                        }
+
+                        /**
+                         * @param string $name
+                         * @param mixed $value
+                         */
+                        public function __set($name, $value): void {
+                        }
+                    }
+
+                    $a = new A();
+                    $a->foo = "hello";
+                    $a->bar = "hello"; // not a property',
+            ],
+            'overrideWithReadWritePropertyAnnotations' => [
+                '<?php
+                    namespace Bar;
+
+                    /**
+                     * @psalm-property int $foo
+                     * @property-read string $foo
+                     * @property-write array $foo
+                     */
+                    class A {
+                        /** @param string $name */
+                        public function __get($name): ?string {
+                            if ($name === "foo") {
+                                return "hello";
+                            }
+
+                            return null;
+                        }
+
+                        /**
+                         * @param string $name
+                         * @param mixed $value
+                         */
+                        public function __set($name, $value): void {
+                        }
+
+                        public function takesString(string $s): void {}
+                    }
+
+                    $a = new A();
+                    $a->foo = [];
+
+                    $a = new A();
+                    $a->takesString($a->foo);',
+            ],
         ];
     }
 

--- a/tests/MagicPropertyTest.php
+++ b/tests/MagicPropertyTest.php
@@ -405,6 +405,35 @@ class MagicPropertyTest extends TestCase
                         $o->foo = "hello";
                     }',
             ],
+            'psalmPropertyDocblock' => [
+                '<?php
+                    namespace Bar;
+
+                    /**
+                     * @psalm-property string $foo
+                     */
+                    class A {
+                        /** @param string $name */
+                        public function __get($name): ?string {
+                            if ($name === "foo") {
+                                return "hello";
+                            }
+
+                            return null;
+                        }
+
+                        /**
+                         * @param string $name
+                         * @param mixed $value
+                         */
+                        public function __set($name, $value): void {
+                        }
+                    }
+
+                    $a = new A();
+                    $a->foo = "hello";
+                    $a->bar = "hello"; // not a property',
+            ],
         ];
     }
 


### PR DESCRIPTION
Allow `@psalm-property` to replace `@property` and `@psalm-method` to replace `@method`.