### PR TITLE
Allow deploying phar to any github repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,5 @@ jobs:
           skip_cleanup: true
           on:
             all_branches: true
-            repo: vimeo/psalm
             condition: ' "$TRAVIS_PULL_REQUEST" = "false" '
           script: bin/travis-deploy-phar.sh

--- a/bin/travis-deploy-phar.sh
+++ b/bin/travis-deploy-phar.sh
@@ -2,16 +2,28 @@
 
 set -e
 
-git clone https://${GITHUB_TOKEN}@github.com/psalm/phar.git > /dev/null 2>&1
+
+if [[ ${TRAVIS_REPO_SLUG} != 'vimeo/psalm'  &&  -z ${PHAR_REPO_SLUG} ]]; then
+    echo 'Not attempting phar deployment, as this is not vimeo/psalm, and $PHAR_REPO_SLUG is unset or empty'
+    exit 0;
+fi;
+
+PHAR_REPO_SLUG=${PHAR_REPO_SLUG:=psalm/phar}
+
+git clone https://${GITHUB_TOKEN}@github.com/${PHAR_REPO_SLUG}.git phar > /dev/null 2>&1
+
+set -x # don't do set x above this point to protect the GITHUB_TOKEN
+
 cd phar
 rm -rf *
-cp ../build/psalm.phar ../build/psalm.phar.asc ../assets/psalm-phar/* .
+cp ../build/psalm.phar ../assets/psalm-phar/* .
+cp ../build/psalm.phar.asc || true # not all users have GPG keys
 mv dot-gitignore .gitignore
 git config user.email "travis@travis-ci.org"
 git config user.name "Travis CI"
 git add --all .
 git commit -m "Updated Psalm phar to commit ${TRAVIS_COMMIT}"
-git push --quiet origin master
+git push --quiet origin master > /dev/null 2>&1
 
 if [[ "$TRAVIS_TAG" != '' ]] ; then
     git tag "$TRAVIS_TAG"


### PR DESCRIPTION
Potentially useful for fork owners to test out phar deployment without affecting
the official psalm/phar repo.

To enable phar deployments from your own fork of psalm:

- Enable builds with Travis
- Create a github repository to hold recieve the built phar packages
- Create a new dedicated github user for the deployments
- From your main github account, invite the new user to collobrate on the phar repository
- From the new user's account, accept the invitation
- From the new user's account, obtain a 'new personal access token' ( https://github.com/settings/tokens/new ) with repo scope

- In travis settings for your fork of psalm, set two environment
variables:

- PHAR_REPO_SLUG - this should be the name the phar repo you set up earlier, e.g. fred/phar
- GITHUB_TOKEN - This is the personal access token of the new user you obtained above. Anyone who knows this token
                 can push to the repository, so keep it secret. Make sure 'Display value in build log' is
                 switched off'

Now any push to branches in your fork of psalm, should automatically
result in a commit containing the phar file in your phar repository.