### PR TITLE
Support generating a .console report text file.

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -351,6 +351,7 @@ class ProjectAnalyzer
             '.txt' => Report::TYPE_TEXT,
             '.emacs' => Report::TYPE_EMACS,
             '.pylint' => Report::TYPE_PYLINT,
+            '.console' => Report::TYPE_CONSOLE,
         ];
 
         foreach ($report_file_paths as $report_file_path) {
@@ -361,6 +362,7 @@ class ProjectAnalyzer
                     $o->format = $type;
                     $o->show_info = $show_info;
                     $o->output_path = $report_file_path;
+                    $o->use_color = false;
                     $report_options[] = $o;
                     continue 2;
                 }

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -359,8 +359,8 @@ Output:
 Reports:
     --report=PATH
         The path where to output report file. The output format is based on the file extension.
-        (Currently supported formats: ".json", ".xml", ".txt", ".emacs", ".pylint", "checkstyle.xml", "sonarqube.json",
-        "summary.json", "junit.xml")
+        (Currently supported formats: ".json", ".xml", ".txt", ".emacs", ".pylint", ".console",
+        "checkstyle.xml", "sonarqube.json", "summary.json", "junit.xml")
 
     --report-show-info[=BOOLEAN]
         Whether the report should include non-errors in its output (defaults to true)


### PR DESCRIPTION
This is useful for use cases such as saving multiline taint detection results.

Only the compact and console reports seem to use color right now.
In many cases, adding color codes to a text file would make it harder to read
in an editor.