### PR TITLE
Add class renaming to psalm-refactor

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -210,6 +210,11 @@ class Codebase
     /**
      * @var array<string, string>
      */
+    public $classes_to_move = [];
+
+    /**
+     * @var array<string, string>
+     */
     public $call_transforms = [];
 
     /**
@@ -221,6 +226,11 @@ class Codebase
      * @var array<string, string>
      */
     public $class_constant_transforms = [];
+
+    /**
+     * @var array<string, string>
+     */
+    public $class_transforms = [];
 
     /**
      * @var bool

--- a/src/Psalm/FileManipulation.php
+++ b/src/Psalm/FileManipulation.php
@@ -12,20 +12,43 @@ class FileManipulation
     /** @var string */
     public $insertion_text;
 
+    /** @var bool */
+    public $preserve_indentation;
+
     /**
      * @param int $start
      * @param int $end
      * @param string $insertion_text
      */
-    public function __construct(int $start, int $end, string $insertion_text)
+    public function __construct(int $start, int $end, string $insertion_text, bool $preserve_indentation = false)
     {
         $this->start = $start;
         $this->end = $end;
         $this->insertion_text = $insertion_text;
+        $this->preserve_indentation = $preserve_indentation;
     }
 
     public function getKey() : string
     {
         return sha1($this->start . ':' . $this->insertion_text);
+    }
+
+    public function transform(string $existing_contents) : string
+    {
+        if ($this->preserve_indentation) {
+            $newline_pos = strrpos($existing_contents, "\n", $this->start - strlen($existing_contents));
+
+            $newline_pos = $newline_pos !== false ? $newline_pos + 1 : 0;
+
+            $indentation = substr($existing_contents, $newline_pos, $this->start - $newline_pos);
+
+            if (trim($indentation) === '') {
+                $this->insertion_text = $this->insertion_text . $indentation;
+            }
+        }
+
+        return substr($existing_contents, 0, $this->start)
+            . $this->insertion_text
+            . substr($existing_contents, $this->end);
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -110,6 +110,26 @@ class ForeachAnalyzer
                 $statements_analyzer->getParentFQCLN()
             );
 
+            if ($var_comment->type_start
+                && $var_comment->type_end
+                && $var_comment->line_number
+            ) {
+                $type_location = new CodeLocation\DocblockTypeLocation(
+                    $statements_analyzer,
+                    $var_comment->type_start,
+                    $var_comment->type_end,
+                    $var_comment->line_number,
+                );
+
+                $codebase->classlikes->handleDocblockTypeInMigration(
+                    $codebase,
+                    $statements_analyzer,
+                    $comment_type,
+                    $type_location,
+                    $context->calling_method_id
+                );
+            }
+
             if (isset($context->vars_in_scope[$var_comment->var_id])
                 || $statements_analyzer->isSuperGlobal($var_comment->var_id)
             ) {

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -118,7 +118,7 @@ class ForeachAnalyzer
                     $statements_analyzer,
                     $var_comment->type_start,
                     $var_comment->type_end,
-                    $var_comment->line_number,
+                    $var_comment->line_number
                 );
 
                 $codebase->classlikes->handleDocblockTypeInMigration(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -128,7 +128,7 @@ class AssignmentAnalyzer
                             $statements_analyzer,
                             $var_comment->type_start,
                             $var_comment->type_end,
-                            $var_comment->line_number,
+                            $var_comment->line_number
                         );
 
                         $codebase->classlikes->handleDocblockTypeInMigration(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -120,21 +120,23 @@ class AssignmentAnalyzer
                         $statements_analyzer->getSuppressedIssues()
                     );
 
