### PR TITLE
Removed unused function use since we are not in a namespace here.

### DIFF
--- a/src/psalter.php
+++ b/src/psalter.php
@@ -6,7 +6,6 @@ use Psalm\Config;
 use Psalm\IssueBuffer;
 use Psalm\Progress\DebugProgress;
 use Psalm\Progress\DefaultProgress;
-use function getMemoryLimitInBytes;
 
 // show all errors
 error_reporting(-1);


### PR DESCRIPTION
Currently, when running psalter, it gives a PHP warning:

```
kolja@DESKTOP-C9MTQRH:/mnt/c/Users/Kolja/PhpstormProjects/psalm$ ./psalter
PHP Warning:  The use statement with non-compound name 'getMemoryLimitInBytes' has no effect in /mnt/c/Users/Kolja/PhpstormProjects/psalm/src/psalter.php on line 9
Please specify the issues you want to fix with --issues=IssueOne,IssueTwo or --issues=all, or provide a plugin that has its own manipulations with --plugin=path/to/plugin.php
```

Which is also true since we are not in a namespace here so the use statement for the function does not really make sense. 

Yes, I added this myself and a colleague of me noticed it - shame on me ;) 

Maybe it is a good idea to add CI for psalter in the long run.