### PR TITLE
Add a 'sonarqube' report type

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -234,6 +234,7 @@ class ProjectAnalyzer
 
         $mapping = [
             'checkstyle.xml' => Report::TYPE_CHECKSTYLE,
+            'sonarqube.json' => Report::TYPE_SONARQUBE,
             'summary.json' => Report::TYPE_JSON_SUMMARY,
             '.xml' => Report::TYPE_XML,
             '.json' => Report::TYPE_JSON,

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -11,6 +11,7 @@ use Psalm\Report\EmacsReport;
 use Psalm\Report\JsonReport;
 use Psalm\Report\JsonSummaryReport;
 use Psalm\Report\PylintReport;
+use Psalm\Report\SonarqubeReport;
 use Psalm\Report\TextReport;
 use Psalm\Report\XmlReport;
 
@@ -404,6 +405,10 @@ class IssueBuffer
                     $mixed_expression_count,
                     $total_expression_count
                 );
+                break;
+
+            case Report::TYPE_SONARQUBE:
+                $output = new SonarqubeReport(self::$issues_data, $report_options);
                 break;
 
             case Report::TYPE_PYLINT:

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -8,6 +8,7 @@ abstract class Report
     const TYPE_PYLINT = 'pylint';
     const TYPE_JSON = 'json';
     const TYPE_JSON_SUMMARY = 'json-summary';
+    const TYPE_SONARQUBE = 'sonarqube';
     const TYPE_EMACS = 'emacs';
     const TYPE_XML = 'xml';
     const TYPE_CHECKSTYLE = 'checkstyle';
@@ -19,6 +20,7 @@ abstract class Report
         self::TYPE_PYLINT,
         self::TYPE_JSON,
         self::TYPE_JSON_SUMMARY,
+        self::TYPE_SONARQUBE,
         self::TYPE_EMACS,
         self::TYPE_XML,
         self::TYPE_CHECKSTYLE,

--- a/src/Psalm/Report/SonarqubeReport.php
+++ b/src/Psalm/Report/SonarqubeReport.php
@@ -1,0 +1,44 @@
+<?php
+namespace Psalm\Report;
+
+use Psalm\Config;
+use Psalm\Report;
+
+/**
+ * JSON report format suitable for import into SonarQube or SonarCloud as
+ * generic (external) issue data via `sonar.externalIssuesReportPaths`.
+ *
+ * https://docs.sonarqube.org/latest/analysis/generic-issue/
+ */
+class SonarqubeReport extends Report
+{
+    /**
+     * {{@inheritdoc}}
+     */
+    public function create(): string
+    {
+        $report = ['issues' => []];
+
+        foreach ($this->issues_data as $issue_data) {
+            $report['issues'][] = [
+                'engineId' => 'Psalm',
+                'ruleId' => $issue_data['type'],
+                'primaryLocation' => [
+                    'message' => $issue_data['message'],
+                    'filePath' => $issue_data['file_name'],
+                    'textRange' => [
+                        'startLine' => $issue_data['line_from'],
+                        'endLine' => $issue_data['line_to'],
+                        // Columns in external issue reports are indexed from 0
+                        'startColumn' => max(0, $issue_data['column_from'] - 1),
+                        'endColumn' => max(0, $issue_data['column_to'] - 1),
+                    ],
+                ],
+                'type' => 'CODE_SMELL',
+                'severity' => $issue_data['severity'] == Config::REPORT_ERROR ? 'CRITICAL' : 'MINOR',
+            ];
+        }
+
+        return json_encode($report) . "\n";
+    }
+}

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -198,7 +198,7 @@ Options:
         Only checks methods that have changed (and their dependents)
 
     --output-format=console
-        Changes the output format. Possible values: compact, console, emacs, json, pylint, xml, checkstyle
+        Changes the output format. Possible values: compact, console, emacs, json, pylint, xml, checkstyle, sonarqube
 
     --find-dead-code[=auto]
     --find-unused-code[=auto]

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -179,6 +179,91 @@ echo $a;';
     /**
      * @return void
      */
+    public function testSonarqubeReport()
+    {
+        $this->analyzeFileForReport();
+
+        $issue_data = [
+            'issues' => [
+                [
+                    'engineId' => 'Psalm',
+                    'ruleId' => 'UndefinedVariable',
+                    'primaryLocation' => [
+                        'message' => 'Cannot find referenced variable $as_you',
+                        'filePath' => 'somefile.php',
+                        'textRange' => [
+                            'startLine' => 3,
+                            'endLine' => 3,
+                            'startColumn' => 9,
+                            'endColumn' => 16,
+                        ],
+                    ],
+                    'type' => 'CODE_SMELL',
+                    'severity' => 'CRITICAL',
+                ],
+                [
+                    'engineId' => 'Psalm',
+                    'ruleId' => 'MixedInferredReturnType',
+                    'primaryLocation' => [
+                        'message' => 'Could not verify return type \'string|null\' for psalmCanVerify',
+                        'filePath' => 'somefile.php',
+                        'textRange' => [
+                            'startLine' => 2,
+                            'endLine' => 2,
+                            'startColumn' => 41,
+                            'endColumn' => 48,
+                        ],
+                    ],
+                    'type' => 'CODE_SMELL',
+                    'severity' => 'CRITICAL',
+                ],
+                [
+                    'engineId' => 'Psalm',
+                    'ruleId' => 'UndefinedConstant',
+                    'primaryLocation' => [
+                        'message' => 'Const CHANGE_ME is not defined',
+                        'filePath' => 'somefile.php',
+                        'textRange' => [
+                            'startLine' => 7,
+                            'endLine' => 7,
+                            'startColumn' => 5,
+                            'endColumn' => 14,
+                        ],
+                    ],
+                    'type' => 'CODE_SMELL',
+                    'severity' => 'CRITICAL',
+                ],
+                [
+                    'engineId' => 'Psalm',
+                    'ruleId' => 'PossiblyUndefinedGlobalVariable',
+                    'primaryLocation' => [
+                        'message' => 'Possibly undefined global variable $a, first seen on line 10',
+                        'filePath' => 'somefile.php',
+                        'textRange' => [
+                            'startLine' => 15,
+                            'endLine' => 15,
+                            'startColumn' => 5,
+                            'endColumn' => 7,
+                        ],
+                    ],
+                    'type' => 'CODE_SMELL',
+                    'severity' => 'MINOR',
+                ],
+            ],
+        ];
+
+        $sonarqube_report_options = ProjectAnalyzer::getFileReportOptions([__DIR__ . '/test-sonarqube.json'])[0];
+        $sonarqube_report_options->format = 'sonarqube';
+
+        $this->assertSame(
+            $issue_data,
+            json_decode(IssueBuffer::getOutput($sonarqube_report_options), true)
+        );
+    }
+
+    /**
+     * @return void
+     */
     public function testEmacsReport()
     {
         $this->analyzeFileForReport();


### PR DESCRIPTION
This JSON report is suitable for import into either [SonarCloud](https://sonarcloud.io/) or [SonarQube](https://www.sonarqube.org/) as [Generic Issue Data](https://docs.sonarqube.org/latest/analysis/generic-issue/) (also known as an External Issue Report).

I set up an example of how this looks on SonarCloud by removing a few exclusions from the psalm.xml.dist file. This example should be visible here: https://sonarcloud.io/project/issues?id=lewinski_psalm&open=AWtnup5rBeEiCS_yZRRt&resolved=false&types=CODE_SMELL