### PR TITLE
Always deep scan stubs

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1792,7 +1792,7 @@ class Config
 
         foreach ($stub_files as $file_path) {
             $file_path = \str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $file_path);
-            $codebase->scanner->addFileToShallowScan($file_path);
+            $codebase->scanner->addFileToDeepScan($file_path);
         }
 
         $progress->debug('Registering stub files' . "\n");


### PR DESCRIPTION
In many sitations, stub files will receive a shallow _and_ deep scan when project files require extra analysys on things like parent classes. This makes stub file scanning inconsistent (orders become much less predictable for example), and adds extra process time to scan the files twice. In the case of stubs providing classes and functions for large projects, this is a non-trivial amount of time.

As deep scanning stubs should take just about as long as a shallow scan, it makes sense to just always deep scan them.

Fixes #3568.