### PR TITLE
Don't attempt to deploy phar from forked repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
       env: DEPS="high"
       script:
         - bin/build-phar.sh
-        - if [[ "$TRAVIS_PULL_REQUEST" = 'false' ]]; then bin/travis-deploy-phar.sh; fi
+        - if [[ "$TRAVIS_REPO_SLUG" = 'vimeo/psalm' && "$TRAVIS_PULL_REQUEST" = 'false' ]]; then bin/travis-deploy-phar.sh; fi
       before_deploy:
         - echo $GPG_ENCRYPTION | gpg --passphrase-fd 0 keys.asc.gpg
         - gpg --batch --yes --import keys.asc


### PR DESCRIPTION
Only vimeo/psalm should be deploying. 

This makes it possible to get a successful build status from github repos other than **vimeo/psalm**, so as contributors we can more easily test our work before submitting a PR.

Build passed at https://travis-ci.org/bdsl/psalm/builds/540079192