### PR TITLE
Fix typo of `printr` - the function name is `print_r()`

### DIFF
--- a/src/Psalm/Internal/InternalTaintSinkMap.php
+++ b/src/Psalm/Internal/InternalTaintSinkMap.php
@@ -14,7 +14,6 @@ return [
 'mysqli_query' => [[], ['sql']],
 'passthru' => [['shell']],
 'pcntl_exec' => [['shell']],
-'printr' => [['html', 'user_secret', 'system_secret']],
 'PDO::prepare' => [['sql']],
 'PDO::query' => [['sql']],
 'PDO::exec' => [['sql']],


### PR DESCRIPTION
Related to #3744

`print_r` is only a taint sink when `$return` is false or absent.