### PR TITLE
fix return type of stream_bucket_new

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -13506,7 +13506,7 @@ return [
 'strcspn' => ['int', 'str'=>'string', 'mask'=>'string', 'start='=>'int', 'length='=>'int'],
 'stream_bucket_append' => ['void', 'brigade'=>'resource', 'bucket'=>'object'],
 'stream_bucket_make_writeable' => ['object', 'brigade'=>'resource'],
-'stream_bucket_new' => ['resource|false', 'stream'=>'resource', 'buffer'=>'string'],
+'stream_bucket_new' => ['object|false', 'stream'=>'resource', 'buffer'=>'string'],
 'stream_bucket_prepend' => ['void', 'brigade'=>'resource', 'bucket'=>'object'],
 'stream_context_create' => ['resource', 'options='=>'array', 'params='=>'array'],
 'stream_context_get_default' => ['resource', 'options='=>'array'],


### PR DESCRIPTION
the function returns `object` since 2003 in
php/php-src@c4a491e12cfb9dbd84d88d04f49e00c4ebf9e289 and
`stream_bucket_append()` is type hinted to take `object` too.

This fixes #2430