### PR TITLE
Use same working directory for preparing cache directory as it used in running analysis

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -889,8 +889,19 @@ class Config
 
         $config->cache_directory .= DIRECTORY_SEPARATOR . sha1($base_dir);
 
+        $cwd = null;
+
+        if ($config->resolve_from_config_file) {
+            $cwd = getcwd();
+            chdir($config->base_dir);
+        }
+
         if (is_dir($config->cache_directory) === false && @mkdir($config->cache_directory, 0777, true) === false) {
             trigger_error('Could not create cache directory: ' . $config->cache_directory, E_USER_ERROR);
+        }
+
+        if ($cwd) {
+            chdir($cwd);
         }
 
         if (isset($config_xml['serializer'])) {


### PR DESCRIPTION
Imagine the following directory structure
```
.
|____test
| |____phpunit.xml
|____dev-ops
| |____.build
| |____psalm.xml
|____composer.json
|____src
| |____FooBar.php
```
The psalm.xml looks like this:
```xml
<?xml version="1.0"?>
<psalm
    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
    xmlns="https://getpsalm.org/schema/config"
    xsi:schemaLocation="https://getpsalm.org/schema/config ../vendor/vimeo/psalm/config.xsd"
    cacheDirectory=".build/psalm"
    errorLevel="1"
    resolveFromConfigFile="true"
>
    <projectFiles>
        <directory name="../src/" />
        <directory name="../test/" />
        <ignoreFiles>
            <directory name="../vendor/" />
        </ignoreFiles>
    </projectFiles>
</psalm>
```
The `dev-ops/.build` directory is intended to contain every temporary files that should not be versioned and are only used to be a file dump for caches and processing.

Like this the cache directory is prepared in `.build/psalm/cachehash1234567890` but every cache writes into `dev-ops/.build/psalm/cachehash1234567890`.

This is due to the fact that the config prepares the cache folder before the working directory is later changed during processing https://github.com/vimeo/psalm/blob/9aa46221f6eb7160ce274af3c8864f13d0ef0e2f/src/psalm.php#L310-L313

The solution is open to discussion as I am unsure whether it should be solved like this on the long run but it works out for me not creating an empty directory at a location it should not write to.