### PR TITLE
TestCase/TestConfig: Allow plugins to reuse these files

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,6 +7,7 @@ use const DIRECTORY_SEPARATOR;
 use function getcwd;
 use function ini_set;
 use PHPUnit\Framework\TestCase as BaseTestCase;
+use Psalm\Config;
 use Psalm\Internal\Analyzer\FileAnalyzer;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Provider\Providers;
@@ -44,6 +45,14 @@ class TestCase extends BaseTestCase
     }
 
     /**
+     * @return Config
+     */
+    protected function getConfig() : Config
+    {
+        return new TestConfig();
+    }
+
+    /**
      * @return void
      */
     public function setUp() : void
@@ -54,7 +63,7 @@ class TestCase extends BaseTestCase
 
         $this->file_provider = new \Psalm\Tests\Internal\Provider\FakeFileProvider();
 
-        $config = new TestConfig();
+        $config = $this->getConfig();
 
         $providers = new Providers(
             $this->file_provider,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -47,7 +47,7 @@ class TestCase extends BaseTestCase
     /**
      * @return Config
      */
-    protected function getConfig() : Config
+    protected function makeConfig() : Config
     {
         return new TestConfig();
     }
@@ -63,7 +63,7 @@ class TestCase extends BaseTestCase
 
         $this->file_provider = new \Psalm\Tests\Internal\Provider\FakeFileProvider();
 
-        $config = $this->getConfig();
+        $config = $this->makeConfig();
 
         $providers = new Providers(
             $this->file_provider,

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -26,15 +26,7 @@ class TestConfig extends Config
 
         if (!self::$cached_project_files) {
             self::$cached_project_files = Config\ProjectFileFilter::loadFromXMLElement(
-                new \SimpleXMLElement(
-                    '<?xml version="1.0"?>
-                    <projectFiles>
-                        <directory name="src" />
-                        <ignoreFiles>
-                            <directory name="src/Psalm/Internal/Stubs" />
-                        </ignoreFiles>
-                    </projectFiles>'
-                ),
+                new \SimpleXMLElement($this->getContents()),
                 $this->base_dir,
                 true
             );
@@ -44,6 +36,17 @@ class TestConfig extends Config
 
         $this->collectPredefinedConstants();
         $this->collectPredefinedFunctions();
+    }
+
+    protected function getContents() : string
+    {
+        return '<?xml version="1.0"?>
+                <projectFiles>
+                    <directory name="src" />
+                    <ignoreFiles>
+                        <directory name="src/Psalm/Internal/Stubs" />
+                    </ignoreFiles>
+                </projectFiles>';
     }
 
     public function getComposerFilePathForClassLike($fq_classlike_name)


### PR DESCRIPTION
See: https://github.com/vimeo/psalm/issues/2869\#issuecomment-590490908

Previously, If a plugin tried to reuse the TestConf / TestCase
an exception would likely occur since the default testconfig
is hardcoded to our internal psalm codebase

This commit allows a custom config to be passed into a testcase
thus, a plugin's codebase does not need to match our own.

CC: @weirdan 