### PR TITLE
Infer Return Types for Arrow Functions #3376

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -32,13 +32,6 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
         parent::__construct($function, $source, $storage);
     }
 
-    /** @pararm PhpParser\Node\Expr\Closure|PhpParser\Node\Expr\ArrowFunction $expr */
-    public static function isExprClosureLike(PhpParser\Node\Expr $function): bool
-    {
-        return $function instanceof PhpParser\Node\Expr\Closure
-            || $function instanceof PhpParser\Node\Expr\ArrowFunction;
-    }
-
     public function getTemplateTypeMap()
     {
         return $this->source->getTemplateTypeMap();

--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -32,6 +32,13 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
         parent::__construct($function, $source, $storage);
     }
 
+    /** @pararm PhpParser\Node\Expr\Closure|PhpParser\Node\Expr\ArrowFunction $expr */
+    public static function isExprClosureLike(PhpParser\Node\Expr $function): bool
+    {
+        return $function instanceof PhpParser\Node\Expr\Closure
+            || $function instanceof PhpParser\Node\Expr\ArrowFunction;
+    }
+
     public function getTemplateTypeMap()
     {
         return $this->source->getTemplateTypeMap();

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -129,7 +129,9 @@ class ReturnAnalyzer
         if ($stmt->expr) {
             $context->inside_call = true;
 
-            if (ClosureAnalyzer::isExprClosureLike($stmt->expr)) {
+            if ($stmt->expr instanceof PhpParser\Node\Expr\Closure
+                || $stmt->expr instanceof PhpParser\Node\Expr\ArrowFunction
+            ) {
                 self::potentiallyInferTypesOnClosureFromParentReturnType(
                     $statements_analyzer,
                     $stmt->expr,

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -129,7 +129,7 @@ class ReturnAnalyzer
         if ($stmt->expr) {
             $context->inside_call = true;
 
-            if ($stmt->expr instanceof PhpParser\Node\Expr\Closure) {
+            if (ClosureAnalyzer::isExprClosureLike($stmt->expr)) {
                 self::potentiallyInferTypesOnClosureFromParentReturnType(
                     $statements_analyzer,
                     $stmt->expr,
@@ -591,7 +591,7 @@ class ReturnAnalyzer
      */
     private static function potentiallyInferTypesOnClosureFromParentReturnType(
         StatementsAnalyzer $statements_analyzer,
-        PhpParser\Node\Expr\Closure $expr,
+        PhpParser\Node\FunctionLike $expr,
         Context $context
     ): void {
         // if not returning from inside of a function, return

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -721,6 +721,22 @@ class ReturnTypeTest extends TestCase
                     '$res' => 'iterable<mixed, string>',
                 ],
             ],
+            'infersArrowClosureReturnTypes' => [
+                '<?php
+                    /**
+                     * @param Closure(int, int): bool $op
+                     * @return Closure(int): bool
+                     */
+                    function reflexive(Closure $op): Closure {
+                        return fn ($x) => $op($x, $x) === true;
+                    }
+
+                    $res = reflexive(fn(int $a, int $b): bool => $a === $b);
+                ',
+                'assertions' => [
+                    '$res' => 'Closure(int):bool',
+                ],
+            ],
             'infersClosureReturnTypesWithPartialTypehinting' => [
                 '<?php
                     /**


### PR DESCRIPTION
- Made a small patch to check for closure or arrow
  function when attempting to infer the functions
  params
- Added new isExprClosureLike to start to consolidate
  all checks on closure/arrow fns

Signed-off-by: RJ Garcia <ragboyjr@icloud.com>