### PR TITLE
Add psalm-taint-specialize for preg_replace_callback

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -619,6 +619,7 @@ function preg_replace($search, $replace, $subject, int $limit = -1, &$count = nu
  * @param int $count
  * @return ($subject is array ? array<string> : string)
  *
+ * @psalm-taint-specialize
  * @psalm-flow ($subject) -> return
  */
 function preg_replace_callback($search, $replace, $subject, int $limit = -1, &$count = null) {}


### PR DESCRIPTION
Fixes https://psalm.dev/r/517c4a169e

```php
<?php // --taint-analysis
$x = preg_replace_callback('/a/', function($match) {
    return 'b';
}, $_GET['a']);

$other = preg_replace_callback('/a/', function($match) {
    return '';
}, 'a literal string');
echo $other;  // should not warn, but $a should
```