### PR TITLE
Fixed mysql::$insert_id type

### DIFF
--- a/src/Psalm/Internal/PropertyMap.php
+++ b/src/Psalm/Internal/PropertyMap.php
@@ -260,7 +260,7 @@ return [
         'field_count' => 'int',
         'host_info' => 'string',
         'info' => 'string',
-        'insert_id' => 'int',
+        'insert_id' => 'int|numeric-string',
         'protocol_version' => 'string',
         'server_info' => 'string',
         'server_version' => 'int',

--- a/src/Psalm/Internal/PropertyMap.php
+++ b/src/Psalm/Internal/PropertyMap.php
@@ -260,7 +260,7 @@ return [
         'field_count' => 'int',
         'host_info' => 'string',
         'info' => 'string',
-        'insert_id' => 'int|numeric-string',
+        'insert_id' => 'int',
         'protocol_version' => 'string',
         'server_info' => 'string',
         'server_version' => 'int',

--- a/src/Psalm/Internal/PropertyMap.php
+++ b/src/Psalm/Internal/PropertyMap.php
@@ -260,7 +260,7 @@ return [
         'field_count' => 'int',
         'host_info' => 'string',
         'info' => 'string',
-        'insert_id' => 'mixed',
+        'insert_id' => 'int',
         'protocol_version' => 'string',
         'server_info' => 'string',
         'server_version' => 'int',


### PR DESCRIPTION
Per phpdocs:

> Return Values 
The value of the AUTO_INCREMENT field that was updated by the previous query. Returns zero if there was no previous query on the connection or if the query did not update an AUTO_INCREMENT value.
Note:
If the number is greater than maximal int value, mysqli_insert_id() will return a string.

https://www.php.net/manual/en/mysqli.insert-id.php