### PR TITLE
fix for DeprecatedClass suppress on property

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -3,6 +3,7 @@ namespace Psalm\Internal\Analyzer;
 
 use PhpParser;
 use Psalm\Aliases;
+use Psalm\DocComment;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\ClassTemplateParamCollector;
 use Psalm\Internal\FileManipulation\PropertyDocblockManipulator;
 use Psalm\Internal\Type\UnionTemplateHandler;
@@ -1089,12 +1090,14 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                         && isset($stmt->props[0]->name->name)
                         && $stmt->props[0]->name->name === $property_name;
                 });
+
                 $suppressed = [];
                 if(count($stmt) > 0) {
-                    $statements_analyzer = new StatementsAnalyzer($statements_source, new \Psalm\Internal\Provider\NodeDataProvider());
-                    $statements_analyzer->analyze($stmt, $class_context, null, false);
-                    $docBlock = $statements_analyzer->getParsedDocblock();
-                    if($docBlock) {
+                    /** @var PhpParser\Node\Stmt\Property $stmt */
+                    $stmt = $stmt[0];
+                    $docComment = $stmt->getDocComment();
+                    if($docComment) {
+                        $docBlock = DocComment::parsePreservingLength($docComment);
                         $suppressed = $docBlock->tags['psalm-suppress'] ?? [];
                     }
                 }

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1095,7 +1095,8 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                 $suppressed = [];
                 if(count($stmt) > 0) {
                     /** @var PhpParser\Node\Stmt\Property $stmt */
-                    $stmt = $stmt[0];
+                    $stmt = array_pop($stmt);
+
                     $docComment = $stmt->getDocComment();
                     if($docComment) {
                         try {

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -4,6 +4,7 @@ namespace Psalm\Internal\Analyzer;
 use PhpParser;
 use Psalm\Aliases;
 use Psalm\DocComment;
+use Psalm\Exception\DocblockParseException;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\ClassTemplateParamCollector;
 use Psalm\Internal\FileManipulation\PropertyDocblockManipulator;
 use Psalm\Internal\Type\UnionTemplateHandler;
@@ -1097,8 +1098,12 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                     $stmt = $stmt[0];
                     $docComment = $stmt->getDocComment();
                     if($docComment) {
-                        $docBlock = DocComment::parsePreservingLength($docComment);
-                        $suppressed = $docBlock->tags['psalm-suppress'] ?? [];
+                        try {
+                            $docBlock = DocComment::parsePreservingLength($docComment);
+                            $suppressed = $docBlock->tags['psalm-suppress'] ?? [];
+                        } catch (DocblockParseException $e) {
+                            // do nothing to keep original behavior
+                        }
                     }
                 }
 

--- a/src/Psalm/Internal/TypeVisitor/TypeChecker.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeChecker.php
@@ -187,7 +187,7 @@ class TypeChecker extends NodeVisitor
                         $this->code_location,
                         $atomic->value
                     ),
-                    $this->source->getSuppressedIssues()
+                    $this->source->getSuppressedIssues() + $this->suppressed_issues
                 )) {
                     // fall through
                 }

--- a/tests/DeprecatedAnnotationTest.php
+++ b/tests/DeprecatedAnnotationTest.php
@@ -77,6 +77,9 @@ class DeprecatedAnnotationTest extends TestCase
                          */
                         class TheDeprecatedClass {}
 
+                        /**
+                         * @psalm-suppress MissingConstructor
+                         */
                         class A {
                             /**
                              * @psalm-suppress DeprecatedClass

--- a/tests/DeprecatedAnnotationTest.php
+++ b/tests/DeprecatedAnnotationTest.php
@@ -69,6 +69,22 @@ class DeprecatedAnnotationTest extends TestCase
                         }
                     }'
             ],
+            'suppressDeprecatedClassOnMember' => [
+                    '<?php
+
+                        /**
+                         * @deprecated
+                         */
+                        class TheDeprecatedClass {}
+
+                        class A {
+                            /**
+                             * @psalm-suppress DeprecatedClass
+                             * @var TheDeprecatedClass
+                             */
+                            public $property;
+                        }
+                ']
         ];
     }
 


### PR DESCRIPTION
Related to #3478  
I have added test case for this issue, but can't find out, how it should be fixed.

For some reason, suppressed issues are empty here:
https://github.com/vimeo/psalm/blob/ea52b9d23add23f98cf4ae36812bd203945e7dcc/src/Psalm/Internal/Analyzer/ClassAnalyzer.php#L1084-L1092

I will be glad for any clue, in which point `supressed issues` should be filled.