### PR TITLE
minor: typo in message

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -36,7 +36,7 @@ class MethodCallPurityAnalyzer
         ) {
             if (IssueBuffer::accepts(
                 new ImpureMethodCall(
-                    'Cannot call an mutation-free method '
+                    'Cannot call a non-mutation-free method '
                         . $cased_method_id . ' from a pure context',
                     new CodeLocation($statements_analyzer, $stmt->name)
                 ),


### PR DESCRIPTION
Typo in messages like "Cannot call an mutation-free method DateTime::format from a pure context" - missed "non"