### PR TITLE
chore: mark $called_method_name_lowercase param as lowercase string

### DIFF
--- a/src/Psalm/Plugin/Hook/MethodReturnTypeProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/MethodReturnTypeProviderInterface.php
@@ -17,7 +17,8 @@ interface MethodReturnTypeProviderInterface
     /**
      * @param  array<PhpParser\Node\Arg>    $call_args
      * @param  ?array<Type\Union> $template_type_parameters
-     *
+     * @param lowercase-string $method_name_lowercase
+     * @param lowercase-string $called_method_name_lowercase
      * @return ?Type\Union
      */
     public static function getMethodReturnType(


### PR DESCRIPTION
**Before**
```
ERROR: ArgumentTypeCoercion - src/ReturnTypeProvider/ModelReturnTypeProvider.php:37:73 - Argument 2 of Psalm\Internal\MethodIdentifier::__construct expects lowercase-string, parent type non-empty-string provided (see https://psalm.dev/193)
            $methodId = new MethodIdentifier($called_fq_classlike_name, $called_method_name_lowercase);
```
**After**
```
No errors found!
```
**Notes**

I found https://github.com/vimeo/psalm/issues/3223 so I'm not sure if this was intentional or not. I personally feel like `lowercase-string` is a worthwhile type to have!

