### PR TITLE
Add support for Iterator<X> type

### DIFF
--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -1106,12 +1106,22 @@ extending all its template params.
 
 ```php
 /**
- * @template-implements IteratorAggregate<int>
+ * @template-implements ArrayAccess<int>
  */
-class SomeIterator implements IteratorAggregate
+class SomeIterator implements ArrayAccess
 {
-    public function getIterator() {
-        yield 5;
+    public function offsetSet($offset, $value) {
+    }
+
+    public function offsetExists($offset) {
+        return false;
+    }
+
+    public function offsetUnset($offset) {
+    }
+
+    public function offsetGet($offset) {
+        return null;
     }
 }
 ```

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -251,7 +251,7 @@ abstract class Type
                 && count($generic_params) === 1
             ) {
                 array_unshift($generic_params, new Union([new TArrayKey]));
-            } elseif (($generic_type_value === 'iterable' || $generic_type_value === 'Traversable')
+            } elseif (in_array($generic_type_value, ['iterable', 'Traversable', 'Iterator', 'IteratorAggregate'], true)
                 && count($generic_params) === 1
             ) {
                 array_unshift($generic_params, new Union([new TMixed]));

--- a/tests/Loop/ForeachTest.php
+++ b/tests/Loop/ForeachTest.php
@@ -973,8 +973,6 @@ class ForeachTest extends \Psalm\Tests\TestCase
                 '<?php
                     /**
                      * @param Iterator<string> $arr
-                     * @psalm-suppress MissingTemplateParam
-                     * @psalm-suppress MixedAssignment
                      */
                     function foo(Iterator $arr) : void {
                         foreach ($arr as $a) {}

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -186,7 +186,7 @@ class TypeParseTest extends TestCase
      */
     public function testInteratorAndTraversable()
     {
-        $this->assertSame('Iterator<int>&Traversable', (string) Type::parseString('Iterator<int>&Traversable'));
+        $this->assertSame('Iterator<mixed, int>&Traversable', (string) Type::parseString('Iterator<int>&Traversable'));
     }
 
     /**
@@ -195,7 +195,7 @@ class TypeParseTest extends TestCase
     public function testTraversableAndIteratorOrNull()
     {
         $this->assertSame(
-            'Traversable&Iterator<int>|null',
+            'Traversable&Iterator<mixed, int>|null',
             (string) Type::parseString('Traversable&Iterator<int>|null')
         );
     }


### PR DESCRIPTION
Also added `IteratorAggregate` since `Traversable` is supported but I don't really care about that. I'll revert that if you want.

Should I add a test somewhere?