### PR TITLE
stubs for array_sum

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -469,3 +469,17 @@ function strtolower(string $str) : string {}
  * )
  */
 function implode($glue, array $pieces = []) : string {}
+
+/**
+ * @param array $input
+ *
+ * @return (
+ *     $input is array<int> 
+ *     ? int 
+ *     : ($input is array<float>
+ *         ? float
+ *         : float|int
+ *     )
+ * )
+ */
+function array_sum(array $input) {}

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -570,7 +570,35 @@ class ArrayFunctionCallTest extends TestCase
                 '<?php
                     $foo = array_sum([]) + 1;',
                 'assertions' => [
+                    '$foo' => 'int',
+                ],
+            ],
+            'arraySumOnlyInt' => [
+                '<?php
+                    $foo = array_sum([5,18]);',
+                'assertions' => [
+                    '$foo' => 'int',
+                ],
+            ],
+            'arraySumOnlyFloat' => [
+                '<?php
+                    $foo = array_sum([5.1,18.2]);',
+                'assertions' => [
+                    '$foo' => 'float',
+                ],
+            ],
+            'arraySumNumeric' => [
+                '<?php
+                    $foo = array_sum(["5","18"]);',
+                'assertions' => [
                     '$foo' => 'float|int',
+                ],
+            ],
+            'arraySumMix' => [
+                '<?php
+                    $foo = array_sum([5,18.5]);',
+                'assertions' => [
+                    '$foo' => 'float',
                 ],
             ],
             'arrayMapWithArrayAndCallable' => [


### PR DESCRIPTION
This PR adds a stub for array_sum with a conditional return.
The logic is: 
- an `array<int>` will return an int
- an `array<float>` will return a float
- anything else will return int|float

During the testing, I discovered that `[4, 5.6]` will actually be considered a valid `array<float>` (instead of an `array<int|float>`) and so, will make array_sum return a float. While this is true for array_sum (and so I have a test just for this case), this is probably not strictly correct.