### PR TITLE
Allow plain assertions (@psalm-assert) about $this (fixes #3105)

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -365,7 +365,8 @@ class MethodCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\
         ) {
             $keys_to_remove = [];
 
-            $class_type = clone $class_type;
+            // class_type might have changed via assertion, so we have to fetch it again from context
+            $class_type = clone $context->vars_in_scope[$lhs_var_id];
 
             foreach ($class_type->getAtomicTypes() as $key => $type) {
                 if (!$type instanceof TNamedObject) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -3670,6 +3670,8 @@ class CallAnalyzer
                 }
             } elseif (isset($context->vars_in_scope[$assertion->var_id])) {
                 $assertion_var_id = $assertion->var_id;
+            } elseif ($assertion->var_id === '$this' && !is_null($thisName)) {
+                $assertion_var_id = $thisName;
             } elseif (strpos($assertion->var_id, '$this->') === 0 && !is_null($thisName)) {
                 $assertion_var_id = $thisName . str_replace('$this->', '->', $assertion->var_id);
             }

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -457,6 +457,117 @@ class AssertAnnotationTest extends TestCase
                         }
                     }'
             ],
+            'assertThisTypeCombined' => [
+                '<?php
+                    class Type {
+                        /**
+                         * @psalm-assert FooType $this
+                         */
+                        public function assertFoo() : void {
+                            if (!$this instanceof FooType) {
+                                throw new \Exception();
+                            }
+                            return;
+                        }
+                        
+                        /**
+                         * @psalm-assert BarType $this
+                         */
+                        public function assertBar() : void {
+                            if (!$this instanceof BarType) {
+                                throw new \Exception();
+                            }
+                            return;
+                        }
+                    }
+
+                    interface FooType {
+                        public function foo(): void;
+                    }
+
+                    interface BarType {
+                        public function bar(): void;
+                    }
+
+                    function takesType(Type $t) : void {
+                        $t->assertFoo();
+                        $t->assertBar();
+                        $t->foo();
+                        $t->bar();
+                    }'
+            ],
+            'assertThisTypeSimpleCombined' => [
+                '<?php
+                    class Type {
+                        /**
+                         * @psalm-assert FooType $this
+                         */
+                        public function assertFoo() : void {
+                            if (!$this instanceof FooType) {
+                                throw new \Exception();
+                            }
+                            return;
+                        }
+                        
+                        /**
+                         * @psalm-assert BarType $this
+                         */
+                        public function assertBar() : void {
+                            if (!$this instanceof BarType) {
+                                throw new \Exception();
+                            }
+                            return;
+                        }
+                    }
+
+                    interface FooType {
+                        public function foo(): void;
+                    }
+
+                    interface BarType {
+                        public function bar(): void;
+                    }
+
+                    /** @param Type&FooType $t */
+                    function takesType(Type $t) : void {
+                        $t->assertBar();
+                        $t->foo();
+                        $t->bar();
+                    }'
+            ],
+            'assertThisTypeIfTrueCombined' => [
+                '<?php
+                    class Type {
+                        /**
+                         * @psalm-assert-if-true FooType $this
+                         */
+                        public function assertFoo() : bool {
+                            return $this instanceof FooType;
+                        }
+                        
+                        /**
+                         * @psalm-assert-if-true BarType $this
+                         */
+                        public function assertBar() : bool {
+                            return $this instanceof BarType;
+                        }
+                    }
+
+                    interface FooType {
+                        public function foo(): void;
+                    }
+
+                    interface BarType {
+                        public function bar(): void;
+                    }
+
+                    function takesType(Type $t) : void {
+                        if ($t->assertFoo() && $t->assertBar()) {
+                            $t->foo();
+                            $t->bar();
+                        }
+                    }'
+            ],
             'assertThisTypeSwitchTrue' => [
                 '<?php
                     class Type {

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -412,6 +412,30 @@ class AssertAnnotationTest extends TestCase
 
                     if (!is_int($a)) $a->bar();',
             ],
+            'assertThisType' => [
+                '<?php
+                    class Type {
+                        /**
+                         * @psalm-assert FooType $this
+                         */
+                        public function isFoo() : bool {
+                            if (!$this instanceof FooType) {
+                                throw new \Exception();
+                            }
+                            
+                            return true;
+                        }
+                    }
+
+                    class FooType extends Type {
+                        public function bar(): void {}
+                    }
+
+                    function takesType(Type $t) : void {
+                        $t->isFoo();
+                        $t->bar();
+                    }'
+            ],
             'assertThisTypeIfTrue' => [
                 '<?php
                     class Type {
@@ -1115,6 +1139,31 @@ class AssertAnnotationTest extends TestCase
                         if ($s === "c") {}
                     }',
                 'error_message' => 'DocblockTypeContradiction',
+            ],
+            'assertThisType' => [
+                '<?php
+                    class Type {
+                        /**
+                         * @psalm-assert FooType $this
+                         */
+                        public function isFoo() : bool {
+                            if (!$this instanceof FooType) {
+                                throw new \Exception();
+                            }
+                            
+                            return true;
+                        }
+                    }
+
+                    class FooType extends Type {
+                        public function bar(): void {}
+                    }
+
+                    function takesType(Type $t) : void {
+                        $t->bar();
+                        $t->isFoo();
+                    }',
+                'error_message' => 'UndefinedMethod',
             ],
         ];
     }

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -467,7 +467,6 @@ class AssertAnnotationTest extends TestCase
                             if (!$this instanceof FooType) {
                                 throw new \Exception();
                             }
-                            return;
                         }
                         
                         /**
@@ -477,7 +476,6 @@ class AssertAnnotationTest extends TestCase
                             if (!$this instanceof BarType) {
                                 throw new \Exception();
                             }
-                            return;
                         }
                     }
 
@@ -566,6 +564,36 @@ class AssertAnnotationTest extends TestCase
                             $t->foo();
                             $t->bar();
                         }
+                    }'
+            ],
+            'assertThisTypeSimpleAndIfTrueCombined' => [
+                '<?php
+                    class Type {
+                        /**
+                         * @psalm-assert BarType $this
+                         * @psalm-assert-if-true FooType $this
+                         */
+                        public function isFoo() : bool {
+                            if (!$this instanceof BarType) {
+                                throw new \Exception();
+                            }
+                            return $this instanceof FooType;
+                        }
+                    }
+
+                    interface FooType {
+                        public function foo(): void;
+                    }
+
+                    interface BarType {
+                        public function bar(): void;
+                    }
+
+                    function takesType(Type $t) : void {
+                        if ($t->isFoo()) {
+                            $t->foo();
+                        }
+                        $t->bar();
                     }'
             ],
             'assertThisTypeSwitchTrue' => [


### PR DESCRIPTION
I know it looks stupid, but I need it for my SQL plugin (if `PDOStatements::execute` haven't thrown any exceptions, then it can be fetched etc.)

***UPD:*** combining `@psalm-assert` with `@psalm-assert-if-false` still don't work for `$this`, so still WIP
***UPD2:*** combining two interface assertions [like this](https://psalm.dev/r/0316ca8d0a) doesn't work, I'll try to fix it