### PR TITLE
Fix offset calculation in getReferenceAtPosition

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1217,8 +1217,8 @@ class Codebase
             return null;
         }
 
-        $start_pos = null;
-        $end_pos = null;
+        $reference_start_pos = null;
+        $reference_end_pos = null;
 
         ksort($reference_map);
 
@@ -1230,17 +1230,18 @@ class Codebase
             if ($offset > $end_pos) {
                 continue;
             }
-
+            $reference_start_pos = $start_pos;
+            $reference_end_pos = $end_pos;
             $reference = $possible_reference;
         }
 
-        if ($reference === null || $start_pos === null || $end_pos === null) {
+        if ($reference === null || $reference_start_pos === null || $reference_end_pos === null) {
             return null;
         }
 
         $range = new Range(
-            self::getPositionFromOffset($start_pos, $file_contents),
-            self::getPositionFromOffset($end_pos, $file_contents)
+            self::getPositionFromOffset($reference_start_pos, $file_contents),
+            self::getPositionFromOffset($reference_end_pos, $file_contents)
         );
 
         return [$reference, $range];

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -304,8 +304,8 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $symbol_at_position = $codebase->getReferenceAtPosition('somefile.php', new Position(6, 26));
 
         $this->assertNotNull($symbol_at_position);
-        $this->assertSame( 16, $symbol_at_position[1]->start->character );
-        $this->assertSame( 30, $symbol_at_position[1]->end->character );
+        $this->assertSame(16, $symbol_at_position[1]->start->character);
+        $this->assertSame(30, $symbol_at_position[1]->end->character);
     }
 
     /**

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -278,6 +278,39 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
+    public function testGetSymbolPositionRange()
+    {
+        $codebase = $this->project_analyzer->getCodebase();
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace B;
+
+                function foo() : string {
+                }
+
+                $active_symbol = foo();'
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+        $this->analyzeFile('somefile.php', new Context());
+
+        // This is focusing the $active_symbol variable, the LSP Range that is
+        // returned should also point to the same variable (that's where hover popovers will show)
+        $symbol_at_position = $codebase->getReferenceAtPosition('somefile.php', new Position(6, 26));
+
+        $this->assertNotNull($symbol_at_position);
+        $this->assertSame( 16, $symbol_at_position[1]->start->character );
+        $this->assertSame( 30, $symbol_at_position[1]->end->character );
+    }
+
+    /**
+     * @return void
+     */
     public function testGetTypeInDocblock()
     {
         $codebase = $this->project_analyzer->getCodebase();


### PR DESCRIPTION
`getReferenceAtPosition()` powers the LSP hover functionality, and it seems the logic to return the range of the hovered symbol is incorrect. Reading the `while` loop shows there is no sufficient breaking conditions so `$start_pos` will always be the last item in the `$reference_map`.

Before (hovering the variable on the left):

<img width="496" alt="Screenshot 2020-07-08 at 9 58 40 PM" src="https://user-images.githubusercontent.com/161683/86964531-7f03c580-c166-11ea-902a-ec68186df51c.png">

After: (again hovering on the variable on the left, show by the cursor as expected)

<img width="496" alt="Screenshot 2020-07-08 at 9 57 35 PM" src="https://user-images.githubusercontent.com/161683/86964564-8dea7800-c166-11ea-9326-d933a338371b.png">
