### PR TITLE
Bump callmap version to 7.4

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -2,6 +2,9 @@
 namespace Phan\Language\Internal;
 
 /**
+ * CURRENT PHP TARGET VERSION: 7.4
+ * The version above have to match Psalm\Internal\Codebase\CallMap::PHP_(MAJOR|MINOR)_VERSION
+ *
  * Format
  *
  * '<function_name>' => ['<return_type>, '<arg_name>'=>'<arg_type>']

--- a/src/Psalm/Internal/Codebase/CallMap.php
+++ b/src/Psalm/Internal/Codebase/CallMap.php
@@ -24,7 +24,7 @@ use function version_compare;
 class CallMap
 {
     const PHP_MAJOR_VERSION = 7;
-    const PHP_MINOR_VERSION = 3;
+    const PHP_MINOR_VERSION = 4;
     const LOWEST_AVAILABLE_DELTA = 71;
 
     /**


### PR DESCRIPTION
The content of the callmap corresponds to 7.4, but internally the version was set to 7.3. This caused 7.4 delta to be ignored, and 7.4 types to be used for 7.3.