### PR TITLE
Allow netresearch/jsonmapper ^3.0 to be installed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "composer/xdebug-handler": "^1.1",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
         "felixfbecker/language-server-protocol": "^1.4",
-        "netresearch/jsonmapper": "^1.0 || ^2.0",
+        "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0",
         "nikic/php-parser": "^4.3",
         "ocramius/package-versions": "^1.2",
         "openlss/lib-array2xml": "^1.0",


### PR DESCRIPTION
The major version seems to be the addition of the support of the PHP 7.4 class type properties.

https://github.com/cweiske/jsonmapper/blob/v3.0.0/ChangeLog