### PR TITLE
Scan files included by autoloaders

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,6 @@
         "amphp/amp": "^2.4.2",
         "bamarni/composer-bin-plugin": "^1.2",
         "brianium/paratest": "^4.0.0",
-        "php-coveralls/php-coveralls": "^2.2",
         "phpmyadmin/sql-parser": "5.1.0",
         "phpspec/prophecy": ">=1.9.0",
         "phpunit/phpunit": "^7.5.16 || ^8.5 || ^9.0",

--- a/src/Psalm/Internal/IncludeCollector.php
+++ b/src/Psalm/Internal/IncludeCollector.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Psalm\Internal;
+
+use function array_diff;
+use function array_merge;
+use function array_unique;
+use function array_values;
+use function get_included_files;
+use function preg_grep;
+
+use const PREG_GREP_INVERT;
+
+/**
+ * Include collector
+ *
+ * Used to execute code that may cause file inclusions, and report what files have been included
+ * NOTE: dependencies of this class should be kept at minimum, as it's used before autoloader is
+ * registered.
+ */
+final class IncludeCollector
+{
+    /** @var list<string> */
+    private $included_files = [];
+
+    /**
+     * @template T
+     * @param callable():T $f
+     * @return T
+     */
+    public function runAndCollect(callable $f)
+    {
+        $before = get_included_files();
+        $ret = $f();
+        $after = get_included_files();
+
+        $included = array_diff($after, $before);
+
+        $this->included_files = array_values(array_unique(array_merge($this->included_files, $included)));
+
+        return $ret;
+    }
+
+    /** @return list<string> */
+    public function getIncludedFiles(): array
+    {
+        return $this->included_files;
+    }
+
+    /** @return list<string> */
+    public function getFilteredIncludedFiles(): array
+    {
+        return array_values(preg_grep('@^phar://@', $this->getIncludedFiles(), PREG_GREP_INVERT));
+    }
+}

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -2,7 +2,6 @@
 
 use Composer\Autoload\ClassLoader;
 use Psalm\Config;
