### PR TITLE
Revert config schema, fix b/c break

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -32,6 +32,7 @@
         <xs:attribute name="serializer" type="xs:string" />
 
         <xs:attribute name="addParamDefaultToDocblockType" type="xs:boolean" default="false" />
+        <xs:attribute name="allowCoercionFromStringToClassConst" type="xs:boolean" default="false" />
         <xs:attribute name="allowFileIncludes" type="xs:boolean" default="true" />
         <xs:attribute name="allowPhpStormGenerics" type="xs:boolean" default="false" />
         <xs:attribute name="allowStringToStandInForClass" type="xs:boolean" default="false" />


### PR DESCRIPTION
Previous in d5055ea the allowCoercionFromStringToClassConst attribute has
been removed from the XML configuration file per its schema.

While technically correct (was removed in 3.0), this breaks b/c between
minor versions, breaks with the release of 3.14.0.

Fix is revert.

Ref: d5055ea1d43cb724de2e7e27ae11c6b743a6f727
Caused-by: #3982