### PR TITLE
Namespace autoloaded functions

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -21,8 +21,6 @@ use Psalm\Progress\Progress;
 use Psalm\Progress\VoidProgress;
 use SimpleXMLElement;
 
-use function isAbsolutePath;
-
 class Config
 {
     const DEFAULT_FILE_NAME = 'psalm.xml';

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,4 +1,8 @@
 <?php
+namespace Psalm;
+
+use InvalidArgumentException;
+
 /**
  * @param string $path
  *

--- a/tests/IsAbsolutePathTest.php
+++ b/tests/IsAbsolutePathTest.php
@@ -1,6 +1,8 @@
 <?php
 namespace Psalm\Tests;
 
+use function Psalm\isAbsolutePath;
+
 class IsAbsolutePathTest extends TestCase
 {
     /**


### PR DESCRIPTION
Since functions defined in files referenced in 'files' section in composer autoload config are automatically loaded when composer autoloader is included (for example when Psalm is installed into project's vendors), it's good idea to keep them namespaced. Otherwise it would prevent dependents to declare their own functions in the global namespace with the same names.