### PR TITLE
Fix the signature of sodium_crypto_scalarmult_base()

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -12095,7 +12095,7 @@ return [
 'sodium_crypto_pwhash_str_needs_rehash' => ['bool', 'password'=>'string', 'opslimit'=>'int', 'memlimit'=>'int'],
 'sodium_crypto_pwhash_str_verify' => ['bool', 'hash'=>'string', 'password'=>'string'],
 'sodium_crypto_scalarmult' => ['string', 'string_1'=>'string', 'string_2'=>'string'],
-'sodium_crypto_scalarmult_base' => ['string', 'string_1'=>'string', 'string_2'=>'string'],
+'sodium_crypto_scalarmult_base' => ['string', 'secretkey'=>'string'],
 'sodium_crypto_secretbox' => ['string', 'plaintext'=>'string', 'nonce'=>'string', 'key'=>'string'],
 'sodium_crypto_secretbox_keygen' => ['string'],
 'sodium_crypto_secretbox_open' => ['string|false', 'ciphertext'=>'string', 'nonce'=>'string', 'key'=>'string'],

--- a/src/Psalm/Internal/CallMap_72_delta.php
+++ b/src/Psalm/Internal/CallMap_72_delta.php
@@ -98,7 +98,7 @@ return [
     'sodium_crypto_pwhash_str_needs_rehash' => ['bool', 'password'=>'string', 'opslimit'=>'int', 'memlimit'=>'int'],
     'sodium_crypto_pwhash_str_verify' => ['bool', 'hash'=>'string', 'password'=>'string'],
     'sodium_crypto_scalarmult' => ['string', 'string_1'=>'string', 'string_2'=>'string'],
-    'sodium_crypto_scalarmult_base' => ['string', 'string_1'=>'string', 'string_2'=>'string'],
+    'sodium_crypto_scalarmult_base' => ['string', 'secretkey'=>'string'],
     'sodium_crypto_secretbox' => ['string', 'plaintext'=>'string', 'nonce'=>'string', 'key'=>'string'],
     'sodium_crypto_secretbox_keygen' => ['string'],
     'sodium_crypto_secretbox_open' => ['string|false', 'ciphertext'=>'string', 'nonce'=>'string', 'key'=>'string'],


### PR DESCRIPTION
`sodium_crypto_scalarmult_base()` is an alias of `sodium_crypto_box_publickey_from_secretkey()`
 so it should have the same parameters.

See:
https://www.php.net/manual/en/function.sodium-crypto-scalarmult-base.php