### PR TITLE
Add parameter placeholders when autocompleting method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "openlss/lib-array2xml": "^1.0",
         "ocramius/package-versions": "^1.2",
         "composer/xdebug-handler": "^1.1",
-        "felixfbecker/language-server-protocol": "^1.2",
+        "felixfbecker/language-server-protocol": "^1.3",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
         "netresearch/jsonmapper": "^1.0",
         "webmozart/glob": "^4.1",


### PR DESCRIPTION
<img width="1031" alt="Screen Shot 2019-06-23 at 14 58 10" src="https://user-images.githubusercontent.com/1752683/59976824-00bf9a00-95ca-11e9-90b8-2abc5a7b3e1b.png">

Questions:

- [ ] Does this need a fallback? [The LSP spec](https://microsoft.github.io/language-server-protocol/specification) defines a `snippetSupport` flag. I have not checked if most LSP implementations implement snippets.
- [ ] Should we add an option to disable this behaviour? Not everybody might likes this.