### PR TITLE
Fix variable names from plugin hook

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -766,13 +766,13 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             }
         }
 
-        $plugin_classes = $codebase->config->after_functionlike_checks;
+        $plugin_functions = $codebase->config->after_functionlike_checks;
 
-        if ($plugin_classes) {
+        if ($plugin_functions) {
             $file_manipulations = [];
 
-            foreach ($plugin_classes as $plugin_fq_class_name) {
-                if ($plugin_fq_class_name::afterStatementAnalysis(
+            foreach ($plugin_functions as $plugin_function_name) {
+                if ($plugin_function_name::afterStatementAnalysis(
                     $this->function,
                     $storage,
                     $this,


### PR DESCRIPTION
Sorry, I realized too late that I forgot to rename some variables from last PR.