### PR TITLE
Junit report format fixes

### DIFF
--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -47,12 +47,16 @@ class JunitReport extends Report
             $fname = $error->file_name;
 
             if (!isset($ndata[$fname])) {
+                $failure = [];
+                if ($is_error || ($this->show_info && $is_warning)) {
+                    $failure = [
+                        $this->createFailure($error)
+                    ];
+                }
                 $ndata[$fname] = [
                     'errors'   => $is_error ? 1 : 0,
                     'warnings' => $is_warning ? 1 : 0,
-                    'failures' => [
-                        $this->createFailure($error),
-                    ],
+                    'failures' => $failure,
                 ];
             } else {
                 if ($is_error) {
@@ -61,7 +65,9 @@ class JunitReport extends Report
                     $ndata[$fname]['warnings']++;
                 }
 
-                $ndata[$fname]['failures'][] = $this->createFailure($error);
+                if ($is_error || ($this->show_info && $is_warning)) {
+                    $ndata[$fname]['failures'][] = $this->createFailure($error);
+                }
             }
         }
 

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -173,9 +173,7 @@ class JunitReport extends Report
     {
         $ret = 'message: ' . htmlspecialchars(trim($data->message), ENT_XML1 | ENT_QUOTES) . "\n";
         $ret .= 'type: ' . trim($data->type) . "\n";
-        if ($this->show_snippet) {
-            $ret .= 'snippet: ' . htmlspecialchars(trim($data->snippet), ENT_XML1 | ENT_QUOTES) . "\n";
-        }
+        $ret .= 'snippet: ' . htmlspecialchars(trim($data->snippet), ENT_XML1 | ENT_QUOTES) . "\n";
         $ret .= 'selected_text: ' . trim($data->selected_text) . "\n";
         $ret .= 'line: ' . $data->line_from . "\n";
         $ret .= 'column_from: ' . $data->column_from . "\n";

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -163,9 +163,9 @@ class JunitReport extends Report
             $ret .= 'snippet: ' . trim($data->snippet) . "\n";
         }
         $ret .= 'selected_text: ' . trim($data->selected_text) . "\n";
-        $ret .= 'line: ' . trim($data->line_from) . "\n";
-        $ret .= 'column_from: ' . trim($data->column_from) . "\n";
-        $ret .= 'column_to: ' . trim($data->column_to) . "\n";
+        $ret .= 'line: ' . $data->line_from . "\n";
+        $ret .= 'column_from: ' . $data->column_from . "\n";
+        $ret .= 'column_to: ' . $data->column_to . "\n";
 
         return $ret;
     }

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -112,9 +112,9 @@ class JunitReport extends Report
 
         $testsuite = $dom->createElement('testsuite');
         $testsuite->setAttribute('name', $file);
-        $testsuite->setAttribute('tests', (string) $totalTests);
         $testsuite->setAttribute('failures', (string) $report['errors']);
         $testsuite->setAttribute('errors', '0');
+        $testsuite->setAttribute('tests', (string) $totalTests);
 
         $failuresByType = $this->groupByType($report['failures']);
 
@@ -157,18 +157,15 @@ class JunitReport extends Report
      */
     private function dataToOutput(IssueData $data): string
     {
-        $ret = '';
+        $ret = 'message: ' . trim($data->message) . "\n";
+        $ret .= 'type: ' . trim($data->type) . "\n";
         if ($this->show_snippet) {
-            $ret = "snippet: {$data->snippet}\n";
+            $ret .= 'snippet: ' . trim($data->snippet) . "\n";
         }
-        $ret .= <<<SNIPPET
-message : {$data->message}
-type : {$data->type}
-selected_text : {$data->selected_text}
-line : {$data->line_from}
-column_from : {$data->column_from}
-column_to : {$data->column_to}
-SNIPPET;
+        $ret .= 'selected_text: ' . trim($data->selected_text) . "\n";
+        $ret .= 'line: ' . trim($data->line_from) . "\n";
+        $ret .= 'column_from: ' . trim($data->column_from) . "\n";
+        $ret .= 'column_to: ' . trim($data->column_to) . "\n";
 
         return $ret;
     }

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -72,28 +72,22 @@ class JunitReport extends Report
             'junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd';
 
         $suites = $dom->createElement('testsuites');
-        $testsuite = $dom->createElement('testsuite');
 
