### PR TITLE
removing trailing comma in function call, 

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -84,7 +84,7 @@ class ArrayFilterReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturn
             ) {
                 return new Type\Union([
                     new Type\Atomic\TList(
-                        $inner_type,
+                        $inner_type
                     ),
                 ]);
             }


### PR DESCRIPTION
not detectable by php-cs-fixer re: FriendsOfPHP/PHP-CS-Fixer#4135