### PR TITLE
LSP Completion: Handle late completion requests

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1113,7 +1113,7 @@ class Codebase
             return null;
         }
 
-        $gap = substr($file_contents, $end_pos, $offset - $end_pos);
+        $gap = substr($file_contents, $end_pos, 2);
 
         return [$recent_type, $gap];
     }


### PR DESCRIPTION
Currently, Psalm Language Server is only able to handle completion requests where the gap between a recent known type and the current cursor position is exactly '->' or '::'. However, VS code often doesn't send a completion request until an additional, third character has been typed. This change allows Psalm to successfully serve completion requests where an additional character has been typed.

An alternative to this change would be to instead modify `Psalm\Internal\LanguageServer\Server\TextDocument::completion()` so that it only considers the first two characters of the gap as returned by `Psalm\Codebase::getCompletionDataAtPosition()`.