### PR TITLE
Allow netresearch/jsonmapper ^2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "composer/xdebug-handler": "^1.1",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
         "felixfbecker/language-server-protocol": "^1.4",
-        "netresearch/jsonmapper": "^1.0",
+        "netresearch/jsonmapper": "^1.0 || ^2.0",
         "nikic/php-parser": "^4.3",
         "ocramius/package-versions": "^1.2",
         "openlss/lib-array2xml": "^1.0",


### PR DESCRIPTION
The bumping major in the library is because of [Make "createInstance" protected instead of public](https://github.com/cweiske/jsonmapper/blob/v2.0.0/ChangeLog#L5).