### PR TITLE
Change vimeo/psalm to psalm/phar in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Documentation is available on [Psalm’s website](https://psalm.dev/docs), gener
 Install via [Composer](https://getcomposer.org/):
 
 ```bash
-composer require --dev vimeo/psalm
+composer require --dev psalm/phar
 ```
 
 Add a config:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,7 +3,7 @@
 Psalm Requires PHP >= 7.1 and [Composer](https://getcomposer.org/).
 
 ```bash
-composer require --dev vimeo/psalm
+composer require --dev psalm/phar
 ```
 
 Add a `psalm.xml` config:


### PR DESCRIPTION
I think for most users the phar is better than the separate PHP files. The phar comes with a very short composer.json file, meaning it won't conflict with any other packages they may require, and the fact that everything is packaged into one file may make it easier for people to concentrate on their own code and the code of the libraries they use, by not looking at Psalm's internal code.