### PR TITLE
Add documentation for the <globals> project setting

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -289,3 +289,11 @@ Optional.  A list of exceptions to not report for `checkForThrowsDocblock` or `c
   <class name="fully\qualified\path\Exc" onlyGlobalScope="true" />
 </ignoreExceptions>
 ```
+
+#### `<globals>`
+Optional.  If your codebase uses global variables that are accessed with the `global` keyword, you can declare their type.  e.g.
+```xml
+<globals>
+  <var name="globalVariableName" type="type" />
+</globals>
+```


### PR DESCRIPTION
This change exposes the documentation for the <globals> project setting.