### PR TITLE
Support trailing commas in type aliases

### DIFF
--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -281,6 +281,8 @@ class CommentAnalyzer
             }
 
             $var_line = preg_replace('/[ \t]+/', ' ', preg_replace('@^[ \t]*\*@m', '', $var_line));
+            $var_line = preg_replace('/,\n\s+\}/', '}', $var_line);
+            $var_line = str_replace("\n", '', $var_line);
 
             $var_line_parts = preg_split('/( |=)/', $var_line, -1, PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_NO_EMPTY);
 

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -990,6 +990,17 @@ class AnnotationTest extends TestCase
             'allowClosingComma' => [
                 '<?php
                     /**
+                     * @psalm-type _Alias=array{
+                     *    foo: string,
+                     *    bar: string,
+                     *    baz: array{
+                     *       a: int,
+                     *    },
+                     * }
+                     */
+                    class Foo { }
+
+                    /**
                      * @param array{
                      *    foo: string,
                      *    bar: string,


### PR DESCRIPTION
https://psalm.dev/r/9358a2939f for an example of the issue

I've copied the original fix (b12f05185a76c30c0d42acd79d2d43f2ffaaea2d) over to where the aliases are parsed and added to the existing test case