### PR TITLE
fix TypeError

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
@@ -25,7 +25,7 @@ class GetObjectVarsReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionRetu
         array $call_args,
         Context $context,
         CodeLocation $code_location
-    ): ?Type\Union {
+    ) {
         if (!$statements_source instanceof \Psalm\Internal\Analyzer\StatementsAnalyzer) {
             return Type::getMixed();
         }


### PR DESCRIPTION
If you run psalm on itself with `useDocblockTypes` to false on latest master, It will emit a TypeError and fail.

This is due to the return type I added here:
https://github.com/vimeo/psalm/compare/master...orklah:bug?expand=1#diff-80f04397ff56726f6ffea6f02a230e28R28

There is a path were no return statement will be met. This results in a TypeError when a return type is present.

I'm surprised Psalm didn't catch this error with this issue:
https://github.com/vimeo/psalm/blob/8c7423505a4282d1cdd38f3ff9552b911cbd5fa9/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php#L172

I'll try to debug this to see if there are other cases like this