### PR TITLE
Replace php-cs-fixer/diff in favor of sebastian/diff

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "nikic/php-parser": "^4.0.2 || ^4.1",
         "openlss/lib-array2xml": "^0.0.10||^0.5.1",
         "muglug/package-versions-56": "1.2.4",
-        "php-cs-fixer/diff": "^1.2",
         "composer/xdebug-handler": "^1.1",
         "felixfbecker/language-server-protocol": "^1.2",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
@@ -24,7 +23,8 @@
         "symfony/console": "^3.3||^4.0",
         "amphp/amp": "^2.1",
         "amphp/byte-stream": "^1.5",
-        "phpmyadmin/sql-parser": "^4.0"
+        "phpmyadmin/sql-parser": "^4.0",
+        "sebastian/diff": "^3.0"
     },
     "bin": ["psalm", "psalter", "psalm-language-server", "psalm-plugin"],
     "autoload": {

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -1091,8 +1091,8 @@ class Analyzer
             if ($dry_run) {
                 echo $file_path . ':' . "\n";
 
-                $differ = new \PhpCsFixer\Diff\v2_0\Differ(
-                    new \PhpCsFixer\Diff\GeckoPackages\DiffOutputBuilder\UnifiedDiffOutputBuilder([
+                $differ = new \SebastianBergmann\Diff\Differ(
+                    new \SebastianBergmann\Diff\Output\StrictUnifiedDiffOutputBuilder([
                         'fromFile' => 'Original',
                         'toFile' => 'New',
                     ])


### PR DESCRIPTION
`php-cs-fixer/diff` marked as "internal" for php-cs-fixer tool and not recommended for extrernal usage.

I suggest it was added for compatibility with php 5.6. Now psalm requires ^7.0.

How I check for same output:
```bash
cd /path/to/psalm
./psalter --dry-run --issues=UnusedProperty
```

Output for both versions (`sebastian/diff` vs `php-cs-fixer/diff`)
```
Scanning files...
Analyzing files...
/path/to/psalm/psalm/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php:
--- Original
+++ New
@@ -59,15 +59,6 @@
     /** @var null|string */
     private $new_psalm_return_type;
 
-    /** @var array<string, int> */
-    private $param_typehint_area_starts = [];
-
-    /** @var array<string, int> */
-    private $param_typehint_starts = [];
-
-    /** @var array<string, int> */
-    private $param_typehint_ends = [];
-
     /** @var array<string, string> */
     private $new_php_param_types = [];
 

------------------------------
No errors found!
------------------------------

Checks took 20.68 seconds and used 326.509MB of memory
Psalm was able to infer types for 99.7984% of the codebase

``` 