### PR TITLE
Ignore Tnever when in union with any other type

### DIFF
--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -15,6 +15,7 @@ use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNever;
 use Psalm\Type\Atomic\TString;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Internal\Type\TypeCombination;
@@ -145,6 +146,15 @@ class Union
 
         foreach ($types as $type) {
             $key = $type->getKey();
+
+            if ($type instanceof TNever) {
+                if (! empty($this->types)) {
+                    continue;
+                }
+            } else {
+                unset($this->types['never-return']);
+            }
+
             $this->types[$key] = $type;
 
             if ($type instanceof TLiteralInt) {

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -563,7 +563,7 @@ class ReturnTypeTest extends TestCase
                 '<?php
                     namespace Foo;
                     /**
-                     * @return never-returns|int
+                     * @return int|never-returns
                      */
                     function foo() : int {
                         return 3;

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -549,6 +549,26 @@ class ReturnTypeTest extends TestCase
                         exit();
                     }',
             ],
+            'neverReturnsUnion' => [
+                '<?php
+                    namespace Foo;
+                    /**
+                     * @return never-returns|int
+                     */
+                    function foo() : int {
+                        return 3;
+                    }',
+            ],
+            'neverReturnsReversed' => [
+                '<?php
+                    namespace Foo;
+                    /**
+                     * @return never-returns|int
+                     */
+                    function foo() : int {
+                        return 3;
+                    }',
+            ],
             'neverReturnsCovariance' => [
                 '<?php
                     namespace Foo;

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -559,7 +559,7 @@ class ReturnTypeTest extends TestCase
                         return 3;
                     }',
             ],
-            'neverReturnsReversed' => [
+            'neverReturnsUnionReversed' => [
                 '<?php
                     namespace Foo;
                     /**


### PR DESCRIPTION
Previously an InvalidReturnType would have been emitted for the code
in the new tests. I don't know if there's a practical value to
including Tnever in a union, but I believe it's correct for
TNever|T to always equal T, whatever type T is.