### PR TITLE
Add configuration attribute to find unused @psalm-suppress

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -41,6 +41,7 @@
         <xs:attribute name="ensureArrayStringOffsetsExist" type="xs:boolean" default="false" />
         <xs:attribute name="findUnusedCode" type="xs:boolean" default="false" />
         <xs:attribute name="findUnusedVariablesAndParams" type="xs:boolean" default="false" />
+        <xs:attribute name="findUnusedPsalmSuppress" type="xs:boolean" default="false" />
         <xs:attribute name="forbidEcho" type="xs:boolean" default="false" />
         <xs:attribute name="hideExternalErrors" type="xs:boolean" default="false" />
         <xs:attribute name="hoistConstants" type="xs:boolean" default="false" />

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -247,6 +247,14 @@ When `true`, Psalm will attempt to find all unused variables, the equivalent of 
 ```
 When `true`, Psalm will attempt to find all unused code (including unused variables), the equivalent of running with `--find-unused-code`. Defaults to `false`.
 
+#### findUnusedPsalmSuppress
+```xml
+<psalm
+  findUnusedPsalmSuppress="[bool]"
+>
+```
+When `true`, Psalm will report all `@psalm-suppress` annotations that aren't used, the equivalent of running with `--find-unused-psalm-suppress`. Defaults to `false`.
+
 #### loadXdebugStub
 ```xml
 <psalm

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -405,6 +405,11 @@ class Config
     /**
      * @var bool
      */
+    public $find_unused_psalm_suppress = false;
+
+    /**
+     * @var bool
+     */
     public $run_taint_analysis = false;
 
     /** @var bool */
@@ -836,6 +841,7 @@ class Config
             'usePhpStormMetaPath' => 'use_phpstorm_meta_path',
             'allowInternalNamedArgumentsCalls' => 'allow_internal_named_arg_calls',
             'allowNamedArgumentCalls' => 'allow_named_arg_calls',
+            'findUnusedPsalmSuppress' => 'find_unused_psalm_suppress',
         ];
 
         foreach ($booleanAttributes as $xmlName => $internalName) {

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -667,7 +667,7 @@ if ($config->run_taint_analysis || (isset($options['track-tainted-input'])
     $project_analyzer->trackTaintedInputs();
 }
 
-if (isset($options['find-unused-psalm-suppress'])) {
+if ($config->find_unused_psalm_suppress || isset($options['find-unused-psalm-suppress'])) {
     $project_analyzer->trackUnusedSuppressions();
 }
 


### PR DESCRIPTION
This pull request adds a configuration attribute to find unused `@psalm-suppress` annotations (instead of using the command line argument `--find-unused-psalm-suppress`). Fixes #3011.

```xml
<psalm
  findUnusedPsalmSuppress="[bool]"
>
```