### PR TITLE
Removed obsolete documenation

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -32,7 +32,6 @@
         <xs:attribute name="serializer" type="xs:string" />
 
         <xs:attribute name="addParamDefaultToDocblockType" type="xs:boolean" default="false" />
-        <xs:attribute name="allowCoercionFromStringToClassConst" type="xs:boolean" default="false" />
         <xs:attribute name="allowFileIncludes" type="xs:boolean" default="true" />
         <xs:attribute name="allowPhpStormGenerics" type="xs:boolean" default="false" />
         <xs:attribute name="allowStringToStandInForClass" type="xs:boolean" default="false" />

--- a/docs/annotating_code/type_syntax/scalar_types.md
+++ b/docs/annotating_code/type_syntax/scalar_types.md
@@ -30,7 +30,7 @@ class A {}
 function takesClassName(string $s) : void {}
 ```
 
-`takesClassName("A");` would trigger a `TypeCoercion` issue (or a `PossiblyInvalidArgument` issue if [`allowCoercionFromStringToClassConst`](../running_psalm/configuration.md#coding-style) was set to `false` in your config), whereas `takesClassName(A::class)` is fine.
+`takesClassName("A");` would trigger a `TypeCoercion` issue, whereas `takesClassName(A::class)` is fine.
 
 You can also parameterize `class-string` with an object name e.g. [`class-string<Foo>`](value_types.md#regular-class-constants). This tells Psalm that any matching type must either be a class string of `Foo` or one of its descendants.
 

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -161,15 +161,6 @@ Setting this to `false` means that any function calls will cause Psalm to forget
 ```
 Allows you to specify whether or not to use the typed iterator docblock format supported by PHP Storm e.g. `ArrayIterator|string[]`, which Psalm transforms to `ArrayIterator<string>`. Defaults to `false`.
 
-#### allowCoercionFromStringToClassConst
-
-```xml
-<psalm
-  allowCoercionFromStringToClassConst="[bool]"
->
-```
-When `true`, strings can be coerced to [`class-string`](../annotating_code/templated_annotations.md#param-class-stringt), with Psalm emitting a `TypeCoercion` issue. If disabled, that issue changes to a more serious one. Defaults to `false`.
-
 #### allowStringToStandInForClass
 
 ```xml


### PR DESCRIPTION
`allowCoercionFromStringToClassConst` was removed in 3.0 and never worked since.

Refs vimeo/psalm#3976