### PR TITLE
Allow non-string keys

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -249,11 +249,12 @@ function uksort(array &$arr, callable $callback): bool
 }
 
 /**
+ * @psalm-template K of array-key
  * @psalm-template T
  *
- * @param array<string, T> $arr
+ * @param array<K,T> $arr
  *
- * @return array<string, T>
+ * @return array<K,T>
  * @psalm-pure
  */
 function array_change_key_case(array $arr, int $case = CASE_LOWER)

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1342,6 +1342,12 @@ class ArrayFunctionCallTest extends TestCase
                         return "";
                     }'
             ],
+            'arrayChangeKeyCaseWithNonStringKeys' => [
+                '<?php
+
+                $a = [42, "A" => 42];
+                echo array_change_key_case($a, CASE_LOWER)[0];'
+            ],
         ];
     }
 


### PR DESCRIPTION
Although it would be stupid to provide an array with exclusively
non-string keys, it's possible to have array with a bit of both.

See for instance
https://github.com/doctrine/dbal/blob/155d028be084ef69110d09938c57c351a2126e5d/tests/Doctrine/Tests/DBAL/Functional/DataAccessTest.php#L263-L276