### PR TITLE
Add ability to Go to Definition on Use statements

### DIFF
--- a/src/Psalm/Internal/Analyzer/CanAlias.php
+++ b/src/Psalm/Internal/Analyzer/CanAlias.php
@@ -63,6 +63,12 @@ trait CanAlias
                     break;
 
                 case PhpParser\Node\Stmt\Use_::TYPE_NORMAL:
+                    $codebase->analyzer->addOffsetReference(
+                        $this->getFilePath(),
+                        (int) $use->getAttribute('startFilePos'),
+                        (int) $use->getAttribute('endFilePos'),
+                        $use_path
+                    );
                     if ($codebase->collect_locations) {
                         // register the path
                         $codebase->use_referencing_locations[strtolower($use_path)][] =

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -278,6 +278,33 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
+    public function testGetSymbolPositionUseStatement()
+    {
+        $codebase = $this->project_analyzer->getCodebase();
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace B;
+                use StreamWrapper;
+                '
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+        $this->analyzeFile('somefile.php', new Context());
+
+        $symbol_at_position = $codebase->getReferenceAtPosition('somefile.php', new Position(2, 25));
+        $this->assertNotNull($symbol_at_position);
+
+        $this->assertSame('StreamWrapper', $symbol_at_position[0]);
+    }
+
+    /**
+     * @return void
+     */
     public function testGetSymbolPositionRange()
     {
         $codebase = $this->project_analyzer->getCodebase();


### PR DESCRIPTION
This adds the ability to use the LSP's "Go to Definition" on `use MyClass` statements.