### PR TITLE
[docs] property/method text on Configuration page

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -229,7 +229,7 @@ When `true`, Psalm will check that the developer has caught every exception in g
   ignoreInternalFunctionFalseReturn="[bool]"
 >
 ```
-When `true`, Psalm ignores possibly-false issues stemming from return values of internal functions (like `preg_split`) that may return false, but do so rarely). Defaults to `true`.
+When `true`, Psalm ignores possibly-false issues stemming from return values of internal functions (like `preg_split`) that may return false, but do so rarely. Defaults to `true`.
 
 #### ignoreInternalFunctionNullReturn
 
@@ -323,7 +323,7 @@ When `true`, Psalm will run [Taint Analysis](../security_analysis/index.md) on y
   autoloader="[string]"
 >
 ```
-if your application registers one or more custom autoloaders, and/or declares universal constants/functions, this autoloader script will be executed by Psalm before scanning starts. Psalm always registers composer's autoloader by default.
+If your application registers one or more custom autoloaders, and/or declares universal constants/functions, this autoloader script will be executed by Psalm before scanning starts. Psalm always registers composer's autoloader by default.
 
 #### throwExceptionOnError
 ```xml
@@ -331,7 +331,7 @@ if your application registers one or more custom autoloaders, and/or declares un
   throwExceptionOnError="[bool]"
 >
 ```
-Useful in testing, things makes Psalm throw a regular-old exception when it encounters an error. Defaults to `false`.
+Useful in testing, this makes Psalm throw a regular-old exception when it encounters an error. Defaults to `false`.
 
 #### hideExternalErrors
 ```xml
@@ -339,7 +339,7 @@ Useful in testing, things makes Psalm throw a regular-old exception when it enco
   hideExternalErrors="[bool]"
 >
 ```
-whether or not to show issues in files that are used by your project files, but which are not included in `<projectFiles>`. Defaults to `false`.
+Whether or not to show issues in files that are used by your project files, but which are not included in `<projectFiles>`. Defaults to `false`.
 
 #### cacheDirectory
 ```xml
@@ -365,7 +365,7 @@ Whether or not to allow `require`/`include` calls in your PHP. Defaults to `true
   serializer="['igbinary'|'default']"
 >
 ```
-Allows you to hard-code a serializer for Psalm to use when caching data. By default, Psalm uses `ext-igbinary` *if* the version is greater or equal to 2.0.5, otherwise it defaults to PHP's built-in serializer.
+Allows you to hard-code a serializer for Psalm to use when caching data. By default, Psalm uses `ext-igbinary` *if* the version is greater than or equal to 2.0.5, otherwise it defaults to PHP's built-in serializer.
 
 
 ## Project settings

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -105,7 +105,7 @@ If not using all docblock types, you can still use docblock property types. Defa
   usePhpDocMethodsWithoutMagicCall="[bool]"
 >
 ```
-The PHPDoc `@property`, `@property-read` and `@property-write` annotations normally only apply to classes with `__get`/`__set` methods. Setting this to `true` allows you to use the `@property`, `@property-read` and `@property-write` annotations to override property existance checks and resulting property types. Defaults to `false`.
+The PHPDoc `@method` annotation normally only applies to classes with a `__call` method. Setting this to `true` allows you to use the `@method` annotation to override inherited method return types. Defaults to `false`.
 
 #### usePhpDocPropertiesWithoutMagicCall
 
@@ -114,7 +114,7 @@ The PHPDoc `@property`, `@property-read` and `@property-write` annotations norma
   usePhpDocPropertiesWithoutMagicCall="[bool]"
 >
 ```
-The PHPDoc `@method` annotation normally only applies to classes with a `__call` method. Setting this to `true` allows you to use the `@method` annotation to override inherited method return types. Defaults to `false`.
+The PHPDoc `@property`, `@property-read` and `@property-write` annotations normally only apply to classes with `__get`/`__set` methods. Setting this to `true` allows you to use the `@property`, `@property-read` and `@property-write` annotations to override property existance checks and resulting property types. Defaults to `false`.
 
 #### strictBinaryOperands
 


### PR DESCRIPTION
When I was reading through the docs setting up my Psalm config recently, I was a little confused by the `usePhpDocPropertiesWithoutMagicCall` rule referencing `@method` and vice-versa. After some digging it seems #3748 added the Properties text (highlighted in red below) in the wrong order, at least as far as I can tell.

This PR resolves that and a couple other minor text fixes.

![psalm](https://user-images.githubusercontent.com/1521802/88116556-b46dd180-cbb0-11ea-98ae-21290bb0fce0.png)
