### PR TITLE
Allow NULL $contextnode in DOMXPath::query() (again)

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -2197,7 +2197,7 @@ return [
 'domxml_xslt_version' => ['int'],
 'DOMXPath::__construct' => ['void', 'doc'=>'DOMDocument'],
 'DOMXPath::evaluate' => ['mixed', 'expression'=>'string', 'contextnode='=>'DOMNode|null', 'registernodens='=>'bool'],
-'DOMXPath::query' => ['DOMNodeList|false', 'expression'=>'string', 'contextnode='=>'DOMNode', 'registernodens='=>'bool'],
+'DOMXPath::query' => ['DOMNodeList|false', 'expression'=>'string', 'contextnode='=>'DOMNode|null', 'registernodens='=>'bool'],
 'DOMXPath::registerNamespace' => ['bool', 'prefix'=>'string', 'namespaceuri'=>'string'],
 'DOMXPath::registerPhpFunctions' => ['void', 'restrict='=>'mixed'],
 'DomXsltStylesheet::process' => ['DomDocument', 'xml_doc'=>'DOMDocument', 'xslt_params='=>'array', 'is_xpath_param='=>'bool', 'profile_filename='=>'string'],


### PR DESCRIPTION
Originally fixed in #1965, but recently broken by b7fa15f89d6a66db2892df5a878a06115e69ccb5.
