### PR TITLE
Fix PSR-4 deprecation notices on composer install

### DIFF
--- a/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
+++ b/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
@@ -1,10 +1,13 @@
 <?php
-namespace Psalm\Tests\Functions;
+namespace Psalm\Tests\CommandFunctions;
 
-use function getMemoryLimitInBytes;
 use function ini_set;
 use function ini_get;
+use function Psalm\getMemoryLimitInBytes;
 
+/**
+ * testcase for src/command_functions.php
+ */
 class GetMemoryLimitInBytesTest extends \Psalm\Tests\TestCase
 {
     /**
@@ -61,7 +64,7 @@ class GetMemoryLimitInBytesTest extends \Psalm\Tests\TestCase
         $expectedBytes
     ) {
         ini_set('memory_limit', (string)$setting);
-        $this->assertSame($expectedBytes, \Psalm\getMemoryLimitInBytes(), 'Memory limit in bytes does not fit setting');
+        $this->assertSame($expectedBytes, getMemoryLimitInBytes(), 'Memory limit in bytes does not fit setting');
     }
 
     public function tearDown(): void

--- a/tests/TypeReconciliation/EmptyTest.php
+++ b/tests/TypeReconciliation/EmptyTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Psalm\Tests;
+namespace Psalm\Tests\TypeReconciliation;
 
 class EmptyTest extends \Psalm\Tests\TestCase
 {

--- a/tests/TypeReconciliation/IssetTest.php
+++ b/tests/TypeReconciliation/IssetTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Psalm\Tests;
+namespace Psalm\Tests\TypeReconciliation;
 
 class IssetTest extends \Psalm\Tests\TestCase
 {

--- a/tests/TypeReconciliation/ValueTest.php
+++ b/tests/TypeReconciliation/ValueTest.php
@@ -1,10 +1,10 @@
 <?php
-namespace Psalm\Tests;
+namespace Psalm\Tests\TypeReconciliation;
 
-class ValueTest extends TestCase
+class ValueTest extends \Psalm\Tests\TestCase
 {
-    use Traits\InvalidCodeAnalysisTestTrait;
-    use Traits\ValidCodeAnalysisTestTrait;
+    use \Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+    use \Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
     public function setUp() : void
     {
@@ -13,7 +13,7 @@ class ValueTest extends TestCase
         $this->file_provider = new \Psalm\Tests\Internal\Provider\FakeFileProvider();
 
         $this->project_analyzer = new \Psalm\Internal\Analyzer\ProjectAnalyzer(
-            new TestConfig(),
+            new \Psalm\Tests\TestConfig(),
             new \Psalm\Internal\Provider\Providers(
                 $this->file_provider,
                 new \Psalm\Tests\Internal\Provider\FakeParserCacheProvider()


### PR DESCRIPTION
Previously when checking out the repository and installing the source
package via `$ composer install` composer did spill deprecation notices for
four files not complying with the PSR-4 auto-loading standard.

This is a minor issue, composer install works and can be addressed by
fixing name-spaces (all of those three are in tests).

For the one function test, fixing the directory structure / dirname of the
(single) affected function test (fourth file).