### PR TITLE
Fix multiple issues with @internal and @psalm-internal

### DIFF
--- a/docs/running_psalm/issues/InternalClass.md
+++ b/docs/running_psalm/issues/InternalClass.md
@@ -15,7 +15,7 @@ namespace A {
 
 namespace B {
     class Bat {
-        public function batBat() {
+        public function batBat(): void {
             $a = new \A\Foo();
         }
     }

--- a/docs/running_psalm/issues/InternalMethod.md
+++ b/docs/running_psalm/issues/InternalMethod.md
@@ -17,7 +17,7 @@ namespace A {
 }
 namespace B {
     class Bat {
-        public function batBat() {
+        public function batBat(): void {
             \A\Foo::barBar();
         }
     }

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -302,27 +302,6 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                     }
                 }
 
-                if ($parent_class_storage->internal) {
-                    $code_location = new CodeLocation(
-                        $this,
-                        $class->extends,
-                        $class_context ? $class_context->include_location : null,
-                        true
-                    );
-                    if (! NamespaceAnalyzer::nameSpaceRootsMatch($fq_class_name, $parent_fq_class_name)) {
-                        if (IssueBuffer::accepts(
-                            new InternalClass(
-                                $parent_fq_class_name . ' is marked internal',
-                                $code_location,
-                                $parent_fq_class_name
-                            ),
-                            $storage->suppressed_issues + $this->getSuppressedIssues()
-                        )) {
-                            // fall through
-                        }
-                    }
-                }
-
                 if ($parent_class_storage->psalm_internal &&
                     ! NamespaceAnalyzer::isWithin($fq_class_name, $parent_class_storage->psalm_internal)
                 ) {

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -404,7 +404,9 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
         if (!$inferred) {
             if ($class_storage->psalm_internal) {
                 $sourceNamespace = $statements_source->getNamespace();
-                if (!$sourceNamespace || ! NamespaceAnalyzer::isWithin($sourceNamespace, $class_storage->psalm_internal)) {
+                if (!$sourceNamespace
+                    || ! NamespaceAnalyzer::isWithin($sourceNamespace, $class_storage->psalm_internal)
+                ) {
                     if (IssueBuffer::accepts(
                         new InternalClass(
                             $class_storage->name . ' is internal to ' . $class_storage->psalm_internal,

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -184,16 +184,11 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
         return $className === $namespace || strpos($className, $namespace) === 0;
     }
 
-    public static function nameSpaceRootsMatch(string $fqcnA, string $fqcnB): bool
-    {
-        return strtolower(self::getNameSpaceRoot($fqcnA)) === strtolower(self::getNameSpaceRoot($fqcnB));
-    }
-
     /**
      * @param string $fullyQualifiedClassName, e.g. '\Psalm\Internal\Analyzer\NamespaceAnalyzer'
      * @return string , e.g. 'Psalm'
      */
-    private static function getNameSpaceRoot(string $fullyQualifiedClassName): string
+    public static function getNameSpaceRoot(string $fullyQualifiedClassName): string
     {
         return preg_replace('/^([^\\\]+).*/', '$1', $fullyQualifiedClassName);
     }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -690,21 +690,6 @@ class InstancePropertyAssignmentAnalyzer
                         }
                     }
 
-                    if ($property_storage->internal && $context->self) {
-                        if (! NamespaceAnalyzer::nameSpaceRootsMatch($context->self, $declaring_property_class)) {
-                            if (IssueBuffer::accepts(
-                                new InternalProperty(
-                                    $property_id . ' is marked internal',
-                                    new CodeLocation($statements_analyzer->getSource(), $stmt),
-                                    $property_id
-                                ),
-                                $statements_analyzer->getSuppressedIssues()
-                            )) {
-                                // fall through
-                            }
-                        }
-                    }
-
                     // prevents writing to readonly properties
                     if ($property_storage->readonly) {
                         $appearing_property_class = $codebase->properties->getAppearingClassForProperty(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
@@ -67,28 +67,6 @@ class MethodCallProhibitionAnalyzer
                 }
             }
         }
-
-        if ($storage->internal
-            && $context->self
-            && !$context->collect_initializations
-            && !$context->collect_mutations
-        ) {
-            $declaring_class = $method_id->fq_class_name;
-            if (! NamespaceAnalyzer::nameSpaceRootsMatch($context->self, $declaring_class)) {
-                if (IssueBuffer::accepts(
-                    new InternalMethod(
-                        'The method ' . $codebase_methods->getCasedMethodId($method_id) .
-                            ' has been marked as internal',
-                        $code_location,
-                        (string) $method_id
-                    ),
-                    $suppressed_issues
-                )) {
-                    // fall through
-                }
-            }
-        }
-
         return null;
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -425,21 +425,6 @@ class NewAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAna
                     }
                 }
 
-                if ($storage->internal && $context->self) {
-                    if (! NamespaceAnalyzer::nameSpaceRootsMatch($context->self, $fq_class_name)) {
-                        if (IssueBuffer::accepts(
-                            new InternalClass(
-                                $fq_class_name . ' is marked internal',
-                                new CodeLocation($statements_analyzer->getSource(), $stmt),
-                                $fq_class_name
-                            ),
-                            $statements_analyzer->getSuppressedIssues()
-                        )) {
-                            // fall through
-                        }
-                    }
-                }
-
                 $method_id = new \Psalm\Internal\MethodIdentifier($fq_class_name, '__construct');
 
                 if ($codebase->methods->methodExists(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
@@ -779,25 +779,6 @@ class StaticCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\
                     }
                 }
 
-                if ($class_storage->internal
-                    && $context->self
-                    && !$context->collect_initializations
-                    && !$context->collect_mutations
-                ) {
-                    if (! NamespaceAnalyzer::nameSpaceRootsMatch($context->self, $fq_class_name)) {
-                        if (IssueBuffer::accepts(
-                            new InternalClass(
-                                $fq_class_name . ' is marked internal',
-                                new CodeLocation($statements_analyzer->getSource(), $stmt),
-                                $fq_class_name
-                            ),
-                            $statements_analyzer->getSuppressedIssues()
-                        )) {
-                            // fall through
-                        }
-                    }
-                }
-
                 if (Method\MethodVisibilityAnalyzer::analyze(
                     $method_id,
                     $context,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
@@ -28,6 +28,7 @@ use Psalm\Issue\UndefinedPropertyFetch;
 use Psalm\Issue\UndefinedThisPropertyFetch;
 use Psalm\Issue\UninitializedProperty;
 use Psalm\IssueBuffer;
+use Psalm\Storage\PropertyStorage;
 use Psalm\Type;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Type\Atomic\TGenericObject;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
@@ -835,21 +835,6 @@ class InstancePropertyFetchAnalyzer
                         }
                     }
                 }
-
-                if ($property_storage->internal && $context->self) {
-                    if (! NamespaceAnalyzer::nameSpaceRootsMatch($context->self, $declaring_property_class)) {
-                        if (IssueBuffer::accepts(
-                            new InternalProperty(
-                                $property_id . ' is marked internal',
-                                new CodeLocation($statements_analyzer->getSource(), $stmt),
-                                $property_id
-                            ),
-                            $statements_analyzer->getSuppressedIssues()
-                        )) {
-                            // fall through
-                        }
-                    }
-                }
             }
 
             $class_property_type = $codebase->properties->getPropertyType(

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -250,19 +250,6 @@ class Populator
             }
         }
 
-        if ($storage->internal
-            && !$storage->is_interface
-            && !$storage->is_trait
-        ) {
-            foreach ($storage->methods as $method) {
-                $method->internal = true;
-            }
-
-            foreach ($storage->properties as $property) {
-                $property->internal = true;
-            }
-        }
-
         if ($storage->psalm_internal
             && !$storage->is_interface
             && !$storage->is_trait

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -20,6 +20,7 @@ use Psalm\Type;
 use function reset;
 use function strpos;
 use function strtolower;
+use function strlen;
 
 /**
  * @internal
@@ -259,6 +260,28 @@ class Populator
 
             foreach ($storage->properties as $property) {
                 $property->internal = true;
+            }
+        }
+
+        if ($storage->psalm_internal
+            && !$storage->is_interface
+            && !$storage->is_trait
+        ) {
+            foreach ($storage->methods as $method) {
+                if (null === $method->psalm_internal ||
+                    strlen($storage->psalm_internal) > strlen($method->psalm_internal)
+                ) {
+                    $method->psalm_internal = $storage->psalm_internal;
+                }
+            }
+
+
+            foreach ($storage->properties as $property) {
+                if (null === $property->psalm_internal ||
+                    strlen($storage->psalm_internal) > strlen($property->psalm_internal)
+                ) {
+                    $property->psalm_internal = $storage->psalm_internal;
+                }
             }
         }
 

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -1309,8 +1309,12 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
                 }
 
                 $storage->deprecated = $docblock_info->deprecated;
-                if ($docblock_info->internal && ! $docblock_info->psalm_internal && null !== $this->namespace_name) {
-                    $storage->psalm_internal = $this->namespace_name->getFirst();
+
+                if ($docblock_info->internal
+                    && !$docblock_info->psalm_internal
+                    && $this->aliases->namespace
+                ) {
+                    $storage->psalm_internal = explode('\\', $this->aliases->namespace)[0];
                 } else {
                     $storage->psalm_internal = $docblock_info->psalm_internal;
                 }
@@ -2128,11 +2132,10 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
 
 
         if ($class_storage
-                && !$class_storage->is_trait
-                && $class_storage->psalm_internal
-            && (
-                null === $storage->psalm_internal ||
-                strlen($class_storage->psalm_internal) > strlen($storage->psalm_internal)
+            && !$class_storage->is_trait
+            && $class_storage->psalm_internal
+            && (!$storage->psalm_internal
+                || strlen($class_storage->psalm_internal) > strlen($storage->psalm_internal)
             )
         ) {
             $storage->psalm_internal = $class_storage->psalm_internal;
@@ -2191,13 +2194,14 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
             $storage->deprecated = true;
         }
 
-        if ($docblock_info->internal && ! $docblock_info->psalm_internal && null !== $this->namespace_name) {
-            $storage->psalm_internal = $this->namespace_name->getFirst();
-        }
-
-        if (null === $class_storage ||
-            null === $class_storage->psalm_internal ||
-            (null !== $docblock_info->psalm_internal
+        if ($docblock_info->internal
+            && !$docblock_info->psalm_internal
+            && $this->aliases->namespace
+        ) {
+            $storage->psalm_internal = explode('\\', $this->aliases->namespace)[0];
+        } elseif (!$class_storage
+            || !$class_storage->psalm_internal
+            || ($docblock_info->psalm_internal
                 && strlen($docblock_info->psalm_internal) > strlen($class_storage->psalm_internal)
             )
         ) {

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -2127,9 +2127,9 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         $doc_comment = $stmt->getDocComment();
 
 
-        if ($class_storage &&
-                !$class_storage->is_trait &&
-                $class_storage->psalm_internal &&
+        if ($class_storage
+                && !$class_storage->is_trait
+                && $class_storage->psalm_internal
             (
                 null === $storage->psalm_internal ||
                 strlen($class_storage->psalm_internal) > strlen($storage->psalm_internal)
@@ -2197,8 +2197,8 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
 
         if (null === $class_storage ||
             null === $class_storage->psalm_internal ||
-            (null !== $docblock_info->psalm_internal &&
-                strlen($docblock_info->psalm_internal) > strlen($class_storage->psalm_internal)
+            (null !== $docblock_info->psalm_internal
+                && strlen($docblock_info->psalm_internal) > strlen($class_storage->psalm_internal)
             )
         ) {
             $storage->psalm_internal = $docblock_info->psalm_internal;

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -3415,7 +3415,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
             $property_storage->has_default = $property->default ? true : false;
             $property_storage->deprecated = $var_comment ? $var_comment->deprecated : false;
             $property_storage->psalm_internal = $var_comment ? $var_comment->psalm_internal : null;
-            if (! $property_storage->psalm_internal && $var_comment && $var_comment->internal){
+            if (! $property_storage->psalm_internal && $var_comment && $var_comment->internal) {
                 $property_storage->psalm_internal = NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name);
             }
             $property_storage->readonly = $var_comment ? $var_comment->readonly : false;

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -2130,7 +2130,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         if ($class_storage
                 && !$class_storage->is_trait
                 && $class_storage->psalm_internal
-            (
+            && (
                 null === $storage->psalm_internal ||
                 strlen($class_storage->psalm_internal) > strlen($storage->psalm_internal)
             )

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -2127,7 +2127,11 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         $doc_comment = $stmt->getDocComment();
 
 
-        if ($class_storage && ! $class_storage->is_trait) {
+        if ($class_storage &&
+                !$class_storage->is_trait &&
+                $class_storage->psalm_internal &&
+            (null === $storage->psalm_internal || strlen($class_storage->psalm_internal) > strlen($storage->psalm_internal))
+        ) {
             $storage->psalm_internal = $class_storage->psalm_internal;
         }
 

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -2130,7 +2130,10 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         if ($class_storage &&
                 !$class_storage->is_trait &&
                 $class_storage->psalm_internal &&
-            (null === $storage->psalm_internal || strlen($class_storage->psalm_internal) > strlen($storage->psalm_internal))
+            (
+                null === $storage->psalm_internal ||
+                strlen($class_storage->psalm_internal) > strlen($storage->psalm_internal)
+            )
         ) {
             $storage->psalm_internal = $class_storage->psalm_internal;
         }

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -88,11 +88,6 @@ class ClassLikeStorage
     public $deprecated = false;
 
     /**
-     * @var bool
-     */
-    public $internal = false;
-
-    /**
      * @var null|string
      */
     public $psalm_internal = null;

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -67,11 +67,6 @@ abstract class FunctionLikeStorage
     public $deprecated;
 
     /**
-     * @var ?bool
-     */
-    public $internal;
-
-    /**
      * @var null|string
      */
     public $psalm_internal;

--- a/src/Psalm/Storage/PropertyStorage.php
+++ b/src/Psalm/Storage/PropertyStorage.php
@@ -67,11 +67,6 @@ class PropertyStorage
     /**
      * @var bool
      */
-    public $internal = false;
-
-    /**
-     * @var bool
-     */
     public $readonly = false;
 
     /**

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -185,6 +185,8 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->addFile(
             $file_path,
             '<?php
+                namespace Psalm;
+
                 class A {
                     const C = [
                         "foo" => \Psalm\Internal\Analyzer\ProjectAnalyzer::class . "::foo",

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -76,6 +76,29 @@ class InternalAnnotationTest extends TestCase
                         }
                     }',
             ],
+            'internalClassWithPropertyFetch' => [
+                '<?php
+                    namespace A\B {
+                        /**
+                         * @internal
+                         */
+                        class Foo {
+                            public int $barBar = 0;
+                        }
+
+                        function getFoo(): Foo {
+                            return new Foo();
+                        }
+                    }
+
+                    namespace A\C {
+                        class Bat {
+                            public function batBat(\A\B\Foo $instance): void {
+                                \A\B\getFoo()->barBar;
+                            }
+                        }
+                    }',
+            ],
             'internalClassExtendingNamespaceWithStaticCall' => [
                 '<?php
                     namespace A {
@@ -292,6 +315,30 @@ class InternalAnnotationTest extends TestCase
                         }
                     }',
                 'error_message' => 'InternalMethod',
+            ],
+            'internalClassWithPropertyFetch' => [
+                '<?php
+                    namespace A\B {
+                        /**
+                         * @internal
+                         */
+                        class Foo {
+                            public int $barBar = 0;
+                        }
+
+                        function getFoo(): Foo {
+                            return new Foo();
+                        }
+                    }
+
+                    namespace C {
+                        class Bat {
+                            public function batBat(): void {
+                                \A\B\getFoo()->barBar;
+                            }
+                        }
+                    }',
+                'error_message' => 'A\B\Foo::$barBar is marked internal',
             ],
             'internalClassWithNew' => [
                 '<?php

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -263,7 +263,7 @@ class InternalAnnotationTest extends TestCase
 
                     namespace B {
                         class Bat {
-                            public function batBat() {
+                            public function batBat(): void {
                                 \A\Foo::barBar();
                             }
                         }

--- a/tests/PsalmInternalAnnotationTest.php
+++ b/tests/PsalmInternalAnnotationTest.php
@@ -186,6 +186,26 @@ class PsalmInternalAnnotationTest extends TestCase
                         }
                     }',
             ],
