### PR TITLE
Add an error for throws in global scope

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -45,6 +45,7 @@
         <xs:attribute name="hoistConstants" type="xs:string" />
         <xs:attribute name="addParamDefaultToDocblockType" type="xs:string" />
         <xs:attribute name="checkForThrowsDocblock" type="xs:string" />
+        <xs:attribute name="checkForThrowsInGlobalScope" type="xs:string" />
         <xs:attribute name="forbidEcho" type="xs:string" />
         <xs:attribute name="errorBaseline" type="xs:string" />
         <xs:attribute name="findUnusedCode" type="xs:string" />
@@ -299,6 +300,7 @@
             <xs:element name="TypeCoercion" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TypeDoesNotContainNull" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TypeDoesNotContainType" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UncaughtThrowInGlobalScope" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedClass" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedConstant" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedFunction" type="FunctionIssueHandlerType" minOccurs="0" />

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -149,6 +149,14 @@ Occasionally a param default will not match up with the docblock type. By defaul
 ```
 When `true`, Psalm will check that the developer has supplied `@throws` docblocks for every exception thrown in a given function or method. Defaults to `false`.
 
+#### checkForThrowsInGlobalScope
+```xml
+<psalm
+  checkForThrowsDocblock="[bool]"
+>
+```
+When `true`, Psalm will check that the developer has caught every exception in global scope. Defaults to `false`.
+
 #### ignoreInternalFunctionFalseReturn
 
 ```xml

