### PR TITLE
Use scandir and glob flags to reduce their performance impact

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -28,6 +28,7 @@ use function is_dir;
 use function is_file;
 use function json_decode;
 use function libxml_clear_errors;
+use const GLOB_NOSORT;
 use const LIBXML_ERR_ERROR;
 use const LIBXML_ERR_FATAL;
 use function libxml_get_errors;
@@ -76,6 +77,7 @@ use function chdir;
 use function simplexml_import_dom;
 use const LIBXML_NONET;
 use function is_a;
+use const SCANDIR_SORT_NONE;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor
@@ -1729,7 +1731,7 @@ class Config
         } elseif (is_dir($phpstorm_meta_path)) {
             $phpstorm_meta_path = realpath($phpstorm_meta_path);
 
-            foreach (glob($phpstorm_meta_path . '/*.meta.php') as $glob) {
+            foreach (glob($phpstorm_meta_path . '/*.meta.php', GLOB_NOSORT) as $glob) {
                 if (is_file($glob) && realpath(dirname($glob)) === $phpstorm_meta_path) {
                     $stub_files[] = $glob;
                 }
@@ -1972,7 +1974,7 @@ class Config
     public static function removeCacheDirectory($dir)
     {
         if (is_dir($dir)) {
-            $objects = scandir($dir);
+            $objects = scandir($dir, SCANDIR_SORT_NONE);
 
             if ($objects === false) {
                 throw new \UnexpectedValueException('Not expecting false here');

--- a/src/Psalm/Config/Creator.php
+++ b/src/Psalm/Config/Creator.php
@@ -25,6 +25,7 @@ use function array_filter;
 use function array_sum;
 use function array_keys;
 use function max;
+use const GLOB_NOSORT;
 
 class Creator
 {
@@ -250,9 +251,9 @@ class Creator
 
         /** @var string[] */
         $php_files = array_merge(
-            glob($current_dir . DIRECTORY_SEPARATOR . '*.php'),
-            glob($current_dir . DIRECTORY_SEPARATOR . '**/*.php'),
-            glob($current_dir . DIRECTORY_SEPARATOR . '**/**/*.php')
+            glob($current_dir . DIRECTORY_SEPARATOR . '*.php', GLOB_NOSORT),
+            glob($current_dir . DIRECTORY_SEPARATOR . '**/*.php', GLOB_NOSORT),
+            glob($current_dir . DIRECTORY_SEPARATOR . '**/**/*.php', GLOB_NOSORT)
         );
 
         foreach ($php_files as $php_file) {

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -22,6 +22,8 @@ use function str_replace;
 use function stripos;
 use function strpos;
 use function strtolower;
+use const GLOB_NOSORT;
+use const GLOB_ONLYDIR;
 
 class FileFilter
 {
@@ -116,10 +118,7 @@ class FileFilter
                 if (strpos($prospective_directory_path, '*') !== false) {
                     $globs = array_map(
                         'realpath',
-                        array_filter(
-                            glob($prospective_directory_path),
-                            'is_dir'
-                        )
+                        glob($prospective_directory_path, GLOB_ONLYDIR)
                     );
 
                     if (empty($globs)) {
@@ -231,7 +230,7 @@ class FileFilter
                     $globs = array_map(
                         'realpath',
                         array_filter(
-                            glob($prospective_file_path),
+                            glob($prospective_file_path, GLOB_NOSORT),
                             'file_exists'
                         )
                     );

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -9,6 +9,7 @@ use function scandir;
 use SimpleXMLElement;
 use function strtolower;
 use function substr;
+use const SCANDIR_SORT_NONE;
 
 class IssueHandler
 {
@@ -160,7 +161,7 @@ class IssueHandler
                 function ($file_name) {
                     return substr($file_name, 0, -4);
                 },
-                scandir(dirname(__DIR__) . '/Issue')
+                scandir(dirname(__DIR__) . '/Issue', SCANDIR_SORT_NONE)
             ),
             /**
              * @param string $issue_name

--- a/src/Psalm/Internal/Provider/ParserCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ParserCacheProvider.php
@@ -25,6 +25,7 @@ use function serialize;
 use function touch;
 use function unlink;
 use function unserialize;
+use const SCANDIR_SORT_NONE;
 
 /**
  * @internal
@@ -345,7 +346,7 @@ class ParserCacheProvider
         $cache_directory .= DIRECTORY_SEPARATOR . self::PARSER_CACHE_DIRECTORY;
 
         if (is_dir($cache_directory)) {
-            $directory_files = scandir($cache_directory);
+            $directory_files = scandir($cache_directory, SCANDIR_SORT_NONE);
 
             foreach ($directory_files as $directory_file) {
                 $full_path = $cache_directory . DIRECTORY_SEPARATOR . $directory_file;
@@ -380,7 +381,7 @@ class ParserCacheProvider
         $cache_directory .= DIRECTORY_SEPARATOR . self::PARSER_CACHE_DIRECTORY;
 
         if (is_dir($cache_directory)) {
-            $directory_files = scandir($cache_directory);
+            $directory_files = scandir($cache_directory, SCANDIR_SORT_NONE);
 
             foreach ($directory_files as $directory_file) {
                 $full_path = $cache_directory . DIRECTORY_SEPARATOR . $directory_file;

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -21,6 +21,7 @@ use function trim;
 use function glob;
 use function str_replace;
 use function array_shift;
+use const GLOB_NOSORT;
 
 class DocumentationTest extends TestCase
 {
@@ -40,7 +41,7 @@ class DocumentationTest extends TestCase
 
         $issue_code = [];
 
-        foreach (glob($issues_dir . '/*.md') as $file_path) {
+        foreach (glob($issues_dir . '/*.md', GLOB_NOSORT) as $file_path) {
             $file_contents = file_get_contents($file_path);
 
             $file_lines = explode("\n", $file_contents);

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -21,7 +21,6 @@ use function trim;
 use function glob;
 use function str_replace;
 use function array_shift;
-use const GLOB_NOSORT;
 
 class DocumentationTest extends TestCase
 {
@@ -41,7 +40,7 @@ class DocumentationTest extends TestCase
 
         $issue_code = [];
 
-        foreach (glob($issues_dir . '/*.md', GLOB_NOSORT) as $file_path) {
+        foreach (glob($issues_dir . '/*.md') as $file_path) {
             $file_contents = file_get_contents($file_path);
 
             $file_lines = explode("\n", $file_contents);


### PR DESCRIPTION
This PR applies suggestions from https://github.com/kalessil/phpinspectionsea about performance optimizations with scandir and glob.

The main optimization is to tell scandir and glob not to sort the results. I tried to look but the order of the files didn't seem critical.

There is also an optimization with glob which return only directories. This allows dropping the is_dir filter which need to fetch info from filesystem again.