### PR TITLE
Prevent TypeError when generating XML reports

### DIFF
--- a/src/Psalm/Report/XmlReport.php
+++ b/src/Psalm/Report/XmlReport.php
@@ -3,6 +3,8 @@ namespace Psalm\Report;
 
 use LSS\Array2XML;
 use Psalm\Report;
+use Psalm\Internal\Analyzer\IssueData;
+use function array_map;
 
 class XmlReport extends Report
 {
@@ -11,7 +13,34 @@ class XmlReport extends Report
      */
     public function create(): string
     {
-        $xml = Array2XML::createXML('report', ['item' => $this->issues_data]);
+        $items = array_map(
+            /**
+             * @return array<int, array{severity: string, line_from: int, line_to: int, type: string, message: string,
+             * file_name: string, file_path: string, snippet: string, from: int, to: int,
+             * snippet_from: int, snippet_to: int, column_from: int, column_to: int, selected_text: string}>
+             */
+            function (IssueData $issue_data) {
+                return [
+                    'severity'      => $issue_data->severity,
+                    'line_from'     => $issue_data->line_from,
+                    'line_to'       => $issue_data->line_to,
+                    'type'          => $issue_data->type,
+                    'message'       => $issue_data->message,
+                    'file_name'     => $issue_data->file_name,
+                    'file_path'     => $issue_data->file_path,
+                    'snippet'       => $issue_data->snippet,
+                    'from'          => $issue_data->from,
+                    'to'            => $issue_data->to,
+                    'snippet_from'  => $issue_data->snippet_from,
+                    'snippet_to'    => $issue_data->snippet_to,
+                    'column_from'   => $issue_data->column_from,
+                    'column_to'     => $issue_data->column_to,
+                    'selected_text' => $issue_data->selected_text,
+                ];
+            },
+            $this->issues_data
+        );
+        $xml = Array2XML::createXML('report', ['item' => $items]);
 
         return $xml->saveXML();
     }

--- a/src/Psalm/Report/XmlReport.php
+++ b/src/Psalm/Report/XmlReport.php
@@ -13,34 +13,17 @@ class XmlReport extends Report
      */
     public function create(): string
     {
-        $items = array_map(
-            /**
-             * @return array{severity: string, line_from: int, line_to: int, type: string, message: string,
-             * file_name: string, file_path: string, snippet: string, from: int, to: int,
-             * snippet_from: int, snippet_to: int, column_from: int, column_to: int, selected_text: string}
-             */
-            function (IssueData $issue_data) {
-                return [
-                    'severity'      => $issue_data->severity,
-                    'line_from'     => $issue_data->line_from,
-                    'line_to'       => $issue_data->line_to,
-                    'type'          => $issue_data->type,
-                    'message'       => $issue_data->message,
-                    'file_name'     => $issue_data->file_name,
-                    'file_path'     => $issue_data->file_path,
-                    'snippet'       => $issue_data->snippet,
-                    'from'          => $issue_data->from,
-                    'to'            => $issue_data->to,
-                    'snippet_from'  => $issue_data->snippet_from,
-                    'snippet_to'    => $issue_data->snippet_to,
-                    'column_from'   => $issue_data->column_from,
-                    'column_to'     => $issue_data->column_to,
-                    'selected_text' => $issue_data->selected_text,
-                ];
-            },
-            $this->issues_data
+        $items = Array2XML::createXML(
+            'report',
+            [
+                'item' => 
+                    function (IssueData $issue_data) {
+                        return (array) $issue_data;
+                    },
+                    $this->issues_data
+                )
+            ]
         );
-        $xml = Array2XML::createXML('report', ['item' => $items]);
 
         return $xml->saveXML();
     }

--- a/src/Psalm/Report/XmlReport.php
+++ b/src/Psalm/Report/XmlReport.php
@@ -15,9 +15,9 @@ class XmlReport extends Report
     {
         $items = array_map(
             /**
-             * @return array<int, array{severity: string, line_from: int, line_to: int, type: string, message: string,
+             * @return array{severity: string, line_from: int, line_to: int, type: string, message: string,
              * file_name: string, file_path: string, snippet: string, from: int, to: int,
-             * snippet_from: int, snippet_to: int, column_from: int, column_to: int, selected_text: string}>
+             * snippet_from: int, snippet_to: int, column_from: int, column_to: int, selected_text: string}
              */
             function (IssueData $issue_data) {
                 return [


### PR DESCRIPTION
The XML generator currently in use (LSS\Array2XML) expects a nested array structure. However, due to the recent introduction of the IssueData type to replace what was previously shaped arrays, Array2XML was getting an array of objects instead. It then proceeds to crash from (eventually) passing null to DOMNode->appendChild(). This commit maps the IssueData array back into the array of shaped arrays that Array2XML knew and loved.

Feel free to edit as desired. This is an admittedly rudimentary fix; just wanted to make an attempt at helping in some capacity. 😅