### PR TITLE
Adding a runTaintAnalysis option into the config

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -72,6 +72,7 @@
         <xs:attribute name="usePhpDocPropertiesWithoutMagicCall" type="xs:boolean" default="false" />
         <xs:attribute name="skipChecksOnUnresolvableIncludes" type="xs:boolean" default="true" />
         <xs:attribute name="sealAllMethods" type="xs:boolean" default="false" />
+        <xs:attribute name="runTaintAnalysis" type="xs:boolean" default="false" />
     </xs:complexType>
 
     <xs:complexType name="ProjectFilesType">

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -305,6 +305,16 @@ For backwards compatibility, this defaults to `true`, but if you do not rely on 
 
 When `true`, Psalm will treat all classes as if they had sealed methods, meaning that if you implement the magic method `__call`, you also have to add `@method` for each magic method. Defaults to false.
 
+#### runTaintAnalysis
+
+```xml
+<psalm
+  runTaintAnalysis="[bool]"
+>
+```
+
+When `true`, Psalm will run [Taint Analysis](../security_analysis/index.md) on your codebase. This config is the same as if you were running Psalm with `--taint-analysis`.
+
 ### Running Psalm
 
 #### autoloader

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -400,6 +400,11 @@ class Config
     public $find_unused_variables = false;
 
     /**
+     * @var bool
+     */
+    public $run_taint_analysis = false;
+
+    /**
      * Whether to resolve file and directory paths from the location of the config file,
      * instead of the current working directory.
      *
@@ -801,7 +806,8 @@ class Config
             'ensureArrayIntOffsetsExist' => 'ensure_array_int_offsets_exist',
             'reportMixedIssues' => 'show_mixed_issues',
             'skipChecksOnUnresolvableIncludes' => 'skip_checks_on_unresolvable_includes',
-            'sealAllMethods' => 'seal_all_methods'
+            'sealAllMethods' => 'seal_all_methods',
+            'runTaintAnalysis' => 'run_taint_analysis',
         ];
 
         foreach ($booleanAttributes as $xmlName => $internalName) {

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -587,9 +587,9 @@ if ($config->find_unused_variables || $find_unused_variables) {
     $project_analyzer->getCodebase()->reportUnusedVariables();
 }
 
-if (isset($options['track-tainted-input'])
+if ($config->run_taint_analysis || (isset($options['track-tainted-input'])
     || isset($options['security-analysis'])
-    || isset($options['taint-analysis'])
+    || isset($options['taint-analysis']))
 ) {
     $project_analyzer->trackTaintedInputs();
 }


### PR DESCRIPTION
This adds a new `runTaintAnalysis` option into the root of the config for being able to run Psalm with the `--taint-analysis` option at all times.