### PR TITLE
Fix link to Plugins that currently 404s

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -243,7 +243,7 @@ Contains a list of all the directories that Psalm should inspect. You can also s
 Optional.  A list of extensions to search over. See [Checking non-PHP files](checking_non_php_files.md) to understand how to extend this.
 
 #### `<plugins>`
-Optional.  A list of `<plugin filename="path_to_plugin.php" />` entries. See the [Plugins](plugins.md) section for more information.
+Optional.  A list of `<plugin filename="path_to_plugin.php" />` entries. See the [Plugins](using_plugins.md) section for more information.
 
 #### `<issueHandlers>`
 Optional.  If you don't want Psalm to complain about every single issue it finds, the issueHandler tag allows you to configure that. [Dealing with code issues](dealing_with_code_issues.md) tells you more.


### PR DESCRIPTION
Noticed this when reading the docs.