### PR TITLE
Case-insensitive checks for var_dump and shell_exec

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -634,7 +634,8 @@ class FunctionCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expressio
                 $context->check_consts = false;
             } elseif ($function->parts === ['extract']) {
                 $context->check_variables = false;
-            } elseif (strtolower($function->parts[0]) === 'var_dump' || strtolower($function->parts[0]) === 'shell_exec') {
+            } elseif (strtolower($function->parts[0]) === 'var_dump'
+                || strtolower($function->parts[0]) === 'shell_exec') {
                 if (IssueBuffer::accepts(
                     new ForbiddenCode(
                         'Unsafe ' . implode('', $function->parts),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -634,7 +634,7 @@ class FunctionCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expressio
                 $context->check_consts = false;
             } elseif ($function->parts === ['extract']) {
                 $context->check_variables = false;
-            } elseif ($function->parts === ['var_dump'] || $function->parts === ['shell_exec']) {
+            } elseif (strtolower($function->parts[0]) === 'var_dump' || strtolower($function->parts[0]) === 'shell_exec') {
                 if (IssueBuffer::accepts(
                     new ForbiddenCode(
                         'Unsafe ' . implode('', $function->parts),

--- a/tests/ForbiddenCodeTest.php
+++ b/tests/ForbiddenCodeTest.php
@@ -17,6 +17,11 @@ class ForbiddenCodeTest extends TestCase
                     var_dump("hello");',
                 'error_message' => 'ForbiddenCode',
             ],
+            'varDumpCased' => [
+                '<?php
+                    vAr_dUMp("hello");',
+                'error_message' => 'ForbiddenCode',
+            ],
             'execTicks' => [
                 '<?php
                     `rm -rf`;',
@@ -25,6 +30,11 @@ class ForbiddenCodeTest extends TestCase
             'exec' => [
                 '<?php
                     shell_exec("rm -rf");',
+                'error_message' => 'ForbiddenCode',
+            ],
+            'execCased' => [
+                '<?php
+                    sHeLl_EXeC("rm -rf");',
                 'error_message' => 'ForbiddenCode',
             ],
         ];


### PR DESCRIPTION
Fixes vimeo/psalm#1547

Seeing that other checks in the vicinity of the changed lines are also done in a case-sensitive fashion it might make sense to attempt more general fix.