### PR TITLE
Add ext-dom dependency to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "php": "^7.1.3",
+        "ext-dom": "*",
         "nikic/php-parser": "^4.3",
         "openlss/lib-array2xml": "^1.0",
         "ocramius/package-versions": "^1.2",


### PR DESCRIPTION
I have a fresh PHP 7.4 installation and with the first run of Psalm PHP yelled at me that `DOMDocument` was not found ;)

edit: if you need more formalism on the commit message or anything else, please let me know