### PR TITLE
Add executable PHP files to PHAR distribution

### DIFF
--- a/assets/psalm-phar/README.md
+++ b/assets/psalm-phar/README.md
@@ -1,0 +1,1 @@
+This allows you to install [Psalm](https://github.com/vimeo/psalm) without worrying about composer conflicts.

--- a/assets/psalm-phar/composer.json
+++ b/assets/psalm-phar/composer.json
@@ -1,0 +1,9 @@
+{
+	"name": "psalm/phar",
+	"description": "Composer-based Psalm Phar",
+	"license": ["MIT"],
+	"require": {
+		"php": "^7.0"
+	},
+	"bin": ["psalm.phar", "psalm", "psalter", "psalm-language-server", "psalm-plugin"]
+}

--- a/assets/psalm-phar/composer.json
+++ b/assets/psalm-phar/composer.json
@@ -3,7 +3,7 @@
 	"description": "Composer-based Psalm Phar",
 	"license": ["MIT"],
 	"require": {
-		"php": "^7.0"
+		"php": "^7.1"
 	},
 	"bin": ["psalm.phar", "psalm", "psalter", "psalm-language-server", "psalm-plugin"]
 }

--- a/assets/psalm-phar/dot-gitignore
+++ b/assets/psalm-phar/dot-gitignore
@@ -1,0 +1,6 @@
+composer.phar
+/vendor/
+
+# Commit your application's lock file https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control
+# You may choose to ignore a library lock file http://getcomposer.org/doc/02-libraries.md#lock-file
+# composer.lock

--- a/assets/psalm-phar/psalm
+++ b/assets/psalm-phar/psalm
@@ -1,0 +1,2 @@
+#!/usr/bin/env php
+<?php require_once 'phar://' . __DIR__ . DIRECTORY_SEPARATOR . 'psalm.phar/src/psalm.php';

--- a/assets/psalm-phar/psalm-language-server
+++ b/assets/psalm-phar/psalm-language-server
@@ -1,0 +1,2 @@
+#!/usr/bin/env php
+<?php require_once 'phar://' . __DIR__ . DIRECTORY_SEPARATOR . 'psalm.phar/src/psalm-language-server.php';

--- a/assets/psalm-phar/psalm-plugin
+++ b/assets/psalm-phar/psalm-plugin
@@ -1,0 +1,2 @@
+#!/usr/bin/env php
+<?php require_once 'phar://' . __DIR__ . DIRECTORY_SEPARATOR . 'psalm.phar/src/psalm_plugin.php';

--- a/assets/psalm-phar/psalm-refactor
+++ b/assets/psalm-phar/psalm-refactor
@@ -1,0 +1,2 @@
+#!/usr/bin/env php
+<?php require_once 'phar://' . __DIR__ . DIRECTORY_SEPARATOR . 'psalm.phar/src/psalm-refactor.php';

--- a/assets/psalm-phar/psalter
+++ b/assets/psalm-phar/psalter
@@ -1,0 +1,2 @@
+#!/usr/bin/env php
+<?php require_once 'phar://' . __DIR__ . DIRECTORY_SEPARATOR . 'psalm.phar/src/psalter.php';

--- a/bin/build-phar.sh
+++ b/bin/build-phar.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+set -e
+
 composer bin box install
 
 vendor/bin/box compile

--- a/bin/travis-deploy-phar.sh
+++ b/bin/travis-deploy-phar.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -e
+
 git clone https://${GITHUB_TOKEN}@github.com/psalm/phar.git > /dev/null 2>&1
 cd phar
 rm -rf !(".git")

--- a/bin/travis-deploy-phar.sh
+++ b/bin/travis-deploy-phar.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 
 git clone https://${GITHUB_TOKEN}@github.com/psalm/phar.git > /dev/null 2>&1
-cp build/psalm.phar build/psalm.phar.asc phar/
 cd phar
+rm -rf !(".git")
+cp ../build/psalm.phar ../build/psalm.phar.asc ../assets/psalm-phar/* .
+mv dot-gitignore .gitignore
 git config user.email "travis@travis-ci.org"
 git config user.name "Travis CI"
-git add psalm.phar psalm.phar.asc
+git add --all .
 git commit -m "Updated Psalm phar to commit ${TRAVIS_COMMIT}"
 git push --quiet origin master
 

--- a/box.json.dist
+++ b/box.json.dist
@@ -4,7 +4,9 @@
         "src/command_functions.php",
         "src/psalm.php",
         "src/psalter.php",
-        "src/psalm-language-server.php"
+        "src/psalm-language-server.php",
+        "src/psalm-plugin.php",
+        "src/psalm-refactor.php"
     ],
     "files-bin": ["config.xsd"],
     "directories-bin" : ["assets"],

--- a/box.json.dist
+++ b/box.json.dist
@@ -5,7 +5,7 @@
         "src/psalm.php",
         "src/psalter.php",
         "src/psalm-language-server.php",
-        "src/psalm-plugin.php",
+        "src/psalm_plugin.php",
         "src/psalm-refactor.php"
     ],
     "files-bin": ["config.xsd"],


### PR DESCRIPTION
Previously a user of the phar distribution would have to invoke psalm as
`vendor/bin/psalm.phar`. This is different to the command given in
the psalm documentation, `vendor/bin/psalm`

I also copied all files from the psalm/phar repo into
assets/psalm-phar, so that development can be concentrated in this repo.

The travis-deploy-phar.sh should copy any changes made back into the
psalm/phar.git repo.