### PR TITLE
int-return form of version_compare takes only two arguments

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -15163,7 +15163,7 @@ return [
 'VarnishStat::__construct' => ['void', 'args='=>'array'],
 'VarnishStat::getSnapshot' => ['array'],
 'version_compare' => ['bool', 'ver1'=>'string', 'ver2'=>'string', 'oper'=>'\'\x3c\'|\'lt\'|\'\x3c=\'|\'le\'|\'\x3e\'|\'gt\'|\'\x3e=\'|\'ge\'|\'==\'|\'=\'|\'eq\'|\'!=\'|\'\x3c\x3e\'|\'ne\''],
-'version_compare\'1' => ['int', 'ver1'=>'string', 'ver2'=>'string', 'oper='=>''],
+'version_compare\'1' => ['int', 'ver1'=>'string', 'ver2'=>'string'],
 'vfprintf' => ['int', 'stream'=>'resource', 'format'=>'string', 'args'=>'array'],
 'virtual' => ['bool', 'uri'=>'string'],
 'vpopmail_add_alias_domain' => ['bool', 'domain'=>'string', 'aliasdomain'=>'string'],

--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -15162,7 +15162,7 @@ return [
 'VarnishLog::getTagName' => ['string', 'index'=>'int'],
 'VarnishStat::__construct' => ['void', 'args='=>'array'],
 'VarnishStat::getSnapshot' => ['array'],
-'version_compare' => ['bool', 'ver1'=>'string', 'ver2'=>'string', 'oper'=>'\'\x3c\'|\'lt\'|\'\x3c=\'|\'le\'|\'\x3e\'|\'gt\'|\'\x3e=\'|\'ge\'|\'==\'|\'=\'|\'eq\'|\'!=\'|\'\x3c\x3e\'|\'ne\''],
+'version_compare' => ['bool', 'ver1'=>'string', 'ver2'=>'string', 'oper'=>'\'<\'|\'lt\'|\'<=\'|\'le\'|\'>\'|\'gt\'|\'>=\'|\'ge\'|\'==\'|\'=\'|\'eq\'|\'!=\'|\'<>\'|\'ne\''],
 'version_compare\'1' => ['int', 'ver1'=>'string', 'ver2'=>'string'],
 'vfprintf' => ['int', 'stream'=>'resource', 'format'=>'string', 'args'=>'array'],
 'virtual' => ['bool', 'uri'=>'string'],

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1413,6 +1413,7 @@ class FunctionCallTest extends TestCase
                     '$b' => 'bool',
                     '$c' => 'bool|null',
                 ],
+                'error_levels' => ['PossiblyInvalidArgument'],
             ],
             'getTimeOfDay' => [
                 '<?php

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1399,6 +1399,7 @@ class FunctionCallTest extends TestCase
             ],
             'versionCompare' => [
                 '<?php
+                    /** @return "==="|"==" */
                     function getString() : string {
                         return rand(0, 1) ? "===" : "==";
                     }


### PR DESCRIPTION
re: #1576 