### PR TITLE
fix: pass along final

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -349,7 +349,10 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                     new Type\Union([$lhs_type_part]),
                     $mixin_declaring_class_storage->name,
                     $fq_class_name,
-                    $class_storage->parent_class
+                    $class_storage->parent_class,
+                    true,
+                    false,
+                    $class_storage->final
                 );
 
                 $new_lhs_type_part = array_values($lhs_type_expanded->getAtomicTypes())[0];

--- a/tests/MixinAnnotationTest.php
+++ b/tests/MixinAnnotationTest.php
@@ -277,6 +277,62 @@ class MixinAnnotationTest extends TestCase
                         return (new FooGrandChild)->type();
                     }'
             ],
+            'inheritTemplatedMixinWithStaticAndFinalClass' => [
+                '<?php
+                    /**
+                     * @template T
+                     */
+                    class Mixin {
+                        /**
+                         * @psalm-var T
+                         */
+                        private $var;
+
+                        /**
+                         * @psalm-param T $var
+                         */
+                        public function __construct ($var) {
+                            $this->var = $var;
+                        }
+
+                        /**
+                         * @psalm-return self<T>
+                         */
+                        public function getMixin() {
+                            return $this;
+                        }
+                    }
+
+                    /**
+                     * @template T as object
+                     * @mixin Mixin<T>
+                     */
+                    abstract class Foo {
+                        /** @var Mixin<T> */
+                        public object $obj;
+
+                        public function __call(string $name, array $args) {
+                            return $this->obj->$name(...$args);
+                        }
+                    }
+
+                    /**
+                     * @extends Foo<static>
+                     */
+                    abstract class FooChild extends Foo{}
+
+                    /**
+                     * @psalm-suppress MissingConstructor
+                     */
+                    final class FooGrandChild extends FooChild {}
+
+                    /**
+                    * @psalm-return Mixin<FooGrandChild>
+                    */
+                    function test() : Mixin {
+                        return (new FooGrandChild)->getMixin();
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
closes #3470 

I can make a separate test case if you like. I figured it was fine to merge them together since the title of the test case was `inheritTemplatedMixinWithStatic`