### PR TITLE
Use the correct types for AssignmentRef

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -855,14 +855,15 @@ class AssignmentAnalyzer
         PhpParser\Node\Expr\AssignRef $stmt,
         Context $context
     ) {
-        if (self::analyze(
+        $assignment_type = self::analyze(
             $statements_analyzer,
             $stmt->var,
             $stmt->expr,
             null,
             $context,
             $stmt->getDocComment()
-        ) === false) {
+        );
+        if ($assignment_type === false) {
             return false;
         }
 
@@ -879,11 +880,11 @@ class AssignmentAnalyzer
         );
 
         if ($lhs_var_id) {
-            $context->vars_in_scope[$lhs_var_id] = Type::getMixed();
+            $context->vars_in_scope[$lhs_var_id] = $assignment_type;
             $context->hasVariable($lhs_var_id, $statements_analyzer);
         }
 
-        if ($rhs_var_id) {
+        if ($rhs_var_id && !isset($context->vars_in_scope[$rhs_var_id])) {
             $context->vars_in_scope[$rhs_var_id] = Type::getMixed();
         }
     }

--- a/tests/AssignmentTest.php
+++ b/tests/AssignmentTest.php
@@ -58,6 +58,27 @@ class AssignmentTest extends TestCase
                     /** @var mixed */
                     $b = $a;',
             ],
+            'referenceAssignmentArray' => [
+                '<?php
+                    $matrix = [
+                      [1, 0],
+                      [0, 1],
+                    ];
+                    $row =& $matrix[0];
+                    echo $row[0];',
+            ],
+            'referenceAssignmentLhs' => [
+                '<?php
+                    $a = 1;
+                    $b =& $a;
+                    echo $b;',
+            ],
+            'referenceAssignmentRhs' => [
+                '<?php
+                    $a = 1;
+                    $b =& $a;
+                    echo $a;',
+            ],
         ];
     }
 

--- a/tests/Php70Test.php
+++ b/tests/Php70Test.php
@@ -74,7 +74,7 @@ class Php70Test extends TestCase
                     $var = 0;
                     ($a =& $var) ?? "hello";',
                 'assertions' => [
-                    '$a' => 'mixed',
+                    '$a' => 'int',
                 ],
             ],
             'spaceship' => [


### PR DESCRIPTION
This change assigns the type of the rhs expression to the variable that
will become a reference, as well as preventing clobbering of the rhs if
it is an already-typed variable.

Fixes: #2077