### PR TITLE
Fix expected php 8.0 syntax error

### DIFF
--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -449,7 +449,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
             [new Position(8, 46), 'B\A::bar', 0, 1],
             [new Position(8, 47), 'B\A::foo', 0, 2],
             [new Position(10, 40), 'B\A::staticfoo', 0, 1],
-            #[new Position(12, 28), 'B\foo', 0, 1],
+            // [new Position(12, 28), 'B\foo', 0, 1],
             [new Position(14, 30), 'B\A::__construct', 0, 0],
             [new Position(16, 31), 'strlen', 0, 1],
         ];


### PR DESCRIPTION
This will very likely be parsed as an attribute token in php 8.0
See
https://wiki.php.net/rfc/shorter_attribute_syntax_change#secondary_vote