### PR TITLE
modifying callmap entry for error_get_last()

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -2440,7 +2440,7 @@ return [
 'Error::getTrace' => ['array'],
 'Error::getTraceAsString' => ['string'],
 'error_clear_last' => ['void'],
-'error_get_last' => ['?array'],
+'error_get_last' => ['?array{message:string, type?:int, file?:string, line?:int}'],
 'error_log' => ['bool', 'message'=>'string', 'message_type='=>'int', 'destination='=>'string', 'extra_headers='=>'string'],
 'error_reporting' => ['int', 'new_error_level='=>'int'],
 'ErrorException::__clone' => ['void'],

--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -2440,7 +2440,7 @@ return [
 'Error::getTrace' => ['array'],
 'Error::getTraceAsString' => ['string'],
 'error_clear_last' => ['void'],
-'error_get_last' => ['?array{message:string, type?:int, file?:string, line?:int}'],
+'error_get_last' => ['?array{type:int, message:string, file:string, line:int}'],
 'error_log' => ['bool', 'message'=>'string', 'message_type='=>'int', 'destination='=>'string', 'extra_headers='=>'string'],
 'error_reporting' => ['int', 'new_error_level='=>'int'],
 'ErrorException::__clone' => ['void'],


### PR DESCRIPTION
I've seen error loggers say an error occurs on line 0 of unknown if an error was triggered in a shutdown function.
not sure what happens with type.
pretty sure that message is always there as a string.

* makes conditions checking for type redundant
* makes conditions checking for presence of `$err['message'];` redundant if `is_array($err)` has passed.