### PR TITLE
Allow class constants to refer to other constants

### DIFF
--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -134,7 +134,8 @@ class Populator
                         $class_storage->name
                     );
 
-                    $class_storage->public_class_constants[$const_name] = $const_type ?: Type::getMixed();
+                    $class_storage->public_class_constants[$const_name] =
+                        $const_type ?: Type::getMixedDeferredConstant();
                 }
 
                 foreach ($class_storage->protected_class_constant_nodes as $const_name => $node) {
@@ -147,7 +148,8 @@ class Populator
                         $class_storage->name
                     );
 
-                    $class_storage->protected_class_constants[$const_name] = $const_type ?: Type::getMixed();
+                    $class_storage->protected_class_constants[$const_name] =
+                        $const_type ?: Type::getMixedDeferredConstant();
                 }
 
                 foreach ($class_storage->private_class_constant_nodes as $const_name => $node) {
@@ -160,7 +162,8 @@ class Populator
                         $class_storage->name
                     );
 
-                    $class_storage->private_class_constants[$const_name] = $const_type ?: Type::getMixed();
+                    $class_storage->private_class_constants[$const_name] =
+                        $const_type ?: Type::getMixedDeferredConstant();
                 }
             }
         }
@@ -545,11 +548,11 @@ class Populator
             );
 
             foreach ($parent_storage->public_class_constant_nodes as $name => $_) {
-                $storage->public_class_constants[$name] = Type::getMixed();
+                $storage->public_class_constants[$name] = Type::getMixedDeferredConstant();
             }
 
             foreach ($parent_storage->protected_class_constant_nodes as $name => $_) {
-                $storage->protected_class_constants[$name] = Type::getMixed();
+                $storage->protected_class_constants[$name] = Type::getMixedDeferredConstant();
             }
 
             $storage->pseudo_property_get_types += $parent_storage->pseudo_property_get_types;
@@ -598,7 +601,7 @@ class Populator
             );
 
             foreach ($parent_interface_storage->public_class_constant_nodes as $name => $_) {
-                $storage->public_class_constants[$name] = Type::getMixed();
+                $storage->public_class_constants[$name] = Type::getMixedDeferredConstant();
             }
 
             if ($parent_interface_storage->template_types) {
@@ -685,7 +688,7 @@ class Populator
             );
 
             foreach ($implemented_interface_storage->public_class_constant_nodes as $name => $_) {
-                $storage->public_class_constants[$name] = Type::getMixed();
+                $storage->public_class_constants[$name] = Type::getMixedDeferredConstant();
             }
 
             $storage->invalid_dependencies = array_merge(

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -41,6 +41,7 @@ use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TMixed;
+use Psalm\Type\Atomic\TMixedDeferredConstant;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TNumeric;
@@ -1247,6 +1248,16 @@ abstract class Type
     public static function getMixed($from_loop_isset = false)
     {
         $type = new TMixed($from_loop_isset);
+
+        return new Union([$type]);
+    }
+
+    /**
+     * @return Type\Union
+     */
+    public static function getMixedDeferredConstant()
+    {
+        $type = new TMixedDeferredConstant();
 
         return new Union([$type]);
     }

--- a/src/Psalm/Type/Atomic/TMixedDeferredConstant.php
+++ b/src/Psalm/Type/Atomic/TMixedDeferredConstant.php
@@ -1,0 +1,13 @@
+<?php
+namespace Psalm\Type\Atomic;
+
+class TMixedDeferredConstant extends TMixed
+{
+    /**
+     * @return string
+     */
+    public function getId()
+    {
+        return 'mixed-deferred-constant';
+    }
+}

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -850,6 +850,15 @@ class Union
     /**
      * @return bool
      */
+    public function isMixedDeferredConstant()
+    {
+        return isset($this->types['mixed'])
+            && get_class($this->types['mixed']) === Type\Atomic\TMixedDeferredConstant::class;
+    }
+
+    /**
+     * @return bool
+     */
     public function isArrayKey()
     {
         return isset($this->types['array-key']) && count($this->types) === 1;

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -400,6 +400,14 @@ class ConstantTest extends TestCase
                         }
                     }'
             ],
+            'constantDeferredConstants' => [
+                '<?php
+                    const A = 1;
+                    class B {
+                        public const C = A;
+                    }
+                    echo B::C;'
+            ],
         ];
     }
 


### PR DESCRIPTION
This change introduces the TMixedDeferredConstant type, which marks a
type as being a constant that needs to be resolved at a later stage.

Fixes: #1551