### PR TITLE
Display variable assignment type in LSP hovers

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -450,6 +450,18 @@ class AssignmentAnalyzer
                         );
                     }
 
+                    if ($codebase->store_node_types
+                        && !$context->collect_initializations
+                        && !$context->collect_mutations
+                    ) {
+                        $location = new CodeLocation($statements_analyzer, $assign_var);
+                        $codebase->analyzer->addNodeReference(
+                            $statements_analyzer->getFilePath(),
+                            $assign_var,
+                            $location->raw_file_start . '-' . $location->raw_file_end . ':' . $assign_value_type->getId()
+                        );
+                    }
+
                     if (isset($context->byref_constraints[$var_id]) || $assign_value_type->by_ref) {
                         $statements_analyzer->registerVariableUses([$location->getHash() => $location]);
                     }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -458,7 +458,9 @@ class AssignmentAnalyzer
                         $codebase->analyzer->addNodeReference(
                             $statements_analyzer->getFilePath(),
                             $assign_var,
-                            $location->raw_file_start . '-' . $location->raw_file_end . ':' . $assign_value_type->getId()
+                            $location->raw_file_start
+                                . '-' . $location->raw_file_end
+                                . ':' . $assign_value_type->getId()
                         );
                     }
 


### PR DESCRIPTION
First PR, so this might be totally the wrong approach to fix this!

I wanted to support the hover action via the LSP for variable assignment statements, so I can hover the variable to see it's assigned type (e.g. `$foo = 'hello'`). When hovering `$foo` it should show me `string(hello)` as the variable type.

To do this, I had to add the node reference in the Assignment analyzer. This is because the LSP hover calls `Codebase::getReferenceAtPosition`, hence the variable assignment needs to be part of the reference map fetched via `getMapsForFile`. I'm not actually sure if the reference map is where this should live, as I don't really know what is meant by "reference" in this context. Does it refer to a reference of file positions to tokens/nodes, or is it to track statements that reference a value declared elsewhere in the codebase?

So, I'm not sure if this is the right place to add this code.

Screenshot:

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2020-05-19-11-00-42.27-br1rIgDhr6J3bS3zhnFPnnh6oRxhhubcz7rCtUE3f0dSR5P8rASFUEnkDY5DCgNp7VnvgMFpOIf0LaBAF9l6FAsJvxoIrQVVvqy3.png)

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2020-05-19-11-00-56.18-MbEfzc9C77neE120px9j6ZOTpn5BRyYxJsvRovPUwElN3tJyGUwJHmAd2QkKvGY2xMJPF3mnqtwJp5BvLWJvtGycIqZbt1kJwl32.png)