### PR TITLE
Use composer/package-versions-deprecated instead of ocramius/package-versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "felixfbecker/language-server-protocol": "^1.4",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0",
         "nikic/php-parser": "^4.3",
-        "ocramius/package-versions": "^1.2",
+        "composer/package-versions-deprecated": "^1.8.0",
         "openlss/lib-array2xml": "^1.0",
         "sebastian/diff": "^3.0 || ^4.0",
         "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -55,6 +55,11 @@
                 <referencedMethod name="PhpParser\Comment::getLine" />
             </errorLevel>
         </DeprecatedMethod>
+        <DeprecatedClass>
+            <errorLevel type="suppress">
+                <referencedClass name="PackageVersions\Versions"/>
+            </errorLevel>
+        </DeprecatedClass>
 
         <UnusedParam>
             <errorLevel type="suppress">

--- a/tests/fixtures/SuicidalAutoloader/autoloader.php
+++ b/tests/fixtures/SuicidalAutoloader/autoloader.php
@@ -1,12 +1,16 @@
 <?php
 
 use React\Promise\PromiseInterface as ReactPromise;
+use ResourceBundle;
+use Transliterator;
+use Composer\InstalledVersions;
 
 spl_autoload_register(function (string $className) {
     $knownBadClasses = [
         ReactPromise::class, // amphp/amp
         ResourceBundle::class, // symfony/polyfill-php73
         Transliterator::class, // symfony/string
+        InstalledVersions::class, // composer v2
         // it's unclear why Psalm tries to autoload parent
         'parent',
     ];


### PR DESCRIPTION
It allows wider range of PHP versions in addition to supporting both Composer v1 and v2

Fixes vimeo/psalm#3844