### PR TITLE
Add option to supress a referenced but undefined global variable.

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -334,7 +334,7 @@
             <xs:element name="PossiblyUndefinedIntArrayOffset" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyUndefinedStringArrayOffset" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyUndefinedMethod" type="MethodIssueHandlerType" minOccurs="0" />
-            <xs:element name="PossiblyUndefinedGlobalVariable" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="PossiblyUndefinedGlobalVariable" type="VariableIssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyUndefinedVariable" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyUnusedMethod" type="MethodIssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyUnusedParam" type="IssueHandlerType" minOccurs="0" />
@@ -373,7 +373,7 @@
             <xs:element name="UndefinedThisPropertyFetch" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedTrace" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedTrait" type="IssueHandlerType" minOccurs="0" />
-            <xs:element name="UndefinedGlobalVariable" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UndefinedGlobalVariable" type="VariableIssueHandlerType" minOccurs="0" />
             <xs:element name="UndefinedVariable" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnimplementedAbstractMethod" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnimplementedInterfaceMethod" type="IssueHandlerType" minOccurs="0" />
@@ -510,6 +510,24 @@
                         <xs:element name="directory" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                         <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                         <xs:element name="referencedProperty" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+                    </xs:choice>
+
+                    <xs:attribute name="type" type="xs:string" use="required" />
+                </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+
+        <xs:attribute name="errorLevel" type="xs:string" />
+    </xs:complexType>
+
+    <xs:complexType name="VariableIssueHandlerType">
+        <xs:sequence>
+            <xs:element name="errorLevel" minOccurs="0" maxOccurs="unbounded">
+                <xs:complexType>
+                    <xs:choice maxOccurs="unbounded">
+                        <xs:element name="directory" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+                        <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
+                        <xs:element name="referencedVariable" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                     </xs:choice>
 
                     <xs:attribute name="type" type="xs:string" use="required" />

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2,6 +2,7 @@
 namespace Psalm;
 
 use Composer\Semver\Semver;
+use Psalm\Issue\VariableIssue;
 use Webmozart\PathUtil\Path;
 use function array_merge;
 use function array_pop;
@@ -1416,6 +1417,8 @@ class Config
             $reporting_level = $this->getReportingLevelForProperty($issue_type, $e->property_id);
         } elseif ($e instanceof ArgumentIssue && $e->function_id) {
             $reporting_level = $this->getReportingLevelForArgument($issue_type, $e->function_id);
+        } elseif ($e instanceof VariableIssue) {
+            $reporting_level = $this->getReportingLevelForVariable($issue_type, $e->var_name);
         }
 
         if ($reporting_level === null) {
@@ -1625,6 +1628,19 @@ class Config
     {
         if (isset($this->issue_handlers[$issue_type])) {
             return $this->issue_handlers[$issue_type]->getReportingLevelForProperty($property_id);
+        }
+    }
+
+    /**
+     * @param   string $issue_type
+     * @param   string $var_name
+     *
+     * @return  string|null
+     */
+    public function getReportingLevelForVariable(string $issue_type, string $var_name)
+    {
+        if (isset($this->issue_handlers[$issue_type])) {
+            return $this->issue_handlers[$issue_type]->getReportingLevelForVariable($var_name);
         }
     }
 

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -60,6 +60,11 @@ class FileFilter
     /**
      * @var array<string>
      */
+    protected $var_names = [];
+
+    /**
+     * @var array<string>
+     */
     protected $files_lowercase = [];
 
     /**
@@ -310,6 +315,13 @@ class FileFilter
             }
         }
 
+        if ($e->referencedVariable) {
+            /** @var \SimpleXMLElement $referenced_variable */
+            foreach ($e->referencedVariable as $referenced_variable) {
+                $filter->var_names[] = strtolower((string)$referenced_variable['name']);
+            }
+        }
+
         return $filter;
     }
 
@@ -457,6 +469,16 @@ class FileFilter
     public function allowsProperty($property_id)
     {
         return in_array(strtolower($property_id), $this->property_ids, true);
+    }
+
+    /**
+     * @param  string  $var_name
+     *
+     * @return bool
+     */
+    public function allowsVariable($var_name)
+    {
+        return in_array(strtolower($var_name), $this->var_names, true);
     }
 
     /**

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -146,6 +146,20 @@ class IssueHandler
     }
 
     /**
+     * @param string $var_name
+     *
+     * @return string|null
+     */
+    public function getReportingLevelForVariable($var_name)
+    {
+        foreach ($this->custom_levels as $custom_level) {
+            if ($custom_level->allowsVariable($var_name)) {
+                return $custom_level->getErrorLevel();
+            }
+        }
+    }
+
+    /**
      * @return       string[]
      * @psalm-return array<string>
      */