-        if ($testsuite === false) {
-            throw new \UnexpectedValueException('Bad falsy value');
-        }
-
-        $testsuite->setAttribute('failures', (string) $errors);
-        $testsuite->setAttribute('warnings', (string) $warnings);
-        $testsuite->setAttribute('name', 'psalm');
-        $testsuite->setAttribute('tests', (string) $tests);
-        $testsuite->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
-        $testsuite->setAttribute('xsi:noNamespaceSchemaLocation', $schema);
-        $suites->appendChild($testsuite);
+        $suites->setAttribute('failures', (string) $errors);
+        $suites->setAttribute('errors', "0");
+        $suites->setAttribute('name', 'psalm');
+        $suites->setAttribute('tests', (string) $tests);
+        $suites->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
+        $suites->setAttribute('xsi:noNamespaceSchemaLocation', $schema);
         $dom->appendChild($suites);
 
         if (!count($ndata)) {
             $testcase = $dom->createElement('testcase');
             $testcase->setAttribute('name', 'psalm');
-            $testsuite->appendChild($testcase);
+            $suites->appendChild($testcase);
         } else {
             foreach ($ndata as $file => $report) {
-                $this->createTestSuite($dom, $testsuite, $file, $report);
+                $this->createTestSuite($dom, $suites, $file, $report);
             }
         }
 

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -1,7 +1,6 @@
 <?php
 namespace Psalm\Report;
 
-use ArrayObject;
 use DOMDocument;
 use DOMElement;
 use Psalm\Config;

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -7,7 +7,10 @@ use DOMElement;
 use Psalm\Config;
 use Psalm\Report;
 use Psalm\Internal\Analyzer\IssueData;
+use const ENT_XML1;
+use const ENT_QUOTES;
 use function count;
