### PR TITLE
feat: add simple helper for making a union type

### DIFF
--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -1980,4 +1980,9 @@ abstract class Type
     {
         self::$memoized_tokens = [];
     }
+
+    public static function union(Atomic ...$types): Union
+    {
+        return new Union($types);
+    }
 }

--- a/tests/TypeTest.php
+++ b/tests/TypeTest.php
@@ -1,0 +1,33 @@
+<?php
+namespace Psalm\Tests;
+
+use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TMixed;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Union;
+use Psalm\Type;
+use function array_values;
+use function end;
+
+class TypeTest extends TestCase
+{
+    public function testMakesUnionFromOneAtomicType(): void
+    {
+        $union = Type::union(new TMixed());
+        $atomicTypes = $union->getAtomicTypes();
+
+        $this->assertCount(1, $atomicTypes);
+        $this->assertInstanceOf(TMixed::class, end($atomicTypes));
+    }
+
+    public function testMakesUnionFromMultipleAtomicTypes(): void
+    {
+        $union = Type::union(new TMixed(), new TInt(), new TString());
+        $atomicTypes = $union->getAtomicTypes();
+
+        $this->assertCount(3, $atomicTypes);
+        $this->assertInstanceOf(TMixed::class, array_values($atomicTypes)[0]);
+        $this->assertInstanceOf(TInt::class, array_values($atomicTypes)[1]);
+        $this->assertInstanceOf(TString::class, array_values($atomicTypes)[2]);
+    }
+}


### PR DESCRIPTION
👋 any interest in this? I know it's incredibly simple but hey, it isn't too much simpler than `Type::getNumeric` 😂 

While developing plugins, I _constantly_ create instances of `PhpParser\NodeAbstract\UnionType` by accident instead of `Psalm\Type\Union`, and other times I forget to pass an array of types and instead pass a single type