### PR TITLE
Add \Error stub

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreImmutableClasses.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreImmutableClasses.phpstub
@@ -77,3 +77,57 @@ class Exception implements Throwable
      */
     public final function getLine(){}
 }
+
+class Error implements Throwable
+{
+    /**
+     * @var string
+     */
+    protected $message = '';
+
+    /**
+     * @var int
+     */
+    protected $code = 0;
+
+    /**
+     * @var string
+     */
+    protected $file = '';
+
+    /**
+     * @var int
+     */
+    protected $line = 0;
+
+    /**
+     * @psalm-external-mutation-free
+     * @param string $message
+     * @param int $code
+     * @param Throwable $previous
+     */
+    public function __construct($message = "", $code = 0, Throwable $previous = null) {}
+
+    /**
+     * @psalm-mutation-free
+     */
+    public final function getMessage() : string {}
+
+    /**
+     * @psalm-mutation-free
+     * @return int|string
+     */
+    public final function getCode(){}
+
+    /**
+     * @psalm-mutation-free
+     * @return string
+     */
+    public final function getFile(){}
+
+    /**
+     * @psalm-mutation-free
+     * @return int
+     */
+    public final function getLine(){}
+}


### PR DESCRIPTION
Otherwise, errors are generated if \Error is extended: https://psalm.dev/r/8169465beb