### PR TITLE
Resolve unresolved constants in TypeExpander

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -672,7 +672,8 @@ class ReturnTypeAnalyzer
         ProjectAnalyzer $project_analyzer,
         FunctionLikeAnalyzer $function_like_analyzer,
         FunctionLikeStorage $storage,
-        Context $context
+        Context $context,
+        StatementsAnalyzer $statements_analyzer
     ) {
         $codebase = $project_analyzer->getCodebase();
 
@@ -713,7 +714,11 @@ class ReturnTypeAnalyzer
                 $storage->return_type,
                 $classlike_storage ? $classlike_storage->name : null,
                 $classlike_storage ? $classlike_storage->name : null,
-                $parent_class
+                $parent_class,
+                true,
+                false,
+                false,
+                $statements_analyzer
             );
 
             $fleshed_out_return_type->check(
@@ -732,7 +737,11 @@ class ReturnTypeAnalyzer
             $storage->signature_return_type,
             $classlike_storage ? $classlike_storage->name : null,
             $classlike_storage ? $classlike_storage->name : null,
-            $parent_class
+            $parent_class,
+            true,
+            false,
+            false,
+            $statements_analyzer
         );
 
         if ($fleshed_out_signature_type->check(
@@ -756,7 +765,9 @@ class ReturnTypeAnalyzer
             $classlike_storage ? $classlike_storage->name : null,
             $parent_class,
             true,
-            true
+            true,
+            false,
+            $statements_analyzer
         );
 
         if ($fleshed_out_return_type->check(

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1106,7 +1106,11 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                     $param_type,
                     $context->self,
                     $context->self,
-                    $this->getParentFQCLN()
+                    $this->getParentFQCLN(),
+                    true,
+                    false,
+                    false,
+                    $statements_analyzer
                 );
 
                 if ($function_param->type_location) {

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -539,7 +539,8 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $project_analyzer,
             $this,
             $storage,
-            $context
+            $context,
+            $statements_analyzer
         ) === false) {
             $check_stmts = false;
         }

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -2,6 +2,7 @@
 namespace Psalm\Internal\Type;
 
 use Psalm\Codebase;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Type;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\Atomic\TNamedObject;
@@ -33,7 +34,8 @@ class TypeExpander
         ?string $parent_class,
         bool $evaluate_class_constants = true,
         bool $evaluate_conditional_types = false,
-        bool $final = false
+        bool $final = false,
+        ?StatementsAnalyzer $statements_analyzer = null
     ) {
         $return_type = clone $return_type;
 
@@ -50,7 +52,8 @@ class TypeExpander
                 $parent_class,
                 $evaluate_class_constants,
                 $evaluate_conditional_types,
-                $final
+                $final,
+                $statements_analyzer
             );
 
             if (is_array($parts)) {
@@ -97,7 +100,8 @@ class TypeExpander
         ?string $parent_class,
         bool $evaluate_class_constants = true,
         bool $evaluate_conditional_types = false,
-        bool $final = false
+        bool $final = false,
+        ?StatementsAnalyzer $statements_analyzer = null
     ) {
         if ($return_type instanceof TNamedObject
             || $return_type instanceof TTemplateParam
@@ -256,7 +260,8 @@ class TypeExpander
                         $class_constant = $codebase->classlikes->getConstantForClass(
                             $return_type->fq_classlike_name,
                             $matching_constant,
-                            \ReflectionProperty::IS_PRIVATE
+                            \ReflectionProperty::IS_PRIVATE,
+                            $statements_analyzer
                         );
                     } catch (\Psalm\Exception\CircularReferenceException $e) {
                         $class_constant = null;

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -992,6 +992,19 @@ class ConstantTest extends TestCase
                     }
                 ',
             ],
+            'classConstInitializedFromGlobalConstUsedAsReturnType' => [
+                '<?php
+                    const FOO = 3;
+                    class BAR
+                    {
+                        const BAZ = FOO;
+                        /** @return BAR::BAZ */
+                        public function b(): int {
+                            return 3;
+                        }
+                    }
+                ',
+            ],
         ];
     }
 

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -978,7 +978,20 @@ class ConstantTest extends TestCase
                     '$dir===' => 'non-empty-string',
                     '$file===' => 'non-empty-string',
                 ]
-            ]
+            ],
+            'classConstInitializedFromGlobalConstUsedAsParam' => [
+                '<?php
+                    const FOO = 3;
+                    class Bar
+                    {
+                        public const BAZ = FOO;
+                    }
+                    /** @param Bar::BAZ $p */
+                    function f(int $p): int {
+                        return $p;
+                    }
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
This fixes vimeo/psalm#4044 by passing down `$statements_analyzer` all the way down to `getConstantForClass()`