### PR TITLE
Try/catch block when getting docblock method parameter types

### DIFF
--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -1041,7 +1041,10 @@ class CommentAnalyzer
                         try {
                             $param_type = Type::getTypeFromTree($method_tree_child->children[0], $codebase);
                         } catch (TypeParseTreeException $e) {
-                            throw new DocblockParseException('Badly-formatted @method parameters for ' . $method_entry.'; have you checked if a variable passed by reference has a space between the ampersand and the start of the variable?');
+                            $msg = 'Badly-formatted @method parameters for ' . $method_entry;
+                            $msg .= '; have you checked if a variable passed by reference has a space between';
+                            $msg .= ' the ampersand and the start of the variable?';
+                            throw new DocblockParseException($msg);
                         }
                         $docblock_lines[] = '@param \\' . $param_type . ' '
                             . ($method_tree_child->variadic ? '...' : '')

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -1038,7 +1038,12 @@ class CommentAnalyzer
 
 
                     if ($method_tree_child->children) {
-                        $param_type = Type::getTypeFromTree($method_tree_child->children[0], $codebase);
+                        try {
+                            $param_type = Type::getTypeFromTree($method_tree_child->children[0], $codebase);
+                        }
+                        catch (TypeParseTreeException $e) {
+                            throw new DocblockParseException('Badly-formatted @method parameters for ' . $method_entry.'; have you checked if a variable passed by reference has a space between the ampersand and the start of the variable?');
+                        }
                         $docblock_lines[] = '@param \\' . $param_type . ' '
                             . ($method_tree_child->variadic ? '...' : '')
                             . $method_tree_child->name;

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -1040,8 +1040,7 @@ class CommentAnalyzer
                     if ($method_tree_child->children) {
                         try {
                             $param_type = Type::getTypeFromTree($method_tree_child->children[0], $codebase);
-                        }
-                        catch (TypeParseTreeException $e) {
+                        } catch (TypeParseTreeException $e) {
                             throw new DocblockParseException('Badly-formatted @method parameters for ' . $method_entry.'; have you checked if a variable passed by reference has a space between the ampersand and the start of the variable?');
                         }
                         $docblock_lines[] = '@param \\' . $param_type . ' '


### PR DESCRIPTION
Resolves https://github.com/vimeo/psalm/issues/3340

Add try/catch block to provide a better message when types fail to parse, specifically added because of an issue where `& $var` was treated as a union type but was actually meant to be a pass-by-reference variable in the docblock