### PR TITLE
send php native warnings/errors/notices on stderr instead of stdout

### DIFF
--- a/src/psalm.php
+++ b/src/psalm.php
@@ -136,7 +136,7 @@ array_map(
 );
 
 if (!array_key_exists('use-ini-defaults', $options)) {
-    ini_set('display_errors', '1');
+    ini_set('display_errors', 'stderr');
     ini_set('display_startup_errors', '1');
     ini_set('memory_limit', (string) (8 * 1024 * 1024 * 1024));
 }


### PR DESCRIPTION
- sending errors on stderr is best practice..  on stdout only "regular data" should be sent
- don't break unix pipe-operations which error on unexpected output like errors/warnings