### PR TITLE
Changed path output in PhpStorm report to absolute

### DIFF
--- a/src/Psalm/Report/PhpStormReport.php
+++ b/src/Psalm/Report/PhpStormReport.php
@@ -36,7 +36,7 @@ class PhpStormReport extends Report
         $issue_reference = ' (see ' . $issue_data->link . ')';
 
         $issue_string .= ': ' . $issue_data->type
-            . "\nat " . $issue_data->file_name . ':' . $issue_data->line_from . ':' . $issue_data->column_from
+            . "\nat " . $issue_data->file_path . ':' . $issue_data->line_from . ':' . $issue_data->column_from
             . "\n" . $issue_data->message . $issue_reference . "\n";
 
 


### PR DESCRIPTION
Needs to be absolute to be recognized and linked up by PhpStorm terminal (at least for me on Windows).

See #3271, https://youtrack.jetbrains.com/issue/IDEA-154439