### PR TITLE
Fix non-empty-array @param in namespace

### DIFF
--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -52,6 +52,7 @@ abstract class Type
         'empty' => true,
         'callable' => true,
         'array' => true,
+        'non-empty-array' => true,
         'iterable' => true,
         'null' => true,
         'mixed' => true,

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -913,6 +913,27 @@ class AnnotationTest extends TestCase
                         foo($arr);
                     }'
             ],
+            'nonEmptyArrayInNamespace' => [
+                '<?php
+                    namespace ns;
+
+                    /** @param non-empty-array<string> $arr */
+                    function foo(array $arr) : void {
+                        foreach ($arr as $a) {}
+                        echo $a;
+                    }
+
+                    foo(["a", "b", "c"]);
+
+                    /** @param array<string> $arr */
+                    function bar(array $arr) : void {
+                        if (!$arr) {
+                            return;
+                        }
+
+                        foo($arr);
+                    }'
+            ],
         ];
     }
 
@@ -1284,6 +1305,19 @@ class AnnotationTest extends TestCase
             ],
             'nonEmptyArrayCalledWithEmpty' => [
                 '<?php
+                    /** @param non-empty-array<string> $arr */
+                    function foo(array $arr) : void {
+                        foreach ($arr as $a) {}
+                        echo $a;
+                    }
+
+                    foo([]);',
+                'error_message' => 'InvalidArgument',
+            ],
+            'nonEmptyArrayCalledWithEmptyInNamespace' => [
+                '<?php
+                    namespace ns;
+
                     /** @param non-empty-array<string> $arr */
                     function foo(array $arr) : void {
                         foreach ($arr as $a) {}


### PR DESCRIPTION
Make `non-empty-array` a reserved word.