### PR TITLE
Make Throwable methods overridable

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreImmutableClasses.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreImmutableClasses.phpstub
@@ -21,39 +21,39 @@ interface Throwable
     /**
      * @psalm-mutation-free
      */
-    public final function getMessage() : string;
+    public function getMessage() : string;
 
     /**
      * @psalm-mutation-free
      *
      * @return int|string https://www.php.net/manual/en/throwable.getcode.php
      */
-    public final function getCode();
+    public function getCode();
 
     /**
      * @psalm-mutation-free
      */
-    public final function getFile() : string;
+    public function getFile() : string;
 
     /**
      * @psalm-mutation-free
      */
-    public final function getLine() : int;
+    public function getLine() : int;
 
     /**
      * @psalm-mutation-free
      */
-    public final function getTrace() : array;
+    public function getTrace() : array;
 
     /**
      * @psalm-mutation-free
      */
-    public final function getPrevious() : ?Throwable;
+    public function getPrevious() : ?Throwable;
 
     /**
      * @psalm-mutation-free
      */
-    public final function getTraceAsString() : string;
+    public function getTraceAsString() : string;
 }
 
 class Exception implements Throwable

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -773,6 +773,25 @@ class MethodSignatureTest extends TestCase
                 [],
                 '7.4'
             ],
+            'allowOverridingThrowable' => [
+                '<?php
+                    /**
+                     * @psalm-immutable
+                     */
+                    interface MyException extends \Throwable
+                    {
+                        /**
+                         * Informative comment
+                         */
+                        public function getMessage(): string;
+                        public function getCode();
+                        public function getFile(): string;
+                        public function getLine(): int;
+                        public function getTrace(): array;
+                        public function getPrevious(): ?\Throwable;
+                        public function getTraceAsString(): string;
+                    }'
+            ]
         ];
     }
 


### PR DESCRIPTION
Methods from \Exception cannot be overriden, but that does not mean
methods from \Throwable cannot be.

Closes #3202