### PR TITLE
Fix getSymbolInformation() for symbols containing ":"

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1032,7 +1032,7 @@ class Codebase
     public function getSymbolInformation(string $file_path, string $symbol)
     {
         if (\is_numeric($symbol[0])) {
-            return \preg_replace('/[^:]*:/', '', $symbol);
+            return \preg_replace('/^[^:]*:/', '', $symbol);
         }
 
         try {


### PR DESCRIPTION
Currently a Symbol like `10-15:array{foo: string}` will return ` string}`, as the regex does not specify a string-start caret.