### PR TITLE
Flesh out callable arg types

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -1089,6 +1089,29 @@ class ExpressionAnalyzer
             }
         }
 
+        if ($return_type instanceof Type\Atomic\TCallable) {
+            if ($return_type->params) {
+                foreach ($return_type->params as $param) {
+                    if ($param->type) {
+                        $param->type = self::fleshOutType(
+                            $codebase,
+                            $param->type,
+                            $self_class,
+                            $static_class_type
+                        );
+                    }
+                }
+            }
+            if ($return_type->return_type) {
+                $return_type->return_type = self::fleshOutType(
+                    $codebase,
+                    $return_type->return_type,
+                    $self_class,
+                    $static_class_type
+                );
+            }
+        }
+
         return $return_type;
     }
 

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -693,7 +693,9 @@ class CallableTest extends TestCase
             ],
             'callableSelfArg' => [
                 '<?php
-                    class Clazz {
+                    class A {}
+
+                    class B extends A {
                         /**
                          * @param callable(static) $f
                          */
@@ -714,7 +716,48 @@ class CallableTest extends TestCase
                         function func3(callable $f): void {
                             $f($this);
                         }
-                    }',
+                    }
+
+                    class C extends B {}
+
+                    $b = new B();
+                    $c = new C();
+
+                    $b->func1(function(B $x): void {});
+                    $c->func1(function(C $x): void {});
+                    $b->func2(function(B $x): void {});
+                    $c->func2(function(B $x): void {});',
+            ],
+            'callableSelfReturn' => [
+                '<?php
+                    class A {}
+
+                    class B extends A {
+                        /**
+                         * @param callable():static $f
+                         */
+                        function func1(callable $f): void {}
+
+                        /**
+                         * @param callable():self $f
+                         */
+                        function func2(callable $f): void {}
+
+                        /**
+                         * @param callable():parent $f
+                         */
+                        function func3(callable $f): void {}
+                    }
+
+                    class C extends B {}
+
+                    $b = new B();
+                    $c = new C();
+
+                    $b->func1(function(): B { return new B(); });
+                    $c->func1(function(): C { return new C(); });
+                    $b->func2(function(): B { return new B(); });
+                    $c->func2(function(): B { return new B(); });',
             ],
             'selfArrayMapCallableWrongClass' => [
                 '<?php


### PR DESCRIPTION
`callable(self)` didn't resolve `self` when checking parameters.