### PR TITLE
using regex to reformat the opening attributes for cleaner git diffs

### DIFF
--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -16,6 +16,8 @@ use function usort;
 use function implode;
 use function phpversion;
 use function array_map;
+use function preg_replace_callback;
+use function explode;
 
 class ErrorBaseline
 {

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -267,7 +267,7 @@ class ErrorBaseline
         $xml = preg_replace_callback(
             '/<files (psalm-version="[^"]+") (?:php-version="(.+)">\n)/',
             /**
-            * @param array{0:string, 1:string, 2:string} $matches
+            * @param array<int, string> $matches
             */
             function (array $matches) : string {
                 return

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -225,7 +225,7 @@ class ErrorBaseline
 
         usort($extensions, 'strnatcasecmp');
 
-        $filesNode->setAttribute('php-version', implode('; ', array_merge(
+        $filesNode->setAttribute('php-version', implode(';' . "\n\t", array_merge(
             [
                 ('php:' . phpversion()),
             ],
@@ -261,6 +261,26 @@ class ErrorBaseline
         $baselineDoc->appendChild($filesNode);
         $baselineDoc->formatOutput = true;
 
-        $fileProvider->setContents($baselineFile, $baselineDoc->saveXML());
+        $xml = preg_replace_callback(
+            '/<files (psalm-version="[^"]+") (?:php-version="(.+)">\n)/',
+            function (array $matches) : string {
+                return
+                    '<files' .
+                    "\n  " .
+                    $matches[1] .
+                    "\n" .
+                    '  php-version="' .
+                    "\n    " .
+                    implode("\n    ", explode('&#10;&#9;', $matches[2])) .
+                    "\n" .
+                    '  "' .
+                    "\n" .
+                    '>' .
+                    "\n";
+            },
+            $baselineDoc->saveXML()
+        );
+
+        $fileProvider->setContents($baselineFile, $xml);
     }
 }

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -287,7 +287,7 @@ class ErrorBaseline
             $baselineDoc->saveXML()
         );
 
-        if (is_null($xml)) {
+        if ($xml === null) {
             throw new RuntimeException('Failed to reformat opening attributes!');
         }
 

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -266,6 +266,9 @@ class ErrorBaseline
 
         $xml = preg_replace_callback(
             '/<files (psalm-version="[^"]+") (?:php-version="(.+)">\n)/',
+            /**
+            * @param array{0:string, 1:string, 2:string} $matches
+            */
             function (array $matches) : string {
                 return
                     '<files' .

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -2,6 +2,7 @@
 namespace Psalm;
 
 use Psalm\Internal\Provider\FileProvider;
+use RuntimeException;
 use function array_reduce;
 use const LIBXML_NOBLANKS;
 use function str_replace;
@@ -282,6 +283,10 @@ class ErrorBaseline
             },
             $baselineDoc->saveXML()
         );
+
+        if (is_null($xml)) {
+            throw new RuntimeException('Failed to reformat opening attributes!');
+        }
 
         $fileProvider->setContents($baselineFile, $xml);
     }


### PR DESCRIPTION
this is the slightly cludgy use of regex I referenced on twitter over the weekend.