### PR TITLE
Include variadic and pass-by-ref params in generated stubs

### DIFF
--- a/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
@@ -256,7 +256,9 @@ class StubsGenerator
                     : null,
                 $param->signature_type
                     ? self::getParserTypeFromPsalmType($param->signature_type)
-                    : null
+                    : null,
+                $param->by_ref,
+                $param->is_variadic
             );
         }
 


### PR DESCRIPTION
When generating stubs, params that are passed by ref or variadic don't get added to the generated code stub output.