### PR TITLE
Improve autocompletion by using CompletionItem::$detail for type info

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1201,9 +1201,9 @@ class Codebase
                         $method_storage = $this->methods->getStorage($declaring_method_id);
 
                         $completion_item = new \LanguageServerProtocol\CompletionItem(
-                            (string)$method_storage,
+                            $method_storage->cased_name,
                             \LanguageServerProtocol\CompletionItemKind::METHOD,
-                            null,
+                            (string)$method_storage,
                             null,
                             (string)$method_storage->visibility,
                             $method_storage->cased_name,
@@ -1223,9 +1223,9 @@ class Codebase
                         );
 
                         $completion_item = new \LanguageServerProtocol\CompletionItem(
-                            $property_storage->getInfo() . ' $' . $property_name,
+                            '$' . $property_name,
                             \LanguageServerProtocol\CompletionItemKind::PROPERTY,
-                            null,
+                            $property_storage->getInfo(),
                             null,
                             (string)$property_storage->visibility,
                             $property_name,


### PR DESCRIPTION
Currently, autocompletion looks like this in Visual Studio Code:

<img width="576" alt="Screen Shot 2019-06-21 at 20 10 25" src="https://user-images.githubusercontent.com/1752683/59950469-4ff4b600-9476-11e9-82f8-8d33cf596950.png">

As you can see, if the method signature is very long you can't see the method name. To improve this we could use the  `description` property in the `CompletionItem`:

<img width="816" alt="Screen Shot 2019-06-21 at 22 50 32" src="https://user-images.githubusercontent.com/1752683/59950887-8bdc4b00-9477-11e9-8a2a-06dfbc7ddbed.png">

It's not quite as neat as I'd like (no highlighting, hard to read, signature only visible for one element at a time) but it's better than not seeing the name of the element.