### PR TITLE
Support using paratest for local development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
         "brianium/paratest": "^4.0.0",
         "phpmyadmin/sql-parser": "5.1.0",
         "phpspec/prophecy": ">=1.9.0",
-        "phpunit/phpunit": "^7.5.16 || ^8.0",
+        "phpunit/phpunit": "^7.5.16 || ^8.5",
         "psalm/plugin-phpunit": "^0.9",
         "slevomat/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,9 @@
         "psalm/psalm": "self.version"
     },
     "require-dev": {
-        "bamarni/composer-bin-plugin": "^1.2",
         "ext-curl": "*",
+        "bamarni/composer-bin-plugin": "^1.2",
+        "brianium/paratest": "^4.0.0",
         "phpmyadmin/sql-parser": "5.1.0",
         "phpspec/prophecy": ">=1.9.0",
         "phpunit/phpunit": "^7.5.16 || ^8.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,9 +11,11 @@
          verbose="true"
          executionOrder="default"
 >
-    <testsuite name="psalm">
-        <directory>tests</directory>
-    </testsuite>
+    <testsuites>
+        <testsuite name="psalm">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">


### PR DESCRIPTION
https://phpunit.de/manual/6.5/en/appendixes.configuration.html#appendixes.configuration.testsuites
documents that `<testsuites>` should typically wrap `<testsuite>` in
phpunit.xml.

> The <testsuites> element and its one or more <testsuite> children can
> be used to compose a test suite out of test suites and test cases.

This project may get a small performance boost
running tests in CI with paratest(2 processes) instead of phpunit.
Paratest works locally, and supports php 7.1+.

See https://github.com/paratestphp/paratest/