### PR TITLE
add psalm config attribute re: #1804

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -53,6 +53,7 @@
         <xs:attribute name="parseSql" type="xs:string" />
         <xs:attribute name="maxStringLength" type="xs:string" />
         <xs:attribute name="resolveFromConfigFile" type="xs:string" />
+        <xs:attribute name="includePhpVersionsInErrorBaseline" type="xs:string" />
     </xs:complexType>
 
     <xs:complexType name="ProjectFilesType">

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -446,6 +446,11 @@ class Config
     /** @var string|null */
     public $error_baseline = null;
 
+    /**
+     * @var bool
+     */
+    public $include_php_versions_in_error_baseline = false;
+
     /** @var string */
     public $shepherd_host = 'shepherd.dev';
 
@@ -738,6 +743,11 @@ class Config
         if (isset($config_xml['errorBaseline'])) {
             $attribute_text = (string) $config_xml['errorBaseline'];
             $config->error_baseline = $attribute_text;
+        }
+
+        if (isset($config_xml['includePhpVersionsInErrorBaseline'])) {
+            $attribute_text = (string) $config_xml['includePhpVersionsInErrorBaseline'];
+            $config->include_php_versions_in_error_baseline = $attribute_text === 'true' || $attribute_text === '1';
         }
 
         if (isset($config_xml['maxStringLength'])) {

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -678,6 +678,7 @@ class Config
             'forbidEcho' => 'forbid_echo',
             'ignoreInternalFunctionFalseReturn' => 'ignore_internal_falsable_issues',
             'ignoreInternalFunctionNullReturn' => 'ignore_internal_nullable_issues',
+            'includePhpVersionsInErrorBaseline' => 'include_php_versions_in_error_baseline',
         ];
 
         foreach ($booleanAttributes as $xmlName => $internalName) {
@@ -743,11 +744,6 @@ class Config
         if (isset($config_xml['errorBaseline'])) {
             $attribute_text = (string) $config_xml['errorBaseline'];
             $config->error_baseline = $attribute_text;
-        }
-
-        if (isset($config_xml['includePhpVersionsInErrorBaseline'])) {
-            $attribute_text = (string) $config_xml['includePhpVersionsInErrorBaseline'];
-            $config->include_php_versions_in_error_baseline = $attribute_text === 'true' || $attribute_text === '1';
         }
 
         if (isset($config_xml['maxStringLength'])) {

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -533,7 +533,7 @@ if (isset($options['set-baseline']) && is_string($options['set-baseline'])) {
             new \Psalm\Internal\Provider\FileProvider,
             $options['set-baseline'],
             IssueBuffer::getIssuesData(),
-            isset($options['include-php-versions'])
+            $config->include_php_versions_in_error_baseline || isset($options['include-php-versions'])
         );
 
         fwrite(STDERR, "Baseline saved to {$options['set-baseline']}.");
@@ -599,7 +599,7 @@ if (isset($options['update-baseline'])) {
                 new \Psalm\Internal\Provider\FileProvider,
                 $baselineFile,
                 IssueBuffer::getIssuesData(),
-                isset($options['include-php-versions'])
+                $config->include_php_versions_in_error_baseline || isset($options['include-php-versions'])
             );
             $total_issues_updated_baseline = ErrorBaseline::countTotalIssues($issue_baseline);
 


### PR DESCRIPTION
* added a psalm config attribute for controlling the default inclusion of php & php extension version info in the error baseline
re: https://github.com/vimeo/psalm/pull/1804#issuecomment-510525056