### PR TITLE
LS Completion: Improve autocomplete suggestions

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1205,7 +1205,7 @@ class Codebase
                             \LanguageServerProtocol\CompletionItemKind::METHOD,
                             null,
                             null,
-                            null,
+                            (string)$method_storage->visibility,
                             null,
                             $method_storage->cased_name . '()'
                         );
@@ -1227,7 +1227,7 @@ class Codebase
                             \LanguageServerProtocol\CompletionItemKind::PROPERTY,
                             null,
                             null,
-                            null,
+                            (string)$property_storage->visibility,
                             null,
                             ($gap === '::' ? '$' : '') . $property_name
                         );

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1192,8 +1192,6 @@ class Codebase
 
         $type = Type::parseString($type_string);
 
-        $completion_items = [];
-
         foreach ($type->getTypes() as $atomic_type) {
             if ($atomic_type instanceof Type\Atomic\TNamedObject) {
                 try {
@@ -1257,19 +1255,15 @@ class Codebase
                     continue;
                 }
             }
+        }
 
-            if ($gap === '->') {
-                $completion_items = array_merge(
-                    $completion_items,
-                    $instance_completion_items
-                );
-            } else {
-                $completion_items = array_merge(
-                    $completion_items,
-                    $instance_completion_items,
-                    $static_completion_items
-                );
-            }
+        if ($gap === '->') {
+            $completion_items = $instance_completion_items;
+        } else {
+            $completion_items = array_merge(
+                $instance_completion_items,
+                $static_completion_items
+            );
         }
 
         return $completion_items;

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1202,7 +1202,7 @@ class Codebase
                     foreach ($class_storage->appearing_method_ids as $declaring_method_id) {
                         $method_storage = $this->methods->getStorage($declaring_method_id);
 
-                        $instance_completion_items[] = new \LanguageServerProtocol\CompletionItem(
+                        $completion_item = new \LanguageServerProtocol\CompletionItem(
                             (string)$method_storage,
                             \LanguageServerProtocol\CompletionItemKind::METHOD,
                             null,
@@ -1211,6 +1211,12 @@ class Codebase
                             null,
                             $method_storage->cased_name . '()'
                         );
+
+                        if ($method_storage->is_static) {
+                            $static_completion_items[] = $completion_item;
+                        } else {
+                            $instance_completion_items[] = $completion_item;
+                        }
                     }
 
                     foreach ($class_storage->declaring_property_ids as $property_name => $declaring_class) {
@@ -1218,7 +1224,7 @@ class Codebase
                             $declaring_class . '::$' . $property_name
                         );
 
-                        $instance_completion_items[] = new \LanguageServerProtocol\CompletionItem(
+                        $completion_item = new \LanguageServerProtocol\CompletionItem(
                             $property_storage->getInfo() . ' $' . $property_name,
                             \LanguageServerProtocol\CompletionItemKind::PROPERTY,
                             null,
@@ -1227,6 +1233,12 @@ class Codebase
                             null,
                             ($gap === '::' ? '$' : '') . $property_name
                         );
+
+                        if ($property_storage->is_static) {
+                            $static_completion_items[] = $completion_item;
+                        } else {
+                            $instance_completion_items[] = $completion_item;
+                        }
                     }
 
                     foreach ($class_storage->class_constant_locations as $const_name => $_) {

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1206,7 +1206,7 @@ class Codebase
                             null,
                             null,
                             (string)$method_storage->visibility,
-                            null,
+                            $method_storage->cased_name,
                             $method_storage->cased_name . '()'
                         );
 
@@ -1228,7 +1228,7 @@ class Codebase
                             null,
                             null,
                             (string)$property_storage->visibility,
-                            null,
+                            $property_name,
                             ($gap === '::' ? '$' : '') . $property_name
                         );
 
@@ -1246,7 +1246,7 @@ class Codebase
                             null,
                             null,
                             null,
-                            null,
+                            $const_name,
                             $const_name
                         );
                     }

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -248,6 +248,8 @@ class TextDocument
      */
     public function completion(TextDocumentIdentifier $textDocument, Position $position): Promise
     {
+        $this->server->doAnalysis();
+
         $file_path = LanguageServer::uriToPath($textDocument->uri);
 
         $completion_data = $this->codebase->getCompletionDataAtPosition($file_path, $position);


### PR DESCRIPTION
Various improvements to the autocomplete suggestions.

1. Do not suggest static members when gap is `->`
2. Fix some bad logic in `Codebase::getCompletionItemsForClassishThing()` which was repeatedly merging the same items into the list of completion items
3. Sort completion items by visibility first, as protected and private scope members are suggested even when they are out of scope (public, then protected, then private)
4. Set `filterText` to the member name for method and property items so the IDE does not search `public function`, etc., when the user begins typing the member name