### PR TITLE
remove duplicate configs for higher levels

### DIFF
--- a/assets/config_levels/6.xml
+++ b/assets/config_levels/6.xml
@@ -116,9 +116,7 @@
 
         <MoreSpecificImplementedParamType errorLevel="info" />
         <LessSpecificImplementedReturnType errorLevel="info" />
-
-        <InvalidReturnStatement errorLevel="info" />
-        <InvalidReturnType errorLevel="info" />
+        
         <UndefinedThisPropertyAssignment errorLevel="info" />
         <UndefinedInterfaceMethod errorLevel="info" />
 

--- a/assets/config_levels/7.xml
+++ b/assets/config_levels/7.xml
@@ -116,9 +116,7 @@
 
         <MoreSpecificImplementedParamType errorLevel="info" />
         <LessSpecificImplementedReturnType errorLevel="info" />
-
-        <InvalidReturnStatement errorLevel="info" />
-        <InvalidReturnType errorLevel="info" />
+        
         <UndefinedThisPropertyAssignment errorLevel="info" />
         <UndefinedInterfaceMethod errorLevel="info" />
 

--- a/assets/config_levels/8.xml
+++ b/assets/config_levels/8.xml
@@ -116,9 +116,7 @@
 
         <MoreSpecificImplementedParamType errorLevel="info" />
         <LessSpecificImplementedReturnType errorLevel="info" />
-
-        <InvalidReturnStatement errorLevel="info" />
-        <InvalidReturnType errorLevel="info" />
+        
         <UndefinedThisPropertyAssignment errorLevel="info" />
         <UndefinedInterfaceMethod errorLevel="info" />
 


### PR DESCRIPTION
InvalidReturnStatement and InvalidReturnType are mentionned twice(at level 6 and 7).

I was not sure if I should remove them in level 6 or 7. I choose to remove them at 6 because other Invalid* rules are present at level 7.