### PR TITLE
Add checks for duplicated params and returns

### DIFF
--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1660,6 +1660,24 @@ class AnnotationTest extends TestCase
                     }',
                 'error_message' => 'FalsableReturnStatement - src' . DIRECTORY_SEPARATOR . 'somefile.php:6:32',
             ],
+            'DuplicatedParam' => [
+                '<?php
+                    /**
+                     * @psalm-param array $arr
+                     * @psalm-param array $arr
+                     */
+                    function bar(array $arr): void {}',
+                'error_message' => 'InvalidDocblock - src' . DIRECTORY_SEPARATOR . 'somefile.php:6:21 - Found duplicated @param or prefixed @param tag in docblock for bar',
+            ],
+            'DuplicatedReturn' => [
+                '<?php
+                    /**
+                     * @return void
+                     * @return void
+                     */
+                    function bar(array $arr): void {}',
+                'error_message' => 'InvalidDocblock - src' . DIRECTORY_SEPARATOR . 'somefile.php:6:21 - Found duplicated @return or prefixed @return tag in docblock for bar',
+            ],
         ];
     }
 }

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -1007,7 +1007,6 @@ class ArrayAccessTest extends TestCase
                 '<?php
                     /**
                      * @return array<int,array<string,float>>|string
-                     * @return string
                      */
                     function return_array() {
                         return rand() % 5 > 3 ? [["key" => 3.5]] : "key:3.5";

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -25,8 +25,8 @@ class MagicMethodAnnotationTest extends TestCase
                  * @method  void setInteger(int $integer)
                  * @method setString(int $integer)
                  * @method  getBool(string $foo) : bool
-                 * @method (string|int)[] getArray() : array
-                 * @method (callable() : string) getCallable() : callable
+                 * @method (string|int)[] getArray()
+                 * @method (callable() : string) getCallable()
                  */
                 class Child {}
 
@@ -174,8 +174,8 @@ class MagicMethodAnnotationTest extends TestCase
                      * @method setAnotherImplicitMixed( $foo, $bar,$baz) dsa sada
                      * @method setYetAnotherImplicitMixed( $foo  ,$bar,  $baz    ) dsa sada
                      * @method  getBool(string $foo)  :   bool dsa sada
-                     * @method (string|int)[] getArray() : array with some text dsa sada
-                     * @method (callable() : string) getCallable() : callable dsa sada
+                     * @method (string|int)[] getArray() with some text dsa sada
+                     * @method (callable() : string) getCallable() dsa sada
                      */
                     class Child extends ParentClass {}
 


### PR DESCRIPTION
This PR should fix #1400 and fix #2245.

It checks for duplicated @param, @return (and prefixed tags too) for duplicated content.

Please tell me if there's anything to change, My goal is also to improve :)

I didn't expect that `MissingDocblockType` Issue would appear in the tests. Not sure if I did something wrong of if it's expected.

I checked PhpUnit and PHPStorm checked CS rules but I didn't launch the full CI on local. I'll fix CI if needed.

EDIT: I also fixed a case of duplicated return on a test. I think it was unrelated to the test itself