### PR TITLE
amending travis config, 7.4snapshot > 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
   - 7.1.3
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
   - nightly
 
 env:


### PR DESCRIPTION
following on from #1948, we no longer need the "snapshot" suffix.