### PR TITLE
Fix #3521 - Add --set-baseline filename to --config specified file

### DIFF
--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -442,7 +442,11 @@ function update_config_file(Config $config, string $config_file_path, string $ba
         return;
     }
 
-    $configFile = Config::locateConfigFile($config_file_path);
+    $configFile = $config_file_path;
+
+    if (is_dir($config_file_path)) {
+        $configFile = Config::locateConfigFile($config_file_path);
+    }
 
     if (!$configFile) {
         fwrite(STDERR, "Don't forget to set errorBaseline=\"{$baseline_path}\" to your config.");


### PR DESCRIPTION
Fixes vimeo/psalm#3521

I found that it's about the call to update_config_file() from psalm.php which uses the Config::locateConfigFile that only searches for Config::DEFAULT_FILE_NAME filenames

The call to Config::locateConfigFile('...path\blah.xml') returns actually '...path\psalm.xml' (or '\path'psalm.xml.dist)

I choosed to skip locateConfigFile based on is_dir (see the call from psalm.php , second argument like : $path_to_config ?? $current_dir)