### PR TITLE
flag class_exists as impure per vimeo/psalm#3975

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -354,6 +354,7 @@ class Functions
             'mt_rand', 'rand', 'random_int', 'random_bytes',
             'wincache_ucache_delete', 'wincache_ucache_set', 'wincache_ucache_inc',
             'class_alias',
+            'class_exists', // impure by virtue of triggering autoloader
 
             // php environment
             'ini_set', 'sleep', 'usleep', 'register_shutdown_function',


### PR DESCRIPTION
`class_exists()` interacts with PHP's autoloader feature, which allows
user-defined behaviour to take place when PHP tries to load a given
class or interface.