### PR TITLE
Fix generator return type collect

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -289,7 +289,7 @@ class ReturnTypeCollector
                     }
                 }
 
-                $yield_types = [
+                $return_types = [
                     new Atomic\TGenericObject(
                         'Generator',
                         [
@@ -300,6 +300,8 @@ class ReturnTypeCollector
                         ]
                     ),
                 ];
+
+                $yield_types = [];
             }
         }
 

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -798,6 +798,30 @@ class ReturnTypeTest extends TestCase
                         echo "$k\n";
                     }'
             ],
+            'infersGeneratorReturnType' => [
+                '<?php
+
+                /**
+                 * @param \Generator<mixed, mixed, mixed, int> $gen
+                 */
+                function accept(\Generator $gen): void {
+                    /** @psalm-suppress ForbiddenCode */
+                    var_dump($gen);
+                }
+
+                accept((function () {
+                    yield;
+
+                    return 42;
+                })());
+
+                accept((function (): \Generator {
+                    yield;
+
+                    return 42;
+                })());
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #3268.

I'm not sure whether `$yield_types = [];` is correct, but without it a test fails.