### PR TITLE
Extending final class is prohibited #3037

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -213,6 +213,7 @@
             <xs:element name="InvalidCast" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidCatch" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidClass" type="ClassIssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidExtendClass" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidClone" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidParamDefault" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidDocblock" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -48,6 +48,7 @@
  - [InvalidCast](issues/InvalidCast.md)
  - [InvalidCatch](issues/InvalidCatch.md)
  - [InvalidClass](issues/InvalidClass.md)
+ - [InvalidExtendClass](issues/InvalidExtendClass.md)
  - [InvalidClone](issues/InvalidClone.md)
  - [InvalidDocblock](issues/InvalidDocblock.md)
  - [InvalidDocblockParamName](issues/InvalidDocblockParamName.md)

--- a/docs/running_psalm/issues/InvalidExtendClass.md
+++ b/docs/running_psalm/issues/InvalidExtendClass.md
@@ -1,0 +1,18 @@
+# InvalidExtendClass
+
+Emitted when attempting to extends a final class or annotated as final.
+
+```php
+<?php
+
+final class A {}
+
+class B extends A {}
+
+/**
+ * @final
+ */
+class DoctrineA {}
+
+class DoctrineB extends DoctrineA {}
+```

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -14,6 +14,7 @@ use Psalm\Issue\DeprecatedInterface;
 use Psalm\Issue\DeprecatedTrait;
 use Psalm\Issue\InaccessibleMethod;
 use Psalm\Issue\InternalClass;
+use Psalm\Issue\InvalidExtendClass;
 use Psalm\Issue\InvalidTemplateParam;
 use Psalm\Issue\MethodSignatureMismatch;
 use Psalm\Issue\MissingConstructor;
@@ -261,6 +262,19 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                             $parent_fq_class_name . ' is not a class',
                             $code_location,
                             $parent_fq_class_name . ' as class'
+                        ),
+                        $storage->suppressed_issues + $this->getSuppressedIssues()
+                    )) {
+                        // fall through
+                    }
+                }
+
+                if ($parent_class_storage->final) {
+                    if (IssueBuffer::accepts(
+                        new InvalidExtendClass(
+                            'Class ' . $fq_class_name  . ' may not inherit from final class ' . $parent_fq_class_name,
+                            $code_location,
+                            $fq_class_name
                         ),
                         $storage->suppressed_issues + $this->getSuppressedIssues()
                     )) {

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -846,6 +846,10 @@ class CommentAnalyzer
             $info->internal = true;
         }
 
+        if (isset($parsed_docblock->tags['final'])) {
+            $info->final = true;
+        }
+
         if (isset($parsed_docblock->tags['psalm-internal'])) {
             $psalm_internal = reset($parsed_docblock->tags['psalm-internal']);
             if ($psalm_internal) {

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -1310,6 +1310,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
                 $storage->deprecated = $docblock_info->deprecated;
                 $storage->internal = $docblock_info->internal;
                 $storage->psalm_internal = $docblock_info->psalm_internal;
+                $storage->final = $storage->final || $docblock_info->final;
 
                 if ($docblock_info->mixin) {
                     $mixin_type = TypeParser::parseTokens(

--- a/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
@@ -21,6 +21,13 @@ class ClassLikeDocblockComment
     public $internal = false;
 
     /**
+     * Whether or not the class is final
+     *
+     * @var bool
+     */
+    public $final = false;
+
+    /**
      * If set, the class is internal to the given namespace.
      *
      * @var null|string

--- a/src/Psalm/Issue/InvalidExtendClass.php
+++ b/src/Psalm/Issue/InvalidExtendClass.php
@@ -1,0 +1,8 @@
+<?php
+namespace Psalm\Issue;
+
+class InvalidExtendClass extends ClassIssue
+{
+    const ERROR_LEVEL = -1;
+    const SHORTCODE = 7;    // to be updated
+}

--- a/tests/ExtendsFinalClassTest.php
+++ b/tests/ExtendsFinalClassTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Psalm\Tests;
+
+class ExtendsFinalClassTest extends TestCase
+{
+    use Traits\InvalidCodeAnalysisTestTrait;
+    use Traits\ValidCodeAnalysisTestTrait;
+
+    /**
+     * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
+     */
+    public function providerValidCodeParse()
+    {
+        return [
+            'suppressingIssueWhenUsedWithKeyword' => [
+                '<?php
+
+                final class A {}
+
+                /**
+                * @psalm-suppress InvalidExtendClass
+                */
+                class B extends A {}'
+            ],
+            'suppressingIssueWhenUsedWithAnnotation' => [
+                '<?php
+
+                /**
+                * @final
+                */
+                class A {}
+
+                /**
+                * @psalm-suppress InvalidExtendClass
+                */
+                class B extends A {}'
+            ],
+        ];
+    }
+
+    /**
+     * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
+     */
+    public function providerInvalidCodeParse()
+    {
+        return [
+            'invalidExtendsFinalClass' => [
+                '<?php
+
+                final class A {}
+
+                class B extends A {}',
+
+                'error_message' => 'InvalidExtendClass',
+            ],
+
+            'invalidExtendsAnnotatedFinalClass' => [
+                '<?php
+
+                /**
+                * @final
+                */
+                class DoctrineA {}
+
+                class DoctrineB extends DoctrineA {}',
+
+                'error_message' => 'InvalidExtendClass',
+            ],
+
+            'invalidExtendsFinalClassAndOtherAnnotation' => [
+                '<?php
+
+                /**
+                * @something-else-no-final annotation
+                */
+                final class DoctrineA {}
+
+                class DoctrineB extends DoctrineA {}',
+
+                'error_message' => 'InvalidExtendClass',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
I tried a simple implementation for prohibiting extending final classes, both by the final keyword and also by the `@final` annotation.
I set the level -1 because in php is a fatal error.

The SHORTCODE seems to link to a doc webpage so should be updated.