### PR TITLE
fixes wrong return type of key() #3838

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -136,7 +136,7 @@ function array_flip(array $arr)
  *
  * @param TArray $arr
  *
- * @return (TArray is array<empty, empty> ? null : (TArray is non-empty-array ? TKey : TKey|null))
+ * @return (TArray is array<empty, empty> ? null : TKey|null)
  * @psalm-pure
  */
 function key($arr)

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -767,14 +767,22 @@ class ArrayFunctionCallTest extends TestCase
                     $a = ["one" => 1, "two" => 3];
                     $b = key($a);',
                 'assertions' => [
-                    '$b' => 'string',
+                    '$b' => 'null|string',
+                ],
+            ],
+            'keyEmptyArray' => [
+                '<?php
+                    $a = [];
+                    $b = key($a);',
+                'assertions' => [
+                    '$b' => 'null',
                 ],
             ],
             'keyNonEmptyArray' => [
                 '<?php
                     /**
                      * @param non-empty-array $arr
-                     * @return array-key
+                     * @return null|array-key
                      */
                     function foo(array $arr) {
                         return key($arr);

--- a/tests/TypeReconciliation/EmptyTest.php
+++ b/tests/TypeReconciliation/EmptyTest.php
@@ -254,6 +254,7 @@ class EmptyTest extends \Psalm\Tests\TestCase
 
                         while (!empty($needle)) {
                             $key = key($needle);
+                            if ($key === null) continue;
                             $val = $needle[$key];
                             unset($needle[$key]);
 


### PR DESCRIPTION
Issue: #3838 
Don't know what to do with test `Psalm\Tests\EmptyTest::testValidCode()#unsetChangesComplicatedArrayEmptiness`. My solution was 54a3a26d6e3195f7d88611bfc540d1ee8c17d126 but you seem to not like it (c0909f318703fa15b2ae873cbc6d8bada623fbdc)