### PR TITLE
fix "iconv_strlen()" return type

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -5149,7 +5149,7 @@ return [
 'iconv_mime_decode_headers' => ['array|false', 'headers'=>'string', 'mode='=>'int', 'charset='=>'string'],
 'iconv_mime_encode' => ['string|false', 'field_name'=>'string', 'field_value'=>'string', 'preference='=>'array'],
 'iconv_set_encoding' => ['bool', 'type'=>'string', 'charset'=>'string'],
-'iconv_strlen' => ['int', 'str'=>'string', 'charset='=>'string'],
+'iconv_strlen' => ['int|false', 'str'=>'string', 'charset='=>'string'],
 'iconv_strpos' => ['int|false', 'haystack'=>'string', 'needle'=>'string', 'offset='=>'int', 'charset='=>'string'],
 'iconv_strrpos' => ['int|false', 'haystack'=>'string', 'needle'=>'string', 'charset='=>'string'],
 'iconv_substr' => ['string|false', 'str'=>'string', 'offset'=>'int', 'length='=>'int', 'charset='=>'string'],


### PR DESCRIPTION
-> some tests in "https://github.com/voku/portable-utf8" fails if I remove the false check e.g. for this string:

// string with UTF-16 (LE) BOM + valid UTF-8 && invalid UTF-8
$string = "\xFF\xFE" . 'string <strong>with utf-8 chars åèä</strong>' . "\xa0\xa1" . ' - doo-bee doo-bee dooh';