### PR TITLE
TemplateChecker: Ensure it's working again

### DIFF
--- a/examples/TemplateChecker.php
+++ b/examples/TemplateChecker.php
@@ -156,7 +156,7 @@ class TemplateAnalyzer extends Psalm\Internal\Analyzer\FileAnalyzer
 
         $class_analyzer = new ClassAnalyzer($class, $this, self::VIEW_CLASS);
 
-        $view_method_analyzer = new MethodAnalyzer($class_method, $class_analyzer);
+        $view_method_analyzer = new MethodAnalyzer($class_method, $class_analyzer, new MethodStorage());
 
         if (!$context->check_variables) {
             $view_method_analyzer->addSuppressedIssue('UndefinedVariable');

--- a/examples/TemplateChecker.php
+++ b/examples/TemplateChecker.php
@@ -11,6 +11,7 @@ use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\DocComment;
+use Psalm\Storage\MethodStorage;
 use Psalm\Type;
 
 class TemplateAnalyzer extends Psalm\Internal\Analyzer\FileAnalyzer


### PR DESCRIPTION
The template checker is erroring on my first template file due to storage missing on my pseudo method. I traced back to your original + noticed the optional param had been removed.