### PR TITLE
Fix typo in PropertyMap

### DIFF
--- a/src/Psalm/Internal/PropertyMap.php
+++ b/src/Psalm/Internal/PropertyMap.php
@@ -407,7 +407,7 @@ return [
     'phpparser\\node\\expr\\array_' => [
         'items' => 'array<int, PhpParser\Node\Expr\ArrayItem|null>',
     ],
-    'phpparser\node\expr\list_' => [
+    'phpparser\\node\\expr\\list_' => [
         'items' => 'array<int, PhpParser\Node\Expr\ArrayItem|null>',
     ],
     'phpparser\\node\\expr\\methodcall' => [


### PR DESCRIPTION
Every other line has two \\ for separator. I figured this must be a typo