### PR TITLE
Fix prophecy warnings

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -85,10 +85,6 @@
         {
             "type": "path",
             "url": "examples/plugins/composer-based/echo-checker"
-        },
-        {
-            "type": "vcs",
-            "url": "https://github.com/weirdan/prophecy-shim"
         }
     ],
     "minimum-stability": "dev",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "phpmyadmin/sql-parser": "5.1.0",
         "phpspec/prophecy": ">=1.9.0",
         "phpunit/phpunit": "^7.5.16 || ^8.5 || ^9.0",
-        "psalm/plugin-phpunit": "^0.10",
+        "psalm/plugin-phpunit": "^0.11",
         "weirdan/prophecy-shim": "^1.0 || ^2.0",
         "slevomat/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "^3.5",

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
         "phpspec/prophecy": ">=1.9.0",
         "phpunit/phpunit": "^7.5.16 || ^8.5 || ^9.0",
         "psalm/plugin-phpunit": "^0.10",
+        "weirdan/prophecy-shim": "^1.0 || ^2.0",
         "slevomat/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/process": "^4.3"
@@ -84,6 +85,10 @@
         {
             "type": "path",
             "url": "examples/plugins/composer-based/echo-checker"
+        },
+        {
+            "type": "vcs",
+            "url": "https://github.com/weirdan/prophecy-shim"
         }
     ],
     "minimum-stability": "dev",

--- a/tests/Config/PluginListTest.php
+++ b/tests/Config/PluginListTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Psalm\Tests\Config;
 
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psalm\Config;
 use Psalm\Internal\PluginManager\ComposerLock;
@@ -11,6 +12,8 @@ use Psalm\Internal\RuntimeCaches;
 /** @group PluginManager */
 class PluginListTest extends \Psalm\Tests\TestCase
 {
+    use ProphecyTrait;
+
     /** @var ObjectProphecy<ConfigFile> */
     private $config_file;
 

--- a/tests/ErrorBaselineTest.php
+++ b/tests/ErrorBaselineTest.php
@@ -1,16 +1,20 @@
 <?php
 namespace Psalm\Tests;
 
-use const LIBXML_NOBLANKS;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psalm\ErrorBaseline;
 use Psalm\Exception\ConfigException;
 use Psalm\Internal\Provider\FileProvider;
 use Psalm\Internal\RuntimeCaches;
 
+use const LIBXML_NOBLANKS;
+
 class ErrorBaselineTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ObjectProphecy */
     private $fileProvider;
 

--- a/tests/PsalmPluginTest.php
+++ b/tests/PsalmPluginTest.php
@@ -1,8 +1,8 @@
 <?php
 namespace Psalm\Tests;
 
-use function preg_quote;
 use Prophecy\Argument;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psalm\Internal\PluginManager\Command\DisableCommand;
 use Psalm\Internal\PluginManager\Command\EnableCommand;
@@ -14,11 +14,16 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Tester\CommandTester;
 
+use function preg_quote;
+
 /** @group PluginManager */
 class PsalmPluginTest extends TestCase
 {
+    use ProphecyTrait;
+
     /** @var ObjectProphecy */
     private $plugin_list;
+
     /** @var ObjectProphecy */
     private $plugin_list_factory;
 


### PR DESCRIPTION
This fixes annoying warnings about `prophesize()` being deprecated. The dependency added (`weirdan/prophecy-shim`) provides forward-compatible (empty) implementation of ProphecyTrait for older PHPUnit versions that are not supported by `phpspec/prophecy-phpunit`.