### PR TITLE
Scan shape properties

### DIFF
--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -546,6 +546,16 @@ abstract class Atomic
                 );
             }
         }
+
+        if ($this instanceof ObjectLike) {
+            foreach ($this->properties as $property) {
+                $property->queueClassLikesForScanning(
+                    $codebase,
+                    $file_storage,
+                    $phantom_classes
+                );
+            }
+        }
     }
 
     public function containsClassLike(string $fq_classlike_name) : bool

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -563,6 +563,15 @@ class AnnotationTest extends TestCase
                      */
                     class A {}',
             ],
+            'builtInClassInAShape' => [
+                '<?php
+                  /**
+                   * @return array{d:Exception}
+                   * @psalm-suppress InvalidReturnType
+                   */
+                  function f() {}
+                '
+            ],
             'slashAfter?' => [
                 '<?php
                     namespace ns;


### PR DESCRIPTION
This prevents crashes when built-in classes are referenced by shape properties.

Fixes vimeo/psalm#2331