### PR TITLE
Codebase::classExtends() now rejects unpopulated classes

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -677,6 +677,8 @@ class Codebase
      * @param  string       $possible_parent
      *
      * @return bool
+     * @throws \Psalm\Exception\UnpopulatedClasslikeException when called on unpopulated class
+     * @throws \InvalidArgumentException when class does not exist
      */
     public function classExtends($fq_class_name, $possible_parent)
     {

--- a/src/Psalm/Exception/UnpopulatedClasslikeException.php
+++ b/src/Psalm/Exception/UnpopulatedClasslikeException.php
@@ -1,0 +1,13 @@
+<?php
+namespace Psalm\Exception;
+
+class UnpopulatedClasslikeException extends \LogicException
+{
+    public function __construct(string $fq_classlike_name)
+    {
+        parent::__construct(
+            'Cannot check inheritance - \'' . $fq_classlike_name . '\' has not been populated yet.'
+            . ' You may need to defer this check to a later phase.'
+        );
+    }
+}

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -204,6 +204,8 @@ class Reflection
                 continue;
             }
         }
+
+        $storage->populated = true;
     }
 
     /**

--- a/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
@@ -34,6 +34,7 @@ class ClassLikeStorageProvider
      * @param  string $fq_classlike_name
      *
      * @return ClassLikeStorage
+     * @throws \InvalidArgumentException when class does not exist
      */
     public function get($fq_classlike_name)
     {

--- a/tests/CodebaseTest.php
+++ b/tests/CodebaseTest.php
@@ -179,4 +179,18 @@ class CodebaseTest extends TestCase
         $this->assertEquals('h', $class_storage->methods['m']->params[0]->custom_metadata['g']);
         $this->assertEquals('j', $file_storage->custom_metadata['i']);
     }
+
+    /**
+     * @test
+     * @return void
+     */
+    public function classExtendsRejectsUnpopulatedClasslikes()
+    {
+        $this->codebase->classlike_storage_provider->create('A');
+        $this->codebase->classlike_storage_provider->create('B');
+
+        $this->expectException(\Psalm\Exception\UnpopulatedClasslikeException::class);
+
+        $this->codebase->classExtends('A', 'B');
+    }
 }


### PR DESCRIPTION
This is done to prevent false negatives, when class storage hasn't been populated yet.

Fixes vimeo/psalm#1387.