### PR TITLE
Add impure functions for mcrypt and iterator_apply

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -296,6 +296,10 @@ class Functions
 
             // output buffer
             'ob_start', 'ob_end_clean', 'readfile', 'printf', 'var_dump', 'phpinfo',
+            'ob_implicit_flush',
+
+            // mcrypt
+            'mcrypt_generic_init', 'mcrypt_generic_deinit', 'mcrypt_module_close',
 
             // internal optimisation
             'opcache_compile_file', 'clearstatcache',
@@ -346,7 +350,7 @@ class Functions
             'ldap_set_option',
 
             // iterators
-            'rewind',
+            'rewind', 'iterator_apply',
 
             // mysqli
             'mysqli_select_db', 'mysqli_dump_debug_info', 'mysqli_kill', 'mysqli_multi_query',


### PR DESCRIPTION
These are among the functions whose result isn't needed.
There is also `ob_implicit_flush` [report](https://psalm.dev/r/9b36f33fc7) with `UnusedFunctionCall`, how is that possible for a void function?