### PR TITLE
Codelocation: Save docblock

### DIFF
--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -77,6 +77,9 @@ class CodeLocation
     /** @var int|null */
     private $docblock_line_number;
 
+    /** @var PhpParser\Comment\Doc|null */
+    private $doc_comment;
+
     /** @var null|int */
     private $regex_type;
 
@@ -121,6 +124,7 @@ class CodeLocation
         $this->text = $selected_text;
 
         $doc_comment = $stmt->getDocComment();
+        $this->doc_comment = $doc_comment;
         $this->preview_start = $doc_comment ? $doc_comment->getFilePos() : $this->file_start;
         $this->docblock_start_line_number = $doc_comment ? $doc_comment->getLine() : null;
         $this->raw_line_number = $stmt->getLine();
@@ -317,6 +321,14 @@ class CodeLocation
         }
 
         $this->end_line_number = $this->getLineNumber() + $newlines;
+    }
+
+    /**
+     * @return PhpParser\Comment\Doc|null
+     */
+    public function getDocComment()
+    {
+        return $this->doc_comment;
     }
 
     /**

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -324,6 +324,7 @@ class CodeLocation
     }
 
     /**
+     * @psalm-suppress PossiblyUnusedMethod for convenience
      * @return PhpParser\Comment\Doc|null
      */
     public function getDocComment()


### PR DESCRIPTION
When using a plugin that inspects the `codebase`, it is not easy to loop over classes and methods pulling out the docblocks.

Since we have code locations at that time, let's stash the docblock on the code location.

Note: I opened this since I could not find an easy way to look up a docblock given a `codelocation` object.