### PR TITLE
Revert "Added `ArrayObject` to the `array_key_exists` signature"

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
@@ -195,7 +195,7 @@ function array_chunk(array $arr, int $size, bool $preserve_keys = false)
  * @psalm-template TKey as array-key
  *
  * @param TKey $key
- * @param array<TKey, mixed>|ArrayObject<TKey, mixed> $search
+ * @param array<TKey, mixed> $search
  *
  * @return bool
  */


### PR DESCRIPTION
Reverts vimeo/psalm#2066 because @weirdan pointed out this functionality is deprecated in 7.4, and so it's sort of a code smell.