### PR TITLE
Ignore unused superglobals

### DIFF
--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -758,6 +758,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
             if ((!$function_storage
                     || !array_key_exists(substr($var_id, 1), $function_storage->param_types))
                 && !isset($this->byref_uses[$var_id])
+                && !$this->isSuperGlobal($var_id)
             ) {
                 if (IssueBuffer::accepts(
                     new UnusedVariable(

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -881,6 +881,15 @@ class UnusedVariableTest extends TestCase
                     };
                     $a();',
             ],
+            'superGlobalInFunction' => [
+                '<?php
+                    function example1() : void {
+                        $_SESSION = [];
+                    }
+                    function example2() : int {
+                        return (int) $_SESSION["str"];
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Superglobals can be used between functions and by PHP functions, so I don't think it's useful to mark them as unused.