### PR TITLE
Mark private properties unused when referenced only in constructor

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -315,7 +315,6 @@ class Codebase
         );
 
         $this->methods = new Internal\Codebase\Methods(
-            $config,
             $providers->classlike_storage_provider,
             $providers->file_reference_provider,
             $this->classlikes

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1232,7 +1232,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                     if (IssueBuffer::accepts(
                         new PropertyNotSetInConstructor(
                             'Property ' . $property_id . ' is not defined in constructor of ' .
-                                $this->fq_class_name . ' or in any methods called in the constructor',
+                                $this->fq_class_name . ' and in any methods called in the constructor',
                             $error_location,
                             $property_id
                         ),

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -3,6 +3,7 @@ namespace Psalm\Internal\Codebase;
 
 use function array_merge;
 use function array_pop;
+use function count;
 use function end;
 use function explode;
 use function get_declared_classes;
@@ -1780,7 +1781,8 @@ class ClassLikes
                     );
 
                     if ($codebase->alter_code) {
-                        if ($property_storage->stmt_location
+                        if (!$property_constructor_referenced
+                            && $property_storage->stmt_location
                             && isset($project_analyzer->getIssuesToFix()['UnusedProperty'])
                             && !$has_variable_calls
                             && !IssueBuffer::isSuppressed($issue, $classlike_storage->suppressed_issues)

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -37,11 +37,6 @@ class Methods
     private $classlike_storage_provider;
 
     /**
-     * @var \Psalm\Config
-     */
-    private $config;
-
-    /**
      * @var bool
      */
     public $collect_locations = false;
@@ -72,13 +67,11 @@ class Methods
      * @param ClassLikeStorageProvider $storage_provider
      */
     public function __construct(
-        \Psalm\Config $config,
         ClassLikeStorageProvider $storage_provider,
         FileReferenceProvider $file_reference_provider,
         ClassLikes $classlikes
     ) {
         $this->classlike_storage_provider = $storage_provider;
-        $this->config = $config;
         $this->file_reference_provider = $file_reference_provider;
         $this->classlikes = $classlikes;
         $this->return_type_provider = new MethodReturnTypeProvider();

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -585,15 +585,19 @@ class UnusedCodeTest extends TestCase
                     class A {
                         /** @var int */
                         private $used;
-                    
+
                         /** @var int */
                         private $unused;
-                    
+
+                        /** @var int */
+                        private static $staticUnused;
+
                         public function __construct() {
                             $this->used = 4;
                             $this->unused = 4;
+                            self::$staticUnused = 4;
                         }
-                    
+
                         public function handle(): void
                         {
                             $this->used++;

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -580,6 +580,28 @@ class UnusedCodeTest extends TestCase
                     new B();',
                 'error_message' => 'PossiblyUnusedProperty',
             ],
+            'propertyUsedOnlyInConstructor' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        private $used;
+                    
+                        /** @var int */
+                        private $unused;
+                    
+                        public function __construct() {
+                            $this->used = 4;
+                            $this->unused = 4;
+                        }
+                    
+                        public function handle(): void
+                        {
+                            $this->used++;
+                        }
+                    }
+                    (new A())->handle();',
+                'error_message' => 'UnusedProperty',
+            ],
         ];
     }
 }


### PR DESCRIPTION
If a private class property is used only in constructor then it's a dead code since it makes no sense to have the property (unless it's unlocked with a reflection). Usually such situations happen when the property usage has been deleted and the property has been left forgotten.
But such static properties can be accessed between the constructor calls, e.g. as a cache (it would be nice to have a cardinal or at countable `FileReferenceProvider::$method_references_to_class_members` instead of a boolean to catch such cases).

I couldn't think of any case where it wouldn't be true. Is this the right place for the code? Otherwise I'd try to make a plugin for our codebase.