### PR TITLE
Support global functions in getSymbolInformation and getSymbolLocation

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1078,14 +1078,20 @@ class Codebase
             }
 
             if (strpos($symbol, '()')) {
-                $file_storage = $this->file_storage_provider->get($file_path);
-
                 $function_id = strtolower(substr($symbol, 0, -2));
+                $file_storage = $this->file_storage_provider->get($file_path);
 
                 if (isset($file_storage->functions[$function_id])) {
                     $function_storage = $file_storage->functions[$function_id];
 
                     return '<?php ' . $function_storage->getSignature(true);
+                }
+
+                try {
+                    $function = $this->functions->getStorage(null, $function_id);
+                    return '<?php ' . $function->getSignature(true);
+                } catch (\UnexpectedValueException $exception) {
+
                 }
 
                 return null;
@@ -1168,6 +1174,13 @@ class Codebase
 
                 if (isset($file_storage->functions[$function_id])) {
                     return $file_storage->functions[$function_id]->location;
+                }
+
+                try {
+                    $function = $this->functions->getStorage(null, $function_id);
+                    return $function->location;
+                } catch (\UnexpectedValueException $exception) {
+
                 }
 
                 return null;

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1087,14 +1087,8 @@ class Codebase
                     return '<?php ' . $function_storage->getSignature(true);
                 }
 
-                try {
-                    $function = $this->functions->getStorage(null, $function_id);
-                    return '<?php ' . $function->getSignature(true);
-                } catch (\UnexpectedValueException $exception) {
-
-                }
-
-                return null;
+                $function = $this->functions->getStorage(null, $function_id);
+                return '<?php ' . $function->getSignature(true);
             }
 
             $storage = $this->classlike_storage_provider->get($symbol);
@@ -1176,14 +1170,8 @@ class Codebase
                     return $file_storage->functions[$function_id]->location;
                 }
 
-                try {
-                    $function = $this->functions->getStorage(null, $function_id);
-                    return $function->location;
-                } catch (\UnexpectedValueException $exception) {
-
-                }
-
-                return null;
+                $function = $this->functions->getStorage(null, $function_id);
+                return $function->location;
             }
 
             $storage = $this->classlike_storage_provider->get($symbol);

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1086,6 +1086,10 @@ class Codebase
 
                     return '<?php ' . $function_storage->getSignature(true);
                 }
+                
+                if (!$function_id) {
+                    return null;
+                }
 
                 $function = $this->functions->getStorage(null, $function_id);
                 return '<?php ' . $function->getSignature(true);
@@ -1168,6 +1172,10 @@ class Codebase
 
                 if (isset($file_storage->functions[$function_id])) {
                     return $file_storage->functions[$function_id]->location;
+                }
+                
+                if (!$function_id) {
+                    return null;
                 }
 
                 $function = $this->functions->getStorage(null, $function_id);


### PR DESCRIPTION
Currently codebase-wide defined function are not found in `Codebase::getSymbolLocation` or `Codebase::getSymbolInformation`. This means hovers via the LSP on functions not in the current file, or "go to definition" do not work for non-locally defined functions.

It looks to me that this might have been an oversight, as methods do support this.

For stubbed functions, "go to definition" will open the stub file, which is also quite hadny.