### PR TITLE
Organizing the --help screen

### DIFF
--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -270,7 +270,103 @@ function getPsalmHelpText(): string
 Usage:
     psalm [options] [file...]
 
-Options:
+Basic configuration:
+    -c, --config=psalm.xml
+        Path to a psalm.xml configuration file. Run psalm --init to create one.
+
+    --use-ini-defaults
+        Use PHP-provided ini defaults for memory and error display
+
+    --disable-extension=[extension]
+        Used to disable certain extensions while Psalm is running.
+
+    --threads=INT
+        If greater than one, Psalm will run analysis on multiple threads, speeding things up.
+
+    --diff
+        Runs Psalm in diff mode, only checking files that have changed (and their dependents)
+
+    --diff-methods
+        Only checks methods that have changed (and their dependents)
+
+Surfacing issues:
+    --show-info[=BOOLEAN]
+        Show non-exception parser findings
+
+    --show-snippet[=true]
+        Show code snippets with errors. Options are 'true' or 'false'
+
+    --find-dead-code[=auto]
+    --find-unused-code[=auto]
+        Look for unused code. Options are 'auto' or 'always'. If no value is specified, default is 'auto'
+
+    --find-unused-psalm-suppress
+        Finds all @psalm-suppress annotations that aren’t used
+
+    --find-references-to=[class|method|property]
+        Searches the codebase for references to the given fully-qualified class or method,
+        where method is in the format class::methodName
+
+    --no-suggestions
+        Hide suggestions
+
+Issue baselines:
+    --set-baseline=PATH
+        Save all current error level issues to a file, to mark them as info in subsequent runs
+
+        Add --include-php-versions to also include a list of PHP extension versions
+
+    --ignore-baseline
+        Ignore the error baseline
+
+    --update-baseline
+        Update the baseline by removing fixed issues. This will not add new issues to the baseline
+
+        Add --include-php-versions to also include a list of PHP extension versions
+
+Plugins:
+    --plugin=PATH
+        Executes a plugin, an alternative to using the Psalm config
+
+Output:
+    -m, --monochrome
+        Enable monochrome output
+
+    --output-format=console
+        Changes the output format. Available formats: compact, console, emacs, json, pylint, xml, checkstyle, sonarqube
+
+    --no-progress
+        Disable the progress indicator
+
+    --long-progress
+        Use a progress indicator suitable for Continuous Integration logs
+
+    --stats
+        Shows a breakdown of Psalm's ability to infer types in the codebase
+
+Reports:
+    --report=PATH
+        The path where to output report file. The output format is based on the file extension.
+        (Currently supported format: ".json", ".xml", ".txt", ".emacs")
+
+    --report-show-info[=BOOLEAN]
+        Whether the report should include non-errors in its output (defaults to true)
+
+Caching:
+    --clear-cache
+        Clears all cache files that Psalm uses for this specific project
+
+    --clear-global-cache
+        Clears all cache files that Psalm uses for all projects
+
+    --no-cache
+        Runs Psalm without using cache
+
+    --no-reflection-cache
+        Runs Psalm without using cached representations of unchanged classes and files.
+        Useful if you want the afterClassLikeVisit plugin hook to run every time you visit a file.
+
+Miscellaneous:
     -h, --help
         Display this help message
 
@@ -287,100 +383,11 @@ Options:
     --debug-by-line
         Debug information on a line-by-line level
 
-    -c, --config=psalm.xml
-        Path to a psalm.xml configuration file. Run psalm --init to create one.
-
-    -m, --monochrome
-        Enable monochrome output
-
     -r, --root
         If running Psalm globally you'll need to specify a project root. Defaults to cwd
 
-    --show-info[=BOOLEAN]
-        Show non-exception parser findings
-
-    --show-snippet[=true]
-        Show code snippets with errors. Options are 'true' or 'false'
-
-    --diff
-        Runs Psalm in diff mode, only checking files that have changed (and their dependents)
-
-    --diff-methods
-        Only checks methods that have changed (and their dependents)
-
-    --output-format=console
-        Changes the output format. Possible values: compact, console, emacs, json, pylint, xml, checkstyle, sonarqube
-
-    --find-dead-code[=auto]
-    --find-unused-code[=auto]
-        Look for unused code. Options are 'auto' or 'always'. If no value is specified, default is 'auto'
-
-    --find-unused-psalm-suppress
-        Finds all @psalm-suppress annotations that aren’t used
-
-    --find-references-to=[class|method|property]
-        Searches the codebase for references to the given fully-qualified class or method,
-        where method is in the format class::methodName
-
-    --threads=INT
-        If greater than one, Psalm will run analysis on multiple threads, speeding things up.
-
-    --report=PATH
-        The path where to output report file. The output format is based on the file extension.
-        (Currently supported format: ".json", ".xml", ".txt", ".emacs")
-
-    --report-show-info[=BOOLEAN]
-        Whether the report should include non-errors in its output (defaults to true)
-
-    --clear-cache
-        Clears all cache files that Psalm uses for this specific project
-
-    --clear-global-cache
-        Clears all cache files that Psalm uses for all projects
-
-    --no-cache
-        Runs Psalm without using cache
-
-    --no-reflection-cache
-        Runs Psalm without using cached representations of unchanged classes and files.
-        Useful if you want the afterClassLikeVisit plugin hook to run every time you visit a file.
-
-    --plugin=PATH
-        Executes a plugin, an alternative to using the Psalm config
-
-    --stats
-        Shows a breakdown of Psalm's ability to infer types in the codebase
-
-    --use-ini-defaults
-        Use PHP-provided ini defaults for memory and error display
-
-    --disable-extension=[extension]
-        Used to disable certain extensions while Psalm is running.
-
-    --set-baseline=PATH
-        Save all current error level issues to a file, to mark them as info in subsequent runs
-
-        Add --include-php-versions to also include a list of PHP extension versions
-
-    --ignore-baseline
-        Ignore the error baseline
-
-    --update-baseline
-        Update the baseline by removing fixed issues. This will not add new issues to the baseline
-
-        Add --include-php-versions to also include a list of PHP extension versions
-
     --generate-json-map=PATH
         Generate a map of node references and types in JSON format, saved to the given path.
