### PR TITLE
Fix isset check

### DIFF
--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -24,7 +24,7 @@ class FileProvider
             return $this->temp_files[strtolower($file_path)];
         }
 
-        if (isset($this->temp_files[strtolower($file_path)])) {
+        if (isset($this->open_files[strtolower($file_path)])) {
             return $this->open_files[strtolower($file_path)];
         }
 


### PR DESCRIPTION
Check if index exists in the array with open files, instead of checking
if index exists in the array with temporary files.

I was receiving errors in Visual Studio Code: ErrorException: Undefined index.