### PR TITLE
Add docs for optional ObjectLike

### DIFF
--- a/docs/running_psalm/plugins/plugins_type_system.md
+++ b/docs/running_psalm/plugins/plugins_type_system.md
@@ -125,7 +125,7 @@ if (true === $first) {
 
 ``` php
 $a = ["a" => 1, "b" => 2]; // is ObjectLike, array{a:int(1),b:int(2)}
-$a = ["a" => null]; // is ObjectLike with optional keys/values, array{a:?int,b?:string}
+$a = rand(0, 1) ? ["a" => null] : ["a" => 1, "b" => "b"]; // is ObjectLike with optional keys/values, array{a:?int,b?:string}
 ```
 
 Note that not all associative arrays are considered object-like. If the keys are not known, the array is treated as a mapping between two types.

--- a/docs/running_psalm/plugins/plugins_type_system.md
+++ b/docs/running_psalm/plugins/plugins_type_system.md
@@ -124,8 +124,8 @@ if (true === $first) {
 `ObjectLike` represents an 'object-like array' - an array with known keys.
 
 ``` php
-$a = ["a" => 1, "b" => 2]; // is ObjectLike, array{a:int(1),b:int(2)}
-$a = rand(0, 1) ? ["a" => null] : ["a" => 1, "b" => "b"]; // is ObjectLike with optional keys/values, array{a:?int,b?:string}
+$x = ["a" => 1, "b" => 2]; // is ObjectLike, array{a: int, b: int}
+$y = rand(0, 1) ? ["a" => null] : ["a" => 1, "b" => "b"]; // is ObjectLike with optional keys/values, array{a: ?int, b?: string}
 ```
 
 Note that not all associative arrays are considered object-like. If the keys are not known, the array is treated as a mapping between two types.

--- a/docs/running_psalm/plugins/plugins_type_system.md
+++ b/docs/running_psalm/plugins/plugins_type_system.md
@@ -125,6 +125,7 @@ if (true === $first) {
 
 ``` php
 $a = ["a" => 1, "b" => 2]; // is ObjectLike, array{a:int(1),b:int(2)}
+$a = ["a" => null]; // is ObjectLike with optional keys/values, array{a:?int,b?:string}
 ```
 
 Note that not all associative arrays are considered object-like. If the keys are not known, the array is treated as a mapping between two types.


### PR DESCRIPTION
ref #634

github search point me to it :)

as a side note; this doc page is :100: but IMHO too much hidden in the current tree: https://psalm.dev/docs/running_psalm/plugins/plugins_type_system/#arrays

somehow intuitively i always go to https://psalm.dev/docs/annotating_code/typing_in_psalm/ first :thinking: 