### PR TITLE
Allow usage of symfony/console v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "netresearch/jsonmapper": "^1.0",
         "webmozart/glob": "^4.1",
         "webmozart/path-util": "^2.3",
-        "symfony/console": "^3.3||^4.0",
+        "symfony/console": "^3.3||^4.0||^5.0",
         "amphp/amp": "^2.1",
         "amphp/byte-stream": "^1.5",
         "sebastian/diff": "^3.0"


### PR DESCRIPTION
Also dropped support for symfony/console:^3.3, as the minimal version of PHP supported by Psalm is also supported by symfony/console:^4.0.