### PR TITLE
Fix required parameter after optional in Psalm

### DIFF
--- a/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
@@ -293,13 +293,13 @@ class TypeAnalyzer
     /**
      * Used for comparing signature typehints, uses PHP's light contravariance rules
      *
-     * @param  Type\Union   $input_type
+     * @param  ?Type\Union  $input_type
      * @param  Type\Union   $container_type
      *
      * @return bool
      */
     public static function isContainedByInPhp(
-        Type\Union $input_type = null,
+        ?Type\Union $input_type,
         Type\Union $container_type
     ) {
         if (!$input_type) {


### PR DESCRIPTION
Psalm supports php 7.1 at minimum, so this is no longer necessary.

Other reason: Future php versions may end up deprecating this, even for null.