### PR TITLE
Add an unqualified classes in PHPUnit/Framework/Assert/Functions.php …

### DIFF
--- a/tests/fixtures/SuicidalAutoloader/autoloader.php
+++ b/tests/fixtures/SuicidalAutoloader/autoloader.php
@@ -13,6 +13,10 @@ spl_autoload_register(function (string $className) {
         InstalledVersions::class, // composer v2
         // it's unclear why Psalm tries to autoload parent
         'parent',
+        'PHPUnit\Framework\ArrayAccess',
+        'PHPUnit\Framework\Countable',
+        'PHPUnit\Framework\DOMDocument',
+        'PHPUnit\Framework\DOMElement',
     ];
 
     if (in_array($className, $knownBadClasses)) {


### PR DESCRIPTION
…to $knownBadClasses

The global class used in PHPUnit/Framework/Assert/Functions.php is not fully qualified name.

- [ArrayAccess](https://github.com/sebastianbergmann/phpunit/blob/9.3.5/src/Framework/Assert/Functions.php#L76)
- [Countable](https://github.com/sebastianbergmann/phpunit/blob/9.3.5/src/Framework/Assert/Functions.php#L186)
- [DOMDocument](https://github.com/sebastianbergmann/phpunit/blob/9.3.5/src/Framework/Assert/Functions.php#L1828)
- [DOMElement](https://github.com/sebastianbergmann/phpunit/blob/9.3.5/src/Framework/Assert/Functions.php#L1903)

```php
    /**
     * Asserts that an array has a specified key.
     *
     * @param int|string        $key
     * @param array|ArrayAccess $array
     *
     * @throws ExpectationFailedException
     * @throws \SebastianBergmann\RecursionContext\InvalidArgumentException
     * @throws Exception
     *
     * @see Assert::assertArrayHasKey
     */
```

This is why SuicidalAutoloaderTest is failed.

It should be fixes by phpunit.
In the meantime, add these classes to $knownBadClasses as workaround.