### PR TITLE
Change return type of `range()` from `array<int, ...>` to `list<...>`

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/RangeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/RangeReturnTypeProvider.php
@@ -58,27 +58,25 @@ class RangeReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypePr
         }
 
         if ($all_ints) {
-            return new Type\Union([new Type\Atomic\TArray([Type::getInt(), Type::getInt()])]);
+            return new Type\Union([new Type\Atomic\TList(new Type\Union([new Type\Atomic\TInt]))]);
         }
 
         if ($all_strings) {
-            return new Type\Union([new Type\Atomic\TArray([Type::getInt(), Type::getString()])]);
+            return new Type\Union([new Type\Atomic\TList(new Type\Union([new Type\Atomic\TString]))]);
         }
 
         if ($all_floats) {
-            return new Type\Union([new Type\Atomic\TArray([Type::getInt(), Type::getFloat()])]);
+            return new Type\Union([new Type\Atomic\TList(new Type\Union([new Type\Atomic\TFloat]))]);
         }
 
         if ($all_numbers) {
-            return new Type\Union([new Type\Atomic\TArray([
-                Type::getInt(),
-                new Type\Union([new Type\Atomic\TInt, new Type\Atomic\TFloat]),
-            ])]);
+            return new Type\Union([new Type\Atomic\TList(
+                new Type\Union([new Type\Atomic\TInt, new Type\Atomic\TFloat])
+            )]);
         }
 
-        return new Type\Union([new Type\Atomic\TArray([
-            Type::getInt(),
-            new Type\Union([new Type\Atomic\TInt, new Type\Atomic\TFloat, new Type\Atomic\TString]),
-        ])]);
+        return new Type\Union([new Type\Atomic\TList(
+            new Type\Union([new Type\Atomic\TInt, new Type\Atomic\TFloat, new Type\Atomic\TString])
+        )]);
     }
 }


### PR DESCRIPTION
If I'm not mistaken, the `range()` function actually returns a `list<...>`, but currently it's not possible to annotate it as that because `list` is more specific than `array`.

See: https://psalm.dev/r/8c1b886927