### PR TITLE
7.0 no longer supported

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,10 +14,6 @@ init:
 environment:
   SSL_CERT_FILE: "C:\\tools\\php\\cacert.pem"
   matrix:
-    - php_ver_target: 7.0
-      DEPS: 'low'
-    - php_ver_target: 7.0
-      DEPS: 'high'
     - php_ver_target: 7.1
       DEPS: 'low'
     - php_ver_target: 7.1


### PR DESCRIPTION
7.0 was dropped in 0bd4dbcbc48ed6ba06dc35367bfd57c2406f8781

p.s. please enable appveyor so we can get windows ci up and running :D