### PR TITLE
Allow taint through strval sprintf

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -665,3 +665,13 @@ function realpath(string $path) {}
  * @return ($right_operand is "0" ? null : numeric-string)
  */
 function bcdiv(string $left_operand, string $right_operand, int $scale = 0): ?string {}
+
+/**
+ * @psalm-pure
+ *
+ * @param scalar|object $var
+ * @return string The string value of var.
+ *
+ * @psalm-flow ($var) -> return
+ */
+function strval ($var): string {}

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -1268,6 +1268,18 @@ class TaintTest extends TestCase
                     echo (new A())->rawinput();',
                 'error_message' => 'TaintedInput',
             ],
+            'taintStringObtainedUsingStrval' => [
+                '<?php
+                    $unsafe = strval($_GET[\'unsafe\']);
+                    echo $unsafe',
+                'error_message' => 'TaintedInput',
+            ],
+            'taintStringObtainedUsingSprintf' => [
+                '<?php
+                    $unsafe = sprintf("%s", strval($_GET[\'unsafe\']));
+                    echo $unsafe;',
+                'error_message' => 'TaintedInput',
+            ],
             'encapsulatedString' => [
                 '<?php
                     $unsafe = $_GET[\'unsafe\'];

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -1222,6 +1222,13 @@ class TaintTest extends TestCase
                     echo $c;',
                 'error_message' => 'TaintedInput',
             ],
+            'ImplodeIndirect' => [
+                '<?php
+                    /** @var array $unsafe */
+                    $unsafe = $_GET[\'unsafe\'];
+                    echo implode(" ", $unsafe);',
+                'error_message' => 'TaintedInput',
+            ],
             'taintThroughPregReplaceCallback' => [
                 '<?php
                     $a = $_GET["bad"];


### PR DESCRIPTION
This is partially related to issue #3636

Actually `sprintf` was already taint-able, but without any test to prove it.

:warning: the second commit is a strange and unexpected behaviour I encountered when using `implode` indirectly. I'm not sure how to fix that.