### PR TITLE
Initial inferred Closure Returns

### DIFF
--- a/src/Psalm/Internal/MethodIdentifier.php
+++ b/src/Psalm/Internal/MethodIdentifier.php
@@ -17,6 +17,32 @@ class MethodIdentifier
         $this->method_name = $method_name;
     }
 
+    /**
+     * Takes any valid reference to a method id and converts
+     * it into a MethodIdentifier
+     * @param string|MethodIdentifier $method_id
+     */
+    public static function wrap($method_id): self
+    {
+        return \is_string($method_id) ? static::fromMethodIdReference($method_id) : $method_id;
+    }
+
+    public static function isValidMethodIdReference(string $method_id): bool
+    {
+        return \strpos($method_id, '::') !== false;
+    }
+
+    public static function fromMethodIdReference(string $method_id): self
+    {
+        if (!static::isValidMethodIdReference($method_id)) {
+            throw new \InvalidArgumentException('Invalid method id reference provided: ' . $method_id);
+        }
+        // remove trailing backslash if it exists
+        $method_id = \preg_replace('/^\\\\/', '', $method_id);
+        $method_id_parts = \explode('::', $method_id);
+        return new static($method_id_parts[0], \strtolower($method_id_parts[1]));
+    }
+
     /** @return string */
     public function __toString()
     {


### PR DESCRIPTION
- Added detection for when we can infer
  closure types from parent fn return types
- Implemented functionality for infering types of
  returned closures
- Added ability to infer type of return from typed
  closures
- Added a new getFunctionLikeStorage method in
  Codebase to support easily getting a function
  despite being a method, closure, or function
- Added some utilities to the MethodIdentifier
  to facilitate creating MethodIdentifier's from
  string method references

Closes #2896

Signed-off-by: RJ Garcia <rj@bighead.net>