### PR TITLE
Add missing "--output-format" example

### DIFF
--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -336,7 +336,7 @@ Output:
 
     --output-format=console
         Changes the output format.
-        Available formats: compact, console, emacs, json, pylint, xml, checkstyle, junit, sonarqube, github
+        Available formats: compact, console, text, emacs, json, pylint, xml, checkstyle, junit, sonarqube, github
 
     --no-progress
         Disable the progress indicator


### PR DESCRIPTION
There is another available format ("text") that provides a simple output, and different from all other formats.

This is an example:

```
$ vendor/bin/psalm --output-format=text 
Scanning files...
Analyzing files...

░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░E░
FileExample.php:38:18:error - TypeDoesNotContainType: array<array-key, mixed> is always defined and non-null
```
