### PR TITLE
Allow coercion from empty to array param

### DIFF
--- a/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
@@ -1591,6 +1591,10 @@ class TypeAnalyzer
                     continue;
                 }
 
+                if ($input_param->isEmpty()) {
+                    continue;
+                }
+
                 if (!self::isContainedBy(
                     $codebase,
                     $input_param,

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -2230,6 +2230,29 @@ class TemplateTest extends TestCase
                     '$y' => 'array<array-key, A&B>',
                 ]
             ],
+            'templateEmptyParamCoercion' => [
+                '<?php
+                    namespace NS;
+                    use Countable;
+
+                    /** @template T */
+                    class Collection
+                    {
+                        /** @psalm-var iterable<T> */
+                        private $data;
+
+                        /** @psalm-param iterable<T> $data */
+                        public function __construct(iterable $data = []) {
+                            $this->data = $data;
+                        }
+                    }
+
+                    class Item {}
+                    /** @psalm-param Collection<Item> $c */
+                    function takesCollectionOfItems(Collection $c): void {}
+
+                    takesCollectionOfItems(new Collection());',
+            ],
         ];
     }
 
@@ -2756,35 +2779,6 @@ class TemplateTest extends TestCase
                         }
                     }',
                 'error_message' => 'InvalidDocblock',
-            ],
-            'noComparisonToEmpty' => [
-                '<?php
-                    /**
-                     * @template K
-                     * @template V
-                     */
-                    class Container {
-                        /** @var array<K, V> */
-                        private $c;
-
-                        /** @param array<K, V> $c */
-                        public function __construct(array $c) {
-                            $this->c = $c;
-                        }
-                    }
-
-                    class Test {
-                        /**
-                         * @var Container<int, DateTime>
-                         */
-                        private $c;
-
-                        public function __construct()
-                        {
-                            $this->c = new Container([]);
-                        }
-                    }',
-                'error_message' => 'InvalidPropertyAssignmentValue'
             ],
             'preventDogCatSnafu' => [
                 '<?php

--- a/tests/Template/TemplateTest.php
+++ b/tests/Template/TemplateTest.php
@@ -2251,7 +2251,8 @@ class TemplateTest extends TestCase
                     /** @psalm-param Collection<Item> $c */
                     function takesCollectionOfItems(Collection $c): void {}
 
-                    takesCollectionOfItems(new Collection());',
+                    takesCollectionOfItems(new Collection());
+                    takesCollectionOfItems(new Collection([]));',
             ],
         ];
     }
@@ -2823,6 +2824,35 @@ class TemplateTest extends TestCase
                         public function set($value): void {}
                     }',
                 'error_message' => 'InvalidTemplateParam',
+            ],
+            'templateEmptyParamCoercionChangeVariable' => [
+                '<?php
+                    namespace NS;
+                    use Countable;
+
+                    /** @template T */
+                    class Collection
+                    {
+                        /** @psalm-var iterable<T> */
+                        private $data;
+
+                        /** @psalm-param iterable<T> $data */
+                        public function __construct(iterable $data = []) {
+                            $this->data = $data;
+                        }
+                    }
+
+                    /** @psalm-param Collection<string> $c */
+                    function takesStringCollection(Collection $c): void {}
+
+                    /** @psalm-param Collection<int> $c */
+                    function takesIntCollection(Collection $c): void {}
+
+                    $collection = new Collection();
+
+                    takesStringCollection($collection);
+                    takesIntCollection($collection);',
+                'error_message' => 'InvalidScalarArgument',
             ],
         ];
     }


### PR DESCRIPTION
This allows users to assign templates with `empty`-inferred types to values with known types.

`empty` is a special type in Psalm that represents a key/value of a yet-to-be-filled array.

Can anyone think of a reason why this might be bad?

cc @vasily-kartashov @iluuu1994 @joshdifabio @SignpostMarv @ocramius