+use function htmlspecialchars;
 use function trim;
 
 /**
@@ -60,9 +63,7 @@ class JunitReport extends Report
                 }
             }
 
-            if ($is_error || ($this->show_info && $is_warning)) {
-                $ndata[$fname]['failures'][] = $error;
-            }
+            $ndata[$fname]['failures'][] = $error;
         }
 
         $dom = new DOMDocument('1.0', 'UTF-8');
@@ -82,9 +83,19 @@ class JunitReport extends Report
         $dom->appendChild($suites);
 
         if (!count($ndata)) {
+            $suites->setAttribute('tests', '1');
+
+            $testsuite = $dom->createElement('testsuite');
+            $testsuite->setAttribute('name', 'psalm');
+            $testsuite->setAttribute('failures', '0');
+            $testsuite->setAttribute('errors', '0');
+            $testsuite->setAttribute('tests', '1');
+
             $testcase = $dom->createElement('testcase');
             $testcase->setAttribute('name', 'psalm');
-            $suites->appendChild($testcase);
+            $testsuite->appendChild($testcase);
+
+            $suites->appendChild($testsuite);
         } else {
             foreach ($ndata as $file => $report) {
                 $this->createTestSuite($dom, $suites, $file, $report);
@@ -125,11 +136,15 @@ class JunitReport extends Report
                 $testcase->setAttribute('classname', $type);
                 $testcase->setAttribute('assertions', (string) count($data));
 
-                $failure = $dom->createElement('failure');
-                $failure->setAttribute('type', $type);
-                $failure->nodeValue = $this->dataToOutput($d);
+                if ($d->severity === Config::REPORT_ERROR) {
+                    $issue = $dom->createElement('failure');
+                    $issue->setAttribute('type', $type);
+                } else {
+                    $issue = $dom->createElement('skipped');
+                }
+                $issue->nodeValue = $this->dataToOutput($d);
 
-                $testcase->appendChild($failure);
+                $testcase->appendChild($issue);
                 $testsuite->appendChild($testcase);
             }
         }
@@ -157,10 +172,10 @@ class JunitReport extends Report
      */
     private function dataToOutput(IssueData $data): string
     {
-        $ret = 'message: ' . trim($data->message) . "\n";
+        $ret = 'message: ' . htmlspecialchars(trim($data->message), ENT_XML1 | ENT_QUOTES) . "\n";
         $ret .= 'type: ' . trim($data->type) . "\n";
         if ($this->show_snippet) {
-            $ret .= 'snippet: ' . trim($data->snippet) . "\n";
+            $ret .= 'snippet: ' . htmlspecialchars(trim($data->snippet), ENT_XML1 | ENT_QUOTES) . "\n";
         }
         $ret .= 'selected_text: ' . trim($data->selected_text) . "\n";
         $ret .= 'line: ' . $data->line_from . "\n";

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -74,7 +74,7 @@ class JunitReport extends Report
         $suites = $dom->createElement('testsuites');
 
         $suites->setAttribute('failures', (string) $errors);
-        $suites->setAttribute('errors', "0");
+        $suites->setAttribute('errors', '0');
         $suites->setAttribute('name', 'psalm');
         $suites->setAttribute('tests', (string) $tests);
         $suites->setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
@@ -122,10 +122,9 @@ class JunitReport extends Report
 
         $testsuite = $dom->createElement('testsuite');
         $testsuite->setAttribute('name', $file);
-        $testsuite->setAttribute('file', $file);
-        $testsuite->setAttribute('assertions', (string) $totalTests);
+        // $testsuite->setAttribute('tests', (string) $totalTests);
         $testsuite->setAttribute('failures', (string) $report['errors']);
-        $testsuite->setAttribute('warnings', (string) $report['warnings']);
+        $testsuite->setAttribute('errors', '0');
 
         $failuresByType = $this->groupByType($report['failures']);
         $testsuite->setAttribute('tests', (string) count($failuresByType));
@@ -135,10 +134,7 @@ class JunitReport extends Report
             foreach ($data as $d) {
                 $testcase = $dom->createElement('testcase');
                 $testcase->setAttribute('name', "{$file}:{$d['line']}");
-                $testcase->setAttribute('file', $file);
-                $testcase->setAttribute('class', $type);
                 $testcase->setAttribute('classname', $type);
-                $testcase->setAttribute('line', (string) $d['line']);
                 $testcase->setAttribute('assertions', (string) count($data));
 
                 $failure = $dom->createElement('failure');

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -228,6 +228,9 @@ class JunitReport extends Report
         $ret = '';
 
         foreach ($data as $key => $value) {
+            if (!$this->show_snippet && $key === 'snippet') {
+                continue;
+            }
             $value = trim((string) $value);
             $ret .= "{$key}: {$value}\n";
         }

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -504,11 +504,10 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:15:6 - Possibly undefined g
 
         $this->assertSame(
             '<?xml version="1.0" encoding="UTF-8"?>
-<testsuites>
-  <testsuite failures="3" warnings="1" name="psalm" tests="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
-    <testsuite name="somefile.php" file="somefile.php" assertions="4" failures="3" warnings="1" tests="4">
-      <testcase name="somefile.php:3" file="somefile.php" class="UndefinedVariable" classname="UndefinedVariable" line="3" assertions="1">
-        <failure type="UndefinedVariable">message: Cannot find referenced variable $as_you
+<testsuites failures="3" errors="0" name="psalm" tests="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
+  <testsuite name="somefile.php" file="somefile.php" assertions="4" failures="3" warnings="1" tests="4">
+    <testcase name="somefile.php:3" file="somefile.php" class="UndefinedVariable" classname="UndefinedVariable" line="3" assertions="1">
+      <failure type="UndefinedVariable">message: Cannot find referenced variable $as_you
 type: UndefinedVariable
 snippet: return $as_you . "type";
 selected_text: $as_you
@@ -516,9 +515,9 @@ line: 3
 column_from: 10
 column_to: 17
 </failure>
-      </testcase>
-      <testcase name="somefile.php:2" file="somefile.php" class="MixedInferredReturnType" classname="MixedInferredReturnType" line="2" assertions="1">
-        <failure type="MixedInferredReturnType">message: Could not verify return type \'null|string\' for psalmCanVerify
+    </testcase>
+    <testcase name="somefile.php:2" file="somefile.php" class="MixedInferredReturnType" classname="MixedInferredReturnType" line="2" assertions="1">
+      <failure type="MixedInferredReturnType">message: Could not verify return type \'null|string\' for psalmCanVerify
 type: MixedInferredReturnType
 snippet: function psalmCanVerify(int $your_code): ?string {
 selected_text: ?string
@@ -526,9 +525,9 @@ line: 2
 column_from: 42
 column_to: 49
 </failure>
-      </testcase>
-      <testcase name="somefile.php:7" file="somefile.php" class="UndefinedConstant" classname="UndefinedConstant" line="7" assertions="1">
-        <failure type="UndefinedConstant">message: Const CHANGE_ME is not defined
+    </testcase>
+    <testcase name="somefile.php:7" file="somefile.php" class="UndefinedConstant" classname="UndefinedConstant" line="7" assertions="1">
+      <failure type="UndefinedConstant">message: Const CHANGE_ME is not defined
 type: UndefinedConstant
 snippet: echo CHANGE_ME;
 selected_text: CHANGE_ME
@@ -536,9 +535,9 @@ line: 7
 column_from: 6
 column_to: 15
 </failure>
-      </testcase>
-      <testcase name="somefile.php:15" file="somefile.php" class="PossiblyUndefinedGlobalVariable" classname="PossiblyUndefinedGlobalVariable" line="15" assertions="1">
-        <failure type="PossiblyUndefinedGlobalVariable">message: Possibly undefined global variable $a, first seen on line 10
+    </testcase>
+    <testcase name="somefile.php:15" file="somefile.php" class="PossiblyUndefinedGlobalVariable" classname="PossiblyUndefinedGlobalVariable" line="15" assertions="1">
+      <failure type="PossiblyUndefinedGlobalVariable">message: Possibly undefined global variable $a, first seen on line 10
 type: PossiblyUndefinedGlobalVariable
 snippet: echo $a
 selected_text: $a
@@ -546,8 +545,7 @@ line: 15
 column_from: 6
 column_to: 8
 </failure>
-      </testcase>
-    </testsuite>
+    </testcase>
   </testsuite>
 </testsuites>
 ',
@@ -555,13 +553,13 @@ column_to: 8
         );
 
         // Validate against junit xsd
-        $dom = new DOMDocument("1.0", "UTF-8");
+        $dom = new DOMDocument('1.0', 'UTF-8');
         $dom->preserveWhiteSpace = false;
         $dom->loadXML($xml);
 
         // Validate against xsd
-        $valid = $dom->schemaValidate(__DIR__ . "/junit.xsd");
-        $this->assertTrue($valid, "Output did not validate against XSD");
+        $valid = $dom->schemaValidate(__DIR__ . '/junit.xsd');
+        $this->assertTrue($valid, 'Output did not validate against XSD');
 
         // FIXME: The XML parser only return strings, all int value are casted, so the assertSame failed
         //$this->assertSame(

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -537,14 +537,14 @@ column_to: 15
 </failure>
     </testcase>
     <testcase name="somefile.php:15" classname="PossiblyUndefinedGlobalVariable" assertions="1">
-      <failure type="PossiblyUndefinedGlobalVariable">message: Possibly undefined global variable $a, first seen on line 10
+      <skipped>message: Possibly undefined global variable $a, first seen on line 10
 type: PossiblyUndefinedGlobalVariable
 snippet: echo $a
 selected_text: $a
 line: 15
 column_from: 6
 column_to: 8
-</failure>
+</skipped>
     </testcase>
   </testsuite>
 </testsuites>

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -505,8 +505,8 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:15:6 - Possibly undefined g
         $this->assertSame(
             '<?xml version="1.0" encoding="UTF-8"?>
 <testsuites failures="3" errors="0" name="psalm" tests="4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/junit-team/junit5/r5.5.1/platform-tests/src/test/resources/jenkins-junit.xsd">
-  <testsuite name="somefile.php" file="somefile.php" assertions="4" failures="3" warnings="1" tests="4">
-    <testcase name="somefile.php:3" file="somefile.php" class="UndefinedVariable" classname="UndefinedVariable" line="3" assertions="1">
+  <testsuite name="somefile.php" failures="3" errors="0" tests="4">
+    <testcase name="somefile.php:3" classname="UndefinedVariable" assertions="1">
       <failure type="UndefinedVariable">message: Cannot find referenced variable $as_you
 type: UndefinedVariable
 snippet: return $as_you . "type";
@@ -516,7 +516,7 @@ column_from: 10
 column_to: 17
 </failure>
     </testcase>
-    <testcase name="somefile.php:2" file="somefile.php" class="MixedInferredReturnType" classname="MixedInferredReturnType" line="2" assertions="1">
+    <testcase name="somefile.php:2" classname="MixedInferredReturnType" assertions="1">
       <failure type="MixedInferredReturnType">message: Could not verify return type \'null|string\' for psalmCanVerify
 type: MixedInferredReturnType
 snippet: function psalmCanVerify(int $your_code): ?string {
@@ -526,7 +526,7 @@ column_from: 42
 column_to: 49
 </failure>
     </testcase>
-    <testcase name="somefile.php:7" file="somefile.php" class="UndefinedConstant" classname="UndefinedConstant" line="7" assertions="1">
+    <testcase name="somefile.php:7" classname="UndefinedConstant" assertions="1">
       <failure type="UndefinedConstant">message: Const CHANGE_ME is not defined
 type: UndefinedConstant
 snippet: echo CHANGE_ME;
@@ -536,7 +536,7 @@ column_from: 6
 column_to: 15
 </failure>
     </testcase>
-    <testcase name="somefile.php:15" file="somefile.php" class="PossiblyUndefinedGlobalVariable" classname="PossiblyUndefinedGlobalVariable" line="15" assertions="1">
+    <testcase name="somefile.php:15" classname="PossiblyUndefinedGlobalVariable" assertions="1">
       <failure type="PossiblyUndefinedGlobalVariable">message: Possibly undefined global variable $a, first seen on line 10
 type: PossiblyUndefinedGlobalVariable
 snippet: echo $a

--- a/tests/junit.xsd
+++ b/tests/junit.xsd
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+ Source: https://svn.jenkins-ci.org/trunk/hudson/dtkit/dtkit-format/dtkit-junit-model/src/main/resources/com/thalesgroup/dtkit/junit/model/xsd/junit-4.xsd
+
+ This file available under the terms of the MIT License as follows:
+
+ *******************************************************************************
+ * Copyright (c) 2010 Thales Corporate Services SAS                             *
+ *                                                                              *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy *
+ * of this software and associated documentation files (the "Software"), to deal*
+ * in the Software without restriction, including without limitation the rights *
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell    *
+ * copies of the Software, and to permit persons to whom the Software is        *
+ * furnished to do so, subject to the following conditions:                     *
+ *                                                                              *
+ * The above copyright notice and this permission notice shall be included in   *
+ * all copies or substantial portions of the Software.                          *
+ *                                                                              *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR   *
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,     *
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE  *
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER       *
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,*
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN    *
+ * THE SOFTWARE.                                                                *
+ ********************************************************************************
+ -->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+    <xs:element name="failure">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="error">
+        <xs:complexType mixed="true">
+            <xs:attribute name="type" type="xs:string" use="optional"/>
+            <xs:attribute name="message" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="properties">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="property" maxOccurs="unbounded"/>
+            </xs:sequence>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="property">
+        <xs:complexType>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="value" type="xs:string" use="required"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="skipped" type="xs:string"/>
+    <xs:element name="system-err" type="xs:string"/>
+    <xs:element name="system-out" type="xs:string"/>
+
+    <xs:element name="testcase">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="skipped" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="error" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="failure" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="assertions" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="classname" type="xs:string" use="optional"/>
+            <xs:attribute name="status" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuite">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="properties" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="testcase" minOccurs="0" maxOccurs="unbounded"/>
+                <xs:element ref="system-out" minOccurs="0" maxOccurs="1"/>
+                <xs:element ref="system-err" minOccurs="0" maxOccurs="1"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="required"/>
+            <xs:attribute name="tests" type="xs:string" use="required"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="skipped" type="xs:string" use="optional"/>
+            <xs:attribute name="timestamp" type="xs:string" use="optional"/>
+            <xs:attribute name="hostname" type="xs:string" use="optional"/>
+            <xs:attribute name="id" type="xs:string" use="optional"/>
+            <xs:attribute name="package" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+    <xs:element name="testsuites">
+        <xs:complexType>
+            <xs:sequence>
+                <xs:element ref="testsuite" minOccurs="0" maxOccurs="unbounded"/>
+            </xs:sequence>
+            <xs:attribute name="name" type="xs:string" use="optional"/>
+            <xs:attribute name="time" type="xs:string" use="optional"/>
+            <xs:attribute name="tests" type="xs:string" use="optional"/>
+            <xs:attribute name="failures" type="xs:string" use="optional"/>
+            <xs:attribute name="disabled" type="xs:string" use="optional"/>
+            <xs:attribute name="errors" type="xs:string" use="optional"/>
+        </xs:complexType>
+    </xs:element>
+
+
+</xs:schema>


### PR DESCRIPTION
This fixes the junit report validation issues from #2748 by removing/renaming everything the xsd said is invalid.
The unit test has been updated to validate the output against the junit xsd file to ensure the report is valid.
Info level issues are changed to a skipped element from a failure element to be more accurate.
Code snippets and issue messages are XML encoded.
The junit xsd was checked in as tests/junit.xsd
