### PR TITLE
Add an exception handler that prints full exception trace

### DIFF
--- a/src/Psalm/Internal/exception_handler.php
+++ b/src/Psalm/Internal/exception_handler.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * If there is an uncaught exception,
+ * then print more of the backtrace than is done by default to stderr,
+ * then exit with a non-zero exit code to indicate failure.
+ */
+set_exception_handler(static function (Throwable $throwable) : void {
+    fwrite(STDERR, "Uncaught $throwable\n");
+    $version = defined('PSALM_VERSION') ? PSALM_VERSION : '(unknown version)';
+    fwrite(STDERR, "(Psalm $version crashed due to an uncaught Throwable)\n");
+    exit(1);
+});

--- a/src/psalm-language-server.php
+++ b/src/psalm-language-server.php
@@ -9,6 +9,8 @@ gc_disable();
 // show all errors
 error_reporting(-1);
 
+require_once __DIR__ . '/Psalm/Internal/exception_handler.php';
+
 $valid_short_options = [
     'h',
     'v',

--- a/src/psalm-refactor.php
+++ b/src/psalm-refactor.php
@@ -16,6 +16,8 @@ ini_set('memory_limit', '8192M');
 gc_collect_cycles();
 gc_disable();
 
+require_once __DIR__ . '/Psalm/Internal/exception_handler.php';
+
 $args = array_slice($argv, 1);
 
 $valid_short_options = ['f:', 'm', 'h', 'r:', 'c:'];

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -93,6 +93,8 @@ if (isset($options['refactor'])) {
     exit;
 }
 
+require_once __DIR__ . '/Psalm/Internal/exception_handler.php';
+
 array_map(
     /**
      * @param string $arg

--- a/src/psalter.php
+++ b/src/psalter.php
@@ -16,6 +16,8 @@ ini_set('memory_limit', '4096M');
 gc_collect_cycles();
 gc_disable();
 
+require_once __DIR__ . '/Psalm/Internal/exception_handler.php';
+
 $args = array_slice($argv, 1);
 
 $valid_short_options = ['f:', 'm', 'h', 'r:', 'c:'];


### PR DESCRIPTION
By default, php will only print the first few thousand bytes of the
exception, for an uncaught exception
(I think that's the default, and not just my configuration)

Instead, print all of the parts of the exception.
Also, print the psalm version, to make handling bug reports easier.

For #1083 (this PR does not cover set_error_handler)

Example output:

```
./psalm
Uncaught Exception: test in /path/to/psalm/src/psalm.php:283
Stack trace:
#0 /path/to/psalm/psalm(2): require_once()
#1 {main}
(Psalm 3.x-dev@99db774c99b53279984eeb8026d29c0c72dcafde crashed due to an uncaught Throwable)
```