### PR TITLE
use file contents intead of filemtime to detect changed files

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -972,12 +972,16 @@ class ProjectAnalyzer
 
         $diff_files = [];
 
+        $last_good_run = $this->parser_cache_provider->getLastGoodRun();
+
         $file_paths = $this->file_provider->getFilesInDir($dir_name, $file_extensions);
 
         foreach ($file_paths as $file_path) {
             if ($config->isInProjectDirs($file_path)) {
-                if ($this->parser_cache_provider->loadExistingFileContentsFromCache($file_path)
-                    !== $this->file_provider->getContents($file_path)) {
+                if ($this->file_provider->getModifiedTime($file_path) > $last_good_run
+                    && $this->parser_cache_provider->loadExistingFileContentsFromCache($file_path)
+                        !== $this->file_provider->getContents($file_path)
+                ) {
                     $diff_files[] = $file_path;
                 }
             }

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -972,13 +972,12 @@ class ProjectAnalyzer
 
         $diff_files = [];
 
-        $last_good_run = $this->parser_cache_provider->getLastGoodRun();
-
         $file_paths = $this->file_provider->getFilesInDir($dir_name, $file_extensions);
 
         foreach ($file_paths as $file_path) {
             if ($config->isInProjectDirs($file_path)) {
-                if ($this->file_provider->getModifiedTime($file_path) > $last_good_run) {
+                if ($this->parser_cache_provider->loadExistingFileContentsFromCache($file_path)
+                    !== $this->file_provider->getContents($file_path)) {
                     $diff_files[] = $file_path;
                 }
             }


### PR DESCRIPTION
This allows `--diff` to be used in CI systems, when saving and restoring a cache.
`git checkout` does not retain filemtimes, so diff never worked.

Can you help me understand why the whole file content is kept in cache? it seems that a file hash would be sufficient here?