### PR TITLE
Improve array function types

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -729,10 +729,8 @@ class CallAnalyzer
         );
 
         $builtin_array_functions = [
-            'shuffle', 'sort', 'rsort', 'usort', 'ksort', 'asort',
-            'uasort',
-            'krsort', 'arsort', 'natcasesort', 'natsort', 'reset',
-            'end', 'next', 'prev', 'array_pop', 'array_shift',
+            'ksort', 'asort', 'krsort', 'arsort', 'natcasesort', 'natsort',
+            'reset', 'end', 'next', 'prev', 'array_pop', 'array_shift',
         ];
 
         if (($var_id && isset($context->vars_in_scope[$var_id]))
@@ -791,12 +789,7 @@ class CallAnalyzer
                     $array_type = new TArray([Type::getInt(), $array_type->type_param]);
                 }
 
-                if (in_array($method_id, ['shuffle', 'sort', 'rsort', 'usort'], true)) {
-                    $tvalue = $array_type->type_params[1];
-                    $by_ref_type = new Type\Union([new TArray([Type::getInt(), clone $tvalue])]);
-                } else {
-                    $by_ref_type = new Type\Union([clone $array_type]);
-                }
+                $by_ref_type = new Type\Union([clone $array_type]);
 
                 ExpressionAnalyzer::assignByRefParam(
                     $statements_analyzer,
@@ -1630,9 +1623,8 @@ class CallAnalyzer
         if (!in_array(
             $method_id,
             [
-                'shuffle', 'sort', 'rsort', 'usort', 'ksort', 'asort',
-                'krsort', 'arsort', 'natcasesort', 'natsort', 'reset',
-                'end', 'next', 'prev', 'array_pop', 'array_shift',
+                'ksort', 'asort', 'krsort', 'arsort', 'natcasesort', 'natsort',
+                'reset', 'end', 'next', 'prev', 'array_pop', 'array_shift',
                 'array_push', 'array_unshift', 'socket_select', 'array_splice',
             ],
             true

--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
@@ -155,35 +155,67 @@ function array_search($needle, array $haystack, bool $strict = false)
 }
 
 /**
- * @template T
+ * @psalm-template T
  *
- * @param array<mixed,T> $arr
+ * @param T[] $arr
  * @param-out list<T> $arr
  */
-function sort(array &$arr, int $sort_flags = \SORT_REGULAR): bool
+function shuffle(array &$arr): bool
 {
 }
 
 /**
- * @template T
+ * @psalm-template T
  *
- * @param array<mixed,T> $arr
+ * @param T[] $arr
+ * @param-out list<T> $arr
+ */
+function sort(array &$arr, int $sort_flags = SORT_REGULAR): bool
+{
+}
+
+/**
+ * @psalm-template T
+ *
+ * @param T[] $arr
+ * @param-out list<T> $arr
+ */
+function rsort(array &$arr, int $sort_flags = SORT_REGULAR): bool
+{
+}
+
+/**
+ * @psalm-template T
+ *
+ * @param T[] $arr
  * @param callable(T,T):int $callback
- * @param-out array<int,T> $arr
+ * @param-out list<T> $arr
  */
 function usort(array &$arr, callable $callback): bool
 {
 }
 
 /**
- * @template TKey
- * @template T
+ * @psalm-template TKey
+ * @psalm-template T
  *
  * @param array<TKey,T> $arr
  * @param callable(T,T):int $callback
  * @param-out array<TKey,T> $arr
  */
 function uasort(array &$arr, callable $callback): bool
+{
+}
+
+/**
+ * @psalm-template TKey
+ * @psalm-template T
+ *
+ * @param array<TKey,T> $arr
+ * @param callable(TKey,TKey):int $callback
+ * @param-out array<TKey,T> $arr
+ */
+function uksort(array &$arr, callable $callback): bool
 {
 }
 
@@ -241,7 +273,7 @@ function array_fill_keys(array $keys, $value): array
 }
 
 /**
- * @template TKey
+ * @psalm-template TKey
  *
  * @param string $pattern
  * @param array<TKey,string> $input

--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.php
@@ -47,6 +47,19 @@ function array_intersect_key(array $arr, array $arr2, array ...$arr3)
  * @psalm-template TKey as array-key
  * @psalm-template TValue
  *
+ * @param array<TKey, TValue> $arr
+ *
+ * @return array<TKey, TValue>
+ * @psalm-pure
+ */
+function array_intersect_assoc(array $arr, array $arr2, array ...$arr3)
+{
+}
+
+/**
+ * @psalm-template TKey as array-key
+ * @psalm-template TValue
+ *
  * @param array<mixed, TKey> $arr
  * @param array<mixed, TValue> $arr2
  *
@@ -85,6 +98,21 @@ function array_diff(array $arr, array $arr2, array ...$arr3)
  * @psalm-pure
  */
 function array_diff_key(array $arr, array $arr2, array ...$arr3)
+{
+}
+
+/**
+ * @psalm-template TKey as array-key
+ * @psalm-template TValue
+ *
+ * @param array<TKey, TValue> $arr
+ * @param array $arr2
+ * @param array ...$arr3
+ *
+ * @return array<TKey, TValue>
+ * @psalm-pure
+ */
+function array_diff_assoc(array $arr, array $arr2, array ...$arr3)
 {
 }
 

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -26,7 +26,7 @@ class ArgTest extends TestCase
                 ',
                 'assertions' => [
                     '$a' => 'array{a: int, b: int}',
-                    '$b' => 'array<int, int>',
+                    '$b' => 'list<int>',
                 ],
             ],
             'arrayModificationFunctions' => [

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -2091,7 +2091,7 @@ class FunctionCallTest extends TestCase
             'versionCompareAsCallable' => [
                 '<?php
                     $a = ["1.0", "2.0"];
-                    uksort($a, "version_compare");',
+                    usort($a, "version_compare");',
             ],
             'coerceToObjectAfterBeingCalled' => [
                 '<?php

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -307,6 +307,18 @@ class FunctionCallTest extends TestCase
                     array_diff_key([], [], [], [], []);',
                 'assertions' => [],
             ],
+            'arrayDiffAssoc' => [
+                '<?php
+                    /**
+                     * @var array<string, int> $a
+                     * @var array $b
+                     * @var array $c
+                     */
+                    $r = array_diff_assoc($a, $b, $c);',
+                'assertions' => [
+                    '$r' => 'array<string, int>',
+                ],
+            ],
             'arrayPopMixed' => [
                 '<?php
                     /** @var mixed */
@@ -1321,6 +1333,18 @@ class FunctionCallTest extends TestCase
                         $r = array_intersect_key((new C)->unknownInstance(), array_filter($s));
                         if (empty($r)) {}
                     }',
+            ],
+            'arrayIntersectAssoc' => [
+                '<?php
+                    /**
+                     * @var array<string, int> $a
+                     * @var array $b
+                     * @var array $c
+                     */
+                    $r = array_intersect_assoc($a, $b, $c);',
+                'assertions' => [
+                    '$r' => 'array<string, int>',
+                ],
             ],
             'arrayReduce' => [
                 '<?php

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -572,6 +572,19 @@ class FunctionCallTest extends TestCase
                     '$manifest' => 'array<string, int>'
                 ],
             ],
