### PR TITLE
Fix maxStringLength handling

### DIFF
--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -1645,9 +1645,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
                 ) {
                     $result = $left->getSingleStringLiteral()->value . $right->getSingleStringLiteral()->value;
 
-                    if (strlen($result) < 50) {
-                        return Type::getString($result);
-                    }
+                    return Type::getString($result);
                 }
 
                 return Type::getString();
@@ -1823,7 +1821,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
         }
 
         if ($stmt instanceof PhpParser\Node\Scalar\String_) {
-            return Type::getString(strlen($stmt->value) < 30 ? $stmt->value : null);
+            return Type::getString($stmt->value);
         }
 
         if ($stmt instanceof PhpParser\Node\Scalar\LNumber) {


### PR DESCRIPTION
There was some hard limits defined in StatementsAnalyzer (30 for strings and 50 for concat), but Type::getString already respects maxStringLength in config so there is no need to additional checks.

This fix comes from developing SQL parsing plugin. I plan to infer `PDOStatement::fetch` return types via parsing SQL query. Also I found config variable `parseSql`. What is it intended for? I haven't found any usages...