### PR TITLE
Fix invalid UndefinedClass using array|callable

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -843,99 +843,124 @@ class ArgumentAnalyzer
                         }
                     }
                 } elseif ($param_type_part instanceof TCallable) {
-                    $function_ids = CallAnalyzer::getFunctionIdsFromCallableArg(
-                        $statements_analyzer,
-                        $input_expr
-                    );
+                    $can_be_callable_like_array = false;
+                    if ($param_type->hasArray()) {
+                        /**
+                         * @psalm-suppress PossiblyUndefinedStringArrayOffset
+                         */
+                        $param_array_type = $param_type->getAtomicTypes()['array'];
 
-                    foreach ($function_ids as $function_id) {
-                        if (strpos($function_id, '::') !== false) {
-                            if ($function_id[0] === '$') {
-                                $function_id = \substr($function_id, 1);
-                            }
+                        $row_type = null;
+                        if ($param_array_type instanceof TList) {
+                            $row_type = $param_array_type->type_param;
+                        } elseif ($param_array_type instanceof TArray) {
+                            $row_type = $param_array_type->type_params[1];
+                        } elseif ($param_array_type instanceof Type\Atomic\ObjectLike) {
+                            $row_type = $param_array_type->getGenericArrayType()->type_params[1];
+                        }
 
-                            $function_id_parts = explode('&', $function_id);
+                        if ($row_type &&
+                            ($row_type->hasMixed() || $row_type->hasString())
+                        ) {
+                            $can_be_callable_like_array = true;
+                        }
+                    }
 
-                            $non_existent_method_ids = [];
-                            $has_valid_method = false;
+                    if (!$can_be_callable_like_array) {
+                        $function_ids = CallAnalyzer::getFunctionIdsFromCallableArg(
+                            $statements_analyzer,
+                            $input_expr
+                        );
 
-                            foreach ($function_id_parts as $function_id_part) {
-                                list($callable_fq_class_name, $method_name) = explode('::', $function_id_part);
-
-                                switch ($callable_fq_class_name) {
-                                    case 'self':
-                                    case 'static':
-                                    case 'parent':
-                                        $container_class = $statements_analyzer->getFQCLN();
-
-                                        if ($callable_fq_class_name === 'parent') {
-                                            $container_class = $statements_analyzer->getParentFQCLN();
-                                        }
-
-                                        if (!$container_class) {
-                                            continue 2;
-                                        }
-
-                                        $callable_fq_class_name = $container_class;
+                        foreach ($function_ids as $function_id) {
+                            if (strpos($function_id, '::') !== false) {
+                                if ($function_id[0] === '$') {
+                                    $function_id = \substr($function_id, 1);
                                 }
 
-                                if (ClassLikeAnalyzer::checkFullyQualifiedClassLikeName(
-                                    $statements_analyzer,
-                                    $callable_fq_class_name,
-                                    $arg_location,
-                                    $context->self,
-                                    $context->calling_method_id,
-                                    $statements_analyzer->getSuppressedIssues()
-                                ) === false
+                                $function_id_parts = explode('&', $function_id);
+
+                                $non_existent_method_ids = [];
+                                $has_valid_method = false;
+
+                                foreach ($function_id_parts as $function_id_part) {
+                                    list($callable_fq_class_name, $method_name) = explode('::', $function_id_part);
+
+                                    switch ($callable_fq_class_name) {
+                                        case 'self':
+                                        case 'static':
+                                        case 'parent':
+                                            $container_class = $statements_analyzer->getFQCLN();
+
+                                            if ($callable_fq_class_name === 'parent') {
+                                                $container_class = $statements_analyzer->getParentFQCLN();
+                                            }
+
+                                            if (!$container_class) {
+                                                continue 2;
+                                            }
+
+                                            $callable_fq_class_name = $container_class;
+                                    }
+
+                                    if (ClassLikeAnalyzer::checkFullyQualifiedClassLikeName(
+                                        $statements_analyzer,
+                                        $callable_fq_class_name,
+                                        $arg_location,
+                                        $context->self,
+                                        $context->calling_method_id,
+                                        $statements_analyzer->getSuppressedIssues()
+                                    ) === false
+                                    ) {
+                                        return;
+                                    }
+
+                                    $function_id_part = new \Psalm\Internal\MethodIdentifier(
+                                        $callable_fq_class_name,
+                                        strtolower($method_name)
+                                    );
+
+                                    $call_method_id = new \Psalm\Internal\MethodIdentifier(
+                                        $callable_fq_class_name,
+                                        '__call'
+                                    );
+
+                                    if (!$codebase->classOrInterfaceExists($callable_fq_class_name)) {
+                                        return;
+                                    }
+
+                                    if (!$codebase->methods->methodExists($function_id_part)
+                                        && !$codebase->methods->methodExists($call_method_id)
+                                    ) {
+                                        $non_existent_method_ids[] = $function_id_part;
+                                    } else {
+                                        $has_valid_method = true;
+                                    }
+                                }
+
+                                if (!$has_valid_method && !$param_type->hasString() && !$param_type->hasArray()) {
+                                    if (MethodAnalyzer::checkMethodExists(
+                                        $codebase,
+                                        $non_existent_method_ids[0],
+                                        $arg_location,
+                                        $statements_analyzer->getSuppressedIssues()
+                                    ) === false
+                                    ) {
+                                        return;
+                                    }
+                                }
+                            } else {
+                                if (!$param_type->hasString()
+                                    && !$param_type->hasArray()
+                                    && CallAnalyzer::checkFunctionExists(
+                                        $statements_analyzer,
+                                        $function_id,
+                                        $arg_location,
+                                        false
+                                    ) === false
                                 ) {
                                     return;
                                 }
-
-                                $function_id_part = new \Psalm\Internal\MethodIdentifier(
-                                    $callable_fq_class_name,
-                                    strtolower($method_name)
-                                );
-
-                                $call_method_id = new \Psalm\Internal\MethodIdentifier(
-                                    $callable_fq_class_name,
-                                    '__call'
-                                );
-
-                                if (!$codebase->classOrInterfaceExists($callable_fq_class_name)) {
-                                    return;
-                                }
-
-                                if (!$codebase->methods->methodExists($function_id_part)
-                                    && !$codebase->methods->methodExists($call_method_id)
-                                ) {
-                                    $non_existent_method_ids[] = $function_id_part;
-                                } else {
-                                    $has_valid_method = true;
-                                }
-                            }
-
-                            if (!$has_valid_method && !$param_type->hasString() && !$param_type->hasArray()) {
-                                if (MethodAnalyzer::checkMethodExists(
-                                    $codebase,
-                                    $non_existent_method_ids[0],
-                                    $arg_location,
-                                    $statements_analyzer->getSuppressedIssues()
-                                ) === false
-                                ) {
-                                    return;
-                                }
-                            }
-                        } else {
-                            if (!$param_type->hasString()
-                                && !$param_type->hasArray()
-                                && CallAnalyzer::checkFunctionExists(
-                                    $statements_analyzer,
-                                    $function_id,
-                                    $arg_location,
-                                    false
-                                ) === false
-                            ) {
-                                return;
                             }
                         }
                     }

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -828,6 +828,15 @@ class CallableTest extends TestCase
 
                     if ($isCalled === true) {}'
             ],
+            'notCallableListNoUndefinedClass' => [
+                '<?php
+                    /**
+                     * @param array|callable $arg
+                     */
+                    function foo($arg): void {}
+
+                    foo([\'a\', \'b\']);'
+            ],
         ];
     }
 

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -835,7 +835,7 @@ class CallableTest extends TestCase
                      */
                     function foo($arg): void {}
 
-                    foo([\'a\', \'b\']);'
+                    foo(["a", "b"]);'
             ],
         ];
     }


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/3653

Now, an array of strings will not be considered as a callable when passing it to a function that also accepts just an array of strings(`callable|array<string>`, `callable|array`, `callable|list` etc. )