### PR TITLE
Improve parse_url() return type

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ParseUrlReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ParseUrlReturnTypeProvider.php
@@ -112,28 +112,30 @@ class ParseUrlReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTyp
             return $nullable_string_or_int;
         }
 
-        $component_key_type = new Type\Union([
-            new Type\Atomic\TLiteralString('scheme'),
-            new Type\Atomic\TLiteralString('user'),
-            new Type\Atomic\TLiteralString('pass'),
-            new Type\Atomic\TLiteralString('host'),
-            new Type\Atomic\TLiteralString('port'),
-            new Type\Atomic\TLiteralString('path'),
-            new Type\Atomic\TLiteralString('query'),
-            new Type\Atomic\TLiteralString('fragment'),
-        ]);
+        $component_types = [
+            'scheme' => Type::getString(),
+            'user' => Type::getString(),
+            'pass' => Type::getString(),
+            'host' => Type::getString(),
+            'port' => Type::getInt(),
+            'path' => Type::getString(),
+            'query' => Type::getString(),
+            'fragment' => Type::getString(),
+        ];
 
-        $nullable_string_or_int = new Type\Union([
-            new Type\Atomic\TArray([$component_key_type, Type::getMixed()]),
-            new Type\Atomic\TFalse,
-        ]);
-
-        $codebase = $statements_source->getCodebase();
-
-        if ($codebase->config->ignore_internal_falsable_issues) {
-            $nullable_string_or_int->ignore_falsable_issues = true;
+        foreach ($component_types as $component_type) {
+            $component_type->possibly_undefined = true;
         }
 
-        return $nullable_string_or_int;
+        $return_type = new Type\Union([
+            new Type\Atomic\ObjectLike($component_types),
+            new Type\Atomic\TFalse(),
+        ]);
+
+        if ($statements_source->getCodebase()->config->ignore_internal_falsable_issues) {
+            $return_type->ignore_falsable_issues = true;
+        }
+
+        return $return_type;
     }
 }

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -544,33 +544,10 @@ class FunctionCallTest extends TestCase
                         return parse_url($s)["host"] ?? "";
                     }
 
-                    function bar(string $s) : string {
-                        $parsed = parse_url($s);
-
-                        return $parsed["host"];
-                    }
-
-                    function baz(string $s) : string {
-                        $parsed = parse_url($s);
-
-                        return $parsed["host"];
-                    }
-
-                    function bag(string $s) : string {
-                        $parsed = parse_url($s);
-
-                        if (is_string($parsed["host"] ?? false)) {
-                            return $parsed["host"];
-                        }
-
-                        return "";
-                    }
-
-
                     function hereisanotherone(string $s) : string {
                         $parsed = parse_url($s);
 
-                        if (isset($parsed["host"]) && is_string($parsed["host"])) {
+                        if (isset($parsed["host"])) {
                             return $parsed["host"];
                         }
 
@@ -580,7 +557,7 @@ class FunctionCallTest extends TestCase
                     function hereisthelastone(string $s) : string {
                         $parsed = parse_url($s);
 
-                        if (isset($parsed["host"]) && is_string($parsed["host"])) {
+                        if (isset($parsed["host"])) {
                             return $parsed["host"];
                         }
 
@@ -630,6 +607,30 @@ class FunctionCallTest extends TestCase
 
                         return "";
                     }',
+            ],
+            'parseUrlTypes' => [
+                '<?php
+                    $url = "foo";
+                    $components = parse_url($url);
+                    $scheme = parse_url($url, PHP_URL_SCHEME);
+                    $host = parse_url($url, PHP_URL_HOST);
+                    $port = parse_url($url, PHP_URL_PORT);
+                    $user = parse_url($url, PHP_URL_USER);
+                    $pass = parse_url($url, PHP_URL_PASS);
+                    $path = parse_url($url, PHP_URL_PATH);
+                    $query = parse_url($url, PHP_URL_QUERY);
+                    $fragment = parse_url($url, PHP_URL_FRAGMENT);',
+                'assertions' => [
+                    '$components' => 'array{fragment?: string, host?: string, pass?: string, path?: string, port?: int, query?: string, scheme?: string, user?: string}|false',
+                    '$scheme' => 'null|string',
+                    '$host' => 'null|string',
+                    '$port' => 'int|null',
+                    '$user' => 'null|string',
+                    '$pass' => 'null|string',
+                    '$path' => 'null|string',
+                    '$query' => 'null|string',
+                    '$fragment' => 'null|string',
+                ],
             ],
             'triggerUserError' => [
                 '<?php
@@ -1709,6 +1710,28 @@ class FunctionCallTest extends TestCase
                         || (\is_array($loop_callback)
                             && !\method_exists(...$loop_callback));',
                 'error_message' => 'UndefinedGlobalVariable'
+            ],
+            'parseUrlPossiblyUndefined' => [
+                '<?php
+                    function bar(string $s) : string {
+                        $parsed = parse_url($s);
+
+                        return $parsed["host"];
+                    }',
+                'error_message' => 'PossiblyUndefinedArrayOffset',
+            ],
+            'parseUrlPossiblyUndefined2' => [
+                '<?php
+                    function bag(string $s) : string {
+                        $parsed = parse_url($s);
+
+                        if (is_string($parsed["host"] ?? false)) {
+                            return $parsed["host"];
+                        }
+
+                        return "";
+                    }',
+                'error_message' => 'PossiblyUndefinedArrayOffset',
             ],
         ];
     }


### PR DESCRIPTION
This PR changes the return type of `parse_url()` with a single argument.

Current:
```
array<'fragment'|'host'|'pass'|'path'|'port'|'query'|'scheme'|'user', mixed>|false
````

New:
```
array{
    fragment?: string,
    host?: string,
    pass?: string,
    path?: string,
    port?: int,
    query?: string,
    scheme?: string,
    user?: string
}|false
```

This allows the specific key types to be inferred. Currently they're all mixed.
