### PR TITLE
fix: mixin parameter of self should be properly resolved

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -1264,7 +1264,9 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
                         Type::fixUpLocalType(
                             $docblock_info->mixin,
                             $this->aliases,
-                            $this->class_template_types
+                            $this->class_template_types,
+                            $this->type_aliases,
+                            $fq_classlike_name
                         ),
                         null,
                         $this->class_template_types

--- a/tests/MixinAnnotationTest.php
+++ b/tests/MixinAnnotationTest.php
@@ -167,6 +167,28 @@ class MixinAnnotationTest extends TestCase
                     '$b' => 'string',
                 ]
             ],
+            'selfTemplatedMixin' => [
+                '<?php
+
+                    /**
+                     * @template T
+                     */
+                    abstract class Foo {
+                        /** @return T */
+                        abstract public function hi();
+                    }
+
+                    /**
+                     * @mixin Foo<self>
+                     */
+                    class Bar {}
+
+                    $bar = new Bar();
+                    $b = $bar->hi();',
+                [
+                    '$b' => 'Bar',
+                ]
+            ],
         ];
     }
 }


### PR DESCRIPTION
👋 took a stab at fixing #3279 

I was able to get a test case passing for `self`. 

I can't get the following test passing for references to `static`, but I think the late static binding is outside of my grasp. Perhaps someone else can finish that.

```
'staticTemplatedMixin' => [
                '<?php

                    /**
                     * @template T
                     */
                    abstract class Foo {
                        /** @return T */
                        abstract public function hi();
                    }

                    /**
                     * @mixin Foo<static>
                     */
                    class Bar {}

                    class Three extends Bar { }

                    $three = new Three();
                    $three = $three->hi();',
                [
                    '$three' => 'Three',
                ]
            ],
```