### PR TITLE
Remove an if statement that repeats the previous if statement

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -685,10 +685,6 @@ class ClassLikes
             return true;
         }
 
-        if (isset($this->classlike_aliases[strtolower($fq_interface_name)])) {
-            return true;
-        }
-
         return isset($this->existing_interfaces[$fq_interface_name]);
     }
 


### PR DESCRIPTION
They're the exact same variables.

This otherwise seems to be reasonable based on classHasCorrectCasing