### PR TITLE
mark ftp_close as impure

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -367,6 +367,9 @@ class Functions
             'mysqli_select_db', 'mysqli_dump_debug_info', 'mysqli_kill', 'mysqli_multi_query',
             'mysqli_next_result', 'mysqli_options', 'mysqli_ping', 'mysqli_query', 'mysqli_report',
             'mysqli_rollback', 'mysqli_savepoint', 'mysqli_set_charset', 'mysqli_ssl_set',
+
+            // ftp
+            'ftp_close',
         ];
 
         if (\in_array(strtolower($function_id), $impure_functions, true)) {


### PR DESCRIPTION
in theory, all `ftp_*` functions are impure, but not marking them encourages the good practice of checking the return value.

However, `ftp_close()`, while it's possible for it to fail, what good would checking the return type do? How is one supposed to handle the failure to close a stream in a way that affects future program flow? Yes, you might want to do logging, but then you're checking the return value anyways - but in all optimistic cases, your program state won't be any different after failing to close the resource.

Also, looking at the PHP source code, the return value of `ftp_close()` doesn't actually say anything about whether the connection had closed or not but only reflects a failure to remove the handle from the internal resource list

https://github.com/php/php-src/blob/32c2ae2939a360854acc46d7dfcd06d4a52c52e9/ext/ftp/php_ftp.c#L1311-L1313
