### PR TITLE
Fix jumping to definition on nullable parameters

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -977,13 +977,17 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $signature_type_location = $function_param->signature_type_location;
 
             if ($signature_type && $signature_type_location && $signature_type->hasObjectType()) {
+                $referenced_type = $signature_type;
+                if ($referenced_type->isNullable()) {
+                    $referenced_type = clone $referenced_type;
+                    $referenced_type->removeType('null');
+                }
                 list($start, $end) = $signature_type_location->getSelectionBounds();
-
                 $codebase->analyzer->addOffsetReference(
                     $this->getFilePath(),
                     $start,
                     $end,
-                    (string) $signature_type
+                    (string) $referenced_type
                 );
             }
 

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -278,6 +278,35 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
+    public function testGetSymbolPositionNullableArg()
+    {
+        $codebase = $this->project_analyzer->getCodebase();
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace B;
+                class AClass {
+                }
+                function B( ?AClass $class ) {
+                }'
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+        $this->analyzeFile('somefile.php', new Context());
+
+        $symbol_at_position = $codebase->getReferenceAtPosition('somefile.php', new Position(4, 33));
+        $this->assertNotNull($symbol_at_position);
+
+        $this->assertSame('B\AClass', $symbol_at_position[0]);
+    }
+
+    /**
+     * @return void
+     */
     public function testGetSymbolPositionRange()
     {
         $codebase = $this->project_analyzer->getCodebase();


### PR DESCRIPTION
Currently it's not possible to "Go to definition" (LSP) on nullable args like `function( ?MyClass $class )` as the reference is stored as `MyClass|null` in the reference map, which will now resolve to a class name.

This PR removed any nullable type from the union before adding it to the reference map (as the reference map is only use to indicate a symbol was used in a given location, I think this makes sense).