### PR TITLE
update proc_open() types for PHP 7.4

### DIFF
--- a/src/Psalm/Internal/CallMap.php
+++ b/src/Psalm/Internal/CallMap.php
@@ -10152,7 +10152,7 @@ return [
 'proc_close' => ['int', 'process'=>'resource'],
 'proc_get_status' => ['array|false', 'process'=>'resource'],
 'proc_nice' => ['bool', 'priority'=>'int'],
-'proc_open' => ['resource|false', 'command'=>'string', 'descriptorspec'=>'array', '&w_pipes'=>'resource[]', 'cwd='=>'?string', 'env='=>'?array', 'other_options='=>'array'],
+'proc_open' => ['resource|false', 'command'=>'string|array', 'descriptorspec'=>'array', '&w_pipes'=>'resource[]', 'cwd='=>'?string', 'env='=>'?array', 'other_options='=>'array'],
 'proc_terminate' => ['bool', 'process'=>'resource', 'signal='=>'int'],
 'projectionObj::__construct' => ['void', 'projectionString'=>'string'],
 'projectionObj::getUnits' => ['int'],

--- a/src/Psalm/Internal/CallMap_74_delta.php
+++ b/src/Psalm/Internal/CallMap_74_delta.php
@@ -17,10 +17,12 @@ return [
 'new' => [
     'password_hash' => ['string|null', 'password'=>'string', 'algo'=>'int|string|null', 'options='=>'array'],
     'password_needs_rehash' => ['bool', 'hash'=>'string', 'algo'=>'int|string|null', 'options='=>'array'],
+    'proc_open' => ['resource|false', 'command'=>'string|array', 'descriptorspec'=>'array', '&w_pipes'=>'resource[]', 'cwd='=>'?string', 'env='=>'?array', 'other_options='=>'array'],
     'ReflectionProperty::getType' => ['?ReflectionType'],
 ],
 'old' => [
     'password_hash' => ['string|false', 'password'=>'string', 'algo'=>'int', 'options='=>'array'],
     'password_needs_rehash' => ['bool', 'hash'=>'string', 'algo'=>'int', 'options='=>'array'],
+    'proc_open' => ['resource|false', 'command'=>'string', 'descriptorspec'=>'array', '&w_pipes'=>'resource[]', 'cwd='=>'?string', 'env='=>'?array', 'other_options='=>'array'],
 ]
 ];


### PR DESCRIPTION
as of PHP 7.4, proc_open() accepts an array for its first argument.
https://www.php.net/manual/en/function.proc-open.php#refsect1-function.proc-open-parameters