### PR TITLE
add config missing from implementation in #2737

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -65,6 +65,7 @@
         <xs:attribute name="useDocblockTypes" type="xs:boolean" default="true" />
         <xs:attribute name="useDocblockPropertyTypes" type="xs:boolean" default="false" />
         <xs:attribute name="usePhpDocMethodsWithoutMagicCall" type="xs:boolean" default="false" />
+        <xs:attribute name="usePhpDocPropertiesWithoutMagicCall" type="xs:boolean" default="false" />
     </xs:complexType>
 
     <xs:complexType name="ProjectFilesType">


### PR DESCRIPTION
This PR adds the config in config.xsd that was implemented in https://github.com/vimeo/psalm/commit/8d7fb2b4151512f3718771c4ab45be33cb1d7264

That missing config prevent using the functionnality with last version.