### PR TITLE
Documented using underscore to suppress unused(param/variable) issues

### DIFF
--- a/docs/running_psalm/issues/PossiblyUnusedParam.md
+++ b/docs/running_psalm/issues/PossiblyUnusedParam.md
@@ -14,3 +14,14 @@ class A {
 $a = new A();
 $a->foo(1, 2);
 ```
+
+Can be suppressed by prefixing the parameter name with an underscore:
+
+```php
+<?php
+class A {
+    public function foo(int $a, int $_b) : int {
+        return $a + 4;
+    }
+}
+```

--- a/docs/running_psalm/issues/UnusedClosureParam.md
+++ b/docs/running_psalm/issues/UnusedClosureParam.md
@@ -16,3 +16,11 @@ function foo(callable $c) : int {
     return $c(2, 4);
 }
 ```
+
+Can be suppressed by prefixing the parameter name with an underscore:
+
+```php
+$f = function (int $_a, int $b) : int {
+    return $b + 4;
+};
+```

--- a/docs/running_psalm/issues/UnusedParam.md
+++ b/docs/running_psalm/issues/UnusedParam.md
@@ -9,3 +9,11 @@ function foo(int $a, int $b) : int {
     return $a + 4;
 }
 ```
+
+Can be suppressed by prefixing the parameter name with an underscore:
+
+```php
+function foo(int $_a, int $b) : int {
+    return $b + 4;
+}
+```

--- a/docs/running_psalm/issues/UnusedVariable.md
+++ b/docs/running_psalm/issues/UnusedVariable.md
@@ -11,3 +11,11 @@ function foo() : void {
     echo $b;
 }
 ```
+
+Can be suppressed by prefixing the variable name with an underscore:
+
+```php
+<?php
+
+$_a = 22;
+```


### PR DESCRIPTION
Previously it was undocumented, as pointed out in vimeo/psalm#3574