### PR TITLE
Allow class constant names to begin with lower-case

### DIFF
--- a/src/Psalm/Internal/Type/ParseTree.php
+++ b/src/Psalm/Internal/Type/ParseTree.php
@@ -514,7 +514,7 @@ class ParseTree
                             $nexter_token = $i + 2 < $c ? $type_tokens[$i + 2] : null;
 
                             if (!$nexter_token
-                                || (!preg_match('/^[A-Z_][a-zA-Z_0-9]*$/', $nexter_token[0])
+                                || (!preg_match('/^[a-zA-Z_][a-zA-Z_0-9]*$/', $nexter_token[0])
                                     && strtolower($nexter_token[0]) !== 'class')
                             ) {
                                 throw new TypeParseTreeException(


### PR DESCRIPTION
Followup to e58ade5803aacb4ff21eebc7475c75fc3fa4960e

(I assume this is what it should do, at least)