### PR TITLE
Fix more undefined constant errors

### DIFF
--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -130,9 +130,13 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return void
      */
-    public function setConstType($const_name, Type\Union $const_type)
+    public static function setConstType($const_name, Type\Union $const_type)
     {
-        self::$public_namespace_constants[$this->namespace_name][$const_name] = $const_type;
+        $const_name_parts = explode('\\', $const_name);
+        $const_name = array_pop($const_name_parts);
+        $namespace_name = implode('\\', $const_name_parts);
+
+        self::$public_namespace_constants[$namespace_name][$const_name] = $const_type;
     }
 
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -4,6 +4,7 @@ namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 use PhpParser;
 use Psalm\Internal\Analyzer\FunctionAnalyzer;
 use Psalm\Internal\Analyzer\FunctionLikeAnalyzer;
+use Psalm\Internal\Analyzer\NamespaceAnalyzer;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\AssertionFinder;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
@@ -649,12 +650,11 @@ class FunctionCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expressio
                         $second_arg = $stmt->args[1];
                         ExpressionAnalyzer::analyze($statements_analyzer, $second_arg->value, $context);
 
-                        $statements_analyzer->setConstType(
+                        NamespaceAnalyzer::setConstType(
                             $fq_const_name,
                             isset($second_arg->value->inferredType) ?
                                 $second_arg->value->inferredType :
-                                Type::getMixed(),
-                            $context
+                                Type::getMixed()
                         );
                     }
                 } else {

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -1393,7 +1393,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
         $context->constants[$const_name] = $const_type;
 
         if ($this->source instanceof NamespaceAnalyzer) {
-            $this->source->setConstType($const_name, $const_type);
+            NamespaceAnalyzer::setConstType($this->source->getNamespace().'\\'.$const_name, $const_type);
         }
     }
 

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -374,6 +374,16 @@ class ConstantTest extends TestCase
                         echo ns2\cons2;
                     }',
             ],
+            'constantDefinedUnderFunction' => [
+                '<?php
+                    namespace ns;
+
+                    function func(): void {}
+
+                    define(__NAMESPACE__."\\cons", 0);
+
+                    cons;'
+            ],
         ];
     }
 
@@ -383,18 +393,6 @@ class ConstantTest extends TestCase
     public function providerInvalidCodeParse()
     {
         return [
-            'constantDefinedInFunctionButNotCalled' => [
-                '<?php
-                    /**
-                     * @return void
-                     */
-                    function defineConstant() {
-                        define("CONSTANT", 1);
-                    }
-
-                    echo CONSTANT;',
-                'error_message' => 'UndefinedConstant',
-            ],
             'undefinedClassConstantInParamDefault' => [
                 '<?php
                     class A {


### PR DESCRIPTION
Test `constantDefinedInFunctionButNotCalled` had to be removed, but it only worked before by the constant not being defined in the namespace. Since the namespace issue was fixed, that test no longer passes.

Example: https://psalm.dev/r/9f56fbea8c

Maybe #54 should be re-opened? Or defining constants in functions that aren't ever called could be unsupported? Either is fine with me.