### PR TITLE
Support suppressing all issues with @psalm-suppress all

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -91,6 +91,8 @@ function addString(?string $s) {
 }
 ```
 
+`@psalm-suppress all` can be used to suppress all issues instead of listing them individually.
+
 ### `@psalm-assert`, `@psalm-assert-if-true` and `@psalm-assert-if-false`
 
 See [Adding assertions](adding_assertions.md).

--- a/docs/running_psalm/dealing_with_code_issues.md
+++ b/docs/running_psalm/dealing_with_code_issues.md
@@ -75,6 +75,8 @@ function (int $a) : string {
 }
 ```
 
+If you wish to suppress all issues, you can use `@psalm-suppress all` instead of multiple annotations.
+
 ## Using a baseline file
 
 If you have a bunch of errors and you don't want to fix them all at once, Psalm can now grandfather-in errors in existing code, while ensuring that new code doesn't have those same sorts of errors.

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -145,6 +145,16 @@ class IssueBuffer
             }
         }
 
+        $suppress_all_position = array_search('all', $suppressed_issues);
+
+        if ($suppress_all_position !== false) {
+            if (\is_int($suppress_all_position)) {
+                self::$used_suppressions[$file_path][$suppress_all_position] = true;
+            }
+
+            return true;
+        }
+
         $reporting_level = $config->getReportingLevelForIssue($e);
 
         if ($reporting_level === Config::REPORT_SUPPRESS) {

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -58,6 +58,44 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
+    public function testUnusedSuppressAllOnFunction()
+    {
+        $this->expectException(\Psalm\Exception\CodeException::class);
+        $this->expectExceptionMessage('UnusedPsalmSuppress');
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                /** @psalm-suppress all */
+                function foo(): string {
+                    return "foo";
+                }'
+        );
+
+        $this->analyzeFile('somefile.php', new \Psalm\Context());
+    }
+
+    /**
+     * @return void
+     */
+    public function testUnusedSuppressAllOnStatement()
+    {
+        $this->expectException(\Psalm\Exception\CodeException::class);
+        $this->expectExceptionMessage('UnusedPsalmSuppress');
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                /** @psalm-suppress all */
+                print("foo");'
+        );
+
+        $this->analyzeFile('somefile.php', new \Psalm\Context());
+    }
+
+    /**
+     * @return void
+     */
     public function testMissingThrowsDocblockSuppressed()
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -240,6 +278,19 @@ class IssueSuppressionTest extends TestCase
                         unknown_function_call();
 
                         return new DateTime();
+                    }',
+            ],
+            'suppressAllStatementIssues' => [
+                '<?php
+                    /** @psalm-suppress all */
+                    strlen(123, 456, 789);',
+            ],
+            'suppressAllFunctionIssues' => [
+                '<?php
+                    /** @psalm-suppress all */
+                    function foo($a)
+                    {
+                        strlen(123, 456, 789);
                     }',
             ],
         ];


### PR DESCRIPTION
This PR implements `@psalm-suppress all`, which suppresses all issues on a statement or a function. Works with `--find-unused-psalm-suppress` too.

Main use case is for code that isn't supported by Psalm (e.g. closures with variables inherited by reference or other `wontfix` stuff). Such code can generate a lot of false-positive issues, especially with `totallyTyped=true`.

There are existing alternatives, but I didn't find them as "clean" to use:

- `<ignoreFiles>` in config can only ignore entire files, not single functions or lines, one would have to move code to separate files only because of Psalm and that might not be feasible
- `@psalm-suppress` for every single issue, perhaps combined with some `@var` annotations or `assert()`s - this can get ugly quick

I considered other syntaxes, but found `@psalm-suppress all` to be most readable:

- `@psalm-suppress *` looks weird in single-line doc-comments
- `@psalm-suppress` without an argument, it isn't obvious what this does and could be used unintentionally when someone forgets the argument

What do you think?