### PR TITLE
WIP: Infer re-thrown exception type

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
@@ -255,6 +255,8 @@ class TryAnalyzer
                 $fq_catch_classes[] = $fq_catch_class;
             }
 
+            $possibly_catch_var_classes = [];
+
             if ($catch_context->collect_exceptions) {
                 foreach ($fq_catch_classes as $fq_catch_class) {
                     $fq_catch_class_lower = strtolower($fq_catch_class);
@@ -268,6 +270,8 @@ class TryAnalyzer
                             || ($codebase->interfaceExists($exception_fqcln)
                                 && $codebase->interfaceExtends($exception_fqcln, $fq_catch_class))
                         ) {
+                            $possibly_catch_var_classes[] = $exception_fqcln;
+
                             unset($original_context->possibly_thrown_exceptions[$exception_fqcln]);
                             unset($context->possibly_thrown_exceptions[$exception_fqcln]);
                             unset($catch_context->possibly_thrown_exceptions[$exception_fqcln]);
@@ -279,6 +283,8 @@ class TryAnalyzer
                  * @var array<string, array<array-key, CodeLocation>>
                  */
                 $catch_context->possibly_thrown_exceptions = [];
+            } else {
+                $possibly_catch_var_classes = $fq_catch_classes;
             }
 
             $catch_var_id = '$' . $catch_var_name;
@@ -302,7 +308,7 @@ class TryAnalyzer
 
                         return $catch_class_type;
                     },
-                    $fq_catch_classes
+                    $possibly_catch_var_classes
                 )
             );
 

--- a/tests/ThrowsAnnotationTest.php
+++ b/tests/ThrowsAnnotationTest.php
@@ -683,4 +683,50 @@ class ThrowsAnnotationTest extends TestCase
 
         $this->analyzeFile('somefile.php', $context);
     }
+
+    public function testInferRethrownExceptionType(): void
+    {
+        Config::getInstance()->check_for_throws_docblock = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                /**
+                 * @throws \DomainException
+                 */
+                function method(): void
+                {
+                    try {
+                        throw new \DomainException();
+                    } catch (\Throwable $e) {
+                        throw $e;
+                    }
+                }'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
+    public function testIgnoreImpossibleRethrownException(): void
+    {
+        Config::getInstance()->check_for_throws_docblock = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                function method(): void
+                {
+                    try {
+                    } catch (\Throwable $e) {
+                        throw $e;
+                    }
+                }'
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
 }


### PR DESCRIPTION
Sometimes it's useful to write catch-all statement to handle all exceptions and re-throw them, for example in logging:
```
try {
    method();
} catch (\Throwable $e) {
    // log exception
    throw $e;
}
```

In that case we don't change the type of the re-thrown exception, so there is no need to require for handling base exception type because it will never be thrown inside `try` section.

https://psalm.dev/r/900c99cab3
