### PR TITLE
Allow ignoring exceptions only in global scope

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -99,8 +99,8 @@
 
     <xs:complexType name="ExceptionsType">
         <xs:sequence>
-            <xs:element name="class" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
-            <xs:element name="classAndDescendants" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+            <xs:element name="class" minOccurs="0" maxOccurs="unbounded" type="ExceptionType" />
+            <xs:element name="classAndDescendants" minOccurs="0" maxOccurs="unbounded" type="ExceptionType" />
         </xs:sequence>
     </xs:complexType>
 
@@ -447,5 +447,10 @@
     <xs:complexType name="IdentifierType">
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="type" type="xs:string" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="ExceptionType">
+        <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:attribute name="onlyGlobalScope" type="xs:string" />
     </xs:complexType>
 </xs:schema>

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -152,7 +152,7 @@ When `true`, Psalm will check that the developer has supplied `@throws` docblock
 #### checkForThrowsInGlobalScope
 ```xml
 <psalm
-  checkForThrowsDocblock="[bool]"
+  checkForThrowsInGlobalScope="[bool]"
 >
 ```
 When `true`, Psalm will check that the developer has caught every exception in global scope. Defaults to `false`.
@@ -253,3 +253,11 @@ Optional. Do you use mock classes in your tests? If you want Psalm to ignore the
 
 #### `<stubs>`
 Optional. If your codebase uses classes and functions that are not visible to Psalm via reflection (e.g. if there are internal packages that your codebase relies on that are not available on the machine running Psalm), you can use stub files. Used by PhpStorm (a popular IDE) and others, stubs provide a description of classes and functions without the implementations. You can find a list of stubs for common classes [here](https://github.com/JetBrains/phpstorm-stubs). List out each file with `<file name="path/to/file.php" />`.
+
+#### `<ignoreExceptions>`
+Optional.  A list of exceptions to not report for `checkForThrowsDocblock` or `checkForThrowsInGlobalScope`. If an exception has `onlyGlobalScope` set to `true`, only `checkForThrowsInGlobalScope` is ignored for that exception, e.g.
+```xml
+<projectFiles>
+  <class name="fully\qualified\path\Exc" onlyGlobalScope="true" />
+</projectFiles>
+```

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -240,7 +240,17 @@ class Config
     /**
      * @var array<string, bool>
      */
+    public $ignored_exceptions_in_global_scope = [];
+
+    /**
+     * @var array<string, bool>
+     */
     public $ignored_exceptions_and_descendants = [];
+
+    /**
+     * @var array<string, bool>
+     */
+    public $ignored_exceptions_and_descendants_in_global_scope = [];
 
     /**
      * @var array<string, bool>
@@ -697,13 +707,23 @@ class Config
             if (isset($config_xml->ignoreExceptions->class)) {
                 /** @var \SimpleXMLElement $exception_class */
                 foreach ($config_xml->ignoreExceptions->class as $exception_class) {
-                    $config->ignored_exceptions[(string) $exception_class['name']] = true;
+                    $exception_name = (string) $exception_class['name'];
+                    $global_attribute_text = (string) $exception_class['onlyGlobalScope'];
+                    if ($global_attribute_text !== 'true' && $global_attribute_text !== '1') {
+                        $config->ignored_exceptions[$exception_name] = true;
+                    }
+                    $config->ignored_exceptions_in_global_scope[$exception_name] = true;
                 }
             }
             if (isset($config_xml->ignoreExceptions->classAndDescendants)) {
                 /** @var \SimpleXMLElement $exception_class */
                 foreach ($config_xml->ignoreExceptions->classAndDescendants as $exception_class) {
-                    $config->ignored_exceptions_and_descendants[(string) $exception_class['name']] = true;
+                    $exception_name = (string) $exception_class['name'];
+                    $global_attribute_text = (string) $exception_class['onlyGlobalScope'];
+                    if ($global_attribute_text !== 'true' && $global_attribute_text !== '1') {
+                        $config->ignored_exceptions_and_descendants[$exception_name] = true;
+                    }
+                    $config->ignored_exceptions_and_descendants_in_global_scope[$exception_name] = true;
                 }
             }
         }

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -1700,11 +1700,16 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
 
         if ($context->collect_exceptions) {
             if ($context->possibly_thrown_exceptions) {
+                $config = $this->codebase->config;
                 $ignored_exceptions = array_change_key_case(
-                    $this->codebase->config->ignored_exceptions
+                    $context->is_global ?
+                        $config->ignored_exceptions_in_global_scope :
+                        $config->ignored_exceptions
                 );
                 $ignored_exceptions_and_descendants = array_change_key_case(
-                    $this->codebase->config->ignored_exceptions_and_descendants
+                    $context->is_global ?
+                        $config->ignored_exceptions_and_descendants_in_global_scope :
+                        $config->ignored_exceptions_and_descendants
                 );
 
                 foreach ($context->possibly_thrown_exceptions as $possibly_thrown_exception => $codelocations) {


### PR DESCRIPTION
Allows requiring that some exceptions are documented but ignoring them in global scope.

```xml
<ignoreExceptions>
    <class name="Exc2" onlyGlobalScope="true" />
</ignoreExceptions>
```

It can be a little unclear how `onlyGlobalScope` is interpreted, so I'm open to other names for it.