### PR TITLE
Allow sebastian/diff 4.0 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "nikic/php-parser": "^4.3",
         "ocramius/package-versions": "^1.2",
         "openlss/lib-array2xml": "^1.0",
-        "sebastian/diff": "^3.0",
+        "sebastian/diff": "^3.0 || ^4.0",
         "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",
         "webmozart/glob": "^4.1",
         "webmozart/path-util": "^2.3"


### PR DESCRIPTION
This is required to allow installation of Psalm alongside PHPUnit 9 using Composer.