### PR TITLE
Casing checker: Ignore call / call static

### DIFF
--- a/examples/plugins/FunctionCasingChecker.php
+++ b/examples/plugins/FunctionCasingChecker.php
@@ -53,6 +53,10 @@ class FunctionCasingChecker implements AfterFunctionCallAnalysisInterface, After
                 return;
             }
 
+            if ($function_storage->cased_name === '__callStatic') {
+                return;
+            }
+
             if ($function_storage->cased_name !== (string)$expr->name) {
                 if (\Psalm\IssueBuffer::accepts(
                     new IncorrectFunctionCasing(


### PR DESCRIPTION
Line 52 ignores `__call`, but not `__callStatic`. This will help us since mainly this comes up when using https://github.com/myclabs/php-enum