### PR TITLE
Drop non-existent param from docblock

### DIFF
--- a/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
@@ -12,8 +12,6 @@ interface FunctionExistenceProviderInterface
     public static function getFunctionIds() : array;
 
     /**
-     * @param  array<PhpParser\Node\Arg>    $call_args
-     *
      * @return ?bool
      */
     public static function doesFunctionExist(


### PR DESCRIPTION
I wonder why psalm didn't catch it.