### PR TITLE
Fix syntax error in travis deploy script

### DIFF
--- a/bin/travis-deploy-phar.sh
+++ b/bin/travis-deploy-phar.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
 set -e
+shopt -s extglob # required for the rm -rf below
 
 git clone https://${GITHUB_TOKEN}@github.com/psalm/phar.git > /dev/null 2>&1
 cd phar
-rm -rf !(".git")
+rm -rf -- !(".git")
 cp ../build/psalm.phar ../build/psalm.phar.asc ../assets/psalm-phar/* .
 mv dot-gitignore .gitignore
 git config user.email "travis@travis-ci.org"


### PR DESCRIPTION
This should resolve the build failure https://travis-ci.org/vimeo/psalm/jobs/542700463

See https://unix.stackexchange.com/a/153863/6974

It might also help diagnostics to add `set -x` to the script, enabling output of all command used. I think it would be fine but I'm slightly paranoid that Travis might fail to properly mask the GITHUB_TOKEN