### PR TITLE
Allow explicitly-annotated mixed assignments

### DIFF
--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -1162,7 +1162,8 @@ function foo(array $a, array $b) : void {
 
 ### MixedAssignment
 
-Emitted when assigning a variable to a value for which Psalm cannot infer a type
+Emitted when assigning an unannotated variable to a value for which Psalm
+cannot infer a type more specific than `mixed`.
 
 ```php
 $a = $_GET['foo'];
@@ -1173,7 +1174,7 @@ $a = $_GET['foo'];
 Emitted when calling a function on a value whose type Psalm cannot infer.
 
 ```php
-/** @psalm-suppress MixedAssignment */
+/** @var mixed */
 $a = $_GET['foo'];
 $a();
 ```

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -254,6 +254,7 @@ class AssignmentAnalyzer
 
             if (!$assign_var instanceof PhpParser\Node\Expr\PropertyFetch
                 && !strpos($root_var_id ?? '', '->')
+                && !$comment_type
             ) {
                 if (IssueBuffer::accepts(
                     new MixedAssignment(

--- a/tests/AssignmentTest.php
+++ b/tests/AssignmentTest.php
@@ -51,6 +51,13 @@ class AssignmentTest extends TestCase
                         echo $foo;
                     }',
             ],
+            'explicitlyTypedMixedAssignment' => [
+                '<?php
+                    /** @var mixed */
+                    $a = 5;
+                    /** @var mixed */
+                    $b = $a;',
+            ],
         ];
     }
 


### PR DESCRIPTION
This change makes it possible to assign mixed expressions to variables
if an annotation is explicitly added to the variable. This allows the
use of `call_user_func` without needing to suppress issues.

Fixes: #1374