### PR TITLE
symfony/process:^4.3 requires php:^7.1.3, adjust dependency constraint to prevent install on < 7.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ stages:
   # - Code coverage analysis
 
 php:
+  - 7.1.3
   - 7.1
   - 7.2
   - 7.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ stages:
 
 php:
   - 7.1.3
-  - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.1.3",
         "nikic/php-parser": "^4.2",
         "openlss/lib-array2xml": "^1.0",
         "ocramius/package-versions": "^1.2",


### PR DESCRIPTION
re: #2136