### PR TITLE
check if phpstorm meta path is a file or directory

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1560,8 +1560,10 @@ class Config
 
         $phpstorm_meta_path = $this->base_dir . DIRECTORY_SEPARATOR . '.phpstorm.meta.php';
 
-        if (file_exists($phpstorm_meta_path)) {
+        if (is_file($phpstorm_meta_path)) {
             $stub_files[] = $phpstorm_meta_path;
+        } elseif (is_dir($phpstorm_meta_path)) {
+            $progress->debug('phpstorm meta path not included in stub files list as it is a directory' . "\n");
         }
 
         if ($this->load_xdebug_stub) {

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -21,6 +21,7 @@ use function get_defined_functions;
 use function in_array;
 use function intval;
 use function is_dir;
+use function is_file;
 use function json_decode;
 use function libxml_clear_errors;
 use const LIBXML_ERR_ERROR;

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -18,6 +18,7 @@ use function filetype;
 use function get_class;
 use function get_defined_constants;
 use function get_defined_functions;
+use function glob;
 use function in_array;
 use function intval;
 use function is_dir;
@@ -1564,7 +1565,13 @@ class Config
         if (is_file($phpstorm_meta_path)) {
             $stub_files[] = $phpstorm_meta_path;
         } elseif (is_dir($phpstorm_meta_path)) {
-            $progress->debug('phpstorm meta path not included in stub files list as it is a directory' . "\n");
+            $phpstorm_meta_path = realpath($phpstorm_meta_path);
+
+            foreach (glob($phpstorm_meta_path . '/*.meta.php') as $glob) {
+                if (is_file($glob) && realpath(dirname($glob)) === $phpstorm_meta_path) {
+                    $stub_files[] = $glob;
+                }
+            }
         }
 
         if ($this->load_xdebug_stub) {


### PR DESCRIPTION
* swaps `file_exists()` for `is_file()`
* adds a debug note in case someone wonders why their phpstorm meta path isn't being handled

leaving this in draft for now, as I'm wondering if it's worth dropping a `.gitkeep` file in an appropriately named folder for coverage purposes?