### PR TITLE
chore: remove backticks because of escaping issue in docs

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -339,7 +339,7 @@ Allows you to hard-code a serializer for Psalm to use when caching data. By defa
 
 ## Project settings
 
-#### `<projectFiles>`
+#### <projectFiles>
 Contains a list of all the directories that Psalm should inspect. You can also specify a set of files and folders to ignore with the `<ignoreFiles>` directive, e.g.
 ```xml
 <projectFiles>
@@ -350,22 +350,22 @@ Contains a list of all the directories that Psalm should inspect. You can also s
 </projectFiles>
 ```
 
-#### `<fileExtensions>`
+#### <fileExtensions>
 Optional.  A list of extensions to search over. See [Checking non-PHP files](checking_non_php_files.md) to understand how to extend this.
 
-#### `<plugins>`
+#### <plugins>
 Optional.  A list of `<plugin filename="path_to_plugin.php" />` entries. See the [Plugins](plugins/using_plugins.md) section for more information.
 
-#### `<issueHandlers>`
+#### <issueHandlers>
 Optional.  If you don't want Psalm to complain about every single issue it finds, the issueHandler tag allows you to configure that. [Dealing with code issues](dealing_with_code_issues.md) tells you more.
 
-#### `<mockClasses>`
+#### <mockClasses>
 Optional. Do you use mock classes in your tests? If you want Psalm to ignore them when checking files, include a fully-qualified path to the class with `<class name="Your\Namespace\ClassName" />`
 
-#### `<stubs>`
+#### <stubs>
 Optional. If your codebase uses classes and functions that are not visible to Psalm via reflection (e.g. if there are internal packages that your codebase relies on that are not available on the machine running Psalm), you can use stub files. Used by PhpStorm (a popular IDE) and others, stubs provide a description of classes and functions without the implementations. You can find a list of stubs for common classes [here](https://github.com/JetBrains/phpstorm-stubs). List out each file with `<file name="path/to/file.php" />`.
 
-#### `<ignoreExceptions>`
+#### <ignoreExceptions>
 Optional.  A list of exceptions to not report for `checkForThrowsDocblock` or `checkForThrowsInGlobalScope`. If an exception has `onlyGlobalScope` set to `true`, only `checkForThrowsInGlobalScope` is ignored for that exception, e.g.
 ```xml
 <ignoreExceptions>
@@ -373,7 +373,7 @@ Optional.  A list of exceptions to not report for `checkForThrowsDocblock` or `c
 </ignoreExceptions>
 ```
 
-#### `<globals>`
+#### <globals>
 Optional.  If your codebase uses global variables that are accessed with the `global` keyword, you can declare their type.  e.g.
 ```xml
 <globals>


### PR DESCRIPTION
👋 I'm sure this is probably an issue with the underlying tool used to generating these docs, but I honestly can't find where that is done in the codebase.

I haven't verified since I'm not  sure how to build the docs, but I'm guessing this will resolve the escaping issue.

## https://psalm.dev/docs/running_psalm/configuration/
![image](https://user-images.githubusercontent.com/5747667/80384184-6cf9d280-8859-11ea-8040-a680eb0a59c0.png)
