### PR TITLE
FileProvider: Consider file open if temp changes

### DIFF
--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -89,7 +89,7 @@ class FileProvider
      */
     public function isOpen(string $file_path)
     {
-        return isset($this->open_files[strtolower($file_path)]);
+        return isset($this->temp_files[strtolower($file_path)]) || isset($this->open_files[strtolower($file_path)]);
     }
 
     /**


### PR DESCRIPTION
The VS Code LSP client does not always send didOpen messages when a file
is being edited. This causes code completion requests to fail because the
completion request refers to files which are not 'open' according to
FileProvider.

This commit changes FileProvider so that a file is considered 'open' if it is
being modified, even if no didOpen message was received from the LSP
client.