### PR TITLE
Fix MethodParamsProvider to accept an empty param list

### DIFF
--- a/src/Psalm/Internal/Provider/MethodParamsProvider.php
+++ b/src/Psalm/Internal/Provider/MethodParamsProvider.php
@@ -106,7 +106,7 @@ class MethodParamsProvider
                 $code_location
             );
 
-            if ($result) {
+            if ($result !== null) {
                 return $result;
             }
         }


### PR DESCRIPTION
If a plugin implementing MethodParamsProviderInterface returns an empty array (ie. the method does not take any parameters), psalm will not use the result and will ultimately throw an exception at https://github.com/vimeo/psalm/blob/f29826b958b3fcb4456f5ea0aa9eefe021b92d1e/src/Psalm/Internal/Codebase/Methods.php#L434