### PR TITLE
Fix wrong annotations in ext-ds method stubs

### DIFF
--- a/src/Psalm/Internal/Stubs/ext-ds.php
+++ b/src/Psalm/Internal/Stubs/ext-ds.php
@@ -23,7 +23,7 @@ use UnderflowException;
  * @package Ds
  * @template TValue
  *
- * @psalm-extends Traversable<mixed, TValue>
+ * @extends Traversable<mixed, TValue>
  */
 interface Collection extends Traversable, Countable, JsonSerializable
 {
@@ -500,9 +500,9 @@ interface Hashable
  * @template TKey
  * @template TValue
  *
- * @psalm-implements Collection<TValue>
- * @psalm-implements ArrayAccess<TKey, TValue>
- * @psalm-implements IteratorAggregate<TKey, TValue>
+ * @implements Collection<TValue>
+ * @implements ArrayAccess<TKey, TValue>
+ * @implements IteratorAggregate<TKey, TValue>
  */
 final class Map implements IteratorAggregate, ArrayAccess, Collection
 {

--- a/src/Psalm/Internal/Stubs/ext-ds.php
+++ b/src/Psalm/Internal/Stubs/ext-ds.php
@@ -79,7 +79,7 @@ interface Collection extends Traversable, Countable, JsonSerializable
  * @package Ds
  * @template TValue
  *
- * @psalm-extends Sequence<TValue>
+ * @implements Sequence<TValue>
  */
 final class Deque implements IteratorAggregate, ArrayAccess, Sequence
 {


### PR DESCRIPTION
Hey, this fixes a couple of annotations that prevented the Ds class stubs from providing accurate information to Psalm. Consider this test file:

```php
<?php

/** @var \Ds\Map<string, string> */
$map = new \Ds\Map;

$map->put('foo', 'bar');
$map->put(12345, 'xyz');

foreach ($map as $key => $value) {
    print $key * 1;
    print $value->hello();
}
```

Without these fixes Psalm returns these not very helpful errors:

```
ERROR: TooManyTemplateParams - /tmp/foo.php:4:1 - Ds\Map has too many template params, expecting 0
/** @var \Ds\Map<string, string> */
$map = new \Ds\Map;

ERROR: InvalidArgument - /tmp/foo.php:6:11 - Argument 1 of Ds\Map::put expects Ds\TKey, string(foo) provided
$map->put('foo', 'bar');

ERROR: InvalidArgument - /tmp/foo.php:6:18 - Argument 2 of Ds\Map::put expects Ds\TValue, string(bar) provided
$map->put('foo', 'bar');

ERROR: InvalidArgument - /tmp/foo.php:7:11 - Argument 1 of Ds\Map::put expects Ds\TKey, int(12345) provided
$map->put(12345, 'xyz');

ERROR: InvalidArgument - /tmp/foo.php:7:18 - Argument 2 of Ds\Map::put expects Ds\TValue, string(xyz) provided
$map->put(12345, 'xyz');
```

With the patch applied:

```
ERROR: InvalidScalarArgument - /tmp/foo.php:7:11 - Argument 1 of Ds\Map::put expects string, int(12345) provided
$map->put(12345, 'xyz');

ERROR: InvalidOperand - /tmp/foo.php:10:11 - Cannot perform a numeric operation with a non-numeric type string
    print $key * 1;

ERROR: InvalidMethodCall - /tmp/foo.php:11:19 - Cannot call method on string variable $value
    print $value->hello();
```