### PR TITLE
Use floor() instead of round() for long progress percentage

### DIFF
--- a/src/Psalm/Progress/LongProgress.php
+++ b/src/Psalm/Progress/LongProgress.php
@@ -2,7 +2,7 @@
 namespace Psalm\Progress;
 
 use const PHP_EOL;
-use function round;
+use function floor;
 use function sprintf;
 use function str_repeat;
 use function strlen;
@@ -87,7 +87,8 @@ class LongProgress extends Progress
         }
 
         $leadingSpaces = 1 + strlen((string) $this->number_of_tasks) - strlen((string) $this->progress);
-        $percentage = round($this->progress / $this->number_of_tasks * 100);
+        // Don't show 100% unless this is the last line of the progress bar.
+        $percentage = floor($this->progress / $this->number_of_tasks * 100);
 
         return sprintf(
             '%s%s / %s (%s%%)',


### PR DESCRIPTION
PHPUnit and many other applications use floor.
Otherwise, the second-last lines would show 100% despite not being
complete.

```
\sprintf(
    ' %' . $this->numTestsWidth . 'd / %' .
    $this->numTestsWidth . 'd (%3s%%)',
    $this->numTestsRun,
    $this->numTests,
    \floor(($this->numTestsRun / $this->numTests) * 100)
)
```