### PR TITLE
\sodium_memzero() sets to null the value of the given reference

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -319,3 +319,11 @@ function preg_grep($pattern, array $input, $flags = 0)
 function fclose(&$handle) : bool
 {
 }
+
+/**
+ * @param string $reference
+ * @param-out null $reference
+ */
+function sodium_memzero(string &$reference): void
+{
+}

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1694,6 +1694,15 @@ class FunctionCallTest extends TestCase
                     (print "test") === 2;',
                 'error_message' => 'TypeDoesNotContainType',
             ],
+            'sodiumMemzeroNullifyString' => [
+                '<?php
+                    function returnsStr(): string {
+                        $str = "x";
+                        sodium_memzero($str);
+                        return $str;
+                    }',
+                'error_message' => 'NullableReturnStatement'
+            ]
         ];
     }
 }


### PR DESCRIPTION
While it is not mentionned in PHP manual \sodium_memzero() always sets
the given parameter to null [0].

[0] https://github.com/php/php-src/blob/cb933d63c2a6df13d58054da1ea2c48f21a2469e/ext/sodium/libsodium.c#L512