### PR TITLE
don't disable checks when includes can't be resolved

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -68,6 +68,7 @@
         <xs:attribute name="useDocblockPropertyTypes" type="xs:boolean" default="false" />
         <xs:attribute name="usePhpDocMethodsWithoutMagicCall" type="xs:boolean" default="false" />
         <xs:attribute name="usePhpDocPropertiesWithoutMagicCall" type="xs:boolean" default="false" />
+        <xs:attribute name="skipChecksOnUnresolvableIncludes" type="xs:boolean" default="true" />
     </xs:complexType>
 
     <xs:complexType name="ProjectFilesType">

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -275,6 +275,17 @@ Set the php version psalm should assume when checking and/or fixing the project.
 
 This can be overridden on the command-line using the `--php-version=` flag which takes the highest precedence over both the `phpVersion` setting and the version derived from `composer.json`.
 
+#### skipChecksOnUnresolvableIncludes
+```xml
+<psalm
+  skipChecksOnUnresolvableIncludes="[bool]"
+>
+```
+
+When `true`, Psalm will skip checking classes, variables and functions after it comes across an `include` or `require` it cannot resolve. This allows code to reference functions and classes unknown to Psalm.
+
+For backwards compatibility, this defaults to `true`, but if you do not rely on dynamically generated includes to cause classes otherwise unknown to psalm to come into existence, it's recommended you set this to `false` in order to reliably detect errors that would be fatal to PHP at runtime.
+
 ### Running Psalm
 
 #### autoloader

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -294,6 +294,11 @@ class Config
     /**
      * @var bool
      */
+    public $skip_checks_on_unresolvable_includes = true;
+
+    /**
+     * @var bool
+     */
     public $memoize_method_calls = false;
 
     /**
@@ -765,6 +770,7 @@ class Config
             'ensureArrayStringOffsetsExist' => 'ensure_array_string_offsets_exist',
             'ensureArrayIntOffsetsExist' => 'ensure_array_int_offsets_exist',
             'reportMixedIssues' => 'show_mixed_issues',
+            'skipChecksOnUnresolvableIncludes' => 'skip_checks_on_unresolvable_includes'
         ];
 
         foreach ($booleanAttributes as $xmlName => $internalName) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -160,6 +160,11 @@ class IncludeAnalyzer
                         $global_context
                     );
                 } catch (\Psalm\Exception\UnpreparedAnalysisException $e) {
+                    if ($config->skip_checks_on_unresolvable_includes) {
+                        $context->check_classes = false;
+                        $context->check_variables = false;
+                        $context->check_functions = false;
+                    }
                 }
 
                 foreach ($include_file_analyzer->getRequiredFilePaths() as $required_file_path) {
@@ -198,6 +203,12 @@ class IncludeAnalyzer
                     // fall through
                 }
             }
+        }
+
+        if ($config->skip_checks_on_unresolvable_includes) {
+            $context->check_classes = false;
+            $context->check_variables = false;
+            $context->check_functions = false;
         }
 
         return null;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -160,9 +160,6 @@ class IncludeAnalyzer
                         $global_context
                     );
                 } catch (\Psalm\Exception\UnpreparedAnalysisException $e) {
-                    $context->check_classes = false;
-                    $context->check_variables = false;
-                    $context->check_functions = false;
                 }
 
                 foreach ($include_file_analyzer->getRequiredFilePaths() as $required_file_path) {
@@ -202,10 +199,6 @@ class IncludeAnalyzer
                 }
             }
         }
-
-        $context->check_classes = false;
-        $context->check_variables = false;
-        $context->check_functions = false;
 
         return null;
     }

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -779,6 +779,25 @@ class IncludeTest extends TestCase
                 ],
                 'error_message' => 'UndefinedConstant',
             ],
+            'undefinedMethodAfterInvalidRequire' => [
+                'files' => [
+                    getcwd() . DIRECTORY_SEPARATOR . 'file2.php' => '<?php
+                        /** @psalm-suppress MissingFile */
+                        require("doesnotexist.php");
+                        require("file1.php");
+
+                        foo();
+                        bar();
+                        ',
+                    getcwd() . DIRECTORY_SEPARATOR . 'file1.php' => '<?php
+                        function bar(): void {}
+                        ',
+                ],
+                'files_to_check' => [
+                    getcwd() . DIRECTORY_SEPARATOR . 'file2.php',
+                ],
+                'error_message' => 'UndefinedFunction',
+            ],
         ];
     }
 }

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -37,6 +37,7 @@ class IncludeTest extends TestCase
         }
 
         $config = $codebase->config;
+        $config->skip_checks_on_unresolvable_includes = true;
 
         foreach ($error_levels as $error_level) {
             $config->setCustomErrorLevel($error_level, \Psalm\Config::REPORT_SUPPRESS);
@@ -83,6 +84,7 @@ class IncludeTest extends TestCase
         }
 
         $config = $codebase->config;
+        $config->skip_checks_on_unresolvable_includes = false;
 
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessageRegExp('/\b' . preg_quote($error_message, '/') . '\b/');
@@ -569,6 +571,25 @@ class IncludeTest extends TestCase
                     getcwd() . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'b' . DIRECTORY_SEPARATOR . 'c' . DIRECTORY_SEPARATOR . 'd' . DIRECTORY_SEPARATOR . 'script.php',
                 ],
             ],
+            'undefinedMethodAfterInvalidRequire' => [
+                'files' => [
+                    getcwd() . DIRECTORY_SEPARATOR . 'file2.php' => '<?php
+                        /** @psalm-suppress MissingFile */
+                        require("doesnotexist.php");
+                        require("file1.php");
+
+                        foo();
+                        bar();
+                        ',
+                    getcwd() . DIRECTORY_SEPARATOR . 'file1.php' => '<?php
+                        function bar(): void {}
+                        ',
+                ],
+                'files_to_check' => [
+                    getcwd() . DIRECTORY_SEPARATOR . 'file2.php',
+                ],
+            ],
+
         ];
     }
 


### PR DESCRIPTION
Any unresolvable include (even suppressed ones) would lead to some subsequent tests being disabled as a side-effect.

this fixes #2817

As noted on that bug report, this might cause big swaths of already-present-but-to-date-hidden issues to be uncovered for people updating to a release with this patch applied.

I'm unsure as to whether we need a switch to toggle this updated behavior or whether we need some changelog warning or whether just fixing this is ok.