### PR TITLE
Allow capitalized @inheritdoc

### DIFF
--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -392,7 +392,7 @@ class CommentAnalyzer
         }
 
         if (strpos(strtolower($comments['description']), '@inheritdoc') !== false
-            || isset($comments['specials']['inheritdoc'])) {
+            || isset($comments['specials']['inheritdoc']) || isset($comments['specials']['inheritDoc'])) {
             $info->inheritdoc = true;
         }
 

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -523,6 +523,18 @@ class InterfaceTest extends TestCase
                         public function foo(array $f) : void {
                             $this->f = $f;
                         }
+                    }
+
+                    class C2 implements I {
+                        /** @var string[] */
+                        private $f = [];
+
+                        /**
+                         * {@inheritDoc}
+                         */
+                        public function foo(array $f) : void {
+                            $this->f = $f;
+                        }
                     }',
             ],
         ];

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -386,7 +386,16 @@ class MethodSignatureTest extends TestCase
                         public function boo(A $class): void {}
                     }
 
-                    (new Y())->boo(new A());',
+                    class Z extends X {
+                        /**
+                         * @inheritDoc
+                         * @param A $class
+                         */
+                        public function boo(A $class): void {}
+                    }
+
+                    (new Y())->boo(new A());
+                    (new Z())->boo(new A());',
             ],
             'allowMixedExtensionOfIteratorAggregate' => [
                 '<?php
@@ -680,6 +689,28 @@ class MethodSignatureTest extends TestCase
                     class Y extends X {
                         /**
                          * @inheritdoc
+                         */
+                        public function boo(A $class): void {}
+                    }
+
+                    (new Y())->boo(new A());',
+                'error_message' => 'TypeCoercion',
+            ],
+            'enforceParameterInheritanceWithCapitalizedInheritDoc' => [
+                '<?php
+                    class A {}
+                    class B extends A {}
+
+                    class X {
+                        /**
+                         * @param B $class
+                         */
+                        public function boo(A $class): void {}
+                    }
+
+                    class Y extends X {
+                        /**
+                         * @inheritDoc
                          */
                         public function boo(A $class): void {}
                     }


### PR DESCRIPTION
The PHPDoc standard capitalizes `@inheritdoc` as [`@inheritDoc`](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#41-making-inheritance-explicit-using-the-inheritdoc-tag), which is not supported now.

<s>It also defines [`{@inheritDoc}`](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md#42-using-the-inheritdoc-inline-tag-to-augment-a-description) to only inherit the documentation, so it should be ignored.</s>