-                    if ($codebase->methods_to_move
-                        && $context->calling_method_id
-                        && isset($codebase->methods_to_move[strtolower($context->calling_method_id)])
-                        && $var_comment->type_start
+                    if ($var_comment->type_start
                         && $var_comment->type_end
                         && $var_comment->line_number
                     ) {
-                        $destination_method_id = $codebase->methods_to_move[strtolower($context->calling_method_id)];
-
-                        $codebase->classlikes->airliftDocblockType(
-                            $var_comment_type,
-                            explode('::', $destination_method_id)[0],
-                            $statements_analyzer->getFilePath(),
+                        $type_location = new CodeLocation\DocblockTypeLocation(
+                            $statements_analyzer,
                             $var_comment->type_start,
-                            $var_comment->type_end
+                            $var_comment->type_end,
+                            $var_comment->line_number,
+                        );
+
+                        $codebase->classlikes->handleDocblockTypeInMigration(
+                            $codebase,
+                            $statements_analyzer,
+                            $var_comment_type,
+                            $type_location,
+                            $context->calling_method_id
                         );
                     }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -246,19 +246,13 @@ class NewAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAna
         }
 
         if ($fq_class_name) {
-            if ($stmt->class instanceof PhpParser\Node\Name
-                && $codebase->methods_to_move
-                && $context->calling_method_id
-                && isset($codebase->methods_to_move[strtolower($context->calling_method_id)])
-            ) {
-                $destination_method_id = $codebase->methods_to_move[strtolower($context->calling_method_id)];
-
-                $codebase->classlikes->airliftClassLikeReference(
+            if ($codebase->alter_code) {
+                $codebase->classlikes->handleClassLikeReferenceInMigration(
+                    $codebase,
+                    $statements_analyzer,
+                    $stmt->class,
                     $fq_class_name,
-                    explode('::', $destination_method_id)[0],
-                    $statements_analyzer->getFilePath(),
-                    (int) $stmt->class->getAttribute('startFilePos'),
-                    (int) $stmt->class->getAttribute('endFilePos') + 1
+                    $context->calling_method_id
                 );
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/PropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/PropertyFetchAnalyzer.php
@@ -1030,35 +1030,45 @@ class PropertyFetchAnalyzer
 
         $declaring_property_id = strtolower((string) $declaring_property_class) . '::$' . $prop_name;
 
-        foreach ($codebase->property_transforms as $original_pattern => $transformation) {
-            if ($declaring_property_id === $original_pattern
-                && $stmt->class instanceof PhpParser\Node\Name
-            ) {
-                list($old_declaring_fq_class_name) = explode('::$', $declaring_property_id);
-                list($new_fq_class_name, $new_property_name) = explode('::$', $transformation);
+        if ($codebase->alter_code && $stmt->class instanceof PhpParser\Node\Name) {
+            $moved_class = $codebase->classlikes->handleClassLikeReferenceInMigration(
+                $codebase,
+                $statements_analyzer,
+                $stmt->class,
+                $fq_class_name,
+                $context->calling_method_id
+            );
 
-                $file_manipulations = [];
+            if (!$moved_class) {
+                foreach ($codebase->property_transforms as $original_pattern => $transformation) {
+                    if ($declaring_property_id === $original_pattern) {
+                        list($old_declaring_fq_class_name) = explode('::$', $declaring_property_id);
+                        list($new_fq_class_name, $new_property_name) = explode('::$', $transformation);
 
-                if (strtolower($new_fq_class_name) !== strtolower($old_declaring_fq_class_name)) {
-                    $file_manipulations[] = new \Psalm\FileManipulation(
-                        (int) $stmt->class->getAttribute('startFilePos'),
-                        (int) $stmt->class->getAttribute('endFilePos') + 1,
-                        Type::getStringFromFQCLN(
-                            $new_fq_class_name,
-                            $statements_analyzer->getNamespace(),
-                            $statements_analyzer->getAliasedClassesFlipped(),
-                            null
-                        )
-                    );
+                        $file_manipulations = [];
+
+                        if (strtolower($new_fq_class_name) !== strtolower($old_declaring_fq_class_name)) {
+                            $file_manipulations[] = new \Psalm\FileManipulation(
+                                (int) $stmt->class->getAttribute('startFilePos'),
+                                (int) $stmt->class->getAttribute('endFilePos') + 1,
+                                Type::getStringFromFQCLN(
+                                    $new_fq_class_name,
+                                    $statements_analyzer->getNamespace(),
+                                    $statements_analyzer->getAliasedClassesFlipped(),
+                                    null
+                                )
+                            );
+                        }
+
+                        $file_manipulations[] = new \Psalm\FileManipulation(
+                            (int) $stmt->name->getAttribute('startFilePos'),
+                            (int) $stmt->name->getAttribute('endFilePos') + 1,
+                            '$' . $new_property_name
+                        );
+
+                        FileManipulationBuffer::add($statements_analyzer->getFilePath(), $file_manipulations);
+                    }
                 }
-
-                $file_manipulations[] = new \Psalm\FileManipulation(
-                    (int) $stmt->name->getAttribute('startFilePos'),
-                    (int) $stmt->name->getAttribute('endFilePos') + 1,
-                    '$' . $new_property_name
-                );
-
-                FileManipulationBuffer::add($statements_analyzer->getFilePath(), $file_manipulations);
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -579,6 +579,16 @@ class ExpressionAnalyzer
                             $fq_class_name
                         );
                     }
+
+                    if ($codebase->alter_code) {
+                        $codebase->classlikes->handleClassLikeReferenceInMigration(
+                            $codebase,
+                            $statements_analyzer,
+                            $stmt->class,
+                            $fq_class_name,
+                            $context->calling_method_id
+                        );
+                    }
                 }
             }
 

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -950,22 +950,23 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
                             $this->getSuppressedIssues()
                         );
 
-                        if ($codebase->methods_to_move
-                            && $context->calling_method_id
-                            && isset($codebase->methods_to_move[strtolower($context->calling_method_id)])
-                            && $var_comment->type_start
+                        if ($var_comment->type_start
                             && $var_comment->type_end
                             && $var_comment->line_number
                         ) {
-                            $destination_method_id
-                                = $codebase->methods_to_move[strtolower($context->calling_method_id)];
-
-                            $codebase->classlikes->airliftDocblockType(
-                                $var_comment_type,
-                                explode('::', $destination_method_id)[0],
-                                $this->getFilePath(),
+                            $type_location = new CodeLocation\DocblockTypeLocation(
+                                $this,
                                 $var_comment->type_start,
-                                $var_comment->type_end
+                                $var_comment->type_end,
+                                $var_comment->line_number
+                            );
+
+                            $codebase->classlikes->handleDocblockTypeInMigration(
+                                $codebase,
+                                $this,
+                                $var_comment_type,
+                                $type_location,
+                                $context->calling_method_id
                             );
                         }
 

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -1156,10 +1156,7 @@ class Analyzer
         $existing_contents = $this->file_provider->getContents($file_path);
 
         foreach ($file_manipulations as $manipulation) {
-            $existing_contents
-                = substr($existing_contents, 0, $manipulation->start)
-                    . $manipulation->insertion_text
-                    . substr($existing_contents, $manipulation->end);
+            $existing_contents = $manipulation->transform($existing_contents);
         }
 
         if ($dry_run) {

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -959,13 +959,6 @@ class ClassLikes
         FileManipulationBuffer::addCodeMigrations($code_migrations);
     }
 
-    /**
-     * @return void
-     */
-    public function moveClasses()
-    {
-    }
-
     public function handleClassLikeReferenceInMigration(
         \Psalm\Codebase $codebase,
         \Psalm\StatementsSource $source,

--- a/src/Psalm/Internal/Visitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/Visitor/ReflectorVisitor.php
@@ -93,6 +93,9 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     /** @var int */
     private $php_minor_version;
 
+    /** @var PhpParser\Node\Name|null */
+    private $namespace_name;
+
     /**
      * @var array<string, array<int, string>>
      */
@@ -161,6 +164,9 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
 
         if ($node instanceof PhpParser\Node\Stmt\Namespace_) {
             $this->file_aliases = $this->aliases;
+
+            $this->namespace_name = $node->name;
+
             $this->aliases = new Aliases(
                 $node->name ? implode('\\', $node->name->parts) : '',
                 $this->aliases->uses,
@@ -818,6 +824,9 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
 
         $storage->stmt_location = $class_location;
         $storage->location = $name_location;
+        if ($this->namespace_name) {
+            $storage->namespace_name_location = new CodeLocation($this->file_scanner, $this->namespace_name);
+        }
         $storage->user_defined = !$this->codebase->register_stub_files;
         $storage->stubbed = $this->codebase->register_stub_files;
         $storage->aliases = $this->aliases;

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -177,6 +177,11 @@ class ClassLikeStorage
     public $stmt_location;
 
     /**
+     * @var CodeLocation|null
+     */
+    public $namespace_name_location;
+
+    /**
      * @var bool
      */
     public $abstract = false;

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -1039,6 +1039,22 @@ abstract class Type
             return $aliased_classes[strtolower($value)];
         }
 
+        if (strpos($value, '\\')) {
+            $parts = explode('\\', $value);
+
+            $suffix = array_pop($parts);
+
+            while ($parts) {
+                $left = implode('\\', $parts);
+
+                if (isset($aliased_classes[strtolower($left)])) {
+                    return $aliased_classes[strtolower($left)] . '\\' . $suffix;
+                }
+
+                $suffix = array_pop($parts) . '\\' . $suffix;
+            }
+        }
+
         return '\\' . $value;
     }
 

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -709,6 +709,148 @@ abstract class Atomic
         }
     }
 
+    public function containsClassLike(string $fq_classlike_name) : bool
+    {
+        if ($this instanceof TNamedObject) {
+            if (strtolower($this->value) === $fq_classlike_name) {
+                return true;
+            }
+        }
+
+        if ($this instanceof TNamedObject
+            || $this instanceof TIterable
+            || $this instanceof TTemplateParam
+        ) {
+            if ($this->extra_types) {
+                foreach ($this->extra_types as $extra_type) {
+                    if ($extra_type->containsClassLike($fq_classlike_name)) {
+                        return true;
+                    }
+                }
+            }
+        }
+
+        if ($this instanceof TScalarClassConstant) {
+            if (strtolower($this->fq_classlike_name) === $fq_classlike_name) {
+                return true;
+            }
+        }
+
+        if ($this instanceof TClassString && $this->as !== 'object') {
+            if (strtolower($this->as) === $fq_classlike_name) {
+                return true;
+            }
+        }
+
+        if ($this instanceof TTemplateParam) {
+            if ($this->as->containsClassLike($fq_classlike_name)) {
+                return true;
+            }
+        }
+
+        if ($this instanceof TLiteralClassString) {
+            if (strtolower($this->value) === $fq_classlike_name) {
+                return true;
+            }
+        }
+
+        if ($this instanceof Type\Atomic\TArray
+            || $this instanceof Type\Atomic\TGenericObject
+            || $this instanceof Type\Atomic\TIterable
+        ) {
+            foreach ($this->type_params as $type_param) {
+                if ($type_param->containsClassLike($fq_classlike_name)) {
+                    return true;
+                }
+            }
+        }
+
+        if ($this instanceof Type\Atomic\TFn
+            || $this instanceof Type\Atomic\TCallable
+        ) {
+            if ($this->params) {
+                foreach ($this->params as $param) {
+                    if ($param->type && $param->type->containsClassLike($fq_classlike_name)) {
+                        return true;
+                    }
+                }
+            }
+
+            if ($this->return_type && $this->return_type->containsClassLike($fq_classlike_name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function replaceClassLike(string $old, string $new) : void
+    {
+        if ($this instanceof TNamedObject) {
+            if (strtolower($this->value) === $old) {
+                $this->value = $new;
+            }
+        }
+
+        if ($this instanceof TNamedObject
+            || $this instanceof TIterable
+            || $this instanceof TTemplateParam
+        ) {
+            if ($this->extra_types) {
+                foreach ($this->extra_types as $extra_type) {
+                    $extra_type->replaceClassLike($old, $new);
+                }
+            }
+        }
+
+        if ($this instanceof TScalarClassConstant) {
+            if (strtolower($old) === $new) {
+                $this->fq_classlike_name = $new;
+            }
+        }
+
+        if ($this instanceof TClassString && $this->as !== 'object') {
+            if (strtolower($this->as) === $old) {
+                $this->as = $new;
+            }
+        }
+
+        if ($this instanceof TTemplateParam) {
+            $this->as->replaceClassLike($old, $new);
+        }
+
+        if ($this instanceof TLiteralClassString) {
+            if (strtolower($this->value) === $old) {
+                $this->value = $new;
+            }
+        }
+
+        if ($this instanceof Type\Atomic\TArray
+            || $this instanceof Type\Atomic\TGenericObject
+            || $this instanceof Type\Atomic\TIterable
+        ) {
+            foreach ($this->type_params as $type_param) {
+                $type_param->replaceClassLike($old, $new);
+            }
+        }
+
+        if ($this instanceof Type\Atomic\TFn
+            || $this instanceof Type\Atomic\TCallable
+        ) {
+            if ($this->params) {
+                foreach ($this->params as $param) {
+                    if ($param->type) {
+                        $param->type->replaceClassLike($old, $new);
+                    }
+                }
+            }
+
+            if ($this->return_type) {
+                $this->return_type->replaceClassLike($old, $new);
+            }
+        }
+    }
+
     /**
      * @param  Atomic $other
      *

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1674,6 +1674,30 @@ class Union
         }
     }
 
+    public function containsClassLike(string $fq_class_like_name) : bool
+    {
+        foreach ($this->types as $atomic_type) {
+            if ($atomic_type->containsClassLike($fq_class_like_name)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function replaceClassLike(string $old, string $new) : void
+    {
+        foreach ($this->types as $key => $atomic_type) {
+            $atomic_type->replaceClassLike($old, $new);
+
+            unset($this->types[$key]);
+
+            $this->types[$atomic_type->getKey()] = $atomic_type;
+        }
+
+        $this->id = null;
+    }
+
     /**
      * @return bool
      */

--- a/tests/FileManipulation/ClassMoveTest.php
+++ b/tests/FileManipulation/ClassMoveTest.php
@@ -1,0 +1,363 @@
+<?php
+namespace Psalm\Tests\FileManipulation;
+
+use Psalm\Context;
+use Psalm\Internal\Analyzer\FileAnalyzer;
+use Psalm\Tests\Internal\Provider;
+use Psalm\Tests\TestConfig;
+
+class ClassMoveTest extends \Psalm\Tests\TestCase
+{
+    /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
+    protected $project_analyzer;
+
+    public function setUp() : void
+    {
+        FileAnalyzer::clearCache();
+        \Psalm\Internal\FileManipulation\FunctionDocblockManipulator::clearCache();
+
+        $this->file_provider = new Provider\FakeFileProvider();
+    }
+
+    /**
+     * @dataProvider providerValidCodeParse
+     *
+     * @param string $input_code
+     * @param string $output_code
+     * @param array<string, string> $constants_to_move
+     * @param array<string, string> $call_transforms
+     *
+     * @return void
+     */
+    public function testValidCode(
+        string $input_code,
+        string $output_code,
+        array $constants_to_move
+    ) {
+        $test_name = $this->getTestName();
+        if (strpos($test_name, 'SKIPPED-') !== false) {
+            $this->markTestSkipped('Skipped due to a bug.');
+        }
+
+        $config = new TestConfig();
+
+        $this->project_analyzer = new \Psalm\Internal\Analyzer\ProjectAnalyzer(
+            $config,
+            new \Psalm\Internal\Provider\Providers(
+                $this->file_provider,
+                new Provider\FakeParserCacheProvider()
+            )
+        );
+
+        $context = new Context();
+
+        $file_path = self::$src_dir_path . 'somefile.php';
+
+        $this->addFile(
+            $file_path,
+            $input_code
+        );
+
+        $codebase = $this->project_analyzer->getCodebase();
+
+        $this->project_analyzer->refactorCodeAfterCompletion($constants_to_move);
+
+        $this->analyzeFile($file_path, $context);
+
+        $this->project_analyzer->prepareMigration();
+
+        $codebase->analyzer->updateFile($file_path, false);
+
+        $this->project_analyzer->migrateCode();
+
+        $this->assertSame($output_code, $codebase->getFileContents($file_path));
+    }
+
+    /**
+     * @return array<string,array{string,string,array<string, string>}>
+     */
+    public function providerValidCodeParse()
+    {
+        return [
+            'renameEmptyClass' => [
+                '<?php
+                    namespace Ns;
+
+                    class A {}
+
+                    class C extends A {
+                        /**
+                         * @var A
+                         */
+                        public $one;
+                    }
+
+                    /**
+                     * @param A $a
+                     * @return A
+                     */
+                    function foo(A $a) : A {
+                        return $a;
+                    }
+
+                    /** @var A */
+                    $i = new A();
+
+                    if ($i instanceof A) {}',
+                '<?php
+                    namespace Ns;
+
+                    class B {}
+
+                    class C extends B {
+                        /**
+                         * @var B
+                         */
+                        public $one;
+                    }
+
+                    /**
+                     * @param B $a
+                     * @return B
+                     */
+                    function foo(B $a) : B {
+                        return $a;
+                    }
+
+                    /** @var B */
+                    $i = new B();
+
+                    if ($i instanceof B) {}',
+                [
+                    'Ns\A' => 'Ns\B',
+                ]
+            ],
+            'renameClassWithInstanceMethod' => [
+                '<?php
+                    namespace Ns;
+
+                    class A {
+                        /**
+                         * @param self $one
+                         * @param A $two
+                         */
+                        public function foo(self $one, A $two) : void {}
+                    }
+
+                    function foo(A $a) : A {
+                        return $a->foo($a, $a);
+                    }',
+                '<?php
+                    namespace Ns;
+
+                    class B {
+                        /**
+                         * @param self $one
+                         * @param self $two
+                         */
+                        public function foo(self $one, self $two) : void {}
+                    }
+
+                    function foo(B $a) : B {
+                        return $a->foo($a, $a);
+                    }',
+                [
+                    'Ns\A' => 'Ns\B',
+                ]
+            ],
+            'renameClassWithStaticMethod' => [
+                '<?php
+                    namespace Ns;
+
+                    class A {
+                        /**
+                         * @param self $one
+                         * @param A $two
+                         */
+                        public static function foo(self $one, A $two) : void {
+                            A::foo($one, $two);
+                        }
+                    }
+
+                    function foo() {
+                        A::foo(new A(), A::foo());
+                    }',
+                '<?php
+                    namespace Ns;
+
+                    class B {
+                        /**
+                         * @param self $one
+                         * @param self $two
+                         */
+                        public static function foo(self $one, self $two) : void {
+                            B::foo($one, $two);
+                        }
+                    }
+
+                    function foo() {
+                        B::foo(new B(), B::foo());
+                    }',
+                [
+                    'Ns\A' => 'Ns\B',
+                ]
+            ],
+            'renameClassWithInstanceProperty' => [
+                '<?php
+                    namespace Ns;
+
+                    class A {
+                        /**
+                         * @var A
+                         */
+                        public $one;
+
+                        /**
+                         * @var self
+                         */
+                        public $two;
+                    }',
+                '<?php
+                    namespace Ns;
+
+                    class B {
+                        /**
+                         * @var self
+                         */
+                        public $one;
+
+                        /**
+                         * @var self
+                         */
+                        public $two;
+                    }',
+                [
+                    'Ns\A' => 'Ns\B',
+                ]
+            ],
+            'renameClassWithStaticProperty' => [
+                '<?php
+                    namespace Ns;
+
+                    class A {
+                        /**
+                         * @var string
+                         */
+                        public static $one = "one";
+                    }
+
+                    echo A::$one;
+                    A::$one = "two";',
+                '<?php
+                    namespace Ns;
+
+                    class B {
+                        /**
+                         * @var string
+                         */
+                        public static $one = "one";
+                    }
+
+                    echo B::$one;
+                    B::$one = "two";',
+                [
+                    'Ns\A' => 'Ns\B',
+                ]
+            ],
+            'moveClassIntoNamespace' => [
+                '<?php
+                    class A {
+                        /** @var ?Exception */
+                        public $x;
+
+                        /**
+                         * @param ArrayObject<int, A> $a
+                         */
+                        public function foo(ArrayObject $a) : Exception {
+                            foreach ($a as $b) {
+                                $b->bar();
+                            }
+
+                            return new Exception("bad");
+                        }
+
+                        public function bar() : void {}
+                    }',
+                '<?php
+                    namespace Foo\Bar\Baz;
+
+                    class B {
+                        /** @var null|\Exception */
+                        public $x;
+
+                        /**
+                         * @param \ArrayObject<int, self> $a
+                         */
+                        public function foo(\ArrayObject $a) : \Exception {
+                            foreach ($a as $b) {
+                                $b->bar();
+                            }
+
+                            return new \Exception("bad");
+                        }
+
+                        public function bar() : void {}
+                    }',
+                [
+                    'A' => 'Foo\Bar\Baz\B',
+                ]
+            ],
+            'moveClassDeeperIntoNamespace' => [
+                '<?php
+                    namespace Foo;
+
+                    use Exception;
+                    use ArrayObject;
+
+                    class A {
+                        /** @var ?Exception */
+                        public $x;
+
+                        /**
+                         * @param ArrayObject<int, A> $a
+                         */
+                        public function foo(ArrayObject $a) : Exception {
+                            foreach ($a as $b) {
+                                $b->bar();
+                            }
+
+                            return new Exception("bad");
+                        }
+
+                        public function bar() : void {}
+                    }',
+                '<?php
+                    namespace Foo\Bar\Baz;
+
+                    use Exception;
+                    use ArrayObject;
+
+                    class B {
+                        /** @var null|Exception */
+                        public $x;
+
+                        /**
+                         * @param ArrayObject<int, self> $a
+                         */
+                        public function foo(ArrayObject $a) : Exception {
+                            foreach ($a as $b) {
+                                $b->bar();
+                            }
+
+                            return new Exception("bad");
+                        }
+
+                        public function bar() : void {}
+                    }',
+                [
+                    'Foo\A' => 'Foo\Bar\Baz\B',
+                ]
+            ],
+        ];
+    }
+}

--- a/tests/FileManipulation/MethodMoveTest.php
+++ b/tests/FileManipulation/MethodMoveTest.php
@@ -6,7 +6,7 @@ use Psalm\Internal\Analyzer\FileAnalyzer;
 use Psalm\Tests\Internal\Provider;
 use Psalm\Tests\TestConfig;
 
-class MoveMethodTest extends \Psalm\Tests\TestCase
+class MethodMoveTest extends \Psalm\Tests\TestCase
 {
     /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
     protected $project_analyzer;

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -888,9 +888,9 @@ class ReturnTypeManipulationTest extends FileManipulationTest
 
                         class D {
                             /**
-                             * @return \A\B\C[]
+                             * @return B\C[]
                              *
-                             * @psalm-return array{0:\A\B\C}
+                             * @psalm-return array{0:B\C}
                              */
                             public function getArrayOfC(): array {
                                 return [new \A\B\C];


### PR DESCRIPTION
Following work to allow moving of methods, properties and class constants, this allows renaming of classes, changes their namespaces and, where possible, moves files as well based on PSR4 paths.

`psalm-refactor --rename "Psalm\Type\Atomic\TFn" --to "Psalm\Type\Atomic\TClosure"`

`psalm-refactor --rename "Root_Namespaced_Clss" --to "Properly\Namespaced\Clss"`