### PR TITLE
Fix syntax error (#3089)

### DIFF
--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -1768,7 +1768,7 @@ abstract class Type
                             if (TypeAnalyzer::isAtomicContainedBy(
                                 $codebase,
                                 $type_2_atomic,
-                                $type_1_atomic,
+                                $type_1_atomic
                             )) {
                                 $combined_type->removeType($t1_key);
                                 $combined_type->addType(clone $type_2_atomic);


### PR DESCRIPTION
Trailing comma in arguments list supported since PHP 7.3, minimal supported PHP version for psalm - 7.1

Fixes #3089 