### PR TITLE
Fix memory leak for exception code locations

### DIFF
--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -213,7 +213,7 @@ class Context
     /**
      * A list of classes or interfaces that may have been thrown
      *
-     * @var array<string, array<int, CodeLocation>>
+     * @var array<string, array<array-key, CodeLocation>>
      */
     public $possibly_thrown_exceptions = [];
 
@@ -774,10 +774,11 @@ class Context
      */
     public function mergeExceptions(Context $other_context)
     {
-        $this->possibly_thrown_exceptions = array_merge_recursive(
-            $this->possibly_thrown_exceptions,
-            $other_context->possibly_thrown_exceptions
-        );
+        foreach ($other_context->possibly_thrown_exceptions as $possibly_thrown_exception => $codelocations) {
+            foreach ($codelocations as $hash => $codelocation) {
+                $this->possibly_thrown_exceptions[$possibly_thrown_exception][$hash] = $codelocation;
+            }
+        }
     }
 
     /**
@@ -805,8 +806,9 @@ class Context
         FunctionLikeStorage $function_storage,
         CodeLocation $codelocation
     ) {
+        $hash = $codelocation->getHash();
         foreach ($function_storage->throws as $possibly_thrown_exception => $_) {
-            $this->possibly_thrown_exceptions[$possibly_thrown_exception][] = $codelocation;
+            $this->possibly_thrown_exceptions[$possibly_thrown_exception][$hash] = $codelocation;
         }
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
@@ -47,7 +47,7 @@ class TryAnalyzer
         $existing_thrown_exceptions = $context->possibly_thrown_exceptions;
 
         /**
-         * @var array<string, array<int, CodeLocation>>
+         * @var array<string, array<array-key, CodeLocation>>
          */
         $context->possibly_thrown_exceptions = [];
 
@@ -399,10 +399,11 @@ class TryAnalyzer
             }
         }
 
-        $context->possibly_thrown_exceptions = array_merge_recursive(
-            $context->possibly_thrown_exceptions,
-            $existing_thrown_exceptions
-        );
+        foreach ($existing_thrown_exceptions as $possibly_thrown_exception => $codelocations) {
+            foreach ($codelocations as $hash => $codelocation) {
+                $context->possibly_thrown_exceptions[$possibly_thrown_exception][$hash] = $codelocation;
+            }
+        }
 
         return null;
     }

--- a/src/Psalm/Internal/Analyzer/Statements/ThrowAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ThrowAnalyzer.php
@@ -53,9 +53,10 @@ class ThrowAnalyzer
                     }
                 } elseif (!$context->isSuppressingExceptions($statements_analyzer)) {
                     $codelocation = new CodeLocation($file_analyzer, $stmt);
+                    $hash = $codelocation->getHash();
                     foreach ($throw_type->getTypes() as $throw_atomic_type) {
                         if ($throw_atomic_type instanceof TNamedObject) {
-                            $context->possibly_thrown_exceptions[$throw_atomic_type->value][] = $codelocation;
+                            $context->possibly_thrown_exceptions[$throw_atomic_type->value][$hash] = $codelocation;
                         }
                     }
                 }

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -1692,7 +1692,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     }
 
     /**
-     * @return array<string, array<int, CodeLocation>>
+     * @return array<string, array<array-key, CodeLocation>>
      */
     public function getUncaughtThrows(Context $context)
     {

--- a/tests/ThrowsInGlobalScopeTest.php
+++ b/tests/ThrowsInGlobalScopeTest.php
@@ -238,7 +238,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->addFile(
             'somefile.php',
             '<?php
-                namespace ns;
                 /**
                  * @throws RangeException
                  * @throws InvalidArgumentException
@@ -292,6 +291,46 @@ class ThrowsInGlobalScopeTest extends TestCase
                 }
 
                 /** @psalm-suppress UncaughtThrowInGlobalScope */
+                foo(0, 0);'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
+    /**
+     * @expectedException        \Psalm\Exception\CodeException
+     * @expectedExceptionMessage UncaughtThrowInGlobalScope
+     *
+     * @return                   void
+     */
+    public function testUncaughtDocumentedThrowCallWhenSuppressingFirst()
+    {
+        Config::getInstance()->check_for_throws_in_global_scope = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                /**
+                 * @throws RangeException
+                 * @throws InvalidArgumentException
+                 */
+                function foo(int $x, int $y) : int {
+                    if ($y === 0) {
+                        throw new \RangeException("Cannot divide by zero");
+                    }
+
+                    if ($y < 0) {
+                        throw new \InvalidArgumentException("This is also bad");
+                    }
+
+                    return intdiv($x, $y);
+                }
+
+                /** @psalm-suppress UncaughtThrowInGlobalScope */
+                foo(0, 0);
+
                 foo(0, 0);'
         );
 


### PR DESCRIPTION
After testing `checkForThrowsInGlobalScope` on a larger code base, I found that way too many code locations are stored. Psalm crashes with `Allowed memory size of 4294967296 bytes exhausted`. The same happens for `checkForThrowsDocblock`, since it also causes all code locations to be stored.