### PR TITLE
Add tests for getSymbolInformation across multiple files

### DIFF
--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -94,6 +94,35 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
+    public function testCrossFileSymbolLookup()
+    {
+        $this->addFile(
+            'functions.php',
+            '<?php
+                function foo() : int {
+                    return 5;
+                }'
+        );
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                $foo = foo();'
+        );
+
+        new FileAnalyzer($this->project_analyzer, 'functions.php', 'functions.php');
+        new FileAnalyzer($this->project_analyzer, 'somefile.php', 'somefile.php');
+
+        $codebase = $this->project_analyzer->getCodebase();
+        $context = new Context();
+        $this->analyzeFile('functions.php', $context );
+        $this->analyzeFile('somefile.php', $context );
+
+        $this->assertSame('<?php public function foo() : int', $codebase->getSymbolInformation('somefile.php', 'foo()'));
+    }
+
+    /**
+     * @return void
+     */
     public function testSimpleSymbolLocation()
     {
         $this->addFile(


### PR DESCRIPTION
In #3477 support for getting symbol finformation on functions across files was added. This is a follow-up to add tests for that enhancement.

These are currently failing, because I haven't worked out how to get Psalm to analyze both files. This is currently throwing an error: `UndefinedFunction - somefile.php:2:24 - Function foo does not exist`. It seems either the codebase analyzer is not assuming `functions.php` is included, or they are somehow not getting anaylzed together.

I tried adding `require( "functions.php" );` to `somefile.php`, but this results in a "file not found" error, as it seems it's looking on the filesystem rather than looking at the in-memory file map.

@muglug could you perhaps provide me some guidance on how I should be writing a test that is across more than one file. I had a look through other tests, but I didn't find any that are adding multiple files to a project.

Thanks!