### PR TITLE
Increment CallMap minor version

### DIFF
--- a/src/Psalm/Internal/Codebase/CallMap.php
+++ b/src/Psalm/Internal/Codebase/CallMap.php
@@ -13,7 +13,7 @@ use Psalm\Storage\FunctionLikeParameter;
 class CallMap
 {
     const PHP_MAJOR_VERSION = 7;
-    const PHP_MINOR_VERSION = 3;
+    const PHP_MINOR_VERSION = 4;
 
     /**
      * @var ?int


### PR DESCRIPTION
A callmap exists for version 7.4, so it should be used.