### PR TITLE
callmap changes

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -11046,7 +11046,7 @@ return [
 'ReflectionClassConstant::getDocComment' => ['string|false'],
 'ReflectionClassConstant::getModifiers' => ['int'],
 'ReflectionClassConstant::getName' => ['string'],
-'ReflectionClassConstant::getValue' => ['mixed'],
+'ReflectionClassConstant::getValue' => ['scalar|array<scalar>|null'],
 'ReflectionClassConstant::isPrivate' => ['bool'],
 'ReflectionClassConstant::isProtected' => ['bool'],
 'ReflectionClassConstant::isPublic' => ['bool'],

--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -11735,7 +11735,7 @@ return [
 'SessionUpdateTimestampHandler::validateId' => ['char', 'id'=>'string'],
 'SessionUpdateTimestampHandlerInterface::updateTimestamp' => ['bool', 'key'=>'string', 'val'=>'string'],
 'SessionUpdateTimestampHandlerInterface::validateId' => ['bool', 'key'=>'string'],
-'set_error_handler' => ['?callable', 'error_handler'=>'null|callable(int,string,string=,int=,array=):bool', 'error_types='=>'int'],
+'set_error_handler' => ['null|callable(int,string,string=,int=,array=):bool', 'error_handler'=>'null|callable(int,string,string=,int=,array=):bool', 'error_types='=>'int'],
 'set_exception_handler' => ['null|callable(Throwable):void', 'exception_handler'=>'null|callable(Throwable):void'],
 'set_file_buffer' => ['int', 'fp'=>'resource', 'buffer'=>'int'],
 'set_include_path' => ['string|false', 'new_include_path'=>'string'],

--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -1190,7 +1190,7 @@ return [
 'connection_aborted' => ['int'],
 'connection_status' => ['int'],
 'connection_timeout' => ['int'],
-'constant' => ['mixed', 'const_name'=>'string'],
+'constant' => ['scalar|array<scalar>|null', 'const_name'=>'string'],
 'convert_cyr_string' => ['string', 'str'=>'string', 'from'=>'string', 'to'=>'string'],
 'convert_uudecode' => ['string', 'data'=>'string'],
 'convert_uuencode' => ['string', 'data'=>'string'],


### PR DESCRIPTION
Sorry, I made a mistake and committed two changes where I wanted to create two PR...

1)
set_error_handler returns the previous callback that was set (or null if there wasn't any). Which means the returned type is the same as the parameter

It's used a lot by library to temporary replace the handler

$oldHandler = set_error_handler($callableDoNothing);
//do stuff
set_error_handler($oldHandler);

And with the old "?callable" type, Psalm warns that "null|callable(int,string,string=,int=,array=):bool" is more specific

2)
ReflectionClassConstant::getValue will return the value of a constant. A constant can only be a scalar, an array of scalar or null. Same for constant() function