### PR TITLE
Improve stubs for str_replace and preg_replace

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -560,9 +560,9 @@ function htmlspecialchars_decode(string $string, ?int $quote_style = null) : str
 /**
  * @psalm-pure
  *
- * @param string|int|float|array<string|int|float> $search
- * @param string|int|float|array<string|int|float> $replace
- * @param string|int|float|array<string|int|float> $subject
+ * @param string|array<string|int|float> $search
+ * @param string|array<string|int|float> $replace
+ * @param string|array<string|int|float> $subject
  * @param int $count
  * @return ($subject is array ? array<string> : string)
  *
@@ -574,8 +574,8 @@ function str_replace($search, $replace, $subject, &$count = null) {}
  * @psalm-pure
  *
  * @param string|string[] $search
- * @param string|int|float|array<string|int|float> $replace
- * @param string|int|float|array<string|int|float> $subject
+ * @param string|array<string|int|float> $replace
+ * @param string|array<string|int|float> $subject
  * @param int $count
  * @return ($subject is array ? array<string> : string)
  *

--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -560,11 +560,11 @@ function htmlspecialchars_decode(string $string, ?int $quote_style = null) : str
 /**
  * @psalm-pure
  *
- * @param string|string[] $search
- * @param string|string[] $replace
- * @param string|string[] $subject
+ * @param string|int|float|array<string|int|float> $search
+ * @param string|int|float|array<string|int|float> $replace
+ * @param string|int|float|array<string|int|float> $subject
  * @param int $count
- * @return string|string[]
+ * @return ($subject is array ? array<string> : string)
  *
  * @psalm-flow ($replace, $subject) -> return
  */
@@ -574,10 +574,10 @@ function str_replace($search, $replace, $subject, &$count = null) {}
  * @psalm-pure
  *
  * @param string|string[] $search
- * @param string|string[] $replace
- * @param string|string[] $subject
+ * @param string|int|float|array<string|int|float> $replace
+ * @param string|int|float|array<string|int|float> $subject
  * @param int $count
- * @return string|string[]
+ * @return ($subject is array ? array<string> : string)
  *
  * @psalm-flow ($replace, $subject) -> return
  */


### PR DESCRIPTION
This PR expands accepted values for str_replace and preg_replace and make return conditional based on type of $subject

It fix #3475

After some tests, I found out, ints and floats are accepted and works well. No matter what, the returned type will always be a string or an array of strings. The parameter is always casted to string.

I could have added bool as an accepted value, but given that a casted boolean will be either "" or "1", it didn't make a lot of sense and this is most likely a bug in the application