### PR TITLE
mark additional impure functions

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -290,7 +290,7 @@ class Functions
             'chdir', 'chgrp', 'chmod', 'chown', 'chroot', 'closedir', 'copy', 'file_put_contents',
             'fopen', 'fread', 'fwrite', 'fclose', 'touch', 'fpassthru', 'fputs', 'fscanf', 'fseek',
             'ftruncate', 'fprintf', 'symlink', 'mkdir', 'unlink', 'rename', 'rmdir', 'popen', 'pclose',
-            'fputcsv', 'umask', 'finfo_close', 'readline_add_history', 'stream_set_timeout',
+            'fputcsv', 'umask', 'finfo_close', 'readline_add_history', 'stream_set_timeout', 'fflush',
 
             // stream/socket io
             'stream_context_set_option', 'socket_write', 'stream_set_blocking', 'socket_close',
@@ -304,7 +304,7 @@ class Functions
 
             // output buffer
             'ob_start', 'ob_end_clean', 'readfile', 'printf', 'var_dump', 'phpinfo',
-            'ob_implicit_flush',
+            'ob_implicit_flush', 'vprintf',
 
             // mcrypt
             'mcrypt_generic_init', 'mcrypt_generic_deinit', 'mcrypt_module_close',


### PR DESCRIPTION
both `fflush` and `vprintf` have very similar cousins already declared as having side-effects.

This fixes #2687