### PR TITLE
Fix redundant casts/conditions in psalm

### DIFF
--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -160,7 +160,7 @@ class Reflection
         }
 
         $reflection_methods = $reflected_class->getMethods(
-            (int) (\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED)
+            (\ReflectionMethod::IS_PUBLIC | \ReflectionMethod::IS_PROTECTED)
         );
 
         if ($class_name_lower === 'generator') {

--- a/src/Psalm/Internal/Visitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/Visitor/ReflectorVisitor.php
@@ -779,7 +779,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         if (($function_id === 'array_map' && isset($node->args[0]))
             || ($function_id === 'array_filter' && isset($node->args[1]))
         ) {
-            $node_arg_value = $function_id = 'array_map' ? $node->args[0]->value : $node->args[1]->value;
+            $node_arg_value = $function_id === 'array_map' ? $node->args[0]->value : $node->args[1]->value;
 
             if ($node_arg_value instanceof PhpParser\Node\Scalar\String_
                 || $node_arg_value instanceof PhpParser\Node\Expr\Array_
@@ -1647,7 +1647,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
             if ($param->var instanceof PhpParser\Node\Expr\Error) {
                 if (IssueBuffer::accepts(
                     new InvalidDocblock(
-                        'Param' . ((int) $i + 1) . ' of ' . $cased_function_id . ' has invalid syntax',
+                        'Param' . ($i + 1) . ' of ' . $cased_function_id . ' has invalid syntax',
                         new CodeLocation($this->file_scanner, $param, null, true)
                     )
                 )) {

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -100,8 +100,8 @@ function requireAutoloaders($current_dir, $has_explicit_root, $vendor_dir)
         exit(1);
     }
 
-    define('PSALM_VERSION', (string) \PackageVersions\Versions::getVersion('vimeo/psalm'));
-    define('PHP_PARSER_VERSION', (string) \PackageVersions\Versions::getVersion('nikic/php-parser'));
+    define('PSALM_VERSION', \PackageVersions\Versions::getVersion('vimeo/psalm'));
+    define('PHP_PARSER_VERSION', \PackageVersions\Versions::getVersion('nikic/php-parser'));
 
     return $first_autoloader;
 }

--- a/src/psalm_plugin.php
+++ b/src/psalm_plugin.php
@@ -13,7 +13,7 @@ $vendor_dir = getVendorDir($current_dir);
 requireAutoloaders($current_dir, false, $vendor_dir);
 
 
-$app = new Application('psalm-plugin', (string) Versions::getVersion('vimeo/psalm'));
+$app = new Application('psalm-plugin', Versions::getVersion('vimeo/psalm'));
 
 $psalm_root = dirname(__DIR__) . DIRECTORY_SEPARATOR;
 


### PR DESCRIPTION
This includes a check for array_map that was accidentally an assignment