+            'internalClassWithInstanceOf' => [
+                '<?php
+                    namespace A\B {
+                        interface Bar {};
+
+                        /**
+                         * @internal
+                         * @psalm-internal A\B
+                         */
+                        class Foo { }
+                    }
+
+                    namespace A\B\C {
+                        class Bat {
+                            public function batBat(\A\B\Bar $bar) : void {
+                                $bar instanceOf \A\B\Foo;
+                            }
+                        }
+                    }',
+            ],
             'internalClassWithExtends' => [
                 '<?php
                     namespace A\B {
@@ -412,6 +432,27 @@ class PsalmInternalAnnotationTest extends TestCase
                         }
                     }',
                 'error_message' => 'InternalClass',
+            ],
+            'internalClassWithInstanceOf' => [
+                '<?php
+                    namespace A\B {
+                        interface Bar {};
+
+                        /**
+                         * @internal
+                         * @psalm-internal A\B
+                         */
+                        class Foo { }
+                    }
+
+                    namespace A\C {
+                        class Bat {
+                            public function batBat(\A\B\Bar $bar) : void {
+                                $bar instanceOf \A\B\Foo;
+                            }
+                        }
+                    }',
+                'error_message' => 'A\B\Foo is internal to A\B',
             ],
             'internalClassWithExtends' => [
                 '<?php

--- a/tests/PsalmInternalAnnotationTest.php
+++ b/tests/PsalmInternalAnnotationTest.php
@@ -117,6 +117,30 @@ class PsalmInternalAnnotationTest extends TestCase
                         }
                     }',
             ],
