### PR TITLE
Scan stub files before project files

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1000,9 +1000,9 @@ class ProjectAnalyzer
 
         $this->config->initializePlugins($this);
 
-        $this->codebase->scanFiles($this->threads);
-
         $this->config->visitStubFiles($this->codebase, $this->progress);
+
+        $this->codebase->scanFiles($this->threads);
 
         $this->progress->startAnalyzingFiles();
 
@@ -1153,9 +1153,10 @@ class ProjectAnalyzer
 
         $this->config->initializePlugins($this);
 
+        $this->config->visitStubFiles($this->codebase, $this->progress);
+
         $this->codebase->scanFiles($this->threads);
 
-        $this->config->visitStubFiles($this->codebase, $this->progress);
 
         $this->progress->startAnalyzingFiles();
 
@@ -1192,9 +1193,9 @@ class ProjectAnalyzer
 
         $this->config->initializePlugins($this);
 
-        $this->codebase->scanFiles($this->threads);
-
         $this->config->visitStubFiles($this->codebase, $this->progress);
+
+        $this->codebase->scanFiles($this->threads);
 
         $this->progress->startAnalyzingFiles();
 

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -215,13 +215,13 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 $this->clientStatus('initializing', 'getting code base');
                 $codebase = $this->project_analyzer->getCodebase();
 
-                $this->verboseLog("Initializing: Scanning files...");
-                $this->clientStatus('initializing', 'scanning files');
-                $codebase->scanFiles($this->project_analyzer->threads);
-
                 $this->verboseLog("Initializing: Registering stub files...");
                 $this->clientStatus('initializing', 'registering stub files');
                 $codebase->config->visitStubFiles($codebase, null);
+
+                $this->verboseLog("Initializing: Scanning files...");
+                $this->clientStatus('initializing', 'scanning files');
+                $codebase->scanFiles($this->project_analyzer->threads);
 
                 if ($this->textDocument === null) {
                     $this->textDocument = new TextDocument(

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -671,48 +671,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-       /**
-     * @return void
-     */
-    public function testStubFunctionOverwritingDeclaredFunction()
-    {
-        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
-            TestConfig::loadFromXML(
-                dirname(__DIR__),
-                '<?xml version="1.0"?>
-                <psalm
-                    errorLevel="1"
-                >
-                    <projectFiles>
-                        <directory name="src" />
-                    </projectFiles>
-
-                    <stubs>
-                        <file name="tests/fixtures/stubs/custom_functions.php" />
-                    </stubs>
-                </psalm>'
-            )
-        );
-
-        $file_path = getcwd() . '/src/somefile.php';
-
-        $this->addFile(
-            $file_path,
-            '<?php
-                /**
-                 * @param int $a
-                 * @return integer
-                 */
-                function barBar( int $a ) : int
-                {
-                    return 0;
-                }
-                barBar( 1 );'
-        );
-
-        $this->analyzeFile($file_path, new Context());
-    }
-
     /**
      * @return void
      */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -107,9 +107,9 @@ class TestCase extends BaseTestCase
         $codebase = $this->project_analyzer->getCodebase();
         $codebase->addFilesToAnalyze([$file_path => $file_path]);
 
-        $codebase->scanFiles();
-
         $codebase->config->visitStubFiles($codebase);
+
+        $codebase->scanFiles();
 
         if ($codebase->alter_code) {
             $this->project_analyzer->interpretRefactors();


### PR DESCRIPTION
Currently project files are scanned before stub files, this means if project files have dependencies on things declared in stubs (such as child classes), analysis essentially fails, as the Populator will bail in `populateDataFromParentClass -> 'Populator could not find dependency ...'`.

I imagine there is some reason behind scanning the project files before the stubs, but I'm not sure what it is. I decided to go ahead and make this change and also add a test demonstrating the problem. without switching the order, the attached test case will not throw any errors (when it should!).

Fixes #3328.