### PR TITLE
Exit with error status on baseline read errors

### DIFF
--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -63,7 +63,7 @@ class ErrorBaseline
     public static function read(FileProvider $fileProvider, string $baselineFile): array
     {
         if (!$fileProvider->fileExists($baselineFile)) {
-            throw new Exception\ConfigException("{$baselineFile} does not exist or is not readable\n");
+            throw new Exception\ConfigException("{$baselineFile} does not exist or is not readable");
         }
 
         $xmlSource = $fileProvider->getContents($baselineFile);

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -730,7 +730,8 @@ if (!empty(Config::getInstance()->error_baseline) && !isset($options['ignore-bas
             (string)Config::getInstance()->error_baseline
         );
     } catch (\Psalm\Exception\ConfigException $exception) {
-        die('Error while reading baseline: ' . $exception->getMessage());
+        fwrite(STDERR, 'Error while reading baseline: ' . $exception->getMessage() . PHP_EOL);
+        exit(1);
     }
 }
 


### PR DESCRIPTION
This PR changes `psalm` to exit with status 1 on baseline read errors. Current behaviour is to `die()` which exits with status 0.

The current behaviour is risky because, for example, CI jobs do not fail on corrupt baseline files, causing them to pass any code without emitting errors.