### PR TITLE
Add PHPCS job to CircleCI workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,14 @@ jobs:
           root: /home/docker/project/
           paths:
             - .
+  "Code Style Analysis":
+    executor: php-72
+    steps:
+      - attach_workspace:
+          at: /home/docker/project/
+      - run:
+          name: Code Style Analysis with PHPCS
+          command: vendor/bin/phpcs
   test:
     executor: php-72
     steps:
@@ -105,15 +113,20 @@ workflows:
       - test:
           requires:
             - install-and-self-analyse
+      - "Code Style Analysis":
+          requires:
+            - install-and-self-analyse
       - coverage:
           requires:
             - test
+            - "Code Style Analysis"
       - mutation:
           requires:
             - coverage
       - phar-build:
           requires:
             - test
+            - "Code Style Analysis"
       - test-with-real-projects:
           requires:
             - phar-build


### PR DESCRIPTION
Screenshot from a sample job with a deliberate code style error:

![Screenshot from 2019-06-17 22-26-20](https://user-images.githubusercontent.com/159481/59637983-0db63680-914f-11e9-9c3c-45780b24fa1b.png)

Only the first three jobs in the workflow are run in this situation. 