### PR TITLE
Fix redundant condition

### DIFF
--- a/src/Psalm/Type/Atomic/TGenericObject.php
+++ b/src/Psalm/Type/Atomic/TGenericObject.php
@@ -36,7 +36,7 @@ class TGenericObject extends TNamedObject
 
         $extra_types = '';
 
-        if ($this instanceof TNamedObject && $this->extra_types) {
+        if ($this->extra_types) {
             $extra_types = '&' . implode('&', $this->extra_types);
         }
 


### PR DESCRIPTION
TGenericObject is always a TNamedObject (it's a subclass)