### PR TITLE
GithubActions: update actions/checkout to v2

### DIFF
--- a/.github/workflows/shepherd.yml
+++ b/.github/workflows/shepherd.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Install dependencies
       run: export COMPOSER_ROOT_VERSION=dev-master && composer install --prefer-dist --no-progress --no-suggest


### PR DESCRIPTION
See https://github.com/actions/checkout/releases/tag/v2.0.0