### PR TITLE
Modular config files

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -11,6 +11,29 @@ Psalm uses an XML config file (by default, `psalm.xml`). A barebones example loo
 </psalm>
 ```
 
+Configuration file may be split into several files using [XInclude](https://www.w3.org/TR/xinclude/) tags (c.f. previous example):
+#### psalm.xml
+```xml
+<?xml version="1.0"?>
+<psalm
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+>
+    <xi:include href="files.xml"/>
+</psalm>
+```
+#### files.xml
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<projectFiles xmlns="https://getpsalm.org/schema/config">
+    <file name="Bar.php" />
+    <file name="Bat.php" />
+</projectFiles>
+```
+
+
 ## Optional `<psalm />` attributes
 
 ### Coding style

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -1195,6 +1195,20 @@ class ConfigTest extends \Psalm\Tests\TestCase
         }
     }
 
+    /** @return void */
+    public function testModularConfig()
+    {
+        $root = __DIR__ . '/../fixtures/ModularConfig';
+        $config = Config::loadFromXMLFile($root . '/psalm.xml', $root);
+        $this->assertEquals(
+            [
+                realpath($root . '/Bar.php'),
+                realpath($root . '/Bat.php')
+            ],
+            $config->getProjectFiles()
+        );
+    }
+
     public function tearDown(): void
     {
         parent::tearDown();

--- a/tests/fixtures/ModularConfig/Bar.php
+++ b/tests/fixtures/ModularConfig/Bar.php
@@ -1,0 +1,23 @@
+<?php
+namespace Vimeo\Test\DummyProject;
+
+class Bar
+{
+    use SomeTrait;
+
+    /** @var string */
+    public $x;
+
+    public function __construct()
+    {
+        $this->x = 'hello';
+    }
+}
+
+/**
+ * @return void
+ */
+function someFunction()
+{
+    echo 'here';
+}

--- a/tests/fixtures/ModularConfig/Bat.php
+++ b/tests/fixtures/ModularConfig/Bat.php
@@ -1,0 +1,13 @@
+<?php
+namespace Vimeo\Test\DummyProject;
+
+class Bat
+{
+    public function __construct()
+    {
+        $a = new Bar();
+
+        someFunction();
+        someOtherFunction();
+    }
+}

--- a/tests/fixtures/ModularConfig/SomeTrait.php
+++ b/tests/fixtures/ModularConfig/SomeTrait.php
@@ -1,0 +1,14 @@
+<?php
+namespace Vimeo\Test\DummyProject;
+
+trait SomeTrait
+{
+}
+
+/**
+ * @return void
+ */
+function someOtherFunction()
+{
+    echo 'here';
+}

--- a/tests/fixtures/ModularConfig/files.xml
+++ b/tests/fixtures/ModularConfig/files.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectFiles xmlns="https://getpsalm.org/schema/config">
+    <file name="Bar.php" />
+    <file name="Bat.php" />
+</projectFiles>

--- a/tests/fixtures/ModularConfig/psalm.xml
+++ b/tests/fixtures/ModularConfig/psalm.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="true"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    xmlns:xi="http://www.w3.org/2001/XInclude"
+>
+    <xi:include href="files.xml"/>
+</psalm>


### PR DESCRIPTION
This change introduces an option to have the configuration split across several files using standard XInclude tags. This may be useful for more complex configs, or to include auto-generated parts into a manually written config file.