### PR TITLE
Fix typos in psalm with codespell's dictionary

### DIFF
--- a/docs/issues.md
+++ b/docs/issues.md
@@ -278,7 +278,7 @@ class B extends A {
 
 ### ImplicitToStringCast
 
-Emitted when implictly converting an object with a `__toString` method to a string
+Emitted when implicitly converting an object with a `__toString` method to a string
 
 ```php
 class A {

--- a/src/Psalm/Config/ErrorLevelFileFilter.php
+++ b/src/Psalm/Config/ErrorLevelFileFilter.php
@@ -28,7 +28,7 @@ class ErrorLevelFileFilter extends FileFilter
             $filter->error_level = (string) $e['type'];
 
             if (!in_array($filter->error_level, \Psalm\Config::$ERROR_LEVELS, true)) {
-                throw new \Psalm\Exception\ConfigException('Unexepected error level ' . $filter->error_level);
+                throw new \Psalm\Exception\ConfigException('Unexpected error level ' . $filter->error_level);
             }
         } else {
             throw new \Psalm\Exception\ConfigException('<type> element expects a level');

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -29,7 +29,7 @@ class IssueHandler
             $handler->error_level = (string) $e['errorLevel'];
 
             if (!in_array($handler->error_level, \Psalm\Config::$ERROR_LEVELS, true)) {
-                throw new \Psalm\Exception\ConfigException('Unexepected error level ' . $handler->error_level);
+                throw new \Psalm\Exception\ConfigException('Unexpected error level ' . $handler->error_level);
             }
         }
 
@@ -49,7 +49,7 @@ class IssueHandler
     public function setErrorLevel($error_level)
     {
         if (!in_array($error_level, \Psalm\Config::$ERROR_LEVELS, true)) {
-            throw new \Psalm\Exception\ConfigException('Unexepected error level ' . $error_level);
+            throw new \Psalm\Exception\ConfigException('Unexpected error level ' . $error_level);
         }
 
         $this->error_level = $error_level;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/PropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/PropertyFetchAnalyzer.php
@@ -136,7 +136,7 @@ class PropertyFetchAnalyzer
                 ) {
                     if (IssueBuffer::accepts(
                         new UninitializedProperty(
-                            'Cannot use unitialized property ' . $var_id,
+                            'Cannot use uninitialized property ' . $var_id,
                             new CodeLocation($statements_analyzer->getSource(), $stmt),
                             $var_id
                         ),

--- a/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
@@ -3,7 +3,7 @@
 namespace Psalm\Internal\ExecutionEnvironment;
 
 /**
- * Environment variables collector for CI envrionment.
+ * Environment variables collector for CI environment.
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
  */

--- a/src/Psalm/Internal/LanguageServer/EmitterInterface.php
+++ b/src/Psalm/Internal/LanguageServer/EmitterInterface.php
@@ -25,7 +25,7 @@ interface EmitterInterface
     /**
      * Emits an event.
      *
-     * This method will return true if 0 or more listeners were succesfully
+     * This method will return true if 0 or more listeners were successfully
      * handled. false is returned if one of the events broke the event chain.
      *
      * If the continueCallBack is specified, this callback will be called every

--- a/src/Psalm/Internal/LanguageServer/EmitterTrait.php
+++ b/src/Psalm/Internal/LanguageServer/EmitterTrait.php
@@ -47,7 +47,7 @@ trait EmitterTrait
     /**
      * Emits an event.
      *
-     * This method will return true if 0 or more listeners were succesfully
+     * This method will return true if 0 or more listeners were successfully
      * handled. false is returned if one of the events broke the event chain.
      *
      * If the continueCallBack is specified, this callback will be called every

--- a/src/Psalm/Internal/Scope/IfScope.php
+++ b/src/Psalm/Internal/Scope/IfScope.php
@@ -67,7 +67,7 @@ class IfScope
 
     /**
      * These are the set of clauses that could be applied after the `if`
-     * statement, if the `if` statement contains branches with leaving statments,
+     * statement, if the `if` statement contains branches with leaving statements,
      * and the else leaves too
      *
      * @var array<int, Clause>

--- a/src/Psalm/Type/Algebra.php
+++ b/src/Psalm/Type/Algebra.php
@@ -533,10 +533,10 @@ class Algebra
 
         $impossibilities = [];
 
-        foreach ($clause->possibilities as $var_id => $possiblity) {
+        foreach ($clause->possibilities as $var_id => $possibility) {
             $impossibility = [];
 
-            foreach ($possiblity as $type) {
+            foreach ($possibility as $type) {
                 if (($type[0] !== '=' && $type[0] !== '~'
                         && (!isset($type[1]) || ($type[1] !== '=' && $type[1] !== '~')))
                     || strpos($type, '(')


### PR DESCRIPTION
some typos were detected with https://github.com/TysonAndre/PhanTypoCheck (wraps token_get_all() to be aware of php files)