### PR TITLE
Appveyor config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -47,6 +47,7 @@ install:
     - IF %PHP%==1 copy php.ini-production php.ini /Y
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
     - IF %PHP%==1 echo extension_dir=ext >> php.ini
+    - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
     - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
     - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
     - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -12,6 +12,7 @@ init:
   - SET ANSICON=121x90 (121x90)
 
 environment:
+  SSL_CERT_FILE: "C:\\tools\\php\\cacert.pem"
   matrix:
     - php_ver_target: 7.0
       DEPS: 'low'
@@ -43,11 +44,14 @@ cache:
 install:
     - IF EXIST c:\tools\php (SET PHP=0) # Checks for the PHP install being cached
     - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+    - appveyor DownloadFile https://curl.haxx.se/ca/cacert.pem -FileName C:\tools\php\cacert.pem
     - cd c:\tools\php
     - IF %PHP%==1 copy php.ini-production php.ini /Y
     - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
     - IF %PHP%==1 echo extension_dir=ext >> php.ini
     - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
+    - IF NOT EXIST php-installed.txt echo curl.cainfo="C:/tools/php/cacert.pem" >> php.ini
+    - IF NOT EXIST php-installed.txt echo openssl.cafile="C:/tools/php/cacert.pem" >> php.ini
     - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
     - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
     - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,69 @@
+build: false
+platform:
+  - x64
+
+clone_folder: c:\projects\php-project-workspace
+
+## Set up environment variables
+init:
+  - SET PATH=C:\Program Files\OpenSSL;c:\tools\php;%PATH%
+  - SET COMPOSER_NO_INTERACTION=1
+  - SET PHP=1 # This var is connected to PHP install cache
+  - SET ANSICON=121x90 (121x90)
+
+environment:
+  matrix:
+    - php_ver_target: 7.0
+      DEPS: 'low'
+    - php_ver_target: 7.0
+      DEPS: 'high'
+    - php_ver_target: 7.1
+      DEPS: 'low'
+    - php_ver_target: 7.1
+      DEPS: 'high'
+    - php_ver_target: 7.2
+      DEPS: 'low'
+    - php_ver_target: 7.2
+      DEPS: 'high'
+    - php_ver_target: 7.3
+      DEPS: 'low'
+    - php_ver_target: 7.3
+      DEPS: 'high'
+
+cache:
+  - '%LOCALAPPDATA%\Composer\files -> composer.lock'
+  - composer.phar
+  # Cache chocolatey packages
+  - C:\ProgramData\chocolatey\bin -> .appveyor.yml
+  - C:\ProgramData\chocolatey\lib -> .appveyor.yml
+  # Cache php install
+  - c:\tools\php -> .appveyor.yml
+
+## Install PHP and composer, and run the appropriate composer command
+install:
+    - IF EXIST c:\tools\php (SET PHP=0) # Checks for the PHP install being cached
+    - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+    - cd c:\tools\php
+    - IF %PHP%==1 copy php.ini-production php.ini /Y
+    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
+    - IF %PHP%==1 echo extension_dir=ext >> php.ini
+    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
+    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
+    - IF %PHP%==1 echo zend.assertions=1 >> php.ini
+    - IF %PHP%==1 echo assert.exception=On >> php.ini
+    - IF %PHP%==1 echo error_reporting=E_ALL >> php.ini
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
+    - appveyor-retry appveyor DownloadFile https://getcomposer.org/composer.phar
+    - cd c:\projects\php-project-workspace
+    - php -r "phpinfo(INFO_GENERAL);"
+    - if NOT DEFINED APPVEYOR_REPO_TAG_NAME (set COMPOSER_ROOT_VERSION=dev-master)
+    - if %DEPS%==low appveyor-retry composer update --no-interaction --no-suggest --prefer-source --no-progress --profile --prefer-lowest --prefer-stable
+    - if %DEPS%==high appveyor-retry composer update --no-interaction --no-suggest --prefer-source --no-progress --profile
+    - composer show
+
+## Run the actual test
+test_script:
+    - cd c:\projects\php-project-workspace
+    - vendor/bin/phpunit
+    - php ./psalm --shepherd

--- a/tests/Traits/InvalidCodeAnalysisTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisTestTrait.php
@@ -57,6 +57,8 @@ trait InvalidCodeAnalysisTestTrait
 
         $this->project_analyzer->setPhpVersion($php_version);
 
+        $error_message = preg_replace('/ src[\/\\\\]somefile\.php/', ' src/somefile.php', $error_message);
+
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessageRegExp('/\b' . preg_quote($error_message, '/') . '\b/');
 


### PR DESCRIPTION
so a few things:
1) ~Only the March 23rd commit 6235a5e is needed (probably) at present.~
2) ~The last 3 a4e1310 7e47f8e and 508297b were only added because of my misunderstanding the composer error output on the first build; `psalm/plugin-phpunit` refuses to install because it's not currently on *dev-master*. 508267b features a workaround, I'm hoping there's a better workaround should it actually become an issue in future~
3) ~I am insufficiently familiar with appveyor to determine what'll happen with regards to pull requests (i.e. how travis etc. can run tests on pull requests).~
4) ~Running the tests on appveyor highlights the recurring windows-specific path issues described in #667, #1292, #1404, and #1467 - it does not fix them; that is to come later as described in #1467 re: "seeing what happens if everything is switched to unix paths"~ seemingly resolved in 877345a, hoping this doesn't break anything.

@muglug @weirdan if you both can take a look at your convenience at the config and the [build output](https://ci.appveyor.com/project/SignpostMarv/psalm/builds/23314606)  to see if we're missing anything useful before I start the experiment with switching to all unix paths?