### PR TITLE
Fixed PHP 7.4 related issues

### DIFF
--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -389,7 +389,7 @@ class Reflection
             $suffix = '|null';
         }
 
-        return Type::parseString($reflection_type . $suffix);
+        return Type::parseString($reflection_type->getName() . $suffix);
     }
 
     /**

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -25,7 +25,7 @@ class CallableTest extends TestCase
                      * @return void
                      * @psalm-suppress MixedArgument
                      */
-                    function fn() {
+                    function f() {
                         run_function(
                             /**
                              * @return void
@@ -37,7 +37,7 @@ class CallableTest extends TestCase
                         echo $data;
                     }
 
-                    fn();',
+                    f();',
             ],
             'inferredArg' => [
                 '<?php


### PR DESCRIPTION
- `s/fn/f/g` (fn is a reserved keyword in 7.4)
- `ReflectionType::__toString()` warning (this method is deprecated in 7.4)

Note that some issues are caused by `phpspec/propecy` code and will be fixed when phpspec/propecy#432 lands. Most were caused by `ReflectionType::__toString()` usage in
`Psalm\Internal\Codebase\Reflection` though.