### PR TITLE
Simplify PSR4 namespace config.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,8 +68,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Psalm\\Plugin\\": "src/Psalm/Plugin",
-            "Psalm\\": "src/Psalm"
+            "Psalm\\": "src/Psalm/"
         },
         "files": [
             "src/functions.php",
@@ -78,7 +77,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Psalm\\Tests\\": "tests"
+            "Psalm\\Tests\\": "tests/"
         }
     },
     "repositories": [


### PR DESCRIPTION
This seems to be some relict from refactoring back in https://github.com/vimeo/psalm/commit/a338e76ef68bce75a0cc9c5616b6413e9d92bfcd
Those additional lines do not seem needed or useful anymore.
Also consolidated paths to the best practice for psr-4 config.