### PR TITLE
add plugin hook to be called after every function call

### DIFF
--- a/docs/running_psalm/plugins/authoring_plugins.md
+++ b/docs/running_psalm/plugins/authoring_plugins.md
@@ -16,8 +16,9 @@ class SomePlugin implements \Psalm\Plugin\Hook\AfterStatementAnalysisInterface
 - `AfterClassLikeExistenceCheckInterface` - called after Psalm analyzes a reference to a class, interface or trait.
 - `AfterClassLikeVisitInterface` - called after Psalm crawls the parsed Abstract Syntax Tree for a class-like (class, interface, trait). Due to caching the AST is crawled the first time Psalm sees the file, and is only re-crawled if the file changes, the cache is cleared, or you're disabling cache with `--no-cache`/`--no-reflection-cache`. Use this if you want to collect or modify information about a class before Psalm begins its analysis.
 - `AfterCodebasePopulatedInterface` - called after Psalm has scanned necessary files and populated codebase data.
+- `AfterEveryFunctionCallAnalysisInterface` - called after Psalm evaluates any function call. Cannot influence the call further.
 - `AfterExpressionAnalysisInterface` - called after Psalm evaluates an expression.
-- `AfterFunctionCallAnalysisInterface` - called after Psalm evaluates an function call.
+- `AfterFunctionCallAnalysisInterface` - called after Psalm evaluates a function call to any function defined within the project itself. Can alter the return type or perform modifications of the call.
 - `AfterMethodCallAnalysisInterface` - called after Psalm analyzes a method call.
 - `AfterStatementAnalysisInterface` - called after Psalm evaluates an statement.
 - `FunctionExistenceProviderInterface` - can be used to override Psalm's builtin function existence checks for one or more functions.

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -398,11 +398,27 @@ class Config
     public $after_method_checks = [];
 
     /**
-     * Static methods to be called after function checks have completed
+     * Static methods to be called after project function checks have completed
+     *
+     * Called after function calls to functions defined in the project.
+     *
+     * Allows influencing the return type and adding of modifications.
      *
      * @var class-string<Hook\AfterFunctionCallAnalysisInterface>[]
      */
     public $after_function_checks = [];
+
+    /**
+     * Static methods to be called after every function call
+     *
+     * Called after each function call, including php internal functions.
+     *
+     * Cannot change the call or influence its return type
+     *
+     * @var class-string<Hook\AfterEveryFunctionCallAnalysisInterface>[]
+     */
+    public $after_every_function_checks = [];
+
 
     /**
      * Static methods to be called after expression checks have completed

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -635,6 +635,18 @@ class FunctionCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expressio
                 if ($stmt_type) {
                     $statements_analyzer->node_data->setType($real_stmt, $stmt_type);
                 }
+
+                if ($config->after_every_function_checks) {
+                    foreach ($config->after_every_function_checks as $plugin_fq_class_name) {
+                        $plugin_fq_class_name::afterEveryFunctionCallAnalysis(
+                            $stmt,
+                            $function_id,
+                            $context,
+                            $statements_analyzer->getSource(),
+                            $codebase
+                        );
+                    }
+                }
             }
 
             foreach ($defined_constants as $const_name => $const_type) {

--- a/src/Psalm/Plugin/Hook/AfterEveryFunctionCallAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterEveryFunctionCallAnalysisInterface.php
@@ -1,0 +1,18 @@
+<?php
+namespace Psalm\Plugin\Hook;
+
+use PhpParser\Node\Expr\FuncCall;
+use Psalm\Codebase;
+use Psalm\Context;
+use Psalm\StatementsSource;
+
+interface AfterEveryFunctionCallAnalysisInterface
+{
+    public static function afterEveryFunctionCallAnalysis(
+        FuncCall $expr,
+        string $function_id,
+        Context $context,
+        StatementsSource $statements_source,
+        Codebase $codebase
+    ): void;
+}

--- a/src/Psalm/PluginRegistrationSocket.php
+++ b/src/Psalm/PluginRegistrationSocket.php
@@ -46,6 +46,10 @@ class PluginRegistrationSocket implements RegistrationInterface
             $this->config->after_function_checks[$handler] = $handler;
         }
 
+        if (is_subclass_of($handler, Hook\AfterEveryFunctionCallAnalysisInterface::class)) {
+            $this->config->after_every_function_checks[$handler] = $handler;
+        }
+
         if (is_subclass_of($handler, Hook\AfterExpressionAnalysisInterface::class)) {
             $this->config->after_expression_checks[$handler] = $handler;
         }


### PR DESCRIPTION
This PR provides a possible fix for #2804 by introducing an additional hook interface that is called regardless of how the called function is defined at the cost of the two by-ref parameters present in `AfterFunctionCallAnalysisInterface` which don't make sense for php internals.

I might be a bit overly cautious with introducing an additional interface and the existing `AfterFunctionCallAnalysisInterface` could also be made to work with existing functions, but that would either mess with existing plugins that were written with the intention to provide file manipulations or tweak the inferred return type.

I'll leave that for you to decide.

this fixes #2804