### PR TITLE
add pure-callable type

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -367,6 +367,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
 
             if ($storage instanceof FunctionStorage) {
                 $closure_type->byref_uses = $storage->byref_uses;
+                $closure_type->is_pure = $storage->pure;
             }
 
             $type_provider->setType(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -567,6 +567,18 @@ class FunctionCallAnalyzer extends CallAnalyzer
 
             foreach ($stmt_name_type->getAtomicTypes() as $var_type_part) {
                 if ($var_type_part instanceof Type\Atomic\TFn || $var_type_part instanceof Type\Atomic\TCallable) {
+                    if (!$var_type_part->is_pure && $context->pure) {
+                        if (IssueBuffer::accepts(
+                            new ImpureFunctionCall(
+                                'Cannot call an impure function from a mutation-free context',
+                                new CodeLocation($statements_analyzer->getSource(), $stmt)
+                            ),
+                            $statements_analyzer->getSuppressedIssues()
+                        )) {
+                            // fall through
+                        }
+                    }
+
                     $function_params = $var_type_part->params;
 
                     if (($stmt_type = $statements_analyzer->node_data->getType($real_stmt))

--- a/src/Psalm/Internal/Diff/AstDiffer.php
+++ b/src/Psalm/Internal/Diff/AstDiffer.php
@@ -23,8 +23,6 @@ class AstDiffer
      * @param array<int, PhpParser\Node\Stmt> $b
      *
      * @return array{0:array<int, array<int, int>>, 1: int, 2: int, 3: array<int, bool>}
-     *
-     * @psalm-pure
      */
     protected static function calculateTrace(
         \Closure $is_equal,

--- a/src/Psalm/Internal/Type/ParseTreeCreator.php
+++ b/src/Psalm/Internal/Type/ParseTreeCreator.php
@@ -745,7 +745,7 @@ class ParseTreeCreator
                 break;
 
             case '(':
-                if (in_array(strtolower($type_token[0]), ['closure', 'callable', '\closure'], true)) {
+                if (in_array(strtolower($type_token[0]), ['closure', 'callable', '\closure', 'pure-callable'], true)) {
                     $new_leaf = new ParseTree\CallableTree(
                         $type_token[0],
                         $new_parent
@@ -760,7 +760,7 @@ class ParseTreeCreator
                     );
                 } else {
                     throw new TypeParseTreeException(
-                        'Bracket must be preceded by “Closure”, “callable” or a valid @method name'
+                        'Bracket must be preceded by “Closure”, “callable”, "pure-callable" or a valid @method name'
                     );
                 }
 

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -675,12 +675,13 @@ class TypeParser
                 },
                 $parse_tree->children
             );
+            $pure = strpos($parse_tree->value, 'pure-') === 0;
 
             if (in_array(strtolower($parse_tree->value), ['closure', '\closure'], true)) {
-                return new TFn('Closure', $params);
+                return new TFn('Closure', $params, null, $pure);
             }
 
-            return new TCallable($parse_tree->value, $params);
+            return new TCallable($parse_tree->value, $params, null, $pure);
         }
 
         if ($parse_tree instanceof ParseTree\EncapsulationTree) {

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -164,6 +164,11 @@ abstract class Atomic implements TypeNode
 
             case 'callable':
                 return new TCallable();
+            case 'pure-callable':
+                $type = new TCallable();
+                $type->is_pure = true;
+
+                return $type;
 
             case 'array':
             case 'associative-array':

--- a/src/Psalm/Type/Atomic/TCallable.php
+++ b/src/Psalm/Type/Atomic/TCallable.php
@@ -26,6 +26,10 @@ class TCallable extends \Psalm\Type\Atomic
         $php_major_version,
         $php_minor_version
     ) {
+        if ($this->is_pure) {
+            return 'pure-callable';
+        }
+
         return 'callable';
     }
 

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -1146,6 +1146,42 @@ class CallableTest extends TestCase
                     $a();',
                 'error_message' => 'InvalidFunctionCall',
             ],
+            'ImpureFunctionCall' => [
+                '<?php
+                    /**
+                     * @psalm-template T
+                     *
+                     * @psalm-param array<int, T> $values
+                     * @psalm-param (callable(T): numeric) $num_func
+                     *
+                     * @psalm-return null|T
+                     *
+                     * @psalm-pure
+                     */
+                    function max_by(array $values, callable $num_func)
+                    {
+                        $max = null;
+                        $max_num = null;
+                        foreach ($values as $value) {
+                            $value_num = $num_func($value);
+                            if (null === $max_num || $value_num >= $max_num) {
+                                $max = $value;
+                                $max_num = $value_num;
+                            }
+                        }
+
+                        return $max;
+                    }
+
+                    $c = max_by([1, 2, 3], static function(int $a): int {
+                        return $a + mt_rand(0, $a);
+                    });
+
+                    echo $c;
+                ',
+                'error_message' => 'ImpureFunctionCall',
+                'error_levels' => [],
+            ]
         ];
     }
 }

