### PR TITLE
Track taint in some implicit `__toString()` casts

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
@@ -27,7 +27,7 @@ class EncapsulatedStringAnalyzer
             $part_type = $statements_analyzer->node_data->getType($part);
 
             if ($part_type) {
-                CastAnalyzer::castStringAttempt($statements_analyzer, $context, $part);
+                $part_type_after_cast = CastAnalyzer::castStringAttempt($statements_analyzer, $context, $part);
 
                 if ($codebase->taint
                     && $codebase->config->trackTaintsInPath($statements_analyzer->getFilePath())
@@ -41,6 +41,11 @@ class EncapsulatedStringAnalyzer
 
                     if ($part_type->parent_nodes) {
                         foreach ($part_type->parent_nodes as $parent_node) {
+                            $codebase->taint->addPath($parent_node, $new_parent_node, 'concat');
+                        }
+                    }
+                    if ($part_type_after_cast->parent_nodes) {
+                        foreach ($part_type_after_cast->parent_nodes as $parent_node) {
                             $codebase->taint->addPath($parent_node, $new_parent_node, 'concat');
                         }
                     }

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -1229,6 +1229,30 @@ class TaintTest extends TestCase
                     echo "$unsafe";',
                 'error_message' => 'TaintedInput',
             ],
+            'encapsulatedToStringMagic' => [
+                '<?php
+                    class MyClass {
+                        public function __toString() {
+                            return $_GET["blah"];
+                        }
+                    }
+                    $unsafe = new MyClass();
+                    echo "unsafe: $unsafe";',
+                'error_message' => 'TaintedInput',
+            ],
+            'castToStringMagic' => [
+                '<?php
+                    class MyClass {
+                        public function __toString() {
+                            return $_GET["blah"];
+                        }
+                    }
+                    $unsafe = new MyClass();
+                    echo (string) $unsafe;',  // Psalm does not yet warn without a (string) cast.
+                'error_message' => 'TaintedInput',
+            ],
+            // TODO: This is not implemented for the majority of param type casts to strings such as `echo $unsafeStringableObject;`.
+            // It may be possible to patch TypeComparisonResult to add taintedness to the expression based on the observed __toString implementations.
             'namespacedFunction' => [
                 '<?php
                     namespace ns;


### PR DESCRIPTION
Partially support #3697

There are other ways that objects can be cast to string that this PR
does not analyze (concat, `echo $unsafeStringableObject;`).
I'm not familiar enough with psalm to know the best way to implement it or if it'd make sense for psalm to support that.