### PR TITLE
fix: code location is nullable

### DIFF
--- a/src/Psalm/Plugin/Hook/MethodVisibilityProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/MethodVisibilityProviderInterface.php
@@ -20,6 +20,6 @@ interface MethodVisibilityProviderInterface
         string $fq_classlike_name,
         string $method_name_lowercase,
         Context $context,
-        CodeLocation $code_location
+        CodeLocation $code_location = null
     );
 }


### PR DESCRIPTION
Added `MethodVisibilityProviderInterface` to a class and immediately got
```
Uncaught TypeError: Argument 5 passed to Psalm\LaravelPlugin\ReturnTypeProvider\EloquentBuilderReturnTypeProvider::isMethodVisible() must be an instance of Psalm\CodeLocation, null given
```

https://github.com/vimeo/psalm/blob/master/src/Psalm/Internal/Provider/MethodVisibilityProvider.php#L81 has this marked as nullable