--- a/docs/issues.md
+++ b/docs/issues.md
@@ -1957,6 +1957,20 @@ $a = "hello";
 if ($a === 5) {}
 ```
 
+### UncaughtThrowInGlobalScope
+
+Emitted when a possible exception isn't caught in global scope
+
+```php
+/**
+ * @throws \Exception
+ */
+function foo() : int {
+    return random_int(0, 1);
+}
+foo();
+```
+
 ### UndefinedClass
 
 Emitted when referencing a class that doesn’t exist

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -220,6 +220,11 @@ class Config
     /**
      * @var bool
      */
+    public $check_for_throws_in_global_scope = false;
+
+    /**
+     * @var bool
+     */
     public $ignore_internal_falsable_issues = true;
 
     /**
@@ -633,6 +638,11 @@ class Config
         if (isset($config_xml['checkForThrowsDocblock'])) {
             $attribute_text = (string) $config_xml['checkForThrowsDocblock'];
             $config->check_for_throws_docblock = $attribute_text === 'true' || $attribute_text === '1';
+        }
+
+        if (isset($config_xml['checkForThrowsInGlobalScope'])) {
+            $attribute_text = (string) $config_xml['checkForThrowsInGlobalScope'];
+            $config->check_for_throws_in_global_scope = $attribute_text === 'true' || $attribute_text === '1';
         }
 
         if (isset($config_xml['forbidEcho'])) {

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -213,7 +213,7 @@ class Context
     /**
      * A list of classes or interfaces that may have been thrown
      *
-     * @var array<string, bool>
+     * @var array<string, CodeLocation>
      */
     public $possibly_thrown_exceptions = [];
 

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -831,7 +831,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer implements Statements
             }
         }
 
-        foreach ($statements_analyzer->getUncaughtThrows($context) as $possibly_thrown_exception => $_) {
+        foreach ($statements_analyzer->getUncaughtThrows($context) as $possibly_thrown_exception => $codelocation) {
             $is_expected = false;
 
             foreach ($storage->throws as $expected_exception => $_) {
@@ -848,12 +848,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer implements Statements
                     new MissingThrowsDocblock(
                         $possibly_thrown_exception . ' is thrown but not caught - please either catch'
                             . ' or add a @throws annotation',
-                        new CodeLocation(
-                            $this,
-                            $this->function,
-                            null,
-                            true
-                        )
+                        $codelocation
                     ),
                     $this->getSuppressedIssues()
                 )) {

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -87,6 +87,7 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
             $context->collect_references = $codebase->collect_references;
             $context->is_global = true;
             $context->defineGlobals();
+            $context->collect_exceptions = $codebase->config->check_for_throws_in_global_scope;
             $statements_analyzer->analyze($leftover_stmts, $context);
         }
     }

--- a/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
@@ -3,6 +3,7 @@ namespace Psalm\Internal\Analyzer;
 
 use Psalm\Aliases;
 use Psalm\Codebase;
+use Psalm\Context;
 use Psalm\StatementsSource;
 use Psalm\Type;
 

--- a/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
@@ -47,7 +47,7 @@ class TryAnalyzer
         $existing_thrown_exceptions = $context->possibly_thrown_exceptions;
 
         /**
-         * @var array<string, bool>
+         * @var array<string, CodeLocation>
          */
         $context->possibly_thrown_exceptions = [];
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -391,7 +391,10 @@ class FunctionCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expressio
                         }
 
                         if ($function_storage && $context->collect_exceptions) {
-                            $context->possibly_thrown_exceptions += $function_storage->throws;
+                            $context->possibly_thrown_exceptions += array_fill_keys(
+                                array_keys($function_storage->throws),
+                                new CodeLocation($statements_analyzer->getSource(), $stmt)
+                            );
                         }
 
                         try {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -275,7 +275,10 @@ class CallAnalyzer
             $method_storage = $declaring_class_storage->methods[strtolower($declaring_method_name)];
 
             if ($context->collect_exceptions) {
-                $context->possibly_thrown_exceptions += $method_storage->throws;
+                $context->possibly_thrown_exceptions += array_fill_keys(
+                    array_keys($method_storage->throws),
+                    $code_location
+                );
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/ThrowAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ThrowAnalyzer.php
@@ -52,9 +52,10 @@ class ThrowAnalyzer
                         return false;
                     }
                 } elseif ($context->collect_exceptions) {
+                    $codelocation = new CodeLocation($file_analyzer, $stmt);
                     foreach ($throw_type->getTypes() as $throw_atomic_type) {
                         if ($throw_atomic_type instanceof TNamedObject) {
-                            $context->possibly_thrown_exceptions[$throw_atomic_type->value] = true;
+                            $context->possibly_thrown_exceptions[$throw_atomic_type->value] = $codelocation;
                         }
                     }
                 }

--- a/src/Psalm/Internal/Visitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/Visitor/ReflectorVisitor.php
@@ -1717,7 +1717,9 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
 
         $storage->suppressed_issues = $docblock_info->suppress;
 
-        if ($this->config->check_for_throws_docblock) {
+        if ($this->config->check_for_throws_docblock ||
+            $this->config->check_for_throws_in_global_scope
+        ) {
             foreach ($docblock_info->throws as $throw_class) {
                 $exception_fqcln = Type::getFQCLNFromString(
                     $throw_class,

--- a/src/Psalm/Issue/UncaughtThrowInGlobalScope.php
+++ b/src/Psalm/Issue/UncaughtThrowInGlobalScope.php
@@ -1,0 +1,6 @@
+<?php
+namespace Psalm\Issue;
+
+class UncaughtThrowInGlobalScope extends CodeIssue
+{
+}

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -155,6 +155,9 @@ class DocumentationTest extends TestCase
                 case 'MissingThrowsDocblock':
                     continue 2;
 
+                case 'UncaughtThrowInGlobalScope':
+                    continue 2;
+
                 case 'InvalidStringClass':
                     continue 2;
 

--- a/tests/ThrowsAnnotationTest.php
+++ b/tests/ThrowsAnnotationTest.php
@@ -388,4 +388,108 @@ class ThrowsAnnotationTest extends TestCase
 
         $this->analyzeFile('somefile.php', $context);
     }
+
+    /**
+     * @expectedException        \Psalm\Exception\CodeException
+     * @expectedExceptionMessage UncaughtThrowInGlobalScope
+     *
+     * @return                   void
+     */
+    public function testUncaughtDocumentedThrowCallInGlobalScope()
+    {
+        Config::getInstance()->check_for_throws_in_global_scope = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                /**
+                 * @throws RangeException
+                 * @throws InvalidArgumentException
+                 */
+                function foo(int $x, int $y) : int {
+                    if ($y === 0) {
+                        throw new \RangeException("Cannot divide by zero");
+                    }
+
+                    if ($y < 0) {
+                        throw new \InvalidArgumentException("This is also bad");
+                    }
+
+                    return intdiv($x, $y);
+                }
+
+                foo(0, 0);'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
+    /**
+     * @return                   void
+     */
+    public function testCaughtDocumentedThrowCallInGlobalScope()
+    {
+        Config::getInstance()->check_for_throws_docblock = true;
+        Config::getInstance()->check_for_throws_in_global_scope = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                /**
+                 * @throws RangeException
+                 * @throws InvalidArgumentException
+                 */
+                function foo(int $x, int $y) : int {
+                    if ($y === 0) {
+                        throw new \RangeException("Cannot divide by zero");
+                    }
+
+                    if ($y < 0) {
+                        throw new \InvalidArgumentException("This is also bad");
+                    }
+
+                    return intdiv($x, $y);
+                }
+
+                try {
+                    foo(0, 0);
+                } catch (Exception $e) {}'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
+    /**
+     * @return                   void
+     */
+    public function testUncaughtUndocumentedThrowCallInGlobalScope()
+    {
+        Config::getInstance()->check_for_throws_in_global_scope = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                function foo(int $x, int $y) : int {
+                    if ($y === 0) {
+                        throw new \RangeException("Cannot divide by zero");
+                    }
+
+                    if ($y < 0) {
+                        throw new \InvalidArgumentException("This is also bad");
+                    }
+
+                    return intdiv($x, $y);
+                }
+
+                foo(0, 0);'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
 }

--- a/tests/TryCatchTest.php
+++ b/tests/TryCatchTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace Psalm\Tests;
 
+use Psalm\Config;
+use Psalm\Context;
+
 class TryCatchTest extends TestCase
 {
     use Traits\ValidCodeAnalysisTestTrait;
@@ -273,5 +276,46 @@ class TryCatchTest extends TestCase
                 'error_message' => 'InvalidReturnType',
             ],
         ];
+    }
+
+    /**
+     * @expectedException        \Psalm\Exception\CodeException
+     * @expectedExceptionMessage UncaughtThrowInGlobalScope
+     *
+     * @return                   void
+     */
+    public function testUncaughtThrowInGlobalScope()
+    {
+        Config::getInstance()->check_for_throws_in_global_scope = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                throw new \Exception();'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
+    /**
+     * @return                   void
+     */
+    public function testCaughtThrowInGlobalScope()
+    {
+        Config::getInstance()->check_for_throws_in_global_scope = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                try {
+                    throw new \Exception();
+                } catch (\Exception $e) {}'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
     }
 }


### PR DESCRIPTION
Adds `checkForThrowsInGlobalScope`, which is similar to `checkForThrowsDocblock`, but it checks in global scope instead of function scope.

I also made the code location for `MissingThrowsDocblock` more accurate. It now shows the line that throws instead of the function that has a throw inside. I can revert that if you want to keep the old location.