### PR TITLE
Add sample for optional keys in array shapes

### DIFF
--- a/docs/annotating_code/type_syntax/array_types.md
+++ b/docs/annotating_code/type_syntax/array_types.md
@@ -107,3 +107,9 @@ You can specify types in that format yourself, e.g.
 ```php
 /** @return array{foo: string, bar: int} */
 ```
+
+Optional keys can be denoted by a trailing `?`, e.g.:
+
+```php
+/** @return array{optional?: string, bar: int} */
+```


### PR DESCRIPTION
I found this lacking and only figured it by reading it somewhere else by accident.