### PR TITLE
Fix #1622 - add allow-backwards-incompatible-changes flag to psalter

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -176,6 +176,11 @@ class Codebase
     public $diff_methods = false;
 
     /**
+     * @var bool
+     */
+    public $allow_backwards_incompatible_changes = true;
+
+    /**
      * @var int
      */
     public $php_major_version = PHP_MAJOR_VERSION;

--- a/src/psalter.php
+++ b/src/psalter.php
@@ -21,6 +21,7 @@ $valid_long_options = [
     'help', 'debug', 'debug-by-line', 'config:', 'file:', 'root:',
     'plugin:', 'issues:', 'php-version:', 'dry-run', 'safe-types',
     'find-unused-code', 'threads:', 'codeowner:',
+    'allow-backwards-incompatible-changes:',
 ];
 
 // get options from command line
@@ -117,6 +118,9 @@ Options:
 
     --codeowner=[codeowner]
         You can specify a GitHub code ownership group, and only that owner's code will be updated.
+
+    --allow-backwards-incompatible-changes=BOOL
+        Allow Psalm modify method signatures that could break code outside the project. Defaults to true.
 HELP;
 
     exit;
@@ -300,6 +304,20 @@ if (isset($options['codeowner'])) {
             die('User/group ' . $desired_codeowner . ' does not own any PHP files' . PHP_EOL);
         }
     }
+}
+
+if (isset($options['allow-backwards-incompatible-changes'])) {
+    $allow_backwards_incompatible_changes = filter_var(
+        $options['allow-backwards-incompatible-changes'],
+        FILTER_VALIDATE_BOOLEAN,
+        ['flags' => FILTER_NULL_ON_FAILURE]
+    );
+
+    if ($allow_backwards_incompatible_changes === null) {
+        die('--allow-backwards-incompatible-changes expectes a boolean value [true|false|1|0]' . PHP_EOL);
+    }
+
+    $project_analyzer->getCodebase()->allow_backwards_incompatible_changes = $allow_backwards_incompatible_changes;
 }
 
 $plugins = [];

--- a/tests/FileManipulation/FileManipulationTest.php
+++ b/tests/FileManipulation/FileManipulationTest.php
@@ -30,10 +30,11 @@ abstract class FileManipulationTest extends \Psalm\Tests\TestCase
      * @param string $php_version
      * @param string[] $issues_to_fix
      * @param bool $safe_types
+     * @param bool $allow_backwards_incompatible_changes
      *
      * @return void
      */
-    public function testValidCode($input_code, $output_code, $php_version, array $issues_to_fix, $safe_types)
+    public function testValidCode($input_code, $output_code, $php_version, array $issues_to_fix, $safe_types, bool $allow_backwards_incompatible_changes = true)
     {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
@@ -77,6 +78,7 @@ abstract class FileManipulationTest extends \Psalm\Tests\TestCase
             false,
             $safe_types
         );
+        $this->project_analyzer->getCodebase()->allow_backwards_incompatible_changes = $allow_backwards_incompatible_changes;
 
         $this->project_analyzer->getCodebase()->reportUnusedCode();
 

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -1132,6 +1132,82 @@ class ReturnTypeManipulationTest extends FileManipulationTest
                 ['InvalidReturnType'],
                 false,
             ],
+            'fixInvalidIntReturnTypeJustInPhpDocWhenDisallowingBackwardsIncompatibleChanges' => [
+                '<?php
+                    class A {
+                        /**
+                         * @return int
+                         */
+                        protected function foo() {}
+                    }',
+                '<?php
+                    class A {
+                        /**
+                         * @return void
+                         */
+                        protected function foo() {}
+                    }',
+                '7.3',
+                ['InvalidReturnType'],
+                false,
+                false,
+            ],
+            'fixInvalidIntReturnTypeInFinalMethodWhenDisallowingBackwardsIncompatibleChanges' => [
+                '<?php
+                    class A {
+                        /**
+                         * @return int
+                         */
+                        protected final function foo() {}
+                    }',
+                '<?php
+                    class A {
+                        /**
+                         * @return void
+                         */
+                        protected final function foo(): void {}
+                    }',
+                '7.3',
+                ['InvalidReturnType'],
+                false,
+                false,
+            ],
+            'fixInvalidIntReturnTypeInFinalClassWhenDisallowingBackwardsIncompatibleChanges' => [
+                '<?php
+                    final class A {
+                        /**
+                         * @return int
+                         */
+                        protected function foo() {}
+                    }',
+                '<?php
+                    final class A {
+                        /**
+                         * @return void
+                         */
+                        protected function foo(): void {}
+                    }',
+                '7.3',
+                ['InvalidReturnType'],
+                false,
+                false,
+            ],
+            'fixInvalidIntReturnTypeInFunctionWhenDisallowingBackwardsIncompatibleChanges' => [
+                '<?php
+                    /**
+                     * @return int
+                     */
+                    function foo() {}',
+                '<?php
+                    /**
+                     * @return void
+                     */
+                    function foo(): void {}',
+                '7.3',
+                ['InvalidReturnType'],
+                false,
+                false,
+            ],
         ];
     }
 }


### PR DESCRIPTION
The flag prevents psalter from adding native return types