### PR TITLE
Do not reconcile outer_vars after analyzing If if there is continue inside

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
@@ -900,7 +900,8 @@ class IfAnalyzer
             }
         }
 
-        if ($has_leaving_statements && !$has_break_statement && !$stmt->else && !$stmt->elseifs) {
+        if ($has_leaving_statements && !$has_break_statement && !$has_continue_statement
+            && !$stmt->else && !$stmt->elseifs) {
             if ($if_scope->negated_types) {
                 $changed_var_ids = [];
 

--- a/tests/Loop/ForTest.php
+++ b/tests/Loop/ForTest.php
@@ -117,6 +117,28 @@ class ForTest extends \Psalm\Tests\TestCase
 
                     echo $i * $j;'
             ],
+            'forLoopWithSkippingFirst' => [
+                '<?php
+                    for ($i = 0; $i < 2; $i++) {
+                        if ($i === 0) {
+                            continue;
+                        }
+                    }'
+            ],
+            'forLoopWithSkippingAlways' => [
+                '<?php
+                    /**
+                     * @param list<string|null> $arr
+                     */
+                    function test($arr): void {
+                        for ($i = 0; $i < 2; $i++) {
+                            if ($arr[$i] === null) {
+                                continue;
+                            }
+                            echo strlen($arr[$i]);
+                        }
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
https://psalm.dev/r/2e491782ca

any other comparison works good, but in that case it fails.

I have tried to fix it by myself, but I'm not sure if I have done it right. I have added some tests. and there was no new failing tests, but I'm still insecure about that change.