### PR TITLE
WIP: Introduce @psalm-use to import types

### DIFF
--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -267,7 +267,7 @@ class DocComment
                     $special_key,
                     [
                         'return', 'param', 'template', 'var', 'type',
-                        'template-covariant', 'property', 'method',
+                        'template-covariant', 'property', 'method', 'use',
                         'assert', 'assert-if-true', 'assert-if-false', 'suppress',
                         'ignore-nullable-return', 'override-property-visibility',
                         'override-method-visibility', 'seal-properties', 'seal-methods',

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -3,6 +3,7 @@ namespace Psalm\Internal\Analyzer;
 
 use PhpParser;
 use Psalm\Aliases;
+use Psalm\Codebase;
 use Psalm\DocComment;
 use Psalm\Exception\DocblockParseException;
 use Psalm\Exception\IncorrectDocblockException;
@@ -11,8 +12,11 @@ use Psalm\FileSource;
 use Psalm\Internal\Scanner\ClassLikeDocblockComment;
 use Psalm\Internal\Scanner\FunctionDocblockComment;
 use Psalm\Internal\Scanner\VarDocblockComment;
+use Psalm\Internal\Taint\Source;
 use Psalm\Internal\Type\ParseTree;
 use Psalm\Type;
+use function array_map;
+use function array_values;
 use function trim;
 use function substr_count;
 use function strlen;
@@ -22,6 +26,7 @@ use function preg_match;
 use function count;
 use function reset;
 use function preg_split;
+use function var_dump;
 use const PREG_SPLIT_DELIM_CAPTURE;
 use const PREG_SPLIT_NO_EMPTY;
 use function array_shift;
@@ -241,10 +246,20 @@ class CommentAnalyzer
      */
     public static function getTypeAliasesFromComment(
         PhpParser\Comment\Doc $comment,
+        Codebase $codebase,
         Aliases $aliases,
         array $type_aliases = null
     ) {
         $parsed_docblock = DocComment::parsePreservingLength($comment);
+
+        if (isset($parsed_docblock['specials']['psalm-use'])) {
+
+            // @todo Is it possible to get the Aliases form another class using {@see $codebase}?
+            return [
+                // @todo faking the data
+                'TData' => [['array', 4], ['{', 1], ['name', 4], [':', 1], ['string', 5], ['}', 1]]
+            ];
+        }
 
         if (!isset($parsed_docblock['specials']['psalm-type'])) {
             return [];

--- a/src/Psalm/Internal/Visitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/Visitor/ReflectorVisitor.php
@@ -161,6 +161,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
                 try {
                     $type_alias_tokens = CommentAnalyzer::getTypeAliasesFromComment(
                         $comment,
+                        $this->codebase,
                         $this->aliases,
                         $this->type_aliases
                     );


### PR DESCRIPTION
**The implementation is very hacky, just to test what I want to achieve here.**

That is a proposal of how we could import types defined in other
classes, so we don't need to repeat the types over and over again.

That could be interesting when composing types as well.

```php
/** @psalm-type TPhone = array{phone: string} */
class Phone {
    /** @psalm-return TPhone */
    toArray(): array {}
}

/** @psalm-type TName = array{name: string} */
class Name {
    /** @psalm-return TName */
    toArray(): array {}
}

/**
 * @psalm-use TPhone from Phone
 * @psalm-use TName from Name
 *
 * @psalm-type TUserArray = TPhone&TName
 */
class User {
    /** @psalm-return TUserArray */
    toArray(): array {}
}
```