### PR TITLE
Only add newlines to function signature on hover

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -941,7 +941,7 @@ class Codebase
 
                     $storage = $this->methods->getStorage($declaring_method_id);
 
-                    return '<?php ' . $storage;
+                    return '<?php ' . $storage->getSignature(true);
                 }
 
                 list(, $symbol_name) = explode('::', $symbol);
@@ -974,7 +974,7 @@ class Codebase
                 if (isset($file_storage->functions[$function_id])) {
                     $function_storage = $file_storage->functions[$function_id];
 
-                    return '<?php ' . $function_storage;
+                    return '<?php ' . $function_storage->getSignature(true);
                 }
 
                 return null;

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -171,15 +171,22 @@ class FunctionLikeStorage
 
     public function __toString()
     {
-        $symbol_text = 'function ' . $this->cased_name . '(' . (!empty($this->params) ? PHP_EOL : '') . implode(
-            ',' . PHP_EOL,
+        return $this->getSignature(false);
+    }
+
+    public function getSignature(bool $allow_newlines = false): string
+    {
+        $newlines = $allow_newlines && !empty($this->params);
+
+        $symbol_text = 'function ' . $this->cased_name . '(' . ($newlines ? PHP_EOL : '') . implode(
+            ',' . ($newlines ? PHP_EOL : ' '),
             array_map(
-                function (FunctionLikeParameter $param) : string {
-                    return '    ' . ($param->type ?: 'mixed') . ' $' . $param->name;
+                function (FunctionLikeParameter $param) use ($newlines) : string {
+                    return ($newlines ? '    ' : '') . ($param->type ?: 'mixed') . ' $' . $param->name;
                 },
                 $this->params
             )
-        ) . (!empty($this->params) ? PHP_EOL : '') . ') : ' . ($this->return_type ?: 'mixed');
+        ) . ($newlines ? PHP_EOL : '') . ') : ' . ($this->return_type ?: 'mixed');
 
         if (!$this instanceof MethodStorage) {
             return $symbol_text;


### PR DESCRIPTION
Most editors do not render the newlines for autocompletions which makes
things look worse.