### PR TITLE
ZipArchive::open() does not return resource

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -16542,7 +16542,7 @@ return [
 'ZipArchive::getStatusString' => ['string|false'],
 'ZipArchive::getStream' => ['resource|false', 'entryname'=>'string'],
 'ZipArchive::locateName' => ['int|false', 'filename'=>'string', 'flags='=>'int'],
-'ZipArchive::open' => ['resource|int|bool', 'source'=>'string', 'flags='=>'int'],
+'ZipArchive::open' => ['int|bool', 'source'=>'string', 'flags='=>'int'],
 'ZipArchive::renameIndex' => ['bool', 'index'=>'int', 'new_name'=>'string'],
 'ZipArchive::renameName' => ['bool', 'name'=>'string', 'new_name'=>'string'],
 'ZipArchive::setArchiveComment' => ['bool', 'comment'=>'string'],


### PR DESCRIPTION
I think https://github.com/vimeo/psalm/pull/3046 accidentally added `ZipArchive::open()` to return `resource`, which is against what the original pull request description said.

Source: https://github.com/php/php-src/blob/php-7.4.4/ext/zip/php_zip.c#L1431
Manual: https://www.php.net/manual/en/ziparchive.open.php
Playground: https://psalm.dev/r/e76cb4e762