### PR TITLE
Remove references to deleted scripts in psalm/phar composer.json

### DIFF
--- a/assets/psalm-phar/composer.json
+++ b/assets/psalm-phar/composer.json
@@ -8,5 +8,5 @@
 	"conflict": {
 		"vimeo/psalm" : "*"
 	},
-	"bin": ["psalm.phar", "psalm", "psalter", "psalm-language-server", "psalm-plugin"]
+	"bin": ["psalm.phar"]
 }


### PR DESCRIPTION
This should stop the error messages we are seeing on installing
psalm/phar:
    Skipped installation of bin psalm for package psalm/phar: file not
    found in package
    Skipped installation of bin psalter for package psalm/phar: file
    not found in package
    Skipped installation of bin psalm-language-server for
    package psalm/phar: file not found in package
    Skipped installation of bin psalm-plugin for package
    psalm/phar: file not found in package

They can be put back in future if/when
https://github.com/psalm/phar/issues/1 is fixed