### PR TITLE
Write Psalm version to baseline

### DIFF
--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -204,6 +204,7 @@ class ErrorBaseline
     ) {
         $baselineDoc = new \DOMDocument('1.0', 'UTF-8');
         $filesNode = $baselineDoc->createElement('files');
+        $filesNode->setAttribute('psalm-version', PSALM_VERSION);
 
         foreach ($groupedIssues as $file => $issueTypes) {
             $fileNode = $baselineDoc->createElement('file');


### PR DESCRIPTION
For our baseline we've found that it's quite relevant to note on which version of Psalm the baseline was created, primarily because the rapid development of Psalm means we often run into "new" issues, because they simply weren't detected before. Since the "rule" within our development department is to only ever add issues to the baseline when the Psalm version updates, this would help transparency.

Also, we've started committing a readable version of the baseline and generating that with the version number in the baseline would make it more reliable and easier to build.

<img width="942" alt="Screen Shot 2019-05-24 at 14 38 19" src="https://user-images.githubusercontent.com/19645273/58328195-cd0a1c80-7e31-11e9-9067-21586863614e.png">
