### PR TITLE
Require stable version of openlss/lib-array2xml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": "^7.1",
         "nikic/php-parser": "^4.0.2 || ^4.1",
-        "openlss/lib-array2xml": "^0.0.10||^0.5.1",
+        "openlss/lib-array2xml": "^1.0",
         "ocramius/package-versions": "^1.2",
         "composer/xdebug-handler": "^1.1",
         "felixfbecker/language-server-protocol": "^1.2",


### PR DESCRIPTION
`openlss/lib-array2xml` now has a stable 1.0.0 version.