### PR TITLE
specify requirement phpdocumentor/reflection-docblock:^4.3.4 || ^5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "amphp/amp": "^2.4.2",
         "bamarni/composer-bin-plugin": "^1.2",
         "brianium/paratest": "^4.0.0",
+        "phpdocumentor/reflection-docblock": "^4.3.4 || ^5",
         "phpmyadmin/sql-parser": "5.1.0",
         "phpspec/prophecy": ">=1.9.0",
         "phpunit/phpunit": "^7.5.16 || ^8.5 || ^9.0",


### PR DESCRIPTION
specify requirements for the sake of travis "low" deps fails.

![ダウンロード (4)](https://user-images.githubusercontent.com/42755/89727398-689ba300-da5f-11ea-9e6c-5754887f0000.png)
  - https://travis-ci.org/github/vimeo/psalm/jobs/716250055

----


"low" deps would install phpdocumentor/reflection-docblock with `4.0.0`. but, reflection-docblock 4.0.0. has bug `Uninitialized string offset: 0 `.
  - see https://github.com/phpDocumentor/ReflectionDocBlock/issues/111

---

 - Currently, psalm requirements `"php": "^7.1.3|^8"` 
 - phpspec/prophecy:1.9.0, 1.10.0 requirements `php:"^5.3|^7.0"`
 - phpspec/prophecy:1.9.0, 1.10.0 requirements `"phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",`

But, prophecy upper version drop support php 7.1.
 - phpspec/prophecy:1.11.0 requirements `php:"^7.2"`,
 - phpspec/prophecy:1.11.0 requirements `"phpdocumentor/reflection-docblock": "^5.0",`.
and reflection-docblock:5 also requires `"php": "^7.2"`

So, specify requirement phpdocumentor/reflection-docblock:^4.3.4 || ^5 .