### PR TITLE
LS Completion: Ensure any queued file analyses are done before completion

### DIFF
--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -248,6 +248,8 @@ class TextDocument
      */
     public function completion(TextDocumentIdentifier $textDocument, Position $position): Promise
     {
+        $this->server->doAnalysis();
+
         $file_path = LanguageServer::uriToPath($textDocument->uri);
 
         $completion_data = $this->codebase->getCompletionDataAtPosition($file_path, $position);


### PR DESCRIPTION
When typing quickly, the LSP client can send multiple messages in a group, including `didChange` messages followed by `completion` messages. Currently, `LanguageServer::doAnalysis()` is only called after a message group is processed. This can result in completion being done with outdated file contents. For example:

Message group with two messages is received
  1. `didChange`: file analysis is queued for modified file
  2. `completion`: completion attempted on stale file contents
  3. `messageGroupRead`: analysis is done, but too late for completion

This commit ensures that any queued file analyses are done prior to serving completion requests.

Edit: What very commonly happens is that when I type `->`, the second `didChange` message which contains the `>` character is grouped with a `completion` request. The completion request fails because, although `didChange` was processed, `LanguageServer::doAnalysis()` was not yet called. This PR resolves this issue as `LanguageServer::doAnalysis()` is always called prior to attempting to serve the `completion` request.