### PR TITLE
Fix InvalidCast after is_callable([$val, '__toString']) check

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -1897,6 +1897,20 @@ class AssertionFinder
         } elseif (self::hasCallableCheck($expr)) {
             if ($first_var_name) {
                 $if_types[$first_var_name] = [[$prefix . 'callable']];
+            } elseif ($expr->args[0]->value instanceof PhpParser\Node\Expr\Array_
+                && isset($expr->args[0]->value->items[0], $expr->args[0]->value->items[1])
+                && $expr->args[0]->value->items[1]->value instanceof PhpParser\Node\Scalar\String_
+            ) {
+                $first_var_name_in_array_argument = ExpressionAnalyzer::getArrayVarId(
+                    $expr->args[0]->value->items[0]->value,
+                    $this_class_name,
+                    $source
+                );
+                if ($first_var_name_in_array_argument) {
+                    $if_types[$first_var_name_in_array_argument] = [
+                        [$prefix . 'hasmethod-' . $expr->args[0]->value->items[1]->value->value]
+                    ];
+                }
             }
         } elseif (self::hasIterableCheck($expr)) {
             if ($first_var_name) {

--- a/tests/ToStringTest.php
+++ b/tests/ToStringTest.php
@@ -140,7 +140,13 @@ class ToStringTest extends TestCase
                     if (method_exists($object, \'__toString\')) {
                         $a = (string) $object;
                         echo $a;
-                    }'
+                    }
+
+                    if (is_callable([$object, \'__toString\'])) {
+                        $a = (string) $object;
+                        echo $a;
+                    }
+                    '
             ],
         ];
     }


### PR DESCRIPTION
Attempt to fix https://github.com/vimeo/psalm/issues/3345. First pull request here :)