### PR TITLE
Add test case for false positive RedundantCondition with boolean operator

### DIFF
--- a/tests/TypeReconciliation/RedundantConditionTest.php
+++ b/tests/TypeReconciliation/RedundantConditionTest.php
@@ -800,6 +800,16 @@ class RedundantConditionTest extends \Psalm\Tests\TestCase
                         }
                     }'
             ],
+            'noFalsePositivesWithBooleanOperator' => [
+                '<?php
+                    $result = true;
+                    $result &= false;
+
+                    if ($result) {
+                    }',
+                'assertions' => [],
+                'error_levels' => [''],
+            ],
         ];
     }
 


### PR DESCRIPTION
Found while introducing Psalm to the Nextcloud code base.

Unfortunately this is only the test case that shows the problem and is missing the actual fix. Feel free to just push to this branch to fix the issue.

cc @rullzer @kesselb 