### PR TITLE
Inherit throws docblock from parent class by default

### DIFF
--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -303,11 +303,10 @@ class Populator
                     $declaring_method_storage->overridden_downstream = true;
                     $declaring_method_storage->overridden_somewhere = true;
 
-                    if (!$method_storage->throws
-                        && $method_storage->inheritdoc
-                        && $declaring_method_storage->throws
+                    if ($declaring_method_storage->throws
+                        && (!$method_storage->throws || $method_storage->inheritdoc)
                     ) {
-                        $method_storage->throws = $declaring_method_storage->throws;
+                        $method_storage->throws += $declaring_method_storage->throws;
                     }
 
                     if (count($storage->overridden_method_ids[$method_name]) === 1
@@ -774,11 +773,10 @@ class Populator
                         if (isset($interface_storage->methods[$method_name])) {
                             $interface_method_storage = $interface_storage->methods[$method_name];
 
-                            if (!$method_storage->throws
-                                && $method_storage->inheritdoc
-                                && $interface_method_storage->throws
+                            if ($interface_method_storage->throws
+                                && (!$method_storage->throws || $method_storage->inheritdoc)
                             ) {
-                                $method_storage->throws = $interface_method_storage->throws;
+                                $method_storage->throws += $interface_method_storage->throws;
                             }
 
                             if ($interface_method_storage->return_type

--- a/tests/ThrowsAnnotationTest.php
+++ b/tests/ThrowsAnnotationTest.php
@@ -449,6 +449,113 @@ class ThrowsAnnotationTest extends TestCase
      */
     public function testDocumentedThrowInInterfaceWithoutInheritDocblock()
     {
+        Config::getInstance()->check_for_throws_docblock = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                interface Foo
+                {
+                    /**
+                     * @throws \InvalidArgumentException
+                     */
+                    public function test(): void;
+                }
+
+                class Bar implements Foo
+                {
+                    public function test(): void
+                    {
+                        throw new \InvalidArgumentException();
+                    }
+                }
+                '
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDocumentedThrowInSubclassWithExtendedInheritDocblock()
+    {
+        Config::getInstance()->check_for_throws_docblock = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                interface Foo
+                {
+                    /**
+                     * @throws \InvalidArgumentException
+                     */
+                    public function test(): void;
+                }
+
+                class Bar implements Foo
+                {
+                    /**
+                     * {@inheritdoc}
+                     * @throws \OutOfBoundsException
+                     */
+                    public function test(): void
+                    {
+                        throw new \OutOfBoundsException();
+                    }
+                }
+                '
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDocumentedThrowInInterfaceWithExtendedInheritDocblock()
+    {
+        Config::getInstance()->check_for_throws_docblock = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                interface Foo
+                {
+                    /**
+                     * @throws \InvalidArgumentException
+                     */
+                    public function test(): void;
+                }
+
+                class Bar implements Foo
+                {
+                    /**
+                     * {@inheritdoc}
+                     * @throws \OutOfBoundsException
+                     */
+                    public function test(): void
+                    {
+                        throw new \InvalidArgumentException();
+                    }
+                }
+                '
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
+    /**
+     * @return void
+     */
+    public function testDocumentedThrowInInterfaceWithOverriddenDocblock()
+    {
         $this->expectExceptionMessage('MissingThrowsDocblock');
         $this->expectException(\Psalm\Exception\CodeException::class);
         Config::getInstance()->check_for_throws_docblock = true;
@@ -466,6 +573,9 @@ class ThrowsAnnotationTest extends TestCase
 
                 class Bar implements Foo
                 {
+                    /**
+                     * @throws \OutOfBoundsException
+                     */
                     public function test(): void
                     {
                         throw new \InvalidArgumentException();


### PR DESCRIPTION
1. Inherit throws docblock when `{@inheritdoc}` is not set.

Today Psalm doesn't inherit `@throws` from parent class unless inheritDoc is set, unlike params and return docblock. In order to keep the same behavior, `@throws` is also inherited by default.

2. Merge inherited `@throws` with a docblock defined in the subclass.

The same behavior as in PHPStorm. When the subclass defines its own exceptions and `@inheritDoc` is set, exceptions documented in parent class are merged to the child.
