### PR TITLE
Getters automagic

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/AtomicMethodCallAnalyzer.php
@@ -490,20 +490,28 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
 
         $can_memoize = false;
 
-        $return_type_candidate = MethodCallReturnTypeFetcher::fetch(
-            $statements_analyzer,
-            $codebase,
-            $stmt,
-            $context,
-            $method_id,
-            $declaring_method_id,
-            $cased_method_id,
-            $lhs_type_part,
-            $static_type,
-            $args,
-            $result,
-            $template_result
-        );
+        $class_storage_for_method = $codebase->methods->getClassLikeStorageForMethod($method_id);
+        $plain_getter_property = null;
+        if ((isset($class_storage_for_method->methods[$method_name_lc]))
+            && ($plain_getter_property = $class_storage_for_method->methods[$method_name_lc]->plain_getter)
+            && isset($context->vars_in_scope[$getter_var_id = $lhs_var_id . '->' . $plain_getter_property])) {
+            $return_type_candidate = $context->vars_in_scope[$getter_var_id];
+        } else {
+            $return_type_candidate = MethodCallReturnTypeFetcher::fetch(
+                $statements_analyzer,
+                $codebase,
+                $stmt,
+                $context,
+                $method_id,
+                $declaring_method_id,
+                $cased_method_id,
+                $lhs_type_part,
+                $static_type,
+                $args,
+                $result,
+                $template_result
+            );
+        }
 
         $in_call_map = CallMap::inCallMap((string) ($declaring_method_id ?: $method_id));
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/AtomicMethodCallAnalyzer.php
@@ -493,6 +493,8 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
         $class_storage_for_method = $codebase->methods->getClassLikeStorageForMethod($method_id);
         $plain_getter_property = null;
         if ((isset($class_storage_for_method->methods[$method_name_lc]))
+            && !$class_storage_for_method->methods[$method_name_lc]->overridden_somewhere
+            && !$class_storage_for_method->methods[$method_name_lc]->overridden_downstream
             && ($plain_getter_property = $class_storage_for_method->methods[$method_name_lc]->plain_getter)
             && isset($context->vars_in_scope[$getter_var_id = $lhs_var_id . '->' . $plain_getter_property])) {
             $return_type_candidate = $context->vars_in_scope[$getter_var_id];

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -1862,6 +1862,14 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
                 $storage->mutation_free = true;
                 $storage->external_mutation_free = true;
                 $storage->mutation_free_inferred = true;
+
+                if ($stmt->stmts[0]->expr->name instanceof PhpParser\Node\Identifier) {
+                    $storage->plain_getter = $stmt->stmts[0]->expr->name->name;
+                    $storage->if_true_assertions[] = new \Psalm\Storage\Assertion(
+                        '$this->' . $storage->plain_getter,
+                        [['!falsy']]
+                    );
+                }
             } elseif (strpos($stmt->name->name, 'assert') === 0) {
                 $var_assertions = [];
 

--- a/src/Psalm/Storage/MethodStorage.php
+++ b/src/Psalm/Storage/MethodStorage.php
@@ -67,4 +67,9 @@ class MethodStorage extends FunctionLikeStorage
      * @var ?array<string, bool>
      */
     public $this_property_mutations = null;
+
+    /**
+     * @var ?string
+     */
+    public $plain_getter = null;
 }

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -1004,6 +1004,65 @@ class MethodCallTest extends TestCase
                     (new A)->fooFoo();',
                 'error_message' => 'TooFewArguments',
             ],
+            'getterAutomagicOverridden' => [
+                '<?php
+                    class A {
+                        /** @var string|null */
+                        public $a;
+                    
+                        /** @return string|null */
+                        function getA() {
+                            return $this->a;                        
+                        }
+                    }
+                    
+                    class AChild extends A {
+                        function getA() {
+                            return rand(0, 1) ? $this->a : null;
+                        }
+                    }
+                    
+                    function foo(A $a) : void {
+                        if ($a->getA()) {
+                            echo strlen($a->getA());
+                        }
+                    }
+                    
+                    foo(new AChild());',
+                'error_message' => 'PossiblyNullArgument'
+            ],
+            'getterAutomagicOverriddenWithAssertion' => [
+                '<?php
+                    class A {
+                        /** @var string|null */
+                        public $a;
+                    
+                        /** @psalm-assert-if-true string $this->a */
+                        function hasA() {
+                            return is_string($this->a);                        
+                        }
+
+                        /** @return string|null */
+                        function getA() {
+                            return $this->a;                        
+                        }
+                    }
+                    
+                    class AChild extends A {
+                        function getA() {
+                            return rand(0, 1) ? $this->a : null;
+                        }
+                    }
+                    
+                    function foo(A $a) : void {
+                        if ($a->hasA()) {
+                            echo strlen($a->getA());
+                        }
+                    }
+                    
+                    foo(new AChild());',
+                'error_message' => 'PossiblyNullArgument'
+            ]
         ];
     }
 }

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -575,6 +575,51 @@ class MethodCallTest extends TestCase
 
                     takesWithoutArguments(new C);'
             ],
+            'getterTypeInferring' => [
+                '<?php
+                    class A {
+                        /** @var int|string|null */
+                        public $a;
+                        
+                        /** @return int|string|null */
+                        function getA() {
+                            return $this->a;                        
+                        }
+                        
+                        function takesNullOrA(?A $a) : void {}
+                    }
+
+                    $a = new A();
+                    
+                    $a->a = 1;
+                    echo $a->getA() + 2;
+                    
+                    $a->a = "string";
+                    echo strlen($a->getA());
+                    
+                    $a->a = null;
+                    $a->takesNullOrA($a->getA());
+                    '
+            ],
+            'getterAutomagicAssertion' => [
+                '<?php
+                    class A {
+                        /** @var string|null */
+                        public $a;
+                        
+                        /** @return string|null */
+                        function getA() {
+                            return $this->a;                        
+                        }
+                    }
+
+                    $a = new A();
+                    
+                    if ($a->getA()) {
+                        echo strlen($a->getA());
+                    }
+                    '
+            ],
         ];
     }
 


### PR DESCRIPTION
When method is a plain getter, we can:

1. correct method return type if property type is known
2. auto assert-if-true that corresponding property is not falsy

Covers cases like:

```php
if ($a->getSomething()) {
   doesNotAcceptNull($a->getSomething())
}
```

and

```php
if ($a->hasSomething()) {
   doesNotAcceptNull($a->getSomething())
}
```

The last one inspired by #2749 