### PR TITLE
fix --help end of line

### DIFF
--- a/src/psalm.php
+++ b/src/psalm.php
@@ -228,6 +228,7 @@ Options:
 
     --alter
         Run Psalter
+
 HELP;
 
     exit;


### PR DESCRIPTION
Given `psalm -h`

```
    --alter
        Run Psalter/app $ 
```

but should be

```
    --alter
        Run Psalter
/app $ 
```
