### PR TITLE
[easy fix] Update example for @no-named-arguments

### DIFF
--- a/docs/running_psalm/issues/ParamNameMismatch.md
+++ b/docs/running_psalm/issues/ParamNameMismatch.md
@@ -56,7 +56,7 @@ Alternatively you can ignore this issue by adding a `@no-named-arguments` annota
 <?php
 
 class A {
-    /** @no-named-params */
+    /** @no-named-arguments */
     public function foo(string $str, bool $b = false) : void {}
 }
 


### PR DESCRIPTION
The text mentions `@no-named-arguments`, but the example shows `@no-named-params`.
`@no-named-params` can not be found in the psalm source.
Updated example to `@no-named-arguments`.
[search for no-named-params](https://github.com/vimeo/psalm/search?q=no-named-params&unscoped_q=no-named-params) 1 result (this example)
[search for no-named-arguments](https://github.com/vimeo/psalm/search?q=no-named-arguments&unscoped_q=no-named-arguments) 2 results (this example and in CommentAnalyzer.php)