### PR TITLE
@psalm-trace as a low-level issue

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -337,6 +337,7 @@
             <xs:element name="ReservedWord" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="StringIncrement" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TaintedInput" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="Trace" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TraitMethodSignatureMismatch" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TooFewArguments" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="TooManyArguments" type="ArgumentIssueHandlerType" minOccurs="0" />
@@ -359,6 +360,7 @@
             <xs:element name="UndefinedPropertyFetch" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedThisPropertyAssignment" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedThisPropertyFetch" type="PropertyIssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedTrace" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedTrait" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedGlobalVariable" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedVariable" type="IssueHandlerType" minOccurs="0" />

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -397,6 +397,8 @@ $username = $_GET['username']; // prints something like "test.php:4 $username: m
 
 ```
 
+*Note*: it throws [special low-level issue](../running_psalm/issues/Trace.md), so you have to set errorLevel to 1, override it in config or invoke Psalm with `--show-info=true`.
+
 ## Type Syntax
 
 Psalm supports PHPDoc’s [type syntax](https://docs.phpdoc.org/guides/types.html), and also the [proposed PHPDoc PSR type syntax](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types).

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -98,6 +98,8 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
  - [MixedStringOffsetAssignment](issues/MixedStringOffsetAssignment.md)
  - [MutableDependency](issues/MutableDependency.md)
  - [PossiblyNullOperand](issues/PossiblyNullOperand.md)
+ - [Trace](issues/Trace.md)
+ - [UndefinedTrace](issues/UndefinedTrace.md)
 
 ## Errors ignored at level 3 and higher
 

--- a/docs/running_psalm/issues/Trace.md
+++ b/docs/running_psalm/issues/Trace.md
@@ -1,0 +1,14 @@
+# Trace
+
+Not really an issue. Just reports type of the variable.
+
+```php
+<?php
+
+/** @psalm-trace $x */
+$x = getmypid();
+```
+
+## How to fix
+
+Use it for debugging purposes, not for production

--- a/docs/running_psalm/issues/UndefinedTrace.md
+++ b/docs/running_psalm/issues/UndefinedTrace.md
@@ -1,0 +1,14 @@
+# UndefinedTrace
+
+Attempt to trace an undefined variable
+
+```php
+<?php
+
+/** @psalm-trace $x */
+echo 'Hello World!';
+```
+
+## How to fix
+
+Provide existing variable or remove it

--- a/src/Psalm/Issue/Trace.php
+++ b/src/Psalm/Issue/Trace.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Psalm\Issue;
+
+class Trace extends CodeIssue
+{
+    const ERROR_LEVEL = 1;
+    const SHORTCODE = 224;
+}

--- a/src/Psalm/Issue/UndefinedTrace.php
+++ b/src/Psalm/Issue/UndefinedTrace.php
@@ -1,0 +1,10 @@
+<?php
+
+
+namespace Psalm\Issue;
+
+class UndefinedTrace extends CodeIssue
+{
+    const ERROR_LEVEL = 2;
+    const SHORTCODE = 225;
+}

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace Psalm\Tests;
+
+class TraceTest extends TestCase
+{
+    use Traits\InvalidCodeAnalysisTestTrait;
+
+    /**
+     * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
+     */
+    public function providerInvalidCodeParse()
+    {
+        return [
+            'traceVariable' => [
+                '<?php
+                    /** @psalm-trace $a */
+                    $a = getmypid();',
+                'error_message' => 'Trace',
+            ],
+            'undefinedTraceVariable' => [
+                '<?php
+                    /** @psalm-trace $b */
+                    echo 1;',
+                'error_message' => 'UndefinedTrace',
+                'error_levels' => [
+                    'MixedAssignment',
+                ],
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
`@psalm-trace` is now a specific low-level issue, because plain debug print [breaks structured output](https://github.com/vimeo/psalm/pull/3080#issuecomment-610264757)