### PR TITLE
Fix $assertion_var_id calculation in method calls

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -3668,12 +3668,12 @@ class CallAnalyzer
                 if ($arg_var_id) {
                     $assertion_var_id = $arg_var_id;
                 }
-            } elseif (isset($context->vars_in_scope[$assertion->var_id])) {
-                $assertion_var_id = $assertion->var_id;
             } elseif ($assertion->var_id === '$this' && !is_null($thisName)) {
                 $assertion_var_id = $thisName;
             } elseif (strpos($assertion->var_id, '$this->') === 0 && !is_null($thisName)) {
                 $assertion_var_id = $thisName . str_replace('$this->', '->', $assertion->var_id);
+            } elseif (isset($context->vars_in_scope[$assertion->var_id])) {
+                $assertion_var_id = $assertion->var_id;
             }
 
             if ($assertion_var_id) {

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -494,6 +494,44 @@ class AssertAnnotationTest extends TestCase
                         $t->bar();
                     }'
             ],
+            'assertThisTypeCombinedInsideMethod' => [
+                '<?php
+                    class Type {
+                        /**
+                         * @psalm-assert FooType $this
+                         */
+                        public function assertFoo() : void {
+                            if (!$this instanceof FooType) {
+                                throw new \Exception();
+                            }
+                        }
+                        
+                        /**
+                         * @psalm-assert BarType $this
+                         */
+                        public function assertBar() : void {
+                            if (!$this instanceof BarType) {
+                                throw new \Exception();
+                            }
+                        }
+                        
+                        function takesType(Type $t) : void {
+                            $t->assertFoo();
+                            $t->assertBar();
+                            $t->foo();
+                            $t->bar();
+                        }
+                    }
+
+                    interface FooType {
+                        public function foo(): void;
+                    }
+
+                    interface BarType {
+                        public function bar(): void;
+                    }
+'
+            ],
             'assertThisTypeSimpleCombined' => [
                 '<?php
                     class Type {


### PR DESCRIPTION
Continuing #3105 

changed order to get [code like this](https://psalm.dev/r/f1456d620e) working.

Assertion about `$this` must be applied to `$thisName` even when `vars_in_scope['$this']` exists.