### PR TITLE
Proposal: Use different psalm cache for different versions

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -827,7 +827,7 @@ class Config
 
         $config->global_cache_directory = $config->cache_directory;
 
-        $config->cache_directory .= DIRECTORY_SEPARATOR . sha1($base_dir);
+        $config->cache_directory .= DIRECTORY_SEPARATOR . sha1($base_dir . '::' . PSALM_VERSION);
 
         if (is_dir($config->cache_directory) === false && @mkdir($config->cache_directory, 0777, true) === false) {
             trigger_error('Could not create cache directory: ' . $config->cache_directory, E_USER_ERROR);


### PR DESCRIPTION
Older psalm versions may be missing cache entries that newer psalm
versions may cache.
Newer versions may remove/use a different form of cache entries
than that expected by older psalm versions.

Motivation: I've seen build failures when updating psalm on one branch but not others when the directory is on a shared CI host