### PR TITLE
fixed that psalm forgets return type of ArrayIterator->current

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericClasses.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericClasses.phpstub
@@ -866,6 +866,7 @@ class ArrayIterator implements SeekableIterator, ArrayAccess, Serializable, Coun
      * @link http://php.net/manual/en/arrayiterator.current.php
      *
      * @return TValue The current array entry.
+     * @psalm-mutation-free
      *
      * @since 5.0.0
      */

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -354,6 +354,35 @@ class ArrayAccessTest extends TestCase
     public function providerValidCodeParse()
     {
         return [
+            'arrayIteratorRememberCurrentType' => [
+                '<?php
+                    function makeArray(): array { return [1, 2, 3, "1", "2", "3"]; }
+                    function takesString(string $str): void { }
+
+                    $arr = makeArray();
+
+                    for ($arrIt = new ArrayIterator($arr); $arrIt->valid(); $arrIt->next()) {
+                        if (is_string($arrIt->current())) {
+                            takesString($arrIt->current());
+                        }
+                    }',
+            ],
+            'arrayIteratorForgetCurrentType' => [
+                '<?php
+                    function makeArray(): array { return [1, 2, 3, "1", "2", "3"]; }
+                    function takesString(string $str): void { }
+
+                    $arr = makeArray();
+                    $arrIt = new ArrayIterator($arr);
+                    $a = "";
+                    if ($arrIt->valid() && is_string($arrIt->current())) {
+                        $arrIt->next();
+                        $a = $arrIt->current();
+                    }',
+                'assertions' => [
+                    '$a' => 'mixed',
+                ],
+            ],
             'instanceOfStringOffset' => [
                 '<?php
                     class A {


### PR DESCRIPTION
See #4007 

After annotating `ArrayIterator->current()` with `@psalm-mutation-free` psalm can remember the return type.
**BUT** now it wont forget it after a call to `ArrayIterator->next()`.

Did I missunderstood how the annotation should work? Do I need to add something like `@psalm-mutating` to `next`?
Or is this out of the scope of what psalm is capable of?

Ideas / help appreciated!

When this is resolved I will go through all Iterators and annotate them (if the assumption holds for that Iterator). I'd really like to annotate the Iterator interface, but I think someone will write an iterator which isn't mutation free...

And in which file do the tests for this belong?