### PR TITLE
Update PhpStorm usage

### DIFF
--- a/docs/running_psalm/language_server.md
+++ b/docs/running_psalm/language_server.md
@@ -37,10 +37,11 @@ When you install the plugin, you should see a "Language Server Protocol" section
 
 In the "Server definitions" tab you should add a definition for Psalm:
 
+ - Select `Executable`
  - Extension: `php`
- - Path: `<path-to-php-binary>` e.g. `/usr/local/bin/php`
+ - Path: `<path-to-php-binary>` e.g. `/usr/local/bin/php` or `C:\php\php.exe`
     - this should be an absolute path, not just `php`
- - Args: `vendor/bin/psalm-language-server`
+ - Args: `vendor/bin/psalm-language-server` (on Windows use `vendor/vimeo/psalm/psalm-language-server`)
 
 In the "Timeouts" tab you can adjust the initialization timeout. This is important if you have a large project. You should set the "Init" value to the number of milliseconds you allow Psalm to scan your entire project and your project's dependencies.
 


### PR DESCRIPTION
For https://psalm.dev/docs/running_psalm/language_server/#phpstorm

There is a new option that defaults to Artifact. It should be Executable.
Windows can't figure out that the PHP interpreter will run a shell script that then calls  PHP (not sure if this even works on Unix)
And added a PHP bin dir example for Wins.

Basically I was only able to make it run with:
![image](https://user-images.githubusercontent.com/183722/70091856-cb4cbd00-15fb-11ea-8e3a-37605c325697.png)

Maybe helps another Windows users.