### PR TITLE
Allow backslash after drive name

### DIFF
--- a/src/functions.php
+++ b/src/functions.php
@@ -16,7 +16,7 @@ function isAbsolutePath($path)
     $regex = '%^(?<wrappers>(?:[[:print:]]{2,}://)*)';
 
     // Optional root prefix.
-    $regex .= '(?<root>(?:[[:alpha:]]:/|/)?)';
+    $regex .= '(?<root>(?:[[:alpha:]]:[\\\/]|[\\\/])?)';
 
     // Actual path.
     $regex .= '(?<path>(?:[[:print:]]*))$%';

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -4,7 +4,6 @@ namespace Psalm\Tests\Config;
 use function define;
 use function defined;
 use const DIRECTORY_SEPARATOR;
-use const PHP_OS;
 use function dirname;
 use function get_class;
 use function getcwd;
@@ -18,7 +17,6 @@ use Psalm\PluginRegistrationSocket;
 use Psalm\Tests\Internal\Provider;
 use Psalm\Tests\TestConfig;
 use function sprintf;
-use function stripos;
 
 class PluginTest extends \Psalm\Tests\TestCase
 {
@@ -821,10 +819,6 @@ class PluginTest extends \Psalm\Tests\TestCase
      */
     public function testPluginFilenameCanBeAbsolute()
     {
-        if ($this->runningOnWindows()) {
-            $this->markTestIncomplete('Test fails on Windows - see https://github.com/vimeo/psalm/issues/1913');
-        }
-
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
                 dirname(__DIR__, 2) . DIRECTORY_SEPARATOR,
@@ -870,10 +864,5 @@ class PluginTest extends \Psalm\Tests\TestCase
         );
 
         $this->project_analyzer->getCodebase()->config->initializePlugins($this->project_analyzer);
-    }
-
-    private function runningOnWindows(): bool
-    {
-        return stripos(PHP_OS, 'WIN') === 0;
     }
 }

--- a/tests/IsAbsolutePathTest.php
+++ b/tests/IsAbsolutePathTest.php
@@ -29,6 +29,10 @@ class IsAbsolutePathTest extends TestCase
             ['relative/path/to/something', false],
             ['relative/path/to/something/file.php', false],
             ['c:/path/to/something', true],
+            ['C:\path\to\something', true],
+            ['C:\path/to\something', true],
+            ['\path\to\something', true],
+            ['C:\path/to\..\..\something', true],
             ['file://c:/path/to/something', true],
             ['zlib://c:/path/to/something', true],
         ];


### PR DESCRIPTION
Before, paths like `C:/path/to/something` were considered absolute, but `C:\path/to/something` were not

Refs vimeo/psalm#1913