### PR TITLE
Remove non-existent $serverctrls parameter for \ldap_bind()

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -6659,7 +6659,7 @@ return [
 'ldap_8859_to_t61' => ['string', 'value'=>'string'],
 'ldap_add' => ['bool', 'link_identifier'=>'resource', 'dn'=>'string', 'entry'=>'array', 'serverctrls='=>'array'],
 'ldap_add_ext' => ['resource|false', 'link_identifier'=>'resource', 'dn'=>'string', 'entry'=>'array', 'serverctrls='=>'array'],
-'ldap_bind' => ['bool', 'link_identifier'=>'resource', 'bind_rdn='=>'string|null', 'bind_password='=>'string|null', 'serverctrls=' => 'array'],
+'ldap_bind' => ['bool', 'link_identifier'=>'resource', 'bind_rdn='=>'string|null', 'bind_password='=>'string|null'],
 'ldap_bind_ext' => ['resource|false', 'link_identifier'=>'resource', 'bind_rdn='=>'string|null', 'bind_password='=>'string|null', 'serverctrls' => 'array'],
 'ldap_close' => ['bool', 'link_identifier'=>'resource'],
 'ldap_compare' => ['bool|int', 'link_identifier'=>'resource', 'dn'=>'string', 'attr'=>'string', 'value'=>'string'],


### PR DESCRIPTION
In a8e58b0ba0242819ce201870ac56e05f7604e6ef a `$serverctrls` parameter
was incorrectly added to the \ldap_bind() function.

See php/doc-en#20.