### PR TITLE
Fix setting of current_dir with 'root' command parameter

### DIFF
--- a/src/psalm.php
+++ b/src/psalm.php
@@ -180,6 +180,20 @@ if (isset($options['root'])) {
 
 $current_dir = (string)getcwd() . DIRECTORY_SEPARATOR;
 
+if (isset($options['r']) && is_string($options['r'])) {
+    $root_path = realpath($options['r']);
+
+    if (!$root_path) {
+        fwrite(
+            STDERR,
+            'Could not locate root directory ' . $current_dir . DIRECTORY_SEPARATOR . $options['r'] . PHP_EOL
+        );
+        exit(1);
+    }
+
+    $current_dir = $root_path . DIRECTORY_SEPARATOR;
+}
+
 $path_to_config = get_path_to_config($options);
 
 $vendor_dir = getVendorDir($current_dir);
@@ -256,22 +270,6 @@ if ($config->resolve_from_config_file) {
     $current_dir = $config->base_dir;
     chdir($current_dir);
 }
-
-
-if (isset($options['r']) && is_string($options['r'])) {
-    $root_path = realpath($options['r']);
-
-    if (!$root_path) {
-        fwrite(
-            STDERR,
-            'Could not locate root directory ' . $current_dir . DIRECTORY_SEPARATOR . $options['r'] . PHP_EOL
-        );
-        exit(1);
-    }
-
-    $current_dir = $root_path . DIRECTORY_SEPARATOR;
-}
-
 
 $threads = isset($options['threads']) ? (int)$options['threads'] : 1;
 


### PR DESCRIPTION
Hey,
I'm quite new to psalm and I am currently trying to introduce it to [Shopware](https://github.com/shopware/platform). Works good so far, but I had an issue, when I was using psalm for our pre-commit hook. Due to our development setup it is necessary to set the `--root` command parameter, but psalm fails to load the autoloader files.
After some researching I found out, that the `$current_dir` variable was not set to the given root directory, before searching for the composer files. This issue was introduce with #1904 
This PR fixes the issue and works nice in my environment.