### PR TITLE
Added tests for docblock breaking CRLF 

### DIFF
--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -183,7 +183,7 @@ class DocComment
         $docblock = $docblock->getText();
 
         // Strip off comments.
-        $docblock = trim($docblock);
+        $docblock = str_replace("\r", '', trim($docblock));
 
         $docblock = preg_replace('@^/\*\*@', '', $docblock);
         $docblock = preg_replace('@\*\*?/$@', '', $docblock);
@@ -197,7 +197,7 @@ class DocComment
         foreach ($lines as $k => $line) {
             if (preg_match('/^[ \t]*\*?\s?@\w/i', $line)) {
                 $last = $k;
-            } elseif (preg_match('/^\s*\r?$/', $line)) {
+            } elseif (preg_match('/^\s*$/', $line)) {
                 $last = false;
             } elseif ($last !== false) {
                 $old_last_line = $lines[$last];
@@ -210,10 +210,6 @@ class DocComment
         $line_offset = 0;
 
         foreach ($lines as $line) {
-            $original_line_length = strlen($line);
-
-            $line = str_replace("\r", '', $line);
-
             if (preg_match('/^[ \t]*\*?\s?@([\w\-:]+)[\t ]*(.*)$/sm', $line, $matches, PREG_OFFSET_CAPTURE)) {
                 /** @var array<int, array{string, int}> $matches */
                 list($full_match_info, $type_info, $data_info) = $matches;
@@ -237,7 +233,7 @@ class DocComment
                 $special[$type][$data_offset + 3] = $data;
             }
 
-            $line_offset += $original_line_length + 1;
+            $line_offset += strlen($line) + 1;
         }
 
         $docblock = str_replace("\t", '  ', $docblock);

--- a/tests/DocComment/LinebreakTest.php
+++ b/tests/DocComment/LinebreakTest.php
@@ -2,6 +2,8 @@
 namespace Psalm\Tests\Config;
 
 use Psalm\DocComment;
+use function str_replace;
+use function current;
 
 class LinebreakTest extends \Psalm\Tests\TestCase
 {

--- a/tests/DocComment/LinebreakTest.php
+++ b/tests/DocComment/LinebreakTest.php
@@ -1,0 +1,25 @@
+<?php
+namespace Psalm\Tests\Config;
+
+use Psalm\DocComment;
+
+class LinebreakTest extends \Psalm\Tests\TestCase
+{
+    public function testCarriageReturnIsIgnoredInParameters()
+    {
+        $comment = <<<COMMENT
+/**
+ * @param string|null \$bla
+ * @return array{
+ *          0: \Some\Weird\Space\A|null,
+ *          1: null
+ *          }
+ */
+COMMENT;
+
+        $doc = new \PhpParser\Comment\Doc(str_replace("\n", "\r\n", $comment));
+        $return = DocComment::parsePreservingLength($doc);
+
+        $this->assertSame('string|null $bla', current($return['specials']['param']));
+    }
+}

--- a/tests/DocComment/LinebreakTest.php
+++ b/tests/DocComment/LinebreakTest.php
@@ -5,7 +5,7 @@ use Psalm\DocComment;
 
 class LinebreakTest extends \Psalm\Tests\TestCase
 {
-    public function testCarriageReturnIsIgnoredInParameters()
+    public function testCarriageReturnIsIgnoredInParameters(): void
     {
         $comment = <<<COMMENT
 /**

--- a/tests/DocComment/LinebreakTest.php
+++ b/tests/DocComment/LinebreakTest.php
@@ -7,6 +7,24 @@ use function current;
 
 class LinebreakTest extends \Psalm\Tests\TestCase
 {
+    public function testParameterIsRecognizedWithoutCarriageReturn(): void
+    {
+        $comment = <<<COMMENT
+/**
+ * @param string|null \$bla
+ * @return array{
+ *          0: \Some\Weird\Space\A|null,
+ *          1: null
+ *          }
+ */
+COMMENT;
+
+        $doc = new \PhpParser\Comment\Doc($comment);
+        $return = DocComment::parsePreservingLength($doc);
+
+        $this->assertSame('string|null $bla', current($return['specials']['param']));
+    }
+
     public function testCarriageReturnIsIgnoredInParameters(): void
     {
         $comment = <<<COMMENT
@@ -23,5 +41,51 @@ COMMENT;
         $return = DocComment::parsePreservingLength($doc);
 
         $this->assertSame('string|null $bla', current($return['specials']['param']));
+    }
+
+    public function testDescriptionIsRecognizedWithoutCarriageReturn(): void
+    {
+        $description = <<<DESC
+This is the description with
+* some breaks
+*
+* and even empty lines in between
+*
+DESC;
+
+        $comment = <<<COMMENT
+/**
+ $description
+ * @param string|null \$bla
+ */
+COMMENT;
+
+        $doc = new \PhpParser\Comment\Doc($comment);
+        $return = DocComment::parsePreservingLength($doc);
+
+        $this->assertSame($description, $return['description']);
+    }
+
+    public function testCarriageReturnIsIgnoredInDescription(): void
+    {
+        $description = <<<DESC
+This is the description with
+* some breaks
+*
+* and even empty lines in between
+*
+DESC;
+
+        $comment = <<<COMMENT
+/**
+ $description
+ * @param string|null \$bla
+ */
+COMMENT;
+
+        $doc = new \PhpParser\Comment\Doc(str_replace("\n", "\r\n", $comment));
+        $return = DocComment::parsePreservingLength($doc);
+
+        $this->assertSame($description, $return['description']);
     }
 }


### PR DESCRIPTION
I went ahead and added some tests for the fix that was provided to #2953 in 3cf5621. 

Doing this, I noticed that the description was not parsed properly as well, which is why I went ahead and refactored the "ignorance" to a more drastric approach by just removing all carriage returns in the very beginning.

@muglug This lead to me reverting what you did in 3cf5621. I reckon that this way the lower code part never knows of the carriage return in the first place and therefore the foreach does not get the "wrong `$line_offset `" since it never knows of a different length including the `\r` to begin with - would you agree?