### PR TITLE
Fix incomplete types

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -923,12 +923,11 @@ class Codebase
 
     /**
      * @param  string|\Psalm\Internal\MethodIdentifier $method_id
-     * @param  string $self_class
      * @param  array<int, PhpParser\Node\Arg> $call_args
      *
      * @return Type\Union|null
      */
-    public function getMethodReturnType($method_id, &$self_class, array $call_args = [])
+    public function getMethodReturnType($method_id, ?string &$self_class, array $call_args = [])
     {
         return $this->methods->getMethodReturnType(
             Internal\MethodIdentifier::wrap($method_id),

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -623,14 +623,13 @@ class Methods
     }
 
     /**
-     * @param  string $self_class
      * @param  array<int, PhpParser\Node\Arg>|null $args
      *
      * @return Type\Union|null
      */
     public function getMethodReturnType(
         MethodIdentifier $method_id,
-        &$self_class,
+        ?string &$self_class,
         \Psalm\Internal\Analyzer\SourceAnalyzer $source_analyzer = null,
         array $args = null
     ) {


### PR DESCRIPTION
I was trying to add some native parameters types in Psalm and I noticed that those two params would throw an error because they can be null. This PR adds the right type (natively) for those params.