+            'uksort' => [
+                '<?php
+                    $array = ["b" => 1, "a" => 2];
+                    uksort(
+                        $array,
+                        function (string $a, string $b) {
+                            return $a <=> $b;
+                        }
+                    );',
+                'assertions' => [
+                    '$array' => 'array<string, int>',
+                ],
+            ],
             'byRefAfterCallable' => [
                 '<?php
                     /**
@@ -2351,6 +2364,38 @@ class FunctionCallTest extends TestCase
                     $result = array_fill_keys($keys, true);',
                 'assertions' => [
                     '$result' => 'array<int, true>',
+                ],
+            ],
+            'shuffle' => [
+                '<?php
+                    $array = ["foo" => 123, "bar" => 456];
+                    shuffle($array);',
+                'assertions' => [
+                    '$array' => 'list<int>',
+                ],
+            ],
+            'sort' => [
+                '<?php
+                    $array = ["foo" => 123, "bar" => 456];
+                    sort($array);',
+                'assertions' => [
+                    '$array' => 'list<int>',
+                ],
+            ],
+            'rsort' => [
+                '<?php
+                    $array = ["foo" => 123, "bar" => 456];
+                    sort($array);',
+                'assertions' => [
+                    '$array' => 'list<int>',
+                ],
+            ],
+            'usort' => [
+                '<?php
+                    $array = ["foo" => 123, "bar" => 456];
+                    usort($array, function (int $a, int $b) { return $a <=> $b; });',
+                'assertions' => [
+                    '$array' => 'list<int>',
                 ],
             ],
         ];


### PR DESCRIPTION
This PR aims to improve type definitions for the following functions using generics:

- `shuffle()`
- `sort()`
- `rsort()`
- `usort()`
- `uksort()`
- `array_diff_assoc()`
- `array_intersect_assoc()`

I've skipped `ksort()` and similar key-preserving sorting functions that are hardcoded in `CallAnalyzer`, because the `ksortPreserveShape` test would fail. I'm not sure if that is something that can be dropped, but `uksort()` didn't and doesn't have this special handling.

`array_uintersect_assoc()`, `array_intersect_ukey()`, `array_udiff_assoc()`, `array_diff_ukey()` have dynamic signatures with varargs in the middle that I didn't feel like dealing with right now 😃