### PR TITLE
Fix going to definition on return type

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -505,6 +505,17 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             }
         }
 
+        if ($storage->signature_return_type && $storage->signature_return_type_location) {
+            list($start, $end) = $storage->signature_return_type_location->getSelectionBounds();
+
+            $codebase->analyzer->addOffsetReference(
+                $this->getFilePath(),
+                $start,
+                $end,
+                (string) $storage->signature_return_type
+            );
+        }
+
         if (ReturnTypeAnalyzer::checkReturnType(
             $this->function,
             $project_analyzer,
@@ -574,17 +585,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                     );
                 }
             }
-        }
-
-        if ($storage->signature_return_type && $storage->signature_return_type_location) {
-            list($start, $end) = $storage->signature_return_type_location->getSelectionBounds();
-
-            $codebase->analyzer->addOffsetReference(
-                $this->getFilePath(),
-                $start,
-                $end,
-                (string) $storage->signature_return_type
-            );
         }
 
         if ($this->function instanceof Closure

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -277,8 +277,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
 
     /**
      * @return void
-    /**
-     * @return void
      */
     public function testGetSymbolPositionMethodWrongReturnType()
     {

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -277,6 +277,41 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
 
     /**
      * @return void
+    /**
+     * @return void
+     */
+    public function testGetSymbolPositionMethodWrongReturnType()
+    {
+        $codebase = $this->project_analyzer->getCodebase();
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace B;
+                class AClass {
+                    /**
+                     * @return Some
+                     */
+                    protected function get_command() : AClass {
+                    }
+                }
+                '
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+        $this->analyzeFile('somefile.php', new Context());
+
+        $symbol_at_position = $codebase->getReferenceAtPosition('somefile.php', new Position(6, 60));
+        $this->assertNotNull($symbol_at_position);
+
+        $this->assertSame('B\AClass', $symbol_at_position[0]);
+    }
+
+    /**
+     * @return void
      */
     public function testGetSymbolPositionRange()
     {


### PR DESCRIPTION
If a return type of a method or function is set incorrectly (with the PHP doc), then the references are not added for the `function() : MyClass` symbol, so the "Go to definition" feature of the LSP won't work. I don't believe an invalid return type or not should stop the symbol location being tracked (and not allowing code navigation).

In moved the symbol location tracking to be before the return early short circuit.