### PR TITLE
add native return types

### DIFF
--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -333,7 +333,7 @@ class CodeLocation
     /**
      * @return int
      */
-    public function getLineNumber()
+    public function getLineNumber(): int
     {
         return $this->docblock_line_number ?: $this->raw_line_number;
     }
@@ -341,7 +341,7 @@ class CodeLocation
     /**
      * @return int
      */
-    public function getEndLineNumber()
+    public function getEndLineNumber(): int
     {
         $this->calculateRealLocation();
 
@@ -351,7 +351,7 @@ class CodeLocation
     /**
      * @return string
      */
-    public function getSnippet()
+    public function getSnippet(): string
     {
         $this->calculateRealLocation();
 
@@ -361,7 +361,7 @@ class CodeLocation
     /**
      * @return string
      */
-    public function getSelectedText()
+    public function getSelectedText(): string
     {
         $this->calculateRealLocation();
 
@@ -371,7 +371,7 @@ class CodeLocation
     /**
      * @return int
      */
-    public function getColumn()
+    public function getColumn(): int
     {
         $this->calculateRealLocation();
 
@@ -381,7 +381,7 @@ class CodeLocation
     /**
      * @return int
      */
-    public function getEndColumn()
+    public function getEndColumn(): int
     {
         $this->calculateRealLocation();
 
@@ -391,7 +391,7 @@ class CodeLocation
     /**
      * @return array{0: int, 1: int}
      */
-    public function getSelectionBounds()
+    public function getSelectionBounds(): array
     {
         $this->calculateRealLocation();
 
@@ -401,7 +401,7 @@ class CodeLocation
     /**
      * @return array{0: int, 1: int}
      */
-    public function getSnippetBounds()
+    public function getSnippetBounds(): array
     {
         $this->calculateRealLocation();
 
@@ -411,7 +411,7 @@ class CodeLocation
     /**
      * @return string
      */
-    public function getHash()
+    public function getHash(): string
     {
         return (string) $this->file_start;
     }

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -330,17 +330,11 @@ class CodeLocation
         $this->end_line_number = $this->getLineNumber() + $newlines;
     }
 
-    /**
-     * @return int
-     */
     public function getLineNumber(): int
     {
         return $this->docblock_line_number ?: $this->raw_line_number;
     }
 
-    /**
-     * @return int
-     */
     public function getEndLineNumber(): int
     {
         $this->calculateRealLocation();
@@ -348,9 +342,6 @@ class CodeLocation
         return $this->end_line_number;
     }
 
-    /**
-     * @return string
-     */
     public function getSnippet(): string
     {
         $this->calculateRealLocation();
@@ -358,9 +349,6 @@ class CodeLocation
         return $this->snippet;
     }
 
-    /**
-     * @return string
-     */
     public function getSelectedText(): string
     {
         $this->calculateRealLocation();
@@ -368,9 +356,6 @@ class CodeLocation
         return (string)$this->text;
     }
 
-    /**
-     * @return int
-     */
     public function getColumn(): int
     {
         $this->calculateRealLocation();
@@ -378,9 +363,6 @@ class CodeLocation
         return $this->column_from;
     }
 
-    /**
-     * @return int
-     */
     public function getEndColumn(): int
     {
         $this->calculateRealLocation();
@@ -408,9 +390,6 @@ class CodeLocation
         return [$this->preview_start, $this->preview_end];
     }
 
-    /**
-     * @return string
-     */
     public function getHash(): string
     {
         return (string) $this->file_start;

--- a/src/Psalm/CodeLocation/Raw.php
+++ b/src/Psalm/CodeLocation/Raw.php
@@ -6,11 +6,6 @@ use function substr_count;
 
 class Raw extends \Psalm\CodeLocation
 {
-    /**
-     * @param string $file_path
-     * @param string $file_name
-     * @param string $file_contents
-     */
     public function __construct(
         string $file_contents,
         string $file_path,

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -486,7 +486,7 @@ class Codebase
      *
      * @return string
      */
-    public function getFileContents($file_path)
+    public function getFileContents($file_path): string
     {
         return $this->file_provider->getContents($file_path);
     }
@@ -510,7 +510,7 @@ class Codebase
      *
      * @return ClassLikeStorage
      */
-    public function createClassLikeStorage($fq_classlike_name)
+    public function createClassLikeStorage($fq_classlike_name): ClassLikeStorage
     {
         return $this->classlike_storage_provider->create($fq_classlike_name);
     }
@@ -566,7 +566,7 @@ class Codebase
      *
      * @return FileStorage
      */
-    public function createFileStorageForPath($file_path)
+    public function createFileStorageForPath($file_path): FileStorage
     {
         return $this->file_storage_provider->create($file_path);
     }
@@ -576,7 +576,7 @@ class Codebase
      *
      * @return \Psalm\CodeLocation[]
      */
-    public function findReferencesToSymbol($symbol)
+    public function findReferencesToSymbol($symbol): array
     {
         if (!$this->collect_locations) {
             throw new \UnexpectedValueException('Should not be checking references');
@@ -598,7 +598,7 @@ class Codebase
      *
      * @return \Psalm\CodeLocation[]
      */
-    public function findReferencesToMethod($method_id)
+    public function findReferencesToMethod($method_id): array
     {
         return $this->file_reference_provider->getClassMethodLocations(strtolower($method_id));
     }
@@ -606,7 +606,7 @@ class Codebase
     /**
      * @return \Psalm\CodeLocation[]
      */
-    public function findReferencesToProperty(string $property_id)
+    public function findReferencesToProperty(string $property_id): array
     {
         [$fq_class_name, $property_name] = explode('::', $property_id);
 
@@ -620,7 +620,7 @@ class Codebase
      *
      * @return \Psalm\CodeLocation[]
      */
-    public function findReferencesToClassLike($fq_class_name)
+    public function findReferencesToClassLike($fq_class_name): array
     {
         $fq_class_name_lc = strtolower($fq_class_name);
         $locations = $this->file_reference_provider->getClassLocations($fq_class_name_lc);
@@ -638,7 +638,7 @@ class Codebase
      *
      * @return FunctionLikeStorage
      */
-    public function getClosureStorage($file_path, $closure_id)
+    public function getClosureStorage($file_path, $closure_id): FunctionLikeStorage
     {
         $file_storage = $this->file_storage_provider->get($file_path);
 
@@ -668,7 +668,7 @@ class Codebase
      *
      * @return Type\Union|null
      */
-    public function getStubbedConstantType($const_id)
+    public function getStubbedConstantType($const_id): ?Type\Union
     {
         return isset(self::$stubbed_constants[$const_id]) ? self::$stubbed_constants[$const_id] : null;
     }
@@ -676,7 +676,7 @@ class Codebase
     /**
      * @return array<string, Type\Union>
      */
-    public function getAllStubbedConstants()
+    public function getAllStubbedConstants(): array
     {
         return self::$stubbed_constants;
     }
@@ -686,7 +686,7 @@ class Codebase
      *
      * @return bool
      */
-    public function fileExists($file_path)
+    public function fileExists($file_path): bool
     {
         return $this->file_provider->fileExists($file_path);
     }
@@ -704,7 +704,7 @@ class Codebase
         CodeLocation $code_location = null,
         ?string $calling_fq_class_name = null,
         ?string $calling_method_id = null
-    ) {
+    ): bool {
         return $this->classlikes->classOrInterfaceExists(
             $fq_class_name,
             $code_location,
@@ -719,7 +719,7 @@ class Codebase
      *
      * @return bool
      */
-    public function classExtendsOrImplements($fq_class_name, $possible_parent)
+    public function classExtendsOrImplements($fq_class_name, $possible_parent): bool
     {
         return $this->classlikes->classExtends($fq_class_name, $possible_parent)
             || $this->classlikes->classImplements($fq_class_name, $possible_parent);
@@ -737,7 +737,7 @@ class Codebase
         CodeLocation $code_location = null,
         ?string $calling_fq_class_name = null,
         ?string $calling_method_id = null
-    ) {
+    ): bool {
         return $this->classlikes->classExists(
             $fq_class_name,
             $code_location,
@@ -757,7 +757,7 @@ class Codebase
      *
      * @return bool
      */
-    public function classExtends($fq_class_name, $possible_parent)
+    public function classExtends($fq_class_name, $possible_parent): bool
     {
         return $this->classlikes->classExtends($fq_class_name, $possible_parent, true);
     }
@@ -770,7 +770,7 @@ class Codebase
      *
      * @return bool
      */
-    public function classImplements($fq_class_name, $interface)
+    public function classImplements($fq_class_name, $interface): bool
     {
         return $this->classlikes->classImplements($fq_class_name, $interface);
     }
@@ -785,7 +785,7 @@ class Codebase
         CodeLocation $code_location = null,
         ?string $calling_fq_class_name = null,
         ?string $calling_method_id = null
-    ) {
+    ): bool {
         return $this->classlikes->interfaceExists(
             $fq_interface_name,
             $code_location,
@@ -800,7 +800,7 @@ class Codebase
      *
      * @return bool
      */
-    public function interfaceExtends($interface_name, $possible_parent)
+    public function interfaceExtends($interface_name, $possible_parent): bool
     {
         return $this->classlikes->interfaceExtends($interface_name, $possible_parent);
     }
@@ -810,7 +810,7 @@ class Codebase
      *
      * @return array<string>   all interfaces extended by $interface_name
      */
-    public function getParentInterfaces($fq_interface_name)
+    public function getParentInterfaces($fq_interface_name): array
     {
         return $this->classlikes->getParentInterfaces(
             $this->classlikes->getUnAliasedName($fq_interface_name)
@@ -824,7 +824,7 @@ class Codebase
      *
      * @return bool
      */
-    public function classHasCorrectCasing($fq_class_name)
+    public function classHasCorrectCasing($fq_class_name): bool
     {
         return $this->classlikes->classHasCorrectCasing($fq_class_name);
     }
@@ -834,7 +834,7 @@ class Codebase
      *
      * @return bool
      */
-    public function interfaceHasCorrectCasing($fq_interface_name)
+    public function interfaceHasCorrectCasing($fq_interface_name): bool
     {
         return $this->classlikes->interfaceHasCorrectCasing($fq_interface_name);
     }
@@ -844,7 +844,7 @@ class Codebase
      *
      * @return bool
      */
-    public function traitHasCorrectCase($fq_trait_name)
+    public function traitHasCorrectCase($fq_trait_name): bool
     {
         return $this->classlikes->traitHasCorrectCase($fq_trait_name);
     }
@@ -891,7 +891,7 @@ class Codebase
         ?CodeLocation $code_location = null,
         $calling_method_id = null,
         ?string $file_path = null
-    ) {
+    ): bool {
         return $this->methods->methodExists(
             Internal\MethodIdentifier::wrap($method_id),
             is_string($calling_method_id) ? strtolower($calling_method_id) : strtolower((string) $calling_method_id),
@@ -906,7 +906,7 @@ class Codebase
      *
      * @return array<int, \Psalm\Storage\FunctionLikeParameter>
      */
-    public function getMethodParams($method_id)
+    public function getMethodParams($method_id): array
     {
         return $this->methods->getMethodParams(Internal\MethodIdentifier::wrap($method_id));
     }
@@ -916,7 +916,7 @@ class Codebase
      *
      * @return bool
      */
-    public function isVariadic($method_id)
+    public function isVariadic($method_id): bool
     {
         return $this->methods->isVariadic(Internal\MethodIdentifier::wrap($method_id));
     }
@@ -927,7 +927,7 @@ class Codebase
      *
      * @return Type\Union|null
      */
-    public function getMethodReturnType($method_id, ?string &$self_class, array $call_args = [])
+    public function getMethodReturnType($method_id, ?string &$self_class, array $call_args = []): ?Type\Union
     {
         return $this->methods->getMethodReturnType(
             Internal\MethodIdentifier::wrap($method_id),
@@ -942,7 +942,7 @@ class Codebase
      *
      * @return bool
      */
-    public function getMethodReturnsByRef($method_id)
+    public function getMethodReturnsByRef($method_id): bool
     {
         return $this->methods->getMethodReturnsByRef(Internal\MethodIdentifier::wrap($method_id));
     }
@@ -956,7 +956,7 @@ class Codebase
     public function getMethodReturnTypeLocation(
         $method_id,
         CodeLocation &$defined_location = null
-    ) {
+    ): ?CodeLocation {
         return $this->methods->getMethodReturnTypeLocation(
             Internal\MethodIdentifier::wrap($method_id),
             $defined_location
@@ -968,7 +968,7 @@ class Codebase
      *
      * @return string|null
      */
-    public function getDeclaringMethodId($method_id)
+    public function getDeclaringMethodId($method_id): ?string
     {
         return $this->methods->getDeclaringMethodId(Internal\MethodIdentifier::wrap($method_id));
     }
@@ -980,7 +980,7 @@ class Codebase
      *
      * @return string|null
      */
-    public function getAppearingMethodId($method_id)
+    public function getAppearingMethodId($method_id): ?string
     {
         return $this->methods->getAppearingMethodId(Internal\MethodIdentifier::wrap($method_id));
     }
@@ -990,7 +990,7 @@ class Codebase
      *
      * @return array<string>
      */
-    public function getOverriddenMethodIds($method_id)
+    public function getOverriddenMethodIds($method_id): array
     {
         return $this->methods->getOverriddenMethodIds(Internal\MethodIdentifier::wrap($method_id));
     }
@@ -1000,7 +1000,7 @@ class Codebase
      *
      * @return string
      */
-    public function getCasedMethodId($method_id)
+    public function getCasedMethodId($method_id): string
     {
         return $this->methods->getCasedMethodId(Internal\MethodIdentifier::wrap($method_id));
     }
@@ -1031,7 +1031,7 @@ class Codebase
     /**
      * @return ?string
      */
-    public function getSymbolInformation(string $file_path, string $symbol)
+    public function getSymbolInformation(string $file_path, string $symbol): ?string
     {
         if (\is_numeric($symbol[0])) {
             return \preg_replace('/^[^:]*:/', '', $symbol);
@@ -1197,7 +1197,7 @@ class Codebase
     /**
      * @return array{0: string, 1: Range}|null
      */
-    public function getReferenceAtPosition(string $file_path, Position $position)
+    public function getReferenceAtPosition(string $file_path, Position $position): ?array
     {
         $is_open = $this->file_provider->isOpen($file_path);
 
@@ -1250,7 +1250,7 @@ class Codebase
     /**
      * @return array{0: non-empty-string, 1: int, 2: Range}|null
      */
-    public function getFunctionArgumentAtPosition(string $file_path, Position $position)
+    public function getFunctionArgumentAtPosition(string $file_path, Position $position): ?array
     {
         $is_open = $this->file_provider->isOpen($file_path);
 
@@ -1365,7 +1365,7 @@ class Codebase
     /**
      * @return array{0: string, 1: '->'|'::'|'symbol', 2: int}|null
      */
-    public function getCompletionDataAtPosition(string $file_path, Position $position)
+    public function getCompletionDataAtPosition(string $file_path, Position $position): ?array
     {
         $is_open = $this->file_provider->isOpen($file_path);
 

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -484,7 +484,6 @@ class Codebase
     /**
      * @param  string $file_path
      *
-     * @return string
      */
     public function getFileContents($file_path): string
     {
@@ -508,7 +507,6 @@ class Codebase
     /**
      * @param  string $fq_classlike_name
      *
-     * @return ClassLikeStorage
      */
     public function createClassLikeStorage($fq_classlike_name): ClassLikeStorage
     {
@@ -564,7 +562,6 @@ class Codebase
     /**
      * @param  string $file_path
      *
-     * @return FileStorage
      */
     public function createFileStorageForPath($file_path): FileStorage
     {
@@ -636,7 +633,6 @@ class Codebase
      * @param  string $file_path
      * @param  string $closure_id
      *
-     * @return FunctionLikeStorage
      */
     public function getClosureStorage($file_path, $closure_id): FunctionLikeStorage
     {
@@ -654,7 +650,6 @@ class Codebase
 
     /**
      * @param  string $const_id
-     * @param  Type\Union $type
      *
      * @return  void
      */
@@ -666,7 +661,6 @@ class Codebase
     /**
      * @param  string $const_id
      *
-     * @return Type\Union|null
      */
     public function getStubbedConstantType($const_id): ?Type\Union
     {
@@ -684,7 +678,6 @@ class Codebase
     /**
      * @param  string $file_path
      *
-     * @return bool
      */
     public function fileExists($file_path): bool
     {
@@ -695,9 +688,7 @@ class Codebase
      * Check whether a class/interface exists
      *
      * @param  string          $fq_class_name
-     * @param  CodeLocation $code_location
      *
-     * @return bool
      */
     public function classOrInterfaceExists(
         $fq_class_name,
@@ -717,7 +708,6 @@ class Codebase
      * @param  string       $fq_class_name
      * @param  string       $possible_parent
      *
-     * @return bool
      */
     public function classExtendsOrImplements($fq_class_name, $possible_parent): bool
     {
@@ -730,7 +720,6 @@ class Codebase
      *
      * @param  string       $fq_class_name
      *
-     * @return bool
      */
     public function classExists(
         $fq_class_name,
@@ -755,7 +744,6 @@ class Codebase
      * @throws \Psalm\Exception\UnpopulatedClasslikeException when called on unpopulated class
      * @throws \InvalidArgumentException when class does not exist
      *
-     * @return bool
      */
     public function classExtends($fq_class_name, $possible_parent): bool
     {
@@ -768,7 +756,6 @@ class Codebase
      * @param  string       $fq_class_name
      * @param  string       $interface
      *
-     * @return bool
      */
     public function classImplements($fq_class_name, $interface): bool
     {
@@ -778,7 +765,6 @@ class Codebase
     /**
      * @param  string         $fq_interface_name
      *
-     * @return bool
      */
     public function interfaceExists(
         $fq_interface_name,
@@ -798,7 +784,6 @@ class Codebase
      * @param  string         $interface_name
      * @param  string         $possible_parent
      *
-     * @return bool
      */
     public function interfaceExtends($interface_name, $possible_parent): bool
     {
@@ -822,7 +807,6 @@ class Codebase
      *
      * @param  string $fq_class_name
      *
-     * @return bool
      */
     public function classHasCorrectCasing($fq_class_name): bool
     {
@@ -832,7 +816,6 @@ class Codebase
     /**
      * @param  string $fq_interface_name
      *
-     * @return bool
      */
     public function interfaceHasCorrectCasing($fq_interface_name): bool
     {
@@ -842,7 +825,6 @@ class Codebase
     /**
      * @param  string $fq_trait_name
      *
-     * @return bool
      */
     public function traitHasCorrectCase($fq_trait_name): bool
     {
@@ -914,7 +896,6 @@ class Codebase
     /**
      * @param  string|\Psalm\Internal\MethodIdentifier $method_id
      *
-     * @return bool
      */
     public function isVariadic($method_id): bool
     {
@@ -925,7 +906,6 @@ class Codebase
      * @param  string|\Psalm\Internal\MethodIdentifier $method_id
      * @param  array<int, PhpParser\Node\Arg> $call_args
      *
-     * @return Type\Union|null
      */
     public function getMethodReturnType($method_id, ?string &$self_class, array $call_args = []): ?Type\Union
     {
@@ -940,7 +920,6 @@ class Codebase
     /**
      * @param  string|\Psalm\Internal\MethodIdentifier $method_id
      *
-     * @return bool
      */
     public function getMethodReturnsByRef($method_id): bool
     {
@@ -951,7 +930,6 @@ class Codebase
      * @param  string|\Psalm\Internal\MethodIdentifier   $method_id
      * @param  CodeLocation|null    $defined_location
      *
-     * @return CodeLocation|null
      */
     public function getMethodReturnTypeLocation(
         $method_id,
@@ -966,7 +944,6 @@ class Codebase
     /**
      * @param  string|\Psalm\Internal\MethodIdentifier $method_id
      *
-     * @return string|null
      */
     public function getDeclaringMethodId($method_id): ?string
     {
@@ -978,7 +955,6 @@ class Codebase
      *
      * @param  string|\Psalm\Internal\MethodIdentifier $method_id
      *
-     * @return string|null
      */
     public function getAppearingMethodId($method_id): ?string
     {
@@ -998,7 +974,6 @@ class Codebase
     /**
      * @param  string|\Psalm\Internal\MethodIdentifier $method_id
      *
-     * @return string
      */
     public function getCasedMethodId($method_id): string
     {
@@ -1006,7 +981,6 @@ class Codebase
     }
 
     /**
-     * @param string $file_path
      *
      * @return void
      */
@@ -1027,10 +1001,7 @@ class Codebase
 
         $this->file_storage_provider->remove($file_path);
     }
-
-    /**
-     * @return ?string
-     */
+    
     public function getSymbolInformation(string $file_path, string $symbol): ?string
     {
         if (\is_numeric($symbol[0])) {

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -164,7 +164,7 @@ class Config
     /**
      * The directory to store PHP Parser (and other) caches
      *
-     * @var string
+     * @var string|null
      */
     public $cache_directory;
 
@@ -632,7 +632,7 @@ class Config
      * @throws ConfigException if a config path is not found
      *
      */
-    public static function getConfigForPath($path, $current_dir, $output_format)
+    public static function getConfigForPath($path, $current_dir, $output_format): Config
     {
         $config_path = self::locateConfigFile($path);
 
@@ -655,7 +655,7 @@ class Config
      *
      * @return ?string
      */
-    public static function locateConfigFile(string $path)
+    public static function locateConfigFile(string $path): ?string
     {
         $dir_path = realpath($path);
 
@@ -688,7 +688,7 @@ class Config
      *
      * @return self
      */
-    public static function loadFromXMLFile($file_path, $current_dir)
+    public static function loadFromXMLFile($file_path, $current_dir): Config
     {
         $file_contents = file_get_contents($file_path);
 
@@ -721,7 +721,7 @@ class Config
      *
      * @return self
      */
-    public static function loadFromXML($base_dir, $file_contents, $current_dir = null)
+    public static function loadFromXML($base_dir, $file_contents, $current_dir = null): Config
     {
         if ($current_dir === null) {
             $current_dir = $base_dir;
@@ -1112,7 +1112,7 @@ class Config
     /**
      * @return $this
      */
-    public static function getInstance()
+    public static function getInstance(): Config
     {
         if (self::$instance) {
             return self::$instance;
@@ -1343,7 +1343,7 @@ class Config
      *
      * @return string
      */
-    public function shortenFileName($file_name)
+    public function shortenFileName($file_name): string
     {
         return preg_replace('/^' . preg_quote($this->base_dir, '/') . '/', '', $file_name);
     }
@@ -1354,7 +1354,7 @@ class Config
      *
      * @return  bool
      */
-    public function reportIssueInFile($issue_type, $file_path)
+    public function reportIssueInFile($issue_type, $file_path): bool
     {
         if (($this->show_mixed_issues === false || $this->level > 2)
             && in_array($issue_type, self::MIXED_ISSUES, true)
@@ -1409,7 +1409,7 @@ class Config
      *
      * @return  bool
      */
-    public function isInProjectDirs($file_path)
+    public function isInProjectDirs($file_path): bool
     {
         return $this->project_files && $this->project_files->allows($file_path);
     }
@@ -1419,7 +1419,7 @@ class Config
      *
      * @return  bool
      */
-    public function isInExtraDirs($file_path)
+    public function isInExtraDirs($file_path): bool
     {
         return $this->extra_files && $this->extra_files->allows($file_path);
     }
@@ -1429,7 +1429,7 @@ class Config
      *
      * @return  bool
      */
-    public function mustBeIgnored($file_path)
+    public function mustBeIgnored($file_path): bool
     {
         return $this->project_files && $this->project_files->forbids($file_path);
     }
@@ -1489,7 +1489,7 @@ class Config
      *
      * @psalm-pure
      */
-    public static function getParentIssueType($issue_type)
+    public static function getParentIssueType($issue_type): ?string
     {
         if ($issue_type === 'PossiblyUndefinedIntArrayOffset'
             || $issue_type === 'PossiblyUndefinedStringArrayOffset'
@@ -1580,7 +1580,7 @@ class Config
      *
      * @return  string
      */
-    public function getReportingLevelForFile($issue_type, $file_path)
+    public function getReportingLevelForFile($issue_type, $file_path): string
     {
         if (isset($this->issue_handlers[$issue_type])) {
             return $this->issue_handlers[$issue_type]->getReportingLevelForFile($file_path);
@@ -1678,7 +1678,7 @@ class Config
     /**
      * @return array<string>
      */
-    public function getProjectDirectories()
+    public function getProjectDirectories(): array
     {
         if (!$this->project_files) {
             return [];
@@ -1690,7 +1690,7 @@ class Config
     /**
      * @return array<string>
      */
-    public function getProjectFiles()
+    public function getProjectFiles(): array
     {
         if (!$this->project_files) {
             return [];
@@ -1702,7 +1702,7 @@ class Config
     /**
      * @return array<string>
      */
-    public function getExtraDirectories()
+    public function getExtraDirectories(): array
     {
         if (!$this->extra_files) {
             return [];
@@ -1716,7 +1716,7 @@ class Config
      *
      * @return  bool
      */
-    public function reportTypeStatsForFile($file_path)
+    public function reportTypeStatsForFile($file_path): bool
     {
         return $this->project_files
             && $this->project_files->allows($file_path)
@@ -1728,7 +1728,7 @@ class Config
      *
      * @return  bool
      */
-    public function useStrictTypesForFile($file_path)
+    public function useStrictTypesForFile($file_path): bool
     {
         return $this->project_files && $this->project_files->useStrictTypes($file_path);
     }
@@ -1736,7 +1736,7 @@ class Config
     /**
      * @return array<string>
      */
-    public function getFileExtensions()
+    public function getFileExtensions(): array
     {
         return $this->file_extensions;
     }
@@ -1744,7 +1744,7 @@ class Config
     /**
      * @return array<string, class-string<FileScanner>>
      */
-    public function getFiletypeScanners()
+    public function getFiletypeScanners(): array
     {
         return $this->filetype_scanners;
     }
@@ -1752,7 +1752,7 @@ class Config
     /**
      * @return array<string, class-string<FileAnalyzer>>
      */
-    public function getFiletypeAnalyzers()
+    public function getFiletypeAnalyzers(): array
     {
         return $this->filetype_analyzers;
     }
@@ -1760,7 +1760,7 @@ class Config
     /**
      * @return array<int, string>
      */
-    public function getMockClasses()
+    public function getMockClasses(): array
     {
         return $this->mock_classes;
     }
@@ -1852,9 +1852,9 @@ class Config
     }
 
     /**
-     * @return string
+     * @return string|null
      */
-    public function getCacheDirectory()
+    public function getCacheDirectory(): ?string
     {
         return $this->cache_directory;
     }
@@ -1862,7 +1862,7 @@ class Config
     /**
      * @return ?string
      */
-    public function getGlobalCacheDirectory()
+    public function getGlobalCacheDirectory(): ?string
     {
         return $this->global_cache_directory;
     }
@@ -1870,7 +1870,7 @@ class Config
     /**
      * @return array<string, mixed>
      */
-    public function getPredefinedConstants()
+    public function getPredefinedConstants(): array
     {
         return $this->predefined_constants;
     }
@@ -1886,7 +1886,7 @@ class Config
     /**
      * @return array<callable-string, bool>
      */
-    public function getPredefinedFunctions()
+    public function getPredefinedFunctions(): array
     {
         return $this->predefined_functions;
     }

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -628,7 +628,6 @@ class Config
      * @param  string $current_dir
      * @param  string $output_format
      *
-     * @return Config
      * @throws ConfigException if a config path is not found
      *
      */
@@ -653,7 +652,6 @@ class Config
      *
      * @throws ConfigException
      *
-     * @return ?string
      */
     public static function locateConfigFile(string $path): ?string
     {
@@ -686,7 +684,6 @@ class Config
      * @param  string           $file_path
      * @param  string           $current_dir
      *
-     * @return self
      */
     public static function loadFromXMLFile($file_path, $current_dir): Config
     {
@@ -713,13 +710,11 @@ class Config
     /**
      * Creates a new config object from an XML string
      *
-     * @throws ConfigException
-     *
      * @param  string           $base_dir
      * @param  string           $file_contents
      * @param  string|null      $current_dir Current working directory, if different to $base_dir
      *
-     * @return self
+     * @throws ConfigException
      */
     public static function loadFromXML($base_dir, $file_contents, $current_dir = null): Config
     {
@@ -1341,7 +1336,6 @@ class Config
     /**
      * @param  string $file_name
      *
-     * @return string
      */
     public function shortenFileName($file_name): string
     {
@@ -1352,7 +1346,6 @@ class Config
      * @param   string $issue_type
      * @param   string $file_path
      *
-     * @return  bool
      */
     public function reportIssueInFile($issue_type, $file_path): bool
     {
@@ -1407,7 +1400,6 @@ class Config
     /**
      * @param   string $file_path
      *
-     * @return  bool
      */
     public function isInProjectDirs($file_path): bool
     {
@@ -1417,7 +1409,6 @@ class Config
     /**
      * @param   string $file_path
      *
-     * @return  bool
      */
     public function isInExtraDirs($file_path): bool
     {
@@ -1427,7 +1418,6 @@ class Config
     /**
      * @param   string $file_path
      *
-     * @return  bool
      */
     public function mustBeIgnored($file_path): bool
     {
@@ -1485,7 +1475,6 @@ class Config
     /**
      * @param string $issue_type
      *
-     * @return string|null
      *
      * @psalm-pure
      */
@@ -1578,7 +1567,6 @@ class Config
      * @param   string $issue_type
      * @param   string $file_path
      *
-     * @return  string
      */
     public function getReportingLevelForFile($issue_type, $file_path): string
     {
@@ -1663,8 +1651,6 @@ class Config
     }
 
     /**
-     * @param   string $issue_type
-     * @param   string $var_name
      *
      * @return  string|null
      */
@@ -1714,7 +1700,6 @@ class Config
     /**
      * @param   string $file_path
      *
-     * @return  bool
      */
     public function reportTypeStatsForFile($file_path): bool
     {
@@ -1726,7 +1711,6 @@ class Config
     /**
      * @param   string $file_path
      *
-     * @return  bool
      */
     public function useStrictTypesForFile($file_path): bool
     {
@@ -1850,18 +1834,12 @@ class Config
 
         $codebase->register_stub_files = false;
     }
-
-    /**
-     * @return string|null
-     */
+    
     public function getCacheDirectory(): ?string
     {
         return $this->cache_directory;
     }
-
-    /**
-     * @return ?string
-     */
+    
     public function getGlobalCacheDirectory(): ?string
     {
         return $this->global_cache_directory;

--- a/src/Psalm/Config/Creator.php
+++ b/src/Psalm/Config/Creator.php
@@ -122,7 +122,7 @@ class Creator
             // remove any issues where < 0.1% of expressions are affected
             $filtered_issues = array_filter(
                 $issues,
-                function ($amount) {
+                function ($amount): bool {
                     return $amount > 0.1;
                 }
             );

--- a/src/Psalm/Config/ErrorLevelFileFilter.php
+++ b/src/Psalm/Config/ErrorLevelFileFilter.php
@@ -22,7 +22,7 @@ class ErrorLevelFileFilter extends FileFilter
         SimpleXMLElement $e,
         $base_dir,
         $inclusive
-    ) {
+    ): ErrorLevelFileFilter {
         $filter = parent::loadFromXMLElement($e, $base_dir, $inclusive);
 
         if (isset($e['type'])) {
@@ -41,7 +41,7 @@ class ErrorLevelFileFilter extends FileFilter
     /**
      * @return string
      */
-    public function getErrorLevel()
+    public function getErrorLevel(): string
     {
         return $this->error_level;
     }

--- a/src/Psalm/Config/ErrorLevelFileFilter.php
+++ b/src/Psalm/Config/ErrorLevelFileFilter.php
@@ -12,7 +12,6 @@ class ErrorLevelFileFilter extends FileFilter
     private $error_level = '';
 
     /**
-     * @param  SimpleXMLElement $e
      * @param  string           $base_dir
      * @param  bool             $inclusive
      *
@@ -38,9 +37,6 @@ class ErrorLevelFileFilter extends FileFilter
         return $filter;
     }
 
-    /**
-     * @return string
-     */
     public function getErrorLevel(): string
     {
         return $this->error_level;

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -349,7 +349,7 @@ class FileFilter
      *
      * @psalm-pure
      */
-    protected static function slashify($str)
+    protected static function slashify($str): string
     {
         return preg_replace('/\/?$/', DIRECTORY_SEPARATOR, $str);
     }
@@ -360,7 +360,7 @@ class FileFilter
      *
      * @return bool
      */
-    public function allows($file_name, $case_sensitive = false)
+    public function allows($file_name, $case_sensitive = false): bool
     {
         if ($this->inclusive) {
             foreach ($this->directories as $include_dir) {
@@ -419,7 +419,7 @@ class FileFilter
      *
      * @return bool
      */
-    public function allowsClass($fq_classlike_name)
+    public function allowsClass($fq_classlike_name): bool
     {
         if ($this->fq_classlike_patterns) {
             foreach ($this->fq_classlike_patterns as $pattern) {
@@ -437,7 +437,7 @@ class FileFilter
      *
      * @return bool
      */
-    public function allowsMethod($method_id)
+    public function allowsMethod($method_id): bool
     {
         if (!$this->method_ids) {
             return false;
@@ -471,7 +471,7 @@ class FileFilter
      *
      * @return bool
      */
-    public function allowsProperty($property_id)
+    public function allowsProperty($property_id): bool
     {
         return in_array(strtolower($property_id), $this->property_ids, true);
     }
@@ -481,7 +481,7 @@ class FileFilter
      *
      * @return bool
      */
-    public function allowsVariable($var_name)
+    public function allowsVariable($var_name): bool
     {
         return in_array(strtolower($var_name), $this->var_names, true);
     }
@@ -489,7 +489,7 @@ class FileFilter
     /**
      * @return array<string>
      */
-    public function getDirectories()
+    public function getDirectories(): array
     {
         return $this->directories;
     }
@@ -497,7 +497,7 @@ class FileFilter
     /**
      * @return array<string>
      */
-    public function getFiles()
+    public function getFiles(): array
     {
         return $this->files;
     }

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -91,7 +91,6 @@ class FileFilter
     }
 
     /**
-     * @param  SimpleXMLElement $e
      * @param  string           $base_dir
      * @param  bool             $inclusive
      *
@@ -345,7 +344,6 @@ class FileFilter
     /**
      * @param string $str
      *
-     * @return string
      *
      * @psalm-pure
      */
@@ -358,7 +356,6 @@ class FileFilter
      * @param  string  $file_name
      * @param  bool $case_sensitive
      *
-     * @return bool
      */
     public function allows($file_name, $case_sensitive = false): bool
     {
@@ -417,7 +414,6 @@ class FileFilter
     /**
      * @param  string  $fq_classlike_name
      *
-     * @return bool
      */
     public function allowsClass($fq_classlike_name): bool
     {
@@ -435,7 +431,6 @@ class FileFilter
     /**
      * @param  string  $method_id
      *
-     * @return bool
      */
     public function allowsMethod($method_id): bool
     {
@@ -469,7 +464,6 @@ class FileFilter
     /**
      * @param  string  $property_id
      *
-     * @return bool
      */
     public function allowsProperty($property_id): bool
     {
@@ -479,7 +473,6 @@ class FileFilter
     /**
      * @param  string  $var_name
      *
-     * @return bool
      */
     public function allowsVariable($var_name): bool
     {

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -29,7 +29,7 @@ class IssueHandler
      *
      * @return self
      */
-    public static function loadFromXMLElement(SimpleXMLElement $e, $base_dir)
+    public static function loadFromXMLElement(SimpleXMLElement $e, $base_dir): IssueHandler
     {
         $handler = new self();
 
@@ -68,7 +68,7 @@ class IssueHandler
      *
      * @return string
      */
-    public function getReportingLevelForFile($file_path)
+    public function getReportingLevelForFile($file_path): string
     {
         foreach ($this->custom_levels as $custom_level) {
             if ($custom_level->allows($file_path)) {
@@ -163,7 +163,7 @@ class IssueHandler
      * @return       string[]
      * @psalm-return array<string>
      */
-    public static function getAllIssueTypes()
+    public static function getAllIssueTypes(): array
     {
         return array_filter(
             array_map(
@@ -182,7 +182,7 @@ class IssueHandler
              *
              * @return bool
              */
-            function ($issue_name) {
+            function ($issue_name): bool {
                 return !empty($issue_name)
                     && $issue_name !== 'MethodIssue'
                     && $issue_name !== 'PropertyIssue'

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -24,10 +24,8 @@ class IssueHandler
     private $custom_levels = [];
 
     /**
-     * @param  SimpleXMLElement $e
      * @param  string           $base_dir
      *
-     * @return self
      */
     public static function loadFromXMLElement(SimpleXMLElement $e, $base_dir): IssueHandler
     {
@@ -66,7 +64,6 @@ class IssueHandler
     /**
      * @param string $file_path
      *
-     * @return string
      */
     public function getReportingLevelForFile($file_path): string
     {
@@ -180,7 +177,6 @@ class IssueHandler
             /**
              * @param string $issue_name
              *
-             * @return bool
              */
             function ($issue_name): bool {
                 return !empty($issue_name)

--- a/src/Psalm/Config/ProjectFileFilter.php
+++ b/src/Psalm/Config/ProjectFileFilter.php
@@ -13,7 +13,6 @@ class ProjectFileFilter extends FileFilter
     private $file_filter = null;
 
     /**
-     * @param  SimpleXMLElement $e
      * @param  string           $base_dir
      * @param  bool             $inclusive
      *
@@ -42,7 +41,6 @@ class ProjectFileFilter extends FileFilter
      * @param  string  $file_name
      * @param  bool $case_sensitive
      *
-     * @return bool
      */
     public function allows($file_name, $case_sensitive = false): bool
     {
@@ -59,7 +57,6 @@ class ProjectFileFilter extends FileFilter
      * @param  string  $file_name
      * @param  bool $case_sensitive
      *
-     * @return bool
      */
     public function forbids($file_name, $case_sensitive = false): bool
     {
@@ -76,7 +73,6 @@ class ProjectFileFilter extends FileFilter
      * @param  string $file_name
      * @param  bool   $case_sensitive
      *
-     * @return bool
      */
     public function reportTypeStats($file_name, $case_sensitive = false): bool
     {
@@ -99,7 +95,6 @@ class ProjectFileFilter extends FileFilter
      * @param  string $file_name
      * @param  bool   $case_sensitive
      *
-     * @return bool
      */
     public function useStrictTypes($file_name, $case_sensitive = false): bool
     {

--- a/src/Psalm/Config/ProjectFileFilter.php
+++ b/src/Psalm/Config/ProjectFileFilter.php
@@ -23,7 +23,7 @@ class ProjectFileFilter extends FileFilter
         SimpleXMLElement $e,
         $base_dir,
         $inclusive
-    ) {
+    ): ProjectFileFilter {
         $filter = parent::loadFromXMLElement($e, $base_dir, $inclusive);
 
         if (isset($e->ignoreFiles)) {
@@ -44,7 +44,7 @@ class ProjectFileFilter extends FileFilter
      *
      * @return bool
      */
-    public function allows($file_name, $case_sensitive = false)
+    public function allows($file_name, $case_sensitive = false): bool
     {
         if ($this->inclusive && $this->file_filter) {
             if (!$this->file_filter->allows($file_name, $case_sensitive)) {
@@ -61,7 +61,7 @@ class ProjectFileFilter extends FileFilter
      *
      * @return bool
      */
-    public function forbids($file_name, $case_sensitive = false)
+    public function forbids($file_name, $case_sensitive = false): bool
     {
         if ($this->inclusive && $this->file_filter) {
             if (!$this->file_filter->allows($file_name, $case_sensitive)) {
@@ -78,7 +78,7 @@ class ProjectFileFilter extends FileFilter
      *
      * @return bool
      */
-    public function reportTypeStats($file_name, $case_sensitive = false)
+    public function reportTypeStats($file_name, $case_sensitive = false): bool
     {
         foreach ($this->ignore_type_stats as $exclude_dir => $_) {
             if ($case_sensitive) {
@@ -101,7 +101,7 @@ class ProjectFileFilter extends FileFilter
      *
      * @return bool
      */
-    public function useStrictTypes($file_name, $case_sensitive = false)
+    public function useStrictTypes($file_name, $case_sensitive = false): bool
     {
         foreach ($this->declare_strict_types as $exclude_dir => $_) {
             if ($case_sensitive) {

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -457,7 +457,7 @@ class Context
      *
      * @return array<string,Type\Union>
      */
-    public function getRedefinedVars(array $new_vars_in_scope, $include_new_vars = false)
+    public function getRedefinedVars(array $new_vars_in_scope, $include_new_vars = false): array
     {
         $redefined_vars = [];
 
@@ -489,7 +489,7 @@ class Context
      *
      * @return array<int, string>
      */
-    public static function getNewOrUpdatedVarIds(Context $original_context, Context $new_context)
+    public static function getNewOrUpdatedVarIds(Context $original_context, Context $new_context): array
     {
         $redefined_var_ids = [];
 
@@ -532,7 +532,7 @@ class Context
      *
      * @psalm-pure
      */
-    public static function removeReconciledClauses(array $clauses, array $changed_var_ids)
+    public static function removeReconciledClauses(array $clauses, array $changed_var_ids): array
     {
         $included_clauses = [];
         $rejected_clauses = [];
@@ -756,7 +756,7 @@ class Context
      *
      * @return  bool
      */
-    public function isPhantomClass($class_name)
+    public function isPhantomClass($class_name): bool
     {
         return isset($this->phantom_classes[strtolower($class_name)]);
     }
@@ -766,7 +766,7 @@ class Context
      *
      * @return bool
      */
-    public function hasVariable($var_name, StatementsAnalyzer $statements_analyzer = null)
+    public function hasVariable($var_name, StatementsAnalyzer $statements_analyzer = null): bool
     {
         if (!$var_name) {
             return false;
@@ -847,7 +847,7 @@ class Context
     /**
      * @return bool
      */
-    public function isSuppressingExceptions(StatementsAnalyzer $statements_analyzer)
+    public function isSuppressingExceptions(StatementsAnalyzer $statements_analyzer): bool
     {
         if (!$this->collect_exceptions) {
             return true;

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -395,11 +395,8 @@ class Context
      * Updates the parent context, looking at the changes within a block and then applying those changes, where
      * necessary, to the parent context
      *
-     * @param  Context     $start_context
-     * @param  Context     $end_context
      * @param  bool        $has_leaving_statements   whether or not the parent scope is abandoned between
      *                                               $start_context and $end_context
-     * @param  array       $vars_to_update
      * @param  array<string, bool>  $updated_vars
      *
      * @return void
@@ -484,8 +481,6 @@ class Context
     }
 
     /**
-     * @param  Context $original_context
-     * @param  Context $new_context
      *
      * @return array<int, string>
      */
@@ -738,7 +733,6 @@ class Context
     }
 
     /**
-     * @param   Context $op_context
      *
      * @return  void
      */
@@ -754,7 +748,6 @@ class Context
     /**
      * @param   string $class_name
      *
-     * @return  bool
      */
     public function isPhantomClass($class_name): bool
     {
@@ -764,7 +757,6 @@ class Context
     /**
      * @param  string|null  $var_name
      *
-     * @return bool
      */
     public function hasVariable($var_name, StatementsAnalyzer $statements_analyzer = null): bool
     {
@@ -843,10 +835,7 @@ class Context
             }
         }
     }
-
-    /**
-     * @return bool
-     */
+    
     public function isSuppressingExceptions(StatementsAnalyzer $statements_analyzer): bool
     {
         if (!$this->collect_exceptions) {

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -57,7 +57,7 @@ class DocComment
      *
      * @psalm-pure
      */
-    public static function parse($docblock, $line_number = null, $preserve_format = false)
+    public static function parse($docblock, $line_number = null, $preserve_format = false): array
     {
         // Strip off comments.
         $docblock = trim($docblock);

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -180,7 +180,6 @@ class DocComment
     /**
      * Parse a docblock comment into its parts.
      *
-     * @param  \PhpParser\Comment\Doc  $docblock
      * @param  bool    $preserve_format
      */
     public static function parsePreservingLength(\PhpParser\Comment\Doc $docblock) : ParsedDocblock

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -33,7 +33,7 @@ class ErrorBaseline
      *
      * @psalm-pure
      */
-    public static function countTotalIssues(array $existingIssues)
+    public static function countTotalIssues(array $existingIssues): int
     {
         $totalIssues = 0;
 
@@ -145,7 +145,7 @@ class ErrorBaseline
         string $baselineFile,
         array $issues,
         bool $include_php_versions
-    ) {
+    ): array {
         $existingIssues = self::read($fileProvider, $baselineFile);
         $newIssues = self::countIssueTypesByFile($issues);
 

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -29,7 +29,6 @@ class ErrorBaseline
     /**
      * @param array<string,array<string,array{o:int, s:array<int, string>}>> $existingIssues
      *
-     * @return int
      *
      * @psalm-pure
      */
@@ -54,8 +53,6 @@ class ErrorBaseline
     }
 
     /**
-     * @param FileProvider $fileProvider
-     * @param string $baselineFile
      * @param array<string, list<IssueData>> $issues
      *
      * @return void
@@ -72,12 +69,9 @@ class ErrorBaseline
     }
 
     /**
-     * @param FileProvider $fileProvider
-     * @param string $baselineFile
+     * @return array<string,array<string,array{o:int, s:array<int, string>}>>
      *
      * @throws Exception\ConfigException
-     *
-     * @return array<string,array<string,array{o:int, s:array<int, string>}>>
      */
     public static function read(FileProvider $fileProvider, string $baselineFile): array
     {
@@ -132,13 +126,11 @@ class ErrorBaseline
     }
 
     /**
-     * @param FileProvider $fileProvider
-     * @param string $baselineFile
      * @param array<string, list<IssueData>> $issues
      *
-     * @throws Exception\ConfigException
-     *
      * @return array<string,array<string,array{o:int, s:array<int, string>}>>
+     *
+     * @throws Exception\ConfigException
      */
     public static function update(
         FileProvider $fileProvider,
@@ -237,8 +229,6 @@ class ErrorBaseline
     }
 
     /**
-     * @param FileProvider $fileProvider
-     * @param string $baselineFile
      * @param array<string,array<string,array{o:int, s:array<int, string>}>> $groupedIssues
      *
      * @return void

--- a/src/Psalm/FileBasedPluginAdapter.php
+++ b/src/Psalm/FileBasedPluginAdapter.php
@@ -31,7 +31,6 @@ class FileBasedPluginAdapter implements Plugin\PluginEntryPointInterface
     /**
      * @psalm-suppress PossiblyUnusedParam
      *
-     * @param  Plugin\RegistrationInterface $registration
      * @param  SimpleXMLElement|null        $config
      *
      * @return  void

--- a/src/Psalm/FileManipulation.php
+++ b/src/Psalm/FileManipulation.php
@@ -23,12 +23,7 @@ class FileManipulation
 
     /** @var bool */
     public $remove_trailing_newline;
-
-    /**
-     * @param int $start
-     * @param int $end
-     * @param string $insertion_text
-     */
+    
     public function __construct(
         int $start,
         int $end,

--- a/src/Psalm/FileSource.php
+++ b/src/Psalm/FileSource.php
@@ -3,14 +3,8 @@ namespace Psalm;
 
 interface FileSource
 {
-    /**
-     * @return string
-     */
     public function getFileName(): string;
 
-    /**
-     * @return string
-     */
     public function getFilePath(): string;
 
     /**
@@ -23,8 +17,5 @@ interface FileSource
      */
     public function getRootFilePath();
 
-    /**
-     * @return Aliases
-     */
     public function getAliases(): Aliases;
 }

--- a/src/Psalm/FileSource.php
+++ b/src/Psalm/FileSource.php
@@ -6,12 +6,12 @@ interface FileSource
     /**
      * @return string
      */
-    public function getFileName();
+    public function getFileName(): string;
 
     /**
      * @return string
      */
-    public function getFilePath();
+    public function getFilePath(): string;
 
     /**
      * @return string
@@ -26,5 +26,5 @@ interface FileSource
     /**
      * @return Aliases
      */
-    public function getAliases();
+    public function getAliases(): Aliases;
 }

--- a/src/Psalm/Internal/Analyzer/AlgebraAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/AlgebraAnalyzer.php
@@ -27,8 +27,6 @@ class AlgebraAnalyzer
      *
      * @param  array<int, Clause>   $formula1
      * @param  array<int, Clause>   $formula2
-     * @param  StatementsAnalyzer    $statements_analyzer,
-     * @param  PhpParser\Node       $stmt
      * @param  array<string, bool>  $new_assigned_var_ids
      *
      * @return void

--- a/src/Psalm/Internal/Analyzer/CanAlias.php
+++ b/src/Psalm/Internal/Analyzer/CanAlias.php
@@ -41,7 +41,6 @@ trait CanAlias
     private $aliased_constants = [];
 
     /**
-     * @param  PhpParser\Node\Stmt\Use_ $stmt
      *
      * @return void
      */
@@ -104,7 +103,6 @@ trait CanAlias
     }
 
     /**
-     * @param  PhpParser\Node\Stmt\GroupUse $stmt
      *
      * @return void
      */
@@ -157,9 +155,6 @@ trait CanAlias
         return $this->aliased_classes_flipped_replaceable;
     }
 
-    /**
-     * @return Aliases
-     */
     public function getAliases(): Aliases
     {
         return new Aliases(

--- a/src/Psalm/Internal/Analyzer/CanAlias.php
+++ b/src/Psalm/Internal/Analyzer/CanAlias.php
@@ -144,7 +144,7 @@ trait CanAlias
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlipped()
+    public function getAliasedClassesFlipped(): array
     {
         return $this->aliased_classes_flipped;
     }
@@ -152,7 +152,7 @@ trait CanAlias
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlippedReplaceable()
+    public function getAliasedClassesFlippedReplaceable(): array
     {
         return $this->aliased_classes_flipped_replaceable;
     }
@@ -160,7 +160,7 @@ trait CanAlias
     /**
      * @return Aliases
      */
-    public function getAliases()
+    public function getAliases(): Aliases
     {
         return new Aliases(
             $this->getNamespace(),

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -97,7 +97,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
      *
      * @return string
      */
-    public static function getAnonymousClassName(PhpParser\Node\Stmt\Class_ $class, $file_path)
+    public static function getAnonymousClassName(PhpParser\Node\Stmt\Class_ $class, $file_path): string
     {
         return preg_replace('/[^A-Za-z0-9]/', '_', $file_path)
             . '_' . $class->getLine() . '_' . (int)$class->getAttribute('startFilePos');

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -67,8 +67,6 @@ class ClassAnalyzer extends ClassLikeAnalyzer
     public $inferred_property_types = [];
 
     /**
-     * @param PhpParser\Node\Stmt\Class_    $class
-     * @param SourceAnalyzer                $source
      * @param string|null                   $fq_class_name
      */
     public function __construct(PhpParser\Node\Stmt\Class_ $class, SourceAnalyzer $source, $fq_class_name)
@@ -92,10 +90,8 @@ class ClassAnalyzer extends ClassLikeAnalyzer
     }
 
     /**
-     * @param  PhpParser\Node\Stmt\Class_ $class
      * @param  string                     $file_path
      *
-     * @return string
      */
     public static function getAnonymousClassName(PhpParser\Node\Stmt\Class_ $class, $file_path): string
     {
@@ -1617,7 +1613,6 @@ class ClassAnalyzer extends ClassLikeAnalyzer
     }
 
     /**
-     * @param   PhpParser\Node\Stmt\Property    $stmt
      *
      * @return  void
      */
@@ -1766,9 +1761,6 @@ class ClassAnalyzer extends ClassLikeAnalyzer
     }
 
     /**
-     * @param  PhpParser\Node\Stmt\ClassMethod $stmt
-     * @param  SourceAnalyzer                  $source
-     * @param  Context                         $class_context
      * @param  Context|null                    $global_context
      * @param  bool                            $is_fake
      *

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -415,7 +415,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     public static function getFQCLNFromNameObject(
         PhpParser\Node\Name $class_name,
         Aliases $aliases
-    ) {
+    ): string {
         /** @var string|null */
         $resolved_name = $class_name->getAttribute('resolvedName');
 
@@ -440,7 +440,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlipped()
+    public function getAliasedClassesFlipped(): array
     {
         if ($this->source instanceof NamespaceAnalyzer || $this->source instanceof FileAnalyzer) {
             return $this->source->getAliasedClassesFlipped();
@@ -452,7 +452,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlippedReplaceable()
+    public function getAliasedClassesFlippedReplaceable(): array
     {
         if ($this->source instanceof NamespaceAnalyzer || $this->source instanceof FileAnalyzer) {
             return $this->source->getAliasedClassesFlippedReplaceable();
@@ -464,7 +464,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     /**
      * @return string
      */
-    public function getFQCLN()
+    public function getFQCLN(): string
     {
         return $this->fq_class_name;
     }
@@ -472,7 +472,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     /**
      * @return string|null
      */
-    public function getClassName()
+    public function getClassName(): ?string
     {
         return $this->class->name ? $this->class->name->name : null;
     }
@@ -480,7 +480,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     /**
      * @return array<string, array<string, array{Type\Union}>>|null
      */
-    public function getTemplateTypeMap()
+    public function getTemplateTypeMap(): ?array
     {
         return $this->storage->template_types;
     }
@@ -488,7 +488,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     /**
      * @return string|null
      */
-    public function getParentFQCLN()
+    public function getParentFQCLN(): ?string
     {
         return $this->parent_fq_class_name;
     }
@@ -496,7 +496,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     /**
      * @return bool
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return false;
     }
@@ -508,7 +508,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
      *
      * @return Type\Union
      */
-    public static function getTypeFromValue($value)
+    public static function getTypeFromValue($value): Type\Union
     {
         switch (gettype($value)) {
             case 'boolean':
@@ -555,7 +555,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
         CodeLocation $code_location,
         array $suppressed_issues,
         $emit_issues = true
-    ) {
+    ): ?bool {
         [$fq_class_name, $property_name] = explode('::$', (string)$property_id);
 
         $codebase = $source->getCodebase();
@@ -676,7 +676,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
      *
      * @return  array<string, string>
      */
-    public static function getClassesForFile(Codebase $codebase, $file_path)
+    public static function getClassesForFile(Codebase $codebase, $file_path): array
     {
         try {
             return $codebase->file_storage_provider->get($file_path)->classlikes_in_file;

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -99,8 +99,6 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     protected $storage;
 
     /**
-     * @param PhpParser\Node\Stmt\ClassLike $class
-     * @param SourceAnalyzer                $source
      * @param string                        $fq_class_name
      */
     public function __construct(PhpParser\Node\Stmt\ClassLike $class, SourceAnalyzer $source, $fq_class_name)
@@ -121,7 +119,6 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
 
     /**
      * @param  string       $method_name
-     * @param  Context      $context
      *
      * @return void
      */
@@ -210,7 +207,6 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     }
 
     /**
-     * @param  string           $fq_class_name
      * @param  array<string>    $suppressed_issues
      * @param  bool             $inferred - whether or not the type was inferred
      *
@@ -407,10 +403,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     /**
      * Gets the fully-qualified class name from a Name object
      *
-     * @param  PhpParser\Node\Name      $class_name
-     * @param  Aliases                  $aliases
      *
-     * @return string
      */
     public static function getFQCLNFromNameObject(
         PhpParser\Node\Name $class_name,
@@ -461,17 +454,11 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
         return [];
     }
 
-    /**
-     * @return string
-     */
     public function getFQCLN(): string
     {
         return $this->fq_class_name;
     }
 
-    /**
-     * @return string|null
-     */
     public function getClassName(): ?string
     {
         return $this->class->name ? $this->class->name->name : null;
@@ -485,17 +472,11 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
         return $this->storage->template_types;
     }
 
-    /**
-     * @return string|null
-     */
     public function getParentFQCLN(): ?string
     {
         return $this->parent_fq_class_name;
     }
 
-    /**
-     * @return bool
-     */
     public function isStatic(): bool
     {
         return false;
@@ -506,7 +487,6 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
      *
      * @param  mixed $value
      *
-     * @return Type\Union
      */
     public static function getTypeFromValue($value): Type\Union
     {
@@ -541,12 +521,9 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     /**
      * @param  string           $property_id
      * @param  string|null      $calling_context
-     * @param  SourceAnalyzer   $source
-     * @param  CodeLocation     $code_location
      * @param  string[]         $suppressed_issues
      * @param  bool             $emit_issues
      *
-     * @return bool|null
      */
     public static function checkPropertyVisibility(
         $property_id,

--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -45,7 +45,7 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
         parent::__construct($function, $source, $storage);
     }
 
-    public function getTemplateTypeMap()
+    public function getTemplateTypeMap(): ?array
     {
         return $this->source->getTemplateTypeMap();
     }
@@ -53,7 +53,7 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
     /**
      * @return non-empty-lowercase-string
      */
-    public function getClosureId()
+    public function getClosureId(): string
     {
         return strtolower($this->getFilePath())
             . ':' . $this->function->getLine()

--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -192,9 +192,6 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
     }
 
     /**
-     * @param   StatementsAnalyzer           $statements_analyzer
-     * @param   PhpParser\Node\Expr\Closure $stmt
-     * @param   Context                     $context
      *
      * @return  false|null
      */

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -62,7 +62,7 @@ class CommentAnalyzer
         Aliases $aliases,
         array $template_type_map = null,
         ?array $type_aliases = null
-    ) {
+    ): array {
         $parsed_docblock = DocComment::parsePreservingLength($comment);
 
         return self::arrayToDocblocks(
@@ -264,7 +264,7 @@ class CommentAnalyzer
         Aliases $aliases,
         ?array $type_aliases,
         ?string $self_fqcln
-    ) {
+    ): array {
         $parsed_docblock = DocComment::parsePreservingLength($comment);
 
         if (!isset($parsed_docblock->tags['psalm-type'])) {
@@ -293,7 +293,7 @@ class CommentAnalyzer
         Aliases $aliases,
         ?array $type_aliases,
         ?string $self_fqcln
-    ) {
+    ): array {
         $type_alias_tokens = [];
 
         foreach ($type_alias_comment_lines as $var_line) {
@@ -365,7 +365,7 @@ class CommentAnalyzer
      *
      * @return FunctionDocblockComment
      */
-    public static function extractFunctionDocblockInfo(PhpParser\Comment\Doc $comment)
+    public static function extractFunctionDocblockInfo(PhpParser\Comment\Doc $comment): FunctionDocblockComment
     {
         $parsed_docblock = DocComment::parsePreservingLength($comment);
 
@@ -813,7 +813,7 @@ class CommentAnalyzer
         \PhpParser\Node $node,
         PhpParser\Comment\Doc $comment,
         Aliases $aliases
-    ) {
+    ): ClassLikeDocblockComment {
         $parsed_docblock = DocComment::parsePreservingLength($comment);
         $codebase = ProjectAnalyzer::getInstance()->getCodebase();
 

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -252,12 +252,11 @@ class CommentAnalyzer
     }
 
     /**
-     * @param  Aliases          $aliases
      * @param  array<string, TypeAlias> $type_aliases
      *
-     * @throws DocblockParseException if there was a problem parsing the docblock
-     *
      * @return array<string, TypeAlias\InlineTypeAlias>
+     *
+     * @throws DocblockParseException if there was a problem parsing the docblock
      */
     public static function getTypeAliasesFromComment(
         PhpParser\Comment\Doc $comment,
@@ -281,12 +280,11 @@ class CommentAnalyzer
 
     /**
      * @param  array<string>    $type_alias_comment_lines
-     * @param  Aliases          $aliases
      * @param  array<string, TypeAlias> $type_aliases
      *
-     * @throws DocblockParseException if there was a problem parsing the docblock
-     *
      * @return array<string, TypeAlias\InlineTypeAlias>
+     *
+     * @throws DocblockParseException if there was a problem parsing the docblock
      */
     private static function getTypeAliasesFromCommentLines(
         array $type_alias_comment_lines,
@@ -363,7 +361,6 @@ class CommentAnalyzer
      *
      * @throws DocblockParseException if there was a problem parsing the docblock
      *
-     * @return FunctionDocblockComment
      */
     public static function extractFunctionDocblockInfo(PhpParser\Comment\Doc $comment): FunctionDocblockComment
     {
@@ -806,7 +803,6 @@ class CommentAnalyzer
     /**
      * @throws DocblockParseException if there was a problem parsing the docblock
      *
-     * @return ClassLikeDocblockComment
      * @psalm-suppress MixedArrayAccess
      */
     public static function extractClassLikeDocblockInfo(
@@ -1160,14 +1156,12 @@ class CommentAnalyzer
     }
 
     /**
-     * @param ClassLikeDocblockComment $info
      * @param array<string, array<int, string>> $specials
      * @param 'property'|'psalm-property'|'property-read'|
      *     'psalm-property-read'|'property-write'|'psalm-property-write' $property_tag
      *
      * @throws DocblockParseException
      *
-     * @return void
      */
     protected static function addMagicPropertyToInfo(
         PhpParser\Comment\Doc $comment,
@@ -1358,7 +1352,6 @@ class CommentAnalyzer
     }
 
     /**
-     * @param ParsedDocblock $parsed_docblock
      *
      * @return void
      *

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -294,7 +294,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return array<int, PhpParser\Node\Stmt>
      */
-    public function populateCheckers(array $stmts)
+    public function populateCheckers(array $stmts): array
     {
         $leftover_stmts = [];
 
@@ -476,7 +476,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return null|string
      */
-    public function getNamespace()
+    public function getNamespace(): ?string
     {
         return null;
     }
@@ -486,7 +486,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return array<string, string>
      */
-    public function getAliasedClassesFlipped($namespace_name = null)
+    public function getAliasedClassesFlipped($namespace_name = null): array
     {
         if ($namespace_name && isset($this->namespace_aliased_classes_flipped[$namespace_name])) {
             return $this->namespace_aliased_classes_flipped[$namespace_name];
@@ -500,7 +500,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return array<string, string>
      */
-    public function getAliasedClassesFlippedReplaceable($namespace_name = null)
+    public function getAliasedClassesFlippedReplaceable($namespace_name = null): array
     {
         if ($namespace_name && isset($this->namespace_aliased_classes_flipped_replaceable[$namespace_name])) {
             return $this->namespace_aliased_classes_flipped_replaceable[$namespace_name];
@@ -528,7 +528,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return string
      */
-    public function getFileName()
+    public function getFileName(): string
     {
         return $this->file_name;
     }
@@ -536,7 +536,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return string
      */
-    public function getFilePath()
+    public function getFilePath(): string
     {
         return $this->file_path;
     }
@@ -594,7 +594,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return bool
      */
-    public function hasParentFilePath($file_path)
+    public function hasParentFilePath($file_path): bool
     {
         return $this->file_path === $file_path || isset($this->parent_file_paths[$file_path]);
     }
@@ -604,7 +604,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return bool
      */
-    public function hasAlreadyRequiredFilePath($file_path)
+    public function hasAlreadyRequiredFilePath($file_path): bool
     {
         return isset($this->required_file_paths[$file_path]);
     }
@@ -612,7 +612,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return array<int, string>
      */
-    public function getRequiredFilePaths()
+    public function getRequiredFilePaths(): array
     {
         return array_keys($this->required_file_paths);
     }
@@ -620,7 +620,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return array<int, string>
      */
-    public function getParentFilePaths()
+    public function getParentFilePaths(): array
     {
         return array_keys($this->parent_file_paths);
     }
@@ -628,7 +628,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return int
      */
-    public function getRequireNesting()
+    public function getRequireNesting(): int
     {
         return count($this->parent_file_paths);
     }
@@ -636,7 +636,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return array<string>
      */
-    public function getSuppressedIssues()
+    public function getSuppressedIssues(): array
     {
         return $this->suppressed_issues;
     }
@@ -672,7 +672,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return null|string
      */
-    public function getFQCLN()
+    public function getFQCLN(): ?string
     {
         return null;
     }
@@ -680,7 +680,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return null|string
      */
-    public function getParentFQCLN()
+    public function getParentFQCLN(): ?string
     {
         return null;
     }
@@ -688,7 +688,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return null|string
      */
-    public function getClassName()
+    public function getClassName(): ?string
     {
         return null;
     }
@@ -696,7 +696,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return array<string, array<string, array{Type\Union}>>|null
      */
-    public function getTemplateTypeMap()
+    public function getTemplateTypeMap(): ?array
     {
         return null;
     }
@@ -704,7 +704,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return bool
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return false;
     }

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -373,7 +373,6 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
 
     /**
      * @param string       $fq_class_name
-     * @param ClassAnalyzer $class_analyzer
      *
      * @return  void
      */
@@ -384,7 +383,6 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
 
     /**
      * @param string            $fq_class_name
-     * @param InterfaceAnalyzer  $interface_analyzer
      *
      * @return  void
      */
@@ -473,9 +471,6 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         return $class_analyzer_to_examine->getFunctionLikeAnalyzer($method_name);
     }
 
-    /**
-     * @return null|string
-     */
     public function getNamespace(): ?string
     {
         return null;
@@ -525,17 +520,11 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         \Psalm\Internal\Provider\FileReferenceProvider::clearCache();
     }
 
-    /**
-     * @return string
-     */
     public function getFileName(): string
     {
         return $this->file_name;
     }
 
-    /**
-     * @return string
-     */
     public function getFilePath(): string
     {
         return $this->file_path;
@@ -592,7 +581,6 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @param string $file_path
      *
-     * @return bool
      */
     public function hasParentFilePath($file_path): bool
     {
@@ -602,7 +590,6 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @param string $file_path
      *
-     * @return bool
      */
     public function hasAlreadyRequiredFilePath($file_path): bool
     {
@@ -625,9 +612,6 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         return array_keys($this->parent_file_paths);
     }
 
-    /**
-     * @return int
-     */
     public function getRequireNesting(): int
     {
         return count($this->parent_file_paths);
@@ -669,25 +653,16 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         $this->suppressed_issues = \array_diff_key($this->suppressed_issues, $new_issues);
     }
 
-    /**
-     * @return null|string
-     */
     public function getFQCLN(): ?string
     {
         return null;
     }
 
-    /**
-     * @return null|string
-     */
     public function getParentFQCLN(): ?string
     {
         return null;
     }
 
-    /**
-     * @return null|string
-     */
     public function getClassName(): ?string
     {
         return null;
@@ -701,9 +676,6 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         return null;
     }
 
-    /**
-     * @return bool
-     */
     public function isStatic(): bool
     {
         return false;

--- a/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
@@ -47,7 +47,6 @@ class FunctionAnalyzer extends FunctionLikeAnalyzer
      * @param  string                      $function_id
      * @param  array<PhpParser\Node\Arg>   $call_args
      *
-     * @return Type\Union
      */
     public static function getReturnTypeFromCallMapWithArgs(
         StatementsAnalyzer $statements_analyzer,

--- a/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
@@ -54,7 +54,7 @@ class FunctionAnalyzer extends FunctionLikeAnalyzer
         $function_id,
         array $call_args,
         Context $context
-    ) {
+    ): Type\Union {
         $call_map_key = strtolower($function_id);
 
         $call_map = InternalCallMapHandler::getCallMap();
@@ -282,7 +282,7 @@ class FunctionAnalyzer extends FunctionLikeAnalyzer
     /**
      * @return non-empty-lowercase-string
      */
-    public function getFunctionId()
+    public function getFunctionId(): string
     {
         $namespace = $this->source->getNamespace();
 

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -68,7 +68,7 @@ class ReturnTypeAnalyzer
         array $compatible_method_ids = [],
         bool $did_explicitly_return = false,
         bool $closure_inside_call = false
-    ) {
+    ): ?bool {
         $suppressed_issues = $function_like_analyzer->getSuppressedIssues();
         $codebase = $source->getCodebase();
         $project_analyzer = $source->getProjectAnalyzer();

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -17,7 +17,6 @@ class ReturnTypeCollector
      *
      * @param  array<PhpParser\Node>     $stmts
      * @param  list<Type\Union>         $yield_types
-     * @param  bool                      $collapse_types
      *
      * @return list<Type\Union>    a list of return types
      */
@@ -274,7 +273,6 @@ class ReturnTypeCollector
     }
 
     /**
-     * @param   PhpParser\Node\Expr $stmt
      *
      * @return  list<Type\Union>
      */

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -142,7 +142,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         Context $global_context = null,
         $add_mutations = false,
         array $byref_uses = null
-    ) {
+    ): ?bool {
         $storage = $this->storage;
 
         $function_stmts = $this->function->getStmts() ?: [];
@@ -429,7 +429,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $non_null_param_types = array_filter(
                 $storage->params,
                 /** @return bool */
-                function (FunctionLikeParameter $p) {
+                function (FunctionLikeParameter $p): bool {
                     return $p->type !== null && $p->has_docblock_type;
                 }
             );
@@ -437,7 +437,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $non_null_param_types = array_filter(
                 $storage->params,
                 /** @return bool */
-                function (FunctionLikeParameter $p) {
+                function (FunctionLikeParameter $p): bool {
                     return $p->type !== null;
                 }
             );
@@ -450,7 +450,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $types_without_docblocks = array_filter(
                 $storage->params,
                 /** @return bool */
-                function (FunctionLikeParameter $p) {
+                function (FunctionLikeParameter $p): bool {
                     return !$p->type || !$p->has_docblock_type;
                 }
             );
@@ -1663,7 +1663,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
      *
      * @return string
      */
-    public function getCorrectlyCasedMethodId($context_self = null)
+    public function getCorrectlyCasedMethodId($context_self = null): string
     {
         if ($this->function instanceof ClassMethod) {
             $function_name = (string)$this->function->name;
@@ -1687,7 +1687,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return FunctionLikeStorage
      */
-    public function getFunctionLikeStorage(StatementsAnalyzer $statements_analyzer = null)
+    public function getFunctionLikeStorage(StatementsAnalyzer $statements_analyzer = null): FunctionLikeStorage
     {
         $codebase = $this->codebase;
 
@@ -1741,7 +1741,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlipped()
+    public function getAliasedClassesFlipped(): array
     {
         if ($this->source instanceof NamespaceAnalyzer ||
             $this->source instanceof FileAnalyzer ||
@@ -1756,7 +1756,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlippedReplaceable()
+    public function getAliasedClassesFlippedReplaceable(): array
     {
         if ($this->source instanceof NamespaceAnalyzer ||
             $this->source instanceof FileAnalyzer ||
@@ -1771,7 +1771,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return string|null
      */
-    public function getFQCLN()
+    public function getFQCLN(): ?string
     {
         return $this->source->getFQCLN();
     }
@@ -1779,7 +1779,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return null|string
      */
-    public function getClassName()
+    public function getClassName(): ?string
     {
         return $this->source->getClassName();
     }
@@ -1787,7 +1787,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return array<string, array<string, array{Type\Union}>>|null
      */
-    public function getTemplateTypeMap()
+    public function getTemplateTypeMap(): ?array
     {
         if ($this->source instanceof ClassLikeAnalyzer) {
             return ($this->source->getTemplateTypeMap() ?: [])
@@ -1800,7 +1800,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return string|null
      */
-    public function getParentFQCLN()
+    public function getParentFQCLN(): ?string
     {
         return $this->source->getParentFQCLN();
     }
@@ -1813,7 +1813,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return bool
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return $this->is_static;
     }
@@ -1821,7 +1821,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return StatementsSource
      */
-    public function getSource()
+    public function getSource(): StatementsSource
     {
         return $this->source;
     }
@@ -1836,7 +1836,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
      *
      * @return array<string>
      */
-    public function getSuppressedIssues()
+    public function getSuppressedIssues(): array
     {
         return $this->suppressed_issues;
     }
@@ -1892,7 +1892,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return Type\Union
      */
-    public function getLocalReturnType(Type\Union $storage_return_type, bool $final = false)
+    public function getLocalReturnType(Type\Union $storage_return_type, bool $final = false): Type\Union
     {
         if ($this->local_return_type) {
             return $this->local_return_type;

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -117,7 +117,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
 
     /**
      * @param Closure|Function_|ClassMethod|ArrowFunction $function
-     * @param SourceAnalyzer $source
      */
     protected function __construct($function, SourceAnalyzer $source, FunctionLikeStorage $storage)
     {
@@ -129,7 +128,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     }
 
     /**
-     * @param Context       $context
      * @param Context|null  $global_context
      * @param bool          $add_mutations  whether or not to add mutations to this method
      * @param ?array<string, bool> $byref_uses
@@ -428,7 +426,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         if ($storage instanceof MethodStorage) {
             $non_null_param_types = array_filter(
                 $storage->params,
-                /** @return bool */
                 function (FunctionLikeParameter $p): bool {
                     return $p->type !== null && $p->has_docblock_type;
                 }
@@ -436,7 +433,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         } else {
             $non_null_param_types = array_filter(
                 $storage->params,
-                /** @return bool */
                 function (FunctionLikeParameter $p): bool {
                     return $p->type !== null;
                 }
@@ -449,7 +445,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         ) {
             $types_without_docblocks = array_filter(
                 $storage->params,
-                /** @return bool */
                 function (FunctionLikeParameter $p): bool {
                     return !$p->type || !$p->has_docblock_type;
                 }
@@ -1577,7 +1572,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
      * Adds return types for the given function
      *
      * @param   string  $return_type
-     * @param   Context $context
      *
      * @return  void
      */
@@ -1661,7 +1655,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @param string|null $context_self
      *
-     * @return string
      */
     public function getCorrectlyCasedMethodId($context_self = null): string
     {
@@ -1683,10 +1676,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
 
         return $this->getClosureId();
     }
-
-    /**
-     * @return FunctionLikeStorage
-     */
+    
     public function getFunctionLikeStorage(StatementsAnalyzer $statements_analyzer = null): FunctionLikeStorage
     {
         $codebase = $this->codebase;
@@ -1768,17 +1758,11 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         return [];
     }
 
-    /**
-     * @return string|null
-     */
     public function getFQCLN(): ?string
     {
         return $this->source->getFQCLN();
     }
 
-    /**
-     * @return null|string
-     */
     public function getClassName(): ?string
     {
         return $this->source->getClassName();
@@ -1797,9 +1781,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         return $this->storage->template_types;
     }
 
-    /**
-     * @return string|null
-     */
     public function getParentFQCLN(): ?string
     {
         return $this->source->getParentFQCLN();
@@ -1810,17 +1791,11 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         return $this->source->getNodeTypeProvider();
     }
 
-    /**
-     * @return bool
-     */
     public function isStatic(): bool
     {
         return $this->is_static;
     }
 
-    /**
-     * @return StatementsSource
-     */
     public function getSource(): StatementsSource
     {
         return $this->source;
@@ -1889,9 +1864,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         self::$no_effects_hashes = [];
     }
 
-    /**
-     * @return Type\Union
-     */
     public function getLocalReturnType(Type\Union $storage_return_type, bool $final = false): Type\Union
     {
         if ($this->local_return_type) {

--- a/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
@@ -11,7 +11,6 @@ use Psalm\Issue\UndefinedInterface;
 class InterfaceAnalyzer extends ClassLikeAnalyzer
 {
     /**
-     * @param PhpParser\Node\Stmt\Interface_ $interface
      * @param string                         $fq_interface_name
      */
     public function __construct(PhpParser\Node\Stmt\Interface_ $interface, SourceAnalyzer $source, $fq_interface_name)

--- a/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
@@ -84,7 +84,7 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
         CodeLocation $code_location,
         array $suppressed_issues,
         &$is_dynamic_this_method = false
-    ) {
+    ): bool {
         $codebase_methods = $codebase->methods;
 
         if ($method_id->fq_class_name === 'Closure'
@@ -151,7 +151,7 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
         CodeLocation $code_location,
         array $suppressed_issues,
         ?string $calling_method_id = null
-    ) {
+    ): ?bool {
         if ($codebase->methods->methodExists(
             $method_id,
             $calling_method_id,
@@ -185,7 +185,7 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
         \Psalm\Internal\MethodIdentifier $method_id,
         Context $context,
         StatementsSource $source
-    ) {
+    ): bool {
         $codebase = $source->getCodebase();
 
         $fq_classlike_name = $method_id->fq_class_name;
@@ -274,7 +274,7 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
     public static function checkMethodSignatureMustOmitReturnType(
         MethodStorage $method_storage,
         CodeLocation $code_location
-    ) {
+    ): ?bool {
         if ($method_storage->signature_return_type === null) {
             return null;
         }
@@ -300,7 +300,7 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
      *
      * @return \Psalm\Internal\MethodIdentifier
      */
-    public function getMethodId($context_self = null)
+    public function getMethodId($context_self = null): \Psalm\Internal\MethodIdentifier
     {
         $function_name = (string)$this->function->name;
 

--- a/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
@@ -70,11 +70,9 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
      *
      * @param  bool            $self_call
      * @param  bool            $is_context_dynamic
-     * @param  CodeLocation    $code_location
      * @param  array<string>   $suppressed_issues
      * @param  bool            $is_dynamic_this_method
      *
-     * @return bool
      */
     public static function checkStatic(
         \Psalm\Internal\MethodIdentifier $method_id,
@@ -139,11 +137,9 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
     }
 
     /**
-     * @param  CodeLocation $code_location
      * @param  string[]     $suppressed_issues
      * @param  lowercase-string|null  $calling_method_id
      *
-     * @return bool|null
      */
     public static function checkMethodExists(
         Codebase $codebase,
@@ -174,13 +170,7 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
 
         return null;
     }
-
-    /**
-     * @param  Context          $context
-     * @param  StatementsSource $source
-     *
-     * @return bool
-     */
+    
     public static function isMethodVisible(
         \Psalm\Internal\MethodIdentifier $method_id,
         Context $context,
@@ -267,8 +257,6 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
      * Check that __clone, __construct, and __destruct do not have a return type
      * hint in their signature.
      *
-     * @param  MethodStorage $method_storage
-     * @param  CodeLocation  $code_location
      * @return false|null
      */
     public static function checkMethodSignatureMustOmitReturnType(
@@ -298,7 +286,6 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
     /**
      * @param string|null $context_self
      *
-     * @return \Psalm\Internal\MethodIdentifier
      */
     public function getMethodId($context_self = null): \Psalm\Internal\MethodIdentifier
     {

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -32,14 +32,7 @@ use function substr;
 class MethodComparator
 {
     /**
-     * @param  ClassLikeStorage $implementer_classlike_storage
-     * @param  ClassLikeStorage $guide_classlike_storage
-     * @param  MethodStorage    $implementer_method_storage
-     * @param  MethodStorage    $guide_method_storage
-     * @param  CodeLocation     $code_location
      * @param  string[]         $suppressed_issues
-     * @param  bool             $prevent_abstract_override
-     * @param  bool             $prevent_method_signature_mismatch
      *
      * @return false|null
      */

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -127,7 +127,7 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return string
      */
-    public function getNamespace()
+    public function getNamespace(): string
     {
         return $this->namespace_name;
     }
@@ -149,7 +149,7 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return array<string,Type\Union>
      */
-    public static function getConstantsForNamespace($namespace_name, $visibility)
+    public static function getConstantsForNamespace($namespace_name, $visibility): array
     {
         // @todo this does not allow for loading in namespace constants not already defined in the current sweep
         if (!isset(self::$public_namespace_constants[$namespace_name])) {

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -41,10 +41,6 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
      */
     protected static $public_namespace_constants = [];
 
-    /**
-     * @param Namespace_        $namespace
-     * @param FileAnalyzer       $source
-     */
     public function __construct(Namespace_ $namespace, FileAnalyzer $source)
     {
         $this->source = $source;
@@ -99,7 +95,6 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
     }
 
     /**
-     * @param  PhpParser\Node\Stmt\ClassLike $stmt
      *
      * @return void
      */
@@ -124,9 +119,6 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
         }
     }
 
-    /**
-     * @return string
-     */
     public function getNamespace(): string
     {
         return $this->namespace_name;
@@ -134,7 +126,6 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
 
     /**
      * @param string     $const_name
-     * @param Type\Union $const_type
      *
      * @return void
      */
@@ -171,7 +162,6 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * Returns true if $className is the same as, or starts with $namespace, in a case-insensitive comparison.
      *
-     * @return bool
      *
      * @psalm-pure
      */

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -321,7 +321,10 @@ class ProjectAnalyzer
                 'Composer lockfile change detected, clearing cache' . "\n"
             );
 
-            Config::removeCacheDirectory($this->config->getCacheDirectory());
+            $cache_directory = $this->config->getCacheDirectory();
+            if ($cache_directory !== null) {
+                Config::removeCacheDirectory($cache_directory);
+            }
 
             if ($this->file_reference_provider->cache) {
                 $this->file_reference_provider->cache->hasConfigChanged();
@@ -335,7 +338,10 @@ class ProjectAnalyzer
                 'Config change detected, clearing cache' . "\n"
             );
 
-            Config::removeCacheDirectory($this->config->getCacheDirectory());
+            $cache_directory = $this->config->getCacheDirectory();
+            if ($cache_directory !== null) {
+                Config::removeCacheDirectory($cache_directory);
+            }
 
             if ($this->project_cache_provider) {
                 $this->project_cache_provider->hasLockfileChanged();
@@ -348,7 +354,7 @@ class ProjectAnalyzer
      * @param  bool   $show_info
      * @return array<ReportOptions>
      */
-    public static function getFileReportOptions(array $report_file_paths, bool $show_info = true)
+    public static function getFileReportOptions(array $report_file_paths, bool $show_info = true): array
     {
         $report_options = [];
 
@@ -529,7 +535,7 @@ class ProjectAnalyzer
     /**
      * @return self
      */
-    public static function getInstance()
+    public static function getInstance(): ProjectAnalyzer
     {
         return self::$instance;
     }
@@ -539,7 +545,7 @@ class ProjectAnalyzer
      *
      * @return bool
      */
-    public function canReportIssues($file_path)
+    public function canReportIssues($file_path): bool
     {
         return isset($this->project_files[$file_path]);
     }
@@ -931,7 +937,7 @@ class ProjectAnalyzer
                     /**
                      * @return int
                      */
-                    function (FileManipulation $a, FileManipulation $b) {
+                    function (FileManipulation $a, FileManipulation $b): int {
                         if ($a->start === $b->start) {
                             if ($b->end === $a->end) {
                                 return $b->insertion_text > $a->insertion_text ? 1 : -1;
@@ -1068,7 +1074,7 @@ class ProjectAnalyzer
      *
      * @return array<int, string>
      */
-    private function getAllFiles(Config $config)
+    private function getAllFiles(Config $config): array
     {
         $file_extensions = $config->getFileExtensions();
         $file_paths = [];
@@ -1104,7 +1110,7 @@ class ProjectAnalyzer
      *
      * @return array<string>
      */
-    protected function getDiffFilesInDir($dir_name, Config $config)
+    protected function getDiffFilesInDir($dir_name, Config $config): array
     {
         $file_extensions = $config->getFileExtensions();
 
@@ -1246,7 +1252,7 @@ class ProjectAnalyzer
     /**
      * @return Config
      */
-    public function getConfig()
+    public function getConfig(): Config
     {
         return $this->config;
     }
@@ -1256,7 +1262,7 @@ class ProjectAnalyzer
      *
      * @return array<string, string>
      */
-    public function getReferencedFilesFromDiff(array $diff_files, bool $include_referencing_files = true)
+    public function getReferencedFilesFromDiff(array $diff_files, bool $include_referencing_files = true): array
     {
         $all_inherited_files_to_check = $diff_files;
 
@@ -1288,7 +1294,7 @@ class ProjectAnalyzer
      *
      * @return bool
      */
-    public function fileExists($file_path)
+    public function fileExists($file_path): bool
     {
         return $this->file_provider->fileExists($file_path);
     }
@@ -1385,7 +1391,7 @@ class ProjectAnalyzer
     /**
      * @return array<string, bool>
      */
-    public function getIssuesToFix()
+    public function getIssuesToFix(): array
     {
         return $this->issues_to_fix;
     }
@@ -1393,7 +1399,7 @@ class ProjectAnalyzer
     /**
      * @return Codebase
      */
-    public function getCodebase()
+    public function getCodebase(): Codebase
     {
         return $this->codebase;
     }
@@ -1403,7 +1409,7 @@ class ProjectAnalyzer
      *
      * @return FileAnalyzer
      */
-    public function getFileAnalyzerForClassLike($fq_class_name)
+    public function getFileAnalyzerForClassLike($fq_class_name): FileAnalyzer
     {
         $fq_class_name_lc = strtolower($fq_class_name);
 

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -247,7 +247,6 @@ class ProjectAnalyzer
 
     /**
      * @param array<ReportOptions> $generated_report_options
-     * @param int           $threads
      * @param string        $reports
      */
     public function __construct(
@@ -351,7 +350,6 @@ class ProjectAnalyzer
 
     /**
      * @param  array<string>  $report_file_paths
-     * @param  bool   $show_info
      * @return array<ReportOptions>
      */
     public static function getFileReportOptions(array $report_file_paths, bool $show_info = true): array
@@ -532,9 +530,6 @@ class ProjectAnalyzer
         }
     }
 
-    /**
-     * @return self
-     */
     public static function getInstance(): ProjectAnalyzer
     {
         return self::$instance;
@@ -543,7 +538,6 @@ class ProjectAnalyzer
     /**
      * @param  string $file_path
      *
-     * @return bool
      */
     public function canReportIssues($file_path): bool
     {
@@ -934,9 +928,6 @@ class ProjectAnalyzer
             foreach ($migration_manipulations as $file_path => $file_manipulations) {
                 usort(
                     $file_manipulations,
-                    /**
-                     * @return int
-                     */
                     function (FileManipulation $a, FileManipulation $b): int {
                         if ($a->start === $b->start) {
                             if ($b->end === $a->end) {
@@ -1047,7 +1038,6 @@ class ProjectAnalyzer
 
     /**
      * @param  string $dir_name
-     * @param  Config $config
      * @param  bool   $allow_non_project_files
      *
      * @return void
@@ -1070,7 +1060,6 @@ class ProjectAnalyzer
     }
 
     /**
-     * @param  Config $config
      *
      * @return array<int, string>
      */
@@ -1106,7 +1095,6 @@ class ProjectAnalyzer
 
     /**
      * @param  string $dir_name
-     * @param  Config $config
      *
      * @return array<string>
      */
@@ -1139,7 +1127,6 @@ class ProjectAnalyzer
     }
 
     /**
-     * @param  Config           $config
      * @param  array<string>    $file_list
      *
      * @return void
@@ -1249,9 +1236,6 @@ class ProjectAnalyzer
         }
     }
 
-    /**
-     * @return Config
-     */
     public function getConfig(): Config
     {
         return $this->config;
@@ -1292,7 +1276,6 @@ class ProjectAnalyzer
     /**
      * @param  string $file_path
      *
-     * @return bool
      */
     public function fileExists($file_path): bool
     {
@@ -1396,9 +1379,6 @@ class ProjectAnalyzer
         return $this->issues_to_fix;
     }
 
-    /**
-     * @return Codebase
-     */
     public function getCodebase(): Codebase
     {
         return $this->codebase;
@@ -1407,7 +1387,6 @@ class ProjectAnalyzer
     /**
      * @param  string $fq_class_name
      *
-     * @return FileAnalyzer
      */
     public function getFileAnalyzerForClassLike($fq_class_name): FileAnalyzer
     {
@@ -1425,7 +1404,6 @@ class ProjectAnalyzer
     }
 
     /**
-     * @param  Context  $this_context
      *
      * @return void
      */
@@ -1508,7 +1486,6 @@ class ProjectAnalyzer
      * Copyleft 2018, license: WTFPL
      * @throws \RuntimeException
      * @throws \LogicException
-     * @return int
      * @psalm-suppress ForbiddenCode
      */
     public static function getCpuCount(): int

--- a/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
@@ -36,7 +36,7 @@ class ScopeAnalyzer
      *
      * @return  bool
      */
-    public static function doesEverBreak(array $stmts)
+    public static function doesEverBreak(array $stmts): bool
     {
         if (empty($stmts)) {
             return false;
@@ -346,7 +346,7 @@ class ScopeAnalyzer
      *
      * @return  bool
      */
-    public static function onlyThrowsOrExits(\Psalm\NodeTypeProvider $type_provider, array $stmts)
+    public static function onlyThrowsOrExits(\Psalm\NodeTypeProvider $type_provider, array $stmts): bool
     {
         if (empty($stmts)) {
             return false;

--- a/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
@@ -34,7 +34,6 @@ class ScopeAnalyzer
     /**
      * @param   array<PhpParser\Node\Stmt>   $stmts
      *
-     * @return  bool
      */
     public static function doesEverBreak(array $stmts): bool
     {
@@ -344,7 +343,6 @@ class ScopeAnalyzer
     /**
      * @param   array<PhpParser\Node> $stmts
      *
-     * @return  bool
      */
     public static function onlyThrowsOrExits(\Psalm\NodeTypeProvider $type_provider, array $stmts): bool
     {

--- a/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
@@ -21,9 +21,6 @@ abstract class SourceAnalyzer implements StatementsSource
         $this->source = null;
     }
 
-    /**
-     * @return Aliases
-     */
     public function getAliases(): Aliases
     {
         return $this->source->getAliases();
@@ -45,41 +42,26 @@ abstract class SourceAnalyzer implements StatementsSource
         return $this->source->getAliasedClassesFlippedReplaceable();
     }
 
-    /**
-     * @return string|null
-     */
     public function getFQCLN(): ?string
     {
         return $this->source->getFQCLN();
     }
 
-    /**
-     * @return string|null
-     */
     public function getClassName(): ?string
     {
         return $this->source->getClassName();
     }
 
-    /**
-     * @return string|null
-     */
     public function getParentFQCLN(): ?string
     {
         return $this->source->getParentFQCLN();
     }
 
-    /**
-     * @return string
-     */
     public function getFileName(): string
     {
         return $this->source->getFileName();
     }
 
-    /**
-     * @return string
-     */
     public function getFilePath(): string
     {
         return $this->source->getFilePath();
@@ -115,7 +97,6 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @param string $file_path
      *
-     * @return bool
      */
     public function hasParentFilePath($file_path): bool
     {
@@ -125,16 +106,12 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @param string $file_path
      *
-     * @return bool
      */
     public function hasAlreadyRequiredFilePath($file_path): bool
     {
         return $this->source->hasAlreadyRequiredFilePath($file_path);
     }
 
-    /**
-     * @return int
-     */
     public function getRequireNesting(): int
     {
         return $this->source->getRequireNesting();
@@ -179,17 +156,11 @@ abstract class SourceAnalyzer implements StatementsSource
         $this->source->removeSuppressedIssues($new_issues);
     }
 
-    /**
-     * @return null|string
-     */
     public function getNamespace(): ?string
     {
         return $this->source->getNamespace();
     }
 
-    /**
-     * @return bool
-     */
     public function isStatic(): bool
     {
         return $this->source->isStatic();

--- a/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
@@ -24,7 +24,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return Aliases
      */
-    public function getAliases()
+    public function getAliases(): Aliases
     {
         return $this->source->getAliases();
     }
@@ -32,7 +32,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlipped()
+    public function getAliasedClassesFlipped(): array
     {
         return $this->source->getAliasedClassesFlipped();
     }
@@ -40,7 +40,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlippedReplaceable()
+    public function getAliasedClassesFlippedReplaceable(): array
     {
         return $this->source->getAliasedClassesFlippedReplaceable();
     }
@@ -48,7 +48,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return string|null
      */
-    public function getFQCLN()
+    public function getFQCLN(): ?string
     {
         return $this->source->getFQCLN();
     }
@@ -56,7 +56,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return string|null
      */
-    public function getClassName()
+    public function getClassName(): ?string
     {
         return $this->source->getClassName();
     }
@@ -64,7 +64,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return string|null
      */
-    public function getParentFQCLN()
+    public function getParentFQCLN(): ?string
     {
         return $this->source->getParentFQCLN();
     }
@@ -72,7 +72,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return string
      */
-    public function getFileName()
+    public function getFileName(): string
     {
         return $this->source->getFileName();
     }
@@ -80,7 +80,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return string
      */
-    public function getFilePath()
+    public function getFilePath(): string
     {
         return $this->source->getFilePath();
     }
@@ -117,7 +117,7 @@ abstract class SourceAnalyzer implements StatementsSource
      *
      * @return bool
      */
-    public function hasParentFilePath($file_path)
+    public function hasParentFilePath($file_path): bool
     {
         return $this->source->hasParentFilePath($file_path);
     }
@@ -127,7 +127,7 @@ abstract class SourceAnalyzer implements StatementsSource
      *
      * @return bool
      */
-    public function hasAlreadyRequiredFilePath($file_path)
+    public function hasAlreadyRequiredFilePath($file_path): bool
     {
         return $this->source->hasAlreadyRequiredFilePath($file_path);
     }
@@ -135,7 +135,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return int
      */
-    public function getRequireNesting()
+    public function getRequireNesting(): int
     {
         return $this->source->getRequireNesting();
     }
@@ -154,7 +154,7 @@ abstract class SourceAnalyzer implements StatementsSource
      *
      * @return array<string>
      */
-    public function getSuppressedIssues()
+    public function getSuppressedIssues(): array
     {
         return $this->source->getSuppressedIssues();
     }
@@ -182,7 +182,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return null|string
      */
-    public function getNamespace()
+    public function getNamespace(): ?string
     {
         return $this->source->getNamespace();
     }
@@ -190,7 +190,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return bool
      */
-    public function isStatic()
+    public function isStatic(): bool
     {
         return $this->source->isStatic();
     }
@@ -222,7 +222,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return array<string, array<string, array{Type\Union}>>|null
      */
-    public function getTemplateTypeMap()
+    public function getTemplateTypeMap(): ?array
     {
         return $this->source->getTemplateTypeMap();
     }

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForAnalyzer.php
@@ -18,9 +18,6 @@ use function array_intersect_key;
 class ForAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer           $statements_analyzer
-     * @param   PhpParser\Node\Stmt\For_    $stmt
-     * @param   Context                     $context
      *
      * @return  false|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForAnalyzer.php
@@ -28,7 +28,7 @@ class ForAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\For_ $stmt,
         Context $context
-    ) {
+    ): ?bool {
         $pre_assigned_var_ids = $context->assigned_var_ids;
         $context->assigned_var_ids = [];
 

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -45,9 +45,6 @@ use function array_keys;
 class ForeachAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer               $statements_analyzer
-     * @param   PhpParser\Node\Stmt\Foreach_    $stmt
-     * @param   Context                         $context
      *
      * @return  false|null
      */
@@ -1127,11 +1124,9 @@ class ForeachAnalyzer
     }
 
     /**
-     * @param  string $template_name
      * @param  array<string, array<int|string, Type\Union>>  $template_type_extends
      * @param  array<string, array<string, array{Type\Union}>>  $class_template_types
      * @param  array<int, Type\Union> $calling_type_params
-     * @return Type\Union|null
      */
     private static function getExtendedType(
         string $template_name,

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -55,7 +55,7 @@ class ForeachAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Foreach_ $stmt,
         Context $context
-    ) {
+    ): ?bool {
         $var_comments = [];
 
         $doc_comment = $stmt->getDocComment();
@@ -1140,7 +1140,7 @@ class ForeachAnalyzer
         array $template_type_extends,
         array $class_template_types = null,
         array $calling_type_params = null
-    ) {
+    ): ?Type\Union {
         if ($calling_class === $template_class) {
             if (isset($class_template_types[$template_name]) && $calling_type_params) {
                 $offset = array_search($template_name, array_keys($class_template_types));

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
@@ -65,9 +65,6 @@ class IfAnalyzer
      *   (x: null)
      *   throw new Exception -- effects: remove null from the type of x
      *
-     * @param  StatementsAnalyzer       $statements_analyzer
-     * @param  PhpParser\Node\Stmt\If_ $stmt
-     * @param  Context                 $context
      *
      * @return null|false
      */
@@ -766,12 +763,6 @@ class IfAnalyzer
     }
 
     /**
-     * @param  StatementsAnalyzer        $statements_analyzer
-     * @param  PhpParser\Node\Stmt\If_  $stmt
-     * @param  IfScope                  $if_scope
-     * @param  Context                  $if_context
-     * @param  Context                  $old_if_context
-     * @param  Context                  $outer_context
      * @param  array<string,Type\Union> $pre_assignment_else_redefined_vars
      *
      * @return false|null
@@ -1044,11 +1035,7 @@ class IfAnalyzer
     }
 
     /**
-     * @param  StatementsAnalyzer           $statements_analyzer
-     * @param  PhpParser\Node\Stmt\ElseIf_ $elseif
-     * @param  IfScope                     $if_scope
      * @param  Context                     $elseif_context
-     * @param  Context                     $outer_context
      *
      * @return false|null
      */
@@ -1533,11 +1520,7 @@ class IfAnalyzer
     }
 
     /**
-     * @param  StatementsAnalyzer         $statements_analyzer
      * @param  PhpParser\Node\Stmt\Else_|null $else
-     * @param  IfScope                   $if_scope
-     * @param  Context                   $else_context
-     * @param  Context                   $outer_context
      *
      * @return false|null
      */
@@ -1823,7 +1806,6 @@ class IfAnalyzer
      * Returns statements that are definitely evaluated before any statements after the end of the
      * if/elseif/else blocks
      *
-     * @param  PhpParser\Node\Expr $stmt
      *
      * @return PhpParser\Node\Expr|null
      */
@@ -1871,7 +1853,6 @@ class IfAnalyzer
      * Returns statements that are definitely evaluated before any statements inside
      * the if block
      *
-     * @param  PhpParser\Node\Expr $stmt
      *
      * @return PhpParser\Node\Expr|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
@@ -75,7 +75,7 @@ class IfAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\If_ $stmt,
         Context $context
-    ) {
+    ): ?bool {
         $codebase = $statements_analyzer->getCodebase();
 
         $if_scope = new IfScope();
@@ -213,7 +213,7 @@ class IfAnalyzer
 
         if (array_filter(
             $context->clauses,
-            function ($clause) {
+            function ($clause): bool {
                 return !!$clause->possibilities;
             }
         )) {
@@ -223,7 +223,7 @@ class IfAnalyzer
                  * @param array<string> $carry
                  * @return array<string>
                  */
-                function ($carry, Clause $clause) {
+                function ($carry, Clause $clause): array {
                     return array_merge($carry, array_keys($clause->possibilities));
                 },
                 []
@@ -690,7 +690,7 @@ class IfAnalyzer
              *
              * @return true
              */
-            function (Type\Union $_) {
+            function (Type\Union $_): bool {
                 return true;
             },
             array_diff_key(
@@ -1173,7 +1173,7 @@ class IfAnalyzer
         try {
             if (array_filter(
                 $entry_clauses,
-                function ($clause) {
+                function ($clause): bool {
                     return !!$clause->possibilities;
                 }
             )) {
@@ -1183,7 +1183,7 @@ class IfAnalyzer
                      * @param array<string> $carry
                      * @return array<string>
                      */
-                    function ($carry, Clause $clause) {
+                    function ($carry, Clause $clause): array {
                         return array_merge($carry, array_keys($clause->possibilities));
                     },
                     []

--- a/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
@@ -33,7 +33,6 @@ class LoopAnalyzer
      * @param  PhpParser\Node\Expr[]        $post_expressions
      * @param  Context                      loop_scope->loop_context
      * @param  Context                      $loop_scope->loop_parent_context
-     * @param  bool                         $is_do
      *
      * @return false|null
      */
@@ -605,8 +604,6 @@ class LoopAnalyzer
     }
 
     /**
-     * @param  LoopScope $loop_scope
-     * @param  Context   $pre_outer_context
      *
      * @return void
      */
@@ -648,10 +645,7 @@ class LoopAnalyzer
     }
 
     /**
-     * @param  PhpParser\Node\Expr $pre_condition
      * @param  array<int, Clause>  $pre_condition_clauses
-     * @param  Context             $loop_context
-     * @param  Context             $outer_context
      *
      * @return string[]
      */
@@ -755,7 +749,6 @@ class LoopAnalyzer
      * @param  string                               $first_var_id
      * @param  array<string, array<string, bool>>   $assignment_map
      *
-     * @return int
      */
     private static function getAssignmentMapDepth($first_var_id, array $assignment_map): int
     {

--- a/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
@@ -662,7 +662,7 @@ class LoopAnalyzer
         Context $loop_context,
         Context $outer_context,
         bool $is_do
-    ) {
+    ): array {
         $pre_referenced_var_ids = $loop_context->referenced_var_ids;
         $loop_context->referenced_var_ids = [];
 
@@ -757,7 +757,7 @@ class LoopAnalyzer
      *
      * @return int
      */
-    private static function getAssignmentMapDepth($first_var_id, array $assignment_map)
+    private static function getAssignmentMapDepth($first_var_id, array $assignment_map): int
     {
         $max_depth = 0;
 

--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
@@ -31,7 +31,7 @@ class SwitchAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Switch_ $stmt,
         Context $context
-    ) {
+    ): ?bool {
         $codebase = $statements_analyzer->getCodebase();
 
         $context->inside_conditional = true;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
@@ -21,9 +21,6 @@ use function array_merge;
 class SwitchAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer               $statements_analyzer
-     * @param   PhpParser\Node\Stmt\Switch_     $stmt
-     * @param   Context                         $context
      *
      * @return  false|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
@@ -38,7 +38,7 @@ class TryAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\TryCatch $stmt,
         Context $context
-    ) {
+    ): ?bool {
         $catch_actions = [];
         $all_catches_leave = true;
 

--- a/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
@@ -28,9 +28,6 @@ use const PHP_VERSION;
 class TryAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer               $statements_analyzer
-     * @param   PhpParser\Node\Stmt\TryCatch    $stmt
-     * @param   Context                         $context
      *
      * @return  false|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Block/WhileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/WhileAnalyzer.php
@@ -17,9 +17,6 @@ use function array_merge;
 class WhileAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer           $statements_analyzer
-     * @param   PhpParser\Node\Stmt\While_  $stmt
-     * @param   Context                     $context
      *
      * @return  false|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Block/WhileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/WhileAnalyzer.php
@@ -27,7 +27,7 @@ class WhileAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\While_ $stmt,
         Context $context
-    ) {
+    ): ?bool {
         $while_true = ($stmt->cond instanceof PhpParser\Node\Expr\ConstFetch && $stmt->cond->name->parts === ['true'])
             || ($stmt->cond instanceof PhpParser\Node\Scalar\LNumber && $stmt->cond->value > 0);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -536,7 +536,7 @@ class AssertionFinder
         bool $inside_negation = false,
         bool $cache = true,
         bool $inside_conditional = true
-    ) {
+    ): array {
         $if_types = [];
 
         $null_position = self::hasNullVariable($conditional, $source);
@@ -1172,7 +1172,7 @@ class AssertionFinder
         bool $inside_negation = false,
         bool $cache = true,
         bool $inside_conditional = true
-    ) {
+    ): array {
         $if_types = [];
 
         $null_position = self::hasNullVariable($conditional, $source);
@@ -1788,7 +1788,7 @@ class AssertionFinder
         FileSource $source,
         Codebase $codebase = null,
         $negate = false
-    ) {
+    ): array {
         $prefix = $negate ? '!' : '';
 
         $first_var_name = isset($expr->args[0]->value)
@@ -2279,7 +2279,7 @@ class AssertionFinder
         $this_class_name,
         FileSource $source,
         $negate = false
-    ) {
+    ): array {
         if (!$source instanceof StatementsAnalyzer) {
             return [];
         }
@@ -2499,7 +2499,7 @@ class AssertionFinder
     protected static function hasNullVariable(
         PhpParser\Node\Expr\BinaryOp $conditional,
         FileSource $source
-    ) {
+    ): ?int {
         if ($conditional->right instanceof PhpParser\Node\Expr\ConstFetch
             && strtolower($conditional->right->name->parts[0]) === 'null'
         ) {
@@ -2527,7 +2527,7 @@ class AssertionFinder
      *
      * @return  int|null
      */
-    public static function hasFalseVariable(PhpParser\Node\Expr\BinaryOp $conditional)
+    public static function hasFalseVariable(PhpParser\Node\Expr\BinaryOp $conditional): ?int
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\ConstFetch
             && strtolower($conditional->right->name->parts[0]) === 'false'
@@ -2549,7 +2549,7 @@ class AssertionFinder
      *
      * @return  int|null
      */
-    public static function hasTrueVariable(PhpParser\Node\Expr\BinaryOp $conditional)
+    public static function hasTrueVariable(PhpParser\Node\Expr\BinaryOp $conditional): ?int
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\ConstFetch
             && strtolower($conditional->right->name->parts[0]) === 'true'
@@ -2571,7 +2571,7 @@ class AssertionFinder
      *
      * @return  int|null
      */
-    protected static function hasEmptyArrayVariable(PhpParser\Node\Expr\BinaryOp $conditional)
+    protected static function hasEmptyArrayVariable(PhpParser\Node\Expr\BinaryOp $conditional): ?int
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\Array_
             && !$conditional->right->items
@@ -2986,7 +2986,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasNullCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasNullCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_null') {
             return true;
@@ -3003,7 +3003,7 @@ class AssertionFinder
     protected static function hasIsACheck(
         PhpParser\Node\Expr\FuncCall $stmt,
         StatementsAnalyzer $source
-    ) {
+    ): bool {
         if ($stmt->name instanceof PhpParser\Node\Name
             && (strtolower($stmt->name->parts[0]) === 'is_a'
                 || strtolower($stmt->name->parts[0]) === 'is_subclass_of')
@@ -3033,7 +3033,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasArrayCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasArrayCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_array') {
             return true;
@@ -3047,7 +3047,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasStringCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasStringCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_string') {
             return true;
@@ -3061,7 +3061,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasBoolCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasBoolCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_bool') {
             return true;
@@ -3075,7 +3075,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasObjectCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasObjectCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_object']) {
             return true;
@@ -3089,7 +3089,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasNumericCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasNumericCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_numeric']) {
             return true;
@@ -3103,7 +3103,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasIterableCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasIterableCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_iterable') {
             return true;
@@ -3117,7 +3117,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasCountableCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasCountableCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_countable') {
             return true;
@@ -3131,7 +3131,7 @@ class AssertionFinder
      *
      * @return  0|1|2
      */
-    protected static function hasClassExistsCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasClassExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): int
     {
         if ($stmt->name instanceof PhpParser\Node\Name
             && strtolower($stmt->name->parts[0]) === 'class_exists'
@@ -3159,7 +3159,7 @@ class AssertionFinder
      *
      * @return  0|1|2
      */
-    protected static function hasTraitExistsCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasTraitExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): int
     {
         if ($stmt->name instanceof PhpParser\Node\Name
             && strtolower($stmt->name->parts[0]) === 'trait_exists'
@@ -3187,7 +3187,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasInterfaceExistsCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasInterfaceExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name
             && strtolower($stmt->name->parts[0]) === 'interface_exists'
@@ -3203,7 +3203,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasFunctionExistsCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasFunctionExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'function_exists') {
             return true;
@@ -3217,7 +3217,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasIntCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasIntCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name &&
             ($stmt->name->parts === ['is_int'] ||
@@ -3235,7 +3235,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasFloatCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasFloatCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name &&
             ($stmt->name->parts === ['is_float'] ||
@@ -3253,7 +3253,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasResourceCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasResourceCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_resource']) {
             return true;
@@ -3267,7 +3267,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasScalarCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasScalarCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_scalar']) {
             return true;
@@ -3281,7 +3281,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasCallableCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasCallableCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_callable']) {
             return true;
@@ -3295,7 +3295,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasInArrayCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasInArrayCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name
             && $stmt->name->parts === ['in_array']
@@ -3318,7 +3318,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasNonEmptyCountCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasNonEmptyCountCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name
             && $stmt->name->parts === ['count']
@@ -3334,7 +3334,7 @@ class AssertionFinder
      *
      * @return  bool
      */
-    protected static function hasArrayKeyExistsCheck(PhpParser\Node\Expr\FuncCall $stmt)
+    protected static function hasArrayKeyExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['array_key_exists']) {
             return true;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -1775,9 +1775,7 @@ class AssertionFinder
     }
 
     /**
-     * @param  PhpParser\Node\Expr\FuncCall $expr
      * @param  string|null                  $this_class_name
-     * @param  FileSource                   $source
      * @param  bool                         $negate
      *
      * @return array<string, non-empty-list<non-empty-list<string>>>
@@ -2269,7 +2267,6 @@ class AssertionFinder
     /**
      * @param  PhpParser\Node\Expr\FuncCall|PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall $expr
      * @param  string|null  $this_class_name
-     * @param  FileSource   $source
      * @param  bool         $negate
      *
      * @return array<string, non-empty-list<non-empty-list<string>>>
@@ -2437,9 +2434,7 @@ class AssertionFinder
     }
 
     /**
-     * @param  PhpParser\Node\Expr\Instanceof_ $stmt
      * @param  string|null                     $this_class_name
-     * @param  FileSource                $source
      *
      * @return list<string>
      */
@@ -2490,12 +2485,7 @@ class AssertionFinder
 
         return [];
     }
-
-    /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
-     *
-     * @return  int|null
-     */
+    
     protected static function hasNullVariable(
         PhpParser\Node\Expr\BinaryOp $conditional,
         FileSource $source
@@ -2522,11 +2512,6 @@ class AssertionFinder
         return null;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
-     *
-     * @return  int|null
-     */
     public static function hasFalseVariable(PhpParser\Node\Expr\BinaryOp $conditional): ?int
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\ConstFetch
@@ -2544,11 +2529,6 @@ class AssertionFinder
         return null;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
-     *
-     * @return  int|null
-     */
     public static function hasTrueVariable(PhpParser\Node\Expr\BinaryOp $conditional): ?int
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\ConstFetch
@@ -2566,11 +2546,6 @@ class AssertionFinder
         return null;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
-     *
-     * @return  int|null
-     */
     protected static function hasEmptyArrayVariable(PhpParser\Node\Expr\BinaryOp $conditional): ?int
     {
         if ($conditional->right instanceof PhpParser\Node\Expr\Array_
@@ -2589,7 +2564,6 @@ class AssertionFinder
     }
 
     /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
      *
      * @return  false|int
      */
@@ -2617,7 +2591,6 @@ class AssertionFinder
     }
 
     /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
      *
      * @return  false|int
      */
@@ -2695,7 +2668,6 @@ class AssertionFinder
     }
 
     /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
      *
      * @return  false|int
      */
@@ -2757,7 +2729,6 @@ class AssertionFinder
     }
 
     /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
      *
      * @return  false|int
      */
@@ -2847,7 +2818,6 @@ class AssertionFinder
     }
 
     /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
      *
      * @return  false|int
      */
@@ -2897,7 +2867,6 @@ class AssertionFinder
     }
 
     /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
      *
      * @return  false|int
      */
@@ -2943,7 +2912,6 @@ class AssertionFinder
     }
 
     /**
-     * @param   PhpParser\Node\Expr\BinaryOp    $conditional
      *
      * @return  false|int
      */
@@ -2981,11 +2949,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasNullCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_null') {
@@ -2994,12 +2957,7 @@ class AssertionFinder
 
         return false;
     }
-
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
+    
     protected static function hasIsACheck(
         PhpParser\Node\Expr\FuncCall $stmt,
         StatementsAnalyzer $source
@@ -3028,11 +2986,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasArrayCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_array') {
@@ -3042,11 +2995,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasStringCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_string') {
@@ -3056,11 +3004,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasBoolCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_bool') {
@@ -3070,11 +3013,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasObjectCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_object']) {
@@ -3084,11 +3022,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasNumericCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_numeric']) {
@@ -3098,11 +3031,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasIterableCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_iterable') {
@@ -3112,11 +3040,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasCountableCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'is_countable') {
@@ -3127,7 +3050,6 @@ class AssertionFinder
     }
 
     /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
      *
      * @return  0|1|2
      */
@@ -3155,7 +3077,6 @@ class AssertionFinder
     }
 
     /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
      *
      * @return  0|1|2
      */
@@ -3182,11 +3103,6 @@ class AssertionFinder
         return 0;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasInterfaceExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name
@@ -3198,11 +3114,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasFunctionExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->parts[0]) === 'function_exists') {
@@ -3212,11 +3123,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasIntCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name &&
@@ -3230,11 +3136,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasFloatCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name &&
@@ -3248,11 +3149,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasResourceCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_resource']) {
@@ -3262,11 +3158,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasScalarCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_scalar']) {
@@ -3276,11 +3167,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasCallableCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['is_callable']) {
@@ -3290,11 +3176,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasInArrayCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name
@@ -3313,11 +3194,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasNonEmptyCountCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name
@@ -3329,11 +3205,6 @@ class AssertionFinder
         return false;
     }
 
-    /**
-     * @param   PhpParser\Node\Expr\FuncCall    $stmt
-     *
-     * @return  bool
-     */
     protected static function hasArrayKeyExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
         if ($stmt->name instanceof PhpParser\Node\Name && $stmt->name->parts === ['array_key_exists']) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -31,12 +31,6 @@ use function array_pop;
 class ArrayAssignmentAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer                  $statements_analyzer
-     * @param   PhpParser\Node\Expr\ArrayDimFetch   $stmt
-     * @param   Context                             $context
-     * @param   PhpParser\Node\Expr|null            $assign_value
-     * @param   Type\Union                          $assignment_value_type
-     *
      * @return  void
      */
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -77,7 +77,7 @@ class ArrayAssignmentAnalyzer
         ?PhpParser\Node\Expr $assign_value,
         Type\Union $assignment_type,
         Context $context
-    ) {
+    ): ?bool {
         $root_array_expr = $stmt;
 
         $child_stmts = [];

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -53,12 +53,9 @@ use Psalm\Internal\Taint\TaintNode;
 class InstancePropertyAssignmentAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer               $statements_analyzer
      * @param   PropertyFetch|PropertyProperty  $stmt
      * @param   string                          $prop_name
      * @param   PhpParser\Node\Expr|null        $assignment_value
-     * @param   Type\Union                      $assignment_value_type
-     * @param   Context                         $context
      * @param   bool                            $direct_assignment whether the variable is assigned explicitly
      *
      * @return  false|null

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -71,7 +71,7 @@ class InstancePropertyAssignmentAnalyzer
         Type\Union $assignment_value_type,
         Context $context,
         $direct_assignment = true
-    ) {
+    ): ?bool {
         $class_property_types = [];
 
         $codebase = $statements_analyzer->getCodebase();

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
@@ -28,11 +28,7 @@ use function explode;
 class StaticPropertyAssignmentAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer                         $statements_analyzer
-     * @param   PhpParser\Node\Expr\StaticPropertyFetch   $stmt
      * @param   PhpParser\Node\Expr|null                  $assignment_value
-     * @param   Type\Union                                $assignment_value_type
-     * @param   Context                                   $context
      *
      * @return  false|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -1032,7 +1032,7 @@ class AssignmentAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\AssignOp $stmt,
         Context $context
-    ) {
+    ): bool {
         $array_var_id = ExpressionIdentifier::getArrayVarId(
             $stmt->var,
             $statements_analyzer->getFQCLN(),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -46,12 +46,8 @@ use function substr;
 class AssignmentAnalyzer
 {
     /**
-     * @param  StatementsAnalyzer        $statements_analyzer
-     * @param  PhpParser\Node\Expr      $assign_var
      * @param  PhpParser\Node\Expr|null $assign_value  This has to be null to support list destructuring
      * @param  Type\Union|null          $assign_value_type
-     * @param  Context                  $context
-     * @param  ?PhpParser\Comment\Doc   $doc_comment
      *
      * @return false|Type\Union
      */
@@ -1021,13 +1017,6 @@ class AssignmentAnalyzer
         }
     }
 
-    /**
-     * @param   StatementsAnalyzer               $statements_analyzer
-     * @param   PhpParser\Node\Expr\AssignOp    $stmt
-     * @param   Context                         $context
-     *
-     * @return  bool
-     */
     public static function analyzeAssignmentOperation(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\AssignOp $stmt,
@@ -1307,11 +1296,6 @@ class AssignmentAnalyzer
         return true;
     }
 
-    /**
-     * @param   StatementsAnalyzer               $statements_analyzer
-     * @param   PhpParser\Node\Expr\AssignRef   $stmt
-     * @param   Context                         $context
-     */
     public static function analyzeAssignmentRef(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\AssignRef $stmt,
@@ -1357,11 +1341,6 @@ class AssignmentAnalyzer
     }
 
     /**
-     * @param  StatementsAnalyzer    $statements_analyzer
-     * @param  PhpParser\Node\Expr  $stmt
-     * @param  Type\Union           $by_ref_type
-     * @param  Context              $context
-     * @param  bool                 $constrain_type
      *
      * @return void
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -28,9 +28,6 @@ use function strlen;
 class ConcatAnalyzer
 {
     /**
-     * @param  StatementsAnalyzer     $statements_analyzer
-     * @param  PhpParser\Node\Expr   $left
-     * @param  PhpParser\Node\Expr   $right
      * @param  Type\Union|null       &$result_type
      *
      * @return void

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -46,8 +46,6 @@ use function explode;
 class ArgumentAnalyzer
 {
     /**
-     * @param  ?string $self_fq_class_name
-     * @param  ?string $static_fq_class_name
      * @param  array<string, array<string, array{Type\Union, 1?:int}>> $class_generic_params
      * @return false|null
      */
@@ -145,8 +143,6 @@ class ArgumentAnalyzer
     }
 
     /**
-     * @param  ?string $self_fq_class_name
-     * @param  ?string $static_fq_class_name
      * @param  array<string, array<string, array{Type\Union, 1?:int}>> $class_generic_params
      * @param  array<string, array<string, array{Type\Union, 1?:int}>> $generic_params
      * @param  array<string, array<string, array{Type\Union}>> $template_types

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -42,12 +42,9 @@ use function is_string;
 class ArgumentsAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer                       $statements_analyzer
      * @param   array<int, PhpParser\Node\Arg>          $args
      * @param   array<int, FunctionLikeParameter>|null  $function_params
      * @param   array<string, array<string, array{Type\Union, 1?:int}>>|null   $generic_params
-     * @param   string|null                             $method_id
-     * @param   Context                                 $context
      *
      * @return  false|null
      */
@@ -365,14 +362,11 @@ class ArgumentsAnalyzer
     }
 
     /**
-     * @param   StatementsAnalyzer                       $statements_analyzer
      * @param   array<int, PhpParser\Node\Arg>          $args
      * @param   string|MethodIdentifier|null  $method_id
      * @param   array<int,FunctionLikeParameter>        $function_params
      * @param   FunctionLikeStorage|null                $function_storage
      * @param   ClassLikeStorage|null                   $class_storage
-     * @param   CodeLocation                            $code_location
-     * @param   Context                                 $context
      *
      * @return  false|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
@@ -43,7 +43,6 @@ use Psalm\Internal\Type\TypeExpander;
 class ArrayFunctionArgumentsAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer              $statements_analyzer
      * @param   array<int, PhpParser\Node\Arg> $args
      * @param   string                         $method_id
      *
@@ -122,9 +121,7 @@ class ArrayFunctionArgumentsAnalyzer
     }
 
     /**
-     * @param   StatementsAnalyzer                      $statements_analyzer
      * @param   array<int, PhpParser\Node\Arg>          $args
-     * @param   Context                                 $context
      *
      * @return  false|null
      */
@@ -323,9 +320,7 @@ class ArrayFunctionArgumentsAnalyzer
     }
 
     /**
-     * @param   StatementsAnalyzer                      $statements_analyzer
      * @param   array<int, PhpParser\Node\Arg>          $args
-     * @param   Context                                 $context
      *
      * @return  false|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
@@ -26,7 +26,7 @@ class ClassTemplateParamCollector
         string $method_name = null,
         Type\Atomic $lhs_type_part = null,
         string $lhs_var_id = null
-    ) {
+    ): ?array {
         $static_fq_class_name = $static_class_storage->name;
 
         $non_trait_class_storage = $class_storage->is_trait

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -517,7 +517,7 @@ class FunctionCallAnalyzer extends CallAnalyzer
         PhpParser\Node\Expr\FuncCall $real_stmt,
         PhpParser\Node\Expr $function_name,
         Context $context
-    ) {
+    ): array {
         $function_params = null;
 
         $explicit_function_name = null;
@@ -853,7 +853,7 @@ class FunctionCallAnalyzer extends CallAnalyzer
                 $context->vars_in_scope,
                 $changed_var_ids,
                 array_map(
-                    function ($v) {
+                    function ($v): bool {
                         return true;
                     },
                     $assert_type_assertions

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -44,10 +44,6 @@ use function count;
 class AtomicMethodCallAnalyzer extends CallAnalyzer
 {
     /**
-     * @param  StatementsAnalyzer             $statements_analyzer
-     * @param  PhpParser\Node\Expr\MethodCall $stmt
-     * @param  Codebase                       $codebase
-     * @param  Context                        $context
      * @param  Type\Atomic\TNamedObject|Type\Atomic\TTemplateParam  $static_type
      * @param  ?string                        $lhs_var_id
      */
@@ -1056,8 +1052,6 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
      * If an `@property` annotation is specified, the setter must set something with the correct
      * type.
      *
-     * @param StatementsAnalyzer $statements_analyzer
-     * @param PhpParser\Node\Expr\MethodCall $stmt
      * @param string $fq_class_name
      */
     private static function getMagicGetterOrSetterProperty(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
@@ -24,7 +24,7 @@ class MethodCallProhibitionAnalyzer
         ?string $namespace,
         CodeLocation $code_location,
         array $suppressed_issues
-    ) {
+    ): ?bool {
         $codebase_methods = $codebase->methods;
 
         $method_id = $codebase_methods->getDeclaringMethodId($method_id);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
@@ -12,7 +12,6 @@ use Psalm\IssueBuffer;
 class MethodCallProhibitionAnalyzer
 {
     /**
-     * @param  CodeLocation $code_location
      * @param  string[]     $suppressed_issues
      *
      * @return false|null

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
@@ -26,7 +26,7 @@ class MethodVisibilityAnalyzer
         StatementsSource $source,
         CodeLocation $code_location,
         array $suppressed_issues
-    ) {
+    ): ?bool {
         $codebase = $source->getCodebase();
         $codebase_methods = $codebase->methods;
         $codebase_classlikes = $codebase->classlikes;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
@@ -13,9 +13,6 @@ use function strtolower;
 class MethodVisibilityAnalyzer
 {
     /**
-     * @param  Context          $context
-     * @param  StatementsSource $source
-     * @param  CodeLocation     $code_location
      * @param  string[]         $suppressed_issues
      *
      * @return false|null

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -150,7 +150,7 @@ class MissingMethodCallHandler
             /**
              * @return PhpParser\Node\Expr\ArrayItem
              */
-            function (PhpParser\Node\Arg $arg) {
+            function (PhpParser\Node\Arg $arg): PhpParser\Node\Expr\ArrayItem {
                 return new PhpParser\Node\Expr\ArrayItem($arg->value);
             },
             $stmt->args

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -32,11 +32,6 @@ use function array_reduce;
  */
 class MethodCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer
 {
-    /**
-     * @param   StatementsAnalyzer               $statements_analyzer
-     * @param   PhpParser\Node\Expr\MethodCall  $stmt
-     * @param   Context                         $context
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\MethodCall $stmt,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -708,7 +708,7 @@ class NewAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAna
         array $template_type_extends,
         array $found_generic_params,
         bool $mapped = false
-    ) {
+    ): Type\Union {
         if (isset($found_generic_params[$template_name][$fq_class_name])) {
             if (!$mapped && isset($template_type_extends[$fq_class_name][$template_name])) {
                 foreach ($template_type_extends[$fq_class_name][$template_name]->getAtomicTypes() as $t) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -697,10 +697,8 @@ class NewAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAna
     }
 
     /**
-     * @param  string $template_name
      * @param  array<string, array<int|string, Type\Union>>  $template_type_extends
      * @param  array<string, array<string, array{Type\Union}>>  $found_generic_params
-     * @return Type\Union
      */
     private static function getGenericParamForOffset(
         string $fq_class_name,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
@@ -498,7 +498,7 @@ class StaticCallAnalyzer extends CallAnalyzer
                                 $mixin_candidates[] = clone $mixin_candidate;
                             }
 
-                            $mixin_candidates_no_generic = array_filter($mixin_candidates, function ($check) {
+                            $mixin_candidates_no_generic = array_filter($mixin_candidates, function ($check): bool {
                                 return !($check instanceof Type\Atomic\TGenericObject);
                             });
 
@@ -669,7 +669,7 @@ class StaticCallAnalyzer extends CallAnalyzer
                             /**
                              * @return PhpParser\Node\Expr\ArrayItem
                              */
-                            function (PhpParser\Node\Arg $arg) {
+                            function (PhpParser\Node\Arg $arg): PhpParser\Node\Expr\ArrayItem {
                                 return new PhpParser\Node\Expr\ArrayItem($arg->value);
                             },
                             $args

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -436,7 +436,7 @@ class CallAnalyzer
     public static function getFunctionIdsFromCallableArg(
         \Psalm\FileSource $file_source,
         $callable_arg
-    ) {
+    ): array {
         if ($callable_arg instanceof PhpParser\Node\Expr\BinaryOp\Concat) {
             if ($callable_arg->left instanceof PhpParser\Node\Expr\ClassConstFetch
                 && $callable_arg->left->class instanceof PhpParser\Node\Name
@@ -547,7 +547,7 @@ class CallAnalyzer
         &$function_id,
         CodeLocation $code_location,
         $can_be_in_root_scope
-    ) {
+    ): bool {
         $cased_function_id = $function_id;
         $function_id = strtolower($function_id);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -37,9 +37,6 @@ use function array_merge;
 class CallAnalyzer
 {
     /**
-     * @param   FunctionLikeAnalyzer $source
-     * @param   string              $method_name
-     * @param   Context             $context
      *
      * @return  void
      */
@@ -237,9 +234,6 @@ class CallAnalyzer
 
     /**
      * @param  array<int, PhpParser\Node\Arg>   $args
-     * @param  Context                          $context
-     * @param  CodeLocation                     $code_location
-     * @param  StatementsAnalyzer               $statements_analyzer
      */
     public static function checkMethodArgs(
         ?\Psalm\Internal\MethodIdentifier $method_id,
@@ -535,12 +529,9 @@ class CallAnalyzer
     }
 
     /**
-     * @param  StatementsAnalyzer   $statements_analyzer
      * @param  non-empty-string     $function_id
-     * @param  CodeLocation         $code_location
      * @param  bool                 $can_be_in_root_scope if true, the function can be shortened to the root version
      *
-     * @return bool
      */
     public static function checkFunctionExists(
         StatementsAnalyzer $statements_analyzer,
@@ -586,9 +577,7 @@ class CallAnalyzer
      * @param  \Psalm\Storage\Assertion[] $assertions
      * @param  string $thisName
      * @param  array<int, PhpParser\Node\Arg> $args
-     * @param  Context           $context
      * @param  array<string, array<string, array{Type\Union}>> $template_type_map,
-     * @param  StatementsAnalyzer $statements_analyzer
      *
      * @return void
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/EmptyAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/EmptyAnalyzer.php
@@ -10,13 +10,6 @@ use Psalm\Type;
 
 class EmptyAnalyzer
 {
-    /**
-     * @param   StatementsAnalyzer           $statements_analyzer
-     * @param   PhpParser\Node\Expr\Empty_  $stmt
-     * @param   Context                     $context
-     *
-     * @return  void
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\Empty_ $stmt,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
@@ -14,12 +14,10 @@ use function implode;
 class ExpressionIdentifier
 {
     /**
-     * @param  PhpParser\Node\Expr      $stmt
      * @param  string|null              $this_class_name
      * @param  FileSource|null    $source
      * @param  int|null                 &$nesting
      *
-     * @return string|null
      */
     public static function getVarId(
         PhpParser\Node\Expr $stmt,
@@ -75,11 +73,9 @@ class ExpressionIdentifier
     }
 
     /**
-     * @param  PhpParser\Node\Expr      $stmt
      * @param  string|null              $this_class_name
      * @param  FileSource|null    $source
      *
-     * @return string|null
      */
     public static function getRootVarId(
         PhpParser\Node\Expr $stmt,
@@ -108,11 +104,9 @@ class ExpressionIdentifier
     }
 
     /**
-     * @param  PhpParser\Node\Expr      $stmt
      * @param  string|null              $this_class_name
      * @param  FileSource|null    $source
      *
-     * @return string|null
      */
     public static function getArrayVarId(
         PhpParser\Node\Expr $stmt,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
@@ -26,7 +26,7 @@ class ExpressionIdentifier
         $this_class_name,
         FileSource $source = null,
         &$nesting = null
-    ) {
+    ): ?string {
         if ($stmt instanceof PhpParser\Node\Expr\Variable && is_string($stmt->name)) {
             return '$' . $stmt->name;
         }
@@ -85,7 +85,7 @@ class ExpressionIdentifier
         PhpParser\Node\Expr $stmt,
         $this_class_name,
         FileSource $source = null
-    ) {
+    ): ?string {
         if ($stmt instanceof PhpParser\Node\Expr\Variable
             || $stmt instanceof PhpParser\Node\Expr\StaticPropertyFetch
         ) {
@@ -118,7 +118,7 @@ class ExpressionIdentifier
         PhpParser\Node\Expr $stmt,
         $this_class_name,
         FileSource $source = null
-    ) {
+    ): ?string {
         if ($stmt instanceof PhpParser\Node\Expr\Assign) {
             return self::getArrayVarId($stmt->var, $this_class_name, $source);
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -369,7 +369,7 @@ class ArrayFetchAnalyzer
         Context $context,
         PhpParser\Node\Expr $assign_value = null,
         Type\Union $replacement_type = null
-    ) {
+    ): Type\Union {
         $codebase = $statements_analyzer->getCodebase();
 
         $has_array_access = false;
@@ -1587,7 +1587,7 @@ class ArrayFetchAnalyzer
     /**
      * @return Type\Union
      */
-    public static function replaceOffsetTypeWithInts(Type\Union $offset_type)
+    public static function replaceOffsetTypeWithInts(Type\Union $offset_type): Type\Union
     {
         $offset_types = $offset_type->getAtomicTypes();
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -350,15 +350,7 @@ class ArrayFetchAnalyzer
             $stmt_type->parent_nodes = [$new_parent_node];
         }
     }
-
-    /**
-     * @param  Type\Union $array_type
-     * @param  Type\Union $offset_type
-     * @param  bool       $in_assignment
-     * @param  null|string    $array_var_id
-     *
-     * @return Type\Union
-     */
+    
     public static function getArrayAccessTypeGivenOffset(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\ArrayDimFetch $stmt,
@@ -1583,10 +1575,7 @@ class ArrayFetchAnalyzer
             }
         }
     }
-
-    /**
-     * @return Type\Union
-     */
+    
     public static function replaceOffsetTypeWithInts(Type\Union $offset_type): Type\Union
     {
         $offset_types = $offset_type->getAtomicTypes();

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
@@ -26,9 +26,6 @@ use function array_pop;
 class ConstFetchAnalyzer
 {
     /**
-     * @param   StatementsAnalyzer               $statements_analyzer
-     * @param   PhpParser\Node\Expr\ConstFetch  $stmt
-     * @param   Context                         $context
      *
      * @return  void
      */
@@ -82,11 +79,9 @@ class ConstFetchAnalyzer
     }
 
     /**
-     * @param  Codebase $codebase
      * @param  ?string  $fq_const_name
      * @param  string   $const_name
      *
-     * @return Type\Union|null
      */
     public static function getGlobalConstType(
         Codebase $codebase,
@@ -177,11 +172,8 @@ class ConstFetchAnalyzer
     }
 
     /**
-     * @param   string  $const_name
-     * @param   bool    $is_fully_qualified
      * @param   Context $context
      *
-     * @return  Type\Union|null
      */
     public static function getConstType(
         StatementsAnalyzer $statements_analyzer,
@@ -241,9 +233,6 @@ class ConstFetchAnalyzer
     }
 
     /**
-     * @param   string      $const_name
-     * @param   Type\Union  $const_type
-     * @param   Context     $context
      *
      * @return  void
      */
@@ -289,8 +278,6 @@ class ConstFetchAnalyzer
     }
 
     /**
-     * @param   PhpParser\Node\Stmt\Const_  $stmt
-     * @param   Context                     $context
      *
      * @return  void
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
@@ -92,7 +92,7 @@ class ConstFetchAnalyzer
         Codebase $codebase,
         $fq_const_name,
         $const_name
-    ) {
+    ): ?Type\Union {
         if ($const_name === 'STDERR'
             || $const_name === 'STDOUT'
             || $const_name === 'STDIN'
@@ -188,7 +188,7 @@ class ConstFetchAnalyzer
         string $const_name,
         bool $is_fully_qualified,
         ?Context $context
-    ) {
+    ): ?Type\Union {
         $aliased_constants = $statements_analyzer->getAliases()->constants;
 
         if (isset($aliased_constants[$const_name])) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
@@ -24,11 +24,6 @@ use function explode;
  */
 class StaticPropertyFetchAnalyzer
 {
-    /**
-     * @param   StatementsAnalyzer                       $statements_analyzer
-     * @param   PhpParser\Node\Expr\StaticPropertyFetch $stmt
-     * @param   Context                                 $context
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\StaticPropertyFetch $stmt,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -39,9 +39,6 @@ class VariableFetchAnalyzer
     ];
 
     /**
-     * @param   StatementsAnalyzer               $statements_analyzer
-     * @param   PhpParser\Node\Expr\Variable    $stmt
-     * @param   Context                         $context
      * @param   bool                            $passed_by_reference
      * @param   Type\Union|null                 $by_ref_type
      * @param   bool                            $array_assignment

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -245,10 +245,8 @@ class IncludeAnalyzer
     }
 
     /**
-     * @param  PhpParser\Node\Expr $stmt
      * @param  string              $file_name
      *
-     * @return string|null
      * @psalm-suppress MixedAssignment
      */
     public static function getPathTo(
@@ -358,7 +356,6 @@ class IncludeAnalyzer
      * @param   string  $file_name
      * @param   string  $current_directory
      *
-     * @return  string|null
      */
     public static function resolveIncludePath($file_name, $current_directory): ?string
     {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -257,7 +257,7 @@ class IncludeAnalyzer
         ?StatementsAnalyzer $statements_analyzer,
         $file_name,
         Config $config
-    ) {
+    ): ?string {
         if (DIRECTORY_SEPARATOR === '/') {
             $is_path_relative = $file_name[0] !== DIRECTORY_SEPARATOR;
         } else {
@@ -360,7 +360,7 @@ class IncludeAnalyzer
      *
      * @return  string|null
      */
-    public static function resolveIncludePath($file_name, $current_directory)
+    public static function resolveIncludePath($file_name, $current_directory): ?string
     {
         if (!$current_directory) {
             return $file_name;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
@@ -10,9 +10,6 @@ use Psalm\Type;
 class IssetAnalyzer
 {
     /**
-     * @param  StatementsAnalyzer          $statements_analyzer
-     * @param  PhpParser\Node\Expr\Isset_ $stmt
-     * @param  Context                    $context
      *
      * @return void
      */

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/MatchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/MatchAnalyzer.php
@@ -230,7 +230,7 @@ class MatchAnalyzer
         }
 
         $array_items = array_map(
-            function ($cond) {
+            function ($cond): PhpParser\Node\Expr\ArrayItem {
                 return new PhpParser\Node\Expr\ArrayItem($cond, null, false, $cond->getAttributes());
             },
             $conds

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -29,7 +29,7 @@ class SimpleTypeInferer
         \Psalm\FileSource $file_source = null,
         array $existing_class_constants = null,
         $fq_classlike_name = null
-    ) {
+    ): ?Type\Union {
         if ($stmt instanceof PhpParser\Node\Expr\BinaryOp) {
             if ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Concat) {
                 $left = self::infer(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -15,11 +15,9 @@ use function reset;
 class SimpleTypeInferer
 {
     /**
-     * @param   PhpParser\Node\Expr $stmt
      * @param   ?array<string, Type\Union> $existing_class_constants
      * @param   string $fq_classlike_name
      *
-     * @return  Type\Union|null
      */
     public static function infer(
         \Psalm\Codebase $codebase,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php
@@ -19,11 +19,6 @@ use Psalm\Type;
 
 class YieldAnalyzer
 {
-    /**
-     * @param   StatementsAnalyzer           $statements_analyzer
-     * @param   PhpParser\Node\Expr\Yield_  $stmt
-     * @param   Context                     $context
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\Yield_ $stmt,

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -404,7 +404,7 @@ class ExpressionAnalyzer
      *
      * @return bool
      */
-    public static function isMock($fq_class_name)
+    public static function isMock($fq_class_name): bool
     {
         return in_array(strtolower($fq_class_name), Config::getInstance()->getMockClasses(), true);
     }

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -25,12 +25,6 @@ use function get_class;
  */
 class ExpressionAnalyzer
 {
-    /**
-     * @param   StatementsAnalyzer   $statements_analyzer
-     * @param   PhpParser\Node\Expr $stmt
-     * @param   Context             $context
-     * @param   bool                $array_assignment
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr $stmt,
@@ -402,7 +396,6 @@ class ExpressionAnalyzer
     /**
      * @param  string  $fq_class_name
      *
-     * @return bool
      */
     public static function isMock($fq_class_name): bool
     {

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -35,8 +35,6 @@ use function strtolower;
 class ReturnAnalyzer
 {
     /**
-     * @param  PhpParser\Node\Stmt\Return_ $stmt
-     * @param  Context                     $context
      *
      * @return false|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -44,7 +44,7 @@ class ReturnAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Return_ $stmt,
         Context $context
-    ) {
+    ): ?bool {
         $doc_comment = $stmt->getDocComment();
 
         $var_comments = [];

--- a/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
@@ -25,7 +25,7 @@ class StaticAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Static_ $stmt,
         Context $context
-    ) {
+    ): ?bool {
         $codebase = $statements_analyzer->getCodebase();
 
         if ($context->mutation_free) {

--- a/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
@@ -16,8 +16,6 @@ use function is_string;
 class StaticAnalyzer
 {
     /**
-     * @param   PhpParser\Node\Stmt\Static_ $stmt
-     * @param   Context                     $context
      *
      * @return  false|null
      */

--- a/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
@@ -244,7 +244,7 @@ class UnusedAssignmentRemover
      *          1: PhpParser\Node\Expr\Assign|PhpParser\Node\Expr\AssignOp|PhpParser\Node\Expr\AssignRef|null
      *          }
      */
-    private function findAssignStmt(array $stmts, string $var_id, CodeLocation $original_location)
+    private function findAssignStmt(array $stmts, string $var_id, CodeLocation $original_location): array
     {
         $assign_stmt = null;
         $assign_exp = null;
@@ -344,7 +344,7 @@ class UnusedAssignmentRemover
         string $var_id,
         int $var_start_loc,
         int $search_level = 1
-    ) {
+    ): array {
         if ($current_node instanceof PhpParser\Node\Expr\Assign
             || $current_node instanceof PhpPArser\Node\Expr\AssignOp
             || $current_node instanceof PhpParser\Node\Expr\AssignRef

--- a/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
@@ -29,7 +29,6 @@ class UnusedAssignmentRemover
      * @param array<PhpParser\Node\Stmt>   $stmts
      * @param array<string, CodeLocation> $var_loc_map
      *
-     * @return void
      */
     public function findUnusedAssignment(
         Codebase $codebase,
@@ -116,13 +115,7 @@ class UnusedAssignmentRemover
             $this->removed_unref_vars[$var_id] = $original_location;
         }
     }
-
-    /**
-     * @param  CodeLocation   $var_loc
-     * @param  int  $end_bound
-     * @param  bool   $assign_ref
-     * @return FileManipulation
-     */
+    
     private function getPartialRemovalBounds(
         Codebase $codebase,
         CodeLocation $var_loc,
@@ -178,7 +171,6 @@ class UnusedAssignmentRemover
     /**
      * @param  PhpParser\Node\Expr\Assign|PhpParser\Node\Expr\AssignOp|PhpParser\Node\Expr\AssignRef $cur_assign
      * @param  array<string, CodeLocation>    $var_loc_map
-     * @return void
      */
     private function markRemovedChainAssignVar(PhpParser\Node\Expr $cur_assign, array $var_loc_map): void
     {
@@ -201,7 +193,6 @@ class UnusedAssignmentRemover
     /**
      * @param  PhpParser\Node\Expr\Assign|PhpParser\Node\Expr\AssignOp|PhpParser\Node\Expr\AssignRef $cur_assign
      * @param  array<string, CodeLocation> $var_loc_map
-     * @return bool
      */
     private function checkRemovableChainAssignment(PhpParser\Node\Expr $cur_assign, array $var_loc_map): bool
     {
@@ -237,8 +228,6 @@ class UnusedAssignmentRemover
 
     /**
      * @param  array<PhpParser\Node\Stmt>   $stmts
-     * @param  string   $var_id
-     * @param  CodeLocation   $original_location
      * @return array{
      *          0: PhpParser\Node\Stmt|null,
      *          1: PhpParser\Node\Expr\Assign|PhpParser\Node\Expr\AssignOp|PhpParser\Node\Expr\AssignRef|null
@@ -330,10 +319,6 @@ class UnusedAssignmentRemover
     }
 
     /**
-     * @param  PhpParser\Node\Expr $current_node
-     * @param  string   $var_id
-     * @param  int      $var_start_loc
-     * @param  int     $search_level
      * @return array{
      *          0: PhpParser\Node\Expr\Assign|PhpParser\Node\Expr\AssignOp|PhpParser\Node\Expr\AssignRef|null,
      *          1: int
@@ -365,11 +350,7 @@ class UnusedAssignmentRemover
             return [null, $search_level];
         }
     }
-
-    /**
-     * @param  CodeLocation $var_loc
-     * @return bool
-     */
+    
     public function checkIfVarRemoved(string $var_id, CodeLocation $var_loc): bool
     {
         return array_key_exists($var_id, $this->removed_unref_vars)

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -123,10 +123,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
 
     /** @var \Psalm\Internal\Provider\NodeDataProvider */
     public $node_data;
-
-    /**
-     * @param SourceAnalyzer $source
-     */
+    
     public function __construct(SourceAnalyzer $source, \Psalm\Internal\Provider\NodeDataProvider $node_data)
     {
         $this->source = $source;
@@ -139,7 +136,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
      * Checks an array of statements for validity
      *
      * @param  array<PhpParser\Node\Stmt>   $stmts
-     * @param  Context                                          $context
      * @param  Context|null                                     $global_context
      * @param  bool                                             $root_scope
      *
@@ -721,7 +717,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @param  string       $var_name
      *
-     * @return bool
      */
     public function hasVariable($var_name): bool
     {
@@ -730,7 +725,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
 
     /**
      * @param  string       $var_id
-     * @param  CodeLocation $location
      * @param  int|null     $branch_point
      *
      * @return void
@@ -748,7 +742,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
 
     /**
      * @param  string       $var_id
-     * @param  CodeLocation $location
      *
      * @return void
      */
@@ -782,7 +775,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @param  string  $var_id
      *
-     * @return CodeLocation|null
      */
     public function getFirstAppearance($var_id): ?CodeLocation
     {
@@ -792,7 +784,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @param  string $var_id
      *
-     * @return int|null
      */
     public function getBranchPoint($var_id): ?int
     {

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -355,7 +355,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
                          *
                          * @return string
                          */
-                        function ($line) {
+                        function ($line): string {
                             return preg_split('/[\s]+/', $line)[0];
                         },
                         $statements_analyzer->parsed_docblock->tags['psalm-suppress']
@@ -723,7 +723,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return bool
      */
-    public function hasVariable($var_name)
+    public function hasVariable($var_name): bool
     {
         return isset($this->all_vars[$var_name]);
     }
@@ -772,7 +772,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return array<string, array{0: string, 1: CodeLocation}>
      */
-    public function getUnusedVarLocations()
+    public function getUnusedVarLocations(): array
     {
         return \array_diff_key($this->unused_var_locations, $this->used_var_locations);
     }
@@ -784,7 +784,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return CodeLocation|null
      */
-    public function getFirstAppearance($var_id)
+    public function getFirstAppearance($var_id): ?CodeLocation
     {
         return isset($this->all_vars[$var_id]) ? $this->all_vars[$var_id] : null;
     }
@@ -794,7 +794,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return int|null
      */
-    public function getBranchPoint($var_id)
+    public function getBranchPoint($var_id): ?int
     {
         return isset($this->var_branch_points[$var_id]) ? $this->var_branch_points[$var_id] : null;
     }
@@ -823,7 +823,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return array<string, FunctionAnalyzer>
      */
-    public function getFunctionAnalyzers()
+    public function getFunctionAnalyzers(): array
     {
         return $this->function_analyzers;
     }
@@ -840,7 +840,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return array<string, array<array-key, CodeLocation>>
      */
-    public function getUncaughtThrows(Context $context)
+    public function getUncaughtThrows(Context $context): array
     {
         $uncaught_throws = [];
 
@@ -899,7 +899,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
         return $this->parsed_docblock;
     }
 
-    public function getFQCLN()
+    public function getFQCLN(): ?string
     {
         if ($this->fake_this_class) {
             return $this->fake_this_class;

--- a/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
@@ -33,17 +33,11 @@ class TraitAnalyzer extends ClassLikeAnalyzer
         $this->aliases = $aliases;
     }
 
-    /**
-     * @return null|string
-     */
     public function getNamespace(): ?string
     {
         return $this->aliases->namespace;
     }
 
-    /**
-     * @return Aliases
-     */
     public function getAliases(): Aliases
     {
         return $this->aliases;

--- a/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
@@ -36,7 +36,7 @@ class TraitAnalyzer extends ClassLikeAnalyzer
     /**
      * @return null|string
      */
-    public function getNamespace()
+    public function getNamespace(): ?string
     {
         return $this->aliases->namespace;
     }
@@ -44,7 +44,7 @@ class TraitAnalyzer extends ClassLikeAnalyzer
     /**
      * @return Aliases
      */
-    public function getAliases()
+    public function getAliases(): Aliases
     {
         return $this->aliases;
     }
@@ -52,7 +52,7 @@ class TraitAnalyzer extends ClassLikeAnalyzer
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlipped()
+    public function getAliasedClassesFlipped(): array
     {
         return [];
     }
@@ -60,7 +60,7 @@ class TraitAnalyzer extends ClassLikeAnalyzer
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlippedReplaceable()
+    public function getAliasedClassesFlippedReplaceable(): array
     {
         return [];
     }

--- a/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
@@ -82,7 +82,7 @@ class TypeAnalyzer
      *
      * @return array<string, Type\Union>
      */
-    public static function combineKeyedTypes(array $new_types, array $existing_types)
+    public static function combineKeyedTypes(array $new_types, array $existing_types): array
     {
         $keys = array_merge(array_keys($new_types), array_keys($existing_types));
         $keys = array_unique($keys);

--- a/src/Psalm/Internal/Clause.php
+++ b/src/Psalm/Internal/Clause.php
@@ -117,7 +117,7 @@ class Clause
      *
      * @return bool
      */
-    public function contains(Clause $other_clause)
+    public function contains(Clause $other_clause): bool
     {
         if (count($other_clause->possibilities) > count($this->possibilities)) {
             return false;
@@ -132,7 +132,7 @@ class Clause
         return true;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return implode(
             ' || ',
@@ -143,7 +143,7 @@ class Clause
                  *
                  * @return string
                  */
-                function ($var_id, $values) {
+                function ($var_id, $values): string {
                     return implode(
                         ' || ',
                         array_map(

--- a/src/Psalm/Internal/Clause.php
+++ b/src/Psalm/Internal/Clause.php
@@ -112,11 +112,6 @@ class Clause
         }
     }
 
-    /**
-     * @param  Clause $other_clause
-     *
-     * @return bool
-     */
     public function contains(Clause $other_clause): bool
     {
         if (count($other_clause->possibilities) > count($this->possibilities)) {

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -224,7 +224,7 @@ class Analyzer
      *
      * @return bool
      */
-    public function canReportIssues($file_path)
+    public function canReportIssues($file_path): bool
     {
         return isset($this->files_with_analysis_results[$file_path]);
     }
@@ -235,8 +235,11 @@ class Analyzer
      *
      * @return FileAnalyzer
      */
-    private function getFileAnalyzer(ProjectAnalyzer $project_analyzer, $file_path, array $filetype_analyzers)
-    {
+    private function getFileAnalyzer(
+        ProjectAnalyzer $project_analyzer,
+        $file_path,
+        array $filetype_analyzers
+    ): FileAnalyzer {
         $extension = (string) (pathinfo($file_path)['extension'] ?? '');
 
         $file_name = $this->config->shortenFileName($file_path);
@@ -1077,7 +1080,7 @@ class Analyzer
      *
      * @return array{0:int, 1:int}
      */
-    public function getMixedCountsForFile($file_path)
+    public function getMixedCountsForFile($file_path): array
     {
         if (!isset($this->mixed_counts[$file_path])) {
             $this->mixed_counts[$file_path] = [0, 0];
@@ -1154,7 +1157,7 @@ class Analyzer
     /**
      * @return array<string, array{0: int, 1: int}>
      */
-    public function getMixedCounts()
+    public function getMixedCounts(): array
     {
         $all_deep_scanned_files = [];
 
@@ -1168,7 +1171,7 @@ class Analyzer
     /**
      * @return array<string, float>
      */
-    public function getFunctionTimings()
+    public function getFunctionTimings(): array
     {
         return $this->function_timings;
     }
@@ -1248,7 +1251,7 @@ class Analyzer
     /**
      * @return array{int, int}
      */
-    public function getTotalTypeCoverage(\Psalm\Codebase $codebase)
+    public function getTotalTypeCoverage(\Psalm\Codebase $codebase): array
     {
         $mixed_count = 0;
         $nonmixed_count = 0;
@@ -1272,7 +1275,7 @@ class Analyzer
     /**
      * @return string
      */
-    public function getTypeInferenceSummary(\Psalm\Codebase $codebase)
+    public function getTypeInferenceSummary(\Psalm\Codebase $codebase): string
     {
         $all_deep_scanned_files = [];
 
@@ -1307,7 +1310,7 @@ class Analyzer
     /**
      * @return string
      */
-    public function getNonMixedStats()
+    public function getNonMixedStats(): string
     {
         $stats = '';
 
@@ -1390,7 +1393,7 @@ class Analyzer
             /**
              * @return int
              */
-            function (FileManipulation $a, FileManipulation $b) {
+            function (FileManipulation $a, FileManipulation $b): int {
                 if ($b->end === $a->end) {
                     if ($a->start === $b->start) {
                         return $b->insertion_text > $a->insertion_text ? 1 : -1;
@@ -1506,7 +1509,7 @@ class Analyzer
     /**
      * @return array<string, array<string, int>>
      */
-    public function getAnalyzedMethods()
+    public function getAnalyzedMethods(): array
     {
         return $this->analyzed_methods;
     }
@@ -1514,7 +1517,7 @@ class Analyzer
     /**
      * @return array<string, FileMapType>
      */
-    public function getFileMaps()
+    public function getFileMaps(): array
     {
         $file_maps = [];
 
@@ -1556,7 +1559,7 @@ class Analyzer
     /**
      * @return array<string, array<int, \Psalm\Type\Union>>
      */
-    public function getPossibleMethodParamTypes()
+    public function getPossibleMethodParamTypes(): array
     {
         return $this->possible_method_param_types;
     }
@@ -1585,7 +1588,7 @@ class Analyzer
      *
      * @return bool
      */
-    public function isMethodAlreadyAnalyzed($file_path, $method_id, $is_constructor = false)
+    public function isMethodAlreadyAnalyzed($file_path, $method_id, $is_constructor = false): bool
     {
         if ($is_constructor) {
             return isset($this->analyzed_methods[$file_path][$method_id])

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -221,8 +221,6 @@ class Analyzer
 
     /**
      * @param  string $file_path
-     *
-     * @return bool
      */
     public function canReportIssues($file_path): bool
     {
@@ -232,8 +230,6 @@ class Analyzer
     /**
      * @param  string $file_path
      * @param  array<string, class-string<FileAnalyzer>> $filetype_analyzers
-     *
-     * @return FileAnalyzer
      */
     private function getFileAnalyzer(
         ProjectAnalyzer $project_analyzer,
@@ -256,10 +252,6 @@ class Analyzer
     }
 
     /**
-     * @param  ProjectAnalyzer $project_analyzer
-     * @param  int            $pool_size
-     * @param  bool           $alter_code
-     *
      * @return void
      */
     public function analyzeFiles(
@@ -1272,9 +1264,6 @@ class Analyzer
         return [$mixed_count, $nonmixed_count];
     }
 
-    /**
-     * @return string
-     */
     public function getTypeInferenceSummary(\Psalm\Codebase $codebase): string
     {
         $all_deep_scanned_files = [];
@@ -1307,9 +1296,6 @@ class Analyzer
             . ' of the codebase';
     }
 
-    /**
-     * @return string
-     */
     public function getNonMixedStats(): string
     {
         $stats = '';
@@ -1390,9 +1376,6 @@ class Analyzer
 
         usort(
             $file_manipulations,
-            /**
-             * @return int
-             */
             function (FileManipulation $a, FileManipulation $b): int {
                 if ($b->end === $a->end) {
                     if ($a->start === $b->start) {
@@ -1585,8 +1568,6 @@ class Analyzer
      * @param  string  $file_path
      * @param  string  $method_id
      * @param bool $is_constructor
-     *
-     * @return bool
      */
     public function isMethodAlreadyAnalyzed($file_path, $method_id, $is_constructor = false): bool
     {

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -301,7 +301,7 @@ class ClassLikes
         CodeLocation $code_location = null,
         ?string $calling_fq_class_name = null,
         ?string $calling_method_id = null
-    ) {
+    ): bool {
         $fq_class_name_lc = strtolower($fq_class_name);
 
         if (isset($this->classlike_aliases[$fq_class_name_lc])) {
@@ -377,7 +377,7 @@ class ClassLikes
         CodeLocation $code_location = null,
         ?string $calling_fq_class_name = null,
         ?string $calling_method_id = null
-    ) {
+    ): bool {
         $fq_class_name_lc = strtolower($fq_class_name);
 
         if (isset($this->classlike_aliases[$fq_class_name_lc])) {
@@ -448,7 +448,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function hasFullyQualifiedTraitName($fq_class_name, CodeLocation $code_location = null)
+    public function hasFullyQualifiedTraitName($fq_class_name, CodeLocation $code_location = null): bool
     {
         $fq_class_name_lc = strtolower($fq_class_name);
 
@@ -485,7 +485,7 @@ class ClassLikes
         CodeLocation $code_location = null,
         ?string $calling_fq_class_name = null,
         ?string $calling_method_id = null
-    ) {
+    ): bool {
         if (!$this->classExists($fq_class_name, $code_location, $calling_fq_class_name, $calling_method_id)
             && !$this->interfaceExists($fq_class_name, $code_location, $calling_fq_class_name, $calling_method_id)
         ) {
@@ -507,7 +507,7 @@ class ClassLikes
         CodeLocation $code_location = null,
         ?string $calling_fq_class_name = null,
         ?string $calling_method_id = null
-    ) {
+    ): bool {
         if (isset(ClassLikeAnalyzer::SPECIAL_TYPES[$fq_class_name])) {
             return false;
         }
@@ -535,7 +535,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function classExtends($fq_class_name, $possible_parent, bool $from_api = false)
+    public function classExtends($fq_class_name, $possible_parent, bool $from_api = false): bool
     {
         $fq_class_name_lc = strtolower($fq_class_name);
 
@@ -562,7 +562,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function classImplements($fq_class_name, $interface)
+    public function classImplements($fq_class_name, $interface): bool
     {
         $interface_id = strtolower($interface);
 
@@ -605,7 +605,7 @@ class ClassLikes
         CodeLocation $code_location = null,
         ?string $calling_fq_class_name = null,
         ?string $calling_method_id = null
-    ) {
+    ): bool {
         if (isset(ClassLikeAnalyzer::SPECIAL_TYPES[strtolower($fq_interface_name)])) {
             return false;
         }
@@ -624,7 +624,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function interfaceExtends($interface_name, $possible_parent)
+    public function interfaceExtends($interface_name, $possible_parent): bool
     {
         return isset($this->getParentInterfaces($interface_name)[strtolower($possible_parent)]);
     }
@@ -634,7 +634,7 @@ class ClassLikes
      *
      * @return array<string, string>   all interfaces extended by $interface_name
      */
-    public function getParentInterfaces($fq_interface_name)
+    public function getParentInterfaces($fq_interface_name): array
     {
         $fq_interface_name = strtolower($fq_interface_name);
 
@@ -648,7 +648,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function traitExists($fq_trait_name, CodeLocation $code_location = null)
+    public function traitExists($fq_trait_name, CodeLocation $code_location = null): bool
     {
         return $this->hasFullyQualifiedTraitName($fq_trait_name, $code_location);
     }
@@ -660,7 +660,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function classHasCorrectCasing($fq_class_name)
+    public function classHasCorrectCasing($fq_class_name): bool
     {
         if ($fq_class_name === 'Generator') {
             return true;
@@ -678,7 +678,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function interfaceHasCorrectCasing($fq_interface_name)
+    public function interfaceHasCorrectCasing($fq_interface_name): bool
     {
         if (isset($this->classlike_aliases[strtolower($fq_interface_name)])) {
             return true;
@@ -692,7 +692,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function traitHasCorrectCase($fq_trait_name)
+    public function traitHasCorrectCase($fq_trait_name): bool
     {
         if (isset($this->classlike_aliases[strtolower($fq_trait_name)])) {
             return true;
@@ -706,7 +706,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function isUserDefined($fq_class_name)
+    public function isUserDefined($fq_class_name): bool
     {
         return $this->classlike_storage_provider->get($fq_class_name)->user_defined;
     }
@@ -716,7 +716,7 @@ class ClassLikes
      *
      * @return PhpParser\Node\Stmt\Trait_
      */
-    public function getTraitNode($fq_trait_name)
+    public function getTraitNode($fq_trait_name): PhpParser\Node\Stmt\Trait_
     {
         $fq_trait_name_lc = strtolower($fq_trait_name);
 
@@ -764,7 +764,7 @@ class ClassLikes
     /**
      * @return string
      */
-    public function getUnAliasedName(string $alias_name)
+    public function getUnAliasedName(string $alias_name): string
     {
         $alias_name_lc = strtolower($alias_name);
         if ($this->existing_classlikes_lc[$alias_name_lc] ?? false) {
@@ -1522,7 +1522,7 @@ class ClassLikes
      *
      * @return array<string,Type\Union>
      */
-    public function getConstantsForClass($class_name, $visibility)
+    public function getConstantsForClass($class_name, $visibility): array
     {
         $class_name = strtolower($class_name);
 
@@ -2359,7 +2359,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function isMissingClassLike($fq_classlike_name_lc)
+    public function isMissingClassLike($fq_classlike_name_lc): bool
     {
         return isset($this->existing_classlikes_lc[$fq_classlike_name_lc])
             && $this->existing_classlikes_lc[$fq_classlike_name_lc] === false;
@@ -2370,7 +2370,7 @@ class ClassLikes
      *
      * @return bool
      */
-    public function doesClassLikeExist($fq_classlike_name_lc)
+    public function doesClassLikeExist($fq_classlike_name_lc): bool
     {
         return isset($this->existing_classlikes_lc[$fq_classlike_name_lc])
             && $this->existing_classlikes_lc[$fq_classlike_name_lc];
@@ -2415,7 +2415,7 @@ class ClassLikes
      *     6: array<string, bool>,
      * }
      */
-    public function getThreadData()
+    public function getThreadData(): array
     {
         return [
             $this->existing_classlikes_lc,

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -294,7 +294,6 @@ class ClassLikes
     /**
      * @param string $fq_class_name
      *
-     * @return bool
      */
     public function hasFullyQualifiedClassName(
         $fq_class_name,
@@ -370,7 +369,6 @@ class ClassLikes
     /**
      * @param string $fq_class_name
      *
-     * @return bool
      */
     public function hasFullyQualifiedInterfaceName(
         $fq_class_name,
@@ -446,7 +444,6 @@ class ClassLikes
     /**
      * @param string $fq_class_name
      *
-     * @return bool
      */
     public function hasFullyQualifiedTraitName($fq_class_name, CodeLocation $code_location = null): bool
     {
@@ -476,9 +473,7 @@ class ClassLikes
      * Check whether a class/interface exists
      *
      * @param  string          $fq_class_name
-     * @param  CodeLocation $code_location
      *
-     * @return bool
      */
     public function classOrInterfaceExists(
         $fq_class_name,
@@ -500,7 +495,6 @@ class ClassLikes
      *
      * @param  string       $fq_class_name
      *
-     * @return bool
      */
     public function classExists(
         $fq_class_name,
@@ -533,7 +527,6 @@ class ClassLikes
      * @throws UnpopulatedClasslikeException when called on unpopulated class
      * @throws \InvalidArgumentException when class does not exist
      *
-     * @return bool
      */
     public function classExtends($fq_class_name, $possible_parent, bool $from_api = false): bool
     {
@@ -560,7 +553,6 @@ class ClassLikes
      * @param  string       $fq_class_name
      * @param  string       $interface
      *
-     * @return bool
      */
     public function classImplements($fq_class_name, $interface): bool
     {
@@ -598,7 +590,6 @@ class ClassLikes
     /**
      * @param  string         $fq_interface_name
      *
-     * @return bool
      */
     public function interfaceExists(
         $fq_interface_name,
@@ -622,7 +613,6 @@ class ClassLikes
      * @param  string         $interface_name
      * @param  string         $possible_parent
      *
-     * @return bool
      */
     public function interfaceExtends($interface_name, $possible_parent): bool
     {
@@ -646,7 +636,6 @@ class ClassLikes
     /**
      * @param  string         $fq_trait_name
      *
-     * @return bool
      */
     public function traitExists($fq_trait_name, CodeLocation $code_location = null): bool
     {
@@ -658,7 +647,6 @@ class ClassLikes
      *
      * @param  string $fq_class_name
      *
-     * @return bool
      */
     public function classHasCorrectCasing($fq_class_name): bool
     {
@@ -676,7 +664,6 @@ class ClassLikes
     /**
      * @param  string $fq_interface_name
      *
-     * @return bool
      */
     public function interfaceHasCorrectCasing($fq_interface_name): bool
     {
@@ -690,7 +677,6 @@ class ClassLikes
     /**
      * @param  string $fq_trait_name
      *
-     * @return bool
      */
     public function traitHasCorrectCase($fq_trait_name): bool
     {
@@ -704,7 +690,6 @@ class ClassLikes
     /**
      * @param  lowercase-string  $fq_class_name
      *
-     * @return bool
      */
     public function isUserDefined($fq_class_name): bool
     {
@@ -714,7 +699,6 @@ class ClassLikes
     /**
      * @param  string $fq_trait_name
      *
-     * @return PhpParser\Node\Stmt\Trait_
      */
     public function getTraitNode($fq_trait_name): PhpParser\Node\Stmt\Trait_
     {
@@ -760,10 +744,7 @@ class ClassLikes
     {
         $this->classlike_aliases[$alias_name] = $fq_class_name;
     }
-
-    /**
-     * @return string
-     */
+    
     public function getUnAliasedName(string $alias_name): string
     {
         $alias_name_lc = strtolower($alias_name);
@@ -1846,7 +1827,6 @@ class ClassLikes
     /**
      * @param   string      $class_name
      * @param   string      $const_name
-     * @param   Type\Union  $type
      * @param   int         $visibility
      *
      * @return  void
@@ -2357,7 +2337,6 @@ class ClassLikes
     /**
      * @param  lowercase-string $fq_classlike_name_lc
      *
-     * @return bool
      */
     public function isMissingClassLike($fq_classlike_name_lc): bool
     {
@@ -2368,7 +2347,6 @@ class ClassLikes
     /**
      * @param  lowercase-string $fq_classlike_name_lc
      *
-     * @return bool
      */
     public function doesClassLikeExist($fq_classlike_name_lc): bool
     {

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -156,7 +156,7 @@ class Functions
      *
      * @return bool
      */
-    public function hasStubbedFunction($function_id)
+    public function hasStubbedFunction($function_id): bool
     {
         return isset(self::$stubbed_functions[strtolower($function_id)]);
     }
@@ -164,7 +164,7 @@ class Functions
     /**
      * @return array<string, FunctionStorage>
      */
-    public function getAllStubbedFunctions()
+    public function getAllStubbedFunctions(): array
     {
         return self::$stubbed_functions;
     }
@@ -176,7 +176,7 @@ class Functions
     public function functionExists(
         StatementsAnalyzer $statements_analyzer,
         string $function_id
-    ) {
+    ): bool {
         if ($this->existence_provider->has($function_id)) {
             $function_exists = $this->existence_provider->doesFunctionExist($statements_analyzer, $function_id);
 
@@ -270,7 +270,7 @@ class Functions
      *
      * @return bool
      */
-    public static function isVariadic(Codebase $codebase, $function_id, $file_path)
+    public static function isVariadic(Codebase $codebase, $function_id, $file_path): bool
     {
         $file_storage = $codebase->file_storage_provider->get($file_path);
 

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -154,7 +154,6 @@ class Functions
     /**
      * @param  string  $function_id
      *
-     * @return bool
      */
     public function hasStubbedFunction($function_id): bool
     {
@@ -171,7 +170,6 @@ class Functions
 
     /**
      * @param lowercase-string $function_id
-     * @return bool
      */
     public function functionExists(
         StatementsAnalyzer $statements_analyzer,
@@ -219,7 +217,6 @@ class Functions
 
     /**
      * @param  non-empty-string         $function_name
-     * @param  StatementsSource         $source
      *
      * @return non-empty-string
      */
@@ -268,7 +265,6 @@ class Functions
      * @param  string $function_id
      * @param  string $file_path
      *
-     * @return bool
      */
     public static function isVariadic(Codebase $codebase, $function_id, $file_path): bool
     {

--- a/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
+++ b/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
@@ -62,7 +62,7 @@ class InternalCallMapHandler
         $method_id,
         array $args,
         ?\Psalm\Internal\Provider\NodeDataProvider $nodes
-    ) {
+    ): TCallable {
         $possible_callables = self::getCallablesFromCallMap($method_id);
 
         if ($possible_callables === null) {
@@ -90,7 +90,7 @@ class InternalCallMapHandler
         array $callables,
         array $args,
         ?\Psalm\NodeTypeProvider $nodes
-    ) {
+    ): TCallable {
         if (count($callables) === 1) {
             return $callables[0];
         }
@@ -223,7 +223,7 @@ class InternalCallMapHandler
      * @return array|null
      * @psalm-return array<int, TCallable>|null
      */
-    public static function getCallablesFromCallMap($function_id)
+    public static function getCallablesFromCallMap($function_id): ?array
     {
         $call_map_key = strtolower($function_id);
 
@@ -337,7 +337,7 @@ class InternalCallMapHandler
      * @psalm-suppress MixedReturnStatement
      * @psalm-suppress MixedReturnTypeCoercion
      */
-    public static function getCallMap()
+    public static function getCallMap(): array
     {
         $codebase = ProjectAnalyzer::getInstance()->getCodebase();
         $analyzer_major_version = $codebase->php_major_version;
@@ -415,7 +415,7 @@ class InternalCallMapHandler
      *
      * @return  bool
      */
-    public static function inCallMap($key)
+    public static function inCallMap($key): bool
     {
         return isset(self::getCallMap()[strtolower($key)]);
     }

--- a/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
+++ b/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
@@ -55,7 +55,6 @@ class InternalCallMapHandler
      * @param  string                           $method_id
      * @param  array<int, PhpParser\Node\Arg>   $args
      *
-     * @return TCallable
      */
     public static function getCallableFromCallMapById(
         Codebase $codebase,
@@ -83,7 +82,6 @@ class InternalCallMapHandler
      * @param  array<int, TCallable>  $callables
      * @param  array<int, PhpParser\Node\Arg>                 $args
      *
-     * @return TCallable
      */
     public static function getMatchingCallableFromCallMapOptions(
         Codebase $codebase,
@@ -220,7 +218,6 @@ class InternalCallMapHandler
     /**
      * @param  string $function_id
      *
-     * @return array|null
      * @psalm-return array<int, TCallable>|null
      */
     public static function getCallablesFromCallMap($function_id): ?array
@@ -413,7 +410,6 @@ class InternalCallMapHandler
     /**
      * @param   string $key
      *
-     * @return  bool
      */
     public static function inCallMap($key): bool
     {

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -612,7 +612,7 @@ class Methods
     /**
      * @return bool
      */
-    public function isVariadic(MethodIdentifier $method_id)
+    public function isVariadic(MethodIdentifier $method_id): bool
     {
         $declaring_method_id = $this->getDeclaringMethodId($method_id);
 
@@ -633,7 +633,7 @@ class Methods
         ?string &$self_class,
         \Psalm\Internal\Analyzer\SourceAnalyzer $source_analyzer = null,
         array $args = null
-    ) {
+    ): ?Type\Union {
         $original_fq_class_name = $method_id->fq_class_name;
         $original_method_name = $method_id->method_name;
 
@@ -811,7 +811,7 @@ class Methods
     /**
      * @return bool
      */
-    public function getMethodReturnsByRef(MethodIdentifier $method_id)
+    public function getMethodReturnsByRef(MethodIdentifier $method_id): bool
     {
         $method_id = $this->getDeclaringMethodId($method_id);
 
@@ -838,7 +838,7 @@ class Methods
     public function getMethodReturnTypeLocation(
         MethodIdentifier $method_id,
         CodeLocation &$defined_location = null
-    ) {
+    ): ?CodeLocation {
         $method_id = $this->getDeclaringMethodId($method_id);
 
         if ($method_id === null) {
@@ -949,7 +949,7 @@ class Methods
     /**
      * @return array<MethodIdentifier>
      */
-    public function getOverriddenMethodIds(MethodIdentifier $method_id)
+    public function getOverriddenMethodIds(MethodIdentifier $method_id): array
     {
         $class_storage = $this->classlike_storage_provider->get($method_id->fq_class_name);
         $method_name = $method_id->method_name;
@@ -992,7 +992,7 @@ class Methods
     /**
      * @return ?MethodStorage
      */
-    public function getUserMethodStorage(MethodIdentifier $method_id)
+    public function getUserMethodStorage(MethodIdentifier $method_id): ?MethodStorage
     {
         $declaring_method_id = $this->getDeclaringMethodId($method_id);
 
@@ -1012,7 +1012,7 @@ class Methods
     /**
      * @return ClassLikeStorage
      */
-    public function getClassLikeStorageForMethod(MethodIdentifier $method_id)
+    public function getClassLikeStorageForMethod(MethodIdentifier $method_id): ClassLikeStorage
     {
         $fq_class_name = $method_id->fq_class_name;
         $method_name = $method_id->method_name;
@@ -1046,7 +1046,7 @@ class Methods
     /**
      * @return MethodStorage
      */
-    public function getStorage(MethodIdentifier $method_id)
+    public function getStorage(MethodIdentifier $method_id): MethodStorage
     {
         try {
             $class_storage = $this->classlike_storage_provider->get($method_id->fq_class_name);
@@ -1068,7 +1068,7 @@ class Methods
     /**
      * @return bool
      */
-    public function hasStorage(MethodIdentifier $method_id)
+    public function hasStorage(MethodIdentifier $method_id): bool
     {
         try {
             $class_storage = $this->classlike_storage_provider->get($method_id->fq_class_name);

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -63,10 +63,7 @@ class Methods
 
     /** @var MethodVisibilityProvider */
     public $visibility_provider;
-
-    /**
-     * @param ClassLikeStorageProvider $storage_provider
-     */
+    
     public function __construct(
         ClassLikeStorageProvider $storage_provider,
         FileReferenceProvider $file_reference_provider,
@@ -608,10 +605,7 @@ class Methods
 
         return $extra_added_types;
     }
-
-    /**
-     * @return bool
-     */
+    
     public function isVariadic(MethodIdentifier $method_id): bool
     {
         $declaring_method_id = $this->getDeclaringMethodId($method_id);
@@ -626,7 +620,6 @@ class Methods
     /**
      * @param  array<int, PhpParser\Node\Arg>|null $args
      *
-     * @return Type\Union|null
      */
     public function getMethodReturnType(
         MethodIdentifier $method_id,
@@ -808,9 +801,6 @@ class Methods
         return $candidate_type;
     }
 
-    /**
-     * @return bool
-     */
     public function getMethodReturnsByRef(MethodIdentifier $method_id): bool
     {
         $method_id = $this->getDeclaringMethodId($method_id);
@@ -833,7 +823,6 @@ class Methods
     /**
      * @param  CodeLocation|null    $defined_location
      *
-     * @return CodeLocation|null
      */
     public function getMethodReturnTypeLocation(
         MethodIdentifier $method_id,
@@ -989,9 +978,6 @@ class Methods
         return $fq_class_name . '::' . $storage->cased_name;
     }
 
-    /**
-     * @return ?MethodStorage
-     */
     public function getUserMethodStorage(MethodIdentifier $method_id): ?MethodStorage
     {
         $declaring_method_id = $this->getDeclaringMethodId($method_id);
@@ -1008,10 +994,7 @@ class Methods
 
         return $storage;
     }
-
-    /**
-     * @return ClassLikeStorage
-     */
+    
     public function getClassLikeStorageForMethod(MethodIdentifier $method_id): ClassLikeStorage
     {
         $fq_class_name = $method_id->fq_class_name;
@@ -1043,9 +1026,6 @@ class Methods
         return $this->classlike_storage_provider->get($declaring_fq_class_name);
     }
 
-    /**
-     * @return MethodStorage
-     */
     public function getStorage(MethodIdentifier $method_id): MethodStorage
     {
         try {
@@ -1065,9 +1045,6 @@ class Methods
         return $class_storage->methods[$method_name];
     }
 
-    /**
-     * @return bool
-     */
     public function hasStorage(MethodIdentifier $method_id): bool
     {
         try {

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -152,8 +152,6 @@ class Populator
     }
 
     /**
-     * @param  ClassLikeStorage $storage
-     * @param  array            $dependent_classlikes
      *
      * @return void
      */
@@ -890,7 +888,6 @@ class Populator
     }
 
     /**
-     * @param  FileStorage $storage
      * @param  array<string, bool> $dependent_file_paths
      *
      * @return void
@@ -1025,7 +1022,6 @@ class Populator
     }
 
     /**
-     * @param  Type\Union $candidate
      * @param  bool       $is_property
      *
      * @return void
@@ -1085,8 +1081,6 @@ class Populator
     }
 
     /**
-     * @param ClassLikeStorage $storage
-     * @param ClassLikeStorage $parent_storage
      *
      * @return void
      */
@@ -1208,8 +1202,6 @@ class Populator
     }
 
     /**
-     * @param ClassLikeStorage $storage
-     * @param ClassLikeStorage $parent_storage
      *
      * @return void
      */

--- a/src/Psalm/Internal/Codebase/Properties.php
+++ b/src/Psalm/Internal/Codebase/Properties.php
@@ -65,7 +65,6 @@ class Properties
     /**
      * Whether or not a given property exists
      *
-     * @return bool
      */
     public function propertyExists(
         string $property_id,
@@ -219,7 +218,6 @@ class Properties
     /**
      * @param  string $property_id
      *
-     * @return  \Psalm\Storage\PropertyStorage
      */
     public function getStorage($property_id): \Psalm\Storage\PropertyStorage
     {
@@ -245,7 +243,6 @@ class Properties
     /**
      * @param  string $property_id
      *
-     * @return  ?Type\Union
      */
     public function getPropertyType(
         $property_id,

--- a/src/Psalm/Internal/Codebase/Properties.php
+++ b/src/Psalm/Internal/Codebase/Properties.php
@@ -73,7 +73,7 @@ class Properties
         StatementsSource $source = null,
         Context $context = null,
         CodeLocation $code_location = null
-    ) {
+    ): bool {
         // remove trailing backslash if it exists
         $property_id = preg_replace('/^\\\\/', '', $property_id);
 
@@ -221,7 +221,7 @@ class Properties
      *
      * @return  \Psalm\Storage\PropertyStorage
      */
-    public function getStorage($property_id)
+    public function getStorage($property_id): \Psalm\Storage\PropertyStorage
     {
         // remove trailing backslash if it exists
         $property_id = preg_replace('/^\\\\/', '', $property_id);
@@ -252,7 +252,7 @@ class Properties
         bool $property_set,
         StatementsSource $source = null,
         Context $context = null
-    ) {
+    ): ?Type\Union {
         // remove trailing backslash if it exists
         $property_id = preg_replace('/^\\\\/', '', $property_id);
 

--- a/src/Psalm/Internal/Codebase/PropertyMap.php
+++ b/src/Psalm/Internal/Codebase/PropertyMap.php
@@ -18,7 +18,7 @@ class PropertyMap
      *
      * @return array<string, array<string, string>>
      */
-    public static function getPropertyMap()
+    public static function getPropertyMap(): array
     {
         if (self::$property_map !== null) {
             return self::$property_map;
@@ -42,7 +42,7 @@ class PropertyMap
      *
      * @return  bool
      */
-    public static function inPropertyMap($class_name)
+    public static function inPropertyMap($class_name): bool
     {
         return isset(self::getPropertyMap()[strtolower($class_name)]);
     }

--- a/src/Psalm/Internal/Codebase/PropertyMap.php
+++ b/src/Psalm/Internal/Codebase/PropertyMap.php
@@ -40,7 +40,6 @@ class PropertyMap
     /**
      * @param   string $class_name
      *
-     * @return  bool
      */
     public static function inPropertyMap($class_name): bool
     {

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -220,7 +220,6 @@ class Reflection
     }
 
     /**
-     * @param \ReflectionMethod $method
      *
      * @return void
      */
@@ -318,11 +317,6 @@ class Reflection
         }
     }
 
-    /**
-     * @param  \ReflectionParameter $param
-     *
-     * @return FunctionLikeParameter
-     */
     private function getReflectionParamData(\ReflectionParameter $param): FunctionLikeParameter
     {
         $param_type = self::getPsalmTypeFromReflectionType($param->getType());
@@ -504,7 +498,6 @@ class Reflection
     /**
      * @param  string  $function_id
      *
-     * @return bool
      */
     public function hasFunction($function_id): bool
     {
@@ -514,7 +507,6 @@ class Reflection
     /**
      * @param  string  $function_id
      *
-     * @return FunctionStorage
      */
     public function getFunctionStorage($function_id): FunctionStorage
     {

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -323,7 +323,7 @@ class Reflection
      *
      * @return FunctionLikeParameter
      */
-    private function getReflectionParamData(\ReflectionParameter $param)
+    private function getReflectionParamData(\ReflectionParameter $param): FunctionLikeParameter
     {
         $param_type = self::getPsalmTypeFromReflectionType($param->getType());
         $param_name = (string)$param->getName();
@@ -506,7 +506,7 @@ class Reflection
      *
      * @return bool
      */
-    public function hasFunction($function_id)
+    public function hasFunction($function_id): bool
     {
         return isset(self::$builtin_functions[$function_id]);
     }
@@ -516,7 +516,7 @@ class Reflection
      *
      * @return FunctionStorage
      */
-    public function getFunctionStorage($function_id)
+    public function getFunctionStorage($function_id): FunctionStorage
     {
         if (isset(self::$builtin_functions[$function_id])) {
             return self::$builtin_functions[$function_id];

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -250,7 +250,7 @@ class Scanner
      *
      * @return string
      */
-    public function getClassLikeFilePath($fq_classlike_name_lc)
+    public function getClassLikeFilePath($fq_classlike_name_lc): string
     {
         if (!isset($this->classlike_files[$fq_classlike_name_lc])) {
             throw new \UnexpectedValueException('Could not find file for ' . $fq_classlike_name_lc);
@@ -320,7 +320,7 @@ class Scanner
     /**
      * @return bool
      */
-    public function scanFiles(ClassLikes $classlikes, int $pool_size = 1)
+    public function scanFiles(ClassLikes $classlikes, int $pool_size = 1): bool
     {
         $has_changes = false;
         while ($this->files_to_scan || $this->classes_to_scan) {
@@ -586,7 +586,7 @@ class Scanner
         $file_path,
         array $filetype_scanners,
         $will_analyze = false
-    ) {
+    ): FileScanner {
         $file_scanner = $this->getScannerForPath($file_path, $filetype_scanners, $will_analyze);
 
         if (isset($this->scanned_files[$file_path])
@@ -681,7 +681,7 @@ class Scanner
         $file_path,
         array $filetype_scanners,
         $will_analyze = false
-    ) {
+    ): FileScanner {
         $path_parts = explode(DIRECTORY_SEPARATOR, $file_path);
         $file_name_parts = explode('.', array_pop($path_parts));
         $extension = count($file_name_parts) > 1 ? array_pop($file_name_parts) : null;
@@ -698,7 +698,7 @@ class Scanner
     /**
      * @return array<string, bool>
      */
-    public function getScannedFiles()
+    public function getScannedFiles(): array
     {
         return $this->scanned_files;
     }
@@ -711,7 +711,7 @@ class Scanner
      *
      * @return bool
      */
-    private function fileExistsForClassLike(ClassLikes $classlikes, $fq_class_name)
+    private function fileExistsForClassLike(ClassLikes $classlikes, $fq_class_name): bool
     {
         $fq_class_name_lc = strtolower($fq_class_name);
 

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -248,7 +248,6 @@ class Scanner
     /**
      * @param  string $fq_classlike_name_lc
      *
-     * @return string
      */
     public function getClassLikeFilePath($fq_classlike_name_lc): string
     {
@@ -317,9 +316,6 @@ class Scanner
         }
     }
 
-    /**
-     * @return bool
-     */
     public function scanFiles(ClassLikes $classlikes, int $pool_size = 1): bool
     {
         $has_changes = false;
@@ -580,7 +576,6 @@ class Scanner
      * @param  array<string, class-string<FileScanner>>  $filetype_scanners
      * @param  bool   $will_analyze
      *
-     * @return FileScanner
      */
     private function scanFile(
         $file_path,
@@ -675,7 +670,6 @@ class Scanner
      * @param  array<string, class-string<FileScanner>>  $filetype_scanners
      * @param  bool   $will_analyze
      *
-     * @return FileScanner
      */
     private function getScannerForPath(
         $file_path,
@@ -709,7 +703,6 @@ class Scanner
      *
      * @param  string $fq_class_name
      *
-     * @return bool
      */
     private function fileExistsForClassLike(ClassLikes $classlikes, $fq_class_name): bool
     {

--- a/src/Psalm/Internal/Codebase/Taint.php
+++ b/src/Psalm/Internal/Codebase/Taint.php
@@ -387,7 +387,7 @@ class Taint
 
         return \array_filter(
             $generated_sources,
-            function ($new_source) {
+            function ($new_source): bool {
                 return isset($this->forward_edges[$new_source->id]);
             }
         );

--- a/src/Psalm/Internal/Diff/FileDiffer.php
+++ b/src/Psalm/Internal/Diff/FileDiffer.php
@@ -120,7 +120,7 @@ class FileDiffer
      *
      * @psalm-pure
      */
-    public static function getDiff(string $a_code, string $b_code)
+    public static function getDiff(string $a_code, string $b_code): array
     {
         $a = explode("\n", $a_code);
         $b = explode("\n", $b_code);
@@ -270,7 +270,7 @@ class FileDiffer
      *
      * @psalm-pure
      */
-    private static function coalesceReplacements(array $diff)
+    private static function coalesceReplacements(array $diff): array
     {
         $newDiff = [];
         $c = \count($diff);

--- a/src/Psalm/Internal/Diff/FileStatementsDiffer.php
+++ b/src/Psalm/Internal/Diff/FileStatementsDiffer.php
@@ -27,7 +27,7 @@ class FileStatementsDiffer extends AstDiffer
      *      3: array<int, array{0: int, 1: int, 2: int, 3: int}>
      * }
      */
-    public static function diff(array $a, array $b, $a_code, $b_code)
+    public static function diff(array $a, array $b, $a_code, $b_code): array
     {
         [$trace, $x, $y, $bc] = self::calculateTrace(
             /**
@@ -36,7 +36,13 @@ class FileStatementsDiffer extends AstDiffer
              *
              * @return bool
              */
-            function (PhpParser\Node\Stmt $a, PhpParser\Node\Stmt $b, $a_code, $b_code, bool &$body_change = false) {
+            function (
+                PhpParser\Node\Stmt $a,
+                PhpParser\Node\Stmt $b,
+                $a_code,
+                $b_code,
+                bool &$body_change = false
+            ): bool {
                 if (get_class($a) !== get_class($b)) {
                     return false;
                 }

--- a/src/Psalm/Internal/Diff/NamespaceStatementsDiffer.php
+++ b/src/Psalm/Internal/Diff/NamespaceStatementsDiffer.php
@@ -28,7 +28,7 @@ class NamespaceStatementsDiffer extends AstDiffer
      *      3: array<int, array{0: int, 1: int, 2: int, 3: int}>
      * }
      */
-    public static function diff($name, array $a, array $b, $a_code, $b_code)
+    public static function diff($name, array $a, array $b, $a_code, $b_code): array
     {
         [$trace, $x, $y, $bc] = self::calculateTrace(
             /**
@@ -37,7 +37,13 @@ class NamespaceStatementsDiffer extends AstDiffer
              *
              * @return bool
              */
-            function (PhpParser\Node\Stmt $a, PhpParser\Node\Stmt $b, $a_code, $b_code, bool &$body_change = false) {
+            function (
+                PhpParser\Node\Stmt $a,
+                PhpParser\Node\Stmt $b,
+                $a_code,
+                $b_code,
+                bool &$body_change = false
+            ): bool {
                 if (get_class($a) !== get_class($b)) {
                     return false;
                 }

--- a/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
@@ -245,7 +245,7 @@ class BuildInfoCollector
      * @return $this
      * @psalm-suppress PossiblyUndefinedStringArrayOffset
      */
-    protected function fillGithubActions()
+    protected function fillGithubActions(): BuildInfoCollector
     {
         if (isset($this->env['GITHUB_ACTIONS'])) {
             $this->env['CI_NAME'] = 'github-actions';

--- a/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
@@ -61,6 +61,7 @@ class BuildInfoCollector
      * "TRAVIS", "TRAVIS_JOB_ID" must be set.
      *
      * @return $this
+     *
      * @psalm-suppress PossiblyUndefinedStringArrayOffset
      */
     protected function fillTravisCi() : self
@@ -136,8 +137,9 @@ class BuildInfoCollector
      *
      * "APPVEYOR", "APPVEYOR_BUILD_NUMBER" must be set.
      *
-     * @return $this
      * @psalm-suppress PossiblyUndefinedStringArrayOffset
+     *
+     * @return $this
      */
     protected function fillAppVeyor() : self
     {
@@ -208,8 +210,9 @@ class BuildInfoCollector
      *
      * "JENKINS_URL", "BUILD_NUMBER" must be set.
      *
-     * @return $this
      * @psalm-suppress PossiblyUndefinedStringArrayOffset
+     *
+     * @return $this
      */
     protected function fillScrutinizer() : self
     {

--- a/src/Psalm/Internal/ExecutionEnvironment/GitInfoCollector.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/GitInfoCollector.php
@@ -100,7 +100,7 @@ class GitInfoCollector
      *
      * @return RemoteInfo[]
      */
-    protected function collectRemotes()
+    protected function collectRemotes(): array
     {
         $remotesResult = $this->executor->execute('git remote -v');
 

--- a/src/Psalm/Internal/ExecutionEnvironment/SystemCommandExecutor.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/SystemCommandExecutor.php
@@ -15,7 +15,6 @@ final class SystemCommandExecutor
     /**
      * Execute command.
      *
-     * @param string $command
      *
      * @throws \RuntimeException
      *

--- a/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
@@ -86,7 +86,7 @@ class ClassDocblockManipulator
      *
      * @return string
      */
-    private function getDocblock()
+    private function getDocblock(): string
     {
         $docblock = $this->stmt->getDocComment();
 
@@ -115,7 +115,7 @@ class ClassDocblockManipulator
      *
      * @return array<int, FileManipulation>
      */
-    public static function getManipulationsForFile($file_path)
+    public static function getManipulationsForFile($file_path): array
     {
         if (!isset(self::$manipulators[$file_path])) {
             return [];

--- a/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
@@ -84,7 +84,6 @@ class ClassDocblockManipulator
      * Gets a new docblock given the existing docblock, if one exists, and the updated return types
      * and/or parameters
      *
-     * @return string
      */
     private function getDocblock(): string
     {

--- a/src/Psalm/Internal/FileManipulation/FileManipulationBuffer.php
+++ b/src/Psalm/Internal/FileManipulation/FileManipulationBuffer.php
@@ -176,7 +176,7 @@ class FileManipulationBuffer
      *
      * @return FileManipulation[]
      */
-    public static function getManipulationsForFile($file_path)
+    public static function getManipulationsForFile($file_path): array
     {
         if (!isset(self::$file_manipulations[$file_path])) {
             return [];

--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -103,7 +103,7 @@ class FunctionDocblockManipulator
         ProjectAnalyzer $project_analyzer,
         $file_path,
         FunctionLike $stmt
-    ) {
+    ): FunctionDocblockManipulator {
         if (isset(self::$manipulators[$file_path][$stmt->getLine()])) {
             return self::$manipulators[$file_path][$stmt->getLine()];
         }
@@ -315,7 +315,7 @@ class FunctionDocblockManipulator
      *
      * @return string
      */
-    private function getDocblock()
+    private function getDocblock(): string
     {
         $docblock = $this->stmt->getDocComment();
 
@@ -402,7 +402,7 @@ class FunctionDocblockManipulator
      *
      * @return array<int, FileManipulation>
      */
-    public static function getManipulationsForFile($file_path)
+    public static function getManipulationsForFile($file_path): array
     {
         if (!isset(self::$manipulators[$file_path])) {
             return [];
@@ -512,7 +512,7 @@ class FunctionDocblockManipulator
     /**
      * @return array<string, array<int, FunctionDocblockManipulator>>
      */
-    public static function getManipulators()
+    public static function getManipulators(): array
     {
         return self::$manipulators;
     }

--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -97,7 +97,6 @@ class FunctionDocblockManipulator
      * @param  string $file_path
      * @param  Closure|Function_|ClassMethod|ArrowFunction $stmt
      *
-     * @return self
      */
     public static function getForFunction(
         ProjectAnalyzer $project_analyzer,
@@ -283,10 +282,6 @@ class FunctionDocblockManipulator
     /**
      * Sets a new param type
      *
-     * @param   string      $param_name
-     * @param   ?string     $php_type
-     * @param   string      $new_type
-     * @param   string      $phpdoc_type
      * @param   bool        $is_php_compatible
      *
      * @return  void
@@ -313,7 +308,6 @@ class FunctionDocblockManipulator
      * Gets a new docblock given the existing docblock, if one exists, and the updated return types
      * and/or parameters
      *
-     * @return string
      */
     private function getDocblock(): string
     {

--- a/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
@@ -156,7 +156,7 @@ class PropertyDocblockManipulator
      *
      * @return string
      */
-    private function getDocblock()
+    private function getDocblock(): string
     {
         $docblock = $this->stmt->getDocComment();
 
@@ -212,7 +212,7 @@ class PropertyDocblockManipulator
      *
      * @return array<int, FileManipulation>
      */
-    public static function getManipulationsForFile($file_path)
+    public static function getManipulationsForFile($file_path): array
     {
         if (!isset(self::$manipulators[$file_path])) {
             return [];

--- a/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
@@ -154,7 +154,6 @@ class PropertyDocblockManipulator
      * Gets a new docblock given the existing docblock, if one exists, and the updated return types
      * and/or parameters
      *
-     * @return string
      */
     private function getDocblock(): string
     {

--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -298,7 +298,7 @@ class Pool
      *
      * @psalm-suppress MixedAssignment
      */
-    private function readResultsFromChildren()
+    private function readResultsFromChildren(): array
     {
         // Create an array of all active streams, indexed by
         // resource id.
@@ -429,7 +429,7 @@ class Pool
      *
      * @return  bool
      */
-    public function didHaveError()
+    public function didHaveError(): bool
     {
         return $this->did_have_error;
     }

--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -294,7 +294,6 @@ class Pool
      * The results are returned in an array, one for each worker. The order of the results
      * is not maintained.
      *
-     * @return array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -381,7 +380,6 @@ class Pool
     /**
      * Wait for all child processes to complete
      *
-     * @return array
      */
     public function wait(): array
     {
@@ -427,7 +425,6 @@ class Pool
     /**
      * Returns true if this had an error, e.g. due to memory limits or due to a child process crashing.
      *
-     * @return  bool
      */
     public function didHaveError(): bool
     {

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -43,7 +43,6 @@ class PsalmRestarter extends \Composer\XdebugHandler\XdebugHandler
             /**
              * @param string $extension
              *
-             * @return bool
              */
             function ($extension): bool {
                 return extension_loaded($extension);

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -36,7 +36,7 @@ class PsalmRestarter extends \Composer\XdebugHandler\XdebugHandler
     /**
      * @param mixed $isLoaded
      */
-    protected function requiresRestart($isLoaded)
+    protected function requiresRestart($isLoaded): bool
     {
         $this->required = (bool) array_filter(
             $this->disabledExtensions,
@@ -45,7 +45,7 @@ class PsalmRestarter extends \Composer\XdebugHandler\XdebugHandler
              *
              * @return bool
              */
-            function ($extension) {
+            function ($extension): bool {
                 return extension_loaded($extension);
             }
         );

--- a/src/Psalm/Internal/Json/Json.php
+++ b/src/Psalm/Internal/Json/Json.php
@@ -22,9 +22,7 @@ class Json
 
     /**
      * @param mixed $data
-     * @param int|null $options
      *
-     * @return string
      *
      * @psalm-pure
      */

--- a/src/Psalm/Internal/LanguageServer/Client/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Client/TextDocument.php
@@ -34,7 +34,6 @@ class TextDocument
     /**
      * Diagnostics notification are sent from the server to the client to signal results of validation runs.
      *
-     * @param string $uri
      * @param Diagnostic[] $diagnostics
      *
      * @return Promise<void>

--- a/src/Psalm/Internal/LanguageServer/IdGenerator.php
+++ b/src/Psalm/Internal/LanguageServer/IdGenerator.php
@@ -15,7 +15,6 @@ class IdGenerator
     /**
      * Returns a unique ID
      *
-     * @return int
      */
     public function generate(): int
     {

--- a/src/Psalm/Internal/LanguageServer/IdGenerator.php
+++ b/src/Psalm/Internal/LanguageServer/IdGenerator.php
@@ -17,7 +17,7 @@ class IdGenerator
      *
      * @return int
      */
-    public function generate()
+    public function generate(): int
     {
         return $this->counter++;
     }

--- a/src/Psalm/Internal/LanguageServer/LanguageClient.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageClient.php
@@ -42,7 +42,7 @@ class LanguageClient
      *  - 2 = Warning
      *  - 3 = Info
      *  - 4 = Log
-
+     *
      * @return Promise<void>
      */
     public function logMessage(string $message, int $type = 4, string $method = 'window/logMessage'): Promise

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -112,7 +112,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 /**
                  * @return \Generator<int, \Amp\Promise, mixed, void>
                  */
-                function (Message $msg) {
+                function (Message $msg): \Generator {
                     if (!$msg->body) {
                         return;
                     }
@@ -524,7 +524,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      *
      * @return string
      */
-    public static function uriToPath(string $uri)
+    public static function uriToPath(string $uri): string
     {
         $fragments = parse_url($uri);
         if ($fragments === false

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -80,10 +80,6 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      */
     protected $onchange_paths_to_analyze = [];
 
-    /**
-     * @param ProtocolReader  $reader
-     * @param ProtocolWriter $writer
-     */
     public function __construct(
         ProtocolReader $reader,
         ProtocolWriter $writer,
@@ -452,7 +448,6 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      *  - 2 = Warning
      *  - 3 = Info
      *  - 4 = Log
-     * @return Promise
      */
     private function verboseLog(string $message, int $type = 4): Promise
     {
@@ -476,7 +471,6 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      * @param string $status The log message to send to the client. Should not contain colons `:`.
      * @param string|null $additional_info This is additional info that the client
      *                                       can use as part of the display message.
-     * @return Promise
      */
     private function clientStatus(string $status, string $additional_info = null): Promise
     {
@@ -495,9 +489,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * Transforms an absolute file path into a URI as used by the language server protocol.
      *
-     * @param string $filepath
      *
-     * @return string
      *
      * @psalm-pure
      */
@@ -520,9 +512,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * Transforms URI into file path
      *
-     * @param string $uri
      *
-     * @return string
      */
     public static function uriToPath(string $uri): string
     {

--- a/src/Psalm/Internal/LanguageServer/Message.php
+++ b/src/Psalm/Internal/LanguageServer/Message.php
@@ -25,9 +25,7 @@ class Message
     /**
      * Parses a message
      *
-     * @param string $msg
      *
-     * @return Message
      * @psalm-suppress UnusedMethod
      */
     public static function parse(string $msg): Message
@@ -46,7 +44,6 @@ class Message
     }
 
     /**
-     * @param \AdvancedJsonRpc\Message $body
      * @param string[] $headers
      */
     public function __construct(MessageBody $body = null, array $headers = [])

--- a/src/Psalm/Internal/LanguageServer/ProtocolStreamReader.php
+++ b/src/Psalm/Internal/LanguageServer/ProtocolStreamReader.php
@@ -81,11 +81,6 @@ class ProtocolStreamReader implements ProtocolReader
         );
     }
 
-    /**
-     * @param string $buffer
-     *
-     * @return int
-     */
     private function readMessages(string $buffer) : int
     {
         $emitted_messages = 0;

--- a/src/Psalm/Internal/LanguageServer/ProtocolWriter.php
+++ b/src/Psalm/Internal/LanguageServer/ProtocolWriter.php
@@ -9,7 +9,6 @@ interface ProtocolWriter
     /**
      * Sends a Message to the client
      *
-     * @param Message $msg
      *
      * @return Promise Resolved when the message has been fully written out to the output stream
      */

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -92,7 +92,6 @@ class TextDocument
     /**
      * The document change notification is sent from the client to the server to signal changes to a text document.
      *
-     * @param \LanguageServerProtocol\VersionedTextDocumentIdentifier $textDocument
      * @param \LanguageServerProtocol\TextDocumentContentChangeEvent[] $contentChanges
      *
      * @return void

--- a/src/Psalm/Internal/MethodIdentifier.php
+++ b/src/Psalm/Internal/MethodIdentifier.php
@@ -56,7 +56,7 @@ class MethodIdentifier
     }
 
     /** @return non-empty-string */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->fq_class_name . '::' . $this->method_name;
     }

--- a/src/Psalm/Internal/MethodIdentifier.php
+++ b/src/Psalm/Internal/MethodIdentifier.php
@@ -11,7 +11,6 @@ class MethodIdentifier
     public $method_name;
 
     /**
-     * @param  string $fq_class_name
      * @param  lowercase-string $method_name
      */
     public function __construct(string $fq_class_name, string $method_name)

--- a/src/Psalm/Internal/PhpVisitor/AssignmentMapVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/AssignmentMapVisitor.php
@@ -27,11 +27,6 @@ class AssignmentMapVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
         $this->this_class_name = $this_class_name;
     }
 
-    /**
-     * @param  PhpParser\Node $node
-     *
-     * @return null|int
-     */
     public function enterNode(PhpParser\Node $node): ?int
     {
         if ($node instanceof PhpParser\Node\Expr\Assign) {

--- a/src/Psalm/Internal/PhpVisitor/AssignmentMapVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/AssignmentMapVisitor.php
@@ -32,7 +32,7 @@ class AssignmentMapVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
      *
      * @return null|int
      */
-    public function enterNode(PhpParser\Node $node)
+    public function enterNode(PhpParser\Node $node): ?int
     {
         if ($node instanceof PhpParser\Node\Expr\Assign) {
             $left_var_id = ExpressionIdentifier::getRootVarId($node->var, $this->this_class_name);
@@ -80,7 +80,7 @@ class AssignmentMapVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
     /**
      * @return array<string, array<string, bool>>
      */
-    public function getAssignmentMap()
+    public function getAssignmentMap(): array
     {
         return $this->assignment_map;
     }

--- a/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
@@ -17,7 +17,7 @@ class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract implements P
      * @param  PhpParser\Node\Expr $node
      * @return bool
      */
-    private function checkNonTrivialExpr(PhpParser\Node\Expr $node)
+    private function checkNonTrivialExpr(PhpParser\Node\Expr $node): bool
     {
         /**
          * @psalm-suppress UndefinedClass
@@ -60,7 +60,7 @@ class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract implements P
      * @param  PhpParser\Node $node
      * @return null|int
      */
-    public function enterNode(PhpParser\Node $node)
+    public function enterNode(PhpParser\Node $node): ?int
     {
         if ($node instanceof PhpParser\Node\Expr) {
             // Check for Non-Trivial Expression first
@@ -82,7 +82,7 @@ class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract implements P
     /**
      * @return array<int, PhpParser\Node\Expr>
      */
-    public function getNonTrivialExpr()
+    public function getNonTrivialExpr(): array
     {
         return $this->non_trivial_expr;
     }

--- a/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
@@ -13,10 +13,6 @@ class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract implements P
      */
     protected $non_trivial_expr = [];
 
-    /**
-     * @param  PhpParser\Node\Expr $node
-     * @return bool
-     */
     private function checkNonTrivialExpr(PhpParser\Node\Expr $node): bool
     {
         /**
@@ -56,10 +52,7 @@ class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract implements P
             return false;
         }
     }
-    /**
-     * @param  PhpParser\Node $node
-     * @return null|int
-     */
+
     public function enterNode(PhpParser\Node $node): ?int
     {
         if ($node instanceof PhpParser\Node\Expr) {

--- a/src/Psalm/Internal/PhpVisitor/CloningVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/CloningVisitor.php
@@ -23,7 +23,7 @@ class CloningVisitor extends NodeVisitorAbstract
                     /**
                      * @return \PhpParser\Comment
                      */
-                    function (\PhpParser\Comment $c) {
+                    function (\PhpParser\Comment $c): \PhpParser\Comment {
                         return clone $c;
                     },
                     $cs

--- a/src/Psalm/Internal/PhpVisitor/NodeCleanerVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/NodeCleanerVisitor.php
@@ -15,11 +15,6 @@ class NodeCleanerVisitor extends PhpParser\NodeVisitorAbstract implements PhpPar
         $this->type_provider = $type_provider;
     }
 
-    /**
-     * @param  PhpParser\Node $node
-     *
-     * @return null|int
-     */
     public function enterNode(PhpParser\Node $node): ?int
     {
         if ($node instanceof PhpParser\Node\Expr) {

--- a/src/Psalm/Internal/PhpVisitor/NodeCleanerVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/NodeCleanerVisitor.php
@@ -20,7 +20,7 @@ class NodeCleanerVisitor extends PhpParser\NodeVisitorAbstract implements PhpPar
      *
      * @return null|int
      */
-    public function enterNode(PhpParser\Node $node)
+    public function enterNode(PhpParser\Node $node): ?int
     {
         if ($node instanceof PhpParser\Node\Expr) {
             $this->type_provider->clearNodeOfTypeAndAssertions($node);

--- a/src/Psalm/Internal/PhpVisitor/NodeCounterVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/NodeCounterVisitor.php
@@ -12,7 +12,6 @@ class NodeCounterVisitor extends PhpParser\NodeVisitorAbstract implements PhpPar
     public $count = 0;
 
     /**
-     * @param  PhpParser\Node $node
      *
      * @return null|int
      */

--- a/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
@@ -21,7 +21,6 @@ class OffsetShifterVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
     }
 
     /**
-     * @param  PhpParser\Node $node
      *
      * @return null|int
      */

--- a/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
@@ -31,7 +31,6 @@ class ParamReplacementVisitor extends PhpParser\NodeVisitorAbstract implements P
     }
 
     /**
-     * @param  PhpParser\Node $node
      *
      * @return null|int
      */

--- a/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
@@ -59,7 +59,6 @@ class PartialParserVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
     }
 
     /**
-     * @param  PhpParser\Node $node
      * @param  bool $traverseChildren
      *
      * @return null|int|PhpParser\Node

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -608,7 +608,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
             }
 
             $converted_aliases = \array_map(
-                function (TypeAlias\InlineTypeAlias $t) {
+                function (TypeAlias\InlineTypeAlias $t): ?TypeAlias\ClassTypeAlias {
                     try {
                         $union = TypeParser::parseTokens(
                             $t->replacement_tokens,
@@ -2620,7 +2620,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
             $storage->has_docblock_param_types = (bool) array_filter(
                 $storage->params,
                 /** @return bool */
-                function (FunctionLikeParameter $p) {
+                function (FunctionLikeParameter $p): bool {
                     return $p->type !== null && $p->has_docblock_type;
                 }
             );
@@ -4037,7 +4037,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     /**
      * @return string
      */
-    public function getFilePath()
+    public function getFilePath(): string
     {
         return $this->file_path;
     }
@@ -4045,7 +4045,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     /**
      * @return string
      */
-    public function getFileName()
+    public function getFileName(): string
     {
         return $this->file_scanner->getFileName();
     }
@@ -4053,7 +4053,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     /**
      * @return string
      */
-    public function getRootFilePath()
+    public function getRootFilePath(): string
     {
         return $this->file_scanner->getRootFilePath();
     }
@@ -4061,7 +4061,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     /**
      * @return string
      */
-    public function getRootFileName()
+    public function getRootFileName(): string
     {
         return $this->file_scanner->getRootFileName();
     }
@@ -4069,7 +4069,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     /**
      * @return Aliases
      */
-    public function getAliases()
+    public function getAliases(): Aliases
     {
         return $this->aliases;
     }

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -162,7 +162,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     }
 
     /**
-     * @param  PhpParser\Node $node
      *
      * @return null|int
      */
@@ -1817,7 +1816,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     }
 
     /**
-     * @param  PhpParser\Node\FunctionLike $stmt
      * @param  bool $fake_method in the case of @method annotations we do something a little strange
      *
      * @return FunctionLikeStorage|false
@@ -2619,7 +2617,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         if ($storage instanceof MethodStorage) {
             $storage->has_docblock_param_types = (bool) array_filter(
                 $storage->params,
-                /** @return bool */
                 function (FunctionLikeParameter $p): bool {
                     return $p->type !== null && $p->has_docblock_type;
                 }
@@ -3131,11 +3128,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         return $assertion_type_parts;
     }
 
-    /**
-     * @param  PhpParser\Node\Param $param
-     *
-     * @return FunctionLikeParameter
-     */
     public function getTranslatedFunctionParam(
         PhpParser\Node\Param $param,
         PhpParser\Node\FunctionLike $stmt,
@@ -3280,9 +3272,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     }
 
     /**
-     * @param  FunctionLikeStorage          $storage
      * @param  array<int, array{type:string,name:string,line_number:int,start:int,end:int}>  $docblock_params
-     * @param  PhpParser\Node\FunctionLike  $function
      *
      * @return void
      */
@@ -3502,8 +3492,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     }
 
     /**
-     * @param   PhpParser\Node\Stmt\Property    $stmt
-     * @param   Config                          $config
      * @param   string                          $fq_classlike_name
      *
      * @return  void
@@ -3693,7 +3681,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     }
 
     /**
-     * @param   PhpParser\Node\Stmt\ClassConst  $stmt
      * @param   string $fq_classlike_name
      *
      * @return  void
@@ -3973,7 +3960,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     }
 
     /**
-     * @param  PhpParser\Node\Expr\Include_ $stmt
      *
      * @return void
      */
@@ -4034,41 +4020,26 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         }
     }
 
-    /**
-     * @return string
-     */
     public function getFilePath(): string
     {
         return $this->file_path;
     }
 
-    /**
-     * @return string
-     */
     public function getFileName(): string
     {
         return $this->file_scanner->getFileName();
     }
 
-    /**
-     * @return string
-     */
     public function getRootFilePath(): string
     {
         return $this->file_scanner->getRootFilePath();
     }
 
-    /**
-     * @return string
-     */
     public function getRootFileName(): string
     {
         return $this->file_scanner->getRootFileName();
     }
 
-    /**
-     * @return Aliases
-     */
     public function getAliases(): Aliases
     {
         return $this->aliases;

--- a/src/Psalm/Internal/PhpVisitor/ShortClosureVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ShortClosureVisitor.php
@@ -28,7 +28,7 @@ class ShortClosureVisitor extends PhpParser\NodeVisitorAbstract implements PhpPa
     /**
      * @return array<string, bool>
      */
-    public function getUsedVariables()
+    public function getUsedVariables(): array
     {
         return $this->used_variables;
     }

--- a/src/Psalm/Internal/PhpVisitor/ShortClosureVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ShortClosureVisitor.php
@@ -14,7 +14,6 @@ class ShortClosureVisitor extends PhpParser\NodeVisitorAbstract implements PhpPa
     protected $used_variables = [];
 
     /**
-     * @param  PhpParser\Node $node
      *
      * @return null|int
      */

--- a/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
@@ -54,7 +54,7 @@ class SimpleNameResolver extends NodeVisitorAbstract
         $this->nameContext = new NameContext($errorHandler);
     }
 
-    public function beforeTraverse(array $nodes)
+    public function beforeTraverse(array $nodes): ?array
     {
         $this->nameContext->startNamespace();
 
@@ -203,7 +203,7 @@ class SimpleNameResolver extends NodeVisitorAbstract
      *
      * @return Name Resolved name, or original name with attribute
      */
-    protected function resolveName(Name $name, $type)
+    protected function resolveName(Name $name, $type): Name
     {
         $resolvedName = $this->nameContext->getResolvedName($name, $type);
         if (null !== $resolvedName) {
@@ -216,7 +216,7 @@ class SimpleNameResolver extends NodeVisitorAbstract
     /**
      * @return Name
      */
-    protected function resolveClassName(Name $name)
+    protected function resolveClassName(Name $name): Name
     {
         return $this->resolveName($name, Stmt\Use_::TYPE_NORMAL);
     }

--- a/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
@@ -213,9 +213,6 @@ class SimpleNameResolver extends NodeVisitorAbstract
         return $name;
     }
 
-    /**
-     * @return Name
-     */
     protected function resolveClassName(Name $name): Name
     {
         return $this->resolveName($name, Stmt\Use_::TYPE_NORMAL);

--- a/src/Psalm/Internal/PhpVisitor/TraitFinder.php
+++ b/src/Psalm/Internal/PhpVisitor/TraitFinder.php
@@ -21,7 +21,6 @@ class TraitFinder extends PhpParser\NodeVisitorAbstract implements PhpParser\Nod
     }
 
     /**
-     * @param  PhpParser\Node $node
      * @param  bool $traverseChildren
      *
      * @return null|int|PhpParser\Node

--- a/src/Psalm/Internal/PluginManager/Command/DisableCommand.php
+++ b/src/Psalm/Internal/PluginManager/Command/DisableCommand.php
@@ -44,9 +44,6 @@ class DisableCommand extends Command
         $this->addUsage('\'Plugin\Class\Name\' [-c path/to/psalm.xml]');
     }
 
-    /**
-     * @return int
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Psalm/Internal/PluginManager/Command/DisableCommand.php
+++ b/src/Psalm/Internal/PluginManager/Command/DisableCommand.php
@@ -47,7 +47,7 @@ class DisableCommand extends Command
     /**
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Psalm/Internal/PluginManager/Command/EnableCommand.php
+++ b/src/Psalm/Internal/PluginManager/Command/EnableCommand.php
@@ -44,9 +44,6 @@ class EnableCommand extends Command
         $this->addUsage('\'Plugin\Class\Name\' [-c path/to/psalm.xml]');
     }
 
-    /**
-     * @return int
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Psalm/Internal/PluginManager/Command/EnableCommand.php
+++ b/src/Psalm/Internal/PluginManager/Command/EnableCommand.php
@@ -47,7 +47,7 @@ class EnableCommand extends Command
     /**
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
 

--- a/src/Psalm/Internal/PluginManager/Command/ShowCommand.php
+++ b/src/Psalm/Internal/PluginManager/Command/ShowCommand.php
@@ -42,7 +42,7 @@ class ShowCommand extends Command
     /**
      * @return int
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
         $current_dir = (string) getcwd() . DIRECTORY_SEPARATOR;

--- a/src/Psalm/Internal/PluginManager/Command/ShowCommand.php
+++ b/src/Psalm/Internal/PluginManager/Command/ShowCommand.php
@@ -39,9 +39,6 @@ class ShowCommand extends Command
             ->addUsage('[-c path/to/psalm.xml]');
     }
 
-    /**
-     * @return int
-     */
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);

--- a/src/Psalm/Internal/PluginManager/PluginList.php
+++ b/src/Psalm/Internal/PluginManager/PluginList.php
@@ -81,7 +81,6 @@ class PluginList
         return $class;
     }
 
-    /** @return null|string */
     public function findPluginPackage(string $class): ?string
     {
         // pluginClass => ?pluginPackage

--- a/src/Psalm/Internal/PluginManager/PluginList.php
+++ b/src/Psalm/Internal/PluginManager/PluginList.php
@@ -82,7 +82,7 @@ class PluginList
     }
 
     /** @return null|string */
-    public function findPluginPackage(string $class)
+    public function findPluginPackage(string $class): ?string
     {
         // pluginClass => ?pluginPackage
         $plugin_classes = $this->getAll();

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -121,7 +121,7 @@ class ClassLikeStorageCacheProvider
      *
      * @return string
      */
-    private function getCacheHash($file_path, $file_contents)
+    private function getCacheHash($file_path, $file_contents): string
     {
         return sha1(($file_path ? $file_contents : '') . $this->modified_timestamps);
     }
@@ -133,7 +133,7 @@ class ClassLikeStorageCacheProvider
      *
      * @return ClassLikeStorage|null
      */
-    private function loadFromCache($fq_classlike_name_lc, $file_path)
+    private function loadFromCache($fq_classlike_name_lc, $file_path): ?ClassLikeStorage
     {
         $cache_location = $this->getCacheLocationForClass($fq_classlike_name_lc, $file_path);
 
@@ -167,7 +167,7 @@ class ClassLikeStorageCacheProvider
      *
      * @return string
      */
-    private function getCacheLocationForClass($fq_classlike_name_lc, $file_path, $create_directory = false)
+    private function getCacheLocationForClass($fq_classlike_name_lc, $file_path, $create_directory = false): string
     {
         $root_cache_directory = $this->config->getCacheDirectory();
 

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -119,7 +119,6 @@ class ClassLikeStorageCacheProvider
      * @param  string|null $file_path
      * @param  string|null $file_contents
      *
-     * @return string
      */
     private function getCacheHash($file_path, $file_contents): string
     {
@@ -131,7 +130,6 @@ class ClassLikeStorageCacheProvider
      * @param  string|null  $file_path
      * @psalm-suppress MixedAssignment
      *
-     * @return ClassLikeStorage|null
      */
     private function loadFromCache($fq_classlike_name_lc, $file_path): ?ClassLikeStorage
     {
@@ -165,7 +163,6 @@ class ClassLikeStorageCacheProvider
      * @param  string|null  $file_path
      * @param  bool $create_directory
      *
-     * @return string
      */
     private function getCacheLocationForClass($fq_classlike_name_lc, $file_path, $create_directory = false): string
     {

--- a/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
@@ -36,7 +36,6 @@ class ClassLikeStorageProvider
      * @param  string $fq_classlike_name
      * @throws \InvalidArgumentException when class does not exist
      *
-     * @return ClassLikeStorage
      */
     public function get($fq_classlike_name): ClassLikeStorage
     {
@@ -51,7 +50,6 @@ class ClassLikeStorageProvider
     /**
      * @param  string $fq_classlike_name
      *
-     * @return bool
      */
     public function has($fq_classlike_name): bool
     {
@@ -65,7 +63,6 @@ class ClassLikeStorageProvider
      * @param  string|null $file_path
      * @param  string|null $file_contents
      *
-     * @return ClassLikeStorage
      */
     public function exhume($fq_classlike_name, $file_path, $file_contents): ClassLikeStorage
     {
@@ -125,7 +122,6 @@ class ClassLikeStorageProvider
     /**
      * @param  string $fq_classlike_name
      *
-     * @return ClassLikeStorage
      */
     public function create($fq_classlike_name): ClassLikeStorage
     {

--- a/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
@@ -38,7 +38,7 @@ class ClassLikeStorageProvider
      *
      * @return ClassLikeStorage
      */
-    public function get($fq_classlike_name)
+    public function get($fq_classlike_name): ClassLikeStorage
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
         if (!isset(self::$storage[$fq_classlike_name_lc])) {
@@ -53,7 +53,7 @@ class ClassLikeStorageProvider
      *
      * @return bool
      */
-    public function has($fq_classlike_name)
+    public function has($fq_classlike_name): bool
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
 
@@ -67,7 +67,7 @@ class ClassLikeStorageProvider
      *
      * @return ClassLikeStorage
      */
-    public function exhume($fq_classlike_name, $file_path, $file_contents)
+    public function exhume($fq_classlike_name, $file_path, $file_contents): ClassLikeStorage
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
 
@@ -90,7 +90,7 @@ class ClassLikeStorageProvider
     /**
      * @return array<string, ClassLikeStorage>
      */
-    public function getAll()
+    public function getAll(): array
     {
         return self::$storage;
     }
@@ -98,7 +98,7 @@ class ClassLikeStorageProvider
     /**
      * @return array<string, ClassLikeStorage>
      */
-    public function getNew()
+    public function getNew(): array
     {
         return self::$new_storage;
     }
@@ -127,7 +127,7 @@ class ClassLikeStorageProvider
      *
      * @return ClassLikeStorage
      */
-    public function create($fq_classlike_name)
+    public function create($fq_classlike_name): ClassLikeStorage
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
 

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -24,7 +24,6 @@ class FileProvider
     /**
      * @param  string  $file_path
      *
-     * @return string
      */
     public function getContents($file_path, bool $go_to_source = false): string
     {
@@ -82,7 +81,6 @@ class FileProvider
     /**
      * @param  string $file_path
      *
-     * @return int
      */
     public function getModifiedTime($file_path): int
     {
@@ -117,9 +115,6 @@ class FileProvider
         $this->open_files[strtolower($file_path)] = $this->getContents($file_path, true);
     }
 
-    /**
-     * @return bool
-     */
     public function isOpen(string $file_path): bool
     {
         return isset($this->temp_files[strtolower($file_path)]) || isset($this->open_files[strtolower($file_path)]);
@@ -136,7 +131,6 @@ class FileProvider
     /**
      * @param  string $file_path
      *
-     * @return bool
      */
     public function fileExists($file_path): bool
     {

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -26,7 +26,7 @@ class FileProvider
      *
      * @return string
      */
-    public function getContents($file_path, bool $go_to_source = false)
+    public function getContents($file_path, bool $go_to_source = false): string
     {
         if (!$go_to_source && isset($this->temp_files[strtolower($file_path)])) {
             return $this->temp_files[strtolower($file_path)];
@@ -84,7 +84,7 @@ class FileProvider
      *
      * @return int
      */
-    public function getModifiedTime($file_path)
+    public function getModifiedTime($file_path): int
     {
         if (!file_exists($file_path)) {
             throw new \UnexpectedValueException('File should exist to get modified time');
@@ -120,7 +120,7 @@ class FileProvider
     /**
      * @return bool
      */
-    public function isOpen(string $file_path)
+    public function isOpen(string $file_path): bool
     {
         return isset($this->temp_files[strtolower($file_path)]) || isset($this->open_files[strtolower($file_path)]);
     }
@@ -138,7 +138,7 @@ class FileProvider
      *
      * @return bool
      */
-    public function fileExists($file_path)
+    public function fileExists($file_path): bool
     {
         return file_exists($file_path);
     }
@@ -149,7 +149,7 @@ class FileProvider
      *
      * @return array<int, string>
      */
-    public function getFilesInDir($dir_path, array $file_extensions)
+    public function getFilesInDir($dir_path, array $file_extensions): array
     {
         $file_paths = [];
 

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -57,7 +57,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedFileReferences()
+    public function getCachedFileReferences(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -85,7 +85,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedClassLikeFiles()
+    public function getCachedClassLikeFiles(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -113,7 +113,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedNonMethodClassReferences()
+    public function getCachedNonMethodClassReferences(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -141,7 +141,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedMethodClassReferences()
+    public function getCachedMethodClassReferences(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -169,7 +169,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedMethodMemberReferences()
+    public function getCachedMethodMemberReferences(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -197,7 +197,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedMethodMissingMemberReferences()
+    public function getCachedMethodMissingMemberReferences(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -225,7 +225,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedFileMemberReferences()
+    public function getCachedFileMemberReferences(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -253,7 +253,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedFileMissingMemberReferences()
+    public function getCachedFileMissingMemberReferences(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -282,7 +282,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedMixedMemberNameReferences()
+    public function getCachedMixedMemberNameReferences(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -310,7 +310,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedMethodParamUses()
+    public function getCachedMethodParamUses(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 
@@ -338,7 +338,7 @@ class FileReferenceCacheProvider
      *
      * @psalm-suppress MixedAssignment
      */
-    public function getCachedIssues()
+    public function getCachedIssues(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
 

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -53,7 +53,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -81,7 +80,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -109,7 +107,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -137,7 +134,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -165,7 +161,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -193,7 +188,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -221,7 +215,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -249,7 +242,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -278,7 +270,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -306,7 +297,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */
@@ -334,7 +324,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     * @return ?array
      *
      * @psalm-suppress MixedAssignment
      */

--- a/src/Psalm/Internal/Provider/FileReferenceProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceProvider.php
@@ -145,7 +145,7 @@ class FileReferenceProvider
     /**
      * @return array<string>
      */
-    public function getDeletedReferencedFiles()
+    public function getDeletedReferencedFiles(): array
     {
         if (self::$deleted_files === null) {
             self::$deleted_files = array_filter(
@@ -155,7 +155,7 @@ class FileReferenceProvider
                  *
                  * @return bool
                  */
-                function ($file_name) {
+                function ($file_name): bool {
                     return !file_exists($file_name);
                 }
             );
@@ -176,7 +176,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array<string,bool>>
      */
-    public function getAllNonMethodReferencesToClasses()
+    public function getAllNonMethodReferencesToClasses(): array
     {
         return self::$nonmethod_references_to_classes;
     }
@@ -227,7 +227,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array<string,bool>>
      */
-    public function getAllFileReferencesToClassMembers()
+    public function getAllFileReferencesToClassMembers(): array
     {
         return self::$file_references_to_class_members;
     }
@@ -235,7 +235,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array<string,bool>>
      */
-    public function getAllFileReferencesToMissingClassMembers()
+    public function getAllFileReferencesToMissingClassMembers(): array
     {
         return self::$file_references_to_missing_class_members;
     }
@@ -302,7 +302,7 @@ class FileReferenceProvider
      *
      * @return  array<int, string>
      */
-    private function calculateFilesReferencingFile(Codebase $codebase, $file)
+    private function calculateFilesReferencingFile(Codebase $codebase, $file): array
     {
         $referenced_files = [];
 
@@ -343,7 +343,7 @@ class FileReferenceProvider
      *
      * @return  array<int, string>
      */
-    private function calculateFilesInheritingFile(Codebase $codebase, $file)
+    private function calculateFilesInheritingFile(Codebase $codebase, $file): array
     {
         $referenced_files = [];
 
@@ -384,7 +384,7 @@ class FileReferenceProvider
      *
      * @return array<string>
      */
-    public function getFilesReferencingFile($file)
+    public function getFilesReferencingFile($file): array
     {
         return isset(self::$file_references[$file]['a']) ? self::$file_references[$file]['a'] : [];
     }
@@ -394,7 +394,7 @@ class FileReferenceProvider
      *
      * @return array<string>
      */
-    public function getFilesInheritingFromFile($file)
+    public function getFilesInheritingFromFile($file): array
     {
         return isset(self::$file_references[$file]['i']) ? self::$file_references[$file]['i'] : [];
     }
@@ -402,7 +402,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array<string, bool>>
      */
-    public function getAllMethodReferencesToClassMembers()
+    public function getAllMethodReferencesToClassMembers(): array
     {
         return self::$method_references_to_class_members;
     }
@@ -410,7 +410,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array<string, bool>>
      */
-    public function getAllMethodReferencesToClasses()
+    public function getAllMethodReferencesToClasses(): array
     {
         return self::$method_references_to_classes;
     }
@@ -418,7 +418,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array<string, bool>>
      */
-    public function getAllMethodReferencesToMissingClassMembers()
+    public function getAllMethodReferencesToMissingClassMembers(): array
     {
         return self::$method_references_to_missing_class_members;
     }
@@ -426,7 +426,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array<string,bool>>
      */
-    public function getAllReferencesToMixedMemberNames()
+    public function getAllReferencesToMixedMemberNames(): array
     {
         return self::$references_to_mixed_member_names;
     }
@@ -434,7 +434,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array<int, array<string, bool>>>
      */
-    public function getAllMethodParamUses()
+    public function getAllMethodParamUses(): array
     {
         return self::$method_param_uses;
     }
@@ -445,7 +445,7 @@ class FileReferenceProvider
      * @return bool
      * @psalm-suppress MixedPropertyTypeCoercion
      */
-    public function loadReferenceCache($force_reload = true)
+    public function loadReferenceCache($force_reload = true): bool
     {
         if ($this->cache && (!$this->loaded_from_cache || $force_reload)) {
             $this->loaded_from_cache = true;
@@ -1041,7 +1041,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array{int, int}>
      */
-    public function getTypeCoverage()
+    public function getTypeCoverage(): array
     {
         return self::$mixed_counts;
     }
@@ -1059,7 +1059,7 @@ class FileReferenceProvider
     /**
      * @return array<string, array<string, int>>
      */
-    public function getAnalyzedMethods()
+    public function getAnalyzedMethods(): array
     {
         return self::$analyzed_methods;
     }
@@ -1067,7 +1067,7 @@ class FileReferenceProvider
     /**
      * @return array<string, FileMapType>
      */
-    public function getFileMaps()
+    public function getFileMaps(): array
     {
         return self::$file_maps;
     }

--- a/src/Psalm/Internal/Provider/FileReferenceProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceProvider.php
@@ -153,7 +153,6 @@ class FileReferenceProvider
                 /**
                  * @param  string $file_name
                  *
-                 * @return bool
                  */
                 function ($file_name): bool {
                     return !file_exists($file_name);
@@ -442,7 +441,6 @@ class FileReferenceProvider
     /**
      * @param bool $force_reload
      *
-     * @return bool
      * @psalm-suppress MixedPropertyTypeCoercion
      */
     public function loadReferenceCache($force_reload = true): bool
@@ -1002,7 +1000,6 @@ class FileReferenceProvider
 
     /**
      * @param string $file_path
-     * @param IssueData $issue
      *
      * @return void
      */

--- a/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
@@ -91,7 +91,7 @@ class FileStorageCacheProvider
      *
      * @return FileStorage|null
      */
-    public function getLatestFromCache($file_path, $file_contents)
+    public function getLatestFromCache($file_path, $file_contents): ?FileStorage
     {
         $file_path = strtolower($file_path);
         $cached_value = $this->loadFromCache($file_path);
@@ -134,7 +134,7 @@ class FileStorageCacheProvider
      *
      * @return string
      */
-    private function getCacheHash($file_path, $file_contents)
+    private function getCacheHash($file_path, $file_contents): string
     {
         return sha1(strtolower($file_path) . ' ' . $file_contents . $this->modified_timestamps);
     }
@@ -145,7 +145,7 @@ class FileStorageCacheProvider
      *
      * @return FileStorage|null
      */
-    private function loadFromCache($file_path)
+    private function loadFromCache($file_path): ?FileStorage
     {
         $cache_location = $this->getCacheLocationForPath($file_path);
 
@@ -178,7 +178,7 @@ class FileStorageCacheProvider
      *
      * @return string
      */
-    private function getCacheLocationForPath($file_path, $create_directory = false)
+    private function getCacheLocationForPath($file_path, $create_directory = false): string
     {
         $root_cache_directory = $this->config->getCacheDirectory();
 

--- a/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
@@ -89,7 +89,6 @@ class FileStorageCacheProvider
      * @param  string $file_path
      * @param  string $file_contents
      *
-     * @return FileStorage|null
      */
     public function getLatestFromCache($file_path, $file_contents): ?FileStorage
     {
@@ -132,7 +131,6 @@ class FileStorageCacheProvider
      * @param  string $file_path
      * @param  string $file_contents
      *
-     * @return string
      */
     private function getCacheHash($file_path, $file_contents): string
     {
@@ -143,7 +141,6 @@ class FileStorageCacheProvider
      * @param  string  $file_path
      * @psalm-suppress MixedAssignment
      *
-     * @return FileStorage|null
      */
     private function loadFromCache($file_path): ?FileStorage
     {
@@ -176,7 +173,6 @@ class FileStorageCacheProvider
      * @param  string  $file_path
      * @param  bool $create_directory
      *
-     * @return string
      */
     private function getCacheLocationForPath($file_path, $create_directory = false): string
     {

--- a/src/Psalm/Internal/Provider/FileStorageProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageProvider.php
@@ -41,7 +41,7 @@ class FileStorageProvider
      *
      * @return FileStorage
      */
-    public function get($file_path)
+    public function get($file_path): FileStorage
     {
         $file_path = strtolower($file_path);
 
@@ -68,7 +68,7 @@ class FileStorageProvider
      *
      * @return bool
      */
-    public function has($file_path, string $file_contents = null)
+    public function has($file_path, string $file_contents = null): bool
     {
         $file_path = strtolower($file_path);
 
@@ -99,7 +99,7 @@ class FileStorageProvider
     /**
      * @return array<string, FileStorage>
      */
-    public function getAll()
+    public function getAll(): array
     {
         return self::$storage;
     }
@@ -107,7 +107,7 @@ class FileStorageProvider
     /**
      * @return array<string, FileStorage>
      */
-    public function getNew()
+    public function getNew(): array
     {
         return self::$new_storage;
     }
@@ -128,7 +128,7 @@ class FileStorageProvider
      *
      * @return FileStorage
      */
-    public function create($file_path)
+    public function create($file_path): FileStorage
     {
         $file_path_lc = strtolower($file_path);
 

--- a/src/Psalm/Internal/Provider/FileStorageProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageProvider.php
@@ -39,7 +39,6 @@ class FileStorageProvider
     /**
      * @param  string $file_path
      *
-     * @return FileStorage
      */
     public function get($file_path): FileStorage
     {
@@ -64,9 +63,7 @@ class FileStorageProvider
 
     /**
      * @param  string $file_path
-     * @param  string $file_contents
      *
-     * @return bool
      */
     public function has($file_path, string $file_contents = null): bool
     {
@@ -126,7 +123,6 @@ class FileStorageProvider
     /**
      * @param  string $file_path
      *
-     * @return FileStorage
      */
     public function create($file_path): FileStorage
     {

--- a/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
@@ -65,7 +65,7 @@ class FunctionExistenceProvider
     public function doesFunctionExist(
         StatementsSource $statements_source,
         string $function_id
-    ) {
+    ): ?bool {
         foreach (self::$handlers[strtolower($function_id)] as $function_handler) {
             $function_exists = $function_handler(
                 $statements_source,

--- a/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
@@ -60,7 +60,6 @@ class FunctionExistenceProvider
     /**
      * @param  array<PhpParser\Node\Arg>  $call_args
      *
-     * @return ?bool
      */
     public function doesFunctionExist(
         StatementsSource $statements_source,

--- a/src/Psalm/Internal/Provider/FunctionParamsProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionParamsProvider.php
@@ -75,7 +75,7 @@ class FunctionParamsProvider
         array $call_args,
         Context $context = null,
         CodeLocation $code_location = null
-    ) {
+    ): ?array {
         foreach (self::$handlers[strtolower($function_id)] as $class_handler) {
             $result = $class_handler(
                 $statements_source,

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -105,7 +105,7 @@ class FunctionReturnTypeProvider
         array $call_args,
         Context $context,
         CodeLocation $code_location
-    ) {
+    ): ?Type\Union {
         foreach (self::$handlers[strtolower($function_id)] as $function_handler) {
             $return_type = $function_handler(
                 $statements_source,

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -97,7 +97,6 @@ class FunctionReturnTypeProvider
      * @param  non-empty-string $function_id
      * @param  array<PhpParser\Node\Arg>  $call_args
      *
-     * @return ?Type\Union
      */
     public function getReturnType(
         StatementsSource $statements_source,

--- a/src/Psalm/Internal/Provider/MethodExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/MethodExistenceProvider.php
@@ -65,7 +65,6 @@ class MethodExistenceProvider
     /**
      * @param  array<PhpParser\Node\Arg>  $call_args
      *
-     * @return ?bool
      */
     public function doesMethodExist(
         string $fq_classlike_name,

--- a/src/Psalm/Internal/Provider/MethodExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/MethodExistenceProvider.php
@@ -72,7 +72,7 @@ class MethodExistenceProvider
         string $method_name_lowercase,
         StatementsSource $source = null,
         CodeLocation $code_location = null
-    ) {
+    ): ?bool {
         foreach (self::$handlers[strtolower($fq_classlike_name)] as $method_handler) {
             $method_exists = $method_handler(
                 $fq_classlike_name,

--- a/src/Psalm/Internal/Provider/MethodParamsProvider.php
+++ b/src/Psalm/Internal/Provider/MethodParamsProvider.php
@@ -80,7 +80,7 @@ class MethodParamsProvider
         StatementsSource $statements_source = null,
         Context $context = null,
         CodeLocation $code_location = null
-    ) {
+    ): ?array {
         foreach (self::$handlers[strtolower($fq_classlike_name)] as $class_handler) {
             $result = $class_handler(
                 $fq_classlike_name,

--- a/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
@@ -94,7 +94,7 @@ class MethodReturnTypeProvider
         array $template_type_parameters = null,
         string $called_fq_classlike_name = null,
         string $called_method_name = null
-    ) {
+    ): ?Type\Union {
         foreach (self::$handlers[strtolower($fq_classlike_name)] as $class_handler) {
             $result = $class_handler(
                 $statements_source,

--- a/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
@@ -82,7 +82,6 @@ class MethodReturnTypeProvider
      * @param array<PhpParser\Node\Arg>  $call_args
      * @param  ?array<Type\Union> $template_type_parameters
      *
-     * @return  ?Type\Union
      */
     public function getReturnType(
         StatementsSource $statements_source,

--- a/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
@@ -68,7 +68,6 @@ class MethodVisibilityProvider
     /**
      * @param  array<PhpParser\Node\Arg>  $call_args
      *
-     * @return ?bool
      */
     public function isMethodVisible(
         StatementsSource $source,

--- a/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
@@ -76,7 +76,7 @@ class MethodVisibilityProvider
         string $method_name,
         Context $context,
         CodeLocation $code_location = null
-    ) {
+    ): ?bool {
         foreach (self::$handlers[strtolower($fq_classlike_name)] as $method_handler) {
             $method_visible = $method_handler(
                 $source,

--- a/src/Psalm/Internal/Provider/ParserCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ParserCacheProvider.php
@@ -175,7 +175,7 @@ class ParserCacheProvider
     /**
      * @return array<string, string>
      */
-    private function getExistingFileContentHashes()
+    private function getExistingFileContentHashes(): array
     {
         $config = Config::getInstance();
         $root_cache_directory = $config->getCacheDirectory();
@@ -259,7 +259,7 @@ class ParserCacheProvider
     /**
      * @return array<string, string>
      */
-    public function getNewFileContentHashes()
+    public function getNewFileContentHashes(): array
     {
         return $this->new_file_content_hashes;
     }
@@ -333,7 +333,7 @@ class ParserCacheProvider
      *
      * @return int
      */
-    public function deleteOldParserCaches($time_before)
+    public function deleteOldParserCaches($time_before): int
     {
         $cache_directory = Config::getInstance()->getCacheDirectory();
 
@@ -429,7 +429,7 @@ class ParserCacheProvider
      *
      * @return string
      */
-    private function getParserCacheKey($file_name)
+    private function getParserCacheKey($file_name): string
     {
         return md5($file_name) . ($this->use_igbinary ? '-igbinary' : '') . '-r';
     }

--- a/src/Psalm/Internal/Provider/ParserCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ParserCacheProvider.php
@@ -331,7 +331,6 @@ class ParserCacheProvider
     /**
      * @param  float $time_before
      *
-     * @return int
      */
     public function deleteOldParserCaches($time_before): int
     {
@@ -427,7 +426,6 @@ class ParserCacheProvider
     /**
      * @param  string  $file_name
      *
-     * @return string
      */
     private function getParserCacheKey($file_name): string
     {

--- a/src/Psalm/Internal/Provider/ProjectCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ProjectCacheProvider.php
@@ -33,9 +33,6 @@ class ProjectCacheProvider
         $this->composer_lock_location = $composer_lock_location;
     }
 
-    /**
-     * @return bool
-     */
     public function canDiffFiles(): bool
     {
         $cache_directory = Config::getInstance()->getCacheDirectory();
@@ -61,9 +58,6 @@ class ProjectCacheProvider
         \touch($run_cache_location, (int)$start_time);
     }
 
-    /**
-     * @return int
-     */
     public function getLastRun(): int
     {
         if ($this->last_run === null) {

--- a/src/Psalm/Internal/Provider/ProjectCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ProjectCacheProvider.php
@@ -36,7 +36,7 @@ class ProjectCacheProvider
     /**
      * @return bool
      */
-    public function canDiffFiles()
+    public function canDiffFiles(): bool
     {
         $cache_directory = Config::getInstance()->getCacheDirectory();
 
@@ -64,7 +64,7 @@ class ProjectCacheProvider
     /**
      * @return int
      */
-    public function getLastRun()
+    public function getLastRun(): int
     {
         if ($this->last_run === null) {
             $cache_directory = Config::getInstance()->getCacheDirectory();

--- a/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
@@ -69,7 +69,6 @@ class PropertyExistenceProvider
     /**
      * @param  array<PhpParser\Node\Arg>  $call_args
      *
-     * @return ?bool
      */
     public function doesPropertyExist(
         string $fq_classlike_name,

--- a/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
@@ -78,7 +78,7 @@ class PropertyExistenceProvider
         StatementsSource $source = null,
         Context $context = null,
         CodeLocation $code_location = null
-    ) {
+    ): ?bool {
         foreach (self::$handlers[strtolower($fq_classlike_name)] as $property_handler) {
             $property_exists = $property_handler(
                 $fq_classlike_name,

--- a/src/Psalm/Internal/Provider/PropertyTypeProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyTypeProvider.php
@@ -68,7 +68,6 @@ class PropertyTypeProvider
     /**
      * @param  array<PhpParser\Node\Arg>  $call_args
      *
-     * @return ?Type\Union
      */
     public function getPropertyType(
         string $fq_classlike_name,

--- a/src/Psalm/Internal/Provider/PropertyTypeProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyTypeProvider.php
@@ -76,7 +76,7 @@ class PropertyTypeProvider
         bool $read_mode,
         StatementsSource $source = null,
         Context $context = null
-    ) {
+    ): ?Type\Union {
         foreach (self::$handlers[strtolower($fq_classlike_name)] as $property_handler) {
             $property_type = $property_handler(
                 $fq_classlike_name,

--- a/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
@@ -79,7 +79,7 @@ class PropertyVisibilityProvider
         bool $read_mode,
         Context $context,
         CodeLocation $code_location
-    ) {
+    ): ?bool {
         foreach (self::$handlers[strtolower($fq_classlike_name)] as $property_handler) {
             $property_visible = $property_handler(
                 $source,

--- a/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
@@ -70,7 +70,6 @@ class PropertyVisibilityProvider
     /**
      * @param  array<PhpParser\Node\Arg>  $call_args
      *
-     * @return ?bool
      */
     public function isPropertyVisible(
         StatementsSource $source,

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayChunkReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayChunkReturnTypeProvider.php
@@ -22,7 +22,7 @@ class ArrayChunkReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnT
         array $call_args,
         Context $context,
         CodeLocation $code_location
-    ) {
+    ): ?Type\Union {
         if (count($call_args) >= 2
             && ($array_arg_type = $statements_source->getNodeTypeProvider()->getType($call_args[0]->value))
             && $array_arg_type->isSingle()

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
@@ -24,7 +24,6 @@ class ArrayMapReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTyp
 
     /**
      * @param  array<PhpParser\Node\Arg>    $call_args
-     * @param  CodeLocation                 $code_location
      */
     public static function getFunctionReturnType(
         StatementsSource $statements_source,

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPadReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPadReturnTypeProvider.php
@@ -22,7 +22,7 @@ class ArrayPadReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTyp
         array $call_args,
         Context $context,
         CodeLocation $code_location
-    ) {
+    ): ?Type\Union {
         $type_provider = $statements_source->getNodeTypeProvider();
 
         if (count($call_args) >= 3

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FirstArgStringReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FirstArgStringReturnTypeProvider.php
@@ -25,7 +25,7 @@ class FirstArgStringReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionRet
         array $call_args,
         Context $context,
         CodeLocation $code_location
-    ) {
+    ): ?Type\Union {
         if (!$statements_source instanceof \Psalm\Internal\Analyzer\StatementsAnalyzer) {
             return Type::getMixed();
         }

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetClassMethodsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetClassMethodsReturnTypeProvider.php
@@ -25,7 +25,7 @@ class GetClassMethodsReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionRe
         array $call_args,
         Context $context,
         CodeLocation $code_location
-    ) {
+    ): ?Type\Union {
         if (!$statements_source instanceof \Psalm\Internal\Analyzer\StatementsAnalyzer) {
             return Type::getMixed();
         }

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
@@ -25,7 +25,7 @@ class GetObjectVarsReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionRetu
         array $call_args,
         Context $context,
         CodeLocation $code_location
-    ) {
+    ): ?Type\Union {
         if (!$statements_source instanceof \Psalm\Internal\Analyzer\StatementsAnalyzer) {
             return Type::getMixed();
         }

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/HexdecReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/HexdecReturnTypeProvider.php
@@ -16,7 +16,6 @@ class HexdecReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeP
 
     /**
      * @param  array<PhpParser\Node\Arg>    $call_args
-     * @param  CodeLocation                 $code_location
      */
     public static function getFunctionReturnType(
         StatementsSource $statements_source,

--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -187,7 +187,7 @@ class StatementsProvider
                      *
                      * @return bool
                      */
-                    function ($_) {
+                    function ($_): bool {
                         return true;
                     },
                     array_flip($unchanged_members)
@@ -199,7 +199,7 @@ class StatementsProvider
                      *
                      * @return bool
                      */
-                    function ($_) {
+                    function ($_): bool {
                         return true;
                     },
                     array_flip($unchanged_signature_members)
@@ -224,7 +224,7 @@ class StatementsProvider
                      *
                      * @return bool
                      */
-                    function ($_) {
+                    function ($_): bool {
                         return true;
                     },
                     array_flip($changed_members)
@@ -282,7 +282,7 @@ class StatementsProvider
     /**
      * @return array<string, array<string, bool>>
      */
-    public function getChangedMembers()
+    public function getChangedMembers(): array
     {
         return $this->changed_members;
     }
@@ -300,7 +300,7 @@ class StatementsProvider
     /**
      * @return array<string, array<string, bool>>
      */
-    public function getUnchangedSignatureMembers()
+    public function getUnchangedSignatureMembers(): array
     {
         return $this->unchanged_signature_members;
     }
@@ -330,7 +330,7 @@ class StatementsProvider
     /**
      * @return array<string, array<int, array{0: int, 1: int, 2: int, 3: int}>>
      */
-    public function getDiffMap()
+    public function getDiffMap(): array
     {
         return $this->diff_map;
     }

--- a/src/Psalm/Internal/ReferenceConstraint.php
+++ b/src/Psalm/Internal/ReferenceConstraint.php
@@ -11,9 +11,6 @@ class ReferenceConstraint
     /** @var Type\Union|null */
     public $type;
 
-    /**
-     * @param  Type\Union $type
-     */
     public function __construct(Type\Union $type = null)
     {
         if ($type) {

--- a/src/Psalm/Internal/Scanner/FileScanner.php
+++ b/src/Psalm/Internal/Scanner/FileScanner.php
@@ -98,41 +98,26 @@ class FileScanner implements FileSource
         $file_storage->deep_scan = $this->will_analyze;
     }
 
-    /**
-     * @return string
-     */
     public function getFilePath(): string
     {
         return $this->file_path;
     }
 
-    /**
-     * @return string
-     */
     public function getFileName(): string
     {
         return $this->file_name;
     }
 
-    /**
-     * @return string
-     */
     public function getRootFilePath(): string
     {
         return $this->file_path;
     }
 
-    /**
-     * @return string
-     */
     public function getRootFileName(): string
     {
         return $this->file_name;
     }
 
-    /**
-     * @return \Psalm\Aliases
-     */
     public function getAliases(): \Psalm\Aliases
     {
         return new \Psalm\Aliases();

--- a/src/Psalm/Internal/Scanner/FileScanner.php
+++ b/src/Psalm/Internal/Scanner/FileScanner.php
@@ -101,7 +101,7 @@ class FileScanner implements FileSource
     /**
      * @return string
      */
-    public function getFilePath()
+    public function getFilePath(): string
     {
         return $this->file_path;
     }
@@ -109,7 +109,7 @@ class FileScanner implements FileSource
     /**
      * @return string
      */
-    public function getFileName()
+    public function getFileName(): string
     {
         return $this->file_name;
     }
@@ -117,7 +117,7 @@ class FileScanner implements FileSource
     /**
      * @return string
      */
-    public function getRootFilePath()
+    public function getRootFilePath(): string
     {
         return $this->file_path;
     }
@@ -125,7 +125,7 @@ class FileScanner implements FileSource
     /**
      * @return string
      */
-    public function getRootFileName()
+    public function getRootFileName(): string
     {
         return $this->file_name;
     }
@@ -133,7 +133,7 @@ class FileScanner implements FileSource
     /**
      * @return \Psalm\Aliases
      */
-    public function getAliases()
+    public function getAliases(): \Psalm\Aliases
     {
         return new \Psalm\Aliases();
     }

--- a/src/Psalm/Internal/Scanner/ParsedDocblock.php
+++ b/src/Psalm/Internal/Scanner/ParsedDocblock.php
@@ -82,7 +82,6 @@ class ParsedDocblock
     /**
      * Sets whether a new line should be added between the annotations or not.
      *
-     * @param bool $should
      */
     public static function addNewLineBetweenAnnotations(bool $should = true): void
     {

--- a/src/Psalm/Internal/Taint/Taintable.php
+++ b/src/Psalm/Internal/Taint/Taintable.php
@@ -71,7 +71,7 @@ abstract class Taintable
         int $argument_offset,
         ?CodeLocation $arg_location,
         ?CodeLocation $code_location = null
-    ) {
+    ): Taintable {
         $arg_id = strtolower($method_id) . '#' . ($argument_offset + 1);
 
         $label = $cased_method_id . '#' . ($argument_offset + 1);
@@ -96,7 +96,7 @@ abstract class Taintable
     final public static function getForAssignment(
         string $var_id,
         CodeLocation $assignment_location
-    ) {
+    ): Taintable {
         $id = $var_id
             . '-' . $assignment_location->file_name
             . ':' . $assignment_location->raw_file_start
@@ -113,7 +113,7 @@ abstract class Taintable
         string $cased_method_id,
         ?CodeLocation $code_location,
         ?CodeLocation $function_location = null
-    ) {
+    ): Taintable {
         $specialization_key = null;
 
         if ($function_location) {
@@ -128,7 +128,7 @@ abstract class Taintable
         );
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->id;
     }

--- a/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
@@ -32,7 +32,7 @@ class ObjectComparator
         Type\Atomic $container_type_part,
         bool $allow_interface_equality,
         ?TypeComparisonResult $atomic_comparison_result
-    ) {
+    ): bool {
         $intersection_input_types = $input_type_part->extra_types ?: [];
         $intersection_input_types[$input_type_part->getKey(false)] = $input_type_part;
 

--- a/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
@@ -24,7 +24,6 @@ class ObjectComparator
      * @param  TNamedObject|TTemplateParam|TIterable  $input_type_part
      * @param  TNamedObject|TTemplateParam|TIterable  $container_type_part
      *
-     * @return bool
      */
     public static function isShallowlyContainedBy(
         Codebase $codebase,

--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -258,10 +258,7 @@ class UnionTypeComparator
     /**
      * Used for comparing signature typehints, uses PHP's light contravariance rules
      *
-     * @param  ?Type\Union  $input_type
-     * @param  Type\Union   $container_type
      *
-     * @return bool
      */
     public static function isContainedByInPhp(
         ?Type\Union $input_type,
@@ -299,8 +296,6 @@ class UnionTypeComparator
     /**
      * Used for comparing docblock types to signature types before we know about all types
      *
-     * @param  Type\Union   $input_type
-     * @param  Type\Union   $container_type
      */
     public static function isSimplyContainedBy(
         Type\Union $input_type,
@@ -345,12 +340,9 @@ class UnionTypeComparator
     /**
      * Does the input param type match the given param type
      *
-     * @param  Type\Union   $input_type
-     * @param  Type\Union   $container_type
      * @param  bool         $ignore_null
      * @param  bool         $ignore_false
      *
-     * @return bool
      */
     public static function canBeContainedBy(
         Codebase $codebase,
@@ -402,7 +394,6 @@ class UnionTypeComparator
     /**
      * Can any part of the $type1 be equal to any part of $type2
      *
-     * @return bool
      */
     public static function canExpressionTypesBeIdentical(
         Codebase $codebase,

--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -266,7 +266,7 @@ class UnionTypeComparator
     public static function isContainedByInPhp(
         ?Type\Union $input_type,
         Type\Union $container_type
-    ) {
+    ): bool {
         if (!$input_type) {
             return false;
         }
@@ -359,7 +359,7 @@ class UnionTypeComparator
         $ignore_null = false,
         $ignore_false = false,
         array &$matching_input_keys = []
-    ) {
+    ): bool {
         if ($container_type->hasMixed()) {
             return true;
         }
@@ -408,7 +408,7 @@ class UnionTypeComparator
         Codebase $codebase,
         Type\Union $type1,
         Type\Union $type2
-    ) {
+    ): bool {
         if ($type1->hasMixed() || $type2->hasMixed()) {
             return true;
         }

--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -30,7 +30,6 @@ class NegatedAssertionReconciler extends Reconciler
      * @param  string[]   $suppressed_issues
      * @param  0|1|2      $failed_reconciliation
      *
-     * @return Type\Union
      */
     public static function reconcile(
         StatementsAnalyzer $statements_analyzer,
@@ -284,14 +283,8 @@ class NegatedAssertionReconciler extends Reconciler
     }
 
     /**
-     * @param  string     $assertion
-     * @param  int        $bracket_pos
-     * @param  string     $old_var_type_string
-     * @param  string|null $key
-     * @param  CodeLocation|null $code_location
      * @param  string[]   $suppressed_issues
      *
-     * @return Type\Union
      */
     private static function handleLiteralNegatedEquality(
         StatementsAnalyzer $statements_analyzer,

--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -44,7 +44,7 @@ class NegatedAssertionReconciler extends Reconciler
         ?CodeLocation $code_location,
         array $suppressed_issues,
         int &$failed_reconciliation
-    ) {
+    ): Type\Union {
         $is_equality = $is_strict_equality || $is_loose_equality;
 
         // this is a specific value comparison type that cannot be negated
@@ -303,7 +303,7 @@ class NegatedAssertionReconciler extends Reconciler
         ?CodeLocation $code_location,
         array $suppressed_issues,
         bool $is_strict_equality
-    ) {
+    ): Type\Union {
         $scalar_type = substr($assertion, 0, $bracket_pos);
 
         $existing_var_atomic_types = $existing_var_type->getAtomicTypes();

--- a/src/Psalm/Internal/Type/ParseTree/Value.php
+++ b/src/Psalm/Internal/Type/ParseTree/Value.php
@@ -22,7 +22,6 @@ class Value extends \Psalm\Internal\Type\ParseTree
     public $offset_end;
 
     /**
-     * @param string $value
      * @param \Psalm\Internal\Type\ParseTree|null $parent
      */
     public function __construct(

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -2166,7 +2166,7 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
                 || ($array_atomic_type instanceof Type\Atomic\TKeyedArray
                     && array_filter(
                         $array_atomic_type->properties,
-                        function (Type\Union $t) {
+                        function (Type\Union $t): bool {
                             return !$t->possibly_undefined;
                         }
                     ))

--- a/src/Psalm/Internal/Type/TypeCombination.php
+++ b/src/Psalm/Internal/Type/TypeCombination.php
@@ -158,7 +158,6 @@ class TypeCombination
      * @param  int    $literal_limit any greater number of literal types than this
      *                               will be merged to a scalar
      *
-     * @return Union
      */
     public static function combineTypes(
         array $types,
@@ -613,8 +612,6 @@ class TypeCombination
     }
 
     /**
-     * @param  Atomic  $type
-     * @param  TypeCombination $combination
      * @param  Codebase|null   $codebase
      *
      * @return null|Union

--- a/src/Psalm/Internal/Type/TypeCombination.php
+++ b/src/Psalm/Internal/Type/TypeCombination.php
@@ -166,7 +166,7 @@ class TypeCombination
         bool $overwrite_empty_array = false,
         bool $allow_mixed_union = true,
         int $literal_limit = 500
-    ) {
+    ): Union {
         if (in_array(null, $types, true)) {
             return Type::getMixed();
         }
@@ -1302,7 +1302,7 @@ class TypeCombination
 
                     $all_nonnegative = !array_filter(
                         $combination->ints,
-                        function ($int) {
+                        function ($int): bool {
                             return $int->value < 0;
                         }
                     );
@@ -1322,7 +1322,7 @@ class TypeCombination
                     if ($combination->ints) {
                         $all_nonnegative = !array_filter(
                             $combination->ints,
-                            function ($int) {
+                            function ($int): bool {
                                 return $int->value < 0;
                             }
                         );
@@ -1421,7 +1421,7 @@ class TypeCombination
     /**
      * @return array<string, bool>
      */
-    private static function getClassLikes(Codebase $codebase, string $fq_classlike_name)
+    private static function getClassLikes(Codebase $codebase, string $fq_classlike_name): array
     {
         try {
             $class_storage = $codebase->classlike_storage_provider->get($fq_classlike_name);

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -34,7 +34,7 @@ class TypeExpander
         bool $evaluate_class_constants = true,
         bool $evaluate_conditional_types = false,
         bool $final = false
-    ) {
+    ): Type\Union {
         $return_type = clone $return_type;
 
         $new_return_type_parts = [];

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -19,11 +19,8 @@ use function array_values;
 class TypeExpander
 {
     /**
-     * @param  Type\Union   $return_type
-     * @param  string|null  $self_class
      * @param  string|Type\Atomic\TNamedObject|Type\Atomic\TTemplateParam|null $static_class_type
      *
-     * @return Type\Union
      */
     public static function expandUnion(
         Codebase $codebase,
@@ -83,8 +80,6 @@ class TypeExpander
     }
 
     /**
-     * @param  Type\Atomic  &$return_type
-     * @param  string|null  $self_class
      * @param  string|Type\Atomic\TNamedObject|Type\Atomic\TTemplateParam|null $static_class_type
      *
      * @return Type\Atomic|non-empty-array<int, Type\Atomic>

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -104,7 +104,6 @@ class TypeParser
     }
 
     /**
-     * @param  ParseTree $parse_tree
      * @param  array{int,int}|null   $php_version
      * @param  array<string, array<string, array{Union}>> $template_type_map
      * @param  array<string, TypeAlias> $type_aliases

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -282,10 +282,8 @@ class TypeTokenizer
     }
 
     /**
-     * @param string $type_string
      * @param array{int,int}|null   $php_version
      *
-     * @return string
      *
      * @psalm-pure
      */

--- a/src/Psalm/Internal/TypeVisitor/TypeChecker.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeChecker.php
@@ -66,11 +66,8 @@ class TypeChecker extends NodeVisitor
     private $calling_method_id;
 
     /**
-     * @param  StatementsSource $source
-     * @param  CodeLocation     $code_location
      * @param  array<string>    $suppressed_issues
      * @param  array<string, bool> $phantom_classes
-     * @param  bool             $inferred
      *
      * @return null|false
      */

--- a/src/Psalm/Issue/ArgumentIssue.php
+++ b/src/Psalm/Issue/ArgumentIssue.php
@@ -12,8 +12,6 @@ abstract class ArgumentIssue extends CodeIssue
 
     /**
      * @param string        $message
-     * @param \Psalm\CodeLocation  $code_location
-     * @param string        $function_id
      */
     public function __construct(
         $message,

--- a/src/Psalm/Issue/ClassIssue.php
+++ b/src/Psalm/Issue/ClassIssue.php
@@ -10,7 +10,6 @@ abstract class ClassIssue extends CodeIssue
 
     /**
      * @param string        $message
-     * @param \Psalm\CodeLocation  $code_location
      * @param string        $fq_classlike_name
      */
     public function __construct(

--- a/src/Psalm/Issue/CodeIssue.php
+++ b/src/Psalm/Issue/CodeIssue.php
@@ -37,7 +37,7 @@ abstract class CodeIssue
     /**
      * @return CodeLocation
      */
-    public function getLocation()
+    public function getLocation(): CodeLocation
     {
         return $this->code_location;
     }
@@ -45,7 +45,7 @@ abstract class CodeIssue
     /**
      * @return string
      */
-    public function getShortLocationWithPrevious()
+    public function getShortLocationWithPrevious(): string
     {
         $previous_text = '';
 
@@ -60,7 +60,7 @@ abstract class CodeIssue
     /**
      * @return string
      */
-    public function getShortLocation()
+    public function getShortLocation(): string
     {
         return $this->code_location->file_name . ':' . $this->code_location->getLineNumber();
     }
@@ -68,7 +68,7 @@ abstract class CodeIssue
     /**
      * @return string
      */
-    public function getFilePath()
+    public function getFilePath(): string
     {
         return $this->code_location->file_path;
     }
@@ -78,7 +78,7 @@ abstract class CodeIssue
      *
      * @psalm-suppress PossiblyUnusedMethod for convenience
      */
-    public function getFileName()
+    public function getFileName(): string
     {
         return $this->code_location->file_name;
     }
@@ -86,7 +86,7 @@ abstract class CodeIssue
     /**
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
@@ -96,7 +96,7 @@ abstract class CodeIssue
      *
      * @return \Psalm\Internal\Analyzer\IssueData
      */
-    public function toIssueData($severity = Config::REPORT_ERROR)
+    public function toIssueData($severity = Config::REPORT_ERROR): \Psalm\Internal\Analyzer\IssueData
     {
         $location = $this->getLocation();
         $selection_bounds = $location->getSelectionBounds();

--- a/src/Psalm/Issue/CodeIssue.php
+++ b/src/Psalm/Issue/CodeIssue.php
@@ -24,7 +24,6 @@ abstract class CodeIssue
 
     /**
      * @param string        $message
-     * @param CodeLocation  $code_location
      */
     public function __construct(
         $message,
@@ -34,17 +33,11 @@ abstract class CodeIssue
         $this->message = $message;
     }
 
-    /**
-     * @return CodeLocation
-     */
     public function getLocation(): CodeLocation
     {
         return $this->code_location;
     }
 
-    /**
-     * @return string
-     */
     public function getShortLocationWithPrevious(): string
     {
         $previous_text = '';
@@ -57,24 +50,17 @@ abstract class CodeIssue
         return $this->code_location->file_name . ':' . $this->code_location->getLineNumber() . $previous_text;
     }
 
-    /**
-     * @return string
-     */
     public function getShortLocation(): string
     {
         return $this->code_location->file_name . ':' . $this->code_location->getLineNumber();
     }
 
-    /**
-     * @return string
-     */
     public function getFilePath(): string
     {
         return $this->code_location->file_path;
     }
 
     /**
-     * @return string
      *
      * @psalm-suppress PossiblyUnusedMethod for convenience
      */
@@ -83,9 +69,6 @@ abstract class CodeIssue
         return $this->code_location->file_name;
     }
 
-    /**
-     * @return string
-     */
     public function getMessage(): string
     {
         return $this->message;
@@ -94,7 +77,6 @@ abstract class CodeIssue
     /**
      * @param  string          $severity
      *
-     * @return \Psalm\Internal\Analyzer\IssueData
      */
     public function toIssueData($severity = Config::REPORT_ERROR): \Psalm\Internal\Analyzer\IssueData
     {

--- a/src/Psalm/Issue/FunctionIssue.php
+++ b/src/Psalm/Issue/FunctionIssue.php
@@ -12,7 +12,6 @@ abstract class FunctionIssue extends CodeIssue
 
     /**
      * @param string        $message
-     * @param \Psalm\CodeLocation  $code_location
      * @param string        $function_id
      */
     public function __construct(

--- a/src/Psalm/Issue/MethodIssue.php
+++ b/src/Psalm/Issue/MethodIssue.php
@@ -12,7 +12,6 @@ abstract class MethodIssue extends CodeIssue
 
     /**
      * @param string        $message
-     * @param \Psalm\CodeLocation  $code_location
      * @param string        $method_id
      */
     public function __construct(

--- a/src/Psalm/Issue/PropertyIssue.php
+++ b/src/Psalm/Issue/PropertyIssue.php
@@ -10,7 +10,6 @@ abstract class PropertyIssue extends CodeIssue
 
     /**
      * @param string        $message
-     * @param \Psalm\CodeLocation  $code_location
      * @param string        $property_id
      */
     public function __construct(

--- a/src/Psalm/Issue/TaintedInput.php
+++ b/src/Psalm/Issue/TaintedInput.php
@@ -23,7 +23,6 @@ class TaintedInput extends CodeIssue
 
     /**
      * @param string        $message
-     * @param CodeLocation  $code_location
      * @param list<array{location: ?CodeLocation, label: string, entry_path_type: string}> $journey
      */
     public function __construct(

--- a/src/Psalm/Issue/VariableIssue.php
+++ b/src/Psalm/Issue/VariableIssue.php
@@ -12,7 +12,6 @@ abstract class VariableIssue extends CodeIssue
 
     /**
      * @param string $message
-     * @param \Psalm\CodeLocation $code_location
      * @param string $var_name
      */
     public function __construct(

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -84,10 +84,8 @@ class IssueBuffer
     protected static $used_suppressions = [];
 
     /**
-     * @param   CodeIssue $e
      * @param   string[]  $suppressed_issues
      *
-     * @return  bool
      */
     public static function accepts(CodeIssue $e, array $suppressed_issues = [], bool $is_fixable = false): bool
     {
@@ -116,10 +114,8 @@ class IssueBuffer
     }
 
     /**
-     * @param   CodeIssue $e
      * @param   string[]  $suppressed_issues
      *
-     * @return  bool
      */
     public static function isSuppressed(CodeIssue $e, array $suppressed_issues = []) : bool
     {
@@ -187,11 +183,9 @@ class IssueBuffer
     }
 
     /**
-     * @param   CodeIssue $e
      *
      * @throws  Exception\CodeException
      *
-     * @return  bool
      */
     public static function add(CodeIssue $e, bool $is_fixable = false): bool
     {
@@ -398,9 +392,6 @@ class IssueBuffer
         }
     }
 
-    /**
-     * @return int
-     */
     public static function getErrorCount(): int
     {
         return self::$error_count;
@@ -428,10 +419,6 @@ class IssueBuffer
     }
 
     /**
-     * @param  ProjectAnalyzer                   $project_analyzer
-     * @param  bool                             $is_full
-     * @param  float                            $start_time
-     * @param  bool                             $add_stats
      * @param  array<string,array<string,array{o:int, s:array<int, string>}>>  $issue_baseline
      *
      * @return void
@@ -679,7 +666,6 @@ class IssueBuffer
      * @param array<string, array<int, IssueData>> $issues_data
      * @param array{int, int} $mixed_counts
      *
-     * @return string
      */
     public static function getOutput(
         array $issues_data,
@@ -753,7 +739,6 @@ class IssueBuffer
     /**
      * @param  string $message
      *
-     * @return bool
      */
     protected static function alreadyEmitted($message): bool
     {
@@ -795,9 +780,6 @@ class IssueBuffer
         return $current_data;
     }
 
-    /**
-     * @return bool
-     */
     public static function isRecording(): bool
     {
         return self::$recording_level > 0;

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -89,7 +89,7 @@ class IssueBuffer
      *
      * @return  bool
      */
-    public static function accepts(CodeIssue $e, array $suppressed_issues = [], bool $is_fixable = false)
+    public static function accepts(CodeIssue $e, array $suppressed_issues = [], bool $is_fixable = false): bool
     {
         if (self::isSuppressed($e, $suppressed_issues)) {
             return false;
@@ -193,7 +193,7 @@ class IssueBuffer
      *
      * @return  bool
      */
-    public static function add(CodeIssue $e, bool $is_fixable = false)
+    public static function add(CodeIssue $e, bool $is_fixable = false): bool
     {
         $config = Config::getInstance();
 
@@ -293,7 +293,7 @@ class IssueBuffer
     /**
      * @return array<string, list<IssueData>>
      */
-    public static function getIssuesData()
+    public static function getIssuesData(): array
     {
         return self::$issues_data;
     }
@@ -309,7 +309,7 @@ class IssueBuffer
     /**
      * @return array<string, int>
      */
-    public static function getFixableIssues()
+    public static function getFixableIssues(): array
     {
         return self::$fixable_issue_counts;
     }
@@ -401,7 +401,7 @@ class IssueBuffer
     /**
      * @return int
      */
-    public static function getErrorCount()
+    public static function getErrorCount(): int
     {
         return self::$error_count;
     }
@@ -685,7 +685,7 @@ class IssueBuffer
         array $issues_data,
         \Psalm\Report\ReportOptions $report_options,
         array $mixed_counts = [0, 0]
-    ) {
+    ): string {
         $total_expression_count = $mixed_counts[0] + $mixed_counts[1];
         $mixed_expression_count = $mixed_counts[0];
 
@@ -755,7 +755,7 @@ class IssueBuffer
      *
      * @return bool
      */
-    protected static function alreadyEmitted($message)
+    protected static function alreadyEmitted($message): bool
     {
         $sham = sha1($message);
 
@@ -786,7 +786,7 @@ class IssueBuffer
     /**
      * @return array<string, list<IssueData>>
      */
-    public static function clear()
+    public static function clear(): array
     {
         $current_data = self::$issues_data;
         self::$issues_data = [];
@@ -798,7 +798,7 @@ class IssueBuffer
     /**
      * @return bool
      */
-    public static function isRecording()
+    public static function isRecording(): bool
     {
         return self::$recording_level > 0;
     }
@@ -827,7 +827,7 @@ class IssueBuffer
     /**
      * @return array<int, CodeIssue>
      */
-    public static function clearRecordingLevel()
+    public static function clearRecordingLevel(): array
     {
         if (self::$recording_level === 0) {
             throw new \UnexpectedValueException('Not currently recording');

--- a/src/Psalm/Plugin/Hook/AfterFunctionLikeAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterFunctionLikeAnalysisInterface.php
@@ -22,5 +22,5 @@ interface AfterFunctionLikeAnalysisInterface
         StatementsSource $statements_source,
         Codebase $codebase,
         array &$file_replacements = []
-    );
+    ): ?bool;
 }

--- a/src/Psalm/Plugin/Hook/MethodVisibilityProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/MethodVisibilityProviderInterface.php
@@ -21,5 +21,5 @@ interface MethodVisibilityProviderInterface
         string $method_name_lowercase,
         Context $context,
         CodeLocation $code_location = null
-    );
+    ): ?bool;
 }

--- a/src/Psalm/Plugin/Hook/MethodVisibilityProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/MethodVisibilityProviderInterface.php
@@ -12,9 +12,6 @@ interface MethodVisibilityProviderInterface
      */
     public static function getClassLikeNames() : array;
 
-    /**
-     * @return ?bool
-     */
     public static function isMethodVisible(
         StatementsSource $source,
         string $fq_classlike_name,

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -95,8 +95,5 @@ abstract class Report
         $this->total_expression_count = $total_expression_count;
     }
 
-    /**
-     * @return string
-     */
     abstract public function create(): string;
 }

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -166,9 +166,6 @@ class JunitReport extends Report
         return $nfailures;
     }
 
-    /**
-     * @param  IssueData  $data
-     */
     private function dataToOutput(IssueData $data): string
     {
         $ret = 'message: ' . htmlspecialchars(trim($data->message), ENT_XML1 | ENT_QUOTES) . "\n";

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -155,7 +155,7 @@ class JunitReport extends Report
      *
      * @return array<string, list<IssueData>>
      */
-    private function groupByType(array $failures)
+    private function groupByType(array $failures): array
     {
         $nfailures = [];
 

--- a/src/Psalm/Report/PylintReport.php
+++ b/src/Psalm/Report/PylintReport.php
@@ -20,9 +20,6 @@ class PylintReport extends Report
         return $output;
     }
 
-    /**
-     * @return string
-     */
     private function format(\Psalm\Internal\Analyzer\IssueData $issue_data): string
     {
         $message = sprintf(

--- a/src/Psalm/Report/XmlReport.php
+++ b/src/Psalm/Report/XmlReport.php
@@ -17,7 +17,7 @@ class XmlReport extends Report
             'report',
             [
                 'item' => array_map(
-                    function (IssueData $issue_data) {
+                    function (IssueData $issue_data): array {
                         return (array) $issue_data;
                     },
                     $this->issues_data

--- a/src/Psalm/SourceControl/Git/CommitInfo.php
+++ b/src/Psalm/SourceControl/Git/CommitInfo.php
@@ -85,7 +85,6 @@ class CommitInfo
     /**
      * Return commit ID.
      *
-     * @return ?string
      */
     public function getId(): ?string
     {
@@ -105,7 +104,6 @@ class CommitInfo
     /**
      * Return author name.
      *
-     * @return null|string
      */
     public function getAuthorName(): ?string
     {
@@ -115,7 +113,6 @@ class CommitInfo
     /**
      * Set author email.
      *
-     * @param string $author_email
      */
     public function setAuthorEmail(string $author_email) : self
     {
@@ -127,7 +124,6 @@ class CommitInfo
     /**
      * Return author email.
      *
-     * @return null|string
      */
     public function getAuthorEmail(): ?string
     {
@@ -147,7 +143,6 @@ class CommitInfo
     /**
      * Return committer name.
      *
-     * @return null|string
      */
     public function getCommitterName(): ?string
     {
@@ -167,7 +162,6 @@ class CommitInfo
     /**
      * Return committer email.
      *
-     * @return null|string
      */
     public function getCommitterEmail(): ?string
     {
@@ -187,7 +181,6 @@ class CommitInfo
     /**
      * Return commit message.
      *
-     * @return null|string
      */
     public function getMessage(): ?string
     {
@@ -207,7 +200,6 @@ class CommitInfo
     /**
      * Return commit date.
      *
-     * @return null|int
      */
     public function getDate(): ?int
     {

--- a/src/Psalm/SourceControl/Git/CommitInfo.php
+++ b/src/Psalm/SourceControl/Git/CommitInfo.php
@@ -87,7 +87,7 @@ class CommitInfo
      *
      * @return ?string
      */
-    public function getId()
+    public function getId(): ?string
     {
         return $this->id;
     }
@@ -107,7 +107,7 @@ class CommitInfo
      *
      * @return null|string
      */
-    public function getAuthorName()
+    public function getAuthorName(): ?string
     {
         return $this->author_name;
     }
@@ -129,7 +129,7 @@ class CommitInfo
      *
      * @return null|string
      */
-    public function getAuthorEmail()
+    public function getAuthorEmail(): ?string
     {
         return $this->author_email;
     }
@@ -149,7 +149,7 @@ class CommitInfo
      *
      * @return null|string
      */
-    public function getCommitterName()
+    public function getCommitterName(): ?string
     {
         return $this->committer_name;
     }
@@ -169,7 +169,7 @@ class CommitInfo
      *
      * @return null|string
      */
-    public function getCommitterEmail()
+    public function getCommitterEmail(): ?string
     {
         return $this->committer_email;
     }
@@ -189,7 +189,7 @@ class CommitInfo
      *
      * @return null|string
      */
-    public function getMessage()
+    public function getMessage(): ?string
     {
         return $this->message;
     }
@@ -209,7 +209,7 @@ class CommitInfo
      *
      * @return null|int
      */
-    public function getDate()
+    public function getDate(): ?int
     {
         return $this->date;
     }

--- a/src/Psalm/SourceControl/Git/GitInfo.php
+++ b/src/Psalm/SourceControl/Git/GitInfo.php
@@ -83,7 +83,6 @@ class GitInfo extends SourceControlInfo
     /**
      * Return branch name.
      *
-     * @return string
      */
     public function getBranch() : string
     {
@@ -93,7 +92,6 @@ class GitInfo extends SourceControlInfo
     /**
      * Return HEAD commit.
      *
-     * @return CommitInfo
      */
     public function getHead() : CommitInfo
     {

--- a/src/Psalm/SourceControl/Git/RemoteInfo.php
+++ b/src/Psalm/SourceControl/Git/RemoteInfo.php
@@ -49,7 +49,6 @@ class RemoteInfo
     /**
      * Return remote name.
      *
-     * @return null|string
      */
     public function getName(): ?string
     {
@@ -73,7 +72,6 @@ class RemoteInfo
     /**
      * Return remote URL.
      *
-     * @return null|string
      */
     public function getUrl(): ?string
     {

--- a/src/Psalm/SourceControl/Git/RemoteInfo.php
+++ b/src/Psalm/SourceControl/Git/RemoteInfo.php
@@ -39,7 +39,7 @@ class RemoteInfo
      *
      * @return $this
      */
-    public function setName(string $name)
+    public function setName(string $name): RemoteInfo
     {
         $this->name = $name;
 
@@ -51,7 +51,7 @@ class RemoteInfo
      *
      * @return null|string
      */
-    public function getName()
+    public function getName(): ?string
     {
         return $this->name;
     }
@@ -63,7 +63,7 @@ class RemoteInfo
      *
      * @return $this
      */
-    public function setUrl(string $url)
+    public function setUrl(string $url): RemoteInfo
     {
         $this->url = $url;
 
@@ -75,7 +75,7 @@ class RemoteInfo
      *
      * @return null|string
      */
-    public function getUrl()
+    public function getUrl(): ?string
     {
         return $this->url;
     }

--- a/src/Psalm/StatementsSource.php
+++ b/src/Psalm/StatementsSource.php
@@ -3,9 +3,6 @@ namespace Psalm;
 
 interface StatementsSource extends FileSource
 {
-    /**
-     * @return null|string
-     */
     public function getNamespace(): ?string;
 
     /**
@@ -18,19 +15,10 @@ interface StatementsSource extends FileSource
      */
     public function getAliasedClassesFlippedReplaceable(): array;
 
-    /**
-     * @return string|null
-     */
     public function getFQCLN(): ?string;
 
-    /**
-     * @return string|null
-     */
     public function getClassName(): ?string;
 
-    /**
-     * @return string|null
-     */
     public function getParentFQCLN(): ?string;
 
     /**
@@ -49,25 +37,17 @@ interface StatementsSource extends FileSource
     /**
      * @param string $file_path
      *
-     * @return bool
      */
     public function hasParentFilePath($file_path): bool;
 
     /**
      * @param string $file_path
      *
-     * @return bool
      */
     public function hasAlreadyRequiredFilePath($file_path): bool;
 
-    /**
-     * @return int
-     */
     public function getRequireNesting(): int;
 
-    /**
-     * @return bool
-     */
     public function isStatic(): bool;
 
     /**

--- a/src/Psalm/StatementsSource.php
+++ b/src/Psalm/StatementsSource.php
@@ -6,37 +6,37 @@ interface StatementsSource extends FileSource
     /**
      * @return null|string
      */
-    public function getNamespace();
+    public function getNamespace(): ?string;
 
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlipped();
+    public function getAliasedClassesFlipped(): array;
 
     /**
      * @return array<string, string>
      */
-    public function getAliasedClassesFlippedReplaceable();
+    public function getAliasedClassesFlippedReplaceable(): array;
 
     /**
      * @return string|null
      */
-    public function getFQCLN();
+    public function getFQCLN(): ?string;
 
     /**
      * @return string|null
      */
-    public function getClassName();
+    public function getClassName(): ?string;
 
     /**
      * @return string|null
      */
-    public function getParentFQCLN();
+    public function getParentFQCLN(): ?string;
 
     /**
      * @return array<string, array<string, array{Type\Union}>>|null
      */
-    public function getTemplateTypeMap();
+    public function getTemplateTypeMap(): ?array;
 
     /**
      * @param string $file_path
@@ -51,24 +51,24 @@ interface StatementsSource extends FileSource
      *
      * @return bool
      */
-    public function hasParentFilePath($file_path);
+    public function hasParentFilePath($file_path): bool;
 
     /**
      * @param string $file_path
      *
      * @return bool
      */
-    public function hasAlreadyRequiredFilePath($file_path);
+    public function hasAlreadyRequiredFilePath($file_path): bool;
 
     /**
      * @return int
      */
-    public function getRequireNesting();
+    public function getRequireNesting(): int;
 
     /**
      * @return bool
      */
-    public function isStatic();
+    public function isStatic(): bool;
 
     /**
      * @return StatementsSource|null
@@ -82,7 +82,7 @@ interface StatementsSource extends FileSource
      *
      * @return array<string>
      */
-    public function getSuppressedIssues();
+    public function getSuppressedIssues(): array;
 
     /**
      * @param array<int, string> $new_issues

--- a/src/Psalm/Storage/FunctionLikeParameter.php
+++ b/src/Psalm/Storage/FunctionLikeParameter.php
@@ -90,7 +90,6 @@ class FunctionLikeParameter
 
     /**
      * @param string        $name
-     * @param bool       $by_ref
      * @param Type\Union|null    $type
      * @param CodeLocation|null  $location
      * @param bool       $is_optional

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -204,7 +204,7 @@ abstract class FunctionLikeStorage
      */
     public $allow_named_arg_calls = true;
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getSignature(false);
     }

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -62,7 +62,7 @@ abstract class Type
         $type_string,
         array $php_version = null,
         array $template_type_map = []
-    ) {
+    ): Union {
         return TypeParser::parseTokens(
             TypeTokenizer::tokenize(
                 $type_string
@@ -163,7 +163,7 @@ abstract class Type
      *
      * @return Type\Union
      */
-    public static function getInt($from_calculation = false, $value = null)
+    public static function getInt($from_calculation = false, $value = null): Union
     {
         if ($value !== null) {
             $union = new Union([new TLiteralInt($value)]);
@@ -182,7 +182,7 @@ abstract class Type
      *
      * @return Type\Union
      */
-    public static function getPositiveInt(bool $from_calculation = false)
+    public static function getPositiveInt(bool $from_calculation = false): Union
     {
         $union = new Union([new Type\Atomic\TPositiveInt()]);
         $union->from_calculation = $from_calculation;
@@ -193,7 +193,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getNumeric()
+    public static function getNumeric(): Union
     {
         $type = new TNumeric;
 
@@ -205,7 +205,7 @@ abstract class Type
      *
      * @return Type\Union
      */
-    public static function getString($value = null)
+    public static function getString($value = null): Union
     {
         $type = null;
 
@@ -239,7 +239,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getSingleLetter()
+    public static function getSingleLetter(): Union
     {
         $type = new TSingleLetter;
 
@@ -251,7 +251,7 @@ abstract class Type
      *
      * @return Type\Union
      */
-    public static function getClassString($extends = 'object')
+    public static function getClassString($extends = 'object'): Union
     {
         return new Union([
             new TClassString(
@@ -268,7 +268,7 @@ abstract class Type
      *
      * @return Type\Union
      */
-    public static function getLiteralClassString($class_type)
+    public static function getLiteralClassString($class_type): Union
     {
         $type = new TLiteralClassString($class_type);
 
@@ -278,7 +278,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getNull()
+    public static function getNull(): Union
     {
         $type = new TNull;
 
@@ -290,7 +290,7 @@ abstract class Type
      *
      * @return Type\Union
      */
-    public static function getMixed($from_loop_isset = false)
+    public static function getMixed($from_loop_isset = false): Union
     {
         $type = new TMixed($from_loop_isset);
 
@@ -300,7 +300,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getScalar()
+    public static function getScalar(): Union
     {
         $type = new TScalar();
 
@@ -310,7 +310,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getEmpty()
+    public static function getEmpty(): Union
     {
         $type = new TEmpty();
 
@@ -320,7 +320,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getBool()
+    public static function getBool(): Union
     {
         $type = new TBool;
 
@@ -332,7 +332,7 @@ abstract class Type
      *
      * @return Type\Union
      */
-    public static function getFloat($value = null)
+    public static function getFloat($value = null): Union
     {
         if ($value !== null) {
             $type = new TLiteralFloat($value);
@@ -346,7 +346,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getObject()
+    public static function getObject(): Union
     {
         $type = new TObject;
 
@@ -356,7 +356,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getClosure()
+    public static function getClosure(): Union
     {
         $type = new Type\Atomic\TFn('Closure');
 
@@ -366,7 +366,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getArrayKey()
+    public static function getArrayKey(): Union
     {
         $type = new TArrayKey();
 
@@ -376,7 +376,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getArray()
+    public static function getArray(): Union
     {
         $type = new TArray(
             [
@@ -391,7 +391,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getEmptyArray()
+    public static function getEmptyArray(): Union
     {
         $array_type = new TArray(
             [
@@ -408,7 +408,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getList()
+    public static function getList(): Union
     {
         $type = new TList(new Type\Union([new TMixed]));
 
@@ -418,7 +418,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getNonEmptyList()
+    public static function getNonEmptyList(): Union
     {
         $type = new Type\Atomic\TNonEmptyList(new Type\Union([new TMixed]));
 
@@ -428,7 +428,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getVoid()
+    public static function getVoid(): Union
     {
         $type = new TVoid;
 
@@ -438,7 +438,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getFalse()
+    public static function getFalse(): Union
     {
         $type = new TFalse;
 
@@ -448,7 +448,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getTrue()
+    public static function getTrue(): Union
     {
         $type = new TTrue;
 
@@ -458,7 +458,7 @@ abstract class Type
     /**
      * @return Type\Union
      */
-    public static function getResource()
+    public static function getResource(): Union
     {
         return new Union([new TResource]);
     }
@@ -494,7 +494,7 @@ abstract class Type
         bool $overwrite_empty_array = false,
         bool $allow_mixed_union = true,
         int $literal_limit = 500
-    ) {
+    ): Union {
         if ($type_1 === $type_2) {
             return $type_1;
         }
@@ -587,7 +587,7 @@ abstract class Type
         Union $type_1,
         Union $type_2,
         Codebase $codebase
-    ) {
+    ): ?Union {
         $intersection_performed = false;
 
         if ($type_1->isMixed() && $type_2->isMixed()) {

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -56,7 +56,6 @@ abstract class Type
      * @param  array{int,int}|null   $php_version
      * @param  array<string, array<string, array{Type\Union}>> $template_type_map
      *
-     * @return Union
      */
     public static function parseString(
         $type_string,
@@ -161,7 +160,6 @@ abstract class Type
      * @param bool $from_calculation
      * @param int|null $value
      *
-     * @return Type\Union
      */
     public static function getInt($from_calculation = false, $value = null): Union
     {
@@ -177,10 +175,8 @@ abstract class Type
     }
 
     /**
-     * @param bool $from_calculation
      * @param int|null $value
      *
-     * @return Type\Union
      */
     public static function getPositiveInt(bool $from_calculation = false): Union
     {
@@ -190,9 +186,6 @@ abstract class Type
         return $union;
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getNumeric(): Union
     {
         $type = new TNumeric;
@@ -203,7 +196,6 @@ abstract class Type
     /**
      * @param string|null $value
      *
-     * @return Type\Union
      */
     public static function getString($value = null): Union
     {
@@ -236,9 +228,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getSingleLetter(): Union
     {
         $type = new TSingleLetter;
@@ -249,7 +238,6 @@ abstract class Type
     /**
      * @param string $extends
      *
-     * @return Type\Union
      */
     public static function getClassString($extends = 'object'): Union
     {
@@ -266,7 +254,6 @@ abstract class Type
     /**
      * @param string $class_type
      *
-     * @return Type\Union
      */
     public static function getLiteralClassString($class_type): Union
     {
@@ -275,9 +262,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getNull(): Union
     {
         $type = new TNull;
@@ -288,7 +272,6 @@ abstract class Type
     /**
      * @param bool $from_loop_isset
      *
-     * @return Type\Union
      */
     public static function getMixed($from_loop_isset = false): Union
     {
@@ -297,9 +280,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getScalar(): Union
     {
         $type = new TScalar();
@@ -307,9 +287,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getEmpty(): Union
     {
         $type = new TEmpty();
@@ -317,9 +294,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getBool(): Union
     {
         $type = new TBool;
@@ -330,7 +304,6 @@ abstract class Type
     /**
      * @param float|null $value
      *
-     * @return Type\Union
      */
     public static function getFloat($value = null): Union
     {
@@ -343,9 +316,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getObject(): Union
     {
         $type = new TObject;
@@ -353,9 +323,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getClosure(): Union
     {
         $type = new Type\Atomic\TFn('Closure');
@@ -363,9 +330,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getArrayKey(): Union
     {
         $type = new TArrayKey();
@@ -373,9 +337,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getArray(): Union
     {
         $type = new TArray(
@@ -388,9 +349,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getEmptyArray(): Union
     {
         $array_type = new TArray(
@@ -405,9 +363,6 @@ abstract class Type
         ]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getList(): Union
     {
         $type = new TList(new Type\Union([new TMixed]));
@@ -415,9 +370,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getNonEmptyList(): Union
     {
         $type = new Type\Atomic\TNonEmptyList(new Type\Union([new TMixed]));
@@ -425,9 +377,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getVoid(): Union
     {
         $type = new TVoid;
@@ -435,9 +384,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getFalse(): Union
     {
         $type = new TFalse;
@@ -445,9 +391,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getTrue(): Union
     {
         $type = new TTrue;
@@ -455,9 +398,6 @@ abstract class Type
         return new Union([$type]);
     }
 
-    /**
-     * @return Type\Union
-     */
     public static function getResource(): Union
     {
         return new Union([new TResource]);
@@ -480,12 +420,9 @@ abstract class Type
     /**
      * Combines two union types into one
      *
-     * @param  Union  $type_1
-     * @param  Union  $type_2
      * @param  int    $literal_limit any greater number of literal types than this
      *                               will be merged to a scalar
      *
-     * @return Union
      */
     public static function combineUnionTypes(
         Union $type_1,
@@ -578,10 +515,7 @@ abstract class Type
     /**
      * Combines two union types into one via an intersection
      *
-     * @param  Union  $type_1
-     * @param  Union  $type_2
      *
-     * @return ?Union
      */
     public static function intersectUnionTypes(
         Union $type_1,

--- a/src/Psalm/Type/Algebra.php
+++ b/src/Psalm/Type/Algebra.php
@@ -30,7 +30,7 @@ class Algebra
      *
      * @psalm-pure
      */
-    public static function negateTypes(array $all_types)
+    public static function negateTypes(array $all_types): array
     {
         return array_filter(
             array_map(
@@ -39,7 +39,7 @@ class Algebra
                  *
                  * @return list<non-empty-list<string>>
                  */
-                function (array $anded_types) {
+                function (array $anded_types): array {
                     if (count($anded_types) > 1) {
                         $new_anded_types = [];
 
@@ -74,7 +74,7 @@ class Algebra
      *
      * @psalm-pure
      */
-    public static function negateType($type)
+    public static function negateType($type): string
     {
         if ($type === 'mixed') {
             return $type;
@@ -533,7 +533,7 @@ class Algebra
         ?int $creating_conditional_id = null,
         array &$cond_referenced_var_ids = [],
         array &$active_truths = []
-    ) {
+    ): array {
         $truths = [];
         $active_truths = [];
 
@@ -573,7 +573,7 @@ class Algebra
                          *
                          * @return bool
                          */
-                        function ($possible_type) {
+                        function ($possible_type): bool {
                             return $possible_type[0] !== '!';
                         }
                     );
@@ -606,7 +606,7 @@ class Algebra
      *
      * @psalm-pure
      */
-    public static function groupImpossibilities(array $clauses)
+    public static function groupImpossibilities(array $clauses): array
     {
         $complexity = 1;
 
@@ -695,8 +695,11 @@ class Algebra
      *
      * @psalm-pure
      */
-    public static function combineOredClauses(array $left_clauses, array $right_clauses, int $conditional_object_id)
-    {
+    public static function combineOredClauses(
+        array $left_clauses,
+        array $right_clauses,
+        int $conditional_object_id
+    ): array {
         $clauses = [];
 
         $all_wedges = true;

--- a/src/Psalm/Type/Algebra.php
+++ b/src/Psalm/Type/Algebra.php
@@ -70,8 +70,6 @@ class Algebra
     /**
      * @param string $type
      *
-     * @return string
-     *
      * @psalm-pure
      */
     public static function negateType($type): string
@@ -84,9 +82,7 @@ class Algebra
     }
 
     /**
-     * @param  PhpParser\Node\Expr      $conditional
      * @param  string|null              $this_class_name
-     * @param  FileSource         $source
      *
      * @return array<int, Clause>
      */
@@ -570,8 +566,6 @@ class Algebra
                         $possible_types,
                         /**
                          * @param  string $possible_type
-                         *
-                         * @return bool
                          */
                         function ($possible_type): bool {
                             return $possible_type[0] !== '!';

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -292,9 +292,6 @@ abstract class Atomic implements TypeNode
      */
     abstract public function getKey(bool $include_extra = true);
 
-    /**
-     * @return bool
-     */
     public function isNumericType(): bool
     {
         return $this instanceof TInt
@@ -303,9 +300,6 @@ abstract class Atomic implements TypeNode
             || $this instanceof TNumeric;
     }
 
-    /**
-     * @return bool
-     */
     public function isObjectType(): bool
     {
         return $this instanceof TObject
@@ -314,9 +308,6 @@ abstract class Atomic implements TypeNode
                 && $this->as->hasObjectType());
     }
 
-    /**
-     * @return bool
-     */
     public function isNamedObjectType(): bool
     {
         return $this instanceof TNamedObject
@@ -332,9 +323,6 @@ abstract class Atomic implements TypeNode
             );
     }
 
-    /**
-     * @return bool
-     */
     public function isCallableType(): bool
     {
         return $this instanceof TCallable
@@ -345,9 +333,6 @@ abstract class Atomic implements TypeNode
             || $this instanceof TCallableKeyedArray;
     }
 
-    /**
-     * @return bool
-     */
     public function isIterable(Codebase $codebase): bool
     {
         return $this instanceof TIterable
@@ -357,9 +342,6 @@ abstract class Atomic implements TypeNode
             || $this instanceof TList;
     }
 
-    /**
-     * @return bool
-     */
     public function isCountable(Codebase $codebase): bool
     {
         return $this->hasCountableInterface($codebase)
@@ -368,9 +350,6 @@ abstract class Atomic implements TypeNode
             || $this instanceof TList;
     }
 
-    /**
-     * @return bool
-     */
     public function hasTraversableInterface(Codebase $codebase): bool
     {
         return $this instanceof TNamedObject
@@ -396,9 +375,6 @@ abstract class Atomic implements TypeNode
             );
     }
 
-    /**
-     * @return bool
-     */
     public function hasCountableInterface(Codebase $codebase): bool
     {
         return $this instanceof TNamedObject
@@ -424,9 +400,6 @@ abstract class Atomic implements TypeNode
             );
     }
 
-    /**
-     * @return bool
-     */
     public function isArrayAccessibleWithStringKey(Codebase $codebase): bool
     {
         return $this instanceof TArray
@@ -437,18 +410,12 @@ abstract class Atomic implements TypeNode
             || ($this instanceof TNamedObject && $this->value === 'SimpleXMLElement');
     }
 
-    /**
-     * @return bool
-     */
     public function isArrayAccessibleWithIntOrStringKey(Codebase $codebase): bool
     {
         return $this instanceof TString
             || $this->isArrayAccessibleWithStringKey($codebase);
     }
 
-    /**
-     * @return bool
-     */
     public function hasArrayAccessInterface(Codebase $codebase): bool
     {
         return $this instanceof TNamedObject
@@ -466,7 +433,6 @@ abstract class Atomic implements TypeNode
                     $this->extra_types
                     && array_filter(
                         $this->extra_types,
-                        /** @param Atomic $a */
                         function (Atomic $a) use ($codebase) : bool {
                             return $a->hasArrayAccessInterface($codebase);
                         }
@@ -585,9 +551,6 @@ abstract class Atomic implements TypeNode
         return $this->__toString();
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return $this->getId();
@@ -596,7 +559,6 @@ abstract class Atomic implements TypeNode
     /**
      * @param  array<string, string> $aliased_classes
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -651,9 +613,6 @@ abstract class Atomic implements TypeNode
         // do nothing
     }
 
-    /**
-     * @return bool
-     */
     public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== get_class($this)) {

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -295,7 +295,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function isNumericType()
+    public function isNumericType(): bool
     {
         return $this instanceof TInt
             || $this instanceof TFloat
@@ -306,7 +306,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function isObjectType()
+    public function isObjectType(): bool
     {
         return $this instanceof TObject
             || $this instanceof TNamedObject
@@ -317,7 +317,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function isNamedObjectType()
+    public function isNamedObjectType(): bool
     {
         return $this instanceof TNamedObject
             || ($this instanceof TTemplateParam
@@ -335,7 +335,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function isCallableType()
+    public function isCallableType(): bool
     {
         return $this instanceof TCallable
             || $this instanceof TCallableObject
@@ -348,7 +348,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function isIterable(Codebase $codebase)
+    public function isIterable(Codebase $codebase): bool
     {
         return $this instanceof TIterable
             || $this->hasTraversableInterface($codebase)
@@ -360,7 +360,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function isCountable(Codebase $codebase)
+    public function isCountable(Codebase $codebase): bool
     {
         return $this->hasCountableInterface($codebase)
             || $this instanceof TArray
@@ -371,7 +371,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function hasTraversableInterface(Codebase $codebase)
+    public function hasTraversableInterface(Codebase $codebase): bool
     {
         return $this instanceof TNamedObject
             && (
@@ -399,7 +399,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function hasCountableInterface(Codebase $codebase)
+    public function hasCountableInterface(Codebase $codebase): bool
     {
         return $this instanceof TNamedObject
             && (
@@ -427,7 +427,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function isArrayAccessibleWithStringKey(Codebase $codebase)
+    public function isArrayAccessibleWithStringKey(Codebase $codebase): bool
     {
         return $this instanceof TArray
             || $this instanceof TKeyedArray
@@ -440,7 +440,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function isArrayAccessibleWithIntOrStringKey(Codebase $codebase)
+    public function isArrayAccessibleWithIntOrStringKey(Codebase $codebase): bool
     {
         return $this instanceof TString
             || $this->isArrayAccessibleWithStringKey($codebase);
@@ -449,7 +449,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function hasArrayAccessInterface(Codebase $codebase)
+    public function hasArrayAccessInterface(Codebase $codebase): bool
     {
         return $this instanceof TNamedObject
             && (
@@ -553,7 +553,7 @@ abstract class Atomic implements TypeNode
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return '';
     }
@@ -588,7 +588,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return $this->getId();
     }
@@ -603,7 +603,7 @@ abstract class Atomic implements TypeNode
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return $this->getKey();
     }
 
@@ -654,7 +654,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    public function equals(Atomic $other_type)
+    public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== get_class($this)) {
             return false;

--- a/src/Psalm/Type/Atomic/CallableTrait.php
+++ b/src/Psalm/Type/Atomic/CallableTrait.php
@@ -37,7 +37,6 @@ trait CallableTrait
      *
      * @param string                            $value
      * @param array<int, FunctionLikeParameter> $params
-     * @param Union                             $return_type
      */
     public function __construct(
         $value = 'callable',
@@ -62,9 +61,6 @@ trait CallableTrait
         $this->return_type = $this->return_type ? clone $this->return_type : null;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return $this->__toString();
@@ -73,7 +69,6 @@ trait CallableTrait
     /**
      * @param  array<string, string> $aliased_classes
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -144,7 +139,6 @@ trait CallableTrait
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string
      */
     public function toPhpString(
         $namespace,
@@ -160,9 +154,6 @@ trait CallableTrait
         return $this->value;
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         $param_string = '';

--- a/src/Psalm/Type/Atomic/CallableTrait.php
+++ b/src/Psalm/Type/Atomic/CallableTrait.php
@@ -65,7 +65,7 @@ trait CallableTrait
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return $this->__toString();
     }
@@ -80,7 +80,7 @@ trait CallableTrait
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($use_phpdoc_format) {
             if ($this instanceof TNamedObject) {
                 return parent::toNamespacedString($namespace, $aliased_classes, $this_class, true);
@@ -152,7 +152,7 @@ trait CallableTrait
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): string {
         if ($this instanceof TNamedObject) {
             return parent::toNamespacedString($namespace, $aliased_classes, $this_class, true);
         }
@@ -163,7 +163,7 @@ trait CallableTrait
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         $param_string = '';
         $return_type_string = '';
@@ -191,7 +191,7 @@ trait CallableTrait
             . $this->value . $param_string . $return_type_string;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getId();
     }

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -28,7 +28,7 @@ trait GenericTrait
      */
     public $type_params;
 
-    public function __toString()
+    public function __toString(): string
     {
         $s = '';
         foreach ($this->type_params as $type_param) {
@@ -47,7 +47,7 @@ trait GenericTrait
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         $s = '';
         foreach ($this->type_params as $type_param) {
@@ -81,7 +81,7 @@ trait GenericTrait
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         $base_value = $this instanceof TNamedObject
             ? parent::toNamespacedString($namespace, $aliased_classes, $this_class, $use_phpdoc_format)
             : $this->value;

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -44,9 +44,6 @@ trait GenericTrait
         return $this->value . '<' . substr($s, 0, -2) . '>' . $extra_types;
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         $s = '';
@@ -74,7 +71,6 @@ trait GenericTrait
     /**
      * @param  array<string, string> $aliased_classes
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/GetClassT.php
+++ b/src/Psalm/Type/Atomic/GetClassT.php
@@ -30,7 +30,7 @@ class GetClassT extends TString
         $this->as_type = $as_type;
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->as_type->isMixed()
             || $this->as_type->hasObject()
@@ -41,7 +41,7 @@ class GetClassT extends TString
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/GetClassT.php
+++ b/src/Psalm/Type/Atomic/GetClassT.php
@@ -38,9 +38,6 @@ class GetClassT extends TString
             : 'class-string<' . $this->as_type->getId() . '>';
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/GetTypeT.php
+++ b/src/Psalm/Type/Atomic/GetTypeT.php
@@ -21,9 +21,6 @@ class GetTypeT extends TString
         $this->typeof = $typeof;
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/GetTypeT.php
+++ b/src/Psalm/Type/Atomic/GetTypeT.php
@@ -24,7 +24,7 @@ class GetTypeT extends TString
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/Scalar.php
+++ b/src/Psalm/Type/Atomic/Scalar.php
@@ -10,7 +10,6 @@ abstract class Scalar extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/Scalar.php
+++ b/src/Psalm/Type/Atomic/Scalar.php
@@ -18,7 +18,7 @@ abstract class Scalar extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version >= 7 ? $this->getKey() : null;
     }
 

--- a/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
+++ b/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
@@ -9,7 +9,7 @@ class TAnonymousClassInstance extends TNamedObject
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version >= 7 && $php_minor_version >= 2 ? 'object' : null;
     }
 
@@ -26,7 +26,7 @@ class TAnonymousClassInstance extends TNamedObject
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return 'object';
     }
 }

--- a/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
+++ b/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
@@ -14,12 +14,8 @@ class TAnonymousClassInstance extends TNamedObject
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string, string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TArray.php
+++ b/src/Psalm/Type/Atomic/TArray.php
@@ -32,7 +32,7 @@ class TArray extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'array';
     }
@@ -52,11 +52,11 @@ class TArray extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): string {
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return $this->type_params[0]->isArrayKey() && $this->type_params[1]->isMixed();
     }
@@ -64,7 +64,7 @@ class TArray extends \Psalm\Type\Atomic
     /**
      * @return bool
      */
-    public function equals(Atomic $other_type)
+    public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== static::class) {
             return false;
@@ -93,7 +93,7 @@ class TArray extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return $this->getKey();
     }

--- a/src/Psalm/Type/Atomic/TArray.php
+++ b/src/Psalm/Type/Atomic/TArray.php
@@ -29,9 +29,6 @@ class TArray extends \Psalm\Type\Atomic
         $this->type_params = $type_params;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'array';
@@ -44,7 +41,6 @@ class TArray extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string
      */
     public function toPhpString(
         $namespace,
@@ -61,9 +57,6 @@ class TArray extends \Psalm\Type\Atomic
         return $this->type_params[0]->isArrayKey() && $this->type_params[1]->isMixed();
     }
 
-    /**
-     * @return bool
-     */
     public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== static::class) {
@@ -90,9 +83,6 @@ class TArray extends \Psalm\Type\Atomic
         return true;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return $this->getKey();

--- a/src/Psalm/Type/Atomic/TArrayKey.php
+++ b/src/Psalm/Type/Atomic/TArrayKey.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TArrayKey extends Scalar
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'array-key';
     }
@@ -11,7 +11,7 @@ class TArrayKey extends Scalar
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'array-key';
     }
@@ -31,11 +31,11 @@ class TArrayKey extends Scalar
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TArrayKey.php
+++ b/src/Psalm/Type/Atomic/TArrayKey.php
@@ -8,9 +8,6 @@ class TArrayKey extends Scalar
         return 'array-key';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'array-key';
@@ -23,7 +20,6 @@ class TArrayKey extends Scalar
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TAssertionFalsy.php
+++ b/src/Psalm/Type/Atomic/TAssertionFalsy.php
@@ -8,17 +8,11 @@ class TAssertionFalsy extends \Psalm\Type\Atomic
         return 'falsy';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'falsy';
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'falsy';
@@ -31,7 +25,6 @@ class TAssertionFalsy extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TAssertionFalsy.php
+++ b/src/Psalm/Type/Atomic/TAssertionFalsy.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TAssertionFalsy extends \Psalm\Type\Atomic
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'falsy';
     }
@@ -11,7 +11,7 @@ class TAssertionFalsy extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'falsy';
     }
@@ -19,7 +19,7 @@ class TAssertionFalsy extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'falsy';
     }
@@ -39,11 +39,11 @@ class TAssertionFalsy extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TBool.php
+++ b/src/Psalm/Type/Atomic/TBool.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TBool extends Scalar
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'bool';
     }
@@ -11,7 +11,7 @@ class TBool extends Scalar
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'bool';
     }
@@ -31,7 +31,7 @@ class TBool extends Scalar
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version >= 7 ? 'bool' : null;
     }
 }

--- a/src/Psalm/Type/Atomic/TBool.php
+++ b/src/Psalm/Type/Atomic/TBool.php
@@ -8,9 +8,6 @@ class TBool extends Scalar
         return 'bool';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'bool';
@@ -23,7 +20,6 @@ class TBool extends Scalar
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TCallable.php
+++ b/src/Psalm/Type/Atomic/TCallable.php
@@ -17,7 +17,6 @@ class TCallable extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TCallable.php
+++ b/src/Psalm/Type/Atomic/TCallable.php
@@ -25,11 +25,11 @@ class TCallable extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): string {
         return 'callable';
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return $this->params === null && $this->return_type === null;
     }

--- a/src/Psalm/Type/Atomic/TCallableArray.php
+++ b/src/Psalm/Type/Atomic/TCallableArray.php
@@ -11,7 +11,7 @@ class TCallableArray extends TNonEmptyArray
      */
     public $value = 'callable-array';
 
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'array';
     }

--- a/src/Psalm/Type/Atomic/TCallableKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TCallableKeyedArray.php
@@ -8,7 +8,7 @@ class TCallableKeyedArray extends TKeyedArray
 {
     const KEY = 'callable-array';
 
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'array';
     }

--- a/src/Psalm/Type/Atomic/TCallableObject.php
+++ b/src/Psalm/Type/Atomic/TCallableObject.php
@@ -8,9 +8,6 @@ class TCallableObject extends TObject
         return 'callable-object';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'callable-object';
@@ -23,7 +20,6 @@ class TCallableObject extends TObject
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,
@@ -35,17 +31,11 @@ class TCallableObject extends TObject
         return $php_major_version >= 7 && $php_minor_version >= 2 ? 'object' : null;
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'object';

--- a/src/Psalm/Type/Atomic/TCallableObject.php
+++ b/src/Psalm/Type/Atomic/TCallableObject.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TCallableObject extends TObject
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'callable-object';
     }
@@ -11,7 +11,7 @@ class TCallableObject extends TObject
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'callable-object';
     }
@@ -31,14 +31,14 @@ class TCallableObject extends TObject
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version >= 7 && $php_minor_version >= 2 ? 'object' : null;
     }
 
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -46,7 +46,7 @@ class TCallableObject extends TObject
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'object';
     }

--- a/src/Psalm/Type/Atomic/TCallableString.php
+++ b/src/Psalm/Type/Atomic/TCallableString.php
@@ -6,12 +6,12 @@ class TCallableString extends TString
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'callable-string';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->getKey();
     }
@@ -19,7 +19,7 @@ class TCallableString extends TString
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -27,7 +27,7 @@ class TCallableString extends TString
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'string';
     }

--- a/src/Psalm/Type/Atomic/TCallableString.php
+++ b/src/Psalm/Type/Atomic/TCallableString.php
@@ -3,9 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TCallableString extends TString
 {
-    /**
-     * @return string
-     */
+
     public function getKey(bool $include_extra = true): string
     {
         return 'callable-string';
@@ -16,17 +14,11 @@ class TCallableString extends TString
         return $this->getKey();
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'string';

--- a/src/Psalm/Type/Atomic/TClassString.php
+++ b/src/Psalm/Type/Atomic/TClassString.php
@@ -34,7 +34,7 @@ class TClassString extends TString
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'class-string' . ($this->as === 'object' ? '' : '<' . $this->as_type . '>');
     }
@@ -42,17 +42,17 @@ class TClassString extends TString
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getKey();
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->getKey();
     }
 
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'class-string';
     }
@@ -72,7 +72,7 @@ class TClassString extends TString
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return 'string';
     }
 
@@ -89,7 +89,7 @@ class TClassString extends TString
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($this->as === 'object') {
             return 'class-string';
         }
@@ -116,7 +116,7 @@ class TClassString extends TString
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClassString.php
+++ b/src/Psalm/Type/Atomic/TClassString.php
@@ -31,17 +31,11 @@ class TClassString extends TString
         $this->as_type = $as_type;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'class-string' . ($this->as === 'object' ? '' : '<' . $this->as_type . '>');
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->getKey();
@@ -64,7 +58,6 @@ class TClassString extends TString
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -77,12 +70,8 @@ class TClassString extends TString
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -113,9 +102,6 @@ class TClassString extends TString
         return 'class-string<\\' . $this->as . '>';
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/TClassStringMap.php
+++ b/src/Psalm/Type/Atomic/TClassStringMap.php
@@ -79,7 +79,6 @@ class TClassStringMap extends \Psalm\Type\Atomic
     /**
      * @param  array<string, string> $aliased_classes
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -119,7 +118,6 @@ class TClassStringMap extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string
      */
     public function toPhpString(
         $namespace,
@@ -136,9 +134,6 @@ class TClassStringMap extends \Psalm\Type\Atomic
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'array';
@@ -216,9 +211,6 @@ class TClassStringMap extends \Psalm\Type\Atomic
         return [$this->value_param];
     }
 
-    /**
-     * @return bool
-     */
     public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== static::class) {
@@ -232,9 +224,6 @@ class TClassStringMap extends \Psalm\Type\Atomic
         return true;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return $this->getKey();

--- a/src/Psalm/Type/Atomic/TClassStringMap.php
+++ b/src/Psalm/Type/Atomic/TClassStringMap.php
@@ -45,7 +45,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
         $this->as_type = $as_type;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         /** @psalm-suppress MixedOperand */
         return static::KEY
@@ -58,7 +58,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
             . '>';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         /** @psalm-suppress MixedOperand */
         return static::KEY
@@ -86,7 +86,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($use_phpdoc_format) {
             return (new TArray([Type::getString(), $this->value_param]))
                 ->toNamespacedString(
@@ -121,12 +121,17 @@ class TClassStringMap extends \Psalm\Type\Atomic
      *
      * @return string
      */
-    public function toPhpString($namespace, array $aliased_classes, $this_class, $php_major_version, $php_minor_version)
-    {
+    public function toPhpString(
+        $namespace,
+        array $aliased_classes,
+        $this_class,
+        $php_major_version,
+        $php_minor_version
+    ): string {
         return 'array';
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -134,7 +139,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'array';
     }
@@ -214,7 +219,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
     /**
      * @return bool
      */
-    public function equals(Atomic $other_type)
+    public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== static::class) {
             return false;
@@ -230,7 +235,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return $this->getKey();
     }

--- a/src/Psalm/Type/Atomic/TClosedResource.php
+++ b/src/Psalm/Type/Atomic/TClosedResource.php
@@ -6,7 +6,7 @@ use Psalm\StatementsSource;
 
 class TClosedResource extends \Psalm\Type\Atomic
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'closed-resource';
     }
@@ -14,7 +14,7 @@ class TClosedResource extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'closed-resource';
     }
@@ -22,7 +22,7 @@ class TClosedResource extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'closed-resource';
     }
@@ -42,11 +42,11 @@ class TClosedResource extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClosedResource.php
+++ b/src/Psalm/Type/Atomic/TClosedResource.php
@@ -11,17 +11,11 @@ class TClosedResource extends \Psalm\Type\Atomic
         return 'closed-resource';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'closed-resource';
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'closed-resource';
@@ -34,7 +28,6 @@ class TClosedResource extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TConditional.php
+++ b/src/Psalm/Type/Atomic/TConditional.php
@@ -63,7 +63,7 @@ class TConditional extends \Psalm\Type\Atomic
         $this->else_type = $else_type;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return '('
             . $this->param_name
@@ -84,7 +84,7 @@ class TConditional extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return $this->__toString();
     }
@@ -92,12 +92,12 @@ class TConditional extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return '';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return '('
             . $this->param_name . ':' . $this->defining_class
@@ -139,7 +139,7 @@ class TConditional extends \Psalm\Type\Atomic
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return '';
     }
 
@@ -151,7 +151,7 @@ class TConditional extends \Psalm\Type\Atomic
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TConditional.php
+++ b/src/Psalm/Type/Atomic/TConditional.php
@@ -44,9 +44,6 @@ class TConditional extends \Psalm\Type\Atomic
      */
     public $else_type;
 
-    /**
-     * @param string $defining_class
-     */
     public function __construct(
         string $param_name,
         string $defining_class,
@@ -81,17 +78,11 @@ class TConditional extends \Psalm\Type\Atomic
         $this->as_type = clone $this->as_type;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return $this->__toString();
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return '';
@@ -127,12 +118,8 @@ class TConditional extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string, string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -148,9 +135,6 @@ class TConditional extends \Psalm\Type\Atomic
         return [$this->conditional_type, $this->if_type, $this->else_type];
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/TEmpty.php
+++ b/src/Psalm/Type/Atomic/TEmpty.php
@@ -8,9 +8,6 @@ class TEmpty extends Scalar
         return 'empty';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'empty';
@@ -23,7 +20,6 @@ class TEmpty extends Scalar
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TEmpty.php
+++ b/src/Psalm/Type/Atomic/TEmpty.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TEmpty extends Scalar
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'empty';
     }
@@ -11,7 +11,7 @@ class TEmpty extends Scalar
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'empty';
     }
@@ -31,7 +31,7 @@ class TEmpty extends Scalar
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 }

--- a/src/Psalm/Type/Atomic/TEmptyMixed.php
+++ b/src/Psalm/Type/Atomic/TEmptyMixed.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class TEmptyMixed extends TMixed
 {
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'empty-mixed';

--- a/src/Psalm/Type/Atomic/TEmptyMixed.php
+++ b/src/Psalm/Type/Atomic/TEmptyMixed.php
@@ -6,7 +6,7 @@ class TEmptyMixed extends TMixed
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'empty-mixed';
     }

--- a/src/Psalm/Type/Atomic/TEmptyNumeric.php
+++ b/src/Psalm/Type/Atomic/TEmptyNumeric.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class TEmptyNumeric extends TNumeric
 {
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'empty-numeric';

--- a/src/Psalm/Type/Atomic/TEmptyNumeric.php
+++ b/src/Psalm/Type/Atomic/TEmptyNumeric.php
@@ -6,7 +6,7 @@ class TEmptyNumeric extends TNumeric
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'empty-numeric';
     }

--- a/src/Psalm/Type/Atomic/TEmptyScalar.php
+++ b/src/Psalm/Type/Atomic/TEmptyScalar.php
@@ -6,7 +6,7 @@ class TEmptyScalar extends TScalar
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'empty-scalar';
     }

--- a/src/Psalm/Type/Atomic/TEmptyScalar.php
+++ b/src/Psalm/Type/Atomic/TEmptyScalar.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class TEmptyScalar extends TScalar
 {
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'empty-scalar';

--- a/src/Psalm/Type/Atomic/TFalse.php
+++ b/src/Psalm/Type/Atomic/TFalse.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TFalse extends TBool
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'false';
     }
@@ -11,12 +11,12 @@ class TFalse extends TBool
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'false';
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TFalse.php
+++ b/src/Psalm/Type/Atomic/TFalse.php
@@ -7,10 +7,7 @@ class TFalse extends TBool
     {
         return 'false';
     }
-
-    /**
-     * @return string
-     */
+    
     public function getKey(bool $include_extra = true): string
     {
         return 'false';

--- a/src/Psalm/Type/Atomic/TFloat.php
+++ b/src/Psalm/Type/Atomic/TFloat.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TFloat extends Scalar
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'float';
     }
@@ -11,7 +11,7 @@ class TFloat extends Scalar
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'float';
     }

--- a/src/Psalm/Type/Atomic/TFloat.php
+++ b/src/Psalm/Type/Atomic/TFloat.php
@@ -8,9 +8,6 @@ class TFloat extends Scalar
         return 'float';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'float';

--- a/src/Psalm/Type/Atomic/TFn.php
+++ b/src/Psalm/Type/Atomic/TFn.php
@@ -14,7 +14,7 @@ class TFn extends TNamedObject
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TFn.php
+++ b/src/Psalm/Type/Atomic/TFn.php
@@ -11,9 +11,6 @@ class TFn extends TNamedObject
     /** @var array<string, bool> */
     public $byref_uses = [];
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/TGenericObject.php
+++ b/src/Psalm/Type/Atomic/TGenericObject.php
@@ -28,9 +28,6 @@ class TGenericObject extends TNamedObject
         $this->type_params = $type_params;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         $s = '';
@@ -48,9 +45,6 @@ class TGenericObject extends TNamedObject
         return $this->value . '<' . substr($s, 0, -2) . '>' . $extra_types;
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;
@@ -63,7 +57,6 @@ class TGenericObject extends TNamedObject
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -75,9 +68,6 @@ class TGenericObject extends TNamedObject
         return parent::toNamespacedString($namespace, $aliased_classes, $this_class, false);
     }
 
-    /**
-     * @return bool
-     */
     public function equals(Atomic $other_type): bool
     {
         if (!$other_type instanceof self) {
@@ -97,9 +87,6 @@ class TGenericObject extends TNamedObject
         return true;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return $this->value;

--- a/src/Psalm/Type/Atomic/TGenericObject.php
+++ b/src/Psalm/Type/Atomic/TGenericObject.php
@@ -31,7 +31,7 @@ class TGenericObject extends TNamedObject
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         $s = '';
 
@@ -51,7 +51,7 @@ class TGenericObject extends TNamedObject
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -71,14 +71,14 @@ class TGenericObject extends TNamedObject
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return parent::toNamespacedString($namespace, $aliased_classes, $this_class, false);
     }
 
     /**
      * @return bool
      */
-    public function equals(Atomic $other_type)
+    public function equals(Atomic $other_type): bool
     {
         if (!$other_type instanceof self) {
             return false;
@@ -100,7 +100,7 @@ class TGenericObject extends TNamedObject
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return $this->value;
     }

--- a/src/Psalm/Type/Atomic/THtmlEscapedString.php
+++ b/src/Psalm/Type/Atomic/THtmlEscapedString.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class THtmlEscapedString extends TString
 {
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'html-escaped-string';
@@ -16,9 +13,6 @@ class THtmlEscapedString extends TString
         return $this->getKey();
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/THtmlEscapedString.php
+++ b/src/Psalm/Type/Atomic/THtmlEscapedString.php
@@ -6,12 +6,12 @@ class THtmlEscapedString extends TString
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'html-escaped-string';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->getKey();
     }
@@ -19,7 +19,7 @@ class THtmlEscapedString extends TString
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TInt.php
+++ b/src/Psalm/Type/Atomic/TInt.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TInt extends Scalar
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'int';
     }
@@ -11,7 +11,7 @@ class TInt extends Scalar
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'int';
     }

--- a/src/Psalm/Type/Atomic/TInt.php
+++ b/src/Psalm/Type/Atomic/TInt.php
@@ -8,9 +8,6 @@ class TInt extends Scalar
         return 'int';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'int';

--- a/src/Psalm/Type/Atomic/TIterable.php
+++ b/src/Psalm/Type/Atomic/TIterable.php
@@ -41,7 +41,7 @@ class TIterable extends Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         if ($include_extra && $this->extra_types) {
             // do nothing
@@ -53,12 +53,12 @@ class TIterable extends Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'iterable';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         $s = '';
         foreach ($this->type_params as $type_param) {
@@ -74,7 +74,7 @@ class TIterable extends Atomic
         return $this->value . '<' . substr($s, 0, -2) . '>' . $extra_types;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getId();
     }
@@ -94,7 +94,7 @@ class TIterable extends Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version > 7
             || ($php_major_version === 7 && $php_minor_version >= 1)
             ? 'iterable'
@@ -104,7 +104,7 @@ class TIterable extends Atomic
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return $this->type_params[0]->isMixed() && $this->type_params[1]->isMixed();
     }
@@ -112,7 +112,7 @@ class TIterable extends Atomic
     /**
      * @return bool
      */
-    public function equals(Atomic $other_type)
+    public function equals(Atomic $other_type): bool
     {
         if (!$other_type instanceof self) {
             return false;

--- a/src/Psalm/Type/Atomic/TIterable.php
+++ b/src/Psalm/Type/Atomic/TIterable.php
@@ -37,10 +37,7 @@ class TIterable extends Atomic
             $this->type_params = [\Psalm\Type::getMixed(), \Psalm\Type::getMixed()];
         }
     }
-
-    /**
-     * @return string
-     */
+    
     public function getKey(bool $include_extra = true): string
     {
         if ($include_extra && $this->extra_types) {
@@ -50,9 +47,6 @@ class TIterable extends Atomic
         return 'iterable';
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'iterable';
@@ -86,7 +80,6 @@ class TIterable extends Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -101,17 +94,11 @@ class TIterable extends Atomic
             : null;
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return $this->type_params[0]->isMixed() && $this->type_params[1]->isMixed();
     }
 
-    /**
-     * @return bool
-     */
     public function equals(Atomic $other_type): bool
     {
         if (!$other_type instanceof self) {

--- a/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
@@ -24,25 +24,16 @@ class TKeyOfClassConstant extends Scalar
         $this->const_name = $const_name;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'key-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'key-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return $this->getKey();
@@ -55,7 +46,6 @@ class TKeyOfClassConstant extends Scalar
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -73,12 +63,8 @@ class TKeyOfClassConstant extends Scalar
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -117,9 +103,6 @@ class TKeyOfClassConstant extends Scalar
         return 'key-of<\\' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'mixed';

--- a/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
@@ -27,7 +27,7 @@ class TKeyOfClassConstant extends Scalar
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'key-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
@@ -35,7 +35,7 @@ class TKeyOfClassConstant extends Scalar
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return 'key-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
@@ -43,7 +43,7 @@ class TKeyOfClassConstant extends Scalar
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->getKey();
     }
@@ -63,11 +63,11 @@ class TKeyOfClassConstant extends Scalar
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -85,7 +85,7 @@ class TKeyOfClassConstant extends Scalar
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($this->fq_classlike_name === 'static') {
             return 'key-of<static::' . $this->const_name . '>';
         }
@@ -120,7 +120,7 @@ class TKeyOfClassConstant extends Scalar
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'mixed';
     }

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -72,10 +72,10 @@ class TKeyedArray extends \Psalm\Type\Atomic
         $this->class_strings = $class_strings;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $property_strings = array_map(
-            function ($name, Union $type) {
+            function ($name, Union $type): string {
                 if ($this->is_list && $this->sealed) {
                     return (string) $type;
                 }
@@ -98,10 +98,10 @@ class TKeyedArray extends \Psalm\Type\Atomic
         return static::KEY . '{' . implode(', ', $property_strings) . '}';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         $property_strings = array_map(
-            function ($name, Union $type) {
+            function ($name, Union $type): string {
                 if ($this->is_list && $this->sealed) {
                     return $type->getId();
                 }
@@ -140,7 +140,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($use_phpdoc_format) {
             return $this->getGenericArrayType()->toNamespacedString(
                 $namespace,
@@ -191,12 +191,17 @@ class TKeyedArray extends \Psalm\Type\Atomic
      *
      * @return string
      */
-    public function toPhpString($namespace, array $aliased_classes, $this_class, $php_major_version, $php_minor_version)
-    {
+    public function toPhpString(
+        $namespace,
+        array $aliased_classes,
+        $this_class,
+        $php_major_version,
+        $php_minor_version
+    ): string {
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -204,7 +209,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
     /**
      * @return Union
      */
-    public function getGenericKeyType()
+    public function getGenericKeyType(): Union
     {
         $key_types = [];
 
@@ -232,7 +237,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
     /**
      * @return Union
      */
-    public function getGenericValueType()
+    public function getGenericValueType(): Union
     {
         $value_type = null;
 
@@ -314,7 +319,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         /** @var string */
         return static::KEY;
@@ -381,7 +386,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
     /**
      * @return bool
      */
-    public function equals(Atomic $other_type)
+    public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== static::class) {
             return false;
@@ -411,7 +416,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return $this->getKey();
     }

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -133,7 +133,6 @@ class TKeyedArray extends \Psalm\Type\Atomic
     /**
      * @param  array<string, string> $aliased_classes
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -189,7 +188,6 @@ class TKeyedArray extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string
      */
     public function toPhpString(
         $namespace,
@@ -206,9 +204,6 @@ class TKeyedArray extends \Psalm\Type\Atomic
         return false;
     }
 
-    /**
-     * @return Union
-     */
     public function getGenericKeyType(): Union
     {
         $key_types = [];
@@ -234,9 +229,6 @@ class TKeyedArray extends \Psalm\Type\Atomic
         return $key_type;
     }
 
-    /**
-     * @return Union
-     */
     public function getGenericValueType(): Union
     {
         $value_type = null;
@@ -316,9 +308,6 @@ class TKeyedArray extends \Psalm\Type\Atomic
         }
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         /** @var string */
@@ -383,9 +372,6 @@ class TKeyedArray extends \Psalm\Type\Atomic
         return $this->properties;
     }
 
-    /**
-     * @return bool
-     */
     public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== static::class) {
@@ -413,9 +399,6 @@ class TKeyedArray extends \Psalm\Type\Atomic
         return true;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return $this->getKey();

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -52,7 +52,6 @@ class TList extends \Psalm\Type\Atomic
     /**
      * @param  array<string, string> $aliased_classes
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -89,7 +88,6 @@ class TList extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string
      */
     public function toPhpString(
         $namespace,
@@ -106,9 +104,6 @@ class TList extends \Psalm\Type\Atomic
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'array';
@@ -181,9 +176,6 @@ class TList extends \Psalm\Type\Atomic
         $this->type_param->replaceTemplateTypesWithArgTypes($template_result, $codebase);
     }
 
-    /**
-     * @return bool
-     */
     public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== static::class) {
@@ -197,9 +189,6 @@ class TList extends \Psalm\Type\Atomic
         return true;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'list';

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -32,13 +32,13 @@ class TList extends \Psalm\Type\Atomic
         $this->type_param = $type_param;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         /** @psalm-suppress MixedOperand */
         return static::KEY . '<' . $this->type_param . '>';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         /** @psalm-suppress MixedOperand */
         return static::KEY . '<' . $this->type_param->getId() . '>';
@@ -59,7 +59,7 @@ class TList extends \Psalm\Type\Atomic
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($use_phpdoc_format) {
             return (new TArray([Type::getInt(), $this->type_param]))
                 ->toNamespacedString(
@@ -91,12 +91,17 @@ class TList extends \Psalm\Type\Atomic
      *
      * @return string
      */
-    public function toPhpString($namespace, array $aliased_classes, $this_class, $php_major_version, $php_minor_version)
-    {
+    public function toPhpString(
+        $namespace,
+        array $aliased_classes,
+        $this_class,
+        $php_major_version,
+        $php_minor_version
+    ): string {
         return 'array';
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -104,7 +109,7 @@ class TList extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'array';
     }
@@ -179,7 +184,7 @@ class TList extends \Psalm\Type\Atomic
     /**
      * @return bool
      */
-    public function equals(Atomic $other_type)
+    public function equals(Atomic $other_type): bool
     {
         if (get_class($other_type) !== static::class) {
             return false;
@@ -195,7 +200,7 @@ class TList extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'list';
     }

--- a/src/Psalm/Type/Atomic/TLiteralClassString.php
+++ b/src/Psalm/Type/Atomic/TLiteralClassString.php
@@ -18,7 +18,7 @@ class TLiteralClassString extends TLiteralString
         $this->value = $value;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return 'class-string';
     }
@@ -26,7 +26,7 @@ class TLiteralClassString extends TLiteralString
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'class-string(' . $this->value . ')';
     }
@@ -46,14 +46,14 @@ class TLiteralClassString extends TLiteralString
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): string {
         return 'string';
     }
 
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -61,7 +61,7 @@ class TLiteralClassString extends TLiteralString
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->value . '::class';
     }
@@ -69,7 +69,7 @@ class TLiteralClassString extends TLiteralString
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return $this->getKey();
     }
@@ -87,7 +87,7 @@ class TLiteralClassString extends TLiteralString
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($this->value === 'static') {
             return 'static::class';
         }

--- a/src/Psalm/Type/Atomic/TLiteralClassString.php
+++ b/src/Psalm/Type/Atomic/TLiteralClassString.php
@@ -23,9 +23,6 @@ class TLiteralClassString extends TLiteralString
         return 'class-string';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'class-string(' . $this->value . ')';
@@ -50,37 +47,24 @@ class TLiteralClassString extends TLiteralString
         return 'string';
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return $this->value . '::class';
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return $this->getKey();
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -14,17 +14,11 @@ class TLiteralFloat extends TFloat
         $this->value = $value;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'float(' . $this->value . ')';
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'float(' . $this->value . ')';
@@ -37,7 +31,6 @@ class TLiteralFloat extends TFloat
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,
@@ -50,12 +43,8 @@ class TLiteralFloat extends TFloat
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -17,7 +17,7 @@ class TLiteralFloat extends TFloat
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'float(' . $this->value . ')';
     }
@@ -25,7 +25,7 @@ class TLiteralFloat extends TFloat
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'float(' . $this->value . ')';
     }
@@ -45,7 +45,7 @@ class TLiteralFloat extends TFloat
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version >= 7 ? 'float' : null;
     }
 
@@ -62,7 +62,7 @@ class TLiteralFloat extends TFloat
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return 'float';
     }
 }

--- a/src/Psalm/Type/Atomic/TLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TLiteralInt.php
@@ -14,17 +14,11 @@ class TLiteralInt extends TInt
         $this->value = $value;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'int(' . $this->value . ')';
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'int(' . $this->value . ')';
@@ -37,7 +31,6 @@ class TLiteralInt extends TInt
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,
@@ -50,12 +43,8 @@ class TLiteralInt extends TInt
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TLiteralInt.php
@@ -17,7 +17,7 @@ class TLiteralInt extends TInt
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'int(' . $this->value . ')';
     }
@@ -25,7 +25,7 @@ class TLiteralInt extends TInt
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'int(' . $this->value . ')';
     }
@@ -45,7 +45,7 @@ class TLiteralInt extends TInt
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version >= 7 ? 'int' : null;
     }
 
@@ -62,7 +62,7 @@ class TLiteralInt extends TInt
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return 'int';
     }
 }

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -29,7 +29,7 @@ class TLiteralString extends TString
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return 'string';
     }
@@ -62,7 +62,7 @@ class TLiteralString extends TString
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version >= 7 ? 'string' : null;
     }
 
@@ -79,7 +79,7 @@ class TLiteralString extends TString
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return 'string';
     }
 }

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -26,9 +26,6 @@ class TLiteralString extends TString
         return $this->getId();
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'string';
@@ -54,7 +51,6 @@ class TLiteralString extends TString
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -67,12 +63,8 @@ class TLiteralString extends TString
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TLowercaseString.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class TLowercaseString extends TString
 {
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'string';
@@ -16,9 +13,6 @@ class TLowercaseString extends TString
         return 'lowercase-string';
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/TLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TLowercaseString.php
@@ -6,12 +6,12 @@ class TLowercaseString extends TString
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'string';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'lowercase-string';
     }
@@ -19,7 +19,7 @@ class TLowercaseString extends TString
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TMixed.php
+++ b/src/Psalm/Type/Atomic/TMixed.php
@@ -14,7 +14,7 @@ class TMixed extends \Psalm\Type\Atomic
         $this->from_loop_isset = $from_loop_isset;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return 'mixed';
     }
@@ -22,7 +22,7 @@ class TMixed extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'mixed';
     }
@@ -42,11 +42,11 @@ class TMixed extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -54,7 +54,7 @@ class TMixed extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'mixed';
     }

--- a/src/Psalm/Type/Atomic/TMixed.php
+++ b/src/Psalm/Type/Atomic/TMixed.php
@@ -18,10 +18,7 @@ class TMixed extends \Psalm\Type\Atomic
     {
         return 'mixed';
     }
-
-    /**
-     * @return string
-     */
+    
     public function getKey(bool $include_extra = true): string
     {
         return 'mixed';
@@ -34,7 +31,6 @@ class TMixed extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,
@@ -51,9 +47,6 @@ class TMixed extends \Psalm\Type\Atomic
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'mixed';

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -39,7 +39,7 @@ class TNamedObject extends Atomic
         $this->was_static = $was_static;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getKey();
     }
@@ -47,7 +47,7 @@ class TNamedObject extends Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         if ($include_extra && $this->extra_types) {
             return $this->value . '&' . implode('&', $this->extra_types);
@@ -56,7 +56,7 @@ class TNamedObject extends Atomic
         return $this->value;
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         if ($this->extra_types) {
             return $this->value . '&' . implode(
@@ -86,7 +86,7 @@ class TNamedObject extends Atomic
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($this->value === 'static') {
             return 'static';
         }
@@ -117,7 +117,7 @@ class TNamedObject extends Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         if ($this->value === 'static') {
             return null;
         }
@@ -125,7 +125,7 @@ class TNamedObject extends Atomic
         return $this->toNamespacedString($namespace, $aliased_classes, $this_class, false);
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return $this->value !== 'static';
     }

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -44,9 +44,6 @@ class TNamedObject extends Atomic
         return $this->getKey();
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         if ($include_extra && $this->extra_types) {
@@ -74,12 +71,8 @@ class TNamedObject extends Atomic
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string, string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -109,7 +102,6 @@ class TNamedObject extends Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TNever.php
+++ b/src/Psalm/Type/Atomic/TNever.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TNever extends \Psalm\Type\Atomic
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'never-return';
     }
@@ -11,7 +11,7 @@ class TNever extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'never-return';
     }
@@ -31,11 +31,11 @@ class TNever extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNever.php
+++ b/src/Psalm/Type/Atomic/TNever.php
@@ -8,9 +8,6 @@ class TNever extends \Psalm\Type\Atomic
         return 'never-return';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'never-return';
@@ -23,7 +20,6 @@ class TNever extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TNonEmptyList.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyList.php
@@ -16,7 +16,7 @@ class TNonEmptyList extends TList
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'non-empty-list';
     }

--- a/src/Psalm/Type/Atomic/TNonEmptyList.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyList.php
@@ -13,9 +13,6 @@ class TNonEmptyList extends TList
 
     public const KEY = 'non-empty-list';
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'non-empty-list';

--- a/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class TNonEmptyLowercaseString extends TNonEmptyString
 {
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'string';

--- a/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
@@ -6,12 +6,12 @@ class TNonEmptyLowercaseString extends TNonEmptyString
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'string';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'non-empty-lowercase-string';
     }
@@ -19,7 +19,7 @@ class TNonEmptyLowercaseString extends TNonEmptyString
     /**
      * @return false
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNonEmptyMixed.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyMixed.php
@@ -6,7 +6,7 @@ class TNonEmptyMixed extends TMixed
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'non-empty-mixed';
     }

--- a/src/Psalm/Type/Atomic/TNonEmptyMixed.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyMixed.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class TNonEmptyMixed extends TMixed
 {
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'non-empty-mixed';

--- a/src/Psalm/Type/Atomic/TNonEmptyScalar.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyScalar.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class TNonEmptyScalar extends TScalar
 {
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'non-empty-scalar';

--- a/src/Psalm/Type/Atomic/TNonEmptyScalar.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyScalar.php
@@ -6,7 +6,7 @@ class TNonEmptyScalar extends TScalar
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'non-empty-scalar';
     }

--- a/src/Psalm/Type/Atomic/TNonEmptyString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyString.php
@@ -6,9 +6,6 @@ namespace Psalm\Type\Atomic;
  */
 class TNonEmptyString extends TString
 {
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'non-empty-string';

--- a/src/Psalm/Type/Atomic/TNonEmptyString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyString.php
@@ -9,7 +9,7 @@ class TNonEmptyString extends TString
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'non-empty-string';
     }

--- a/src/Psalm/Type/Atomic/TNull.php
+++ b/src/Psalm/Type/Atomic/TNull.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TNull extends \Psalm\Type\Atomic
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'null';
     }
@@ -11,7 +11,7 @@ class TNull extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'null';
     }
@@ -31,11 +31,11 @@ class TNull extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNull.php
+++ b/src/Psalm/Type/Atomic/TNull.php
@@ -8,9 +8,6 @@ class TNull extends \Psalm\Type\Atomic
         return 'null';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'null';
@@ -23,7 +20,6 @@ class TNull extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TNumeric.php
+++ b/src/Psalm/Type/Atomic/TNumeric.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TNumeric extends Scalar
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'numeric';
     }
@@ -11,7 +11,7 @@ class TNumeric extends Scalar
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'numeric';
     }
@@ -31,11 +31,11 @@ class TNumeric extends Scalar
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNumeric.php
+++ b/src/Psalm/Type/Atomic/TNumeric.php
@@ -8,9 +8,6 @@ class TNumeric extends Scalar
         return 'numeric';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'numeric';
@@ -23,7 +20,6 @@ class TNumeric extends Scalar
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TNumericString.php
+++ b/src/Psalm/Type/Atomic/TNumericString.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class TNumericString extends TString
 {
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'numeric-string';
@@ -21,17 +18,11 @@ class TNumericString extends TString
         return $this->getKey();
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'string';

--- a/src/Psalm/Type/Atomic/TNumericString.php
+++ b/src/Psalm/Type/Atomic/TNumericString.php
@@ -6,17 +6,17 @@ class TNumericString extends TString
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'numeric-string';
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return 'numeric-string';
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->getKey();
     }
@@ -24,7 +24,7 @@ class TNumericString extends TString
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -32,7 +32,7 @@ class TNumericString extends TString
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'string';
     }

--- a/src/Psalm/Type/Atomic/TObject.php
+++ b/src/Psalm/Type/Atomic/TObject.php
@@ -8,9 +8,6 @@ class TObject extends \Psalm\Type\Atomic
         return 'object';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'object';
@@ -23,7 +20,6 @@ class TObject extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TObject.php
+++ b/src/Psalm/Type/Atomic/TObject.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TObject extends \Psalm\Type\Atomic
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'object';
     }
@@ -11,7 +11,7 @@ class TObject extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'object';
     }
@@ -31,14 +31,14 @@ class TObject extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version > 7
             || ($php_major_version === 7 && $php_minor_version >= 2)
             ? $this->getKey()
             : null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return true;
     }

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -44,7 +44,7 @@ class TObjectWithProperties extends TObject
         $this->methods = $methods;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $extra_types = '';
 
@@ -61,7 +61,7 @@ class TObjectWithProperties extends TObject
                  *
                  * @return string
                  */
-                function ($name, Union $type) {
+                function ($name, Union $type): string {
                     return $name . ($type->possibly_undefined ? '?' : '') . ':' . $type;
                 },
                 array_keys($this->properties),
@@ -72,7 +72,7 @@ class TObjectWithProperties extends TObject
         $methods_string = implode(
             ', ',
             array_map(
-                function (string $name) {
+                function (string $name): string {
                     return $name . '()';
                 },
                 array_keys($this->methods)
@@ -85,7 +85,7 @@ class TObjectWithProperties extends TObject
             . '}' . $extra_types;
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         $extra_types = '';
 
@@ -102,7 +102,7 @@ class TObjectWithProperties extends TObject
                  *
                  * @return string
                  */
-                function ($name, Union $type) {
+                function ($name, Union $type): string {
                     return $name . ($type->possibly_undefined ? '?' : '') . ':' . $type->getId();
                 },
                 array_keys($this->properties),
@@ -113,7 +113,7 @@ class TObjectWithProperties extends TObject
         $methods_string = implode(
             ', ',
             array_map(
-                function (string $name) {
+                function (string $name): string {
                     return $name . '()';
                 },
                 array_keys($this->methods)
@@ -139,7 +139,7 @@ class TObjectWithProperties extends TObject
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($use_phpdoc_format) {
             return 'object';
         }
@@ -186,15 +186,20 @@ class TObjectWithProperties extends TObject
      *
      * @return string
      */
-    public function toPhpString($namespace, array $aliased_classes, $this_class, $php_major_version, $php_minor_version)
-    {
+    public function toPhpString(
+        $namespace,
+        array $aliased_classes,
+        $this_class,
+        $php_major_version,
+        $php_minor_version
+    ): string {
         return $this->getKey();
     }
 
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -209,7 +214,7 @@ class TObjectWithProperties extends TObject
     /**
      * @return bool
      */
-    public function equals(Atomic $other_type)
+    public function equals(Atomic $other_type): bool
     {
         if (!$other_type instanceof self) {
             return false;
@@ -297,7 +302,7 @@ class TObjectWithProperties extends TObject
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return $this->getKey();
     }

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -127,12 +127,8 @@ class TObjectWithProperties extends TObject
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string, string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -196,9 +192,6 @@ class TObjectWithProperties extends TObject
         return $this->getKey();
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;
@@ -211,9 +204,6 @@ class TObjectWithProperties extends TObject
         }
     }
 
-    /**
-     * @return bool
-     */
     public function equals(Atomic $other_type): bool
     {
         if (!$other_type instanceof self) {
@@ -299,9 +289,6 @@ class TObjectWithProperties extends TObject
         return array_merge($this->properties, $this->extra_types !== null ? array_values($this->extra_types) : []);
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return $this->getKey();

--- a/src/Psalm/Type/Atomic/TPositiveInt.php
+++ b/src/Psalm/Type/Atomic/TPositiveInt.php
@@ -3,9 +3,6 @@ namespace Psalm\Type\Atomic;
 
 class TPositiveInt extends TInt
 {
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'positive-int';

--- a/src/Psalm/Type/Atomic/TPositiveInt.php
+++ b/src/Psalm/Type/Atomic/TPositiveInt.php
@@ -6,7 +6,7 @@ class TPositiveInt extends TInt
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'positive-int';
     }
@@ -14,7 +14,7 @@ class TPositiveInt extends TInt
     /**
      * @return false
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TResource.php
+++ b/src/Psalm/Type/Atomic/TResource.php
@@ -11,9 +11,6 @@ class TResource extends \Psalm\Type\Atomic
         return 'resource';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'resource';
@@ -26,7 +23,6 @@ class TResource extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TResource.php
+++ b/src/Psalm/Type/Atomic/TResource.php
@@ -6,7 +6,7 @@ use Psalm\StatementsSource;
 
 class TResource extends \Psalm\Type\Atomic
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'resource';
     }
@@ -14,7 +14,7 @@ class TResource extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'resource';
     }
@@ -34,11 +34,11 @@ class TResource extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TScalar.php
+++ b/src/Psalm/Type/Atomic/TScalar.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TScalar extends Scalar
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'scalar';
     }
@@ -11,7 +11,7 @@ class TScalar extends Scalar
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'scalar';
     }
@@ -31,11 +31,11 @@ class TScalar extends Scalar
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -43,7 +43,7 @@ class TScalar extends Scalar
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'scalar';
     }

--- a/src/Psalm/Type/Atomic/TScalar.php
+++ b/src/Psalm/Type/Atomic/TScalar.php
@@ -8,9 +8,6 @@ class TScalar extends Scalar
         return 'scalar';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'scalar';
@@ -23,7 +20,6 @@ class TScalar extends Scalar
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,
@@ -40,9 +36,6 @@ class TScalar extends Scalar
         return false;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'scalar';

--- a/src/Psalm/Type/Atomic/TScalarClassConstant.php
+++ b/src/Psalm/Type/Atomic/TScalarClassConstant.php
@@ -25,7 +25,7 @@ class TScalarClassConstant extends Scalar
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'scalar-class-constant(' . $this->fq_classlike_name . '::' . $this->const_name . ')';
     }
@@ -33,7 +33,7 @@ class TScalarClassConstant extends Scalar
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->fq_classlike_name . '::' . $this->const_name;
     }
@@ -41,7 +41,7 @@ class TScalarClassConstant extends Scalar
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->getKey();
     }
@@ -61,11 +61,11 @@ class TScalarClassConstant extends Scalar
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -83,7 +83,7 @@ class TScalarClassConstant extends Scalar
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($this->fq_classlike_name === 'static') {
             return 'static::' . $this->const_name;
         }
@@ -96,7 +96,7 @@ class TScalarClassConstant extends Scalar
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'mixed';
     }

--- a/src/Psalm/Type/Atomic/TScalarClassConstant.php
+++ b/src/Psalm/Type/Atomic/TScalarClassConstant.php
@@ -22,25 +22,16 @@ class TScalarClassConstant extends Scalar
         $this->const_name = $const_name;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'scalar-class-constant(' . $this->fq_classlike_name . '::' . $this->const_name . ')';
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->fq_classlike_name . '::' . $this->const_name;
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return $this->getKey();
@@ -53,7 +44,6 @@ class TScalarClassConstant extends Scalar
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -71,12 +61,8 @@ class TScalarClassConstant extends Scalar
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string, string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -93,9 +79,6 @@ class TScalarClassConstant extends Scalar
             . $this->const_name;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'mixed';

--- a/src/Psalm/Type/Atomic/TString.php
+++ b/src/Psalm/Type/Atomic/TString.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TString extends Scalar
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'string';
     }

--- a/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
+++ b/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
@@ -31,7 +31,7 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return $this->array_param_name . '[' . $this->offset_param_name . ']';
     }
@@ -39,7 +39,7 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getKey();
     }
@@ -47,7 +47,7 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->getKey();
     }
@@ -67,11 +67,11 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -89,7 +89,7 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return $this->getKey();
     }
 }

--- a/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
+++ b/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
@@ -28,25 +28,16 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
         $this->defining_class = $defining_class;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return $this->array_param_name . '[' . $this->offset_param_name . ']';
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->getKey();
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return $this->getKey();
@@ -59,7 +50,6 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -77,12 +67,8 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TTemplateKeyOf.php
+++ b/src/Psalm/Type/Atomic/TTemplateKeyOf.php
@@ -33,7 +33,7 @@ class TTemplateKeyOf extends TArrayKey
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'key-of<' . $this->param_name . '>';
     }
@@ -41,7 +41,7 @@ class TTemplateKeyOf extends TArrayKey
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return 'key-of<' . $this->param_name . '>';
     }
@@ -49,7 +49,7 @@ class TTemplateKeyOf extends TArrayKey
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'key-of<' . $this->param_name . ':' . $this->defining_class . ' as ' . $this->as->getId() . '>';
     }
@@ -69,14 +69,14 @@ class TTemplateKeyOf extends TArrayKey
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
     /**
      * @return false
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -94,7 +94,7 @@ class TTemplateKeyOf extends TArrayKey
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return 'key-of<' . $this->param_name . '>';
     }
 }

--- a/src/Psalm/Type/Atomic/TTemplateKeyOf.php
+++ b/src/Psalm/Type/Atomic/TTemplateKeyOf.php
@@ -30,25 +30,16 @@ class TTemplateKeyOf extends TArrayKey
         $this->as = $as;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'key-of<' . $this->param_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'key-of<' . $this->param_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'key-of<' . $this->param_name . ':' . $this->defining_class . ' as ' . $this->as->getId() . '>';
@@ -61,7 +52,6 @@ class TTemplateKeyOf extends TArrayKey
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -82,12 +72,8 @@ class TTemplateKeyOf extends TArrayKey
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TTemplateParam.php
+++ b/src/Psalm/Type/Atomic/TTemplateParam.php
@@ -41,7 +41,7 @@ class TTemplateParam extends \Psalm\Type\Atomic
         $this->defining_class = $defining_class;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->param_name;
     }
@@ -49,7 +49,7 @@ class TTemplateParam extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         if ($include_extra && $this->extra_types) {
             return $this->param_name . ':' . $this->defining_class . '&' . implode('&', $this->extra_types);
@@ -61,12 +61,12 @@ class TTemplateParam extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return $this->as->getId();
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         if ($this->extra_types) {
             return '(' . $this->param_name . ':' . $this->defining_class . ' as ' . $this->as->getId()
@@ -112,7 +112,7 @@ class TTemplateParam extends \Psalm\Type\Atomic
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($use_phpdoc_format) {
             return $this->as->toNamespacedString(
                 $namespace,
@@ -140,7 +140,7 @@ class TTemplateParam extends \Psalm\Type\Atomic
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTemplateParam.php
+++ b/src/Psalm/Type/Atomic/TTemplateParam.php
@@ -31,9 +31,6 @@ class TTemplateParam extends \Psalm\Type\Atomic
      */
     public $defining_class;
 
-    /**
-     * @param string $defining_class
-     */
     public function __construct(string $param_name, Union $extends, string $defining_class)
     {
         $this->param_name = $param_name;
@@ -46,9 +43,6 @@ class TTemplateParam extends \Psalm\Type\Atomic
         return $this->param_name;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         if ($include_extra && $this->extra_types) {
@@ -58,9 +52,6 @@ class TTemplateParam extends \Psalm\Type\Atomic
         return $this->param_name . ':' . $this->defining_class;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return $this->as->getId();
@@ -100,12 +91,8 @@ class TTemplateParam extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string, string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -137,9 +124,6 @@ class TTemplateParam extends \Psalm\Type\Atomic
         return [$this->as];
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/TTemplateParamClass.php
+++ b/src/Psalm/Type/Atomic/TTemplateParamClass.php
@@ -38,7 +38,7 @@ class TTemplateParamClass extends TClassString
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'class-string<' . $this->param_name . '>';
     }
@@ -46,7 +46,7 @@ class TTemplateParamClass extends TClassString
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return 'class-string<' . $this->param_name . '>';
     }
@@ -54,7 +54,7 @@ class TTemplateParamClass extends TClassString
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return 'class-string<' . $this->param_name . ':' . $this->defining_class . ' as ' . $this->as . '>';
     }
@@ -62,7 +62,7 @@ class TTemplateParamClass extends TClassString
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'class-string<' . $this->param_name . '>';
     }
@@ -82,11 +82,11 @@ class TTemplateParamClass extends TClassString
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return 'string';
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -104,7 +104,7 @@ class TTemplateParamClass extends TClassString
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return $this->param_name . '::class';
     }
 

--- a/src/Psalm/Type/Atomic/TTemplateParamClass.php
+++ b/src/Psalm/Type/Atomic/TTemplateParamClass.php
@@ -35,33 +35,21 @@ class TTemplateParamClass extends TClassString
         $this->defining_class = $defining_class;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'class-string<' . $this->param_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'class-string<' . $this->param_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return 'class-string<' . $this->param_name . ':' . $this->defining_class . ' as ' . $this->as . '>';
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'class-string<' . $this->param_name . '>';
@@ -74,7 +62,6 @@ class TTemplateParamClass extends TClassString
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -92,12 +79,8 @@ class TTemplateParamClass extends TClassString
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TTraitString.php
+++ b/src/Psalm/Type/Atomic/TTraitString.php
@@ -3,17 +3,11 @@ namespace Psalm\Type\Atomic;
 
 class TTraitString extends TString
 {
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'trait-string';
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return $this->getKey();
@@ -31,7 +25,6 @@ class TTraitString extends TString
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -44,12 +37,8 @@ class TTraitString extends TString
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -60,9 +49,6 @@ class TTraitString extends TString
         return 'trait-string';
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/TTraitString.php
+++ b/src/Psalm/Type/Atomic/TTraitString.php
@@ -6,7 +6,7 @@ class TTraitString extends TString
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'trait-string';
     }
@@ -14,12 +14,12 @@ class TTraitString extends TString
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getKey();
     }
 
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->getKey();
     }
@@ -39,7 +39,7 @@ class TTraitString extends TString
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return 'string';
     }
 
@@ -56,14 +56,14 @@ class TTraitString extends TString
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return 'trait-string';
     }
 
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTrue.php
+++ b/src/Psalm/Type/Atomic/TTrue.php
@@ -8,9 +8,6 @@ class TTrue extends TBool
         return 'true';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'true';

--- a/src/Psalm/Type/Atomic/TTrue.php
+++ b/src/Psalm/Type/Atomic/TTrue.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TTrue extends TBool
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'true';
     }
@@ -11,12 +11,12 @@ class TTrue extends TBool
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'true';
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTypeAlias.php
+++ b/src/Psalm/Type/Atomic/TTypeAlias.php
@@ -28,7 +28,7 @@ class TTypeAlias extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'type-alias(' . $this->declaring_fq_classlike_name . '::' . $this->alias_name . ')';
     }
@@ -36,13 +36,13 @@ class TTypeAlias extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         if ($this->extra_types) {
             return $this->getKey() . '&' . implode(
                 '&',
                 array_map(
-                    function ($type) {
+                    function ($type): string {
                         return (string) $type;
                     },
                     $this->extra_types
@@ -56,7 +56,7 @@ class TTypeAlias extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         if ($this->extra_types) {
             return $this->getKey() . '&' . implode(
@@ -88,11 +88,11 @@ class TTypeAlias extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -110,14 +110,14 @@ class TTypeAlias extends \Psalm\Type\Atomic
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         return $this->getKey();
     }
 
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'mixed';
     }

--- a/src/Psalm/Type/Atomic/TTypeAlias.php
+++ b/src/Psalm/Type/Atomic/TTypeAlias.php
@@ -25,17 +25,11 @@ class TTypeAlias extends \Psalm\Type\Atomic
         $this->alias_name = $alias_name;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'type-alias(' . $this->declaring_fq_classlike_name . '::' . $this->alias_name . ')';
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         if ($this->extra_types) {
@@ -53,9 +47,6 @@ class TTypeAlias extends \Psalm\Type\Atomic
         return $this->getKey();
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         if ($this->extra_types) {
@@ -80,7 +71,6 @@ class TTypeAlias extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -98,12 +88,8 @@ class TTypeAlias extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string, string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -114,9 +100,6 @@ class TTypeAlias extends \Psalm\Type\Atomic
         return $this->getKey();
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'mixed';

--- a/src/Psalm/Type/Atomic/TValueOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TValueOfClassConstant.php
@@ -19,25 +19,16 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
         $this->const_name = $const_name;
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'value-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function __toString(): string
     {
         return 'value-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return $this->getKey();
@@ -50,7 +41,6 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return string|null
      */
     public function toPhpString(
         $namespace,
@@ -68,12 +58,8 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  string|null   $namespace
      * @param  array<string, string> $aliased_classes
-     * @param  string|null   $this_class
-     * @param  bool          $use_phpdoc_format
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -90,9 +76,6 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
             . '>::' . $this->const_name . '>';
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         return 'mixed';

--- a/src/Psalm/Type/Atomic/TValueOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TValueOfClassConstant.php
@@ -22,7 +22,7 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'value-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
@@ -30,7 +30,7 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return 'value-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
@@ -38,7 +38,7 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->getKey();
     }
@@ -58,11 +58,11 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }
@@ -80,7 +80,7 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         if ($this->fq_classlike_name === 'static') {
             return 'value-of<static::' . $this->const_name . '>';
         }
@@ -93,7 +93,7 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         return 'mixed';
     }

--- a/src/Psalm/Type/Atomic/TVoid.php
+++ b/src/Psalm/Type/Atomic/TVoid.php
@@ -8,9 +8,6 @@ class TVoid extends \Psalm\Type\Atomic
         return 'void';
     }
 
-    /**
-     * @return string
-     */
     public function getKey(bool $include_extra = true): string
     {
         return 'void';
@@ -23,7 +20,6 @@ class TVoid extends \Psalm\Type\Atomic
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,

--- a/src/Psalm/Type/Atomic/TVoid.php
+++ b/src/Psalm/Type/Atomic/TVoid.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 class TVoid extends \Psalm\Type\Atomic
 {
-    public function __toString()
+    public function __toString(): string
     {
         return 'void';
     }
@@ -11,7 +11,7 @@ class TVoid extends \Psalm\Type\Atomic
     /**
      * @return string
      */
-    public function getKey(bool $include_extra = true)
+    public function getKey(bool $include_extra = true): string
     {
         return 'void';
     }
@@ -31,11 +31,11 @@ class TVoid extends \Psalm\Type\Atomic
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         return $php_major_version >= 7 && $php_minor_version >= 1 ? $this->getKey() : null;
     }
 
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return true;
     }

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -82,7 +82,7 @@ class Reconciler
         array $template_type_map = [],
         bool $inside_loop = false,
         CodeLocation $code_location = null
-    ) {
+    ): array {
         if (!$new_types) {
             return $existing_types;
         }
@@ -381,7 +381,7 @@ class Reconciler
      *
      * @return array<int, string>
      */
-    public static function breakUpPathIntoParts($path)
+    public static function breakUpPathIntoParts($path): array
     {
         if (isset(self::$broken_paths[$path])) {
             return self::$broken_paths[$path];
@@ -504,7 +504,7 @@ class Reconciler
         bool $has_empty,
         bool $inside_loop,
         bool &$has_object_array_access
-    ) {
+    ): ?Union {
         $key_parts = self::breakUpPathIntoParts($key);
 
         if (count($key_parts) === 1) {

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -66,7 +66,6 @@ class Reconciler
      * @param  array<string, Type\Union> $existing_types
      * @param  array<string, bool>       $changed_var_ids
      * @param  array<string, bool>       $referenced_var_ids
-     * @param  StatementsAnalyzer         $statements_analyzer
      * @param  CodeLocation|null         $code_location
      * @param  array<string, array<string, array{Type\Union}>> $template_type_map
      *
@@ -486,12 +485,10 @@ class Reconciler
     /**
      * Gets the type for a given (non-existent key) based on the passed keys
      *
-     * @param  string                    $key
      * @param  array<string,Type\Union>  $existing_keys
      * @param  array<string,mixed>       $new_assertions
      * @param  string[][]                $new_type_parts
      *
-     * @return Type\Union|null
      */
     private static function getValueForKey(
         Codebase $codebase,
@@ -814,10 +811,6 @@ class Reconciler
     }
 
     /**
-     * @param  string       $key
-     * @param  string       $old_var_type_string
-     * @param  string       $assertion
-     * @param  bool         $redundant
      * @param  string[]     $suppressed_issues
      *
      * @return void

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -362,9 +362,6 @@ class Union implements TypeNode
         return implode('|', $types);
     }
 
-    /**
-     * @return string
-     */
     public function getId(): string
     {
         if ($this->id) {
@@ -392,9 +389,6 @@ class Union implements TypeNode
         return $id;
     }
 
-    /**
-     * @return string
-     */
     public function getAssertionString(): string
     {
         foreach ($this->types as $type) {
@@ -407,7 +401,6 @@ class Union implements TypeNode
     /**
      * @param  array<string, string> $aliased_classes
      *
-     * @return string
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -458,7 +451,6 @@ class Union implements TypeNode
      * @param  int           $php_major_version
      * @param  int           $php_minor_version
      *
-     * @return null|string
      */
     public function toPhpString(
         $namespace,
@@ -505,9 +497,6 @@ class Union implements TypeNode
         return null;
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         if (!$this->isSingleAndMaybeNullable()) {
@@ -532,7 +521,6 @@ class Union implements TypeNode
     /**
      * @param  string $type_string
      *
-     * @return bool
      */
     public function removeType($type_string): bool
     {
@@ -594,32 +582,22 @@ class Union implements TypeNode
     /**
      * @param  string  $type_string
      *
-     * @return bool
      */
     public function hasType($type_string): bool
     {
         return isset($this->types[$type_string]);
     }
 
-    /**
-     * @return bool
-     */
     public function hasArray(): bool
     {
         return isset($this->types['array']);
     }
 
-    /**
-     * @return bool
-     */
     public function hasList(): bool
     {
         return isset($this->types['array']) && $this->types['array'] instanceof Atomic\TList;
     }
 
-    /**
-     * @return bool
-     */
     public function hasClassStringMap(): bool
     {
         return isset($this->types['array']) && $this->types['array'] instanceof Atomic\TClassStringMap;
@@ -638,9 +616,6 @@ class Union implements TypeNode
             ) === 1;
     }
 
-    /**
-     * @return bool
-     */
     public function hasEmptyArray(): bool
     {
         return isset($this->types['array'])
@@ -658,9 +633,6 @@ class Union implements TypeNode
         );
     }
 
-    /**
-     * @return bool
-     */
     public function hasCallableType(): bool
     {
         return $this->getCallableTypes() || $this->getClosureTypes();
@@ -692,17 +664,11 @@ class Union implements TypeNode
         );
     }
 
-    /**
-     * @return bool
-     */
     public function hasObject(): bool
     {
         return isset($this->types['object']);
     }
 
-    /**
-     * @return bool
-     */
     public function hasObjectType(): bool
     {
         foreach ($this->types as $type) {
@@ -714,9 +680,6 @@ class Union implements TypeNode
         return false;
     }
 
-    /**
-     * @return bool
-     */
     public function isObjectType(): bool
     {
         foreach ($this->types as $type) {
@@ -728,9 +691,6 @@ class Union implements TypeNode
         return true;
     }
 
-    /**
-     * @return bool
-     */
     public function hasNamedObjectType(): bool
     {
         foreach ($this->types as $type) {
@@ -742,9 +702,6 @@ class Union implements TypeNode
         return false;
     }
 
-    /**
-     * @return bool
-     */
     public function isFormerStaticObject(): bool
     {
         foreach ($this->types as $type) {
@@ -758,9 +715,6 @@ class Union implements TypeNode
         return true;
     }
 
-    /**
-     * @return bool
-     */
     public function hasFormerStaticObject(): bool
     {
         foreach ($this->types as $type) {
@@ -774,9 +728,6 @@ class Union implements TypeNode
         return false;
     }
 
-    /**
-     * @return bool
-     */
     public function isNullable(): bool
     {
         if (isset($this->types['null'])) {
@@ -792,9 +743,6 @@ class Union implements TypeNode
         return false;
     }
 
-    /**
-     * @return bool
-     */
     public function isFalsable(): bool
     {
         if (isset($this->types['false'])) {
@@ -810,17 +758,11 @@ class Union implements TypeNode
         return false;
     }
 
-    /**
-     * @return bool
-     */
     public function hasBool(): bool
     {
         return isset($this->types['bool']) || isset($this->types['false']) || isset($this->types['true']);
     }
 
-    /**
-     * @return bool
-     */
     public function hasString(): bool
     {
         return isset($this->types['string'])
@@ -831,9 +773,6 @@ class Union implements TypeNode
             || $this->typed_class_strings;
     }
 
-    /**
-     * @return bool
-     */
     public function hasLowercaseString(): bool
     {
         return isset($this->types['string'])
@@ -841,49 +780,31 @@ class Union implements TypeNode
                 || $this->types['string'] instanceof Atomic\TNonEmptyLowercaseString);
     }
 
-    /**
-     * @return bool
-     */
     public function hasLiteralClassString(): bool
     {
         return count($this->typed_class_strings) > 0;
     }
 
-    /**
-     * @return bool
-     */
     public function hasInt(): bool
     {
         return isset($this->types['int']) || isset($this->types['array-key']) || $this->literal_int_types;
     }
 
-    /**
-     * @return bool
-     */
     public function hasPositiveInt(): bool
     {
         return isset($this->types['int']) && $this->types['int'] instanceof Type\Atomic\TPositiveInt;
     }
 
-    /**
-     * @return bool
-     */
     public function hasArrayKey(): bool
     {
         return isset($this->types['array-key']);
     }
 
-    /**
-     * @return bool
-     */
     public function hasFloat(): bool
     {
         return isset($this->types['float']) || $this->literal_float_types;
     }
 
-    /**
-     * @return bool
-     */
     public function hasDefinitelyNumericType(bool $include_literal_int = true): bool
     {
         return isset($this->types['int'])
@@ -893,9 +814,6 @@ class Union implements TypeNode
             || $this->literal_float_types;
     }
 
-    /**
-     * @return bool
-     */
     public function hasPossiblyNumericType(): bool
     {
         return isset($this->types['int'])
@@ -907,25 +825,16 @@ class Union implements TypeNode
             || $this->literal_string_types;
     }
 
-    /**
-     * @return bool
-     */
     public function hasScalar(): bool
     {
         return isset($this->types['scalar']);
     }
 
-    /**
-     * @return bool
-     */
     public function hasNumeric(): bool
     {
         return isset($this->types['numeric']);
     }
 
-    /**
-     * @return bool
-     */
     public function hasScalarType(): bool
     {
         return isset($this->types['int'])
@@ -944,9 +853,6 @@ class Union implements TypeNode
             || $this->typed_class_strings;
     }
 
-    /**
-     * @return bool
-     */
     public function hasTemplate(): bool
     {
         return (bool) array_filter(
@@ -966,9 +872,6 @@ class Union implements TypeNode
         );
     }
 
-    /**
-     * @return bool
-     */
     public function hasConditional(): bool
     {
         return (bool) array_filter(
@@ -979,9 +882,6 @@ class Union implements TypeNode
         );
     }
 
-    /**
-     * @return bool
-     */
     public function hasTemplateOrStatic(): bool
     {
         return (bool) array_filter(
@@ -1004,34 +904,22 @@ class Union implements TypeNode
         );
     }
 
-    /**
-     * @return bool
-     */
     public function hasMixed(): bool
     {
         return isset($this->types['mixed']);
     }
 
-    /**
-     * @return bool
-     */
     public function isMixed(): bool
     {
         return isset($this->types['mixed']) && count($this->types) === 1;
     }
 
-    /**
-     * @return bool
-     */
     public function isEmptyMixed(): bool
     {
         return isset($this->types['mixed'])
             && $this->types['mixed'] instanceof Type\Atomic\TEmptyMixed;
     }
 
-    /**
-     * @return bool
-     */
     public function isVanillaMixed(): bool
     {
         /**
@@ -1044,57 +932,36 @@ class Union implements TypeNode
             && count($this->types) === 1;
     }
 
-    /**
-     * @return bool
-     */
     public function isArrayKey(): bool
     {
         return isset($this->types['array-key']) && count($this->types) === 1;
     }
 
-    /**
-     * @return bool
-     */
     public function isNull(): bool
     {
         return count($this->types) === 1 && isset($this->types['null']);
     }
 
-    /**
-     * @return bool
-     */
     public function isFalse(): bool
     {
         return count($this->types) === 1 && isset($this->types['false']);
     }
 
-    /**
-     * @return bool
-     */
     public function isTrue(): bool
     {
         return count($this->types) === 1 && isset($this->types['true']);
     }
 
-    /**
-     * @return bool
-     */
     public function isVoid(): bool
     {
         return isset($this->types['void']);
     }
 
-    /**
-     * @return bool
-     */
     public function isNever(): bool
     {
         return isset($this->types['never-return']);
     }
 
-    /**
-     * @return bool
-     */
     public function isGenerator(): bool
     {
         return count($this->types) === 1
@@ -1102,9 +969,6 @@ class Union implements TypeNode
             && ($single_type->value === 'Generator');
     }
 
-    /**
-     * @return bool
-     */
     public function isEmpty(): bool
     {
         return isset($this->types['empty']);
@@ -1484,9 +1348,6 @@ class Union implements TypeNode
         }
     }
 
-    /**
-     * @return bool
-     */
     public function isSingle(): bool
     {
         $type_count = count($this->types);
@@ -1509,9 +1370,6 @@ class Union implements TypeNode
         return $type_count === 1;
     }
 
-    /**
-     * @return bool
-     */
     public function isSingleAndMaybeNullable(): bool
     {
         $is_nullable = isset($this->types['null']);
@@ -1632,17 +1490,11 @@ class Union implements TypeNode
             || isset($this->types['true']);
     }
 
-    /**
-     * @return bool
-     */
     public function hasLiteralString(): bool
     {
         return count($this->literal_string_types) > 0;
     }
 
-    /**
-     * @return bool
-     */
     public function hasLiteralInt(): bool
     {
         return count($this->literal_int_types) > 0;
@@ -1671,13 +1523,9 @@ class Union implements TypeNode
     }
 
     /**
-     * @param  StatementsSource $source
-     * @param  CodeLocation     $code_location
      * @param  array<string>    $suppressed_issues
      * @param  array<string, bool> $phantom_classes
-     * @param  bool             $inferred
      *
-     * @return bool
      */
     public function check(
         StatementsSource $source,
@@ -1774,9 +1622,6 @@ class Union implements TypeNode
         }
     }
 
-    /**
-     * @return bool
-     */
     public function equals(Union $other_type): bool
     {
         if ($other_type === $this) {

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -213,7 +213,7 @@ class Union implements TypeNode
      * @deprecated in favour of getAtomicTypes()
      * @psalm-suppress PossiblyUnusedMethod
      */
-    public function getTypes()
+    public function getTypes(): array
     {
         return $this->types;
     }
@@ -221,7 +221,7 @@ class Union implements TypeNode
     /**
      * @return non-empty-array<string, Atomic>
      */
-    public function getAtomicTypes()
+    public function getAtomicTypes(): array
     {
         return $this->types;
     }
@@ -287,7 +287,7 @@ class Union implements TypeNode
         }
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         $types = [];
 
@@ -365,7 +365,7 @@ class Union implements TypeNode
     /**
      * @return string
      */
-    public function getId()
+    public function getId(): string
     {
         if ($this->id) {
             return $this->id;
@@ -395,7 +395,7 @@ class Union implements TypeNode
     /**
      * @return string
      */
-    public function getAssertionString()
+    public function getAssertionString(): string
     {
         foreach ($this->types as $type) {
             return $type->getAssertionString();
@@ -414,7 +414,7 @@ class Union implements TypeNode
         array $aliased_classes,
         ?string $this_class,
         bool $use_phpdoc_format
-    ) {
+    ): string {
         $printed_int = false;
         $printed_float = false;
         $printed_string = false;
@@ -466,7 +466,7 @@ class Union implements TypeNode
         $this_class,
         $php_major_version,
         $php_minor_version
-    ) {
+    ): ?string {
         $nullable = false;
 
         if (!$this->isSingleAndMaybeNullable()
@@ -508,7 +508,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         if (!$this->isSingleAndMaybeNullable()) {
             return false;
@@ -534,7 +534,7 @@ class Union implements TypeNode
      *
      * @return bool
      */
-    public function removeType($type_string)
+    public function removeType($type_string): bool
     {
         if (isset($this->types[$type_string])) {
             unset($this->types[$type_string]);
@@ -596,7 +596,7 @@ class Union implements TypeNode
      *
      * @return bool
      */
-    public function hasType($type_string)
+    public function hasType($type_string): bool
     {
         return isset($this->types[$type_string]);
     }
@@ -604,7 +604,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasArray()
+    public function hasArray(): bool
     {
         return isset($this->types['array']);
     }
@@ -612,7 +612,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasList()
+    public function hasList(): bool
     {
         return isset($this->types['array']) && $this->types['array'] instanceof Atomic\TList;
     }
@@ -620,7 +620,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasClassStringMap()
+    public function hasClassStringMap(): bool
     {
         return isset($this->types['array']) && $this->types['array'] instanceof Atomic\TClassStringMap;
     }
@@ -631,7 +631,7 @@ class Union implements TypeNode
             && count(
                 array_filter(
                     $this->types,
-                    function ($type) {
+                    function ($type): bool {
                         return $type instanceof Atomic\TTemplateParamClass;
                     }
                 )
@@ -641,7 +641,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasEmptyArray()
+    public function hasEmptyArray(): bool
     {
         return isset($this->types['array'])
             && $this->types['array'] instanceof Atomic\TArray
@@ -661,7 +661,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasCallableType()
+    public function hasCallableType(): bool
     {
         return $this->getCallableTypes() || $this->getClosureTypes();
     }
@@ -669,11 +669,11 @@ class Union implements TypeNode
     /**
      * @return array<Atomic\TCallable>
      */
-    private function getCallableTypes()
+    private function getCallableTypes(): array
     {
         return array_filter(
             $this->types,
-            function ($type) {
+            function ($type): bool {
                 return $type instanceof Atomic\TCallable;
             }
         );
@@ -682,11 +682,11 @@ class Union implements TypeNode
     /**
      * @return array<Atomic\TFn>
      */
-    public function getClosureTypes()
+    public function getClosureTypes(): array
     {
         return array_filter(
             $this->types,
-            function ($type) {
+            function ($type): bool {
                 return $type instanceof Atomic\TFn;
             }
         );
@@ -695,7 +695,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasObject()
+    public function hasObject(): bool
     {
         return isset($this->types['object']);
     }
@@ -703,7 +703,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasObjectType()
+    public function hasObjectType(): bool
     {
         foreach ($this->types as $type) {
             if ($type->isObjectType()) {
@@ -717,7 +717,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isObjectType()
+    public function isObjectType(): bool
     {
         foreach ($this->types as $type) {
             if (!$type->isObjectType()) {
@@ -731,7 +731,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasNamedObjectType()
+    public function hasNamedObjectType(): bool
     {
         foreach ($this->types as $type) {
             if ($type->isNamedObjectType()) {
@@ -745,7 +745,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isFormerStaticObject()
+    public function isFormerStaticObject(): bool
     {
         foreach ($this->types as $type) {
             if (!$type instanceof TNamedObject
@@ -761,7 +761,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasFormerStaticObject()
+    public function hasFormerStaticObject(): bool
     {
         foreach ($this->types as $type) {
             if ($type instanceof TNamedObject
@@ -777,7 +777,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isNullable()
+    public function isNullable(): bool
     {
         if (isset($this->types['null'])) {
             return true;
@@ -795,7 +795,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isFalsable()
+    public function isFalsable(): bool
     {
         if (isset($this->types['false'])) {
             return true;
@@ -813,7 +813,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasBool()
+    public function hasBool(): bool
     {
         return isset($this->types['bool']) || isset($this->types['false']) || isset($this->types['true']);
     }
@@ -821,7 +821,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasString()
+    public function hasString(): bool
     {
         return isset($this->types['string'])
             || isset($this->types['class-string'])
@@ -834,7 +834,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasLowercaseString()
+    public function hasLowercaseString(): bool
     {
         return isset($this->types['string'])
             && ($this->types['string'] instanceof Atomic\TLowercaseString
@@ -844,7 +844,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasLiteralClassString()
+    public function hasLiteralClassString(): bool
     {
         return count($this->typed_class_strings) > 0;
     }
@@ -852,7 +852,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasInt()
+    public function hasInt(): bool
     {
         return isset($this->types['int']) || isset($this->types['array-key']) || $this->literal_int_types;
     }
@@ -860,7 +860,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasPositiveInt()
+    public function hasPositiveInt(): bool
     {
         return isset($this->types['int']) && $this->types['int'] instanceof Type\Atomic\TPositiveInt;
     }
@@ -868,7 +868,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasArrayKey()
+    public function hasArrayKey(): bool
     {
         return isset($this->types['array-key']);
     }
@@ -876,7 +876,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasFloat()
+    public function hasFloat(): bool
     {
         return isset($this->types['float']) || $this->literal_float_types;
     }
@@ -884,7 +884,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasDefinitelyNumericType(bool $include_literal_int = true)
+    public function hasDefinitelyNumericType(bool $include_literal_int = true): bool
     {
         return isset($this->types['int'])
             || isset($this->types['float'])
@@ -896,7 +896,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasPossiblyNumericType()
+    public function hasPossiblyNumericType(): bool
     {
         return isset($this->types['int'])
             || isset($this->types['float'])
@@ -910,7 +910,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasScalar()
+    public function hasScalar(): bool
     {
         return isset($this->types['scalar']);
     }
@@ -918,7 +918,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasNumeric()
+    public function hasNumeric(): bool
     {
         return isset($this->types['numeric']);
     }
@@ -926,7 +926,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasScalarType()
+    public function hasScalarType(): bool
     {
         return isset($this->types['int'])
             || isset($this->types['float'])
@@ -947,7 +947,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasTemplate()
+    public function hasTemplate(): bool
     {
         return (bool) array_filter(
             $this->types,
@@ -957,7 +957,7 @@ class Union implements TypeNode
                         && $type->extra_types
                         && array_filter(
                             $type->extra_types,
-                            function ($t) {
+                            function ($t): bool {
                                 return $t instanceof Type\Atomic\TTemplateParam;
                             }
                         )
@@ -969,7 +969,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasConditional()
+    public function hasConditional(): bool
     {
         return (bool) array_filter(
             $this->types,
@@ -982,7 +982,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasTemplateOrStatic()
+    public function hasTemplateOrStatic(): bool
     {
         return (bool) array_filter(
             $this->types,
@@ -993,7 +993,7 @@ class Union implements TypeNode
                             || ($type->extra_types
                                 && array_filter(
                                     $type->extra_types,
-                                    function ($t) {
+                                    function ($t): bool {
                                         return $t instanceof Type\Atomic\TTemplateParam;
                                     }
                                 )
@@ -1007,7 +1007,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasMixed()
+    public function hasMixed(): bool
     {
         return isset($this->types['mixed']);
     }
@@ -1015,7 +1015,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isMixed()
+    public function isMixed(): bool
     {
         return isset($this->types['mixed']) && count($this->types) === 1;
     }
@@ -1023,7 +1023,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isEmptyMixed()
+    public function isEmptyMixed(): bool
     {
         return isset($this->types['mixed'])
             && $this->types['mixed'] instanceof Type\Atomic\TEmptyMixed;
@@ -1032,7 +1032,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isVanillaMixed()
+    public function isVanillaMixed(): bool
     {
         /**
          * @psalm-suppress UndefinedPropertyFetch
@@ -1047,7 +1047,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isArrayKey()
+    public function isArrayKey(): bool
     {
         return isset($this->types['array-key']) && count($this->types) === 1;
     }
@@ -1055,7 +1055,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isNull()
+    public function isNull(): bool
     {
         return count($this->types) === 1 && isset($this->types['null']);
     }
@@ -1063,7 +1063,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isFalse()
+    public function isFalse(): bool
     {
         return count($this->types) === 1 && isset($this->types['false']);
     }
@@ -1071,7 +1071,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isTrue()
+    public function isTrue(): bool
     {
         return count($this->types) === 1 && isset($this->types['true']);
     }
@@ -1079,7 +1079,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isVoid()
+    public function isVoid(): bool
     {
         return isset($this->types['void']);
     }
@@ -1087,7 +1087,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isNever()
+    public function isNever(): bool
     {
         return isset($this->types['never-return']);
     }
@@ -1095,7 +1095,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isGenerator()
+    public function isGenerator(): bool
     {
         return count($this->types) === 1
             && (($single_type = reset($this->types)) instanceof TNamedObject)
@@ -1105,7 +1105,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isEmpty()
+    public function isEmpty(): bool
     {
         return isset($this->types['empty']);
     }
@@ -1487,7 +1487,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isSingle()
+    public function isSingle(): bool
     {
         $type_count = count($this->types);
 
@@ -1512,7 +1512,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function isSingleAndMaybeNullable()
+    public function isSingleAndMaybeNullable(): bool
     {
         $is_nullable = isset($this->types['null']);
 
@@ -1543,7 +1543,7 @@ class Union implements TypeNode
     /**
      * @return bool true if this is an int
      */
-    public function isInt(bool $check_templates = false)
+    public function isInt(bool $check_templates = false): bool
     {
         return count(
             array_filter(
@@ -1562,7 +1562,7 @@ class Union implements TypeNode
     /**
      * @return bool true if this is a float
      */
-    public function isFloat()
+    public function isFloat(): bool
     {
         if (!$this->isSingle()) {
             return false;
@@ -1574,7 +1574,7 @@ class Union implements TypeNode
     /**
      * @return bool true if this is a string
      */
-    public function isString(bool $check_templates = false)
+    public function isString(bool $check_templates = false): bool
     {
         return count(
             array_filter(
@@ -1593,7 +1593,7 @@ class Union implements TypeNode
     /**
      * @return bool true if this is a string literal with only one possible value
      */
-    public function isSingleStringLiteral()
+    public function isSingleStringLiteral(): bool
     {
         return count($this->types) === 1 && count($this->literal_string_types) === 1;
     }
@@ -1635,7 +1635,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasLiteralString()
+    public function hasLiteralString(): bool
     {
         return count($this->literal_string_types) > 0;
     }
@@ -1643,7 +1643,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function hasLiteralInt()
+    public function hasLiteralInt(): bool
     {
         return count($this->literal_int_types) > 0;
     }
@@ -1651,7 +1651,7 @@ class Union implements TypeNode
     /**
      * @return bool true if this is a int literal with only one possible value
      */
-    public function isSingleIntLiteral()
+    public function isSingleIntLiteral(): bool
     {
         return count($this->types) === 1 && count($this->literal_int_types) === 1;
     }
@@ -1777,7 +1777,7 @@ class Union implements TypeNode
     /**
      * @return bool
      */
-    public function equals(Union $other_type)
+    public function equals(Union $other_type): bool
     {
         if ($other_type === $this) {
             return true;
@@ -1837,7 +1837,7 @@ class Union implements TypeNode
     /**
      * @return array<string, TLiteralString>
      */
-    public function getLiteralStrings()
+    public function getLiteralStrings(): array
     {
         return $this->literal_string_types;
     }
@@ -1845,7 +1845,7 @@ class Union implements TypeNode
     /**
      * @return array<string, TLiteralInt>
      */
-    public function getLiteralInts()
+    public function getLiteralInts(): array
     {
         return $this->literal_int_types;
     }
@@ -1853,7 +1853,7 @@ class Union implements TypeNode
     /**
      * @return array<string, TLiteralFloat>
      */
-    public function getLiteralFloats()
+    public function getLiteralFloats(): array
     {
         return $this->literal_float_types;
     }

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -44,7 +44,7 @@ use function strtoupper;
  *
  * @return ?\Composer\Autoload\ClassLoader
  */
-function requireAutoloaders($current_dir, $has_explicit_root, $vendor_dir)
+function requireAutoloaders($current_dir, $has_explicit_root, $vendor_dir): ?ClassLoader
 {
     $autoload_roots = [$current_dir];
 
@@ -150,7 +150,7 @@ function requireAutoloaders($current_dir, $has_explicit_root, $vendor_dir)
  * @psalm-suppress MixedAssignment
  * @psalm-suppress PossiblyUndefinedStringArrayOffset
  */
-function getVendorDir($current_dir)
+function getVendorDir($current_dir): string
 {
     $composer_json_path = $current_dir . DIRECTORY_SEPARATOR . 'composer.json';
 
@@ -219,7 +219,7 @@ function getArguments() : array
  *
  * @return string[]|null
  */
-function getPathsToCheck($f_paths)
+function getPathsToCheck($f_paths): ?array
 {
     global $argv;
 

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -42,7 +42,6 @@ use function strtoupper;
  * @param  bool   $has_explicit_root
  * @param  string $vendor_dir
  *
- * @return ?\Composer\Autoload\ClassLoader
  */
 function requireAutoloaders($current_dir, $has_explicit_root, $vendor_dir): ?ClassLoader
 {
@@ -144,7 +143,6 @@ function requireAutoloaders($current_dir, $has_explicit_root, $vendor_dir): ?Cla
 /**
  * @param  string $current_dir
  *
- * @return string
  *
  * @psalm-suppress MixedArrayAccess
  * @psalm-suppress MixedAssignment

--- a/src/functions.php
+++ b/src/functions.php
@@ -5,7 +5,6 @@ use Webmozart\PathUtil\Path;
 
 /**
  * @param string $path
- * @return bool
  *
  * @deprecated Use {@see Webmozart\PathUtil\Path::isAbsolute} instead
  */

--- a/src/functions.php
+++ b/src/functions.php
@@ -9,7 +9,7 @@ use Webmozart\PathUtil\Path;
  *
  * @deprecated Use {@see Webmozart\PathUtil\Path::isAbsolute} instead
  */
-function isAbsolutePath($path)
+function isAbsolutePath($path): bool
 {
     return Path::isAbsolute($path);
 }

--- a/src/psalm-language-server.php
+++ b/src/psalm-language-server.php
@@ -248,7 +248,9 @@ $config->setServerMode();
 if (isset($options['clear-cache'])) {
     $cache_directory = $config->getCacheDirectory();
 
-    Config::removeCacheDirectory($cache_directory);
+    if ($cache_directory !== null) {
+        Config::removeCacheDirectory($cache_directory);
+    }
     echo 'Cache directory deleted' . PHP_EOL;
     exit;
 }

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -307,7 +307,7 @@ if (isset($options['i'])) {
          *
          * @return bool
          */
-        function ($arg) {
+        function ($arg): bool {
             return $arg !== '--ansi'
                 && $arg !== '--no-ansi'
                 && $arg !== '-i'
@@ -530,7 +530,9 @@ if (isset($options['shepherd'])) {
 if (isset($options['clear-cache'])) {
     $cache_directory = $config->getCacheDirectory();
 
-    Config::removeCacheDirectory($cache_directory);
+    if ($cache_directory !== null) {
+        Config::removeCacheDirectory($cache_directory);
+    }
     echo 'Cache directory deleted' . PHP_EOL;
     exit;
 }

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -305,7 +305,6 @@ if (isset($options['i'])) {
         /**
          * @param string $arg
          *
-         * @return bool
          */
         function ($arg): bool {
             return $arg !== '--ansi'

--- a/tests/CodebaseTest.php
+++ b/tests/CodebaseTest.php
@@ -19,7 +19,6 @@ class CodebaseTest extends TestCase
     /** @var Codebase */
     private $codebase;
 
-    /** @return void */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/Config/ConfigFileTest.php
+++ b/tests/Config/ConfigFileTest.php
@@ -20,14 +20,12 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
     /** @var string */
     private $file_path;
 
-    /** @return void */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();
         $this->file_path = tempnam(sys_get_temp_dir(), 'psalm-test-config');
     }
 
-    /** @return void */
     public function tearDown() : void
     {
         @unlink($this->file_path);

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -29,9 +29,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
     protected $project_analyzer;
 
-    /**
-     * @return void
-     */
     public static function setUpBeforeClass() : void
     {
         self::$config = new TestConfig();
@@ -45,9 +42,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -34,9 +34,6 @@ class PluginTest extends \Psalm\Tests\TestCase
     /** @var ?\Psalm\Internal\Analyzer\ProjectAnalyzer */
     protected $project_analyzer;
 
-    /**
-     * @return void
-     */
     public static function setUpBeforeClass() : void
     {
         self::$config = new TestConfig();
@@ -50,9 +47,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -77,9 +77,6 @@ class DocumentationTest extends TestCase
         return $issue_code;
     }
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();

--- a/tests/ErrorBaselineTest.php
+++ b/tests/ErrorBaselineTest.php
@@ -18,9 +18,6 @@ class ErrorBaselineTest extends TestCase
     /** @var ObjectProphecy */
     private $fileProvider;
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();

--- a/tests/FileReferenceTest.php
+++ b/tests/FileReferenceTest.php
@@ -13,9 +13,6 @@ class FileReferenceTest extends TestCase
     /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
     protected $project_analyzer;
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();

--- a/tests/FileUpdates/AnalyzedMethodTest.php
+++ b/tests/FileUpdates/AnalyzedMethodTest.php
@@ -13,9 +13,6 @@ use function strpos;
 
 class AnalyzedMethodTest extends \Psalm\Tests\TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/FileUpdates/CachedStorageTest.php
+++ b/tests/FileUpdates/CachedStorageTest.php
@@ -13,9 +13,6 @@ use function strpos;
 
 class CachedStorageTest extends \Psalm\Tests\TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/FileUpdates/ErrorAfterUpdateTest.php
+++ b/tests/FileUpdates/ErrorAfterUpdateTest.php
@@ -14,9 +14,6 @@ use Psalm\Tests\TestConfig;
 
 class ErrorAfterUpdateTest extends \Psalm\Tests\TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/FileUpdates/ErrorFixTest.php
+++ b/tests/FileUpdates/ErrorFixTest.php
@@ -13,9 +13,6 @@ use Psalm\Tests\TestConfig;
 
 class ErrorFixTest extends \Psalm\Tests\TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/FileUpdates/TemporaryUpdateTest.php
+++ b/tests/FileUpdates/TemporaryUpdateTest.php
@@ -16,9 +16,6 @@ use Psalm\Tests\TestConfig;
 
 class TemporaryUpdateTest extends \Psalm\Tests\TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/Internal/Provider/FakeFileProvider.php
+++ b/tests/Internal/Provider/FakeFileProvider.php
@@ -22,7 +22,7 @@ class FakeFileProvider extends \Psalm\Internal\Provider\FileProvider
      *
      * @return bool
      */
-    public function fileExists($file_path)
+    public function fileExists($file_path): bool
     {
         return isset($this->fake_files[$file_path]) || parent::fileExists($file_path);
     }
@@ -32,7 +32,7 @@ class FakeFileProvider extends \Psalm\Internal\Provider\FileProvider
      *
      * @return string
      */
-    public function getContents($file_path, bool $go_to_source = false)
+    public function getContents($file_path, bool $go_to_source = false): string
     {
         if (!$go_to_source && isset($this->temp_files[strtolower($file_path)])) {
             return $this->temp_files[strtolower($file_path)];
@@ -61,7 +61,7 @@ class FakeFileProvider extends \Psalm\Internal\Provider\FileProvider
      *
      * @return int
      */
-    public function getModifiedTime($file_path)
+    public function getModifiedTime($file_path): int
     {
         if (isset($this->fake_file_times[$file_path])) {
             return $this->fake_file_times[$file_path];
@@ -89,7 +89,7 @@ class FakeFileProvider extends \Psalm\Internal\Provider\FileProvider
      *
      * @return array<int, string>
      */
-    public function getFilesInDir($dir_path, array $file_extensions)
+    public function getFilesInDir($dir_path, array $file_extensions): array
     {
         $file_paths = parent::getFilesInDir($dir_path, $file_extensions);
 

--- a/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
+++ b/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
@@ -60,89 +60,56 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
         $this->config = \Psalm\Config::getInstance();
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedFileReferences(): ?array
     {
         return $this->cached_file_references;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedClassLikeFiles(): ?array
     {
         return $this->cached_classlike_files;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedMethodClassReferences(): ?array
     {
         return $this->cached_method_class_references;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedNonMethodClassReferences(): ?array
     {
         return $this->cached_method_class_references;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedFileMemberReferences(): ?array
     {
         return $this->cached_file_member_references;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedMethodMemberReferences(): ?array
     {
         return $this->cached_method_member_references;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedFileMissingMemberReferences(): ?array
     {
         return $this->cached_file_missing_member_references;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedMixedMemberNameReferences(): ?array
     {
         return $this->cached_unknown_member_references;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedMethodMissingMemberReferences(): ?array
     {
         return $this->cached_method_missing_member_references;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedMethodParamUses(): ?array
     {
         return $this->cached_method_missing_member_references;
     }
 
-    /**
-     * @return ?array
-     */
     public function getCachedIssues(): ?array
     {
         return $this->cached_issues;

--- a/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
+++ b/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
@@ -63,7 +63,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedFileReferences()
+    public function getCachedFileReferences(): ?array
     {
         return $this->cached_file_references;
     }
@@ -71,7 +71,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedClassLikeFiles()
+    public function getCachedClassLikeFiles(): ?array
     {
         return $this->cached_classlike_files;
     }
@@ -79,7 +79,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedMethodClassReferences()
+    public function getCachedMethodClassReferences(): ?array
     {
         return $this->cached_method_class_references;
     }
@@ -87,7 +87,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedNonMethodClassReferences()
+    public function getCachedNonMethodClassReferences(): ?array
     {
         return $this->cached_method_class_references;
     }
@@ -95,7 +95,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedFileMemberReferences()
+    public function getCachedFileMemberReferences(): ?array
     {
         return $this->cached_file_member_references;
     }
@@ -103,7 +103,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedMethodMemberReferences()
+    public function getCachedMethodMemberReferences(): ?array
     {
         return $this->cached_method_member_references;
     }
@@ -111,7 +111,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedFileMissingMemberReferences()
+    public function getCachedFileMissingMemberReferences(): ?array
     {
         return $this->cached_file_missing_member_references;
     }
@@ -119,7 +119,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedMixedMemberNameReferences()
+    public function getCachedMixedMemberNameReferences(): ?array
     {
         return $this->cached_unknown_member_references;
     }
@@ -127,7 +127,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedMethodMissingMemberReferences()
+    public function getCachedMethodMissingMemberReferences(): ?array
     {
         return $this->cached_method_missing_member_references;
     }
@@ -135,7 +135,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedMethodParamUses()
+    public function getCachedMethodParamUses(): ?array
     {
         return $this->cached_method_missing_member_references;
     }
@@ -143,7 +143,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return ?array
      */
-    public function getCachedIssues()
+    public function getCachedIssues(): ?array
     {
         return $this->cached_issues;
     }

--- a/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
+++ b/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
@@ -30,7 +30,7 @@ class FileStorageInstanceCacheProvider extends \Psalm\Internal\Provider\FileStor
      *
      * @return FileStorage|null
      */
-    public function getLatestFromCache($file_path, $file_contents)
+    public function getLatestFromCache($file_path, $file_contents): ?FileStorage
     {
         $cached_value = $this->loadFromCache(strtolower($file_path));
 

--- a/tests/Internal/Provider/ProjectCacheProvider.php
+++ b/tests/Internal/Provider/ProjectCacheProvider.php
@@ -18,7 +18,7 @@ class ProjectCacheProvider extends \Psalm\Internal\Provider\ProjectCacheProvider
     /**
      * @return int
      */
-    public function getLastRun()
+    public function getLastRun(): int
     {
         return $this->last_run;
     }
@@ -36,7 +36,7 @@ class ProjectCacheProvider extends \Psalm\Internal\Provider\ProjectCacheProvider
     /**
      * @return bool
      */
-    public function canDiffFiles()
+    public function canDiffFiles(): bool
     {
         return $this->last_run > 0;
     }

--- a/tests/Internal/Provider/ProjectCacheProvider.php
+++ b/tests/Internal/Provider/ProjectCacheProvider.php
@@ -15,9 +15,6 @@ class ProjectCacheProvider extends \Psalm\Internal\Provider\ProjectCacheProvider
     {
     }
 
-    /**
-     * @return int
-     */
     public function getLastRun(): int
     {
         return $this->last_run;
@@ -33,9 +30,6 @@ class ProjectCacheProvider extends \Psalm\Internal\Provider\ProjectCacheProvider
         $this->last_run = (int) $start_time;
     }
 
-    /**
-     * @return bool
-     */
     public function canDiffFiles(): bool
     {
         return $this->last_run > 0;

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -11,9 +11,6 @@ use function substr;
 
 class JsonOutputTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         // `TestCase::setUp()` creates its own ProjectAnalyzer and Config instance, but we don't want to do that in this

--- a/tests/LanguageServer/CompletionTest.php
+++ b/tests/LanguageServer/CompletionTest.php
@@ -12,9 +12,6 @@ use Psalm\Tests\TestConfig;
 
 class CompletionTest extends \Psalm\Tests\TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -12,9 +12,6 @@ use Psalm\Tests\TestConfig;
 
 class SymbolLookupTest extends \Psalm\Tests\TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -28,9 +28,6 @@ class ProjectCheckerTest extends TestCase
     /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
     protected $project_analyzer;
 
-    /**
-     * @return void
-     */
     public static function setUpBeforeClass() : void
     {
         self::$config = new TestConfig();
@@ -44,9 +41,6 @@ class ProjectCheckerTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -22,9 +22,6 @@ use function unlink;
 
 class ReportOutputTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         // `TestCase::setUp()` creates its own ProjectAnalyzer and Config instance, but we don't want to do that in this

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -20,9 +20,6 @@ class StubTest extends TestCase
     /** @var TestConfig */
     protected static $config;
 
-    /**
-     * @return void
-     */
     public static function setUpBeforeClass() : void
     {
         self::$config = new TestConfig();
@@ -36,9 +33,6 @@ class StubTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,9 +27,6 @@ class TestCase extends BaseTestCase
     /** @var Provider\FakeFileProvider */
     protected $file_provider;
 
-    /**
-     * @return void
-     */
     public static function setUpBeforeClass() : void
     {
         ini_set('memory_limit', '-1');
@@ -46,17 +43,11 @@ class TestCase extends BaseTestCase
         self::$src_dir_path = getcwd() . DIRECTORY_SEPARATOR . 'src' . DIRECTORY_SEPARATOR;
     }
 
-    /**
-     * @return Config
-     */
     protected function makeConfig() : Config
     {
         return new TestConfig();
     }
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/TestConfig.php
+++ b/tests/TestConfig.php
@@ -56,7 +56,7 @@ class TestConfig extends Config
         return false;
     }
 
-    public function getProjectDirectories()
+    public function getProjectDirectories(): array
     {
         return [];
     }

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -10,9 +10,6 @@ use function stripos;
 
 class TypeParseTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -19,9 +19,6 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
     /** @var StatementsAnalyzer */
     protected $statements_analyzer;
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         parent::setUp();

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -12,9 +12,6 @@ class UnusedCodeTest extends TestCase
     /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
     protected $project_analyzer;
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -14,9 +14,6 @@ class UnusedVariableTest extends TestCase
     /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
     protected $project_analyzer;
 
-    /**
-     * @return void
-     */
     public function setUp() : void
     {
         RuntimeCaches::clearAll();


### PR DESCRIPTION
this PR propose adding quite a lot of missing return types.

They were suggested by phpstorm and then refined with psalm running and analysing itself.

If this goes well, I plan to do the same with parameters.
EDIT: I may also propose a PR to get rid of all the redundant phpdoc.