### PR TITLE
Patch 1 typos

### DIFF
--- a/docs/how_psalm_works.md
+++ b/docs/how_psalm_works.md
@@ -6,7 +6,7 @@ The entry point for all analysis is [`ProjectAnalyzer`](https://github.com/vimeo
 
 ## Scanning
 
-For any file or set of files, Psalm needs to determine all the possible dependencies and get their function signatures and constants, so that the analysis phase can be done multithreaded.
+For any file or set of files, Psalm needs to determine all the possible dependencies and get their function signatures and constants, so that the analysis phase can be done multi-threaded.
 
 Scanning happens in `Psalm\Internal\Codebase\Scanner`.
 

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -114,7 +114,7 @@ The PHPDoc `@method` annotation normally only applies to classes with a `__call`
   usePhpDocPropertiesWithoutMagicCall="[bool]"
 >
 ```
-The PHPDoc `@property`, `@property-read` and `@property-write` annotations normally only apply to classes with `__get`/`__set` methods. Setting this to `true` allows you to use the `@property`, `@property-read` and `@property-write` annotations to override property existance checks and resulting property types. Defaults to `false`.
+The PHPDoc `@property`, `@property-read` and `@property-write` annotations normally only apply to classes with `__get`/`__set` methods. Setting this to `true` allows you to use the `@property`, `@property-read` and `@property-write` annotations to override property existence checks and resulting property types. Defaults to `false`.
 
 #### strictBinaryOperands
 

--- a/docs/running_psalm/issues/AssignmentToVoid.md
+++ b/docs/running_psalm/issues/AssignmentToVoid.md
@@ -11,7 +11,7 @@ $a = foo();
 
 ## Why this is bad
 
-Though `void`-returning functions are treated by PHP as returning `null` (so this on its own doesn’t lead to runtime errors), `void` is a concept more broadly in programming languages which is not designed for assignment purposes.
+Though `void`-returning functions are treated by PHP as returning `null` (so this on its own does not lead to runtime errors), `void` is a concept more broadly in programming languages which is not designed for assignment purposes.
 
 ## How to fix
 

--- a/docs/running_psalm/issues/DuplicateArrayKey.md
+++ b/docs/running_psalm/issues/DuplicateArrayKey.md
@@ -27,4 +27,4 @@ $arr = [
 ];
 ```
 
-The first matching `'c'` key was removed to prevent a change in behaviour (any new duplicate keys overwrite the values of prevvious ones).
+The first matching `'c'` key was removed to prevent a change in behaviour (any new duplicate keys overwrite the values of previous ones).

--- a/docs/running_psalm/issues/FalseOperand.md
+++ b/docs/running_psalm/issues/FalseOperand.md
@@ -10,4 +10,4 @@ echo 5 . false;
 
 ## Why this is bad
 
-`false` doesn’t make sense in these operations
+`false` does not make sense in these operations

--- a/docs/running_psalm/issues/InvalidDocblockParamName.md
+++ b/docs/running_psalm/issues/InvalidDocblockParamName.md
@@ -1,6 +1,6 @@
 # InvalidDocblockParamName
 
-Emitted when a docblock param name doesn’t match up with a named param in the function, if the param doesn’t have a type or its type is `array`.
+Emitted when a docblock param name does not match up with a named param in the function, if the param does not have a type or its type is `array`.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/MismatchingDocblockParamType.md
+++ b/docs/running_psalm/issues/MismatchingDocblockParamType.md
@@ -1,6 +1,6 @@
 # MismatchingDocblockParamType
 
-Emitted when an `@param` entry in a function’s docblock doesn’t match the param typehint
+Emitted when an `@param` entry in a function’s docblock does not match the param typehint
 
 ```php
 <?php

--- a/docs/running_psalm/issues/MismatchingDocblockReturnType.md
+++ b/docs/running_psalm/issues/MismatchingDocblockReturnType.md
@@ -1,6 +1,6 @@
 # MismatchingDocblockReturnType
 
-Emitted when an `@return` entry in a function’s docblock doesn’t match the function return typehint
+Emitted when an `@return` entry in a function’s docblock does not match the function return typehint
 
 ```php
 <?php

--- a/docs/running_psalm/issues/MissingDependency.md
+++ b/docs/running_psalm/issues/MissingDependency.md
@@ -1,6 +1,6 @@
 # MissingDependency
 
-Emitted when referencing a class that doesn’t exist
+Emitted when referencing a class that does not exist
 
 ```php
 <?php

--- a/docs/running_psalm/issues/MixedMethodCall.md
+++ b/docs/running_psalm/issues/MixedMethodCall.md
@@ -20,7 +20,7 @@ callFoo(
 
 ## Why this is bad
 
-If Psalm doesn’t know what `array_pop($arr)` is, it can't verify whether `array_pop($arr)->foo()` will work or not.
+If Psalm does not know what `array_pop($arr)` is, it can't verify whether `array_pop($arr)->foo()` will work or not.
 
 ## How to fix
 

--- a/docs/running_psalm/issues/MixedPropertyTypeCoercion.md
+++ b/docs/running_psalm/issues/MixedPropertyTypeCoercion.md
@@ -1,6 +1,6 @@
 # MixedPropertyTypeCoercion
 
-Emitted when Psalm cannot be sure that part of an array/iterabble argument's type constraints can be fulfilled
+Emitted when Psalm cannot be sure that part of an array/iterable argument's type constraints can be fulfilled
 
 ```php
 <?php

--- a/docs/running_psalm/issues/MixedReturnTypeCoercion.md
+++ b/docs/running_psalm/issues/MixedReturnTypeCoercion.md
@@ -1,6 +1,6 @@
 # MixedReturnTypeCoercion
 
-Emitted when Psalm cannot be sure that part of an array/iterabble return type's constraints can be fulfilled
+Emitted when Psalm cannot be sure that part of an array/iterable return type's constraints can be fulfilled
 
 ```php
 <?php

--- a/docs/running_psalm/issues/PossiblyFalseArgument.md
+++ b/docs/running_psalm/issues/PossiblyFalseArgument.md
@@ -1,6 +1,6 @@
 # PossiblyFalseArgument
 
-Emitted when a function argument is possibly `false`, but the function doesn’t expect `false`. This is distinct from a function argument is possibly `bool`, which results in `PossiblyInvalidArgument`.
+Emitted when a function argument is possibly `false`, but the function does not expect `false`. This is distinct from a function argument is possibly `bool`, which results in `PossiblyInvalidArgument`.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/PossiblyInvalidPropertyAssignment.md
+++ b/docs/running_psalm/issues/PossiblyInvalidPropertyAssignment.md
@@ -1,6 +1,6 @@
 # PossiblyInvalidPropertyAssignment
 
-Emitted when trying to assign a property on a value that may not be an object or may be an object that doesn’t have the desired property.
+Emitted when trying to assign a property on a value that may not be an object or may be an object that does not have the desired property.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/PossiblyInvalidPropertyFetch.md
+++ b/docs/running_psalm/issues/PossiblyInvalidPropertyFetch.md
@@ -1,6 +1,6 @@
 # PossiblyInvalidPropertyFetch
 
-Emitted when trying to fetch a property on a value that may not be an object or may be an object that doesn’t have the desired property.
+Emitted when trying to fetch a property on a value that may not be an object or may be an object that does not have the desired property.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/PossiblyUndefinedArrayOffset.md
+++ b/docs/running_psalm/issues/PossiblyUndefinedArrayOffset.md
@@ -16,7 +16,7 @@ echo $arr["b"];
 
 ## How to fix
 
-You can use the null coalesce operator to provide a default value in the event the array offset doesn’t exist:
+You can use the null coalesce operator to provide a default value in the event the array offset does not exist:
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedClass.md
+++ b/docs/running_psalm/issues/UndefinedClass.md
@@ -1,6 +1,6 @@
 # UndefinedClass
 
-Emitted when referencing a class that doesn’t exist
+Emitted when referencing a class that does not exist
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedConstant.md
+++ b/docs/running_psalm/issues/UndefinedConstant.md
@@ -1,6 +1,6 @@
 # UndefinedConstant
 
-Emitted when referencing a constant that doesn’t exist
+Emitted when referencing a constant that does not exist
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedDocblockClass.md
+++ b/docs/running_psalm/issues/UndefinedDocblockClass.md
@@ -1,6 +1,6 @@
 # UndefinedDocblockClass
 
-Emitted when referencing a class that doesn’t exist from a docblock
+Emitted when referencing a class that does not exist from a docblock
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedInterface.md
+++ b/docs/running_psalm/issues/UndefinedInterface.md
@@ -1,6 +1,6 @@
 # UndefinedInterface
 
-Emitted when referencing an interface that doesn’t exist but does have an identically-named class.
+Emitted when referencing an interface that does not exist but does have an identically-named class.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedInterfaceMethod.md
+++ b/docs/running_psalm/issues/UndefinedInterfaceMethod.md
@@ -1,6 +1,6 @@
 # UndefinedInterfaceMethod
 
-Emitted when calling a method that doesn’t exist on an interface
+Emitted when calling a method that does not exist on an interface
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedMagicMethod.md
+++ b/docs/running_psalm/issues/UndefinedMagicMethod.md
@@ -1,6 +1,6 @@
 # UndefinedMagicMethod
 
-Emitted when calling a magic method that doesn’t exist
+Emitted when calling a magic method that does not exist
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedMagicPropertyAssignment.md
+++ b/docs/running_psalm/issues/UndefinedMagicPropertyAssignment.md
@@ -1,6 +1,6 @@
 # UndefinedMagicPropertyAssignment
 
-Emitted when assigning a property on an object that doesn’t have that magic property defined
+Emitted when assigning a property on an object that does not have that magic property defined
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedMagicPropertyFetch.md
+++ b/docs/running_psalm/issues/UndefinedMagicPropertyFetch.md
@@ -1,6 +1,6 @@
 # UndefinedMagicPropertyFetch
 
-Emitted when getting a property on an object that doesn’t have that magic property defined
+Emitted when getting a property on an object that does not have that magic property defined
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedMethod.md
+++ b/docs/running_psalm/issues/UndefinedMethod.md
@@ -1,6 +1,6 @@
 # UndefinedMethod
 
-Emitted when calling a method that doesn’t exist
+Emitted when calling a method that does not exist
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedPropertyAssignment.md
+++ b/docs/running_psalm/issues/UndefinedPropertyAssignment.md
@@ -1,6 +1,6 @@
 # UndefinedPropertyAssignment
 
-Emitted when assigning a property on an object that doesn’t have that property defined
+Emitted when assigning a property on an object that does not have that property defined
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedPropertyFetch.md
+++ b/docs/running_psalm/issues/UndefinedPropertyFetch.md
@@ -1,6 +1,6 @@
 # UndefinedPropertyFetch
 
-Emitted when getting a property on an object that doesn’t have that property defined
+Emitted when getting a property on an object that does not have that property defined
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UndefinedTrait.md
+++ b/docs/running_psalm/issues/UndefinedTrait.md
@@ -1,6 +1,6 @@
 # UndefinedTrait
 
-Emitted when referencing a trait that doesn’t exist
+Emitted when referencing a trait that does not exist
 
 ```php
 <?php

--- a/docs/running_psalm/plugins/plugins_type_system.md
+++ b/docs/running_psalm/plugins/plugins_type_system.md
@@ -4,7 +4,7 @@ Psalm's type system represents the types of variables within a program using dif
 
 ## Union types
 
-All type Psalm's type information you are likely to use will be wrapped in a [Union Type](../../annotating_code/docblock_type_syntax.md#union-types).
+All type Psalm's type information you are likely to use will be wrapped in a [Union Type](../../annotating_code/type_syntax/union_types.md).
 
 The `Union` class constructor takes an array of `Atomic` types, and can represent one or more of these types at a time. They correspond to a vertical bar in a doc comment.
 
@@ -168,13 +168,13 @@ foreach (range(1,1) as $_) $a[(string)rand(0,1)] = rand(0,1); // array<string,in
 
 ## Creating type object instances
 
-There are two ways of creating the object instances which describe a given type. They can be created directly using new, or created declaratively from a doc string. Normally, you'd want to use the second option. Howeaver, understanding the structure of this data will help you understand types passed into a plugin.
+There are two ways of creating the object instances which describe a given type. They can be created directly using new, or created declaratively from a doc string. Normally, you'd want to use the second option. However, understanding the structure of this data will help you understand types passed into a plugin.
 
 Note that these classes do sometimes change, so `Type::parseString` is always going to be the more robust option.
 
 ### Creating type object instances directly
 
-The following example constructs a types representing a string, a floating point number, and a class called 'Foo\Bar\SomeClass'.
+The following example constructs types representing a string, a floating-point number, and a class called 'Foo\Bar\SomeClass'.
 
 ``` php
 new TLiteralString('A text string')
@@ -197,7 +197,7 @@ foreach ($types->getTypes() as $atomic)
 
 Also, union trees are always shallow, because Psalm will flatten union of unions into a single-level union `((A|B)|(C|D) => A|B|C|D)`.
 
-More complex types can be constructed as follows. The following represents an assosiative array with 3 keys. Psalm calls these 'object-like arrays', and represents them with the 'ObjectLike' class.
+More complex types can be constructed as follows. The following represents an associative array with 3 keys. Psalm calls these 'object-like arrays', and represents them with the 'ObjectLike' class.
 
 
 ``` php

--- a/docs/security_analysis/avoiding_false_positives.md
+++ b/docs/security_analysis/avoiding_false_positives.md
@@ -73,7 +73,7 @@ echo takesInput($_GET["name"]); // Psalm detects tainted input
 echo takesInput("hello"); // No error
 ```
 
-Here we’re telling Psalm that a function’s taintedness is wholly depenedent on the input to the function.
+Here we’re telling Psalm that a function’s taintedness is wholly dependent on the input to the function.
 
 If you're familiar with [immutability in Psalm](https://psalm.dev/articles/immutability-and-beyond) then this general idea should be familiar, since a pure function is one where the output is wholly dependent on its input. Unsurprisingly, all functions marked `@psalm-pure` _also_ specialize the taintedness of their output based on input:
 

--- a/docs/security_analysis/custom_taint_sinks.md
+++ b/docs/security_analysis/custom_taint_sinks.md
@@ -6,7 +6,7 @@ Any tainted value matching the given [taint type](index.md#taint-types) will be 
 
 ### Example
 
-Here the `PDOWrapper` class has an `exec` method that should not recieve tainted SQL, so we can prevent its insertion:
+Here the `PDOWrapper` class has an `exec` method that should not receive tainted SQL, so we can prevent its insertion:
 
 ```php
 <?php

--- a/docs/security_analysis/index.md
+++ b/docs/security_analysis/index.md
@@ -50,6 +50,6 @@ Nobody likes to wade through a ton of false-positives – [here’s a guide to a
 
 ## Using Baseline With Taint Analysis
 
-Since taint analysis is performed separtely from other static code analysis, it makes sense to use a separate baseline for it.
+Since taint analysis is performed separately from other static code analysis, it makes sense to use a separate baseline for it.
 
 You can use --use-baseline=PATH option to set a different baseline for taint analysis.


### PR DESCRIPTION
While I was looking in the code stumbled over some typos.

Only in docs and should be only typos (and one link correction).