### PR TITLE
Ignore unused static vars

### DIFF
--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -883,6 +883,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
                 $context->vars_in_scope[$var_id] = Type::getMixed();
                 $context->vars_possibly_in_scope[$var_id] = true;
                 $context->assigned_var_ids[$var_id] = true;
+                $this->byref_uses[$var_id] = true;
 
                 $location = new CodeLocation($this, $stmt);
 

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -560,6 +560,17 @@ class UnusedVariableTest extends TestCase
                         echo "token is $token\n";
                     }',
             ],
+            'staticVarUsedLater' => [
+                '<?php
+                    function use_static() : int {
+                        static $x = null;
+                        if ($x) {
+                            return (int) $x;
+                        }
+                        $x = rand(0, 1);
+                        return -1;
+                    }',
+            ],
             'tryCatchWithUseInIf' => [
                 '<?php
                     function example_string() : string {


### PR DESCRIPTION
Static variables are marked unused in some cases where they aren't. They can be used in later calls to the same function. This probably won't have a complete fix until #678 is also fixed.