### PR TITLE
Fix link to template annotations

### DIFF
--- a/docs/annotating_code/type_syntax/object_types.md
+++ b/docs/annotating_code/type_syntax/object_types.md
@@ -4,7 +4,7 @@
 
 #### Generic object types
 
-Psalm supports using generic object types like `ArrayObject<int, string>`. Any generic object should be typehinted with appropriate [`@template` tags](templated_annotations.md).
+Psalm supports using generic object types like `ArrayObject<int, string>`. Any generic object should be typehinted with appropriate [`@template` tags](../templated_annotations.md).
 
 #### Generators
 


### PR DESCRIPTION
The link to template annotation on this page https://psalm.dev/docs/annotating_code/type_syntax/object_types/ is broken