### PR TITLE
Made compact's return array key type more specific

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -1147,7 +1147,7 @@ return [
 'commonmark\render\latex' => ['string', 'node'=>'CommonMark\Node', 'options='=>'int', 'width='=>'int'],
 'commonmark\render\man' => ['string', 'node'=>'CommonMark\Node', 'options='=>'int', 'width='=>'int'],
 'commonmark\render\xml' => ['string', 'node'=>'CommonMark\Node', 'options='=>'int'],
-'compact' => ['array', 'var_name'=>'string|array', '...var_names='=>'string|array'],
+'compact' => ['array<string, mixed>', 'var_name'=>'string|array', '...var_names='=>'string|array'],
 'COMPersistHelper::__construct' => ['void', 'com_object'=>'object'],
 'COMPersistHelper::GetCurFile' => ['string'],
 'COMPersistHelper::GetMaxStreamSize' => ['int'],

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -238,6 +238,9 @@ class FunctionCallTest extends TestCase
             ],
             'compact' => [
                 '<?php
+                    /**
+                     * @return array<string, mixed>
+                     */
                     function test(): array {
                         return compact(["val"]);
                     }',
@@ -1173,6 +1176,9 @@ class FunctionCallTest extends TestCase
             ],
             'compactDefinedVariable' => [
                 '<?php
+                    /**
+                     * @return array<string, mixed>
+                     */
                     function foo(int $a, string $b, bool $c) : array {
                         return compact("a", "b", "c");
                     }',
@@ -1647,6 +1653,9 @@ class FunctionCallTest extends TestCase
             ],
             'compactUndefinedVariable' => [
                 '<?php
+                    /**
+                     * @return array<string, mixed>
+                     */
                     function foo() : array {
                         return compact("a", "b", "c");
                     }',


### PR DESCRIPTION
PHP's `compact` function always returns an array with string keys, so I changed it to be typed as a `string` key instead of the implicit `array-key`. While this improvement is somewhat similar to what was requested at https://github.com/vimeo/psalm/issues/2084, it does not actually address the issue reported.

This is my first attempt at contributing to Psalm, so feedback is very welcome. I didn't add any tests as I wasn't sure I could add any meaningful ones, or perhaps I am just not familiar enough with tests accompanying changes like this. I don't mind adding something if someone can suggest an idea.

Technically, only the change to CallMap.php was necessary, and the tests were still passing after that change. But to help me understand the implications of changing that return type, I tried changing it to return an `int` instead of `array`, which is completely wrong, but that was the point. When it was incorrectly set to `int`, some of the tests in FunctionCallTest.php started failing. Even though those same tests were not failing after making the correct change to CallMap.php, I still went ahead and added more specific types where `compact` was used in those tests. Please let me know if those changes make sense, as I don't completely understand those tests.