### PR TITLE
Enhancement: Keep packages sorted in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,23 +12,23 @@
     "require": {
         "php": "^7.1.3",
         "ext-dom": "*",
-        "ext-SimpleXML": "*",
         "ext-json": "*",
         "ext-libxml": "*",
+        "ext-SimpleXML": "*",
         "ext-tokenizer": "*",
-        "nikic/php-parser": "^4.3",
-        "openlss/lib-array2xml": "^1.0",
-        "ocramius/package-versions": "^1.2",
-        "composer/xdebug-handler": "^1.1",
-        "felixfbecker/language-server-protocol": "^1.4",
-        "felixfbecker/advanced-json-rpc": "^3.0.3",
-        "netresearch/jsonmapper": "^1.0",
-        "webmozart/glob": "^4.1",
-        "webmozart/path-util": "^2.3",
-        "symfony/console": "^3.3||^4.0||^5.0",
         "amphp/amp": "^2.1",
         "amphp/byte-stream": "^1.5",
-        "sebastian/diff": "^3.0"
+        "composer/xdebug-handler": "^1.1",
+        "felixfbecker/advanced-json-rpc": "^3.0.3",
+        "felixfbecker/language-server-protocol": "^1.4",
+        "netresearch/jsonmapper": "^1.0",
+        "nikic/php-parser": "^4.3",
+        "ocramius/package-versions": "^1.2",
+        "openlss/lib-array2xml": "^1.0",
+        "sebastian/diff": "^3.0",
+        "symfony/console": "^3.3||^4.0||^5.0",
+        "webmozart/glob": "^4.1",
+        "webmozart/path-util": "^2.3"
     },
     "bin": ["psalm", "psalter", "psalm-language-server", "psalm-plugin", "psalm-refactor"],
     "autoload": {
@@ -47,21 +47,22 @@
         }
     },
     "config": {
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "sort-packages": true
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
-        "phpunit/phpunit": "^7.5 || ^8.0",
-        "phpspec/prophecy": ">=1.9.0",
-        "squizlabs/php_codesniffer": "^3.5",
+        "ext-curl": "*",
         "bamarni/composer-bin-plugin": "^1.2",
-        "psalm/plugin-phpunit": "^0.6",
-        "phpmyadmin/sql-parser": "^5.0",
-        "symfony/process": "^4.3",
-        "slevomat/coding-standard": "^5.0",
         "friendsofphp/php-cs-fixer": "^2.15",
-        "ext-curl": "*"
+        "phpmyadmin/sql-parser": "^5.0",
+        "phpspec/prophecy": ">=1.9.0",
+        "phpunit/phpunit": "^7.5 || ^8.0",
+        "psalm/plugin-phpunit": "^0.6",
+        "slevomat/coding-standard": "^5.0",
+        "squizlabs/php_codesniffer": "^3.5",
+        "symfony/process": "^4.3"
     },
     "suggest": {
         "ext-igbinary": "^2.0.5"


### PR DESCRIPTION
This PR

* [x] keeps packages sorted in `composer.json`

Slightly related to #2599.

💁‍♂ For reference, see https://getcomposer.org/doc/06-config.md#sort-packages.