+            'internalClassWithPropertyFetch' => [
+                '<?php
+                    namespace A\B {
+                        /**
+                         * @internal
+                         * @psalm-internal A\B
+                         */
+                        class Foo {
+                            public int $barBar = 0;
+                        }
+
+                        function getFoo(): Foo {
+                            return new Foo();
+                        }
+                    }
+
+                    namespace A\B\C {
+                        class Bat {
+                            public function batBat(\A\B\Foo $instance): void {
+                                \A\B\getFoo()->barBar;
+                            }
+                        }
+                    }',
+            ],
             'internalClassExtendingNamespaceWithStaticCall' => [
                 '<?php
                     namespace A {
@@ -318,6 +342,31 @@ class PsalmInternalAnnotationTest extends TestCase
                         }
                     }',
                 'error_message' => 'InternalClass',
+            ],
+            'internalClassWithPropertyFetch' => [
+                '<?php
+                    namespace A\B {
+                        /**
+                         * @internal
+                         * @psalm-internal A\B
+                         */
+                        class Foo {
+                            public int $barBar = 0;
+                        }
+
+                        function getFoo(): Foo {
+                            return new Foo();
+                        }
+                    }
+
+                    namespace A\C {
+                        class Bat {
+                            public function batBat(): void {
+                                \A\B\getFoo()->barBar;
+                            }
+                        }
+                    }',
+                'error_message' => 'A\B\Foo::$barBar is marked internal to A\B',
             ],
             'internalClassWithInstanceCall' => [
                 '<?php


### PR DESCRIPTION
This makes the checking of `@internal` and `@psalm-internal` elements a lot more strict.

I also unified the handling of the two annotations, by treating `@internal` as an `@psalm-internal` to the first part of the relevant namespace.

However there are tests failing at present, and I can't easily work out what's gone wrong. I'd be happy if anyone else can work that out and/or fix it — I'm going to bed now.

Fixes #3706