### PR TITLE
Added `ArrayObject` to the `array_key_exists` signature

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
@@ -195,7 +195,7 @@ function array_chunk(array $arr, int $size, bool $preserve_keys = false)
  * @psalm-template TKey as array-key
  *
  * @param TKey $key
- * @param array<TKey, mixed> $search
+ * @param array<TKey, mixed>|ArrayObject<TKey, mixed> $search
  *
  * @return bool
  */


### PR DESCRIPTION
After a quick check of the documentation and the php sources it looks like `array_key_exists` is implemented to support the `ArrayObject` specifically and in general array functions don't.

Hence a PR just for `array_key_exists`.

Addresses: https://github.com/vimeo/psalm/issues/2064