### PR TITLE
ignoring default phpunit result cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .DS_Store
 /.php_cs.cache
 /.php_cs
+/.phpunit.result.cache
 /.*.swp
 /.*.swo
 /composer.lock


### PR DESCRIPTION
phpunit 7.5 is dumping a result cache by default.