### PR TITLE
Added Hook\AfterCodebasePopulatedInterface

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -306,6 +306,12 @@ class Config
      */
     public $after_visit_classlikes = [];
 
+    /**
+     * Static methods to be called after codebase has been populated
+     * @var class-string<Hook\AfterCodebasePopulatedInterface>[]
+     */
+    public $after_codebase_populated = [];
+
     /** @var array<string, mixed> */
     private $predefined_constants;
 

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -392,6 +392,14 @@ class ProjectAnalyzer
 
         $this->config->visitStubFiles($this->codebase, $this->debug_output);
 
+        $plugin_classes = $this->config->after_codebase_populated;
+
+        if ($plugin_classes) {
+            foreach ($plugin_classes as $plugin_fq_class_name) {
+                $plugin_fq_class_name::afterCodebasePopulated($this->codebase);
+            }
+        }
+
         $this->codebase->analyzer->analyzeFiles($this, $this->threads, $this->codebase->alter_code);
 
         if ($this->parser_cache_provider) {

--- a/src/Psalm/Plugin/Hook/AfterCodebasePopulatedInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterCodebasePopulatedInterface.php
@@ -1,0 +1,13 @@
+<?php
+namespace Psalm\Plugin\Hook;
+
+use Psalm\Codebase;
+
+interface AfterCodebasePopulatedInterface
+{
+    /**
+     * Called after codebase has been populated
+     * @return void
+     */
+    public static function afterCodebasePopulated(Codebase $codebase);
+}

--- a/src/Psalm/PluginRegistrationSocket.php
+++ b/src/Psalm/PluginRegistrationSocket.php
@@ -60,5 +60,9 @@ class PluginRegistrationSocket implements RegistrationInterface
         if (is_subclass_of($handler, Hook\AfterClassLikeVisitInterface::class)) {
             $this->config->after_visit_classlikes[$handler] = $handler;
         }
+
+        if (is_subclass_of($handler, Hook\AfterCodebasePopulatedInterface::class)) {
+            $this->config->after_codebase_populated[$handler] = $handler;
+        }
     }
 }

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -155,7 +155,7 @@ class ProjectAnalyzerTest extends TestCase
 
         ob_start();
         $this->project_analyzer->check('tests/DummyProject');
-        $output = ob_get_clean();
+        ob_end_clean();
 
         $this->assertTrue($hook::$called);
     }


### PR DESCRIPTION
It could be used to perform operations after files have been scanned, but before main analysis is started.