### PR TITLE
`ignoreInternalFunctionFalseReturn` default to false in XSD, but docu…

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -220,7 +220,7 @@ When `true`, Psalm will check that the developer has caught every exception in g
   ignoreInternalFunctionFalseReturn="[bool]"
 >
 ```
-When `true`, Psalm ignores possibly-false issues stemming from return values of internal functions (like `preg_split`) that may return false, but do so rarely). Defaults to `true`.
+When `true`, Psalm ignores possibly-false issues stemming from return values of internal functions (like `preg_split`) that may return false, but do so rarely). Defaults to `false`.
 
 #### ignoreInternalFunctionNullReturn
 


### PR DESCRIPTION
See https://github.com/vimeo/psalm/blob/27598f508ee44911e89305da0c76fb90e9d9b5e4/config.xsd#L46