### PR TITLE
Suppress choco install progress

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,7 +29,7 @@ cache:
 ## Install PHP and composer, and run the appropriate composer command
 install:
     - IF EXIST c:\tools\php (SET PHP=0) # Checks for the PHP install being cached
-    - ps: appveyor-retry cinst --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
+    - ps: appveyor-retry cinst --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
     - appveyor DownloadFile https://curl.haxx.se/ca/cacert.pem -FileName C:\tools\php\cacert.pem
     - cd c:\tools\php
     - IF %PHP%==1 copy php.ini-production php.ini /Y


### PR DESCRIPTION
This should make appveyor logs much more readable. Currently they have thousands of lines like
```
Progress: Downloading php 7.4.3... 98%
Progress: Downloading php 7.4.3... 98%
Progress: Downloading php 7.4.3... 98%
```