### PR TITLE
Add consistent array type for predefined constants

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -550,7 +550,7 @@ class Config
     public $after_functionlike_checks = [];
 
     /** @var array<string, mixed> */
-    private $predefined_constants;
+    private $predefined_constants = [];
 
     /** @var array<callable-string, bool> */
     private $predefined_functions = [];


### PR DESCRIPTION
When running psalm through https://github.com/Roave/infection-static-analysis-plugin, you get a lot of warnings

```
Warning: array_key_exists() expects parameter 2 to be array, null given in /Users/woutersioen/Sites/madewithlove/htaccess/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Sta
tements/Expression/Fetch/ConstFetchAnalyzer.php on line 124
```

This is because the config is instantiated without calling the collectPredefinedConstants method, thus making this a null value.
By adding a default value, we make it not required to call this method before running psalm.