### PR TITLE
Fixes to LSP protocol

### DIFF
--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -92,6 +92,7 @@ class TextDocument
     /**
      * The document change notification is sent from the client to the server to signal changes to a text document.
      *
+     * @param \LanguageServerProtocol\VersionedTextDocumentIdentifier $textDocument
      * @param \LanguageServerProtocol\TextDocumentContentChangeEvent[] $contentChanges
      *
      * @return void

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -244,6 +244,9 @@ class TextDocument
         $this->server->doAnalysis();
 
         $file_path = LanguageServer::uriToPath($textDocument->uri);
+        if (!$this->codebase->config->isInProjectDirs($file_path)) {
+            return new Success([]);
+        }
 
         try {
             $completion_data = $this->codebase->getCompletionDataAtPosition($file_path, $position);


### PR DESCRIPTION
This PR makes two changes:
 1. Add a missing parameter documentation in `textDocument.didChange`, that caused the JSON-RPC dispatcher to generate an error.
 2. Prevent `textDocument.completion` from operating on out-of-project files, to be consistent with other methods.

Wrt out-of-project files, this commit follows the lead of other methods to simply return an empty response for such out-of-project files and otherwise ignore them. I do wonder if it would not be better to return an error response (e.g. raise an exception) in all of these methods instead, or maybe only in `didOpen`, to let the LSP client and possibly the user know that no analysis is actually happening?
