### PR TITLE
Display function signature on multiple lines when it has parameters

### DIFF
--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -171,15 +171,15 @@ class FunctionLikeStorage
 
     public function __toString()
     {
-        $symbol_text = 'function ' . $this->cased_name . '(' . implode(
-            ', ',
+        $symbol_text = 'function ' . $this->cased_name . '(' . (!empty($this->params) ? PHP_EOL : '') . implode(
+            ',' . PHP_EOL,
             array_map(
                 function (FunctionLikeParameter $param) : string {
-                    return ($param->type ?: 'mixed') . ' $' . $param->name;
+                    return '    ' . ($param->type ?: 'mixed') . ' $' . $param->name;
                 },
                 $this->params
             )
-        ) . ') : ' . ($this->return_type ?: 'mixed');
+        ) . (!empty($this->params) ? PHP_EOL : '') . ') : ' . ($this->return_type ?: 'mixed');
 
         if (!$this instanceof MethodStorage) {
             return $symbol_text;

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -65,6 +65,14 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
 
                 function bar() : int {
                     return 5;
+                }
+
+                function baz(int $a) : int {
+                    return $a;
+                }
+
+                function qux(int $a, int $b) : int {
+                    return $a + $b;
                 }'
         );
 
@@ -78,6 +86,8 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame('<?php protected int|null $a', $codebase->getSymbolInformation('somefile.php', 'B\A::$a'));
         $this->assertSame('<?php function B\bar() : int', $codebase->getSymbolInformation('somefile.php', 'B\bar()'));
         $this->assertSame('<?php BANANA', $codebase->getSymbolInformation('somefile.php', 'B\A::BANANA'));
+        $this->assertSame("<?php function B\baz(\n    int \$a\n) : int", $codebase->getSymbolInformation('somefile.php', 'B\baz()'));
+        $this->assertSame("<?php function B\qux(\n    int \$a,\n    int \$b\n) : int", $codebase->getSymbolInformation('somefile.php', 'B\qux()'));
     }
 
     /**


### PR DESCRIPTION
Before:

<img width="838" alt="Screen Shot 2019-06-22 at 18 35 08" src="https://user-images.githubusercontent.com/1752683/59966414-c6e48a00-951c-11e9-9c16-433f4f4d0b01.png">

After:

<img width="647" alt="Screen Shot 2019-06-22 at 18 34 18" src="https://user-images.githubusercontent.com/1752683/59966420-d06df200-951c-11e9-9d30-46840b2ae427.png">