### PR TITLE
Resolve require_once command_functions.php

### DIFF
--- a/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
+++ b/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
@@ -17,7 +17,7 @@ class GetMemoryLimitInBytesTest extends \Psalm\Tests\TestCase
 
     public function setUp(): void
     {
-        require_once 'src/command_functions.php';
+        require_once __DIR__ . '/../../src/command_functions.php';
         $this->previousLimit = (string)ini_get('memory_limit');
         parent::setUp();
     }


### PR DESCRIPTION
Considering the test-suite tests the code from src paired with tests,
not the working directory (or even worse the overall include_path runtime
setting) should lead to relative path resolution, but just the relative
location to the path of the test itself.

Fix by making use of the `__DIR__` constant to anchor the relative location
turning it into an absolute path.