### PR TITLE
Simplify build/sign/deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,22 +62,27 @@ jobs:
       script:
         - vendor/bin/phpcs
 
-      # always build phar, but only deploy on tag builds
     - stage: Phar build
       php: 7.3
       env: DEPS="high"
       script: bin/build-phar.sh
       deploy:
+        # deploy tagged releases to github releases page
         - provider: releases
           skip_cleanup: true
           on:
             tags: true
-            condition: ' "$GITHUB_TOKEN" != "" '
+            repo: vimeo/psalm
           api_key: $GITHUB_TOKEN
           file:
             - build/psalm.phar
             - build/psalm.phar.asc
+
+        # deploy built phar to github.com/psalm/phar repo for all branches and tags, 
+        # but not for pull requests
         - provider: script
           skip_cleanup: true
-          condition: ' "$TRAVIS_PULL_REQUEST" = "false" && "$GITHUB_TOKEN" != "" '
+          on:
+            repo: vimeo/psalm
+            condition: ' "$TRAVIS_PULL_REQUEST" = "false" '
           script: bin/travis-deploy-phar.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,20 +66,18 @@ jobs:
     - stage: Phar build
       php: 7.3
       env: DEPS="high"
-      script:
-        - bin/build-phar.sh
-        - if [[ "$TRAVIS_PULL_REQUEST" = 'false' && "$GITHUB_TOKEN" != '']]; then bin/travis-deploy-phar.sh; fi
-      before_deploy:
-        - echo $GPG_ENCRYPTION | gpg --passphrase-fd 0 keys.asc.gpg
-        - gpg --batch --yes --import keys.asc
-        - echo $SIGNING_KEY | gpg --passphrase-fd 0 -u 8A03EA3B385DBAA1 --armor --detach-sig build/psalm.phar
-        - cd phar && git tag ${TRAVIS_TAG} && git push origin ${TRAVIS_TAG} && cd ..
+      script: bin/build-phar.sh
       deploy:
-        skip_cleanup: true
-        on:
-          tags: true
-        provider: releases
-        api_key: $GITHUB_TOKEN
-        file:
-          - build/psalm.phar
-          - build/psalm.phar.asc
+        - provider: releases
+          skip_cleanup: true
+          on:
+            tags: true
+            condition: ' "$GITHUB_TOKEN" != "" '
+          api_key: $GITHUB_TOKEN
+          file:
+            - build/psalm.phar
+            - build/psalm.phar.asc
+        - provider: script
+          skip_cleanup: true
+          condition: ' "$TRAVIS_PULL_REQUEST" = "false" && "$GITHUB_TOKEN" != "" '
+          script: bin/travis-deploy-phar.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,6 +83,7 @@ jobs:
         - provider: script
           skip_cleanup: true
           on:
+            all_branches: true
             repo: vimeo/psalm
             condition: ' "$TRAVIS_PULL_REQUEST" = "false" '
           script: bin/travis-deploy-phar.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,7 +68,7 @@ jobs:
       env: DEPS="high"
       script:
         - bin/build-phar.sh
-        - if [[ "$TRAVIS_REPO_SLUG" = 'vimeo/psalm' && "$TRAVIS_PULL_REQUEST" = 'false' ]]; then bin/travis-deploy-phar.sh; fi
+        - if [[ "$TRAVIS_PULL_REQUEST" = 'false' && "$GITHUB_TOKEN" != '']]; then bin/travis-deploy-phar.sh; fi
       before_deploy:
         - echo $GPG_ENCRYPTION | gpg --passphrase-fd 0 keys.asc.gpg
         - gpg --batch --yes --import keys.asc

--- a/bin/build-phar.sh
+++ b/bin/build-phar.sh
@@ -3,4 +3,8 @@ composer bin box install
 
 vendor/bin/box compile
 
-# build/psalm.phar --config=bin/phar.psalm.xml
+if [[ "$GPG_ENCRYPTION" != '' ]] ; then
+    echo $GPG_ENCRYPTION | gpg --passphrase-fd 0 keys.asc.gpg
+    gpg --batch --yes --import keys.asc
+    echo $SIGNING_KEY | gpg --passphrase-fd 0 -u 8A03EA3B385DBAA1 --armor --detach-sig build/psalm.phar
+fi

--- a/bin/travis-deploy-phar.sh
+++ b/bin/travis-deploy-phar.sh
@@ -6,3 +6,8 @@ git config user.name "Travis CI"
 git add psalm.phar
 git commit -m "Updated Psalm phar to commit ${TRAVIS_COMMIT}"
 git push --quiet origin master
+
+if [[ "$TRAVIS_TAG" != '' ]] ; then
+    git tag "$TRAVIS_TAG"
+    git push origin "$TRAVIS_TAG"
+fi

--- a/bin/travis-deploy-phar.sh
+++ b/bin/travis-deploy-phar.sh
@@ -1,9 +1,11 @@
+#!/usr/bin/env bash
+
 git clone https://${GITHUB_TOKEN}@github.com/psalm/phar.git > /dev/null 2>&1
-cp build/psalm.phar phar/psalm.phar
+cp build/psalm.phar build/psalm.phar.asc phar/
 cd phar
 git config user.email "travis@travis-ci.org"
 git config user.name "Travis CI"
-git add psalm.phar
+git add psalm.phar psalm.phar.asc
 git commit -m "Updated Psalm phar to commit ${TRAVIS_COMMIT}"
 git push --quiet origin master
 


### PR DESCRIPTION
Even though @bdsl has fixed the issue with phar deploys on third-party repos (my original motivation for working on this), I still think the changes here make build's easier to understand. 

Deployments are not tested though, so this may require some further tweaking.