### PR TITLE
Correct analyze clone expression

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -301,6 +301,7 @@
             <xs:element name="PossiblyInvalidArrayAssignment" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidArrayOffset" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidCast" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="PossiblyInvalidClone" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidFunctionCall" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidIterator" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidMethodCall" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -147,6 +147,7 @@ These issues are treated as errors at level 3 and below.
  - [PossiblyInvalidArrayAssignment](issues/PossiblyInvalidArrayAssignment.md)
  - [PossiblyInvalidArrayOffset](issues/PossiblyInvalidArrayOffset.md)
  - [PossiblyInvalidCast](issues/PossiblyInvalidCast.md)
+ - [PossiblyInvalidClone](issues/PossiblyInvalidClone.md)
  - [PossiblyInvalidFunctionCall](issues/PossiblyInvalidFunctionCall.md)
  - [PossiblyInvalidIterator](issues/PossiblyInvalidIterator.md)
  - [PossiblyInvalidMethodCall](issues/PossiblyInvalidMethodCall.md)

--- a/docs/running_psalm/issues/PossiblyInvalidClone.md
+++ b/docs/running_psalm/issues/PossiblyInvalidClone.md
@@ -1,0 +1,16 @@
+# PossiblyInvalidClone
+
+Emitted when trying to clone a value that's possibly not cloneable
+
+```php
+<?php
+
+class A {}
+
+/**
+ * @param A|string $a
+ */
+function foo($a) {
+    return clone $a;
+}
+```

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
@@ -35,11 +35,9 @@ class CloneAnalyzer
 
             $immutable_cloned = false;
 
-            $types = [];
             $invalid_clones = [];
             $possibly_valid = false;
             $atomic_types = $clone_type->getAtomicTypes();
-            
             while ($atomic_types) {
                 $clone_type_part = \array_pop($atomic_types);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
@@ -35,10 +35,11 @@ class CloneAnalyzer
 
             $immutable_cloned = false;
 
+            $types = [];
             $invalid_clones = [];
             $possibly_valid = false;
             $atomic_types = $clone_type->getAtomicTypes();
-
+            
             while ($atomic_types) {
                 $clone_type_part = \array_pop($atomic_types);
 

--- a/src/Psalm/Issue/PossiblyInvalidClone.php
+++ b/src/Psalm/Issue/PossiblyInvalidClone.php
@@ -1,0 +1,8 @@
+<?php
+namespace Psalm\Issue;
+
+class PossiblyInvalidClone extends CodeIssue
+{
+    const ERROR_LEVEL = 3;
+    const SHORTCODE = 226;
+}

--- a/tests/CloneTest.php
+++ b/tests/CloneTest.php
@@ -95,6 +95,20 @@ class CloneTest extends TestCase
                     }',
                 'error_message' => 'PossiblyInvalidClone',
             ],
+            'mixedTypeInferredIfErrors' => [
+                '<?php
+                    class A {}
+                    /**
+                     * @param A|string $a
+                     */
+                    function foo($a): void {
+                        /**
+                         * @psalm-suppress PossiblyInvalidClone
+                         */
+                        $cloned = clone $a;
+                    }',
+                'error_message' => 'MixedAssignment',
+            ]
         ];
     }
 }

--- a/tests/CloneTest.php
+++ b/tests/CloneTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests;
+
+class CloneTest extends TestCase
+{
+    use Traits\InvalidCodeAnalysisTestTrait;
+    use Traits\ValidCodeAnalysisTestTrait;
+
+    /**
+     * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
+     */
+    public function providerValidCodeParse()
+    {
+        return [
+            'cloneCorrect' => [
+                '<?php
+                    class A {}
+                    function foo(A $a) : A {
+                        return clone $a;
+                    }
+                    $a = foo(new A());',
+            ],
+            'cloneCorrectWithPublicMethod' => [
+                '<?php
+                    class A {
+                        public function __clone() {}
+                    }
+                    function foo(A $a) : A {
+                        return clone $a;
+                    }
+                    foo(new A());',
+            ],
+            'clonePrivateInternally' => [
+                '<?php
+                    class A {
+                        private function __clone() {}
+                        public function foo(): self {
+                            return clone $this;
+                        }
+                    }',
+            ],
+        ];
+    }
+
+    /**
+     * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
+     */
+    public function providerInvalidCodeParse()
+    {
+        return [
+            'invalidIntClone' => [
+                '<?php
+                    $a = 5;
+                    clone $a;',
+                'error_message' => 'InvalidClone',
+            ],
+            'invalidMixedClone' => [
+                '<?php
+                    /** @var mixed $a */
+                    $a = 5;
+                    clone $a;',
+                'error_message' => 'PossiblyInvalidClone',
+            ],
+            'notVisibleCloneMethod' => [
+                '<?php
+                    class A {
+                        private function __clone() {}
+                    }
+                    $a = new A();
+                    clone $a;',
+                'error_message' => 'InvalidClone',
+            ],
+            'invalidGenericClone' => [
+                '<?php
+                    /**
+                     * @template T as int|string
+                     * @param T $a
+                     */
+                    function foo($a): void {
+                        clone $a;
+                    }',
+                'error_message' => 'InvalidClone',
+            ],
+            'possiblyInvalidGenericClone' => [
+                '<?php
+                    /**
+                     * @template T
+                     * @param T $a
+                     */
+                    function foo($a): void {
+                        clone $a;
+                    }',
+                'error_message' => 'PossiblyInvalidClone',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vimeo/psalm/issues/3329

There are still some edge-cases, primarily about the return type of expression with possible invalid clone, e.g. https://psalm.dev/r/1a6bdbac1b . My solution also outputs MixedAssignment in that code sample, but ideally it should infer type `A` from `clone $a` expression, because only `A` in union type `A|string $a` is cloneable(strings are not).

This is not so difficult to do for simple types, but it is a little difficult to do this for cases like generic types - https://psalm.dev/r/27f283d113 (note that current psalm version does not show warnings here because it doesn't treat cloning string as error, and not because it  could infer type `T:fn-foo as A` for $a)

Also 1 more actual question - https://github.com/vimeo/psalm/issues/3329#issuecomment-629769684 . Strict check here cause issues on testing with real projects on circleci.