### PR TITLE
Inherit uncaught throws from namespace scope

### DIFF
--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -89,6 +89,11 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
             $context->defineGlobals();
             $context->collect_exceptions = $codebase->config->check_for_throws_in_global_scope;
             $statements_analyzer->analyze($leftover_stmts, $context);
+
+            $file_context = $this->source->context;
+            if ($file_context) {
+                $file_context->possibly_thrown_exceptions += $context->possibly_thrown_exceptions;
+            }
         }
     }
 

--- a/tests/ThrowsAnnotationTest.php
+++ b/tests/ThrowsAnnotationTest.php
@@ -492,4 +492,42 @@ class ThrowsAnnotationTest extends TestCase
 
         $this->analyzeFile('somefile.php', $context);
     }
+
+    /**
+     * @expectedException        \Psalm\Exception\CodeException
+     * @expectedExceptionMessage UncaughtThrowInGlobalScope
+     *
+     * @return                   void
+     */
+    public function testUncaughtDocumentedThrowCallInNamespace()
+    {
+        Config::getInstance()->check_for_throws_in_global_scope = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace ns;
+                /**
+                 * @throws RangeException
+                 * @throws InvalidArgumentException
+                 */
+                function foo(int $x, int $y) : int {
+                    if ($y === 0) {
+                        throw new \RangeException("Cannot divide by zero");
+                    }
+
+                    if ($y < 0) {
+                        throw new \InvalidArgumentException("This is also bad");
+                    }
+
+                    return intdiv($x, $y);
+                }
+
+                foo(0, 0);'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
 }


### PR DESCRIPTION
This allows `checkThrowsInGlobalScope` to work when the file has namespaces. I didn't consider that Psalm gives namespaces their own scopes.