### PR TITLE
Define globals in more places

### DIFF
--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -745,7 +745,10 @@ class Context
         return json_encode($summary);
     }
 
-    public function defineGlobals() : void
+    /**
+     * @return void
+     */
+    public function defineGlobals()
     {
         $globals = [
             'argv' => new Type\Union([

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -1,10 +1,12 @@
 <?php
 namespace Psalm;
 
+use Psalm\Config;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Clause;
 use Psalm\Storage\FunctionLikeStorage;
 use Psalm\Type\Reconciler;
+use Psalm\Type;
 use Psalm\Type\Union;
 
 class Context
@@ -741,5 +743,26 @@ class Context
             $summary[$k] = $v->getId();
         }
         return json_encode($summary);
+    }
+
+    public function defineGlobals() : void
+    {
+        $globals = [
+            'argv' => new Type\Union([
+                new Type\Atomic\TArray([Type::getInt(), Type::getString()]),
+            ]),
+            'argc' => Type::getInt(),
+        ];
+
+        $config = Config::getInstance();
+
+        foreach ($config->globals as $global_name => $type_string) {
+            $globals[$global_name] = Type::parseString($type_string);
+        }
+
+        foreach ($globals as $global_name => $type) {
+            $this->vars_in_scope['$' . $global_name] = $type;
+            $this->vars_possibly_in_scope[$global_name] = true;
+        }
     }
 }

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -142,6 +142,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         }
 
         $this->context->is_global = true;
+        $this->context->defineGlobals();
 
         try {
             $stmts = $codebase->getStatementsForFile($this->file_path);

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -86,6 +86,7 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
             $context = new Context();
             $context->collect_references = $codebase->collect_references;
             $context->is_global = true;
+            $context->defineGlobals();
             $statements_analyzer->analyze($leftover_stmts, $context);
         }
     }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -110,20 +110,6 @@ class VariableFetchAnalyzer
             return null;
         }
 
-        if ($context->is_global && is_string($stmt->name)) {
-            $var_name = '$' . $stmt->name;
-
-            if (!$context->hasVariable($var_name, $statements_analyzer)) {
-                $type = $statements_analyzer->getGlobalType($stmt->name);
-                if ($type) {
-                    $context->vars_in_scope[$var_name] = $type;
-                    $context->vars_possibly_in_scope[$var_name] = true;
-                    $stmt->inferredType = clone $type;
-                    return null;
-                }
-            }
-        }
-
         if (in_array(
             $stmt->name,
             [

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1200,6 +1200,10 @@ class ConfigTest extends TestCase
                     ord($glob1);
                     ord($glob2["str"]);
                     $glob3->func();
+                }
+                namespace {
+                    ord($glob1 ?? "str");
+                    ord($_GET["str"] ?? "str");
                 }'
         );
 


### PR DESCRIPTION
This puts globals from the config in the global context, which allows them to be used in more places. For example, `$glob1 ?? 'str'` used to be `mixed|string`.