### PR TITLE
Ignore exceptions already caught by previous catch

### DIFF
--- a/tests/ThrowsAnnotationTest.php
+++ b/tests/ThrowsAnnotationTest.php
@@ -656,4 +656,31 @@ class ThrowsAnnotationTest extends TestCase
 
         $this->analyzeFile('somefile.php', $context);
     }
+
+    public function testNextCatchShouldIgnoreExceptionsCaughtByPreviousCatch(): void
+    {
+        Config::getInstance()->check_for_throws_docblock = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                /**
+                 * @throws \RuntimeException
+                 */
+                function method(): void
+                {
+                    try {
+                        throw new \LogicException();
+                    } catch (\LogicException $e) {
+                        throw new \RuntimeException();
+                    } catch (\Exception $e) {
+                        throw new \RuntimeException();
+                    }
+                }'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
 }


### PR DESCRIPTION
Psalm incorrectly infers thrown exceptions in case of multiple `catch` sections.

If an exception from `try {}` context can be caught by previous `catch`, Psalm still tries to handle it by the next `catch`, as a result `MissingThrowsDocblock` issued.
Expecting that already caught exception won't appear in possible thrown exceptions of the next catch context, since it's an unreachable state.
Additionally, `$catch_context` should not inherit possibly thrown exceptions of the `$original_context`, it should either rethrow catched exception or suppress them, so only newly analyzed exceptions should be merged to current `$context`.

https://psalm.dev/r/200055ea8e