### PR TITLE
Add a --debug-emitted-issues flag

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -568,6 +568,11 @@ class Config
      */
     protected $taint_analysis_ignored_files;
 
+    /**
+     * @var bool whether to emit a backtrace of emitted issues to stderr
+     */
+    public $debug_emitted_issues = false;
+
     protected function __construct()
     {
         self::$instance = $this;

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -5,12 +5,16 @@ use function array_pop;
 use function array_search;
 use function array_splice;
 use function count;
+use function debug_print_backtrace;
 use function explode;
 use function file_put_contents;
+use function fwrite;
 use function get_class;
 use function memory_get_peak_usage;
 use function microtime;
 use function number_format;
+use function ob_get_clean;
+use function ob_start;
 use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Issue\CodeIssue;
@@ -33,6 +37,8 @@ use function str_replace;
 use function usort;
 use function array_merge;
 use function array_values;
+use const DEBUG_BACKTRACE_IGNORE_ARGS;
+use const STDERR;
 
 class IssueBuffer
 {
@@ -204,6 +210,13 @@ class IssueBuffer
 
         if ($reporting_level === Config::REPORT_SUPPRESS) {
             return false;
+        }
+
+        if ($config->debug_emitted_issues) {
+            ob_start();
+            debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+            $trace = ob_get_clean();
+            fwrite(STDERR, "\nEmitting {$e->getShortLocation()} $issue_type {$e->getMessage()}\n$trace\n");
         }
 
         $emitted_key = $issue_type . '-' . $e->getShortLocation() . ':' . $e->getLocation()->getColumn();

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -396,6 +396,9 @@ Miscellaneous:
     --debug-by-line
         Debug information on a line-by-line level
 
+    --debug-emitted-issues
+        Print a php backtrace to stderr when emitting issues.
+
     -r, --root
         If running Psalm globally you'll need to specify a project root. Defaults to cwd
 

--- a/src/psalm-refactor.php
+++ b/src/psalm-refactor.php
@@ -22,7 +22,7 @@ $args = array_slice($argv, 1);
 
 $valid_short_options = ['f:', 'm', 'h', 'r:', 'c:'];
 $valid_long_options = [
-    'help', 'debug', 'config:', 'root:',
+    'help', 'debug', 'debug-by-line', 'debug-emitted-issues', 'config:', 'root:',
     'threads:', 'move:', 'into:', 'rename:', 'to:',
 ];
 
@@ -92,7 +92,7 @@ Options:
     -h, --help
         Display this help message
 
-    --debug, --debug-by-line
+    --debug, --debug-by-line, --debug-emitted-issues
         Debug information
 
     -c, --config=psalm.xml
@@ -247,10 +247,14 @@ $providers = new Psalm\Internal\Provider\Providers(
     new Psalm\Internal\Provider\ProjectCacheProvider($current_dir . DIRECTORY_SEPARATOR . 'composer.lock')
 );
 
-$debug = array_key_exists('debug', $options);
+$debug = array_key_exists('debug', $options) || array_key_exists('debug-by-line', $options);
 $progress = $debug
     ? new DebugProgress()
     : new DefaultProgress();
+
+if (array_key_exists('debug-emitted-issues', $options)) {
+    $config->debug_emitted_issues = true;
+}
 
 $project_analyzer = new ProjectAnalyzer(
     $config,
@@ -260,6 +264,10 @@ $project_analyzer = new ProjectAnalyzer(
     $threads,
     $progress
 );
+
+if (array_key_exists('debug-by-line', $options)) {
+    $project_analyzer->debug_lines = true;
+}
 
 $config->visitComposerAutoloadFiles($project_analyzer);
 

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -30,6 +30,7 @@ $valid_long_options = [
     'config:',
     'debug',
     'debug-by-line',
+    'debug-emitted-issues',
     'diff',
     'diff-methods',
     'disable-extension:',
@@ -245,6 +246,7 @@ if (isset($options['i'])) {
                 && $arg !== '--init'
                 && $arg !== '--debug'
                 && $arg !== '--debug-by-line'
+                && $arg !== '--debug-emitted-issues'
                 && strpos($arg, '--disable-extension=') !== 0
                 && strpos($arg, '--root=') !== 0
                 && strpos($arg, '--r=') !== 0;
@@ -388,6 +390,10 @@ $ini_handler->check();
 
 if (is_null($config->load_xdebug_stub) && '' !== $ini_handler->getSkippedVersion()) {
     $config->load_xdebug_stub = true;
+}
+
+if (isset($options['debug-emitted-issues'])) {
+    $config->debug_emitted_issues = true;
 }
 
 setlocale(LC_CTYPE, 'C');

--- a/src/psalter.php
+++ b/src/psalter.php
@@ -27,7 +27,7 @@ $args = array_slice($argv, 1);
 
 $valid_short_options = ['f:', 'm', 'h', 'r:', 'c:'];
 $valid_long_options = [
-    'help', 'debug', 'debug-by-line', 'config:', 'file:', 'root:',
+    'help', 'debug', 'debug-by-line', 'debug-emitted-issues', 'config:', 'file:', 'root:',
     'plugin:', 'issues:', 'list-supported-issues', 'php-version:', 'dry-run', 'safe-types',
     'find-unused-code', 'threads:', 'codeowner:',
     'allow-backwards-incompatible-changes:',
@@ -105,7 +105,7 @@ Options:
     -h, --help
         Display this help message
 
-    --debug, --debug-by-line
+    --debug, --debug-by-line, --debug-emitted-issues
         Debug information
 
     -c, --config=psalm.xml
@@ -223,7 +223,7 @@ if (array_key_exists('list-supported-issues', $options)) {
     exit();
 }
 
-$debug = array_key_exists('debug', $options);
+$debug = array_key_exists('debug', $options) || array_key_exists('debug-by-line', $options);
 $progress = $debug
     ? new DebugProgress()
     : new DefaultProgress();
@@ -242,6 +242,10 @@ $project_analyzer = new ProjectAnalyzer(
 
 if (array_key_exists('debug-by-line', $options)) {
     $project_analyzer->debug_lines = true;
+}
+
+if (array_key_exists('debug-emitted-issues', $options)) {
+    $config->debug_emitted_issues = true;
 }
 
 $config->visitComposerAutoloadFiles($project_analyzer);


### PR DESCRIPTION
And support --debug-by-line in psalter and psalm-refactor.
Those were previously not supported in getopt()

Fixes #3634