### PR TITLE
Add support for more PDOStatement fetch modes

### DIFF
--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -428,10 +428,83 @@ class MethodCallTest extends TestCase
             ],
             'pdoStatementFetchAssoc' => [
                 '<?php
-                    $p = new \PDO("sqlite:::memory:");
-                    $sth = $p->prepare("SELECT 1");
-                    $sth->execute();
-                    while (($row = $sth->fetch(\PDO::FETCH_ASSOC)) !== false) {}'
+                    /** @return array<string,scalar> */
+                    function fetch_assoc() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_ASSOC);
+                    }'
+            ],
+            'pdoStatementFetchBoth' => [
+                '<?php
+                    /** @return array<scalar> */
+                    function fetch_both() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_BOTH);
+                    }'
+            ],
+            'pdoStatementFetchBound' => [
+                '<?php
+                    /** @return true */
+                    function fetch_both() : bool {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_BOUND);
+                    }'
+            ],
+            'pdoStatementFetchClass' => [
+                '<?php
+                    /** @return object */
+                    function fetch_class() : object {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_CLASS);
+                    }'
+            ],
+            'pdoStatementFetchLazy' => [
+                '<?php
+                    /** @return object */
+                    function fetch_lazy() : object {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_LAZY);
+                    }'
+            ],
+            'pdoStatementFetchNamed' => [
+                '<?php
+                    /** @return array<string,scalar|list<scalar>> */
+                    function fetch_named() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_NAMED);
+                    }'
+            ],
+            'pdoStatementFetchNum' => [
+                '<?php
+                    /** @return list<scalar> */
+                    function fetch_named() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_NUM);
+                    }'
+            ],
+            'pdoStatementFetchObj' => [
+                '<?php
+                    /** @return stdClass */
+                    function fetch_named() : object {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_OBJ);
+                    }'
             ],
         ];
     }


### PR DESCRIPTION
The `PDO::FETCH_CLASSTYPE` and `PDO::FETCH_PROPS_LATE` flags aren't supported yet, as implementing them would require some way to read the value of an expression like `PDO::FETCH_CLASS | PDO::FETCH_CLASSTYPE` as the argument to `PDOStatement::fetch()`. This seems like something that might be useful down the road, but I'm hesitant to implement it just for this feature. :)

There are a few other really obscure fetch modes which aren't supported either, like `PDO::FETCH_FUNC` and `PDO::FETCH_SERIALIZE`. They're barely even documented and I'm not sure they even make sense to use outside of `fetchAll()`, so... whatever.

(in re. #2529)