### PR TITLE
Prevent tests from producing output

### DIFF
--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -869,7 +869,9 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->project_analyzer->stdout_report_options->format = \Psalm\Report::TYPE_JSON;
 
         $this->project_analyzer->check('tests/fixtures/DummyProject', true);
+        ob_start();
         \Psalm\IssueBuffer::finish($this->project_analyzer, true, microtime(true));
+        ob_end_clean();
     }
 
     /**

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -22,6 +22,8 @@ use Psalm\PluginRegistrationSocket;
 use Psalm\Tests\Internal\Provider;
 use Psalm\Tests\TestConfig;
 use function sprintf;
+use function ob_start;
+use function ob_end_clean;
 
 class PluginTest extends \Psalm\Tests\TestCase
 {

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -173,7 +173,9 @@ class ProjectCheckerTest extends TestCase
         $this->project_analyzer->stdout_report_options->format = \Psalm\Report::TYPE_JSON;
 
         $this->project_analyzer->check('tests/fixtures/DummyProject', true);
+        ob_start();
         \Psalm\IssueBuffer::finish($this->project_analyzer, true, microtime(true));
+        ob_end_clean();
 
         $this->assertSame(
             'Psalm was able to infer types for 100% of the codebase',
@@ -218,7 +220,9 @@ class ProjectCheckerTest extends TestCase
         $this->project_analyzer->stdout_report_options->format = \Psalm\Report::TYPE_JSON;
 
         $this->project_analyzer->check('tests/fixtures/DummyProject', true);
+        ob_start();
         \Psalm\IssueBuffer::finish($this->project_analyzer, true, microtime(true));
+        ob_end_clean();
 
         $this->assertSame(
             'Psalm was able to infer types for 100% of the codebase',


### PR DESCRIPTION
- These are considered risky by PHPUnit
- And they mess up PHPUnit output