-use Psalm\Exception\ConfigException;
 
 /**
  * @param  string $current_dir
@@ -102,7 +101,7 @@ function requireAutoloaders($current_dir, $has_explicit_root, $vendor_dir)
         exit(1);
     }
 
-    define('PSALM_VERSION', \PackageVersions\Versions::getVersion('vimeo/psalm'));
+    define('PSALM_VERSION', (string)\PackageVersions\Versions::getVersion('vimeo/psalm'));
     define('PHP_PARSER_VERSION', \PackageVersions\Versions::getVersion('nikic/php-parser'));
 
     return $first_autoloader;

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -5,6 +5,7 @@ use Psalm\ErrorBaseline;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Provider;
 use Psalm\Config;
+use Psalm\Internal\IncludeCollector;
 use Psalm\IssueBuffer;
 use Psalm\Progress\DebugProgress;
 use Psalm\Progress\DefaultProgress;
@@ -213,7 +214,14 @@ $path_to_config = get_path_to_config($options);
 
 $vendor_dir = getVendorDir($current_dir);
 
-$first_autoloader = requireAutoloaders($current_dir, isset($options['r']), $vendor_dir);
+require_once __DIR__ . '/' . 'Psalm/Internal/IncludeCollector.php';
+
+$include_collector = new IncludeCollector();
+$first_autoloader = $include_collector->runAndCollect(
+    function () use ($current_dir, $options, $vendor_dir) {
+        return requireAutoloaders($current_dir, isset($options['r']), $vendor_dir);
+    }
+);
 
 
 if (array_key_exists('v', $options)) {
@@ -311,6 +319,8 @@ if (isset($options['i'])) {
         $config->level = $config_level;
     }
 }
+
+$config->setIncludeCollector($include_collector);
 
 if ($config->resolve_from_config_file) {
     $current_dir = $config->base_dir;

--- a/src/psalter.php
+++ b/src/psalter.php
@@ -4,6 +4,7 @@ require_once('command_functions.php');
 use Psalm\DocComment;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Config;
+use Psalm\Internal\IncludeCollector;
 use Psalm\IssueBuffer;
 use Psalm\Progress\DebugProgress;
 use Psalm\Progress\DefaultProgress;
@@ -185,7 +186,14 @@ if (isset($options['r']) && is_string($options['r'])) {
 
 $vendor_dir = getVendorDir($current_dir);
 
-$first_autoloader = requireAutoloaders($current_dir, isset($options['r']), $vendor_dir);
+require_once __DIR__ . '/Psalm/Internal/IncludeCollector.php';
+$include_collector = new IncludeCollector();
+$first_autoloader = $include_collector->runAndCollect(
+    function () use ($current_dir, $options, $vendor_dir) {
+        return requireAutoloaders($current_dir, isset($options['r']), $vendor_dir);
+    }
+);
+
 
 // If Xdebug is enabled, restart without it
 (new \Composer\XdebugHandler\XdebugHandler('PSALTER'))->check();
@@ -195,6 +203,7 @@ $paths_to_check = getPathsToCheck(isset($options['f']) ? $options['f'] : null);
 $path_to_config = get_path_to_config($options);
 
 $config = initialiseConfig($path_to_config, $current_dir, \Psalm\Report::TYPE_CONSOLE, $first_autoloader);
+$config->setIncludeCollector($include_collector);
 
 if ($config->resolve_from_config_file) {
     $current_dir = $config->base_dir;

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -16,6 +16,7 @@ use Psalm\Codebase;
 use Psalm\Config;
 use Psalm\Context;
 use Psalm\Internal\Analyzer\FileAnalyzer;
+use Psalm\Internal\IncludeCollector;
 use Psalm\Plugin\Hook\AfterCodebasePopulatedInterface;
 use Psalm\PluginRegistrationSocket;
 use Psalm\Tests\Internal\Provider;
@@ -62,6 +63,7 @@ class PluginTest extends \Psalm\Tests\TestCase
      */
     private function getProjectAnalyzerWithConfig(Config $config)
     {
+        $config->setIncludeCollector(new IncludeCollector());
         return new \Psalm\Internal\Analyzer\ProjectAnalyzer(
             $config,
             new \Psalm\Internal\Provider\Providers(

--- a/tests/EndToEnd/SuicidalAutoloaderTest.php
+++ b/tests/EndToEnd/SuicidalAutoloaderTest.php
@@ -2,7 +2,6 @@
 namespace Psalm\Tests\EndToEnd;
 
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Process\Process;
 
 class SuicidalAutoloaderTest extends TestCase
 {

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -13,6 +13,7 @@ use function ob_start;
 use Psalm\Codebase;
 use Psalm\Config;
 use Psalm\Internal\Analyzer\FileAnalyzer;
+use Psalm\Internal\IncludeCollector;
 use Psalm\Plugin\Hook\AfterCodebasePopulatedInterface;
 use Psalm\Tests\Internal\Provider;
 use Psalm\Tests\Progress\EchoProgress;
@@ -57,6 +58,7 @@ class ProjectCheckerTest extends TestCase
      */
     private function getProjectAnalyzerWithConfig(Config $config)
     {
+        $config->setIncludeCollector(new IncludeCollector());
         return new \Psalm\Internal\Analyzer\ProjectAnalyzer(
             $config,
             new \Psalm\Internal\Provider\Providers(

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -11,6 +11,7 @@ use const DIRECTORY_SEPARATOR;
 use Psalm\Config;
 use Psalm\Context;
 use Psalm\Internal\Analyzer\FileAnalyzer;
+use Psalm\Internal\IncludeCollector;
 use Psalm\Tests\Internal\Provider;
 
 class StubTest extends TestCase
@@ -59,6 +60,7 @@ class StubTest extends TestCase
         );
         $project_analyzer->setPhpVersion('7.3');
 
+        $config->setIncludeCollector(new IncludeCollector());
         $config->visitComposerAutoloadFiles($project_analyzer, null);
 
         return $project_analyzer;

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -4,6 +4,7 @@ namespace Psalm\Tests;
 use const DIRECTORY_SEPARATOR;
 use function getcwd;
 use Psalm\Config;
+use Psalm\Internal\IncludeCollector;
 
 class TestConfig extends Config
 {
@@ -33,6 +34,7 @@ class TestConfig extends Config
         }
 
         $this->project_files = self::$cached_project_files;
+        $this->setIncludeCollector(new IncludeCollector());
 
         $this->collectPredefinedConstants();
         $this->collectPredefinedFunctions();

--- a/tests/VariadicTest.php
+++ b/tests/VariadicTest.php
@@ -3,6 +3,7 @@ namespace Psalm\Tests;
 
 use Psalm\Config;
 use Psalm\Context;
+use Psalm\Internal\IncludeCollector;
 use Psalm\Tests\Internal\Provider;
 use function dirname;
 use function getcwd;
@@ -144,6 +145,7 @@ class VariadicTest extends TestCase
         );
         $project_analyzer->setPhpVersion('7.3');
 
+        $config->setIncludeCollector(new IncludeCollector());
         $config->visitComposerAutoloadFiles($project_analyzer, null);
 
         return $project_analyzer;

--- a/tests/fixtures/SuicidalAutoloader/autoloader.php
+++ b/tests/fixtures/SuicidalAutoloader/autoloader.php
@@ -1,5 +1,20 @@
 <?php
+
+use React\Promise\PromiseInterface as ReactPromise;
+
 spl_autoload_register(function (string $className) {
+    $knownBadClasses = [
+        ReactPromise::class, // amphp/amp
+        ResourceBundle::class, // symfony/polyfill-php73
+        Transliterator::class, // symfony/string
+        // it's unclear why Psalm tries to autoload parent
+        'parent',
+    ];
+
+    if (in_array($className, $knownBadClasses)) {
+        return;
+    }
+
     $ex = new RuntimeException('Attempted to load ' . $className);
     echo $ex->__toString() . "\n\n" . $ex->getTraceAsString() . "\n\n";
     exit(70);


### PR DESCRIPTION
Refs vimeo/psalm#2861

To provide a bit more context: this PR changes the way Psalm discovers what's been made available during autoloader registration. Previously it would simply deep-scan files listed in `autoloader.file` section of `composer.json`. Now it takes a snapshot of loaded files before autoloader registration and compares that to the included file list after autoloader is registered. This provides almost bullet-proof support for any custom logic autoloader may implement.