### PR TITLE
Usability for cs check and fix.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -103,7 +103,8 @@
             "phpunit"
         ],
         "psalm": "./psalm --find-dead-code",
-        "standards": "phpcs",
+        "cs": "phpcs -p",
+        "cs-fix": "phpcbf -p",
         "tests": [
             "phpcs",
             "phpunit"


### PR DESCRIPTION
Not sure if you are interested in this little usability improvement
But right now, running `composer standards` locally you have no visual feedback for a few minutes.
We always have -p for the "human interaction commands" here for us.
In Travis this can also be useful to know where you are right now (10%, 60%, ..), but I leave that up to you if you want to make them progressable as well.

Also, when quickly needing to fix, appending a `-fix` is easier than to remember the exact scramble code of phpcbf, cognitively speaking.

    composer cs
    composer cs-fix