### PR TITLE
Avoid regenerating docblock when no modification is made

### DIFF
--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -363,12 +363,12 @@ class FunctionDocblockManipulator
             $parsed_docblock['specials']['psalm-return'] = [$this->new_psalm_return_type];
         }
 
-        if (!$modified_docblock) {
-            return (string)$docblock . "\n" . $this->indentation;
-        }
-
         if (!$parsed_docblock['specials'] && !$parsed_docblock['description']) {
             return '';
+        }
+
+        if (!$modified_docblock) {
+            return (string)$docblock . "\n" . $this->indentation;
         }
 
         return DocComment::render($parsed_docblock, $this->indentation);


### PR DESCRIPTION
This should prevent Psalter to regenerate docblock when no change were made. This is purely cosmetic, but it reduce drastically the review on our project (added lines, reformatted comments...)