@@ -174,6 +188,7 @@ class IssueHandler
                     && $issue_name !== 'PropertyIssue'
                     && $issue_name !== 'FunctionIssue'
                     && $issue_name !== 'ArgumentIssue'
+                    && $issue_name !== 'VariableIssue'
                     && $issue_name !== 'ClassIssue'
                     && $issue_name !== 'CodeIssue'
                     && $issue_name !== 'PsalmInternalError'

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -193,7 +193,8 @@ class VariableFetchAnalyzer
                         if (IssueBuffer::accepts(
                             new UndefinedGlobalVariable(
                                 'Cannot find referenced variable ' . $var_name . ' in global scope',
-                                new CodeLocation($statements_analyzer->getSource(), $stmt)
+                                new CodeLocation($statements_analyzer->getSource(), $stmt),
+                                $var_name
                             ),
                             $statements_analyzer->getSuppressedIssues()
                         )) {
@@ -243,7 +244,8 @@ class VariableFetchAnalyzer
                         new PossiblyUndefinedGlobalVariable(
                             'Possibly undefined global variable ' . $var_name . ', first seen on line ' .
                                 $first_appearance->getLineNumber(),
-                            new CodeLocation($statements_analyzer->getSource(), $stmt)
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $var_name
                         ),
                         $statements_analyzer->getSuppressedIssues(),
                         (bool) $statements_analyzer->getBranchPoint($var_name)
@@ -301,7 +303,8 @@ class VariableFetchAnalyzer
                     if (IssueBuffer::accepts(
                         new PossiblyUndefinedGlobalVariable(
                             'Possibly undefined global variable ' . $var_name . ' defined in try block',
-                            new CodeLocation($statements_analyzer->getSource(), $stmt)
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $var_name
                         ),
                         $statements_analyzer->getSuppressedIssues()
                     )) {

--- a/src/Psalm/Issue/PossiblyUndefinedGlobalVariable.php
+++ b/src/Psalm/Issue/PossiblyUndefinedGlobalVariable.php
@@ -1,7 +1,7 @@
 <?php
 namespace Psalm\Issue;
 
-class PossiblyUndefinedGlobalVariable extends CodeIssue
+class PossiblyUndefinedGlobalVariable extends VariableIssue
 {
     const ERROR_LEVEL = 3;
     const SHORTCODE = 126;

--- a/src/Psalm/Issue/UndefinedGlobalVariable.php
+++ b/src/Psalm/Issue/UndefinedGlobalVariable.php
@@ -1,7 +1,7 @@
 <?php
 namespace Psalm\Issue;
 
-class UndefinedGlobalVariable extends CodeIssue
+class UndefinedGlobalVariable extends VariableIssue
 {
     const ERROR_LEVEL = -1;
     const SHORTCODE = 127;

--- a/src/Psalm/Issue/VariableIssue.php
+++ b/src/Psalm/Issue/VariableIssue.php
@@ -1,0 +1,26 @@
+<?php
+namespace Psalm\Issue;
+
+use function strtolower;
+
+abstract class VariableIssue extends CodeIssue
+{
+    /**
+     * @var string
+     */
+    public $var_name;
+
+    /**
+     * @param string $message
+     * @param \Psalm\CodeLocation $code_location
+     * @param string $var_name
+     */
+    public function __construct(
+        $message,
+        \Psalm\CodeLocation $code_location,
+        $var_name
+    ) {
+        parent::__construct($message, $code_location);
+        $this->var_name = strtolower($var_name);
+    }
+}

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -425,6 +425,11 @@ class ConfigTest extends \Psalm\Tests\TestCase
                                 <referencedProperty name="Psalm\Bodger::$find3" />
                             </errorLevel>
                         </UndefinedPropertyFetch>
+                        <UndefinedGlobalVariable>
+                            <errorLevel type="suppress">
+                                <referencedVariable name="a" />
+                            </errorLevel>
+                        </UndefinedGlobalVariable>
                     </issueHandlers>
                 </psalm>'
             )
@@ -554,6 +559,21 @@ class ConfigTest extends \Psalm\Tests\TestCase
             $config->getReportingLevelForMethod(
                 'UndefinedFunction',
                 'foobar'
+            )
+        );
+
+        $this->assertSame(
+            'suppress',
+            $config->getReportingLevelForVariable(
+                'UndefinedGlobalVariable',
+                'a'
+            )
+        );
+
+        $this->assertNull(
+            $config->getReportingLevelForVariable(
+                'UndefinedGlobalVariable',
+                'b'
             )
         );
     }


### PR DESCRIPTION
I would like to suppress only a set of undefined global variables and not the undefined global variables message at all. Similar to referencedMethod and referencedClas. 