### PR TITLE
Improve the reported error when a worker crashes

### DIFF
--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -204,9 +204,12 @@ class Pool
             // Serialize this child's produced results and send them to the parent.
             $process_done_message = new ForkProcessDoneMessage($results ?: []);
         } catch (\Throwable $t) {
-            // This can happen when developing Psalm from source without running `composer update`, or because of rare bugs in Psalm.
+            // This can happen when developing Psalm from source without running `composer update`,
+            // or because of rare bugs in Psalm.
             /** @psalm-suppress MixedArgument on Windows, for some reason */
-            $process_done_message = new ForkProcessErrorMessage($t->getMessage() . "\nStack trace in the forked worker:\n" . $t->getTraceAsString());
+            $process_done_message = new ForkProcessErrorMessage(
+                $t->getMessage() . "\nStack trace in the forked worker:\n" . $t->getTraceAsString()
+            );
         }
 
         $serialized_message = $task_done_buffer . base64_encode(serialize($process_done_message)) . "\n";

--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -204,8 +204,9 @@ class Pool
             // Serialize this child's produced results and send them to the parent.
             $process_done_message = new ForkProcessDoneMessage($results ?: []);
         } catch (\Throwable $t) {
+            // This can happen when developing Psalm from source without running `composer update`, or because of rare bugs in Psalm.
             /** @psalm-suppress MixedArgument on Windows, for some reason */
-            $process_done_message = new ForkProcessErrorMessage($t->getMessage());
+            $process_done_message = new ForkProcessErrorMessage($t->getMessage() . "\nStack trace in the forked worker:\n" . $t->getTraceAsString());
         }
 
         $serialized_message = $task_done_buffer . base64_encode(serialize($process_done_message)) . "\n";


### PR DESCRIPTION
I saw this when I failed to update psalm/plugin-phpunit (and it was fixed by running `composer update`). It's more useful to have a stack trace than to just see that `explode` was passed an object instead of a string.

It may also be useful (for developers) to check the output of `ocramius/package-versions` against psalm's composer.json, and warn if the installed versions don't match composer.json.
This is possible with composer/semver, but this type of bug is probably rare enough for it not to be worked on.