### PR TITLE
Allow Psalm to be installed on PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3",
+        "php": "^7.1.3|^8",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",


### PR DESCRIPTION
PHP 8 won't be released until later this year, but it'd be nice to be able to install Psalm without Composer complaining loudly.