### PR TITLE
Made mysqli_warning::$sqlstate a string

### DIFF
--- a/src/Psalm/Internal/PropertyMap.php
+++ b/src/Psalm/Internal/PropertyMap.php
@@ -302,7 +302,7 @@ return [
     'mysqli_warning' => [
         'errno' => 'int',
         'message' => 'string',
-        'sqlstate' => 'mixed',
+        'sqlstate' => 'string',
     ],
     'eventlistener' => [
         'fd' => 'int',


### PR DESCRIPTION
Like in other mysql objects the sqlstate is a string
https://github.com/vimeo/psalm/pull/3497/files#diff-3a9cb9e92cf88595ca52bb250ebc0bd7L288
https://github.com/vimeo/psalm/pull/3497/files#diff-3a9cb9e92cf88595ca52bb250ebc0bd7L267