-
-    --no-progress
-        Disable the progress indicator
-
-    --long-progress
-        Use a progress indicator suitable for Continuous Integration logs
-
-    --no-suggestions
-        Hide suggestions
 
     --shepherd[=host]
         Send data to Shepherd, Psalm's GitHub integration tool.


### PR DESCRIPTION
This reorganizes the `--help` screen into the following categories:

* Basic configuration
* Surfacing issues
* Issue baselines
* Plugins
* Output
* Reports
* Caching
* Miscellaneous

With the way the current help screen is, it's really difficult to parse for the options you might be looking for, and this should hopefully ease that frustration a bit.

In action:

```
$ ./psalm --help
Usage:
    psalm [options] [file...]

Basic configuration:
    -c, --config=psalm.xml
        Path to a psalm.xml configuration file. Run psalm --init to create one.

    --use-ini-defaults
        Use PHP-provided ini defaults for memory and error display

    --disable-extension=[extension]
        Used to disable certain extensions while Psalm is running.

    --threads=INT
        If greater than one, Psalm will run analysis on multiple threads, speeding things up.

    --diff
        Runs Psalm in diff mode, only checking files that have changed (and their dependents)

    --diff-methods
        Only checks methods that have changed (and their dependents)

Surfacing issues:
    --show-info[=BOOLEAN]
        Show non-exception parser findings

    --show-snippet[=true]
        Show code snippets with errors. Options are 'true' or 'false'

    --find-dead-code[=auto]
    --find-unused-code[=auto]
        Look for unused code. Options are 'auto' or 'always'. If no value is specified, default is 'auto'

    --find-unused-psalm-suppress
        Finds all @psalm-suppress annotations that aren’t used

    --find-references-to=[class|method|property]
        Searches the codebase for references to the given fully-qualified class or method,
        where method is in the format class::methodName

    --no-suggestions
        Hide suggestions

Issue baselines:
    --set-baseline=PATH
        Save all current error level issues to a file, to mark them as info in subsequent runs

        Add --include-php-versions to also include a list of PHP extension versions

    --ignore-baseline
        Ignore the error baseline

    --update-baseline
        Update the baseline by removing fixed issues. This will not add new issues to the baseline

        Add --include-php-versions to also include a list of PHP extension versions

Plugins:
    --plugin=PATH
        Executes a plugin, an alternative to using the Psalm config

Output:
    -m, --monochrome
        Enable monochrome output

    --output-format=console
        Changes the output format. Available formats: compact, console, emacs, json, pylint, xml, checkstyle, sonarqube

    --no-progress
        Disable the progress indicator

    --long-progress
        Use a progress indicator suitable for Continuous Integration logs

    --stats
        Shows a breakdown of Psalm's ability to infer types in the codebase

Reports:
    --report=PATH
        The path where to output report file. The output format is based on the file extension.
        (Currently supported format: ".json", ".xml", ".txt", ".emacs")

    --report-show-info[=BOOLEAN]
        Whether the report should include non-errors in its output (defaults to true)

Caching:
    --clear-cache
        Clears all cache files that Psalm uses for this specific project

    --clear-global-cache
        Clears all cache files that Psalm uses for all projects

    --no-cache
        Runs Psalm without using cache

    --no-reflection-cache
        Runs Psalm without using cached representations of unchanged classes and files.
        Useful if you want the afterClassLikeVisit plugin hook to run every time you visit a file.

Miscellaneous:
    -h, --help
        Display this help message

    -v, --version
        Display the Psalm version

    -i, --init [source_dir=src] [level=3]
        Create a psalm config file in the current directory that points to [source_dir]
        at the required level, from 1, most strict, to 8, most permissive.

    --debug
        Debug information

    --debug-by-line
        Debug information on a line-by-line level

    -r, --root
        If running Psalm globally you'll need to specify a project root. Defaults to cwd

    --generate-json-map=PATH
        Generate a map of node references and types in JSON format, saved to the given path.

    --shepherd[=host]
        Send data to Shepherd, Psalm's GitHub integration tool.

    --alter
        Run Psalter

    --language-server
        Run Psalm Language Server
```