### PR TITLE
Restore gitignore for .*.swp in sub-directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,8 @@
 /.php_cs.cache
 /.php_cs
 /.phpunit.result.cache
-/.*.swp
-/.*.swo
+.*.swp
+.*.swo
 /composer.lock
 /phpunit.xml
 /vendor-bin/*/composer.lock


### PR DESCRIPTION
The `/.*.swp` will only ignore swp files in the root of this project.
(not sub-folders)
It won't ignore swp files in src/, etc.