### PR TITLE
Fix #3437

### DIFF
--- a/src/Psalm/Internal/PropertyMap.php
+++ b/src/Psalm/Internal/PropertyMap.php
@@ -98,7 +98,7 @@ return [
         's' => 'integer',
         'f' => 'float', // only present from 7.1 onwards
         'invert' => 'integer',
-        'days' => 'mixed',
+        'days' => 'false|int',
     ],
     'tokyotyrantexception' => [
         'code' => 'int',


### PR DESCRIPTION
This PR improve the typing for DateInterval::days and fix #3437. This doesn't totally solve the issue but it's the best we can do for now