--- a/tests/PureCallableTest.php
+++ b/tests/PureCallableTest.php
@@ -1,0 +1,241 @@
+<?php
+namespace Psalm\Tests;
+
+class PureCallableTest extends TestCase
+{
+    use Traits\ValidCodeAnalysisTestTrait;
+    use Traits\InvalidCodeAnalysisTestTrait;
+
+    /**
+     * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
+     */
+    public function providerValidCodeParse()
+    {
+        return [
+            'varCallableParamReturnType' => [
+                '<?php
+                    $add_one =
+                        /**
+                         * @psalm-pure
+                         */
+                        function(int $a): int {
+                            return $a + 1;
+                        };
+
+                    /**
+                     * @param pure-callable(int): int $c
+                     */
+                    function bar(callable $c) : int {
+                        return $c(1);
+                    }
+
+                    bar($add_one);',
+            ],
+            'callableToClosure' => [
+                '<?php
+                    /**
+                     * @return pure-callable
+                     */
+                    function foo() {
+                        return
+                            /**
+                             * @psalm-pure
+                             */
+                            function(string $a): string {
+                                return $a . "blah";
+                            };
+                    }',
+            ],
+            'callableToClosureArrow' => [
+                '<?php
+                    /**
+                     * @return pure-callable
+                     */
+                    function foo() {
+                        return
+                            /**
+                             * @psalm-pure
+                             */
+                            fn(string $a): string => $a . "blah";
+                    }',
+                'assertions' => [],
+                'error_levels' => [],
+                '7.4',
+            ],
+            'callableWithNonInvokable' => [
+                '<?php
+                    /**
+                     * @psalm-pure
+                     */
+                    function asd(): void {}
+                    class B {}
+
+                    /**
+                     * @param pure-callable|B $p
+                     */
+                    function passes($p): void {}
+
+                    passes("asd");',
+            ],
+            'callableWithInvokableUnion' => [
+                '<?php
+                    /**
+                     * @psalm-pure
+                     */
+                    function asd(): void {}
+                    class A {public function __invoke(): void {} }
+
+                    /**
+                     * @param pure-callable|A $p
+                     */
+                    function fails($p): void {}
+
+                    fails("asd");',
+            ],
+            'callableWithInvokable' => [
+                '<?php
+                    /**
+                     * @psalm-pure
+                     */
+                    function asd(): void {}
+                    class A {
+                        /**
+                         * @psalm-pure
+                         */
+                        public function __invoke(): void {}
+                    }
+
+                    /**
+                     * @param pure-callable $p
+                     */
+                    function fails($p): void {}
+
+                    fails(new A());
+                    fails("asd");',
+            ],
+            'allowVoidCallable' => [
+                '<?php
+                    /**
+                     * @param pure-callable():void $p
+                     */
+                    function doSomething($p): void {}
+                    doSomething(
+                        /**
+                         * @psalm-pure
+                         */
+                        function(): bool { return false; }
+                    );',
+            ],
+            'callableProperties' => [
+                '<?php
+                    class C {
+                        /** @psalm-var pure-callable():bool */
+                        private $callable;
+
+                        /**
+                         * @psalm-param pure-callable():bool $callable
+                         */
+                        public function __construct(callable $callable) {
+                            $this->callable = $callable;
+                        }
+
+                        public function callTheCallableDirectly(): bool {
+                            return ($this->callable)();
+                        }
+
+                        public function callTheCallableIndirectly(): bool {
+                            $r = $this->callable;
+                            return $r();
+                        }
+                    }',
+            ],
+            'nullableReturnTypeShorthand' => [
+                '<?php
+                    class A {}
+                    /** @param pure-callable(mixed):?A $a */
+                    function foo(callable $a): void {}',
+            ],
+            'callablesCanBeObjects' => [
+                '<?php
+                    /**
+                     * @param pure-callable $c
+                     */
+                    function foo(callable $c) : void {
+                        if (is_object($c)) {
+                            $c();
+                        }
+                    }',
+            ],
+            'goodCallableArgs' => [
+                '<?php
+                    /**
+                     * @param pure-callable(string,string):int $_p
+                     */
+                    function f(callable $_p): void {}
+
+                    class C {
+                        /**
+                         * @psalm-pure
+                         */
+                        public static function m(string $a, string $b): int { return $a <=> $b; }
+                    }
+
+                    f("strcmp");
+                    f([new C, "m"]);
+                    f([C::class, "m"]);',
+            ],
+            'callableWithSpaces' => [
+                '<?php
+                    /**
+                     * @param pure-callable(string, string) : int $p
+                     */
+                    function f(callable $p): void {}',
+            ],
+        ];
+    }
+
+    /**
+     * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
+     */
+    public function providerInvalidCodeParse()
+    {
+        return [
+            'InvalidScalarArgument' => [
+                '<?php
+                    /**
+                     * @psalm-template T
+                     *
+                     * @psalm-param array<int, T> $values
+                     * @psalm-param (pure-callable(T): numeric) $num_func
+                     *
+                     * @psalm-return null|T
+                     *
+                     * @psalm-pure
+                     */
+                    function max_by(array $values, callable $num_func)
+                    {
+                        $max = null;
+                        $max_num = null;
+                        foreach ($values as $value) {
+                            $value_num = $num_func($value);
+                            if (null === $max_num || $value_num >= $max_num) {
+                                $max = $value;
+                                $max_num = $value_num;
+                            }
+                        }
+
+                        return $max;
+                    }
+
+                    $c = max_by([1, 2, 3], static function(int $a): int {
+                        return $a + mt_rand(0, $a);
+                    });
+
+                    echo $c;
+                ',
+                'error_message' => 'InvalidScalarArgument',
+                'error_levels' => [],
+            ]
+        ];
+    }
+}


### PR DESCRIPTION
closes #4062 

TODO:
- [x] add pure-callable type
- [x] type check pure-callable
- [x] handle [$obj, 'method'], ['foo', 'staticmethod'], and invokable objects.
- [x] ban `callable` type usage in pure context.
- [x] tests
