### PR TITLE
Account for PDOException

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreImmutableClasses.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreImmutableClasses.phpstub
@@ -25,8 +25,10 @@ interface Throwable
 
     /**
      * @psalm-mutation-free
+     *
+     * @return int|string https://www.php.net/manual/en/throwable.getcode.php
      */
-    public final function getCode() : int;
+    public final function getCode();
 
     /**
      * @psalm-mutation-free
@@ -91,8 +93,10 @@ class Exception implements Throwable
 
     /**
      * @psalm-mutation-free
+     *
+     * @return int|string https://www.php.net/manual/en/throwable.getcode.php
      */
-    public final function getCode(): int {}
+    public final function getCode() {}
 
     /**
      * @psalm-mutation-free

--- a/tests/PureAnnotationTest.php
+++ b/tests/PureAnnotationTest.php
@@ -214,8 +214,10 @@ class PureAnnotationTest extends TestCase
                 '<?php
                     /**
                      * @psalm-pure
+                     *
+                     * @return int|string https://www.php.net/manual/en/throwable.getcode.php
                      */
-                    function getCode(Throwable $e): int {
+                    function getCode(Throwable $e) {
                         return $e->getCode();
                     }
 


### PR DESCRIPTION
Probably for legacy reasons, PDOException::getCode() can return string (it's an
SQLSTATE code). Note that if you instantiate it yourself, you will get
an integer though.

I changed the signature of the Exception stub accordingly, and then
there were errors about incompatible signatures, so I had to change the
signature of Throwable too, which makes sense since a Throwable could be
a PDOException. The signature at
https://www.php.net/manual/en/throwable.getcode.php seems plain wrong,
and that same page of the docs warns about PDOException. Not sure what
are the plans for future versions of PHP.