### PR TITLE
Fix #3204 normalize namespaced function ids

### DIFF
--- a/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
@@ -51,7 +51,9 @@ use Psalm\Type\Atomic\TTraitString;
 use Psalm\Type\Atomic\TTrue;
 use function get_class;
 use function array_merge;
+use function strpos;
 use function strtolower;
+use function substr;
 use function in_array;
 use function array_values;
 use function count;
@@ -1869,7 +1871,7 @@ class TypeAnalyzer
             try {
                 $function_storage = $codebase->functions->getStorage(
                     $statements_analyzer,
-                    $input_type_part->value
+                    self::getNormalizedCallableFunctionId($input_type_part)
                 );
 
                 return new TCallable(
@@ -2795,5 +2797,15 @@ class TypeAnalyzer
         $unique_type->possibly_undefined = $possibly_undefined;
 
         return $unique_type;
+    }
+
+    /**
+     * @param TLiteralString $atomic_type
+     * @return string
+     */
+    public static function getNormalizedCallableFunctionId($atomic_type) {
+        $lowercase = strtolower($atomic_type->value);
+
+        return strpos($lowercase, '\\') === 0 ? substr($lowercase, 1) : $lowercase;
     }
 }

--- a/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
@@ -2807,7 +2807,7 @@ class TypeAnalyzer
      * @param TLiteralString $input_type
      * @return string
      */
-    public static function getNormalizedCallableFunctionId($input_type)
+    public static function getNormalizedCallableFunctionId(TLiteralString $input_type): string
     {
         $lowercase = strtolower($input_type->value);
         return strpos($lowercase, '\\') === 0 ? substr($lowercase, 1) : $lowercase;

--- a/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
@@ -2800,12 +2800,16 @@ class TypeAnalyzer
     }
 
     /**
-     * @param TLiteralString $atomic_type
+     * Function names are lowercased and the leading \ is removed.
+     *
+     * \NS\some_function => ns\some_function
+     *
+     * @param TLiteralString $input_type
      * @return string
      */
-    public static function getNormalizedCallableFunctionId($atomic_type) {
-        $lowercase = strtolower($atomic_type->value);
-
+    public static function getNormalizedCallableFunctionId($input_type)
+    {
+        $lowercase = strtolower($input_type->value);
         return strpos($lowercase, '\\') === 0 ? substr($lowercase, 1) : $lowercase;
     }
 }

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -1098,13 +1098,13 @@ class CallableTest extends TestCase
                         $action($item);
                     }
 
-                    class A {}
-                    class B {}
+                    class C {}
+                    class D {}
 
-                    function action_b( B $item ): void {
+                    function action_d( \NS\D $item ): void {
                     }
 
-                    execute( new A(), "\NS\action_b" );
+                    execute( new \NS\C(), "\NS\action_d" );
                     ',
                 'error_message' => 'InvalidArgument',
             ],

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -1063,6 +1063,51 @@ class CallableTest extends TestCase
                     run("ff");',
                 'error_message' => 'UndefinedFunction',
             ],
+            'requireMatchingTemplateParams' => [
+                '<?php
+                    /**
+                     * @template T
+                     * @param T $item
+                     * @param callable(T): void $action
+                     * @return void
+                     */
+                    function execute($item, $action) {
+                        $action($item);
+                    }
+
+                    class A {}
+                    class B {}
+
+                    function action_b( B $item ): void {
+                    }
+
+                    execute( new A(), "action_b" );
+                    ',
+                'error_message' => 'InvalidArgument',
+            ],
+            'requireMatchingTemplateParamsInNamespace' => [
+                '<?php
+                    namespace NS;
+                    /**
+                     * @template T
+                     * @param T $item
+                     * @param callable(T): void $action
+                     * @return void
+                     */
+                    function execute($item, $action) {
+                        $action($item);
+                    }
+
+                    class A {}
+                    class B {}
+
+                    function action_b( B $item ): void {
+                    }
+
+                    execute( new A(), "\NS\action_b" );
+                    ',
+                'error_message' => 'InvalidArgument',
+            ],
         ];
     }
 }

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -1063,7 +1063,7 @@ class CallableTest extends TestCase
                     run("ff");',
                 'error_message' => 'UndefinedFunction',
             ],
-            'requireMatchingTemplateParams' => [
+            'requireMatchingTemplateParamsNoNamespace' => [
                 '<?php
                     /**
                      * @template T


### PR DESCRIPTION
Functions in storaged are indexed with lowercase names and preceding backslash removed.

Fixes #3204