### PR TITLE
Added more fine grained strpos stub

### DIFF
--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -486,7 +486,7 @@ function strtoupper(string $str) : string {}
  *
  * @psalm-return positive-int|0|false
  */
-function strpos(string $haystack, string $needle, int $offset = 0) : int {}
+function strpos(string $haystack, $needle, int $offset = 0) : int {}
 
 /**
  * @psalm-pure

--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -486,7 +486,7 @@ function strtoupper(string $str) : string {}
  *
  * @psalm-return positive-int|0|false
  */
-function strpos(string $haystack, string $needle, int $offset) : int {}
+function strpos(string $haystack, string $needle, int $offset = 0) : int {}
 
 /**
  * @psalm-pure

--- a/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
+++ b/src/Psalm/Internal/Stubs/CoreGenericFunctions.phpstub
@@ -484,6 +484,13 @@ function strtoupper(string $str) : string {}
 /**
  * @psalm-pure
  *
+ * @psalm-return positive-int|0|false
+ */
+function strpos(string $haystack, string $needle, int $offset) : int {}
+
+/**
+ * @psalm-pure
+ *
  * @psalm-flow ($str) -> return
  */
 function trim(string $str, string $character_mask = " \t\n\r\0\x0B") : string {}


### PR DESCRIPTION
A shot in the dark.. Might fix the comment https://github.com/vimeo/psalm/issues/4070#issuecomment-680942551

> I would expect psalm to error, because strpos() can never return -1 (this can be a common mistake, because people might be used to javascript in which the equivalent function returns -1)

https://psalm.dev/r/22d89c087e