### PR TITLE
Fix #2914 - falsable functions who only expect to return true now produce errors

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -397,7 +397,7 @@ class ReturnAnalyzer
                     if (!$stmt_type->ignore_falsable_issues
                         && $inferred_type->isFalsable()
                         && !$local_return_type->isFalsable()
-                        && !$local_return_type->hasBool()
+                        && (!$local_return_type->hasBool() || $local_return_type->isTrue())
                         && !$local_return_type->hasScalar()
                     ) {
                         if (IssueBuffer::accepts(

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1001,6 +1001,14 @@ class Union
     /**
      * @return bool
      */
+    public function isTrue()
+    {
+        return count($this->types) === 1 && isset($this->types['true']);
+    }
+
+    /**
+     * @return bool
+     */
     public function isVoid()
     {
         return isset($this->types['void']);

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1108,6 +1108,20 @@ class AnnotationTest extends TestCase
                         return ["a" => 1, "b" => "two"];
                     }'
             ],
+            'falsableFunctionAllowedWhenBooleanExpected' => [
+                '<?php
+
+                    /** @psalm-return bool */
+                    function alwaysFalse1()
+                    {
+                        return false;
+                    }
+
+                    function alwaysFalse2(): bool
+                    {
+                        return false;
+                    }'
+            ],
         ];
     }
 
@@ -1604,6 +1618,26 @@ class AnnotationTest extends TestCase
                      */
                     function f($reference) {}',
                 'error_message' => 'MissingDocblockType',
+            ],
+            'canNeverReturnDeclaredType' => [
+                '<?php
+
+                    /** @psalm-return false */
+                    function alwaysFalse() : bool
+                    {
+                        return true;
+                    }',
+                'error_message' => 'InvalidReturnStatement - src' . DIRECTORY_SEPARATOR . 'somefile.php:6:32',
+            ],
+            'falsableWithExpectedTypeTrue' => [
+                '<?php
+
+                    /** @psalm-return true */
+                    function alwaysFalse()
+                    {
+                        return false;
+                    }',
+                'error_message' => 'FalsableReturnStatement - src' . DIRECTORY_SEPARATOR . 'somefile.php:6:32',
             ],
         ];
     }


### PR DESCRIPTION
```php
<?php

/** @psalm-return true */
function alwaysFalse()
{
    return false;
}
```

will now output a `FalsableReturnStatement` error