### PR TITLE
Support intersection types for object-like arrays

### DIFF
--- a/docs/annotating_code/type_syntax/intersection_types.md
+++ b/docs/annotating_code/type_syntax/intersection_types.md
@@ -10,4 +10,23 @@ $hare = $this->createMock(Hare::class);
 ```
 `$hare` will be an instance of a class that extends `Hare`, and implements `\PHPUnit\Framework\MockObject\MockObject`. So
 `$hare` is typed as `Hare&\PHPUnit\Framework\MockObject\MockObject`. You can use this syntax whenever a value is
-required to implement multiple interfaces. Only *object types* may be used within an intersection.
+required to implement multiple interfaces.
+
+Another use case is being able to merge object-like arrays:
+```php
+/**
+ * @psalm-type A=array{a: int}
+ * @psalm-type B=array{b: int}
+ *
+ * @param A $a
+ * @param B $b
+ *
+ * @return A&B
+ */
+function foo($a, $b) {
+    return $a + $b;
+}
+```
+The returned type will contain the properties of both `A` and `B`. In other words, it will be `{a: int, b: int}`.
+
+Intersections are only valid for lists of only *object types* and lists of only *object-like arrays*.

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -754,6 +754,7 @@ class CommentAnalyzer
         Aliases $aliases
     ) {
         $parsed_docblock = DocComment::parsePreservingLength($comment);
+        $codebase = ProjectAnalyzer::getInstance()->getCodebase();
 
         $info = new ClassLikeDocblockComment();
 
@@ -1012,7 +1013,10 @@ class CommentAnalyzer
                 }
 
                 if ($method_tree instanceof ParseTree\MethodWithReturnTypeTree) {
-                    $docblock_lines[] = '@return ' . Type::getTypeFromTree($method_tree->children[1]);
+                    $docblock_lines[] = '@return ' . Type::getTypeFromTree(
+                        $method_tree->children[1],
+                        $codebase
+                    );
                     $method_tree = $method_tree->children[0];
                 }
 
@@ -1034,7 +1038,7 @@ class CommentAnalyzer
 
 
                     if ($method_tree_child->children) {
-                        $param_type = Type::getTypeFromTree($method_tree_child->children[0]);
+                        $param_type = Type::getTypeFromTree($method_tree_child->children[0], $codebase);
                         $docblock_lines[] = '@param \\' . $param_type . ' '
                             . ($method_tree_child->variadic ? '...' : '')
                             . $method_tree_child->name;

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -216,6 +216,66 @@ class TypeParseTest extends TestCase
         $this->assertSame('iterable<mixed, A>&iterable<mixed, B>', (string) Type::parseString('iterable<A>&iterable<B>'));
     }
 
+    /**
+     * @return void
+     */
+    public function testIntersectionOfObjectLike()
+    {
+        $this->assertSame('array{a: int, b: int}', (string) Type::parseString('array{a: int}&array{b: int}'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntersectionOfObjectLikeWithMergedProperties()
+    {
+        $this->assertSame('array{a: int}', (string) Type::parseString('array{a: int}&array{a: mixed}'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntersectionOfObjectLikeWithPossiblyUndefinedMergedProperties()
+    {
+        $this->assertSame('array{a: int}', (string) Type::parseString('array{a: int}&array{a?: int}'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntersectionOfObjectLikeWithConflictingProperties()
+    {
+        $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
+        Type::parseString('array{a: string}&array{a: int}');
+    }
+
+    /**
+     * @return void
+     */
+    public function testUnionOfIntersectionOfObjectLike()
+    {
+        $this->assertSame('array{a: int|string, b?: int}', (string) Type::parseString('array{a: int}|array{a: string}&array{b: int}'));
+        $this->assertSame('array{a: int|string, b?: int}', (string) Type::parseString('array{b: int}&array{a: string}|array{a: int}'));
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntersectionOfUnionOfObjectLike()
+    {
+        $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
+        Type::parseString('array{a: int}&array{a: string}|array{b: int}');
+    }
+
+    /**
+     * @return void
+     */
+    public function testIntersectionOfObjectLikeAndObject()
+    {
+        $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
+        Type::parseString('array{a: int}&T1');
+    }
+
     public function testIterableContainingObjectLike() : void
     {
         $this->assertSame('iterable<string, array{0: int}>', Type::parseString('iterable<string, array{int}>')->getId());


### PR DESCRIPTION
This change allows expressing the intersection of multiple object-like
arrays. The resulting type will contain the (merged via intersection)
properties of all the object-like arrays involved in the intersection.

This should allow to express the resulting type of an `array_merge()`
operation, which is tricky to do in the context of a templated type.