### PR TITLE
Properly warn when a short option is invalid.

### DIFF
--- a/src/psalm.php
+++ b/src/psalm.php
@@ -110,7 +110,7 @@ array_map(
                 );
                 exit(1);
             }
-        } elseif (substr($arg, 0, 2) === '-' && $arg !== '-' && $arg !== '--') {
+        } elseif (substr($arg, 0, 1) === '-' && $arg !== '-' && $arg !== '--') {
             $arg_name = preg_replace('/=.*$/', '', substr($arg, 1));
 
             if (!in_array($arg_name, $valid_short_options) && !in_array($arg_name . ':', $valid_short_options)) {


### PR DESCRIPTION
Previously, Psalm would not warn or exit - it would skip over the arg and
continue with analysis. (e.g. for `psalm -Z`)