### PR TITLE
ext-curl

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,8 @@
         "phpmyadmin/sql-parser": "^5.0",
         "symfony/process": "^4.3",
         "slevomat/coding-standard": "^5.0",
-        "friendsofphp/php-cs-fixer": "^2.15"
+        "friendsofphp/php-cs-fixer": "^2.15",
+        "ext-curl": "*"
     },
     "suggest": {
         "ext-igbinary": "^2.0.5"


### PR DESCRIPTION
shepherd plugin requires ext-curl, although oddly just for the consts.

seems reasonable enough to add ext-curl to require-dev rather than stubbing out the consts here.