### PR TITLE
Use pretty print for JSON reporting.

### DIFF
--- a/src/Psalm/Internal/Json/Json.php
+++ b/src/Psalm/Internal/Json/Json.php
@@ -9,14 +9,19 @@ use const JSON_UNESCAPED_SLASHES;
 use const JSON_UNESCAPED_UNICODE;
 
 /**
- * Provides pretty printed JSON output.
+ * Provides ability of pretty printed JSON output.
  */
 class Json
 {
     /**
      * @var int
      */
-    protected const OPTIONS = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+    public const PRETTY = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+
+    /**
+     * @var int
+     */
+    public const DEFAULT = 0;
 
     /**
      * @param mixed $data
@@ -26,7 +31,7 @@ class Json
     public static function encode($data, ?int $options = null): string
     {
         if ($options === null) {
-            $options = static::OPTIONS;
+            $options = static::DEFAULT;
         }
 
         $result = json_encode($data, $options);

--- a/src/Psalm/Internal/Json/Json.php
+++ b/src/Psalm/Internal/Json/Json.php
@@ -13,6 +13,9 @@ use const JSON_UNESCAPED_UNICODE;
  */
 class Json
 {
+    /**
+     * @var int
+     */
     protected const OPTIONS = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 
     /**

--- a/src/Psalm/Internal/Json/Json.php
+++ b/src/Psalm/Internal/Json/Json.php
@@ -13,9 +13,6 @@ use const JSON_UNESCAPED_UNICODE;
  */
 class Json
 {
-    /**
-     * @var int
-     */
     public const PRETTY = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
 
     /**
@@ -31,7 +28,7 @@ class Json
     public static function encode($data, ?int $options = null): string
     {
         if ($options === null) {
-            $options = static::DEFAULT;
+            $options = self::DEFAULT;
         }
 
         $result = json_encode($data, $options);

--- a/src/Psalm/Internal/Json/Json.php
+++ b/src/Psalm/Internal/Json/Json.php
@@ -1,0 +1,36 @@
+<?php
+namespace Psalm\Internal\Json;
+
+use RuntimeException;
+
+use function json_encode;
+use const JSON_PRETTY_PRINT;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * Provides pretty printed JSON output.
+ */
+class Json
+{
+    protected const OPTIONS = JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE;
+
+    /**
+     * @param mixed $data
+     * @param int|null $options
+     * @return string
+     */
+    public static function encode($data, ?int $options = null): string
+    {
+        if ($options === null) {
+            $options = static::OPTIONS;
+        }
+
+        $result = json_encode($data, $options);
+        if ($result === false) {
+            throw new RuntimeException('Cannot create JSON string.');
+        }
+
+        return $result;
+    }
+}

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -51,6 +51,9 @@ abstract class Report
     /** @var bool */
     protected $show_info;
 
+    /** @var bool */
+    protected $pretty;
+
     /** @var int */
     protected $mixed_expression_count;
 
@@ -86,6 +89,7 @@ abstract class Report
         $this->use_color = $report_options->use_color;
         $this->show_snippet = $report_options->show_snippet;
         $this->show_info = $report_options->show_info;
+        $this->pretty = $report_options->pretty;
 
         $this->mixed_expression_count = $mixed_expression_count;
         $this->total_expression_count = $total_expression_count;

--- a/src/Psalm/Report/JsonReport.php
+++ b/src/Psalm/Report/JsonReport.php
@@ -14,6 +14,8 @@ class JsonReport extends Report
      */
     public function create(): string
     {
-        return Json::encode(array_values($this->issues_data)) . "\n";
+        $options = $this->pretty ? Json::PRETTY : Json::DEFAULT;
+
+        return Json::encode(array_values($this->issues_data), $options) . "\n";
     }
 }

--- a/src/Psalm/Report/JsonReport.php
+++ b/src/Psalm/Report/JsonReport.php
@@ -2,9 +2,9 @@
 
 namespace Psalm\Report;
 
+use Psalm\Internal\Json\Json;
 use Psalm\Report;
 
-use function json_encode;
 use function array_values;
 
 class JsonReport extends Report
@@ -14,6 +14,6 @@ class JsonReport extends Report
      */
     public function create(): string
     {
-        return json_encode(array_values($this->issues_data)) . "\n";
+        return Json::encode(array_values($this->issues_data)) . "\n";
     }
 }

--- a/src/Psalm/Report/JsonSummaryReport.php
+++ b/src/Psalm/Report/JsonSummaryReport.php
@@ -1,7 +1,7 @@
 <?php
 namespace Psalm\Report;
 
-use function json_encode;
+use Psalm\Internal\Json\Json;
 use Psalm\Report;
 
 class JsonSummaryReport extends Report
@@ -23,7 +23,7 @@ class JsonSummaryReport extends Report
             ++$type_counts[$type];
         }
 
