### PR TITLE
Added support for preg_grep

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
@@ -231,3 +231,15 @@ function array_merge_recursive(array $arr, array ...$arr2)
 function array_fill_keys(array $keys, $value): array
 {
 }
+
+/**
+ * @template TKey
+ *
+ * @param string $pattern
+ * @param array<TKey,string> $input
+ * @param 0|1 $flags 1=PREG_GREP_INVERT
+ * @return array<TKey,string>
+ */
+function preg_grep($pattern, array $input, $flags = 0)
+{
+}

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -14,6 +14,17 @@ class FunctionCallTest extends TestCase
     public function providerValidCodeParse()
     {
         return [
+            'preg_grep' => [
+                '<?php
+                  /**
+                   * @param array<int,string> $strings
+                   * @return array<int,string>
+                   */
+                  function filter(array $strings): array {
+                     return preg_grep("/search/", $strings, PREG_GREP_INVERT);
+                  }
+                '
+            ],
             'arrayFilter' => [
                 '<?php
                     $d = array_filter(["a" => 5, "b" => 12, "c" => null]);


### PR DESCRIPTION
`preg_grep` keeps array key type and only really works on strings as array values, which Psalm previously didn't know.