### PR TITLE
Fix #3810 removing ignore-nullable-return

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -136,7 +136,6 @@ function array_flip(array $arr)
  * @param array<TKey, mixed> $arr
  *
  * @return TKey|null
- * @psalm-ignore-nullable-return
  * @psalm-pure
  */
 function key($arr)
@@ -148,8 +147,7 @@ function key($arr)
  *
  * @param array<TKey, mixed> $arr
  *
- * @return TKey|null
- * @psalm-ignore-nullable-return
+ * @return (TKey is empty ? null : ($arr is non-empty-array ? TKey : TKey|null))
  * @psalm-pure
  */
 function array_key_first($arr)
@@ -161,8 +159,7 @@ function array_key_first($arr)
  *
  * @param array<TKey, mixed> $arr
  *
- * @return TKey|null
- * @psalm-ignore-nullable-return
+ * @return (TKey is empty ? null : ($arr is non-empty-array ? TKey : TKey|null))
  * @psalm-pure
  */
 function array_key_last($arr)

--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -135,7 +135,7 @@ function array_flip(array $arr)
  *
  * @param array<TKey, mixed> $arr
  *
- * @return TKey|null
+ * @return (TKey is empty ? null : ($arr is non-empty-array ? TKey : TKey|null))
  * @psalm-pure
  */
 function key($arr)

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -766,30 +766,79 @@ class ArrayFunctionCallTest extends TestCase
                 '<?php
                     $a = ["one" => 1, "two" => 3];
                     $b = key($a);
-                    $c = $a[$b];',
+                    $c = null;
+                    if ($b !== null) {
+                        $c = $a[$b];
+                    }',
                 'assertions' => [
                     '$b' => 'null|string',
-                    '$c' => 'int',
+                    '$c' => 'int|null',
                 ],
             ],
-            'array_key_first' => [
+            'arrayKeyFirst' => [
+                '<?php
+                    /** @return array<string, int> */
+                    function makeArray(): array { return ["one" => 1, "two" => 3]; }
+                    $a = makeArray();
+                    $b = array_key_first($a);
+                    $c = null;
+                    if ($b !== null) {
+                        $c = $a[$b];
+                    }',
+                'assertions' => [
+                    '$b' => 'null|string',
+                    '$c' => 'int|null',
+                ],
+            ],
+            'arrayKeyFirstNonEmpty' => [
                 '<?php
                     $a = ["one" => 1, "two" => 3];
                     $b = array_key_first($a);
                     $c = $a[$b];',
                 'assertions' => [
-                    '$b' => 'null|string',
+                    '$b' => 'string',
                     '$c' => 'int',
                 ],
             ],
-            'array_key_last' => [
+            'arrayKeyFirstEmpty' => [
+                '<?php
+                    $a = [];
+                    $b = array_key_first($a);',
+                'assertions' => [
+                    '$b' => 'null'
+                ],
+            ],
+            'arrayKeyLast' => [
+                '<?php
+                    /** @return array<string, int> */
+                    function makeArray(): array { return ["one" => 1, "two" => 3]; }
+                    $a = makeArray();
+                    $b = array_key_last($a);
+                    $c = null;
+                    if ($b !== null) {
+                        $c = $a[$b];
+                    }',
+                'assertions' => [
+                    '$b' => 'null|string',
+                    '$c' => 'int|null',
+                ],
+            ],
+            'arrayKeyLastNonEmpty' => [
                 '<?php
                     $a = ["one" => 1, "two" => 3];
                     $b = array_key_last($a);
                     $c = $a[$b];',
                 'assertions' => [
-                    '$b' => 'null|string',
+                    '$b' => 'string',
                     '$c' => 'int',
+                ],
+            ],
+            'arrayKeyLastEmpty' => [
+                '<?php
+                    $a = [];
+                    $b = array_key_last($a);',
+                'assertions' => [
+                    '$b' => 'null'
                 ],
             ],
             'arrayColumnInference' => [

--- a/tests/TypeReconciliation/EmptyTest.php
+++ b/tests/TypeReconciliation/EmptyTest.php
@@ -254,6 +254,7 @@ class EmptyTest extends \Psalm\Tests\TestCase
 
                         while (!empty($needle)) {
                             $key = key($needle);
+                            if ($key === null) continue;
                             $val = $needle[$key];
                             unset($needle[$key]);
 

--- a/tests/TypeReconciliation/EmptyTest.php
+++ b/tests/TypeReconciliation/EmptyTest.php
@@ -254,7 +254,6 @@ class EmptyTest extends \Psalm\Tests\TestCase
 
                         while (!empty($needle)) {
                             $key = key($needle);
-                            if ($key === null) continue;
                             $val = $needle[$key];
                             unset($needle[$key]);
 


### PR DESCRIPTION
Issue: #3810
I noticed `key()` has had that annotation, too.