### PR TITLE
Fix: Set environment variable via env section

### DIFF
--- a/.github/workflows/shepherd.yml
+++ b/.github/workflows/shepherd.yml
@@ -10,7 +10,9 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install dependencies
-      run: export COMPOSER_ROOT_VERSION=dev-master && composer install --prefer-dist --no-progress --no-suggest
-      
+      run: composer install --prefer-dist --no-progress --no-suggest
+      env:
+        COMPOSER_ROOT_VERSION: dev-master
+
     - name: Run Psalm
       run: ./psalm --threads=2 --shepherd


### PR DESCRIPTION
This PR

* [x] sets the `COMPOSER_ROOT_VERSION` environment variable via `env` section

💁‍♂ For reference, see https://help.github.com/en/actions/automating-your-workflow-with-github-actions/using-environment-variables#about-environment-variables.