### PR TITLE
Rate limit the progress bar updates

### DIFF
--- a/src/Psalm/Progress/DefaultProgress.php
+++ b/src/Psalm/Progress/DefaultProgress.php
@@ -20,12 +20,14 @@ class DefaultProgress extends LongProgress
         if ($this->number_of_tasks > self::TOO_MANY_FILES) {
             ++$this->progress;
 
-            // Source for rate limiting: https://github.com/phan/phan/blob/9a788581ee1a4e1c35bebf89c435fd8a238c1d17/src/Phan/CLI.php
+            // Source for rate limiting:
+            // https://github.com/phan/phan/blob/9a788581ee1a4e1c35bebf89c435fd8a238c1d17/src/Phan/CLI.php
             $time = \microtime(true);
 
             // If not enough time has elapsed, then don't update the progress bar.
             // Making the update frequency based on time (instead of the number of files)
-            // prevents the terminal from rapidly flickering while processing small/empty files, and reduces the time spent writing to stderr.
+            // prevents the terminal from rapidly flickering while processing small/empty files,
+            // and reduces the time spent writing to stderr.
             if ($time - $this->previous_update_time < self::PROGRESS_BAR_SAMPLE_INTERVAL) {
                 // Make sure to output the section for 100% completion regardless of limits, to avoid confusion.
                 if ($this->progress !== $this->number_of_tasks) {

--- a/src/Psalm/Progress/DefaultProgress.php
+++ b/src/Psalm/Progress/DefaultProgress.php
@@ -12,6 +12,7 @@ class DefaultProgress extends LongProgress
     // This reduces flickering and reduces the amount of time spent writing to STDERR and updating the terminal.
     const PROGRESS_BAR_SAMPLE_INTERVAL = 0.1;
 
+    /** @var float the last time when the progress bar UI was updated */
     private $previous_update_time = 0.0;
 
     public function taskDone(int $level): void


### PR DESCRIPTION
Writing to the terminal adds time to the analysis, and can also cause flickering if it's fast enough.
Once per 0.1 seconds should be frequent enough for most use cases.

Previously, if there were 5000 files and it took a minute, this would write to stderr 5000 times. After this, it would write at most 600 times