### PR TITLE
Disable composer plugins for end-to-end tests

### DIFF
--- a/tests/EndToEnd/PsalmEndToEndTest.php
+++ b/tests/EndToEnd/PsalmEndToEndTest.php
@@ -53,7 +53,7 @@ class PsalmEndToEndTest extends TestCase
 
         copy(__DIR__ . '/../fixtures/DummyProjectWithErrors/composer.json', self::$tmpDir . '/composer.json');
 
-        (new Process(['composer', 'install'], self::$tmpDir))->mustRun();
+        (new Process(['composer', 'install', '--no-plugins'], self::$tmpDir))->mustRun();
     }
 
     public static function tearDownAfterClass(): void


### PR DESCRIPTION
When Psalm is installed with `composer global require vimeo/psalm` it brings in `ocramius/package-versions`, effectively making it a global composer plugin (so it runs for all `composer install`s, even for
totally unrelated projects).

However `ocramius/package-versions` has a peculiar quirk: it fails when there's no `composer.lock` present, and there's no `composer.lock` for projects that have no dependencies (like the end-to-end test projects).

The net result is that end-to-end tests always fail wherever Psalm is installed globally.

This PR fixes it by disabling composer plugins for end-to-end tests.