### PR TITLE
Add `null` as a possible type parameter to `strval`

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -673,7 +673,7 @@ function bcdiv(string $left_operand, string $right_operand, int $scale = 0): ?st
 /**
  * @psalm-pure
  *
- * @param scalar|object $var
+ * @param scalar|null|object $var
  * @return string The string value of var.
  *
  * @psalm-flow ($var) -> return


### PR DESCRIPTION
https://www.php.net/manual/en/language.types.string.php#language.types.string.casting mentions

> `NULL` is always converted to an empty string.

Which seems to indicate that it is a valid argument for it.

As opposed to stringifying other types (like arrays), `strval(null)` does not cause a warning in PHP.