-        return json_encode([
+        return Json::encode([
             'issue_counts' => $type_counts,
             'mixed_expression_count' => $this->mixed_expression_count,
             'total_expression_count' => $this->total_expression_count,

--- a/src/Psalm/Report/JsonSummaryReport.php
+++ b/src/Psalm/Report/JsonSummaryReport.php
@@ -23,10 +23,12 @@ class JsonSummaryReport extends Report
             ++$type_counts[$type];
         }
 
+        $options = $this->pretty ? Json::PRETTY : Json::DEFAULT;
+
         return Json::encode([
             'issue_counts' => $type_counts,
             'mixed_expression_count' => $this->mixed_expression_count,
             'total_expression_count' => $this->total_expression_count,
-        ]) . "\n";
+        ], $options) . "\n";
     }
 }

--- a/src/Psalm/Report/ReportOptions.php
+++ b/src/Psalm/Report/ReportOptions.php
@@ -26,6 +26,11 @@ class ReportOptions
     public $format = REPORT::TYPE_CONSOLE;
 
     /**
+     * @var bool
+     */
+    public $pretty = false;
+
+    /**
      * @var ?string
      */
     public $output_path;

--- a/src/Psalm/Report/SonarqubeReport.php
+++ b/src/Psalm/Report/SonarqubeReport.php
@@ -1,7 +1,7 @@
 <?php
 namespace Psalm\Report;
 
-use function json_encode;
+use Psalm\Internal\Json\Json;
 use function max;
 use Psalm\Config;
 use Psalm\Report;
@@ -37,10 +37,10 @@ class SonarqubeReport extends Report
                     ],
                 ],
                 'type' => 'CODE_SMELL',
-                'severity' => $issue_data->severity == Config::REPORT_ERROR ? 'CRITICAL' : 'MINOR',
+                'severity' => $issue_data->severity === Config::REPORT_ERROR ? 'CRITICAL' : 'MINOR',
             ];
         }
 
-        return json_encode($report) . "\n";
+        return Json::encode($report) . "\n";
     }
 }

--- a/src/Psalm/Report/SonarqubeReport.php
+++ b/src/Psalm/Report/SonarqubeReport.php
@@ -41,6 +41,8 @@ class SonarqubeReport extends Report
             ];
         }
 
-        return Json::encode($report) . "\n";
+        $options = $this->pretty ? Json::PRETTY : Json::DEFAULT;
+
+        return Json::encode($report, $options) . "\n";
     }
 }

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -68,6 +68,7 @@ $valid_long_options = [
     'long-progress',
     'no-suggestions',
     'include-php-versions', // used for baseline
+    'pretty-print', // used for JSON reports
     'track-tainted-input',
     'find-unused-psalm-suppress',
     'error-level:',
@@ -517,6 +518,7 @@ $stdout_report_options->show_suggestions = !array_key_exists('no-suggestions', $
  */
 $stdout_report_options->format = $output_format;
 $stdout_report_options->show_snippet = !isset($options['show-snippet']) || $options['show-snippet'] !== "false";
+$stdout_report_options->pretty = isset($options['pretty-print']) && $options['pretty-print'] !== "false";
 
 $project_analyzer = new ProjectAnalyzer(
     $config,


### PR DESCRIPTION
Resolves https://github.com/vimeo/psalm/issues/3360

Any preference on the implementation? Or is it OK as such?
I only modified the reporting (not internal JSON encoding for hashing etc), and I put the constants into a dedicated class to keep it DRY and easy to maintain.
While doing that I also captured the "theoretical" `false` return to make the return result more "true" towards documented and expected type `string`.

The constants are used as such for a lot of libraries and frameworks as such, e.g.
psalm/vendor/phpunit/phpunit/src/Util/Json.php