### PR TITLE
Disable progressbar when GitLab CI is detected

### DIFF
--- a/src/psalm.php
+++ b/src/psalm.php
@@ -517,6 +517,7 @@ if (isset($_SERVER['TRAVIS'])
     || isset($_SERVER['APPVEYOR'])
     || isset($_SERVER['JENKINS_URL'])
     || isset($_SERVER['SCRUTINIZER'])
+    || isset($_SERVER['GITLAB_CI'])
 ) {
     $options['no-progress'] = true;
 }


### PR DESCRIPTION
This makes job output clean by default on GitLab as well.

https://docs.gitlab.com/ee/ci/variables/predefined_variables.html