### PR TITLE
More return types

### DIFF
--- a/examples/TemplateChecker.php
+++ b/examples/TemplateChecker.php
@@ -72,9 +72,6 @@ class TemplateAnalyzer extends Psalm\Internal\Analyzer\FileAnalyzer
     }
 
     /**
-     * @param  \Psalm\Internal\MethodIdentifier         $method_id
-     * @param  PhpParser\Node $stmt
-     *
      * @return Context|false
      */
     private function checkMethod(\Psalm\Internal\MethodIdentifier $method_id, PhpParser\Node $stmt, Codebase $codebase)
@@ -132,10 +129,8 @@ class TemplateAnalyzer extends Psalm\Internal\Analyzer\FileAnalyzer
     }
 
     /**
-     * @param  Context $context
      * @param  array<PhpParser\Node\Stmt> $stmts
      *
-     * @return void
      */
     protected function checkWithViewClass(Context $context, array $stmts): void
     {

--- a/examples/TemplateChecker.php
+++ b/examples/TemplateChecker.php
@@ -18,7 +18,7 @@ class TemplateAnalyzer extends Psalm\Internal\Analyzer\FileAnalyzer
 {
     const VIEW_CLASS = 'Your\\View\\Class';
 
-    public function analyze(?Context $file_context = null, bool $preserve_analyzers = false, ?Context $global_context = null)
+    public function analyze(?Context $file_context = null, bool $preserve_analyzers = false, ?Context $global_context = null): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $stmts = $codebase->getStatementsForFile($this->file_path);
@@ -137,7 +137,7 @@ class TemplateAnalyzer extends Psalm\Internal\Analyzer\FileAnalyzer
      *
      * @return void
      */
-    protected function checkWithViewClass(Context $context, array $stmts)
+    protected function checkWithViewClass(Context $context, array $stmts): void
     {
         $pseudo_method_stmts = [];
 

--- a/examples/plugins/ClassUnqualifier.php
+++ b/examples/plugins/ClassUnqualifier.php
@@ -12,7 +12,6 @@ use Psalm\Type;
 class ClassUnqualifier implements AfterClassLikeExistenceCheckInterface
 {
     /**
-     * @param  string             $fq_class_name
      * @param  FileManipulation[] $file_replacements
      *
      * @return void

--- a/examples/plugins/PreventFloatAssignmentChecker.php
+++ b/examples/plugins/PreventFloatAssignmentChecker.php
@@ -31,7 +31,7 @@ class PreventFloatAssignmentChecker implements AfterExpressionAnalysisInterface
         StatementsSource $statements_source,
         Codebase $codebase,
         array &$file_replacements = []
-    ) {
+    ): ?bool {
         if ($expr instanceof PhpParser\Node\Expr\Assign
             && ($expr_type = $statements_source->getNodeTypeProvider()->getType($expr->expr))
             && $expr_type->hasFloat()

--- a/examples/plugins/PreventFloatAssignmentChecker.php
+++ b/examples/plugins/PreventFloatAssignmentChecker.php
@@ -19,8 +19,6 @@ class PreventFloatAssignmentChecker implements AfterExpressionAnalysisInterface
     /**
      * Called after an expression has been checked
      *
-     * @param  PhpParser\Node\Expr  $expr
-     * @param  Context              $context
      * @param  FileManipulation[]   $file_replacements
      *
      * @return null|false
@@ -31,7 +29,7 @@ class PreventFloatAssignmentChecker implements AfterExpressionAnalysisInterface
         StatementsSource $statements_source,
         Codebase $codebase,
         array &$file_replacements = []
-    ): ?bool {
+    ) {
         if ($expr instanceof PhpParser\Node\Expr\Assign
             && ($expr_type = $statements_source->getNodeTypeProvider()->getType($expr->expr))
             && $expr_type->hasFloat()

--- a/examples/plugins/StringChecker.php
+++ b/examples/plugins/StringChecker.php
@@ -17,8 +17,6 @@ class StringChecker implements AfterExpressionAnalysisInterface
     /**
      * Called after an expression has been checked
      *
-     * @param  PhpParser\Node\Expr  $expr
-     * @param  Context              $context
      * @param  FileManipulation[]   $file_replacements
      *
      * @return null|false

--- a/examples/plugins/composer-based/echo-checker/EchoChecker.php
+++ b/examples/plugins/composer-based/echo-checker/EchoChecker.php
@@ -26,7 +26,7 @@ class EchoChecker implements AfterStatementAnalysisInterface
         StatementsSource $statements_source,
         Codebase $codebase,
         array &$file_replacements = []
-    ): ?bool {
+    ) {
         if ($stmt instanceof PhpParser\Node\Stmt\Echo_) {
             foreach ($stmt->exprs as $expr) {
                 $expr_type = $statements_source->getNodeTypeProvider()->getType($expr);

--- a/examples/plugins/composer-based/echo-checker/EchoChecker.php
+++ b/examples/plugins/composer-based/echo-checker/EchoChecker.php
@@ -26,7 +26,7 @@ class EchoChecker implements AfterStatementAnalysisInterface
         StatementsSource $statements_source,
         Codebase $codebase,
         array &$file_replacements = []
-    ) {
+    ): ?bool {
         if ($stmt instanceof PhpParser\Node\Stmt\Echo_) {
             foreach ($stmt->exprs as $expr) {
                 $expr_type = $statements_source->getNodeTypeProvider()->getType($expr);

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -134,7 +134,7 @@ class CodeLocation
     /**
      * @return void
      */
-    public function setCommentLine(int $line)
+    public function setCommentLine(int $line): void
     {
         $this->docblock_line_number = $line;
     }

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -131,9 +131,6 @@ class CodeLocation
         $this->raw_line_number = $stmt->getLine();
     }
 
-    /**
-     * @return void
-     */
     public function setCommentLine(int $line): void
     {
         $this->docblock_line_number = $line;

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -340,9 +340,6 @@ class Codebase
         $this->loadAnalyzer();
     }
 
-    /**
-     * @return void
-     */
     private function loadAnalyzer(): void
     {
         $this->analyzer = new Internal\Codebase\Analyzer(
@@ -356,7 +353,6 @@ class Codebase
     /**
      * @param array<string> $candidate_files
      *
-     * @return void
      */
     public function reloadFiles(ProjectAnalyzer $project_analyzer, array $candidate_files): void
     {
@@ -416,16 +412,12 @@ class Codebase
         $this->populator->populateCodebase();
     }
 
-    /** @return void */
     public function enterServerMode(): void
     {
         $this->server_mode = true;
         $this->store_node_types = true;
     }
 
-    /**
-     * @return void
-     */
     public function collectLocations(): void
     {
         $this->collect_locations = true;
@@ -437,7 +429,6 @@ class Codebase
     /**
      * @param 'always'|'auto' $find_unused_code
      *
-     * @return void
      */
     public function reportUnusedCode(string $find_unused_code = 'auto'): void
     {
@@ -447,9 +438,6 @@ class Codebase
         $this->find_unused_variables = true;
     }
 
-    /**
-     * @return void
-     */
     public function reportUnusedVariables(): void
     {
         $this->collect_references = true;
@@ -459,7 +447,6 @@ class Codebase
     /**
      * @param array<string, string> $files_to_analyze
      *
-     * @return void
      */
     public function addFilesToAnalyze(array $files_to_analyze): void
     {
@@ -470,7 +457,6 @@ class Codebase
     /**
      * Scans all files their related files
      *
-     * @return void
      */
     public function scanFiles(int $threads = 1): void
     {
@@ -503,9 +489,6 @@ class Codebase
         return $this->classlike_storage_provider->create($fq_classlike_name);
     }
 
-    /**
-     * @return void
-     */
     public function cacheClassLikeStorage(ClassLikeStorage $classlike_storage, string $file_path): void
     {
         $file_contents = $this->file_provider->getContents($file_path);
@@ -515,9 +498,6 @@ class Codebase
         }
     }
 
-    /**
-     * @return void
-     */
     public function exhumeClassLikeStorage(string $fq_classlike_name, string $file_path): void
     {
         $file_contents = $this->file_provider->getContents($file_path);
@@ -615,9 +595,6 @@ class Codebase
         );
     }
 
-    /**
-     * @return  void
-     */
     public function addGlobalConstantType(string $const_id, Type\Union $type): void
     {
         self::$stubbed_constants[$const_id] = $type;
@@ -897,7 +874,6 @@ class Codebase
     }
 
     /**
-     *
      * @return void
      */
     public function invalidateInformationForFile(string $file_path)
@@ -1522,17 +1498,11 @@ class Codebase
         );
     }
 
-    /**
-     * @return void
-     */
     public function addTemporaryFileChanges(string $file_path, string $new_content): void
     {
         $this->file_provider->addTemporaryFileChanges($file_path, $new_content);
     }
 
-    /**
-     * @return void
-     */
     public function removeTemporaryFileChanges(string $file_path): void
     {
         $this->file_provider->removeTemporaryFileChanges($file_path);

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -343,7 +343,7 @@ class Codebase
     /**
      * @return void
      */
-    private function loadAnalyzer()
+    private function loadAnalyzer(): void
     {
         $this->analyzer = new Internal\Codebase\Analyzer(
             $this->config,
@@ -358,7 +358,7 @@ class Codebase
      *
      * @return void
      */
-    public function reloadFiles(ProjectAnalyzer $project_analyzer, array $candidate_files)
+    public function reloadFiles(ProjectAnalyzer $project_analyzer, array $candidate_files): void
     {
         $this->loadAnalyzer();
 
@@ -417,7 +417,7 @@ class Codebase
     }
 
     /** @return void */
-    public function enterServerMode()
+    public function enterServerMode(): void
     {
         $this->server_mode = true;
         $this->store_node_types = true;
@@ -426,7 +426,7 @@ class Codebase
     /**
      * @return void
      */
-    public function collectLocations()
+    public function collectLocations(): void
     {
         $this->collect_locations = true;
         $this->classlikes->collect_locations = true;
@@ -439,7 +439,7 @@ class Codebase
      *
      * @return void
      */
-    public function reportUnusedCode(string $find_unused_code = 'auto')
+    public function reportUnusedCode(string $find_unused_code = 'auto'): void
     {
         $this->collect_references = true;
         $this->classlikes->collect_references = true;
@@ -450,7 +450,7 @@ class Codebase
     /**
      * @return void
      */
-    public function reportUnusedVariables()
+    public function reportUnusedVariables(): void
     {
         $this->collect_references = true;
         $this->find_unused_variables = true;
@@ -461,7 +461,7 @@ class Codebase
      *
      * @return void
      */
-    public function addFilesToAnalyze(array $files_to_analyze)
+    public function addFilesToAnalyze(array $files_to_analyze): void
     {
         $this->scanner->addFilesToDeepScan($files_to_analyze);
         $this->analyzer->addFilesToAnalyze($files_to_analyze);
@@ -472,7 +472,7 @@ class Codebase
      *
      * @return void
      */
-    public function scanFiles(int $threads = 1)
+    public function scanFiles(int $threads = 1): void
     {
         $has_changes = $this->scanner->scanFiles($this->classlikes, $threads);
 
@@ -489,7 +489,7 @@ class Codebase
     /**
      * @return list<PhpParser\Node\Stmt>
      */
-    public function getStatementsForFile(string $file_path)
+    public function getStatementsForFile(string $file_path): array
     {
         return $this->statements_provider->getStatementsForFile(
             $file_path,
@@ -506,7 +506,7 @@ class Codebase
     /**
      * @return void
      */
-    public function cacheClassLikeStorage(ClassLikeStorage $classlike_storage, string $file_path)
+    public function cacheClassLikeStorage(ClassLikeStorage $classlike_storage, string $file_path): void
     {
         $file_contents = $this->file_provider->getContents($file_path);
 
@@ -518,7 +518,7 @@ class Codebase
     /**
      * @return void
      */
-    public function exhumeClassLikeStorage(string $fq_classlike_name, string $file_path)
+    public function exhumeClassLikeStorage(string $fq_classlike_name, string $file_path): void
     {
         $file_contents = $this->file_provider->getContents($file_path);
         $storage = $this->classlike_storage_provider->exhume(
@@ -618,7 +618,7 @@ class Codebase
     /**
      * @return  void
      */
-    public function addGlobalConstantType(string $const_id, Type\Union $type)
+    public function addGlobalConstantType(string $const_id, Type\Union $type): void
     {
         self::$stubbed_constants[$const_id] = $type;
     }
@@ -1525,7 +1525,7 @@ class Codebase
     /**
      * @return void
      */
-    public function addTemporaryFileChanges(string $file_path, string $new_content)
+    public function addTemporaryFileChanges(string $file_path, string $new_content): void
     {
         $this->file_provider->addTemporaryFileChanges($file_path, $new_content);
     }
@@ -1533,7 +1533,7 @@ class Codebase
     /**
      * @return void
      */
-    public function removeTemporaryFileChanges(string $file_path)
+    public function removeTemporaryFileChanges(string $file_path): void
     {
         $this->file_provider->removeTemporaryFileChanges($file_path);
     }

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1093,9 +1093,6 @@ class Config
         return $config;
     }
 
-    /**
-     * @return $this
-     */
     public static function getInstance(): Config
     {
         if (self::$instance) {
@@ -1105,17 +1102,11 @@ class Config
         throw new \UnexpectedValueException('No config initialized');
     }
 
-    /**
-     * @return void
-     */
     public function setComposerClassLoader(?ClassLoader $loader = null): void
     {
         $this->composer_class_loader = $loader;
     }
 
-    /**
-     * @return void
-     */
     public function setCustomErrorLevel(string $issue_key, string $error_level): void
     {
         $this->issue_handlers[$issue_key] = new IssueHandler();
@@ -1125,7 +1116,6 @@ class Config
     /**
      * @throws ConfigException if a Config file could not be found
      *
-     * @return void
      */
     private function loadFileExtensions(SimpleXMLElement $extensions): void
     {
@@ -1155,9 +1145,6 @@ class Config
         }
     }
 
-    /**
-     * @return void
-     */
     public function addPluginPath(string $path): void
     {
         if (!file_exists($path)) {
@@ -1167,7 +1154,6 @@ class Config
         $this->plugin_paths[] = $path;
     }
 
-    /** @return void */
     public function addPluginClass(string $class_name, ?SimpleXMLElement $plugin_config = null): void
     {
         $this->plugin_classes[] = ['class' => $class_name, 'config' => $plugin_config];
@@ -1182,7 +1168,6 @@ class Config
     /**
      * Initialises all the plugins (done once the config is fully loaded)
      *
-     * @return void
      * @psalm-suppress MixedAssignment
      */
     public function initializePlugins(ProjectAnalyzer $project_analyzer): void
@@ -1598,7 +1583,6 @@ class Config
     }
 
     /**
-     *
      * @return  string|null
      */
     public function getReportingLevelForVariable(string $issue_type, string $var_name)
@@ -1688,9 +1672,6 @@ class Config
         return $this->mock_classes;
     }
 
-    /**
-     * @return void
-     */
     public function visitStubFiles(Codebase $codebase, ?Progress $progress = null): void
     {
         if ($progress === null) {
@@ -1792,9 +1773,6 @@ class Config
         return $this->predefined_constants;
     }
 
-    /**
-     * @return void
-     */
     public function collectPredefinedConstants(): void
     {
         $this->predefined_constants = get_defined_constants();
@@ -1808,9 +1786,6 @@ class Config
         return $this->predefined_functions;
     }
 
-    /**
-     * @return void
-     */
     public function collectPredefinedFunctions(): void
     {
         $defined_functions = get_defined_functions();
@@ -1834,8 +1809,6 @@ class Config
     }
 
     /**
-     * @return void
-     *
      * @psalm-suppress MixedAssignment
      * @psalm-suppress MixedArrayAccess
      */
@@ -1958,9 +1931,6 @@ class Config
         return $candidate_path;
     }
 
-    /**
-     * @return void
-     */
     public static function removeCacheDirectory(string $dir): void
     {
         if (is_dir($dir)) {
@@ -1985,15 +1955,11 @@ class Config
         }
     }
 
-    /**
-     * @return void
-     */
     public function setServerMode(): void
     {
         $this->cache_directory .= '-s';
     }
 
-    /** @return void */
     public function addStubFile(string $stub_file): void
     {
         $this->stub_files[$stub_file] = $stub_file;

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1108,7 +1108,7 @@ class Config
     /**
      * @return void
      */
-    public function setComposerClassLoader(?ClassLoader $loader = null)
+    public function setComposerClassLoader(?ClassLoader $loader = null): void
     {
         $this->composer_class_loader = $loader;
     }
@@ -1116,7 +1116,7 @@ class Config
     /**
      * @return void
      */
-    public function setCustomErrorLevel(string $issue_key, string $error_level)
+    public function setCustomErrorLevel(string $issue_key, string $error_level): void
     {
         $this->issue_handlers[$issue_key] = new IssueHandler();
         $this->issue_handlers[$issue_key]->setErrorLevel($error_level);
@@ -1127,7 +1127,7 @@ class Config
      *
      * @return void
      */
-    private function loadFileExtensions(SimpleXMLElement $extensions)
+    private function loadFileExtensions(SimpleXMLElement $extensions): void
     {
         foreach ($extensions as $extension) {
             $extension_name = preg_replace('/^\.?/', '', (string)$extension['name']);
@@ -1158,7 +1158,7 @@ class Config
     /**
      * @return void
      */
-    public function addPluginPath(string $path)
+    public function addPluginPath(string $path): void
     {
         if (!file_exists($path)) {
             throw new \InvalidArgumentException('Cannot find plugin file ' . $path);
@@ -1168,7 +1168,7 @@ class Config
     }
 
     /** @return void */
-    public function addPluginClass(string $class_name, ?SimpleXMLElement $plugin_config = null)
+    public function addPluginClass(string $class_name, ?SimpleXMLElement $plugin_config = null): void
     {
         $this->plugin_classes[] = ['class' => $class_name, 'config' => $plugin_config];
     }
@@ -1185,7 +1185,7 @@ class Config
      * @return void
      * @psalm-suppress MixedAssignment
      */
-    public function initializePlugins(ProjectAnalyzer $project_analyzer)
+    public function initializePlugins(ProjectAnalyzer $project_analyzer): void
     {
         $codebase = $project_analyzer->getCodebase();
 
@@ -1278,7 +1278,7 @@ class Config
      *
      * @return class-string<T>
      */
-    private function getPluginClassForPath(Codebase $codebase, string $path, string $must_extend)
+    private function getPluginClassForPath(Codebase $codebase, string $path, string $must_extend): string
     {
         $file_storage = $codebase->createFileStorageForPath($path);
         $file_to_scan = new FileScanner($path, $this->shortenFileName($path), true);
@@ -1691,7 +1691,7 @@ class Config
     /**
      * @return void
      */
-    public function visitStubFiles(Codebase $codebase, ?Progress $progress = null)
+    public function visitStubFiles(Codebase $codebase, ?Progress $progress = null): void
     {
         if ($progress === null) {
             $progress = new VoidProgress();
@@ -1795,7 +1795,7 @@ class Config
     /**
      * @return void
      */
-    public function collectPredefinedConstants()
+    public function collectPredefinedConstants(): void
     {
         $this->predefined_constants = get_defined_constants();
     }
@@ -1811,7 +1811,7 @@ class Config
     /**
      * @return void
      */
-    public function collectPredefinedFunctions()
+    public function collectPredefinedFunctions(): void
     {
         $defined_functions = get_defined_functions();
 
@@ -1839,7 +1839,7 @@ class Config
      * @psalm-suppress MixedAssignment
      * @psalm-suppress MixedArrayAccess
      */
-    public function visitComposerAutoloadFiles(ProjectAnalyzer $project_analyzer, ?Progress $progress = null)
+    public function visitComposerAutoloadFiles(ProjectAnalyzer $project_analyzer, ?Progress $progress = null): void
     {
         if ($progress === null) {
             $progress = new VoidProgress();
@@ -1961,7 +1961,7 @@ class Config
     /**
      * @return void
      */
-    public static function removeCacheDirectory(string $dir)
+    public static function removeCacheDirectory(string $dir): void
     {
         if (is_dir($dir)) {
             $objects = scandir($dir, SCANDIR_SORT_NONE);
@@ -1988,13 +1988,13 @@ class Config
     /**
      * @return void
      */
-    public function setServerMode()
+    public function setServerMode(): void
     {
         $this->cache_directory .= '-s';
     }
 
     /** @return void */
-    public function addStubFile(string $stub_file)
+    public function addStubFile(string $stub_file): void
     {
         $this->stub_files[$stub_file] = $stub_file;
     }

--- a/src/Psalm/Config/Creator.php
+++ b/src/Psalm/Config/Creator.php
@@ -148,7 +148,7 @@ class Creator
     /**
      * @return non-empty-list<string>
      */
-    public static function getPaths(string $current_dir, ?string $suggested_dir)
+    public static function getPaths(string $current_dir, ?string $suggested_dir): array
     {
         $replacements = [];
 

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -468,18 +468,12 @@ class FileFilter
         return $this->files;
     }
 
-    /**
-     * @return  void
-     */
     public function addFile(string $file_name): void
     {
         $this->files[] = $file_name;
         $this->files_lowercase[] = strtolower($file_name);
     }
 
-    /**
-     * @return void
-     */
     public function addDirectory(string $dir_name): void
     {
         $this->directories[] = self::slashify($dir_name);

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -471,7 +471,7 @@ class FileFilter
     /**
      * @return  void
      */
-    public function addFile(string $file_name)
+    public function addFile(string $file_name): void
     {
         $this->files[] = $file_name;
         $this->files_lowercase[] = strtolower($file_name);
@@ -480,7 +480,7 @@ class FileFilter
     /**
      * @return void
      */
-    public function addDirectory(string $dir_name)
+    public function addDirectory(string $dir_name): void
     {
         $this->directories[] = self::slashify($dir_name);
     }

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -43,9 +43,6 @@ class IssueHandler
         return $handler;
     }
 
-    /**
-     * @return void
-     */
     public function setErrorLevel(string $error_level): void
     {
         if (!in_array($error_level, \Psalm\Config::$ERROR_LEVELS, true)) {

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -46,7 +46,7 @@ class IssueHandler
     /**
      * @return void
      */
-    public function setErrorLevel(string $error_level)
+    public function setErrorLevel(string $error_level): void
     {
         if (!in_array($error_level, \Psalm\Config::$ERROR_LEVELS, true)) {
             throw new \Psalm\Exception\ConfigException('Unexpected error level ' . $error_level);

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -396,7 +396,6 @@ class Context
      *                                               $start_context and $end_context
      * @param  array<string, bool>  $updated_vars
      *
-     * @return void
      */
     public function update(
         Context $start_context,
@@ -478,7 +477,6 @@ class Context
     }
 
     /**
-     *
      * @return array<int, string>
      */
     public static function getNewOrUpdatedVarIds(Context $original_context, Context $new_context): array
@@ -496,9 +494,6 @@ class Context
         return $redefined_var_ids;
     }
 
-    /**
-     * @return void
-     */
     public function remove(string $remove_var_id): void
     {
         unset(
@@ -626,9 +621,6 @@ class Context
         return $clauses_to_keep;
     }
 
-    /**
-     * @return void
-     */
     public function removeVarFromConflictingClauses(
         string $remove_var_id,
         ?Union $new_type = null,
@@ -715,10 +707,6 @@ class Context
         $this->clauses = $clauses_to_keep;
     }
 
-    /**
-     *
-     * @return  void
-     */
     public function updateChecks(Context $op_context): void
     {
         $this->check_classes = $this->check_classes && $op_context->check_classes;
@@ -775,9 +763,6 @@ class Context
         return json_encode($summary);
     }
 
-    /**
-     * @return void
-     */
     public function defineGlobals(): void
     {
         $globals = [
@@ -799,9 +784,6 @@ class Context
         }
     }
 
-    /**
-     * @return void
-     */
     public function mergeExceptions(Context $other_context): void
     {
         foreach ($other_context->possibly_thrown_exceptions as $possibly_thrown_exception => $codelocations) {
@@ -833,9 +815,6 @@ class Context
         return false;
     }
 
-    /**
-     * @return void
-     */
     public function mergeFunctionExceptions(
         FunctionLikeStorage $function_storage,
         CodeLocation $codelocation

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -404,7 +404,7 @@ class Context
         bool $has_leaving_statements,
         array $vars_to_update,
         array &$updated_vars
-    ) {
+    ): void {
         foreach ($start_context->vars_in_scope as $var_id => $old_type) {
             // this is only true if there was some sort of type negation
             if (in_array($var_id, $vars_to_update, true)) {
@@ -499,7 +499,7 @@ class Context
     /**
      * @return void
      */
-    public function remove(string $remove_var_id)
+    public function remove(string $remove_var_id): void
     {
         unset(
             $this->referenced_var_ids[$remove_var_id],
@@ -556,7 +556,7 @@ class Context
         array $clauses,
         ?Union $new_type = null,
         ?StatementsAnalyzer $statements_analyzer = null
-    ) {
+    ): array {
         $new_type_string = $new_type ? $new_type->getId() : '';
 
         $clauses_to_keep = [];
@@ -633,7 +633,7 @@ class Context
         string $remove_var_id,
         ?Union $new_type = null,
         ?StatementsAnalyzer $statements_analyzer = null
-    ) {
+    ): void {
         $this->clauses = self::filterClauses($remove_var_id, $this->clauses, $new_type, $statements_analyzer);
 
         if ($this->parent_context) {
@@ -719,7 +719,7 @@ class Context
      *
      * @return  void
      */
-    public function updateChecks(Context $op_context)
+    public function updateChecks(Context $op_context): void
     {
         $this->check_classes = $this->check_classes && $op_context->check_classes;
         $this->check_variables = $this->check_variables && $op_context->check_variables;
@@ -778,7 +778,7 @@ class Context
     /**
      * @return void
      */
-    public function defineGlobals()
+    public function defineGlobals(): void
     {
         $globals = [
             '$argv' => new Type\Union([
@@ -802,7 +802,7 @@ class Context
     /**
      * @return void
      */
-    public function mergeExceptions(Context $other_context)
+    public function mergeExceptions(Context $other_context): void
     {
         foreach ($other_context->possibly_thrown_exceptions as $possibly_thrown_exception => $codelocations) {
             foreach ($codelocations as $hash => $codelocation) {
@@ -839,7 +839,7 @@ class Context
     public function mergeFunctionExceptions(
         FunctionLikeStorage $function_storage,
         CodeLocation $codelocation
-    ) {
+    ): void {
         $hash = $codelocation->getHash();
         foreach ($function_storage->throws as $possibly_thrown_exception => $_) {
             $this->possibly_thrown_exceptions[$possibly_thrown_exception][$hash] = $codelocation;

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -55,7 +55,6 @@ class ErrorBaseline
     /**
      * @param array<string, list<IssueData>> $issues
      *
-     * @return void
      */
     public static function create(
         FileProvider $fileProvider,
@@ -231,7 +230,6 @@ class ErrorBaseline
     /**
      * @param array<string,array<string,array{o:int, s:array<int, string>}>> $groupedIssues
      *
-     * @return void
      */
     private static function writeToFile(
         FileProvider $fileProvider,

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -62,7 +62,7 @@ class ErrorBaseline
         string $baselineFile,
         array $issues,
         bool $include_php_versions
-    ) {
+    ): void {
         $groupedIssues = self::countIssueTypesByFile($issues);
 
         self::writeToFile($fileProvider, $baselineFile, $groupedIssues, $include_php_versions);
@@ -238,7 +238,7 @@ class ErrorBaseline
         string $baselineFile,
         array $groupedIssues,
         bool $include_php_versions
-    ) {
+    ): void {
         $baselineDoc = new \DOMDocument('1.0', 'UTF-8');
         $filesNode = $baselineDoc->createElement('files');
         $filesNode->setAttribute('psalm-version', PSALM_VERSION);

--- a/src/Psalm/FileSource.php
+++ b/src/Psalm/FileSource.php
@@ -7,14 +7,8 @@ interface FileSource
 
     public function getFilePath(): string;
 
-    /**
-     * @return string
-     */
     public function getRootFileName(): string;
 
-    /**
-     * @return string
-     */
     public function getRootFilePath(): string;
 
     public function getAliases(): Aliases;

--- a/src/Psalm/FileSource.php
+++ b/src/Psalm/FileSource.php
@@ -10,12 +10,12 @@ interface FileSource
     /**
      * @return string
      */
-    public function getRootFileName();
+    public function getRootFileName(): string;
 
     /**
      * @return string
      */
-    public function getRootFilePath();
+    public function getRootFilePath(): string;
 
     public function getAliases(): Aliases;
 }

--- a/src/Psalm/Internal/Analyzer/CanAlias.php
+++ b/src/Psalm/Internal/Analyzer/CanAlias.php
@@ -44,7 +44,7 @@ trait CanAlias
      *
      * @return void
      */
-    public function visitUse(PhpParser\Node\Stmt\Use_ $stmt)
+    public function visitUse(PhpParser\Node\Stmt\Use_ $stmt): void
     {
         $codebase = $this->getCodebase();
 
@@ -106,7 +106,7 @@ trait CanAlias
      *
      * @return void
      */
-    public function visitGroupUse(PhpParser\Node\Stmt\GroupUse $stmt)
+    public function visitGroupUse(PhpParser\Node\Stmt\GroupUse $stmt): void
     {
         $use_prefix = implode('\\', $stmt->prefix->parts);
 

--- a/src/Psalm/Internal/Analyzer/CanAlias.php
+++ b/src/Psalm/Internal/Analyzer/CanAlias.php
@@ -40,10 +40,6 @@ trait CanAlias
      */
     private $aliased_constants = [];
 
-    /**
-     *
-     * @return void
-     */
     public function visitUse(PhpParser\Node\Stmt\Use_ $stmt): void
     {
         $codebase = $this->getCodebase();
@@ -102,10 +98,6 @@ trait CanAlias
         }
     }
 
-    /**
-     *
-     * @return void
-     */
     public function visitGroupUse(PhpParser\Node\Stmt\GroupUse $stmt): void
     {
         $use_prefix = implode('\\', $stmt->prefix->parts);

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1606,7 +1606,6 @@ class ClassAnalyzer extends ClassLikeAnalyzer
     }
 
     /**
-     *
      * @return  void
      */
     private function checkForMissingPropertyType(
@@ -2072,9 +2071,6 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         );
     }
 
-    /**
-     * @return void
-     */
     private function checkTemplateParams(
         Codebase $codebase,
         ClassLikeStorage $storage,

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1075,7 +1075,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
             }
 
             if ($property_type_location && !$fleshed_out_type->isMixed()) {
-                $stmt = array_filter($stmts, function ($stmt) use ($property_name) {
+                $stmt = array_filter($stmts, function ($stmt) use ($property_name): bool {
                     return $stmt instanceof PhpParser\Node\Stmt\Property
                         && isset($stmt->props[0]->name->name)
                         && $stmt->props[0]->name->name === $property_name;
@@ -2081,7 +2081,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         ClassLikeStorage $parent_storage,
         CodeLocation $code_location,
         int $expected_param_count
-    ) {
+    ): void {
         $template_type_count = $parent_storage->template_types === null
             ? 0
             : count($parent_storage->template_types);

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -114,9 +114,6 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
         $this->file_analyzer = null;
     }
 
-    /**
-     * @return void
-     */
     public function getMethodMutations(
         string $method_name,
         Context $context

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -120,7 +120,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
     public function getMethodMutations(
         string $method_name,
         Context $context
-    ) {
+    ): void {
         $project_analyzer = $this->getFileAnalyzer()->project_analyzer;
         $codebase = $project_analyzer->getCodebase();
 

--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -191,7 +191,6 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
     }
 
     /**
-     *
      * @return  false|null
      */
     public static function analyzeClosureUses(

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -1350,9 +1350,6 @@ class CommentAnalyzer
     }
 
     /**
-     *
-     * @return void
-     *
      * @throws DocblockParseException if a duplicate is found
      */
     private static function checkDuplicatedTags(ParsedDocblock $parsed_docblock): void
@@ -1372,7 +1369,6 @@ class CommentAnalyzer
     /**
      * @param array<int, string> $param
      *
-     * @return void
      *
      * @throws DocblockParseException  if a duplicate is found
      */

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -1226,7 +1226,7 @@ class CommentAnalyzer
      *
      * @psalm-pure
      */
-    public static function splitDocLine(string $return_block)
+    public static function splitDocLine(string $return_block): array
     {
         $brackets = '';
 
@@ -1355,7 +1355,7 @@ class CommentAnalyzer
      *
      * @throws DocblockParseException if a duplicate is found
      */
-    private static function checkDuplicatedTags(ParsedDocblock $parsed_docblock)
+    private static function checkDuplicatedTags(ParsedDocblock $parsed_docblock): void
     {
         if (count($parsed_docblock->tags['return'] ?? []) > 1
             || count($parsed_docblock->tags['psalm-return'] ?? []) > 1
@@ -1376,7 +1376,7 @@ class CommentAnalyzer
      *
      * @throws DocblockParseException  if a duplicate is found
      */
-    private static function checkDuplicatedParams(array $param)
+    private static function checkDuplicatedParams(array $param): void
     {
         $list_names = self::extractAllParamNames($param);
 
@@ -1392,7 +1392,7 @@ class CommentAnalyzer
      *
      * @psalm-pure
      */
-    private static function extractAllParamNames(array $lines)
+    private static function extractAllParamNames(array $lines): array
     {
         $names = [];
 

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -122,9 +122,6 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         $this->codebase = $project_analyzer->getCodebase();
     }
 
-    /**
-     * @return void
-     */
     public function analyze(
         ?Context $file_context = null,
         bool $preserve_analyzers = false,
@@ -365,17 +362,11 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         }
     }
 
-    /**
-     * @return  void
-     */
     public function addNamespacedClassAnalyzer(string $fq_class_name, ClassAnalyzer $class_analyzer): void
     {
         $this->class_analyzers_to_analyze[strtolower($fq_class_name)] = $class_analyzer;
     }
 
-    /**
-     * @return  void
-     */
     public function addNamespacedInterfaceAnalyzer(string $fq_class_name, InterfaceAnalyzer $interface_analyzer): void
     {
         $this->interface_analyzers_to_analyze[strtolower($fq_class_name)] = $interface_analyzer;
@@ -490,9 +481,6 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         return $this->aliased_classes_flipped_replaceable;
     }
 
-    /**
-     * @return void
-     */
     public static function clearCache(): void
     {
         \Psalm\Internal\Type\TypeTokenizer::clearCache();
@@ -516,17 +504,11 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         return $this->file_path;
     }
 
-    /**
-     * @return string
-     */
     public function getRootFileName(): string
     {
         return $this->root_file_name ?: $this->file_name;
     }
 
-    /**
-     * @return string
-     */
     public function getRootFilePath(): string
     {
         return $this->root_file_path ?: $this->file_path;
@@ -541,17 +523,11 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         $this->root_file_path = $file_path;
     }
 
-    /**
-     * @return void
-     */
     public function addRequiredFilePath(string $file_path): void
     {
         $this->required_file_paths[$file_path] = true;
     }
 
-    /**
-     * @return void
-     */
     public function addParentFilePath(string $file_path): void
     {
         $this->parent_file_paths[$file_path] = true;

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -129,7 +129,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
         ?Context $file_context = null,
         bool $preserve_analyzers = false,
         ?Context $global_context = null
-    ) {
+    ): void {
         $codebase = $this->project_analyzer->getCodebase();
 
         $file_storage = $codebase->file_storage_provider->get($this->file_path);
@@ -368,7 +368,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return  void
      */
-    public function addNamespacedClassAnalyzer(string $fq_class_name, ClassAnalyzer $class_analyzer)
+    public function addNamespacedClassAnalyzer(string $fq_class_name, ClassAnalyzer $class_analyzer): void
     {
         $this->class_analyzers_to_analyze[strtolower($fq_class_name)] = $class_analyzer;
     }
@@ -376,7 +376,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return  void
      */
-    public function addNamespacedInterfaceAnalyzer(string $fq_class_name, InterfaceAnalyzer $interface_analyzer)
+    public function addNamespacedInterfaceAnalyzer(string $fq_class_name, InterfaceAnalyzer $interface_analyzer): void
     {
         $this->interface_analyzers_to_analyze[strtolower($fq_class_name)] = $interface_analyzer;
     }
@@ -493,7 +493,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return void
      */
-    public static function clearCache()
+    public static function clearCache(): void
     {
         \Psalm\Internal\Type\TypeTokenizer::clearCache();
         \Psalm\Internal\Codebase\Reflection::clearCache();
@@ -519,7 +519,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return string
      */
-    public function getRootFileName()
+    public function getRootFileName(): string
     {
         return $this->root_file_name ?: $this->file_name;
     }
@@ -527,7 +527,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return string
      */
-    public function getRootFilePath()
+    public function getRootFilePath(): string
     {
         return $this->root_file_path ?: $this->file_path;
     }
@@ -544,7 +544,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return void
      */
-    public function addRequiredFilePath(string $file_path)
+    public function addRequiredFilePath(string $file_path): void
     {
         $this->required_file_paths[$file_path] = true;
     }
@@ -552,7 +552,7 @@ class FileAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return void
      */
-    public function addParentFilePath(string $file_path)
+    public function addParentFilePath(string $file_path): void
     {
         $this->parent_file_paths[$file_path] = true;
     }

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -832,7 +832,6 @@ class ReturnTypeAnalyzer
     /**
      * @param Closure|Function_|ClassMethod|ArrowFunction $function
      *
-     * @return void
      */
     private static function addOrUpdateReturnType(
         FunctionLike $function,

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -841,7 +841,7 @@ class ReturnTypeAnalyzer
         StatementsSource $source,
         bool $docblock_only = false,
         ?FunctionLikeStorage $function_like_storage = null
-    ) {
+    ): void {
         $manipulator = FunctionDocblockManipulator::getForFunction(
             $project_analyzer,
             $source->getFilePath(),

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -26,7 +26,7 @@ class ReturnTypeCollector
         array $stmts,
         array &$yield_types,
         bool $collapse_types = false
-    ) {
+    ): array {
         $return_types = [];
 
         foreach ($stmts as $stmt) {

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -273,7 +273,6 @@ class ReturnTypeCollector
     }
 
     /**
-     *
      * @return  list<Type\Union>
      */
     protected static function getYieldTypeFromExpression(

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1512,7 +1512,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         string $param_name,
         Type\Union $inferred_return_type,
         bool $docblock_only = false
-    ) {
+    ): void {
         $manipulator = FunctionDocblockManipulator::getForFunction(
             $project_analyzer,
             $this->source->getFilePath(),
@@ -1568,7 +1568,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
      *
      * @return  void
      */
-    public function addReturnTypes(Context $context)
+    public function addReturnTypes(Context $context): void
     {
         if ($this->return_vars_in_scope !== null) {
             $this->return_vars_in_scope = TypeAnalyzer::combineKeyedTypes(
@@ -1597,7 +1597,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         Context $context,
         Codebase $codebase,
         PhpParser\Node $stmt = null
-    ) {
+    ): void {
         $storage = $this->getFunctionLikeStorage($statements_analyzer);
 
         foreach ($storage->params as $param) {
@@ -1838,7 +1838,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
      *
      * @return void
      */
-    public function addSuppressedIssue(string $issue_name)
+    public function addSuppressedIssue(string $issue_name): void
     {
         $this->suppressed_issues[] = $issue_name;
     }
@@ -1846,7 +1846,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * @return void
      */
-    public static function clearCache()
+    public static function clearCache(): void
     {
         self::$no_effects_hashes = [];
     }

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1504,9 +1504,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         );
     }
 
-    /**
-     * @return void
-     */
     public function addOrUpdateParamType(
         ProjectAnalyzer $project_analyzer,
         string $param_name,
@@ -1566,7 +1563,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
      *
      * @param   string  $return_type
      *
-     * @return  void
      */
     public function addReturnTypes(Context $context): void
     {
@@ -1589,9 +1585,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         }
     }
 
-    /**
-     * @return void
-     */
     public function examineParamTypes(
         StatementsAnalyzer $statements_analyzer,
         Context $context,
@@ -1836,16 +1829,12 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     /**
      * Adds a suppressed issue, useful when creating a method checker from scratch
      *
-     * @return void
      */
     public function addSuppressedIssue(string $issue_name): void
     {
         $this->suppressed_issues[] = $issue_name;
     }
 
-    /**
-     * @return void
-     */
     public static function clearCache(): void
     {
         self::$no_effects_hashes = [];

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -48,9 +48,6 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
         $this->namespace_name = $this->namespace->name ? implode('\\', $this->namespace->name->parts) : '';
     }
 
-    /**
-     * @return  void
-     */
     public function collectAnalyzableInformation(): void
     {
         $leftover_stmts = [];
@@ -94,10 +91,6 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
         }
     }
 
-    /**
-     *
-     * @return void
-     */
     public function collectAnalyzableClassLike(PhpParser\Node\Stmt\ClassLike $stmt): void
     {
         if (!$stmt->name) {
@@ -124,9 +117,6 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
         return $this->namespace_name;
     }
 
-    /**
-     * @return void
-     */
     public function setConstType(string $const_name, Type\Union $const_type): void
     {
         self::$public_namespace_constants[$this->namespace_name][$const_name] = $const_type;

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -51,7 +51,7 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return  void
      */
-    public function collectAnalyzableInformation()
+    public function collectAnalyzableInformation(): void
     {
         $leftover_stmts = [];
 
@@ -98,7 +98,7 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
      *
      * @return void
      */
-    public function collectAnalyzableClassLike(PhpParser\Node\Stmt\ClassLike $stmt)
+    public function collectAnalyzableClassLike(PhpParser\Node\Stmt\ClassLike $stmt): void
     {
         if (!$stmt->name) {
             throw new \UnexpectedValueException('Did not expect anonymous class here');
@@ -127,7 +127,7 @@ class NamespaceAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return void
      */
-    public function setConstType(string $const_name, Type\Union $const_type)
+    public function setConstType(string $const_name, Type\Union $const_type): void
     {
         self::$public_namespace_constants[$this->namespace_name][$const_name] = $const_type;
     }

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -404,7 +404,6 @@ class ProjectAnalyzer
 
     /**
      * @param  string|null $address
-     * @return void
      */
     public function server($address = '127.0.0.1:12345', bool $socket_server_mode = false): void
     {
@@ -540,9 +539,6 @@ class ProjectAnalyzer
         return isset($this->project_files[$file_path]);
     }
 
-    /**
-     * @return void
-     */
     public function check(string $base_dir, bool $is_diff = false): void
     {
         $start_checks = (int)microtime(true);
@@ -656,9 +652,6 @@ class ProjectAnalyzer
         }
     }
 
-    /**
-     * @return void
-     */
     public function consolidateAnalyzedData(): void
     {
         $this->codebase->classlikes->consolidateAnalyzedData(
@@ -668,17 +661,11 @@ class ProjectAnalyzer
         );
     }
 
-    /**
-     * @return void
-     */
     public function trackTaintedInputs(): void
     {
         $this->codebase->taint = new Taint();
     }
 
-    /**
-     * @return void
-     */
     public function trackUnusedSuppressions(): void
     {
         $this->codebase->track_unused_suppressions = true;
@@ -967,9 +954,6 @@ class ProjectAnalyzer
         }
     }
 
-    /**
-     * @return void
-     */
     public function findReferencesTo(string $symbol): void
     {
         if (!$this->stdout_report_options) {
@@ -998,9 +982,6 @@ class ProjectAnalyzer
         }
     }
 
-    /**
-     * @return void
-     */
     public function checkDir(string $dir_name): void
     {
         $this->file_reference_provider->loadReferenceCache();
@@ -1025,9 +1006,6 @@ class ProjectAnalyzer
         );
     }
 
-    /**
-     * @return void
-     */
     private function checkDirWithConfig(string $dir_name, Config $config, bool $allow_non_project_files = false): void
     {
         $file_extensions = $config->getFileExtensions();
@@ -1046,7 +1024,6 @@ class ProjectAnalyzer
     }
 
     /**
-     *
      * @return array<int, string>
      */
     private function getAllFiles(Config $config): array
@@ -1067,7 +1044,6 @@ class ProjectAnalyzer
     /**
      * @param  string  $dir_name
      *
-     * @return void
      */
     public function addProjectFile(string $file_path): void
     {
@@ -1113,7 +1089,6 @@ class ProjectAnalyzer
     /**
      * @param  array<string>    $file_list
      *
-     * @return void
      */
     private function checkDiffFilesWithConfig(Config $config, array $file_list = []): void
     {
@@ -1136,9 +1111,6 @@ class ProjectAnalyzer
         $this->codebase->addFilesToAnalyze($files_to_scan);
     }
 
-    /**
-     * @return void
-     */
     public function checkFile(string $file_path): void
     {
         $this->progress->debug('Checking ' . $file_path . "\n");
@@ -1169,7 +1141,6 @@ class ProjectAnalyzer
 
     /**
      * @param string[] $paths_to_check
-     * @return void
      */
     public function checkPaths(array $paths_to_check): void
     {
@@ -1269,7 +1240,6 @@ class ProjectAnalyzer
      * @param bool $dry_run
      * @param bool $safe_types
      *
-     * @return void
      */
     public function alterCodeAfterCompletion(
         $dry_run = false,
@@ -1285,7 +1255,6 @@ class ProjectAnalyzer
     /**
      * @param array<string, string> $to_refactor
      *
-     * @return void
      */
     public function refactorCodeAfterCompletion(array $to_refactor): void
     {
@@ -1294,9 +1263,6 @@ class ProjectAnalyzer
         $this->show_issues = false;
     }
 
-    /**
-     * @return void
-     */
     public function setPhpVersion(string $version): void
     {
         if (!preg_match('/^(5\.[456]|7\.[01234]|8\.[0])(\..*)?$/', $version)) {
@@ -1324,7 +1290,6 @@ class ProjectAnalyzer
      * @param array<string, bool> $issues
      * @throws UnsupportedIssueToFixException
      *
-     * @return void
      */
     public function setIssuesToFix(array $issues): void
     {
@@ -1381,7 +1346,6 @@ class ProjectAnalyzer
     }
 
     /**
-     *
      * @return void
      */
     public function getMethodMutations(

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -406,7 +406,7 @@ class ProjectAnalyzer
      * @param  string|null $address
      * @return void
      */
-    public function server($address = '127.0.0.1:12345', bool $socket_server_mode = false)
+    public function server($address = '127.0.0.1:12345', bool $socket_server_mode = false): void
     {
         $this->visitAutoloadFiles();
         $this->codebase->diff_methods = true;
@@ -543,7 +543,7 @@ class ProjectAnalyzer
     /**
      * @return void
      */
-    public function check(string $base_dir, bool $is_diff = false)
+    public function check(string $base_dir, bool $is_diff = false): void
     {
         $start_checks = (int)microtime(true);
 
@@ -659,7 +659,7 @@ class ProjectAnalyzer
     /**
      * @return void
      */
-    public function consolidateAnalyzedData()
+    public function consolidateAnalyzedData(): void
     {
         $this->codebase->classlikes->consolidateAnalyzedData(
             $this->codebase->methods,
@@ -671,7 +671,7 @@ class ProjectAnalyzer
     /**
      * @return void
      */
-    public function trackTaintedInputs()
+    public function trackTaintedInputs(): void
     {
         $this->codebase->taint = new Taint();
     }
@@ -679,7 +679,7 @@ class ProjectAnalyzer
     /**
      * @return void
      */
-    public function trackUnusedSuppressions()
+    public function trackUnusedSuppressions(): void
     {
         $this->codebase->track_unused_suppressions = true;
     }
@@ -970,7 +970,7 @@ class ProjectAnalyzer
     /**
      * @return void
      */
-    public function findReferencesTo(string $symbol)
+    public function findReferencesTo(string $symbol): void
     {
         if (!$this->stdout_report_options) {
             throw new \UnexpectedValueException('Not expecting to emit output');
@@ -1001,7 +1001,7 @@ class ProjectAnalyzer
     /**
      * @return void
      */
-    public function checkDir(string $dir_name)
+    public function checkDir(string $dir_name): void
     {
         $this->file_reference_provider->loadReferenceCache();
 
@@ -1028,7 +1028,7 @@ class ProjectAnalyzer
     /**
      * @return void
      */
-    private function checkDirWithConfig(string $dir_name, Config $config, bool $allow_non_project_files = false)
+    private function checkDirWithConfig(string $dir_name, Config $config, bool $allow_non_project_files = false): void
     {
         $file_extensions = $config->getFileExtensions();
 
@@ -1069,7 +1069,7 @@ class ProjectAnalyzer
      *
      * @return void
      */
-    public function addProjectFile(string $file_path)
+    public function addProjectFile(string $file_path): void
     {
         $this->project_files[$file_path] = $file_path;
     }
@@ -1115,7 +1115,7 @@ class ProjectAnalyzer
      *
      * @return void
      */
-    private function checkDiffFilesWithConfig(Config $config, array $file_list = [])
+    private function checkDiffFilesWithConfig(Config $config, array $file_list = []): void
     {
         $files_to_scan = [];
 
@@ -1139,7 +1139,7 @@ class ProjectAnalyzer
     /**
      * @return void
      */
-    public function checkFile(string $file_path)
+    public function checkFile(string $file_path): void
     {
         $this->progress->debug('Checking ' . $file_path . "\n");
 
@@ -1171,7 +1171,7 @@ class ProjectAnalyzer
      * @param string[] $paths_to_check
      * @return void
      */
-    public function checkPaths(array $paths_to_check)
+    public function checkPaths(array $paths_to_check): void
     {
         $this->visitAutoloadFiles();
 
@@ -1274,7 +1274,7 @@ class ProjectAnalyzer
     public function alterCodeAfterCompletion(
         $dry_run = false,
         $safe_types = false
-    ) {
+    ): void {
         $this->codebase->alter_code = true;
         $this->codebase->infer_types_from_usage = true;
         $this->show_issues = false;
@@ -1287,7 +1287,7 @@ class ProjectAnalyzer
      *
      * @return void
      */
-    public function refactorCodeAfterCompletion(array $to_refactor)
+    public function refactorCodeAfterCompletion(array $to_refactor): void
     {
         $this->to_refactor = $to_refactor;
         $this->codebase->alter_code = true;
@@ -1297,7 +1297,7 @@ class ProjectAnalyzer
     /**
      * @return void
      */
-    public function setPhpVersion(string $version)
+    public function setPhpVersion(string $version): void
     {
         if (!preg_match('/^(5\.[456]|7\.[01234]|8\.[0])(\..*)?$/', $version)) {
             throw new \UnexpectedValueException('Expecting a version number in the format x.y');
@@ -1326,7 +1326,7 @@ class ProjectAnalyzer
      *
      * @return void
      */
-    public function setIssuesToFix(array $issues)
+    public function setIssuesToFix(array $issues): void
     {
         $supported_issues_to_fix = static::getSupportedIssuesToFix();
 

--- a/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
@@ -67,17 +67,11 @@ abstract class SourceAnalyzer implements StatementsSource
         return $this->source->getFilePath();
     }
 
-    /**
-     * @return string
-     */
     public function getRootFileName(): string
     {
         return $this->source->getRootFileName();
     }
 
-    /**
-     * @return string
-     */
     public function getRootFilePath(): string
     {
         return $this->source->getRootFilePath();

--- a/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
@@ -70,7 +70,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return string
      */
-    public function getRootFileName()
+    public function getRootFileName(): string
     {
         return $this->source->getRootFileName();
     }
@@ -78,7 +78,7 @@ abstract class SourceAnalyzer implements StatementsSource
     /**
      * @return string
      */
-    public function getRootFilePath()
+    public function getRootFilePath(): string
     {
         return $this->source->getRootFilePath();
     }

--- a/src/Psalm/Internal/Analyzer/Statements/Block/DoAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/DoAnalyzer.php
@@ -22,9 +22,6 @@ use function array_merge;
  */
 class DoAnalyzer
 {
-    /**
-     * @return void
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Do_ $stmt,
@@ -66,7 +63,6 @@ class DoAnalyzer
         $while_clauses = array_values(
             array_filter(
                 $while_clauses,
-                /** @return bool */
                 function (Clause $c) use ($mixed_var_ids): bool {
                     $keys = array_keys($c->possibilities);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Block/DoAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/DoAnalyzer.php
@@ -29,7 +29,7 @@ class DoAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Do_ $stmt,
         Context $context
-    ) {
+    ): void {
         $do_context = clone $context;
         $do_context->break_types[] = 'loop';
 
@@ -67,7 +67,7 @@ class DoAnalyzer
             array_filter(
                 $while_clauses,
                 /** @return bool */
-                function (Clause $c) use ($mixed_var_ids) {
+                function (Clause $c) use ($mixed_var_ids): bool {
                     $keys = array_keys($c->possibilities);
 
                     $mixed_var_ids = \array_diff($mixed_var_ids, $keys);

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForAnalyzer.php
@@ -18,7 +18,6 @@ use function array_intersect_key;
 class ForAnalyzer
 {
     /**
-     *
      * @return  false|null
      */
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -45,7 +45,6 @@ use function array_keys;
 class ForeachAnalyzer
 {
     /**
-     *
      * @return  false|null
      */
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
@@ -124,7 +124,7 @@ class IfAnalyzer
                 /**
                  * @return Clause
                  */
-                function (Clause $c) use ($mixed_var_ids, $cond_object_id) {
+                function (Clause $c) use ($mixed_var_ids, $cond_object_id): Clause {
                     $keys = array_keys($c->possibilities);
 
                     $mixed_var_ids = \array_diff($mixed_var_ids, $keys);
@@ -169,7 +169,7 @@ class IfAnalyzer
             $if_context->clauses = array_values(
                 array_filter(
                     $if_context->clauses,
-                    function ($c) use ($reconciled_expression_clauses) {
+                    function ($c) use ($reconciled_expression_clauses): bool {
                         return !in_array($c->hash, $reconciled_expression_clauses);
                     }
                 )
@@ -517,7 +517,7 @@ class IfAnalyzer
         Codebase $codebase,
         IfScope $if_scope,
         ?int $branch_point
-    ) {
+    ): \Psalm\Internal\Scope\IfConditionalScope {
         $entry_clauses = [];
 
         // used when evaluating elseifs
@@ -554,7 +554,7 @@ class IfAnalyzer
                         array_filter(
                             $entry_clauses,
                             /** @return bool */
-                            function (Clause $c) use ($changed_var_ids) {
+                            function (Clause $c) use ($changed_var_ids): bool {
                                 return count($c->possibilities) > 1
                                     || $c->wedge
                                     || !isset($changed_var_ids[array_keys($c->possibilities)[0]]);
@@ -1095,7 +1095,7 @@ class IfAnalyzer
             /**
              * @return Clause
              */
-            function (Clause $c) use ($mixed_var_ids, $elseif_cond_id) {
+            function (Clause $c) use ($mixed_var_ids, $elseif_cond_id): Clause {
                 $keys = array_keys($c->possibilities);
 
                 $mixed_var_ids = \array_diff($mixed_var_ids, $keys);
@@ -1117,7 +1117,7 @@ class IfAnalyzer
             /**
              * @return Clause
              */
-            function (Clause $c) use ($cond_assigned_var_ids, $elseif_cond_id) {
+            function (Clause $c) use ($cond_assigned_var_ids, $elseif_cond_id): Clause {
                 $keys = array_keys($c->possibilities);
 
                 foreach ($keys as $key) {
@@ -1150,7 +1150,7 @@ class IfAnalyzer
             $elseif_context_clauses = array_values(
                 array_filter(
                     $elseif_context_clauses,
-                    function ($c) use ($reconciled_expression_clauses) {
+                    function ($c) use ($reconciled_expression_clauses): bool {
                         return !in_array($c->hash, $reconciled_expression_clauses);
                     }
                 )

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
@@ -507,9 +507,6 @@ class IfAnalyzer
         return null;
     }
 
-    /**
-     * @return \Psalm\Internal\Scope\IfConditionalScope
-     */
     public static function analyzeIfConditional(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr $cond,
@@ -553,7 +550,6 @@ class IfAnalyzer
                     $entry_clauses = array_values(
                         array_filter(
                             $entry_clauses,
-                            /** @return bool */
                             function (Clause $c) use ($changed_var_ids): bool {
                                 return count($c->possibilities) > 1
                                     || $c->wedge

--- a/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
@@ -603,10 +603,6 @@ class LoopAnalyzer
         }
     }
 
-    /**
-     *
-     * @return void
-     */
     private static function updateLoopScopeContexts(
         LoopScope $loop_scope,
         Context $pre_outer_context

--- a/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
@@ -610,7 +610,7 @@ class LoopAnalyzer
     private static function updateLoopScopeContexts(
         LoopScope $loop_scope,
         Context $pre_outer_context
-    ) {
+    ): void {
         $updated_loop_vars = [];
 
         if (!in_array(ScopeAnalyzer::ACTION_CONTINUE, $loop_scope->final_actions, true)) {

--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
@@ -21,7 +21,6 @@ use function array_merge;
 class SwitchAnalyzer
 {
     /**
-     *
      * @return  false|null
      */
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
@@ -291,7 +291,7 @@ class TryAnalyzer
                          *
                          * @return Type\Atomic
                          */
-                        function ($fq_catch_class) use ($codebase) {
+                        function ($fq_catch_class) use ($codebase): Type\Atomic {
                             $catch_class_type = new TNamedObject($fq_catch_class);
 
                             if (version_compare(PHP_VERSION, '7.0.0dev', '>=')

--- a/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
@@ -28,7 +28,6 @@ use const PHP_VERSION;
 class TryAnalyzer
 {
     /**
-     *
      * @return  false|null
      */
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Block/WhileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/WhileAnalyzer.php
@@ -17,7 +17,6 @@ use function array_merge;
 class WhileAnalyzer
 {
     /**
-     *
      * @return  false|null
      */
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -2582,7 +2582,6 @@ class AssertionFinder
     }
 
     /**
-     *
      * @return  false|int
      */
     protected static function hasGetTypeCheck(PhpParser\Node\Expr\BinaryOp $conditional)
@@ -2609,7 +2608,6 @@ class AssertionFinder
     }
 
     /**
-     *
      * @return  false|int
      */
     protected static function hasGetClassCheck(
@@ -2686,7 +2684,6 @@ class AssertionFinder
     }
 
     /**
-     *
      * @return  false|int
      */
     protected static function hasNonEmptyCountEqualityCheck(
@@ -2747,7 +2744,6 @@ class AssertionFinder
     }
 
     /**
-     *
      * @return  false|int
      */
     protected static function hasLessThanCountEqualityCheck(
@@ -2836,7 +2832,6 @@ class AssertionFinder
     }
 
     /**
-     *
      * @return  false|int
      */
     protected static function hasPositiveNumberCheck(
@@ -2885,7 +2880,6 @@ class AssertionFinder
     }
 
     /**
-     *
      * @return  false|int
      */
     protected static function hasReconcilableNonEmptyCountEqualityCheck(PhpParser\Node\Expr\BinaryOp $conditional)
@@ -2930,7 +2924,6 @@ class AssertionFinder
     }
 
     /**
-     *
      * @return  false|int
      */
     protected static function hasTypedValueComparison(
@@ -3068,7 +3061,6 @@ class AssertionFinder
     }
 
     /**
-     *
      * @return  0|1|2
      */
     protected static function hasClassExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): int
@@ -3095,7 +3087,6 @@ class AssertionFinder
     }
 
     /**
-     *
      * @return  0|1|2
      */
     protected static function hasTraitExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): int

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -2460,7 +2460,7 @@ class AssertionFinder
         PhpParser\Node\Expr\Instanceof_ $stmt,
         ?string $this_class_name,
         FileSource $source
-    ) {
+    ): array {
         if ($stmt->class instanceof PhpParser\Node\Name) {
             if (!in_array(strtolower($stmt->class->parts[0]), ['self', 'static', 'parent'], true)) {
                 $instanceof_class = ClassLikeAnalyzer::getFQCLNFromNameObject(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -39,7 +39,7 @@ class ArrayAssignmentAnalyzer
         Context $context,
         ?PhpParser\Node\Expr $assign_value,
         Type\Union $assignment_value_type
-    ) {
+    ): void {
         $nesting = 0;
         $var_id = ExpressionIdentifier::getVarId(
             $stmt->var,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -30,9 +30,6 @@ use function array_pop;
  */
 class ArrayAssignmentAnalyzer
 {
-    /**
-     * @return  void
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\ArrayDimFetch $stmt,
@@ -62,7 +59,6 @@ class ArrayAssignmentAnalyzer
     }
 
     /**
-     *
      * @return false|null
      */
     public static function updateArrayType(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -1340,7 +1340,6 @@ class AssignmentAnalyzer
     }
 
     /**
-     *
      * @return void
      */
     public static function assignByRefParam(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
@@ -93,7 +93,7 @@ class AndAnalyzer
             $context_clauses = array_values(
                 array_filter(
                     $context_clauses,
-                    function ($c) use ($reconciled_expression_clauses) {
+                    function ($c) use ($reconciled_expression_clauses): bool {
                         return !\in_array($c->hash, $reconciled_expression_clauses);
                     }
                 )

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
@@ -64,7 +64,7 @@ class CoalesceAnalyzer
                 /**
                  * @return \Psalm\Internal\Clause
                  */
-                function (\Psalm\Internal\Clause $c) use ($mixed_var_ids, $stmt_id) {
+                function (\Psalm\Internal\Clause $c) use ($mixed_var_ids, $stmt_id): \Psalm\Internal\Clause {
                     $keys = array_keys($c->possibilities);
 
                     $mixed_var_ids = \array_diff($mixed_var_ids, $keys);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
@@ -146,7 +146,7 @@ class OrAnalyzer
             $negated_left_clauses = array_values(
                 array_filter(
                     $negated_left_clauses,
-                    function ($c) use ($reconciled_expression_clauses) {
+                    function ($c) use ($reconciled_expression_clauses): bool {
                         return !\in_array($c->hash, $reconciled_expression_clauses);
                     }
                 )

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
@@ -468,9 +468,6 @@ class ArrayFunctionArgumentsAnalyzer
         );
     }
 
-    /**
-     * @return void
-     */
     public static function handleByRefArrayAdjustment(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Arg $arg,
@@ -563,7 +560,6 @@ class ArrayFunctionArgumentsAnalyzer
     /**
      * @param  (TArray|null)[] $array_arg_types
      *
-     * @return void
      */
     private static function checkClosureType(
         StatementsAnalyzer $statements_analyzer,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
@@ -476,7 +476,7 @@ class ArrayFunctionArgumentsAnalyzer
         PhpParser\Node\Arg $arg,
         Context $context,
         bool $is_array_shift
-    ) {
+    ): void {
         $var_id = ExpressionIdentifier::getVarId(
             $arg->value,
             $statements_analyzer->getFQCLN(),
@@ -575,7 +575,7 @@ class ArrayFunctionArgumentsAnalyzer
         int $max_closure_param_count,
         array $array_arg_types,
         bool $check_functions
-    ) {
+    ): void {
         $codebase = $statements_analyzer->getCodebase();
 
         if (!$closure_type instanceof Type\Atomic\TFn) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
@@ -1483,7 +1483,7 @@ class StaticCallAnalyzer extends CallAnalyzer
         \Psalm\Storage\ClassLikeStorage $class_storage,
         \Psalm\Storage\MethodStorage $pseudo_method_storage,
         Context $context
-    ): ?bool {
+    ) {
         if (ArgumentsAnalyzer::analyze(
             $statements_analyzer,
             $args,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
@@ -1483,7 +1483,7 @@ class StaticCallAnalyzer extends CallAnalyzer
         \Psalm\Storage\ClassLikeStorage $class_storage,
         \Psalm\Storage\MethodStorage $pseudo_method_storage,
         Context $context
-    ) {
+    ): ?bool {
         if (ArgumentsAnalyzer::analyze(
             $statements_analyzer,
             $args,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -589,7 +589,7 @@ class CallAnalyzer
         array $template_type_map,
         Context $context,
         StatementsAnalyzer $statements_analyzer
-    ) {
+    ): void {
         $type_assertions = [];
 
         $asserted_keys = [];

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -37,7 +37,6 @@ use function array_merge;
 class CallAnalyzer
 {
     /**
-     *
      * @return  void
      */
     public static function collectSpecialInformation(
@@ -579,7 +578,6 @@ class CallAnalyzer
      * @param  array<int, PhpParser\Node\Arg> $args
      * @param  array<string, array<string, array{Type\Union}>> $template_type_map,
      *
-     * @return void
      */
     protected static function applyAssertionsToContext(
         $expr,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
@@ -25,10 +25,6 @@ use function array_pop;
  */
 class ConstFetchAnalyzer
 {
-    /**
-     *
-     * @return  void
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\ConstFetch $stmt,
@@ -223,10 +219,6 @@ class ConstFetchAnalyzer
             ?? ConstFetchAnalyzer::getGlobalConstType($codebase, $const_name, $const_name);
     }
 
-    /**
-     *
-     * @return  void
-     */
     public static function setConstType(
         StatementsAnalyzer $statements_analyzer,
         string $const_name,
@@ -268,10 +260,6 @@ class ConstFetchAnalyzer
         return $const_name;
     }
 
-    /**
-     *
-     * @return  void
-     */
     public static function analyzeConstAssignment(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Const_ $stmt,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
@@ -33,7 +33,7 @@ class ConstFetchAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\ConstFetch $stmt,
         Context $context
-    ) {
+    ): void {
         $const_name = implode('\\', $stmt->name->parts);
 
         switch (strtolower($const_name)) {
@@ -232,7 +232,7 @@ class ConstFetchAnalyzer
         string $const_name,
         Type\Union $const_type,
         Context $context
-    ) {
+    ): void {
         $context->vars_in_scope[$const_name] = $const_type;
         $context->constants[$const_name] = $const_type;
 
@@ -276,7 +276,7 @@ class ConstFetchAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Const_ $stmt,
         Context $context
-    ) {
+    ): void {
         foreach ($stmt->consts as $const) {
             ExpressionAnalyzer::analyze($statements_analyzer, $const->value, $context);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
@@ -17,7 +17,7 @@ class IssetAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\Isset_ $stmt,
         Context $context
-    ) {
+    ): void {
         foreach ($stmt->vars as $isset_var) {
             if ($isset_var instanceof PhpParser\Node\Expr\PropertyFetch
                 && $isset_var->var instanceof PhpParser\Node\Expr\Variable

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
@@ -9,10 +9,6 @@ use Psalm\Type;
 
 class IssetAnalyzer
 {
-    /**
-     *
-     * @return void
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\Isset_ $stmt,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/TernaryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/TernaryAnalyzer.php
@@ -85,7 +85,7 @@ class TernaryAnalyzer
                 /**
                  * @return \Psalm\Internal\Clause
                  */
-                function (\Psalm\Internal\Clause $c) use ($mixed_var_ids, $cond_id) {
+                function (\Psalm\Internal\Clause $c) use ($mixed_var_ids, $cond_id): \Psalm\Internal\Clause {
                     $keys = array_keys($c->possibilities);
 
                     $mixed_var_ids = \array_diff($mixed_var_ids, $keys);
@@ -121,7 +121,7 @@ class TernaryAnalyzer
             $ternary_clauses = array_values(
                 array_filter(
                     $ternary_clauses,
-                    function ($c) use ($reconciled_expression_clauses) {
+                    function ($c) use ($reconciled_expression_clauses): bool {
                         return !\in_array($c->hash, $reconciled_expression_clauses);
                     }
                 )

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -35,7 +35,6 @@ use function strtolower;
 class ReturnAnalyzer
 {
     /**
-     *
      * @return false|null
      */
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
@@ -16,7 +16,6 @@ use function is_string;
 class StaticAnalyzer
 {
     /**
-     *
      * @return  false|null
      */
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
@@ -9,9 +9,6 @@ use Psalm\Type;
 
 class UnsetAnalyzer
 {
-    /**
-     * @return void
-     */
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Unset_ $stmt,

--- a/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
@@ -16,7 +16,7 @@ class UnsetAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\Unset_ $stmt,
         Context $context
-    ) {
+    ): void {
         $context->inside_unset = true;
 
         foreach ($stmt->vars as $var) {

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -656,7 +656,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
      * @param  array<PhpParser\Node\Stmt>   $stmts
      * @return void
      */
-    public function checkUnreferencedVars(array $stmts)
+    public function checkUnreferencedVars(array $stmts): void
     {
         $source = $this->getSource();
         $codebase = $source->getCodebase();
@@ -720,7 +720,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return void
      */
-    public function registerVariable(string $var_id, CodeLocation $location, ?int $branch_point)
+    public function registerVariable(string $var_id, CodeLocation $location, ?int $branch_point): void
     {
         $this->all_vars[$var_id] = $location;
 
@@ -734,7 +734,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return void
      */
-    public function registerVariableAssignment(string $var_id, CodeLocation $location)
+    public function registerVariableAssignment(string $var_id, CodeLocation $location): void
     {
         $this->unused_var_locations[$location->getHash()] = [$var_id, $location];
     }
@@ -743,7 +743,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
      * @param array<string, CodeLocation> $locations
      * @return void
      */
-    public function registerVariableUses(array $locations)
+    public function registerVariableUses(array $locations): void
     {
         foreach ($locations as $hash => $_) {
             unset($this->unused_var_locations[$hash]);
@@ -775,7 +775,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
     /**
      * @return void
      */
-    public function addVariableInitialization(string $var_id, int $branch_point)
+    public function addVariableInitialization(string $var_id, int $branch_point): void
     {
         $this->vars_to_initialize[$var_id] = $branch_point;
     }
@@ -802,7 +802,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
      * @param array<string, bool> $byref_uses
      * @return void
      */
-    public function setByRefUses(array $byref_uses)
+    public function setByRefUses(array $byref_uses): void
     {
         $this->byref_uses = $byref_uses;
     }

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -654,7 +654,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
 
     /**
      * @param  array<PhpParser\Node\Stmt>   $stmts
-     * @return void
      */
     public function checkUnreferencedVars(array $stmts): void
     {
@@ -717,9 +716,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
         return isset($this->all_vars[$var_name]);
     }
 
-    /**
-     * @return void
-     */
     public function registerVariable(string $var_id, CodeLocation $location, ?int $branch_point): void
     {
         $this->all_vars[$var_id] = $location;
@@ -731,9 +727,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
         $this->registerVariableAssignment($var_id, $location);
     }
 
-    /**
-     * @return void
-     */
     public function registerVariableAssignment(string $var_id, CodeLocation $location): void
     {
         $this->unused_var_locations[$location->getHash()] = [$var_id, $location];
@@ -741,7 +734,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
 
     /**
      * @param array<string, CodeLocation> $locations
-     * @return void
      */
     public function registerVariableUses(array $locations): void
     {
@@ -772,9 +764,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
         return isset($this->var_branch_points[$var_id]) ? $this->var_branch_points[$var_id] : null;
     }
 
-    /**
-     * @return void
-     */
     public function addVariableInitialization(string $var_id, int $branch_point): void
     {
         $this->vars_to_initialize[$var_id] = $branch_point;
@@ -800,7 +789,6 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
 
     /**
      * @param array<string, bool> $byref_uses
-     * @return void
      */
     public function setByRefUses(array $byref_uses): void
     {

--- a/src/Psalm/Internal/Clause.php
+++ b/src/Psalm/Internal/Clause.php
@@ -147,7 +147,7 @@ class Clause
                              *
                              * @return string
                              */
-                            function ($value) use ($var_id) {
+                            function ($value) use ($var_id): string {
                                 if ($value === 'falsy') {
                                     return '!' . $var_id;
                                 }

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -191,7 +191,6 @@ class Analyzer
     /**
      * @param array<string, string> $files_to_analyze
      *
-     * @return void
      */
     public function addFilesToAnalyze(array $files_to_analyze): void
     {
@@ -202,7 +201,6 @@ class Analyzer
     /**
      * @param array<string, string> $files_to_analyze
      *
-     * @return void
      */
     public function addFilesToShowResults(array $files_to_analyze): void
     {
@@ -212,7 +210,6 @@ class Analyzer
     /**
      * @param array<string> $files_to_update
      *
-     * @return void
      */
     public function setFilesToUpdate(array $files_to_update): void
     {
@@ -247,9 +244,6 @@ class Analyzer
         return $file_analyzer;
     }
 
-    /**
-     * @return void
-     */
     public function analyzeFiles(
         ProjectAnalyzer $project_analyzer,
         int $pool_size,
@@ -334,9 +328,6 @@ class Analyzer
         $filetype_analyzers = $this->config->getFiletypeAnalyzers();
 
         $analysis_worker =
-            /**
-             * @return array
-             */
             function (int $_, string $file_path) use ($project_analyzer, $filetype_analyzers): array {
                 $file_analyzer = $this->getFileAnalyzer($project_analyzer, $file_path, $filetype_analyzers);
 
@@ -591,9 +582,6 @@ class Analyzer
         }
     }
 
-    /**
-     * @return void
-     */
     public function loadCachedResults(ProjectAnalyzer $project_analyzer): void
     {
         $codebase = $project_analyzer->getCodebase();
@@ -875,7 +863,6 @@ class Analyzer
     /**
      * @param array<string, array<int, array{int, int, int, int}>> $diff_map
      *
-     * @return void
      */
     public function shiftFileOffsets(array $diff_map): void
     {
@@ -1028,9 +1015,6 @@ class Analyzer
         return $this->mixed_member_names;
     }
 
-    /**
-     * @return void
-     */
     public function addMixedMemberName(string $member_id, string $reference): void
     {
         $this->mixed_member_names[$member_id][$reference] = true;
@@ -1044,7 +1028,6 @@ class Analyzer
     /**
      * @param array<string, array<string, bool>> $names
      *
-     * @return void
      */
     public function addMixedMemberNames(array $names): void
     {
@@ -1075,7 +1058,6 @@ class Analyzer
     /**
      * @param  array{0:int, 1:int} $mixed_counts
      *
-     * @return void
      */
     public function setMixedCountsForFile(string $file_path, array $mixed_counts): void
     {
@@ -1157,9 +1139,6 @@ class Analyzer
         $this->function_timings[$function_id] = $time_per_node;
     }
 
-    /**
-     * @return void
-     */
     public function addNodeType(
         string $file_path,
         PhpParser\Node $node,
@@ -1194,9 +1173,6 @@ class Analyzer
         ];
     }
 
-    /**
-     * @return void
-     */
     public function addNodeReference(string $file_path, PhpParser\Node $node, string $reference): void
     {
         if (!$reference) {
@@ -1209,9 +1185,6 @@ class Analyzer
         ];
     }
 
-    /**
-     * @return void
-     */
     public function addOffsetReference(string $file_path, int $start, int $end, string $reference): void
     {
         if (!$reference) {
@@ -1313,17 +1286,11 @@ class Analyzer
         return $stats;
     }
 
-    /**
-     * @return void
-     */
     public function disableMixedCounts(): void
     {
         $this->count_mixed = false;
     }
 
-    /**
-     * @return void
-     */
     public function enableMixedCounts(): void
     {
         $this->count_mixed = true;
@@ -1422,9 +1389,6 @@ class Analyzer
         return $applicable_issues;
     }
 
-    /**
-     * @return void
-     */
     public function removeExistingDataForFile(string $file_path, int $start, int $end, ?string $issue_type = null): void
     {
         if (isset($this->existing_issues[$file_path])) {
@@ -1525,9 +1489,6 @@ class Analyzer
         $this->mutable_classes[\strtolower($fqcln)] = true;
     }
 
-    /**
-     * @return void
-     */
     public function setAnalyzedMethod(string $file_path, string $method_id, bool $is_constructor = false): void
     {
         $this->analyzed_methods[$file_path][$method_id] = $is_constructor ? 2 : 1;

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -193,7 +193,7 @@ class Analyzer
      *
      * @return void
      */
-    public function addFilesToAnalyze(array $files_to_analyze)
+    public function addFilesToAnalyze(array $files_to_analyze): void
     {
         $this->files_to_analyze += $files_to_analyze;
         $this->files_with_analysis_results += $files_to_analyze;
@@ -204,7 +204,7 @@ class Analyzer
      *
      * @return void
      */
-    public function addFilesToShowResults(array $files_to_analyze)
+    public function addFilesToShowResults(array $files_to_analyze): void
     {
         $this->files_with_analysis_results += $files_to_analyze;
     }
@@ -214,7 +214,7 @@ class Analyzer
      *
      * @return void
      */
-    public function setFilesToUpdate(array $files_to_update)
+    public function setFilesToUpdate(array $files_to_update): void
     {
         $this->files_to_update = $files_to_update;
     }
@@ -255,7 +255,7 @@ class Analyzer
         int $pool_size,
         bool $alter_code,
         bool $consolidate_analyzed_data = false
-    ) {
+    ): void {
         $this->loadCachedResults($project_analyzer);
 
         $codebase = $project_analyzer->getCodebase();
@@ -337,7 +337,7 @@ class Analyzer
             /**
              * @return array
              */
-            function (int $_, string $file_path) use ($project_analyzer, $filetype_analyzers) {
+            function (int $_, string $file_path) use ($project_analyzer, $filetype_analyzers): array {
                 $file_analyzer = $this->getFileAnalyzer($project_analyzer, $file_path, $filetype_analyzers);
 
                 $this->progress->debug('Analyzing ' . $file_analyzer->getFilePath() . "\n");
@@ -594,7 +594,7 @@ class Analyzer
     /**
      * @return void
      */
-    public function loadCachedResults(ProjectAnalyzer $project_analyzer)
+    public function loadCachedResults(ProjectAnalyzer $project_analyzer): void
     {
         $codebase = $project_analyzer->getCodebase();
 
@@ -877,7 +877,7 @@ class Analyzer
      *
      * @return void
      */
-    public function shiftFileOffsets(array $diff_map)
+    public function shiftFileOffsets(array $diff_map): void
     {
         foreach ($this->existing_issues as $file_path => &$file_issues) {
             if (!isset($this->analyzed_methods[$file_path])) {
@@ -1031,7 +1031,7 @@ class Analyzer
     /**
      * @return void
      */
-    public function addMixedMemberName(string $member_id, string $reference)
+    public function addMixedMemberName(string $member_id, string $reference): void
     {
         $this->mixed_member_names[$member_id][$reference] = true;
     }
@@ -1046,7 +1046,7 @@ class Analyzer
      *
      * @return void
      */
-    public function addMixedMemberNames(array $names)
+    public function addMixedMemberNames(array $names): void
     {
         foreach ($names as $key => $name) {
             if (isset($this->mixed_member_names[$key])) {
@@ -1077,7 +1077,7 @@ class Analyzer
      *
      * @return void
      */
-    public function setMixedCountsForFile(string $file_path, array $mixed_counts)
+    public function setMixedCountsForFile(string $file_path, array $mixed_counts): void
     {
         $this->mixed_counts[$file_path] = $mixed_counts;
     }
@@ -1165,7 +1165,7 @@ class Analyzer
         PhpParser\Node $node,
         string $node_type,
         PhpParser\Node $parent_node = null
-    ) {
+    ): void {
         if (!$node_type) {
             throw new \UnexpectedValueException('non-empty node_type expected');
         }
@@ -1197,7 +1197,7 @@ class Analyzer
     /**
      * @return void
      */
-    public function addNodeReference(string $file_path, PhpParser\Node $node, string $reference)
+    public function addNodeReference(string $file_path, PhpParser\Node $node, string $reference): void
     {
         if (!$reference) {
             throw new \UnexpectedValueException('non-empty node_type expected');
@@ -1212,7 +1212,7 @@ class Analyzer
     /**
      * @return void
      */
-    public function addOffsetReference(string $file_path, int $start, int $end, string $reference)
+    public function addOffsetReference(string $file_path, int $start, int $end, string $reference): void
     {
         if (!$reference) {
             throw new \UnexpectedValueException('non-empty node_type expected');
@@ -1316,7 +1316,7 @@ class Analyzer
     /**
      * @return void
      */
-    public function disableMixedCounts()
+    public function disableMixedCounts(): void
     {
         $this->count_mixed = false;
     }
@@ -1324,7 +1324,7 @@ class Analyzer
     /**
      * @return void
      */
-    public function enableMixedCounts()
+    public function enableMixedCounts(): void
     {
         $this->count_mixed = true;
     }
@@ -1403,7 +1403,7 @@ class Analyzer
     /**
      * @return list<IssueData>
      */
-    public function getExistingIssuesForFile(string $file_path, int $start, int $end, ?string $issue_type = null)
+    public function getExistingIssuesForFile(string $file_path, int $start, int $end, ?string $issue_type = null): array
     {
         if (!isset($this->existing_issues[$file_path])) {
             return [];
@@ -1425,7 +1425,7 @@ class Analyzer
     /**
      * @return void
      */
-    public function removeExistingDataForFile(string $file_path, int $start, int $end, ?string $issue_type = null)
+    public function removeExistingDataForFile(string $file_path, int $start, int $end, ?string $issue_type = null): void
     {
         if (isset($this->existing_issues[$file_path])) {
             foreach ($this->existing_issues[$file_path] as $i => $issue_data) {
@@ -1503,7 +1503,7 @@ class Analyzer
     /**
      * @return FileMapType
      */
-    public function getMapsForFile(string $file_path)
+    public function getMapsForFile(string $file_path): array
     {
         return [
             $this->reference_map[$file_path] ?? [],
@@ -1528,7 +1528,7 @@ class Analyzer
     /**
      * @return void
      */
-    public function setAnalyzedMethod(string $file_path, string $method_id, bool $is_constructor = false)
+    public function setAnalyzedMethod(string $file_path, string $method_id, bool $is_constructor = false): void
     {
         $this->analyzed_methods[$file_path][$method_id] = $is_constructor ? 2 : 1;
     }

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -147,7 +147,7 @@ class ClassLikes
     /**
      * @return void
      */
-    private function collectPredefinedClassLikes()
+    private function collectPredefinedClassLikes(): void
     {
         /** @var array<int, string> */
         $predefined_classes = get_declared_classes();
@@ -185,7 +185,7 @@ class ClassLikes
     /**
      * @return void
      */
-    public function addFullyQualifiedClassName(string $fq_class_name, ?string $file_path = null)
+    public function addFullyQualifiedClassName(string $fq_class_name, ?string $file_path = null): void
     {
         $fq_class_name_lc = strtolower($fq_class_name);
         $this->existing_classlikes_lc[$fq_class_name_lc] = true;
@@ -202,7 +202,7 @@ class ClassLikes
     /**
      * @return void
      */
-    public function addFullyQualifiedInterfaceName(string $fq_class_name, ?string $file_path = null)
+    public function addFullyQualifiedInterfaceName(string $fq_class_name, ?string $file_path = null): void
     {
         $fq_class_name_lc = strtolower($fq_class_name);
         $this->existing_classlikes_lc[$fq_class_name_lc] = true;
@@ -219,7 +219,7 @@ class ClassLikes
     /**
      * @return void
      */
-    public function addFullyQualifiedTraitName(string $fq_class_name, ?string $file_path = null)
+    public function addFullyQualifiedTraitName(string $fq_class_name, ?string $file_path = null): void
     {
         $fq_class_name_lc = strtolower($fq_class_name);
         $this->existing_classlikes_lc[$fq_class_name_lc] = true;
@@ -236,7 +236,7 @@ class ClassLikes
     /**
      * @return void
      */
-    public function addFullyQualifiedClassLikeName(string $fq_class_name_lc, ?string $file_path = null)
+    public function addFullyQualifiedClassLikeName(string $fq_class_name_lc, ?string $file_path = null): void
     {
         if ($file_path) {
             $this->scanner->setClassLikeFilePath($fq_class_name_lc, $file_path);
@@ -672,7 +672,7 @@ class ClassLikes
      * @param lowercase-string $alias_name
      * @return void
      */
-    public function addClassAlias(string $fq_class_name, string $alias_name)
+    public function addClassAlias(string $fq_class_name, string $alias_name): void
     {
         $this->classlike_aliases[$alias_name] = $fq_class_name;
     }
@@ -690,7 +690,7 @@ class ClassLikes
     /**
      * @return void
      */
-    public function consolidateAnalyzedData(Methods $methods, ?Progress $progress, bool $find_unused_code)
+    public function consolidateAnalyzedData(Methods $methods, ?Progress $progress, bool $find_unused_code): void
     {
         if ($progress === null) {
             $progress = new VoidProgress();
@@ -1763,7 +1763,7 @@ class ClassLikes
         string $const_name,
         Type\Union $type,
         int $visibility
-    ) {
+    ): void {
         $storage = $this->classlike_storage_provider->get($class_name);
 
         if ($visibility === ReflectionProperty::IS_PUBLIC) {
@@ -1778,7 +1778,7 @@ class ClassLikes
     /**
      * @return void
      */
-    private function checkMethodReferences(ClassLikeStorage $classlike_storage, Methods $methods)
+    private function checkMethodReferences(ClassLikeStorage $classlike_storage, Methods $methods): void
     {
         $project_analyzer = \Psalm\Internal\Analyzer\ProjectAnalyzer::getInstance();
         $codebase = $project_analyzer->getCodebase();
@@ -2019,7 +2019,7 @@ class ClassLikes
     /**
      * @return void
      */
-    private function findPossibleMethodParamTypes(ClassLikeStorage $classlike_storage)
+    private function findPossibleMethodParamTypes(ClassLikeStorage $classlike_storage): void
     {
         $project_analyzer = \Psalm\Internal\Analyzer\ProjectAnalyzer::getInstance();
         $codebase = $project_analyzer->getCodebase();
@@ -2131,7 +2131,7 @@ class ClassLikes
     /**
      * @return void
      */
-    private function checkPropertyReferences(ClassLikeStorage $classlike_storage)
+    private function checkPropertyReferences(ClassLikeStorage $classlike_storage): void
     {
         $project_analyzer = \Psalm\Internal\Analyzer\ProjectAnalyzer::getInstance();
         $codebase = $project_analyzer->getCodebase();
@@ -2256,7 +2256,7 @@ class ClassLikes
      *
      * @return void
      */
-    public function registerMissingClassLike($fq_classlike_name_lc)
+    public function registerMissingClassLike($fq_classlike_name_lc): void
     {
         $this->existing_classlikes_lc[$fq_classlike_name_lc] = false;
     }
@@ -2289,7 +2289,7 @@ class ClassLikes
     /**
      * @return void
      */
-    public function removeClassLike(string $fq_class_name)
+    public function removeClassLike(string $fq_class_name): void
     {
         $fq_class_name_lc = strtolower($fq_class_name);
 
@@ -2344,7 +2344,7 @@ class ClassLikes
      *
      * @return void
      */
-    public function addThreadData(array $thread_data)
+    public function addThreadData(array $thread_data): void
     {
         [
             $existing_classlikes_lc,

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -144,9 +144,6 @@ class ClassLikes
         $this->collectPredefinedClassLikes();
     }
 
-    /**
-     * @return void
-     */
     private function collectPredefinedClassLikes(): void
     {
         /** @var array<int, string> */
@@ -182,9 +179,6 @@ class ClassLikes
         }
     }
 
-    /**
-     * @return void
-     */
     public function addFullyQualifiedClassName(string $fq_class_name, ?string $file_path = null): void
     {
         $fq_class_name_lc = strtolower($fq_class_name);
@@ -199,9 +193,6 @@ class ClassLikes
         }
     }
 
-    /**
-     * @return void
-     */
     public function addFullyQualifiedInterfaceName(string $fq_class_name, ?string $file_path = null): void
     {
         $fq_class_name_lc = strtolower($fq_class_name);
@@ -216,9 +207,6 @@ class ClassLikes
         }
     }
 
-    /**
-     * @return void
-     */
     public function addFullyQualifiedTraitName(string $fq_class_name, ?string $file_path = null): void
     {
         $fq_class_name_lc = strtolower($fq_class_name);
@@ -233,9 +221,6 @@ class ClassLikes
         }
     }
 
-    /**
-     * @return void
-     */
     public function addFullyQualifiedClassLikeName(string $fq_class_name_lc, ?string $file_path = null): void
     {
         if ($file_path) {
@@ -670,7 +655,6 @@ class ClassLikes
 
     /**
      * @param lowercase-string $alias_name
-     * @return void
      */
     public function addClassAlias(string $fq_class_name, string $alias_name): void
     {
@@ -687,9 +671,6 @@ class ClassLikes
         return $this->classlike_aliases[$alias_name_lc] ?? $alias_name;
     }
 
-    /**
-     * @return void
-     */
     public function consolidateAnalyzedData(Methods $methods, ?Progress $progress, bool $find_unused_code): void
     {
         if ($progress === null) {
@@ -1755,9 +1736,6 @@ class ClassLikes
         return new Type\Atomic\TMixed;
     }
 
-    /**
-     * @return  void
-     */
     public function setConstantType(
         string $class_name,
         string $const_name,
@@ -1775,9 +1753,6 @@ class ClassLikes
         }
     }
 
-    /**
-     * @return void
-     */
     private function checkMethodReferences(ClassLikeStorage $classlike_storage, Methods $methods): void
     {
         $project_analyzer = \Psalm\Internal\Analyzer\ProjectAnalyzer::getInstance();
@@ -2016,9 +1991,6 @@ class ClassLikes
         }
     }
 
-    /**
-     * @return void
-     */
     private function findPossibleMethodParamTypes(ClassLikeStorage $classlike_storage): void
     {
         $project_analyzer = \Psalm\Internal\Analyzer\ProjectAnalyzer::getInstance();
@@ -2128,9 +2100,6 @@ class ClassLikes
         }
     }
 
-    /**
-     * @return void
-     */
     private function checkPropertyReferences(ClassLikeStorage $classlike_storage): void
     {
         $project_analyzer = \Psalm\Internal\Analyzer\ProjectAnalyzer::getInstance();
@@ -2254,7 +2223,6 @@ class ClassLikes
     /**
      * @param  lowercase-string $fq_classlike_name_lc
      *
-     * @return void
      */
     public function registerMissingClassLike($fq_classlike_name_lc): void
     {
@@ -2286,9 +2254,6 @@ class ClassLikes
         $this->existing_classlikes_lc = \array_filter($this->existing_classlikes_lc);
     }
 
-    /**
-     * @return void
-     */
     public function removeClassLike(string $fq_class_name): void
     {
         $fq_class_name_lc = strtolower($fq_class_name);
@@ -2342,7 +2307,6 @@ class ClassLikes
      *     6: array<string, bool>,
      * } $thread_data
      *
-     * @return void
      */
     public function addThreadData(array $thread_data): void
     {

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -141,9 +141,6 @@ class Functions
         return $declaring_file_storage->functions[$function_id];
     }
 
-    /**
-     * @return void
-     */
     public function addGlobalFunction(string $function_id, FunctionStorage $storage): void
     {
         self::$stubbed_functions[strtolower($function_id)] = $storage;

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -144,7 +144,7 @@ class Functions
     /**
      * @return void
      */
-    public function addGlobalFunction(string $function_id, FunctionStorage $storage)
+    public function addGlobalFunction(string $function_id, FunctionStorage $storage): void
     {
         self::$stubbed_functions[strtolower($function_id)] = $storage;
     }

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -863,7 +863,7 @@ class Methods
         string $method_name_lc,
         string $declaring_fq_class_name,
         string $declaring_method_name_lc
-    ) {
+    ): void {
         $class_storage = $this->classlike_storage_provider->get($fq_class_name);
 
         $class_storage->declaring_method_ids[$method_name_lc] = new MethodIdentifier(
@@ -883,7 +883,7 @@ class Methods
         string $method_name_lc,
         string $appearing_fq_class_name,
         string $appearing_method_name_lc
-    ) {
+    ): void {
         $class_storage = $this->classlike_storage_provider->get($fq_class_name);
 
         $class_storage->appearing_method_ids[$method_name_lc] = new MethodIdentifier(

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -856,7 +856,6 @@ class Methods
      * @param lowercase-string $method_name_lc
      * @param lowercase-string $declaring_method_name_lc
      *
-     * @return void
      */
     public function setDeclaringMethodId(
         string $fq_class_name,
@@ -876,7 +875,6 @@ class Methods
      * @param lowercase-string $method_name_lc
      * @param lowercase-string $appearing_method_name_lc
      *
-     * @return void
      */
     public function setAppearingMethodId(
         string $fq_class_name,

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -80,9 +80,6 @@ class Populator
         $this->file_reference_provider = $file_reference_provider;
     }
 
-    /**
-     * @return void
-     */
     public function populateCodebase(): void
     {
         $this->progress->debug('ClassLikeStorage is populating' . "\n");
@@ -152,7 +149,6 @@ class Populator
     }
 
     /**
-     *
      * @return void
      */
     private function populateClassLikeStorage(ClassLikeStorage $storage, array $dependent_classlikes = [])
@@ -279,7 +275,6 @@ class Populator
         }
     }
 
-    /** @return void */
     private function populateOverriddenMethods(
         ClassLikeStorage $storage
     ): void {
@@ -379,9 +374,6 @@ class Populator
         }
     }
 
-    /**
-     * @return void
-     */
     private function populateDataFromTraits(
         ClassLikeStorage $storage,
         ClassLikeStorageProvider $storage_provider,
@@ -626,9 +618,6 @@ class Populator
         $storage->pseudo_methods += $parent_storage->pseudo_methods;
     }
 
-    /**
-     * @return void
-     */
     private function populateInterfaceDataFromParentInterfaces(
         ClassLikeStorage $storage,
         ClassLikeStorageProvider $storage_provider,
@@ -725,9 +714,6 @@ class Populator
         $storage->parent_interfaces = array_merge($parent_interfaces, $storage->parent_interfaces);
     }
 
-    /**
-     * @return void
-     */
     private function populateDataFromImplementedInterfaces(
         ClassLikeStorage $storage,
         ClassLikeStorageProvider $storage_provider,
@@ -1025,7 +1011,6 @@ class Populator
     /**
      * @param  bool       $is_property
      *
-     * @return void
      */
     private function convertPhpStormGenericToPsalmGeneric(Type\Union $candidate, $is_property = false): void
     {
@@ -1081,10 +1066,6 @@ class Populator
         }
     }
 
-    /**
-     *
-     * @return void
-     */
     protected function inheritMethodsFromParent(
         ClassLikeStorage $storage,
         ClassLikeStorage $parent_storage
@@ -1202,10 +1183,6 @@ class Populator
         }
     }
 
-    /**
-     *
-     * @return void
-     */
     private function inheritPropertiesFromParent(
         ClassLikeStorage $storage,
         ClassLikeStorage $parent_storage

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -83,7 +83,7 @@ class Populator
     /**
      * @return void
      */
-    public function populateCodebase()
+    public function populateCodebase(): void
     {
         $this->progress->debug('ClassLikeStorage is populating' . "\n");
 
@@ -282,7 +282,7 @@ class Populator
     /** @return void */
     private function populateOverriddenMethods(
         ClassLikeStorage $storage
-    ) {
+    ): void {
         foreach ($storage->methods as $method_name => $method_storage) {
             if (isset($storage->overridden_method_ids[$method_name])) {
                 $overridden_method_ids = $storage->overridden_method_ids[$method_name];
@@ -386,7 +386,7 @@ class Populator
         ClassLikeStorage $storage,
         ClassLikeStorageProvider $storage_provider,
         array $dependent_classlikes
-    ) {
+    ): void {
         foreach ($storage->used_traits as $used_trait_lc => $_) {
             try {
                 $used_trait_lc = strtolower(
@@ -633,7 +633,7 @@ class Populator
         ClassLikeStorage $storage,
         ClassLikeStorageProvider $storage_provider,
         array $dependent_classlikes
-    ) {
+    ): void {
         $parent_interfaces = [];
 
         foreach ($storage->parent_interfaces as $parent_interface_lc => $_) {
@@ -732,7 +732,7 @@ class Populator
         ClassLikeStorage $storage,
         ClassLikeStorageProvider $storage_provider,
         array $dependent_classlikes
-    ) {
+    ): void {
         $extra_interfaces = [];
 
         foreach ($storage->class_implements as $implemented_interface_lc => $_) {
@@ -1027,7 +1027,7 @@ class Populator
      *
      * @return void
      */
-    private function convertPhpStormGenericToPsalmGeneric(Type\Union $candidate, $is_property = false)
+    private function convertPhpStormGenericToPsalmGeneric(Type\Union $candidate, $is_property = false): void
     {
         $atomic_types = $candidate->getAtomicTypes();
 
@@ -1088,7 +1088,7 @@ class Populator
     protected function inheritMethodsFromParent(
         ClassLikeStorage $storage,
         ClassLikeStorage $parent_storage
-    ) {
+    ): void {
         $fq_class_name = $storage->name;
         $fq_class_name_lc = strtolower($fq_class_name);
 
@@ -1209,7 +1209,7 @@ class Populator
     private function inheritPropertiesFromParent(
         ClassLikeStorage $storage,
         ClassLikeStorage $parent_storage
-    ) {
+    ): void {
         if ($parent_storage->sealed_properties) {
             $storage->sealed_properties = true;
         }

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -423,7 +423,7 @@ class Reflection
     private function registerInheritedMethods(
         string $fq_class_name,
         string $parent_class
-    ) {
+    ): void {
         $parent_storage = $this->storage_provider->get($parent_class);
         $storage = $this->storage_provider->get($fq_class_name);
 
@@ -451,7 +451,7 @@ class Reflection
     private function registerInheritedProperties(
         string $fq_class_name,
         string $parent_class
-    ) {
+    ): void {
         $parent_storage = $this->storage_provider->get($parent_class);
         $storage = $this->storage_provider->get($fq_class_name);
 

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -220,7 +220,6 @@ class Reflection
     }
 
     /**
-     *
      * @return void
      */
     public function extractReflectionMethodInfo(\ReflectionMethod $method)
@@ -417,9 +416,6 @@ class Reflection
         return Type::parseString($reflection_type->getName() . $suffix);
     }
 
-    /**
-     * @return void
-     */
     private function registerInheritedMethods(
         string $fq_class_name,
         string $parent_class
@@ -446,7 +442,6 @@ class Reflection
      * @param lowercase-string $fq_class_name
      * @param lowercase-string $parent_class
      *
-     * @return void
      */
     private function registerInheritedProperties(
         string $fq_class_name,

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -174,7 +174,7 @@ class Scanner
      *
      * @return void
      */
-    public function addFilesToShallowScan(array $files_to_scan)
+    public function addFilesToShallowScan(array $files_to_scan): void
     {
         $this->files_to_scan += $files_to_scan;
     }
@@ -184,7 +184,7 @@ class Scanner
      *
      * @return void
      */
-    public function addFilesToDeepScan(array $files_to_scan)
+    public function addFilesToDeepScan(array $files_to_scan): void
     {
         $this->files_to_scan += $files_to_scan;
         $this->files_to_deep_scan += $files_to_scan;
@@ -193,7 +193,7 @@ class Scanner
     /**
      * @return void
      */
-    public function addFileToShallowScan(string $file_path)
+    public function addFileToShallowScan(string $file_path): void
     {
         $this->files_to_scan[$file_path] = $file_path;
     }
@@ -201,7 +201,7 @@ class Scanner
     /**
      * @return void
      */
-    public function addFileToDeepScan(string $file_path)
+    public function addFileToDeepScan(string $file_path): void
     {
         $this->files_to_scan[$file_path] = $file_path;
         $this->files_to_deep_scan[$file_path] = $file_path;
@@ -210,7 +210,7 @@ class Scanner
     /**
      * @return void
      */
-    public function removeFile(string $file_path)
+    public function removeFile(string $file_path): void
     {
         unset($this->scanned_files[$file_path]);
     }
@@ -218,7 +218,7 @@ class Scanner
     /**
      * @return void
      */
-    public function removeClassLike(string $fq_classlike_name_lc)
+    public function removeClassLike(string $fq_classlike_name_lc): void
     {
         unset(
             $this->classlike_files[$fq_classlike_name_lc],
@@ -229,7 +229,7 @@ class Scanner
     /**
      * @return void
      */
-    public function setClassLikeFilePath(string $fq_classlike_name_lc, string $file_path)
+    public function setClassLikeFilePath(string $fq_classlike_name_lc, string $file_path): void
     {
         $this->classlike_files[$fq_classlike_name_lc] = $file_path;
     }
@@ -492,7 +492,7 @@ class Scanner
     /**
      * @return void
      */
-    private function convertClassesToFilePaths(ClassLikes $classlikes)
+    private function convertClassesToFilePaths(ClassLikes $classlikes): void
     {
         $classes_to_scan = $this->classes_to_scan;
 
@@ -754,7 +754,7 @@ class Scanner
     /**
      * @return ThreadData
      */
-    public function getThreadData()
+    public function getThreadData(): array
     {
         return [
             $this->files_to_scan,
@@ -774,7 +774,7 @@ class Scanner
      *
      * @return void
      */
-    public function addThreadData(array $thread_data)
+    public function addThreadData(array $thread_data): void
     {
         [
             $files_to_scan,
@@ -805,7 +805,7 @@ class Scanner
     /**
      * @return void
      */
-    public function isForked()
+    public function isForked(): void
     {
         $this->is_forked = true;
     }

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -172,7 +172,6 @@ class Scanner
     /**
      * @param array<string, string> $files_to_scan
      *
-     * @return void
      */
     public function addFilesToShallowScan(array $files_to_scan): void
     {
@@ -181,8 +180,6 @@ class Scanner
 
     /**
      * @param array<string, string> $files_to_scan
-     *
-     * @return void
      */
     public function addFilesToDeepScan(array $files_to_scan): void
     {
@@ -190,34 +187,22 @@ class Scanner
         $this->files_to_deep_scan += $files_to_scan;
     }
 
-    /**
-     * @return void
-     */
     public function addFileToShallowScan(string $file_path): void
     {
         $this->files_to_scan[$file_path] = $file_path;
     }
 
-    /**
-     * @return void
-     */
     public function addFileToDeepScan(string $file_path): void
     {
         $this->files_to_scan[$file_path] = $file_path;
         $this->files_to_deep_scan[$file_path] = $file_path;
     }
 
-    /**
-     * @return void
-     */
     public function removeFile(string $file_path): void
     {
         unset($this->scanned_files[$file_path]);
     }
 
-    /**
-     * @return void
-     */
     public function removeClassLike(string $fq_classlike_name_lc): void
     {
         unset(
@@ -226,9 +211,6 @@ class Scanner
         );
     }
 
-    /**
-     * @return void
-     */
     public function setClassLikeFilePath(string $fq_classlike_name_lc, string $file_path): void
     {
         $this->classlike_files[$fq_classlike_name_lc] = $file_path;
@@ -489,9 +471,6 @@ class Scanner
         return true;
     }
 
-    /**
-     * @return void
-     */
     private function convertClassesToFilePaths(ClassLikes $classlikes): void
     {
         $classes_to_scan = $this->classes_to_scan;
@@ -772,7 +751,6 @@ class Scanner
     /**
      * @param ThreadData $thread_data
      *
-     * @return void
      */
     public function addThreadData(array $thread_data): void
     {
@@ -802,9 +780,6 @@ class Scanner
         $this->reflected_classlikes_lc = array_merge($reflected_classlikes_lc, $this->reflected_classlikes_lc);
     }
 
-    /**
-     * @return void
-     */
     public function isForked(): void
     {
         $this->is_forked = true;

--- a/src/Psalm/Internal/Diff/ClassStatementsDiffer.php
+++ b/src/Psalm/Internal/Diff/ClassStatementsDiffer.php
@@ -27,7 +27,7 @@ class ClassStatementsDiffer extends AstDiffer
      *      3: array<int, array{0: int, 1: int, 2: int, 3: int}>
      * }
      */
-    public static function diff(string $name, array $a, array $b, string $a_code, string $b_code)
+    public static function diff(string $name, array $a, array $b, string $a_code, string $b_code): array
     {
         $diff_map = [];
 
@@ -45,7 +45,7 @@ class ClassStatementsDiffer extends AstDiffer
                 $a_code,
                 $b_code,
                 &$body_change = false
-            ) use (&$diff_map) {
+            ) use (&$diff_map): bool {
                 if (get_class($a) !== get_class($b)) {
                     return false;
                 }

--- a/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
@@ -136,7 +136,7 @@ class ClassDocblockManipulator
     /**
      * @return void
      */
-    public static function clearCache()
+    public static function clearCache(): void
     {
         self::$manipulators = [];
     }

--- a/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
@@ -133,9 +133,6 @@ class ClassDocblockManipulator
         return $file_manipulations;
     }
 
-    /**
-     * @return void
-     */
     public static function clearCache(): void
     {
         self::$manipulators = [];

--- a/src/Psalm/Internal/FileManipulation/FileManipulationBuffer.php
+++ b/src/Psalm/Internal/FileManipulation/FileManipulationBuffer.php
@@ -27,7 +27,7 @@ class FileManipulationBuffer
      *
      * @return void
      */
-    public static function add(string $file_path, array $file_manipulations)
+    public static function add(string $file_path, array $file_manipulations): void
     {
         if (!isset(self::$file_manipulations[$file_path])) {
             self::$file_manipulations[$file_path] = [];
@@ -82,7 +82,7 @@ class FileManipulationBuffer
         CodeLocation $code_location,
         string $replacement_text,
         bool $swallow_newlines = false
-    ) {
+    ): void {
         $bounds = $code_location->getSnippetBounds();
 
         if ($swallow_newlines) {
@@ -187,7 +187,7 @@ class FileManipulationBuffer
      *
      * @return array<string, FileManipulation[]>
      */
-    public static function getMigrationManipulations(FileProvider $file_provider)
+    public static function getMigrationManipulations(FileProvider $file_provider): array
     {
         $code_migration_manipulations = [];
 
@@ -240,7 +240,7 @@ class FileManipulationBuffer
     /**
      * @return array<string, FileManipulation[]>
      */
-    public static function getAll()
+    public static function getAll(): array
     {
         return self::$file_manipulations;
     }
@@ -248,7 +248,7 @@ class FileManipulationBuffer
     /**
      * @return void
      */
-    public static function clearCache()
+    public static function clearCache(): void
     {
         self::$file_manipulations = [];
         self::$code_migrations = [];

--- a/src/Psalm/Internal/FileManipulation/FileManipulationBuffer.php
+++ b/src/Psalm/Internal/FileManipulation/FileManipulationBuffer.php
@@ -25,7 +25,6 @@ class FileManipulationBuffer
     /**
      * @param FileManipulation[] $file_manipulations
      *
-     * @return void
      */
     public static function add(string $file_path, array $file_manipulations): void
     {
@@ -75,9 +74,6 @@ class FileManipulationBuffer
         return [$start_offset, $middle_offset];
     }
 
-    /**
-     * @return void
-     */
     public static function addForCodeLocation(
         CodeLocation $code_location,
         string $replacement_text,
@@ -245,9 +241,6 @@ class FileManipulationBuffer
         return self::$file_manipulations;
     }
 
-    /**
-     * @return void
-     */
     public static function clearCache(): void
     {
         self::$file_manipulations = [];

--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -257,7 +257,6 @@ class FunctionDocblockManipulator
     /**
      * Sets the new return type
      *
-     * @return  void
      */
     public function setReturnType(
         ?string $php_type,
@@ -280,7 +279,6 @@ class FunctionDocblockManipulator
      *
      * @param   bool        $is_php_compatible
      *
-     * @return  void
      */
     public function setParamType(
         string $param_name,
@@ -481,9 +479,6 @@ class FunctionDocblockManipulator
         $this->is_pure = true;
     }
 
-    /**
-     * @return void
-     */
     public static function clearCache(): void
     {
         self::$manipulators = [];

--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -265,7 +265,7 @@ class FunctionDocblockManipulator
         string $phpdoc_type,
         bool $is_php_compatible,
         ?string $description
-    ) {
+    ): void {
         $new_type = str_replace(['<mixed, mixed>', '<array-key, mixed>'], '', $new_type);
 
         $this->new_php_return_type = $php_type;
@@ -287,7 +287,7 @@ class FunctionDocblockManipulator
         ?string $php_type,
         string $new_type,
         string $phpdoc_type
-    ) {
+    ): void {
         $new_type = str_replace(['<mixed, mixed>', '<array-key, mixed>', '<empty, empty>'], '', $new_type);
 
         if ($php_type) {
@@ -484,7 +484,7 @@ class FunctionDocblockManipulator
     /**
      * @return void
      */
-    public static function clearCache()
+    public static function clearCache(): void
     {
         self::$manipulators = [];
     }

--- a/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
@@ -264,7 +264,7 @@ class PropertyDocblockManipulator
     /**
      * @return void
      */
-    public static function clearCache()
+    public static function clearCache(): void
     {
         self::$manipulators = [];
     }

--- a/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
@@ -261,9 +261,6 @@ class PropertyDocblockManipulator
         return $file_manipulations;
     }
 
-    /**
-     * @return void
-     */
     public static function clearCache(): void
     {
         self::$manipulators = [];

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -26,7 +26,7 @@ class PsalmRestarter extends \Composer\XdebugHandler\XdebugHandler
     /**
      * @return void
      */
-    public function disableExtension(string $disabledExtension)
+    public function disableExtension(string $disabledExtension): void
     {
         $this->disabledExtensions[] = $disabledExtension;
     }

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -23,9 +23,6 @@ class PsalmRestarter extends \Composer\XdebugHandler\XdebugHandler
      */
     private $disabledExtensions = [];
 
-    /**
-     * @return void
-     */
     public function disableExtension(string $disabledExtension): void
     {
         $this->disabledExtensions[] = $disabledExtension;

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -272,24 +272,17 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * @psalm-suppress PossiblyUnusedMethod
      *
-     * @return void
      */
     public function initialized(): void
     {
         $this->clientStatus('running');
     }
 
-    /**
-     * @return void
-     */
     public function queueTemporaryFileAnalysis(string $file_path, string $uri): void
     {
         $this->onchange_paths_to_analyze[$file_path] = $uri;
     }
 
-    /**
-     * @return void
-     */
     public function queueFileAnalysis(string $file_path, string $uri): void
     {
         $this->onsave_paths_to_analyze[$file_path] = $uri;
@@ -338,7 +331,6 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * @param array<string, string> $uris
      *
-     * @return void
      */
     public function emitIssues(array $uris): void
     {
@@ -430,7 +422,6 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * A notification to ask the server to exit its process.
      *
-     * @return void
      */
     public function exit(): void
     {

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -274,7 +274,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      *
      * @return void
      */
-    public function initialized()
+    public function initialized(): void
     {
         $this->clientStatus('running');
     }
@@ -282,7 +282,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * @return void
      */
-    public function queueTemporaryFileAnalysis(string $file_path, string $uri)
+    public function queueTemporaryFileAnalysis(string $file_path, string $uri): void
     {
         $this->onchange_paths_to_analyze[$file_path] = $uri;
     }
@@ -290,7 +290,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
     /**
      * @return void
      */
-    public function queueFileAnalysis(string $file_path, string $uri)
+    public function queueFileAnalysis(string $file_path, string $uri): void
     {
         $this->onsave_paths_to_analyze[$file_path] = $uri;
     }
@@ -340,7 +340,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      *
      * @return void
      */
-    public function emitIssues(array $uris)
+    public function emitIssues(array $uris): void
     {
         $data = \Psalm\IssueBuffer::clear();
 
@@ -432,7 +432,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      *
      * @return void
      */
-    public function exit()
+    public function exit(): void
     {
         exit(0);
     }

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -92,7 +92,6 @@ class TextDocument
     /**
      * The document change notification is sent from the client to the server to signal changes to a text document.
      *
-     * @param \LanguageServerProtocol\VersionedTextDocumentIdentifier $textDocument
      * @param \LanguageServerProtocol\TextDocumentContentChangeEvent[] $contentChanges
      *
      * @return void
@@ -132,7 +131,6 @@ class TextDocument
      *
      * @param \LanguageServerProtocol\TextDocumentIdentifier $textDocument The document that was closed
      *
-     * @return void
      */
     public function didClose(TextDocumentIdentifier $textDocument): void
     {

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -134,7 +134,7 @@ class TextDocument
      *
      * @return void
      */
-    public function didClose(TextDocumentIdentifier $textDocument)
+    public function didClose(TextDocumentIdentifier $textDocument): void
     {
         $file_path = LanguageServer::uriToPath($textDocument->uri);
 

--- a/src/Psalm/Internal/PhpVisitor/CloningVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/CloningVisitor.php
@@ -13,7 +13,7 @@ use PhpParser\NodeVisitorAbstract;
  */
 class CloningVisitor extends NodeVisitorAbstract
 {
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): Node
     {
         $node = clone $node;
         if ($cs = $node->getComments()) {

--- a/src/Psalm/Internal/PhpVisitor/ConditionCloningVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ConditionCloningVisitor.php
@@ -14,7 +14,7 @@ class ConditionCloningVisitor extends NodeVisitorAbstract
         $this->type_provider = $old_type_provider;
     }
 
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): Node
     {
         /** @var \PhpParser\Node\Expr $node */
         $origNode = $node;

--- a/src/Psalm/Internal/PhpVisitor/NodeCounterVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/NodeCounterVisitor.php
@@ -12,7 +12,6 @@ class NodeCounterVisitor extends PhpParser\NodeVisitorAbstract implements PhpPar
     public $count = 0;
 
     /**
-     *
      * @return null|int
      */
     public function enterNode(PhpParser\Node $node)

--- a/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
@@ -21,7 +21,6 @@ class OffsetShifterVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
     }
 
     /**
-     *
      * @return null|int
      */
     public function enterNode(PhpParser\Node $node)

--- a/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
@@ -31,7 +31,6 @@ class ParamReplacementVisitor extends PhpParser\NodeVisitorAbstract implements P
     }
 
     /**
-     *
      * @return null|int
      */
     public function enterNode(PhpParser\Node $node)

--- a/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
@@ -107,7 +107,7 @@ class ParamReplacementVisitor extends PhpParser\NodeVisitorAbstract implements P
     /**
      * @return list<FileManipulation>
      */
-    public function getReplacements()
+    public function getReplacements(): array
     {
         return $this->replacements;
     }

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -830,7 +830,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     private function registerClassMapFunctionCall(
         string $function_id,
         PhpParser\Node\Expr\FuncCall $node
-    ) {
+    ): void {
         $callables = InternalCallMapHandler::getCallablesFromCallMap($function_id);
 
         if ($callables) {
@@ -3300,7 +3300,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         PhpParser\Node\FunctionLike $function,
         bool $fake_method,
         ?string $fq_classlike_name
-    ) {
+    ): void {
         $base = $this->fq_classlike_names
             ? $this->fq_classlike_names[count($this->fq_classlike_names) - 1] . '::'
             : '';
@@ -3517,7 +3517,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         Config $config,
         ClassLikeStorage $storage,
         string $fq_classlike_name
-    ) {
+    ): void {
         if (!$this->fq_classlike_names) {
             throw new \LogicException('$this->fq_classlike_names should not be empty');
         }
@@ -3703,7 +3703,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         PhpParser\Node\Stmt\ClassConst $stmt,
         ClassLikeStorage $storage,
         string $fq_classlike_name
-    ) {
+    ): void {
         $existing_constants = $storage->protected_class_constants
             + $storage->private_class_constants
             + $storage->public_class_constants;
@@ -4059,7 +4059,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         return $this->aliases;
     }
 
-    public function afterTraverse(array $nodes)
+    public function afterTraverse(array $nodes): void
     {
         $this->file_storage->type_aliases = $this->type_aliases;
     }

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -162,7 +162,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     }
 
     /**
-     *
      * @return null|int
      */
     public function enterNode(PhpParser\Node $node)
@@ -824,9 +823,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         return null;
     }
 
-    /**
-     * @return void
-     */
     private function registerClassMapFunctionCall(
         string $function_id,
         PhpParser\Node\Expr\FuncCall $node
@@ -3292,7 +3288,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     /**
      * @param  array<int, array{type:string,name:string,line_number:int,start:int,end:int}>  $docblock_params
      *
-     * @return void
      */
     private function improveParamsFromDocblock(
         FunctionLikeStorage $storage,
@@ -3509,9 +3504,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         }
     }
 
-    /**
-     * @return  void
-     */
     private function visitPropertyDeclaration(
         PhpParser\Node\Stmt\Property $stmt,
         Config $config,
@@ -3696,9 +3688,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
         }
     }
 
-    /**
-     * @return  void
-     */
     private function visitClassConstDeclaration(
         PhpParser\Node\Stmt\ClassConst $stmt,
         ClassLikeStorage $storage,
@@ -3974,7 +3963,6 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
     }
 
     /**
-     *
      * @return void
      */
     public function visitInclude(PhpParser\Node\Expr\Include_ $stmt)

--- a/src/Psalm/Internal/PhpVisitor/ShortClosureVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ShortClosureVisitor.php
@@ -14,7 +14,6 @@ class ShortClosureVisitor extends PhpParser\NodeVisitorAbstract implements PhpPa
     protected $used_variables = [];
 
     /**
-     *
      * @return null|int
      */
     public function enterNode(PhpParser\Node $node)

--- a/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
@@ -61,7 +61,7 @@ class SimpleNameResolver extends NodeVisitorAbstract
         return null;
     }
 
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): ?int
     {
         if ($node instanceof Stmt\Namespace_) {
             $this->nameContext->startNamespace($node->name);
@@ -142,7 +142,7 @@ class SimpleNameResolver extends NodeVisitorAbstract
     /**
      * @return void
      */
-    private function addAlias(Stmt\UseUse $use, int $type, ?Name $prefix = null)
+    private function addAlias(Stmt\UseUse $use, int $type, ?Name $prefix = null): void
     {
         // Add prefix for group uses
         /** @var Name $name */
@@ -163,7 +163,7 @@ class SimpleNameResolver extends NodeVisitorAbstract
      *
      * @return void
      */
-    private function resolveSignature($node)
+    private function resolveSignature($node): void
     {
         foreach ($node->params as $param) {
             $param->type = $this->resolveType($param->type);
@@ -219,7 +219,7 @@ class SimpleNameResolver extends NodeVisitorAbstract
     /**
      * @return void
      */
-    protected function resolveTrait(Stmt\Trait_ $node)
+    protected function resolveTrait(Stmt\Trait_ $node): void
     {
         $resolvedName = Name::concat($this->nameContext->getNamespace(), (string) $node->name);
 

--- a/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
@@ -139,9 +139,6 @@ class SimpleNameResolver extends NodeVisitorAbstract
         return null;
     }
 
-    /**
-     * @return void
-     */
     private function addAlias(Stmt\UseUse $use, int $type, ?Name $prefix = null): void
     {
         // Add prefix for group uses
@@ -161,7 +158,6 @@ class SimpleNameResolver extends NodeVisitorAbstract
     /**
      * @param Stmt\Function_|Stmt\ClassMethod|Expr\Closure $node
      *
-     * @return void
      */
     private function resolveSignature($node): void
     {
@@ -216,9 +212,6 @@ class SimpleNameResolver extends NodeVisitorAbstract
         return $this->resolveName($name, Stmt\Use_::TYPE_NORMAL);
     }
 
-    /**
-     * @return void
-     */
     protected function resolveTrait(Stmt\Trait_ $node): void
     {
         $resolvedName = Name::concat($this->nameContext->getNamespace(), (string) $node->name);

--- a/src/Psalm/Internal/PhpVisitor/TypeMappingVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/TypeMappingVisitor.php
@@ -18,7 +18,7 @@ class TypeMappingVisitor extends NodeVisitorAbstract
         $this->real_type_provider = $real_type_provider;
     }
 
-    public function enterNode(Node $node)
+    public function enterNode(Node $node): void
     {
         $origNode = $node;
 

--- a/src/Psalm/Internal/PluginManager/ConfigFile.php
+++ b/src/Psalm/Internal/PluginManager/ConfigFile.php
@@ -77,7 +77,7 @@ class ConfigFile
     }
 
     /** @return void */
-    public function addPlugin(string $plugin_class)
+    public function addPlugin(string $plugin_class): void
     {
         $config_xml = $this->readXml();
         /** @var \DomElement */
@@ -126,7 +126,7 @@ class ConfigFile
     }
 
     /** @return void */
-    private function saveXml(DOMDocument $config_xml)
+    private function saveXml(DOMDocument $config_xml): void
     {
         $new_file_contents = $config_xml->saveXML($config_xml);
 

--- a/src/Psalm/Internal/PluginManager/ConfigFile.php
+++ b/src/Psalm/Internal/PluginManager/ConfigFile.php
@@ -76,7 +76,6 @@ class ConfigFile
         $this->saveXml($config_xml);
     }
 
-    /** @return void */
     public function addPlugin(string $plugin_class): void
     {
         $config_xml = $this->readXml();
@@ -125,7 +124,6 @@ class ConfigFile
         return $doc;
     }
 
-    /** @return void */
     private function saveXml(DOMDocument $config_xml): void
     {
         $new_file_contents = $config_xml->saveXML($config_xml);

--- a/src/Psalm/Internal/PluginManager/PluginList.php
+++ b/src/Psalm/Internal/PluginManager/PluginList.php
@@ -94,13 +94,11 @@ class PluginList
         return array_key_exists($class, $this->getEnabled());
     }
 
-    /** @return void */
     public function enable(string $class): void
     {
         $this->config_file->addPlugin($class);
     }
 
-    /** @return void */
     public function disable(string $class): void
     {
         $this->config_file->removePlugin($class);

--- a/src/Psalm/Internal/PluginManager/PluginList.php
+++ b/src/Psalm/Internal/PluginManager/PluginList.php
@@ -95,13 +95,13 @@ class PluginList
     }
 
     /** @return void */
-    public function enable(string $class)
+    public function enable(string $class): void
     {
         $this->config_file->addPlugin($class);
     }
 
     /** @return void */
-    public function disable(string $class)
+    public function disable(string $class): void
     {
         $this->config_file->removePlugin($class);
     }

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -86,7 +86,7 @@ class ClassLikeStorageCacheProvider
     /**
      * @return ClassLikeStorage
      */
-    public function getLatestFromCache(string $fq_classlike_name_lc, ?string $file_path, ?string $file_contents)
+    public function getLatestFromCache(string $fq_classlike_name_lc, ?string $file_path, ?string $file_contents): ClassLikeStorage
     {
         $cached_value = $this->loadFromCache($fq_classlike_name_lc, $file_path);
 

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -83,11 +83,11 @@ class ClassLikeStorageCacheProvider
         }
     }
 
-    /**
-     * @return ClassLikeStorage
-     */
-    public function getLatestFromCache(string $fq_classlike_name_lc, ?string $file_path, ?string $file_contents): ClassLikeStorage
-    {
+    public function getLatestFromCache(
+        string $fq_classlike_name_lc,
+        ?string $file_path,
+        ?string $file_contents
+    ): ClassLikeStorage {
         $cached_value = $this->loadFromCache($fq_classlike_name_lc, $file_path);
 
         if (!$cached_value) {

--- a/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
@@ -93,7 +93,7 @@ class ClassLikeStorageProvider
      *
      * @return void
      */
-    public function addMore(array $more)
+    public function addMore(array $more): void
     {
         self::$new_storage = array_merge(self::$new_storage, $more);
         self::$storage = array_merge(self::$storage, $more);
@@ -102,7 +102,7 @@ class ClassLikeStorageProvider
     /**
      * @return void
      */
-    public function makeNew(string $fq_classlike_name_lc)
+    public function makeNew(string $fq_classlike_name_lc): void
     {
         self::$new_storage[$fq_classlike_name_lc] = self::$storage[$fq_classlike_name_lc];
     }
@@ -121,7 +121,7 @@ class ClassLikeStorageProvider
     /**
      * @return void
      */
-    public function remove(string $fq_classlike_name)
+    public function remove(string $fq_classlike_name): void
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
 
@@ -131,7 +131,7 @@ class ClassLikeStorageProvider
     /**
      * @return void
      */
-    public static function deleteAll()
+    public static function deleteAll(): void
     {
         self::$storage = [];
         self::$new_storage = [];
@@ -140,7 +140,7 @@ class ClassLikeStorageProvider
     /**
      * @return void
      */
-    public static function populated()
+    public static function populated(): void
     {
         self::$new_storage = [];
     }

--- a/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
@@ -91,7 +91,6 @@ class ClassLikeStorageProvider
     /**
      * @param array<string, ClassLikeStorage> $more
      *
-     * @return void
      */
     public function addMore(array $more): void
     {
@@ -99,9 +98,6 @@ class ClassLikeStorageProvider
         self::$storage = array_merge(self::$storage, $more);
     }
 
-    /**
-     * @return void
-     */
     public function makeNew(string $fq_classlike_name_lc): void
     {
         self::$new_storage[$fq_classlike_name_lc] = self::$storage[$fq_classlike_name_lc];
@@ -118,9 +114,6 @@ class ClassLikeStorageProvider
         return $storage;
     }
 
-    /**
-     * @return void
-     */
     public function remove(string $fq_classlike_name): void
     {
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
@@ -128,18 +121,12 @@ class ClassLikeStorageProvider
         unset(self::$storage[$fq_classlike_name_lc]);
     }
 
-    /**
-     * @return void
-     */
     public static function deleteAll(): void
     {
         self::$storage = [];
         self::$new_storage = [];
     }
 
-    /**
-     * @return void
-     */
     public static function populated(): void
     {
         self::$new_storage = [];

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -58,9 +58,6 @@ class FileProvider
         file_put_contents($file_path, $file_contents);
     }
 
-    /**
-     * @return void
-     */
     public function setOpenContents(string $file_path, string $file_contents): void
     {
         if (isset($this->open_files[strtolower($file_path)])) {
@@ -77,25 +74,16 @@ class FileProvider
         return (int)filemtime($file_path);
     }
 
-    /**
-     * @return void
-     */
     public function addTemporaryFileChanges(string $file_path, string $new_content): void
     {
         $this->temp_files[strtolower($file_path)] = $new_content;
     }
 
-    /**
-     * @return void
-     */
     public function removeTemporaryFileChanges(string $file_path): void
     {
         unset($this->temp_files[strtolower($file_path)]);
     }
 
-    /**
-     * @return  void
-     */
     public function openFile(string $file_path): void
     {
         $this->open_files[strtolower($file_path)] = $this->getContents($file_path, true);
@@ -106,9 +94,6 @@ class FileProvider
         return isset($this->temp_files[strtolower($file_path)]) || isset($this->open_files[strtolower($file_path)]);
     }
 
-    /**
-     * @return  void
-     */
     public function closeFile(string $file_path): void
     {
         unset($this->temp_files[strtolower($file_path)], $this->open_files[strtolower($file_path)]);

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -61,7 +61,7 @@ class FileProvider
     /**
      * @return void
      */
-    public function setOpenContents(string $file_path, string $file_contents)
+    public function setOpenContents(string $file_path, string $file_contents): void
     {
         if (isset($this->open_files[strtolower($file_path)])) {
             $this->open_files[strtolower($file_path)] = $file_contents;
@@ -80,7 +80,7 @@ class FileProvider
     /**
      * @return void
      */
-    public function addTemporaryFileChanges(string $file_path, string $new_content)
+    public function addTemporaryFileChanges(string $file_path, string $new_content): void
     {
         $this->temp_files[strtolower($file_path)] = $new_content;
     }
@@ -88,7 +88,7 @@ class FileProvider
     /**
      * @return void
      */
-    public function removeTemporaryFileChanges(string $file_path)
+    public function removeTemporaryFileChanges(string $file_path): void
     {
         unset($this->temp_files[strtolower($file_path)]);
     }
@@ -96,7 +96,7 @@ class FileProvider
     /**
      * @return  void
      */
-    public function openFile(string $file_path)
+    public function openFile(string $file_path): void
     {
         $this->open_files[strtolower($file_path)] = $this->getContents($file_path, true);
     }
@@ -109,7 +109,7 @@ class FileProvider
     /**
      * @return  void
      */
-    public function closeFile(string $file_path)
+    public function closeFile(string $file_path): void
     {
         unset($this->temp_files[strtolower($file_path)], $this->open_files[strtolower($file_path)]);
     }

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -53,7 +53,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedFileReferences(): ?array
@@ -80,7 +79,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedClassLikeFiles(): ?array
@@ -107,7 +105,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedNonMethodClassReferences(): ?array
@@ -134,7 +131,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedMethodClassReferences(): ?array
@@ -161,7 +157,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedMethodMemberReferences(): ?array
@@ -188,7 +183,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedMethodMissingMemberReferences(): ?array
@@ -215,7 +209,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedFileMemberReferences(): ?array
@@ -242,7 +235,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedFileMissingMemberReferences(): ?array
@@ -270,7 +262,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedMixedMemberNameReferences(): ?array
@@ -297,7 +288,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedMethodParamUses(): ?array
@@ -324,7 +314,6 @@ class FileReferenceCacheProvider
     }
 
     /**
-     *
      * @psalm-suppress MixedAssignment
      */
     public function getCachedIssues(): ?array
@@ -669,9 +658,6 @@ class FileReferenceCacheProvider
         return false;
     }
 
-    /**
-     * @return void
-     */
     public function setConfigHashCache(string $hash): void
     {
         $cache_directory = Config::getInstance()->getCacheDirectory();

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -672,7 +672,7 @@ class FileReferenceCacheProvider
     /**
      * @return void
      */
-    public function setConfigHashCache(string $hash)
+    public function setConfigHashCache(string $hash): void
     {
         $cache_directory = Config::getInstance()->getCacheDirectory();
 

--- a/src/Psalm/Internal/Provider/FileReferenceProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceProvider.php
@@ -163,7 +163,7 @@ class FileReferenceProvider
      * @param lowercase-string $fq_class_name_lc
      * @return void
      */
-    public function addNonMethodReferenceToClass(string $source_file, string $fq_class_name_lc)
+    public function addNonMethodReferenceToClass(string $source_file, string $fq_class_name_lc): void
     {
         self::$nonmethod_references_to_classes[$fq_class_name_lc][$source_file] = true;
     }
@@ -181,7 +181,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addNonMethodReferencesToClasses(array $references)
+    public function addNonMethodReferencesToClasses(array $references): void
     {
         foreach ($references as $key => $reference) {
             if (isset(self::$nonmethod_references_to_classes[$key])) {
@@ -206,7 +206,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function addFileReferenceToClassMember(string $source_file, string $referenced_member_id)
+    public function addFileReferenceToClassMember(string $source_file, string $referenced_member_id): void
     {
         self::$file_references_to_class_members[$referenced_member_id][$source_file] = true;
     }
@@ -214,7 +214,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function addFileReferenceToMissingClassMember(string $source_file, string $referenced_member_id)
+    public function addFileReferenceToMissingClassMember(string $source_file, string $referenced_member_id): void
     {
         self::$file_references_to_missing_class_members[$referenced_member_id][$source_file] = true;
     }
@@ -240,7 +240,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addFileReferencesToClassMembers(array $references)
+    public function addFileReferencesToClassMembers(array $references): void
     {
         foreach ($references as $key => $reference) {
             if (isset(self::$file_references_to_class_members[$key])) {
@@ -259,7 +259,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addFileReferencesToMissingClassMembers(array $references)
+    public function addFileReferencesToMissingClassMembers(array $references): void
     {
         foreach ($references as $key => $reference) {
             if (isset(self::$file_references_to_missing_class_members[$key])) {
@@ -276,7 +276,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function addFileInheritanceToClass(string $source_file, string $fq_class_name_lc)
+    public function addFileInheritanceToClass(string $source_file, string $fq_class_name_lc): void
     {
         self::$files_inheriting_classes[$fq_class_name_lc][$source_file] = true;
     }
@@ -284,7 +284,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function addMethodParamUse(string $method_id, int $offset, string $referencing_method_id)
+    public function addMethodParamUse(string $method_id, int $offset, string $referencing_method_id): void
     {
         self::$method_param_uses[$method_id][$offset][$referencing_method_id] = true;
     }
@@ -352,7 +352,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function removeDeletedFilesFromReferences()
+    public function removeDeletedFilesFromReferences(): void
     {
         $deleted_files = self::getDeletedReferencedFiles();
 
@@ -550,7 +550,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function updateReferenceCache(Codebase $codebase, array $visited_files)
+    public function updateReferenceCache(Codebase $codebase, array $visited_files): void
     {
         foreach ($visited_files as $file => $_) {
             $all_file_references = array_unique(
@@ -595,7 +595,7 @@ class FileReferenceProvider
      * @param lowercase-string $fq_class_name_lc
      * @return void
      */
-    public function addMethodReferenceToClass(string $calling_function_id, string $fq_class_name_lc)
+    public function addMethodReferenceToClass(string $calling_function_id, string $fq_class_name_lc): void
     {
         if (!isset(self::$method_references_to_classes[$fq_class_name_lc])) {
             self::$method_references_to_classes[$fq_class_name_lc] = [$calling_function_id => true];
@@ -607,7 +607,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function addMethodReferenceToClassMember(string $calling_function_id, string $referenced_member_id)
+    public function addMethodReferenceToClassMember(string $calling_function_id, string $referenced_member_id): void
     {
         if (!isset(self::$method_references_to_class_members[$referenced_member_id])) {
             self::$method_references_to_class_members[$referenced_member_id] = [$calling_function_id => true];
@@ -619,7 +619,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function addMethodReferenceToMissingClassMember(string $calling_function_id, string $referenced_member_id)
+    public function addMethodReferenceToMissingClassMember(string $calling_function_id, string $referenced_member_id): void
     {
         if (!isset(self::$method_references_to_missing_class_members[$referenced_member_id])) {
             self::$method_references_to_missing_class_members[$referenced_member_id] = [$calling_function_id => true];
@@ -631,7 +631,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function addCallingLocationForClassMethod(CodeLocation $code_location, string $referenced_member_id)
+    public function addCallingLocationForClassMethod(CodeLocation $code_location, string $referenced_member_id): void
     {
         if (!isset(self::$class_method_locations[$referenced_member_id])) {
             self::$class_method_locations[$referenced_member_id] = [$code_location];
@@ -643,7 +643,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function addCallingLocationForClassProperty(CodeLocation $code_location, string $referenced_property_id)
+    public function addCallingLocationForClassProperty(CodeLocation $code_location, string $referenced_property_id): void
     {
         if (!isset(self::$class_property_locations[$referenced_property_id])) {
             self::$class_property_locations[$referenced_property_id] = [$code_location];
@@ -655,7 +655,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function addCallingLocationForClass(CodeLocation $code_location, string $referenced_class)
+    public function addCallingLocationForClass(CodeLocation $code_location, string $referenced_class): void
     {
         if (!isset(self::$class_locations[$referenced_class])) {
             self::$class_locations[$referenced_class] = [$code_location];
@@ -692,7 +692,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function setNonMethodReferencesToClasses(array $references)
+    public function setNonMethodReferencesToClasses(array $references): void
     {
         self::$nonmethod_references_to_classes = $references;
     }
@@ -750,7 +750,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addMethodReferencesToClassMembers(array $references)
+    public function addMethodReferencesToClassMembers(array $references): void
     {
         foreach ($references as $key => $reference) {
             if (isset(self::$method_references_to_class_members[$key])) {
@@ -769,7 +769,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addMethodReferencesToClasses(array $references)
+    public function addMethodReferencesToClasses(array $references): void
     {
         foreach ($references as $key => $reference) {
             if (isset(self::$method_references_to_classes[$key])) {
@@ -788,7 +788,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addMethodReferencesToMissingClassMembers(array $references)
+    public function addMethodReferencesToMissingClassMembers(array $references): void
     {
         foreach ($references as $key => $reference) {
             if (isset(self::$method_references_to_missing_class_members[$key])) {
@@ -807,7 +807,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addMethodParamUses(array $references)
+    public function addMethodParamUses(array $references): void
     {
         foreach ($references as $method_id => $method_param_uses) {
             if (isset(self::$method_param_uses[$method_id])) {
@@ -832,7 +832,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function setCallingMethodReferencesToClasses(array $references)
+    public function setCallingMethodReferencesToClasses(array $references): void
     {
         self::$method_references_to_classes = $references;
     }
@@ -842,7 +842,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function setCallingMethodReferencesToClassMembers(array $references)
+    public function setCallingMethodReferencesToClassMembers(array $references): void
     {
         self::$method_references_to_class_members = $references;
     }
@@ -852,7 +852,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function setCallingMethodReferencesToMissingClassMembers(array $references)
+    public function setCallingMethodReferencesToMissingClassMembers(array $references): void
     {
         self::$method_references_to_missing_class_members = $references;
     }
@@ -862,7 +862,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function setFileReferencesToClassMembers(array $references)
+    public function setFileReferencesToClassMembers(array $references): void
     {
         self::$file_references_to_class_members = $references;
     }
@@ -872,7 +872,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function setFileReferencesToMissingClassMembers(array $references)
+    public function setFileReferencesToMissingClassMembers(array $references): void
     {
         self::$file_references_to_missing_class_members = $references;
     }
@@ -882,7 +882,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function setReferencesToMixedMemberNames(array $references)
+    public function setReferencesToMixedMemberNames(array $references): void
     {
         self::$references_to_mixed_member_names = $references;
     }
@@ -892,7 +892,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function setMethodParamUses(array $references)
+    public function setMethodParamUses(array $references): void
     {
         self::$method_param_uses = $references;
     }
@@ -902,7 +902,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addClassMethodLocations(array $references)
+    public function addClassMethodLocations(array $references): void
     {
         foreach ($references as $referenced_member_id => $locations) {
             if (isset(self::$class_method_locations[$referenced_member_id])) {
@@ -921,7 +921,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addClassPropertyLocations(array $references)
+    public function addClassPropertyLocations(array $references): void
     {
         foreach ($references as $referenced_member_id => $locations) {
             if (isset(self::$class_property_locations[$referenced_member_id])) {
@@ -940,7 +940,7 @@ class FileReferenceProvider
      *
      * @return void
      */
-    public function addClassLocations(array $references)
+    public function addClassLocations(array $references): void
     {
         foreach ($references as $referenced_member_id => $locations) {
             if (isset(self::$class_locations[$referenced_member_id])) {
@@ -965,7 +965,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function clearExistingIssuesForFile(string $file_path)
+    public function clearExistingIssuesForFile(string $file_path): void
     {
         unset(self::$issues[$file_path]);
     }
@@ -973,7 +973,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public function clearExistingFileMapsForFile(string $file_path)
+    public function clearExistingFileMapsForFile(string $file_path): void
     {
         unset(self::$file_maps[$file_path]);
     }
@@ -1000,7 +1000,7 @@ class FileReferenceProvider
      *
      * @return  void
      */
-    public function setAnalyzedMethods(array $analyzed_methods)
+    public function setAnalyzedMethods(array $analyzed_methods): void
     {
         self::$analyzed_methods = $analyzed_methods;
     }
@@ -1026,7 +1026,7 @@ class FileReferenceProvider
      *
      * @return  void
      */
-    public function setTypeCoverage(array $mixed_counts)
+    public function setTypeCoverage(array $mixed_counts): void
     {
         self::$mixed_counts = array_merge(self::$mixed_counts, $mixed_counts);
     }
@@ -1050,7 +1050,7 @@ class FileReferenceProvider
     /**
      * @return void
      */
-    public static function clearCache()
+    public static function clearCache(): void
     {
         self::$files_inheriting_classes = [];
         self::$deleted_files = null;

--- a/src/Psalm/Internal/Provider/FileReferenceProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceProvider.php
@@ -161,7 +161,6 @@ class FileReferenceProvider
 
     /**
      * @param lowercase-string $fq_class_name_lc
-     * @return void
      */
     public function addNonMethodReferenceToClass(string $source_file, string $fq_class_name_lc): void
     {
@@ -179,7 +178,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function addNonMethodReferencesToClasses(array $references): void
     {
@@ -203,17 +201,11 @@ class FileReferenceProvider
         self::$classlike_files += $map;
     }
 
-    /**
-     * @return void
-     */
     public function addFileReferenceToClassMember(string $source_file, string $referenced_member_id): void
     {
         self::$file_references_to_class_members[$referenced_member_id][$source_file] = true;
     }
 
-    /**
-     * @return void
-     */
     public function addFileReferenceToMissingClassMember(string $source_file, string $referenced_member_id): void
     {
         self::$file_references_to_missing_class_members[$referenced_member_id][$source_file] = true;
@@ -238,7 +230,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function addFileReferencesToClassMembers(array $references): void
     {
@@ -257,7 +248,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function addFileReferencesToMissingClassMembers(array $references): void
     {
@@ -273,17 +263,11 @@ class FileReferenceProvider
         }
     }
 
-    /**
-     * @return void
-     */
     public function addFileInheritanceToClass(string $source_file, string $fq_class_name_lc): void
     {
         self::$files_inheriting_classes[$fq_class_name_lc][$source_file] = true;
     }
 
-    /**
-     * @return void
-     */
     public function addMethodParamUse(string $method_id, int $offset, string $referencing_method_id): void
     {
         self::$method_param_uses[$method_id][$offset][$referencing_method_id] = true;
@@ -349,9 +333,6 @@ class FileReferenceProvider
         return array_unique($referenced_files);
     }
 
-    /**
-     * @return void
-     */
     public function removeDeletedFilesFromReferences(): void
     {
         $deleted_files = self::getDeletedReferencedFiles();
@@ -548,7 +529,6 @@ class FileReferenceProvider
     /**
      * @param  array<string, string|bool>  $visited_files
      *
-     * @return void
      */
     public function updateReferenceCache(Codebase $codebase, array $visited_files): void
     {
@@ -593,7 +573,6 @@ class FileReferenceProvider
 
     /**
      * @param lowercase-string $fq_class_name_lc
-     * @return void
      */
     public function addMethodReferenceToClass(string $calling_function_id, string $fq_class_name_lc): void
     {
@@ -604,9 +583,6 @@ class FileReferenceProvider
         }
     }
 
-    /**
-     * @return void
-     */
     public function addMethodReferenceToClassMember(string $calling_function_id, string $referenced_member_id): void
     {
         if (!isset(self::$method_references_to_class_members[$referenced_member_id])) {
@@ -616,11 +592,10 @@ class FileReferenceProvider
         }
     }
 
-    /**
-     * @return void
-     */
-    public function addMethodReferenceToMissingClassMember(string $calling_function_id, string $referenced_member_id): void
-    {
+    public function addMethodReferenceToMissingClassMember(
+        string $calling_function_id,
+        string $referenced_member_id
+    ): void {
         if (!isset(self::$method_references_to_missing_class_members[$referenced_member_id])) {
             self::$method_references_to_missing_class_members[$referenced_member_id] = [$calling_function_id => true];
         } else {
@@ -628,9 +603,6 @@ class FileReferenceProvider
         }
     }
 
-    /**
-     * @return void
-     */
     public function addCallingLocationForClassMethod(CodeLocation $code_location, string $referenced_member_id): void
     {
         if (!isset(self::$class_method_locations[$referenced_member_id])) {
@@ -640,11 +612,10 @@ class FileReferenceProvider
         }
     }
 
-    /**
-     * @return void
-     */
-    public function addCallingLocationForClassProperty(CodeLocation $code_location, string $referenced_property_id): void
-    {
+    public function addCallingLocationForClassProperty(
+        CodeLocation $code_location,
+        string $referenced_property_id
+    ): void {
         if (!isset(self::$class_property_locations[$referenced_property_id])) {
             self::$class_property_locations[$referenced_property_id] = [$code_location];
         } else {
@@ -652,9 +623,6 @@ class FileReferenceProvider
         }
     }
 
-    /**
-     * @return void
-     */
     public function addCallingLocationForClass(CodeLocation $code_location, string $referenced_class): void
     {
         if (!isset(self::$class_locations[$referenced_class])) {
@@ -690,7 +658,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function setNonMethodReferencesToClasses(array $references): void
     {
@@ -748,7 +715,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function addMethodReferencesToClassMembers(array $references): void
     {
@@ -767,7 +733,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function addMethodReferencesToClasses(array $references): void
     {
@@ -786,7 +751,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function addMethodReferencesToMissingClassMembers(array $references): void
     {
@@ -805,7 +769,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<int, array<string, bool>>> $references
      *
-     * @return void
      */
     public function addMethodParamUses(array $references): void
     {
@@ -830,7 +793,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function setCallingMethodReferencesToClasses(array $references): void
     {
@@ -840,7 +802,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function setCallingMethodReferencesToClassMembers(array $references): void
     {
@@ -850,7 +811,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function setCallingMethodReferencesToMissingClassMembers(array $references): void
     {
@@ -860,7 +820,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function setFileReferencesToClassMembers(array $references): void
     {
@@ -870,7 +829,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function setFileReferencesToMissingClassMembers(array $references): void
     {
@@ -880,7 +838,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string,bool>> $references
      *
-     * @return void
      */
     public function setReferencesToMixedMemberNames(array $references): void
     {
@@ -890,7 +847,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<int, array<string, bool>>> $references
      *
-     * @return void
      */
     public function setMethodParamUses(array $references): void
     {
@@ -900,7 +856,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<int, CodeLocation>> $references
      *
-     * @return void
      */
     public function addClassMethodLocations(array $references): void
     {
@@ -919,7 +874,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<int, CodeLocation>> $references
      *
-     * @return void
      */
     public function addClassPropertyLocations(array $references): void
     {
@@ -938,7 +892,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<int, CodeLocation>> $references
      *
-     * @return void
      */
     public function addClassLocations(array $references): void
     {
@@ -962,17 +915,11 @@ class FileReferenceProvider
         return self::$issues;
     }
 
-    /**
-     * @return void
-     */
     public function clearExistingIssuesForFile(string $file_path): void
     {
         unset(self::$issues[$file_path]);
     }
 
-    /**
-     * @return void
-     */
     public function clearExistingFileMapsForFile(string $file_path): void
     {
         unset(self::$file_maps[$file_path]);
@@ -998,7 +945,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array<string, int>> $analyzed_methods
      *
-     * @return  void
      */
     public function setAnalyzedMethods(array $analyzed_methods): void
     {
@@ -1024,7 +970,6 @@ class FileReferenceProvider
     /**
      * @param array<string, array{int, int}> $mixed_counts
      *
-     * @return  void
      */
     public function setTypeCoverage(array $mixed_counts): void
     {
@@ -1047,9 +992,6 @@ class FileReferenceProvider
         return self::$file_maps;
     }
 
-    /**
-     * @return void
-     */
     public static function clearCache(): void
     {
         self::$files_inheriting_classes = [];

--- a/src/Psalm/Internal/Provider/FileStorageProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageProvider.php
@@ -47,9 +47,6 @@ class FileStorageProvider
         return self::$storage[$file_path];
     }
 
-    /**
-     * @return void
-     */
     public function remove(string $file_path): void
     {
         unset(self::$storage[strtolower($file_path)]);
@@ -102,7 +99,6 @@ class FileStorageProvider
     /**
      * @param array<string, FileStorage> $more
      *
-     * @return void
      */
     public function addMore(array $more): void
     {
@@ -121,17 +117,11 @@ class FileStorageProvider
         return $storage;
     }
 
-    /**
-     * @return void
-     */
     public static function deleteAll(): void
     {
         self::$storage = [];
     }
 
-    /**
-     * @return void
-     */
     public static function populated(): void
     {
         self::$new_storage = [];

--- a/src/Psalm/Internal/Provider/FileStorageProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageProvider.php
@@ -50,7 +50,7 @@ class FileStorageProvider
     /**
      * @return void
      */
-    public function remove(string $file_path)
+    public function remove(string $file_path): void
     {
         unset(self::$storage[strtolower($file_path)]);
     }
@@ -104,7 +104,7 @@ class FileStorageProvider
      *
      * @return void
      */
-    public function addMore(array $more)
+    public function addMore(array $more): void
     {
         self::$new_storage = array_merge(self::$new_storage, $more);
         self::$storage = array_merge(self::$storage, $more);
@@ -124,7 +124,7 @@ class FileStorageProvider
     /**
      * @return void
      */
-    public static function deleteAll()
+    public static function deleteAll(): void
     {
         self::$storage = [];
     }
@@ -132,7 +132,7 @@ class FileStorageProvider
     /**
      * @return void
      */
-    public static function populated()
+    public static function populated(): void
     {
         self::$new_storage = [];
     }

--- a/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
@@ -29,7 +29,7 @@ class FunctionExistenceProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'doesFunctionExist']);
 
@@ -47,7 +47,7 @@ class FunctionExistenceProvider
      *
      * @return void
      */
-    public function registerClosure(string $function_id, \Closure $c)
+    public function registerClosure(string $function_id, \Closure $c): void
     {
         self::$handlers[$function_id][] = $c;
     }

--- a/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
@@ -27,7 +27,6 @@ class FunctionExistenceProvider
     /**
      * @param  class-string<FunctionExistenceProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -45,7 +44,6 @@ class FunctionExistenceProvider
      *     string
      *   ) : ?bool $c
      *
-     * @return void
      */
     public function registerClosure(string $function_id, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/FunctionParamsProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionParamsProvider.php
@@ -32,7 +32,6 @@ class FunctionParamsProvider
     /**
      * @param  class-string<FunctionParamsProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -52,7 +51,6 @@ class FunctionParamsProvider
      *     ?CodeLocation=
      *   ) : ?array<int, \Psalm\Storage\FunctionLikeParameter> $c
      *
-     * @return void
      */
     public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/FunctionParamsProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionParamsProvider.php
@@ -34,7 +34,7 @@ class FunctionParamsProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'getFunctionParams']);
 
@@ -54,7 +54,7 @@ class FunctionParamsProvider
      *
      * @return void
      */
-    public function registerClosure(string $fq_classlike_name, \Closure $c)
+    public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {
         self::$handlers[strtolower($fq_classlike_name)][] = $c;
     }

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -62,7 +62,7 @@ class FunctionReturnTypeProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'getFunctionReturnType']);
 
@@ -83,7 +83,7 @@ class FunctionReturnTypeProvider
      *
      * @return void
      */
-    public function registerClosure(string $function_id, \Closure $c)
+    public function registerClosure(string $function_id, \Closure $c): void
     {
         self::$handlers[$function_id][] = $c;
     }

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -60,7 +60,6 @@ class FunctionReturnTypeProvider
     /**
      * @param  class-string<FunctionReturnTypeProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -81,7 +80,6 @@ class FunctionReturnTypeProvider
      *     CodeLocation
      *   ) : ?Type\Union $c
      *
-     * @return void
      */
     public function registerClosure(string $function_id, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/MethodExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/MethodExistenceProvider.php
@@ -32,7 +32,7 @@ class MethodExistenceProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'doesMethodExist']);
 
@@ -52,7 +52,7 @@ class MethodExistenceProvider
      *
      * @return void
      */
-    public function registerClosure(string $fq_classlike_name, \Closure $c)
+    public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {
         self::$handlers[strtolower($fq_classlike_name)][] = $c;
     }

--- a/src/Psalm/Internal/Provider/MethodExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/MethodExistenceProvider.php
@@ -30,7 +30,6 @@ class MethodExistenceProvider
     /**
      * @param  class-string<MethodExistenceProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -50,7 +49,6 @@ class MethodExistenceProvider
      *     ?CodeLocation
      *   ) : ?bool $c
      *
-     * @return void
      */
     public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/MethodParamsProvider.php
+++ b/src/Psalm/Internal/Provider/MethodParamsProvider.php
@@ -37,7 +37,7 @@ class MethodParamsProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'getMethodParams']);
 
@@ -58,7 +58,7 @@ class MethodParamsProvider
      *
      * @return void
      */
-    public function registerClosure(string $fq_classlike_name, \Closure $c)
+    public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {
         self::$handlers[strtolower($fq_classlike_name)][] = $c;
     }

--- a/src/Psalm/Internal/Provider/MethodParamsProvider.php
+++ b/src/Psalm/Internal/Provider/MethodParamsProvider.php
@@ -35,7 +35,6 @@ class MethodParamsProvider
     /**
      * @param  class-string<MethodParamsProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -56,7 +55,6 @@ class MethodParamsProvider
      *     ?CodeLocation=
      *   ) : ?array<int, \Psalm\Storage\FunctionLikeParameter> $c
      *
-     * @return void
      */
     public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
@@ -42,7 +42,6 @@ class MethodReturnTypeProvider
     /**
      * @param  class-string<MethodReturnTypeProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -66,7 +65,6 @@ class MethodReturnTypeProvider
      *     ?lowercase-string=
      *   ) : ?Type\Union $c
      *
-     * @return void
      */
     public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
@@ -44,7 +44,7 @@ class MethodReturnTypeProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'getMethodReturnType']);
 
@@ -68,7 +68,7 @@ class MethodReturnTypeProvider
      *
      * @return void
      */
-    public function registerClosure(string $fq_classlike_name, \Closure $c)
+    public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {
         self::$handlers[strtolower($fq_classlike_name)][] = $c;
     }

--- a/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
@@ -34,7 +34,7 @@ class MethodVisibilityProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'isMethodVisible']);
 
@@ -55,7 +55,7 @@ class MethodVisibilityProvider
      *
      * @return void
      */
-    public function registerClosure(string $fq_classlike_name, \Closure $c)
+    public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {
         self::$handlers[strtolower($fq_classlike_name)][] = $c;
     }

--- a/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
@@ -32,7 +32,6 @@ class MethodVisibilityProvider
     /**
      * @param  class-string<MethodVisibilityProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -53,7 +52,6 @@ class MethodVisibilityProvider
      *     ?CodeLocation
      *   ) : ?bool $c
      *
-     * @return void
      */
     public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/ParserCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ParserCacheProvider.php
@@ -208,12 +208,15 @@ class ParserCacheProvider
     /**
      * @param  list<PhpParser\Node\Stmt>        $stmts
      *
-     * @return void
      *
      * @psalm-suppress UndefinedFunction
      */
-    public function saveStatementsToCache(string $file_path, string $file_content_hash, array $stmts, bool $touch_only): void
-    {
+    public function saveStatementsToCache(
+        string $file_path,
+        string $file_content_hash,
+        array $stmts,
+        bool $touch_only
+    ): void {
         $root_cache_directory = Config::getInstance()->getCacheDirectory();
 
         if (!$root_cache_directory) {
@@ -256,16 +259,12 @@ class ParserCacheProvider
     /**
      * @param array<string, string> $file_content_hashes
      *
-     * @return void
      */
     public function addNewFileContentHashes(array $file_content_hashes): void
     {
         $this->new_file_content_hashes = $file_content_hashes + $this->new_file_content_hashes;
     }
 
-    /**
-     * @return void
-     */
     public function saveFileContentHashes(): void
     {
         $root_cache_directory = Config::getInstance()->getCacheDirectory();
@@ -284,9 +283,6 @@ class ParserCacheProvider
         );
     }
 
-    /**
-     * @return void
-     */
     public function cacheFileContents(string $file_path, string $file_contents): void
     {
         if (!$this->use_file_cache) {

--- a/src/Psalm/Internal/Provider/ParserCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ParserCacheProvider.php
@@ -212,7 +212,7 @@ class ParserCacheProvider
      *
      * @psalm-suppress UndefinedFunction
      */
-    public function saveStatementsToCache(string $file_path, string $file_content_hash, array $stmts, bool $touch_only)
+    public function saveStatementsToCache(string $file_path, string $file_content_hash, array $stmts, bool $touch_only): void
     {
         $root_cache_directory = Config::getInstance()->getCacheDirectory();
 
@@ -258,7 +258,7 @@ class ParserCacheProvider
      *
      * @return void
      */
-    public function addNewFileContentHashes(array $file_content_hashes)
+    public function addNewFileContentHashes(array $file_content_hashes): void
     {
         $this->new_file_content_hashes = $file_content_hashes + $this->new_file_content_hashes;
     }
@@ -266,7 +266,7 @@ class ParserCacheProvider
     /**
      * @return void
      */
-    public function saveFileContentHashes()
+    public function saveFileContentHashes(): void
     {
         $root_cache_directory = Config::getInstance()->getCacheDirectory();
 
@@ -287,7 +287,7 @@ class ParserCacheProvider
     /**
      * @return void
      */
-    public function cacheFileContents(string $file_path, string $file_contents)
+    public function cacheFileContents(string $file_path, string $file_contents): void
     {
         if (!$this->use_file_cache) {
             return;

--- a/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
@@ -33,7 +33,6 @@ class PropertyExistenceProvider
     /**
      * @param  class-string<PropertyExistenceProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -54,7 +53,6 @@ class PropertyExistenceProvider
      *     ?CodeLocation=
      *   ) : ?bool $c
      *
-     * @return void
      */
     public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
@@ -35,7 +35,7 @@ class PropertyExistenceProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'doesPropertyExist']);
 
@@ -56,7 +56,7 @@ class PropertyExistenceProvider
      *
      * @return void
      */
-    public function registerClosure(string $fq_classlike_name, \Closure $c)
+    public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {
         self::$handlers[strtolower($fq_classlike_name)][] = $c;
     }

--- a/src/Psalm/Internal/Provider/PropertyTypeProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyTypeProvider.php
@@ -34,7 +34,7 @@ class PropertyTypeProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'getPropertyType']);
 
@@ -55,7 +55,7 @@ class PropertyTypeProvider
      *
      * @return void
      */
-    public function registerClosure(string $fq_classlike_name, \Closure $c)
+    public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {
         self::$handlers[strtolower($fq_classlike_name)][] = $c;
     }

--- a/src/Psalm/Internal/Provider/PropertyTypeProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyTypeProvider.php
@@ -32,7 +32,6 @@ class PropertyTypeProvider
     /**
      * @param  class-string<PropertyTypeProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -53,7 +52,6 @@ class PropertyTypeProvider
      *     ?Context=
      *   ) : ?Type\Union $c
      *
-     * @return void
      */
     public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
@@ -33,7 +33,6 @@ class PropertyVisibilityProvider
     /**
      * @param  class-string<PropertyVisibilityProviderInterface> $class
      *
-     * @return void
      */
     public function registerClass(string $class): void
     {
@@ -55,7 +54,6 @@ class PropertyVisibilityProvider
      *     CodeLocation
      *   ) : ?bool $c
      *
-     * @return void
      */
     public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {

--- a/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
@@ -35,7 +35,7 @@ class PropertyVisibilityProvider
      *
      * @return void
      */
-    public function registerClass(string $class)
+    public function registerClass(string $class): void
     {
         $callable = \Closure::fromCallable([$class, 'isPropertyVisible']);
 
@@ -57,7 +57,7 @@ class PropertyVisibilityProvider
      *
      * @return void
      */
-    public function registerClosure(string $fq_classlike_name, \Closure $c)
+    public function registerClosure(string $fq_classlike_name, \Closure $c): void
     {
         self::$handlers[strtolower($fq_classlike_name)][] = $c;
     }

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
@@ -172,7 +172,7 @@ class ArrayMapReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTyp
                         /**
                         * @return Type\Union
                         */
-                        function (Type\Union $_) use ($mapping_return_type) {
+                        function (Type\Union $_) use ($mapping_return_type): Type\Union {
                             return clone $mapping_return_type;
                         },
                         $array_arg_atomic_type->properties

--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -84,7 +84,7 @@ class StatementsProvider
     /**
      * @return list<\PhpParser\Node\Stmt>
      */
-    public function getStatementsForFile(string $file_path, string $php_version, ?Progress $progress = null)
+    public function getStatementsForFile(string $file_path, string $php_version, ?Progress $progress = null): array
     {
         if ($progress === null) {
             $progress = new VoidProgress();
@@ -292,7 +292,7 @@ class StatementsProvider
      *
      * @return void
      */
-    public function addChangedMembers(array $more_changed_members)
+    public function addChangedMembers(array $more_changed_members): void
     {
         $this->changed_members = array_merge($more_changed_members, $this->changed_members);
     }
@@ -310,7 +310,7 @@ class StatementsProvider
      *
      * @return void
      */
-    public function addUnchangedSignatureMembers(array $more_unchanged_members)
+    public function addUnchangedSignatureMembers(array $more_unchanged_members): void
     {
         $this->unchanged_signature_members = array_merge($more_unchanged_members, $this->unchanged_signature_members);
     }
@@ -318,7 +318,7 @@ class StatementsProvider
     /**
      * @return void
      */
-    public function setUnchangedFile(string $file_path)
+    public function setUnchangedFile(string $file_path): void
     {
         if (!isset($this->diff_map[$file_path])) {
             $this->diff_map[$file_path] = [];
@@ -338,7 +338,7 @@ class StatementsProvider
      *
      * @return void
      */
-    public function addDiffMap(array $diff_map)
+    public function addDiffMap(array $diff_map): void
     {
         $this->diff_map = array_merge($diff_map, $this->diff_map);
     }
@@ -346,7 +346,7 @@ class StatementsProvider
     /**
      * @return void
      */
-    public function resetDiffs()
+    public function resetDiffs(): void
     {
         $this->changed_members = [];
         $this->unchanged_members = [];
@@ -367,7 +367,7 @@ class StatementsProvider
         ?string $existing_file_contents = null,
         ?array $existing_statements = null,
         ?array $file_changes = null
-    ) {
+    ): array {
         $attributes = [
             'comments', 'startLine', 'startFilePos', 'endFilePos',
         ];

--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -290,7 +290,6 @@ class StatementsProvider
     /**
      * @param array<string, array<string, bool>> $more_changed_members
      *
-     * @return void
      */
     public function addChangedMembers(array $more_changed_members): void
     {
@@ -308,16 +307,12 @@ class StatementsProvider
     /**
      * @param array<string, array<string, bool>> $more_unchanged_members
      *
-     * @return void
      */
     public function addUnchangedSignatureMembers(array $more_unchanged_members): void
     {
         $this->unchanged_signature_members = array_merge($more_unchanged_members, $this->unchanged_signature_members);
     }
 
-    /**
-     * @return void
-     */
     public function setUnchangedFile(string $file_path): void
     {
         if (!isset($this->diff_map[$file_path])) {
@@ -336,16 +331,12 @@ class StatementsProvider
     /**
      * @param array<string, array<int, array{0: int, 1: int, 2: int, 3: int}>> $diff_map
      *
-     * @return void
      */
     public function addDiffMap(array $diff_map): void
     {
         $this->diff_map = array_merge($diff_map, $this->diff_map);
     }
 
-    /**
-     * @return void
-     */
     public function resetDiffs(): void
     {
         $this->changed_members = [];

--- a/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
+++ b/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
@@ -91,7 +91,6 @@ class PhpStormMetaScanner
                     $meta_fq_classlike_name,
                     /**
                      * @param array<PhpParser\Node\Arg> $call_args
-                     * @return ?Type\Union
                      */
                     function (
                         \Psalm\StatementsSource $statements_analyzer,
@@ -149,7 +148,6 @@ class PhpStormMetaScanner
                     $meta_fq_classlike_name,
                     /**
                      * @param array<PhpParser\Node\Arg> $call_args
-                     * @return ?Type\Union
                      */
                     function (
                         \Psalm\StatementsSource $statements_analyzer,
@@ -189,7 +187,6 @@ class PhpStormMetaScanner
                     $meta_fq_classlike_name,
                     /**
                      * @param array<PhpParser\Node\Arg> $call_args
-                     * @return ?Type\Union
                      */
                     function (
                         \Psalm\StatementsSource $statements_analyzer,

--- a/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
+++ b/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
@@ -105,7 +105,7 @@ class PhpStormMetaScanner
                         $offset,
                         $meta_fq_classlike_name,
                         $meta_method_name
-                    ) {
+                    ): ?Type\Union {
                         if (!$statements_analyzer instanceof \Psalm\Internal\Analyzer\StatementsAnalyzer) {
                             return Type::getMixed();
                         }
@@ -163,7 +163,7 @@ class PhpStormMetaScanner
                         $type_offset,
                         $meta_fq_classlike_name,
                         $meta_method_name
-                    ) {
+                    ): ?Type\Union {
                         if (!$statements_analyzer instanceof \Psalm\Internal\Analyzer\StatementsAnalyzer) {
                             return Type::getMixed();
                         }
@@ -203,7 +203,7 @@ class PhpStormMetaScanner
                         $element_type_offset,
                         $meta_fq_classlike_name,
                         $meta_method_name
-                    ) {
+                    ): ?Type\Union {
                         if (!$statements_analyzer instanceof \Psalm\Internal\Analyzer\StatementsAnalyzer) {
                             return Type::getMixed();
                         }

--- a/src/Psalm/Internal/Stubs/Generator/ClassLikeStubGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/ClassLikeStubGenerator.php
@@ -223,7 +223,7 @@ class ClassLikeStubGenerator
     /**
      * @return list<PhpParser\Node\Stmt\ClassMethod>
      */
-    private static function getMethodNodes(ClassLikeStorage $storage) {
+    private static function getMethodNodes(ClassLikeStorage $storage): array {
         $namespace_name = implode('\\', array_slice(explode('\\', $storage->name), 0, -1));
         $method_nodes = [];
 

--- a/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
@@ -244,7 +244,7 @@ class StubsGenerator
     /**
      * @return list<PhpParser\Node\Param>
      */
-    public static function getFunctionParamNodes(\Psalm\Storage\FunctionLikeStorage $method_storage)
+    public static function getFunctionParamNodes(\Psalm\Storage\FunctionLikeStorage $method_storage): array
     {
         $param_nodes = [];
 

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -896,7 +896,7 @@ class AssertionReconciler extends \Psalm\Type\Reconciler
                         && !$codebase->classExists($new_type_part->value)
                         && !array_filter(
                             $existing_type_part->extra_types,
-                            function ($extra_type) use ($codebase) {
+                            function ($extra_type) use ($codebase): bool {
                                 return $extra_type instanceof TNamedObject
                                     && $codebase->classExists($extra_type->value);
                             }

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -1406,9 +1406,6 @@ class SimpleNegatedAssertionReconciler extends Reconciler
         return Type::getMixed();
     }
 
-    /**
-     * @return void
-     */
     private static function removeFalsyNegatedLiteralTypes(
         Type\Union $existing_var_type,
         bool &$did_remove_type

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -1412,7 +1412,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
     private static function removeFalsyNegatedLiteralTypes(
         Type\Union $existing_var_type,
         bool &$did_remove_type
-    ) {
+    ): void {
         if ($existing_var_type->hasString()) {
             $existing_string_types = $existing_var_type->getLiteralStrings();
 

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -234,7 +234,7 @@ class TypeExpander
                     if ($const_name_part) {
                         $matching_constants = \array_filter(
                             $matching_constants,
-                            function ($constant_name) use ($const_name_part) {
+                            function ($constant_name) use ($const_name_part): bool {
                                 return $constant_name !== $const_name_part
                                     && \strpos($constant_name, $const_name_part) === 0;
                             }

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -56,7 +56,6 @@ class TypeParser
      * @param  array<string, array<string, array{Union}>> $template_type_map
      * @param  array<string, TypeAlias> $type_aliases
      *
-     * @return Union
      */
     public static function parseTokens(
         array $type_tokens,
@@ -626,7 +625,11 @@ class TypeParser
                 /**
                  * @return FunctionLikeParameter
                  */
-                function (ParseTree $child_tree) use ($codebase, $template_type_map, $type_aliases): FunctionLikeParameter {
+                function (ParseTree $child_tree) use (
+                    $codebase,
+                    $template_type_map,
+                    $type_aliases
+                ): FunctionLikeParameter {
                     $is_variadic = false;
                     $is_optional = false;
 

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -63,7 +63,7 @@ class TypeParser
         ?array $php_version = null,
         array $template_type_map = [],
         array $type_aliases = []
-    ) {
+    ): Union {
         if (count($type_tokens) === 1) {
             $only_token = $type_tokens[0];
 
@@ -626,7 +626,7 @@ class TypeParser
                 /**
                  * @return FunctionLikeParameter
                  */
-                function (ParseTree $child_tree) use ($codebase, $template_type_map, $type_aliases) {
+                function (ParseTree $child_tree) use ($codebase, $template_type_map, $type_aliases): FunctionLikeParameter {
                     $is_variadic = false;
                     $is_optional = false;
 

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -81,7 +81,7 @@ class TypeTokenizer
     /**
      * @return list<array{0: string, 1: int}>
      */
-    public static function tokenize(string $string_type, bool $ignore_space = true)
+    public static function tokenize(string $string_type, bool $ignore_space = true): array
     {
         $type_tokens = [['', 0]];
         $was_char = false;
@@ -336,7 +336,7 @@ class TypeTokenizer
         ?string $self_fqcln = null,
         ?string $parent_fqcln = null,
         bool $allow_assertions = false
-    ) {
+    ): array {
         $type_tokens = self::tokenize($string_type);
 
         for ($i = 0, $l = count($type_tokens); $i < $l; ++$i) {

--- a/src/Psalm/Issue/TaintedInput.php
+++ b/src/Psalm/Issue/TaintedInput.php
@@ -39,7 +39,7 @@ class TaintedInput extends CodeIssue
     /**
      * @return list<TaintNodeData|array{label: string, entry_path_type: string}>
      */
-    public function getTaintTrace()
+    public function getTaintTrace(): array
     {
         $nodes = [];
 

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -300,7 +300,7 @@ class IssueBuffer
     /**
      * @return list<IssueData>
      */
-    public static function getIssuesDataForFile(string $file_path)
+    public static function getIssuesDataForFile(string $file_path): array
     {
         return self::$issues_data[$file_path] ?? [];
     }
@@ -407,7 +407,7 @@ class IssueBuffer
      *
      * @return void
      */
-    public static function addIssues(array $issues_data)
+    public static function addIssues(array $issues_data): void
     {
         foreach ($issues_data as $file_path => $file_issues) {
             foreach ($file_issues as $issue) {
@@ -435,7 +435,7 @@ class IssueBuffer
         float $start_time,
         bool $add_stats = false,
         array $issue_baseline = []
-    ) {
+    ): void {
         if (!$project_analyzer->stdout_report_options) {
             throw new \UnexpectedValueException('Cannot finish without stdout report options');
         }
@@ -768,7 +768,7 @@ class IssueBuffer
     /**
      * @return void
      */
-    public static function clearCache()
+    public static function clearCache(): void
     {
         self::$issues_data = [];
         self::$emitted = [];
@@ -800,7 +800,7 @@ class IssueBuffer
     /**
      * @return void
      */
-    public static function startRecording()
+    public static function startRecording(): void
     {
         ++self::$recording_level;
         self::$recorded_issues[self::$recording_level] = [];
@@ -809,7 +809,7 @@ class IssueBuffer
     /**
      * @return void
      */
-    public static function stopRecording()
+    public static function stopRecording(): void
     {
         if (self::$recording_level === 0) {
             throw new \UnexpectedValueException('Cannot stop recording - already at base level');

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -185,9 +185,7 @@ class IssueBuffer
     }
 
     /**
-     *
      * @throws  Exception\CodeException
-     *
      */
     public static function add(CodeIssue $e, bool $is_fixable = false): bool
     {
@@ -405,7 +403,6 @@ class IssueBuffer
     /**
      * @param array<string, list<IssueData>> $issues_data
      *
-     * @return void
      */
     public static function addIssues(array $issues_data): void
     {
@@ -427,7 +424,6 @@ class IssueBuffer
     /**
      * @param  array<string,array<string,array{o:int, s:array<int, string>}>>  $issue_baseline
      *
-     * @return void
      */
     public static function finish(
         ProjectAnalyzer $project_analyzer,
@@ -765,9 +761,6 @@ class IssueBuffer
         return false;
     }
 
-    /**
-     * @return void
-     */
     public static function clearCache(): void
     {
         self::$issues_data = [];
@@ -797,18 +790,12 @@ class IssueBuffer
         return self::$recording_level > 0;
     }
 
-    /**
-     * @return void
-     */
     public static function startRecording(): void
     {
         ++self::$recording_level;
         self::$recorded_issues[self::$recording_level] = [];
     }
 
-    /**
-     * @return void
-     */
     public static function stopRecording(): void
     {
         if (self::$recording_level === 0) {

--- a/src/Psalm/Plugin/Hook/AfterStatementAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterStatementAnalysisInterface.php
@@ -22,5 +22,5 @@ interface AfterStatementAnalysisInterface
         StatementsSource $statements_source,
         Codebase $codebase,
         array &$file_replacements = []
-    );
+    ): ?bool;
 }

--- a/src/Psalm/Plugin/Hook/AfterStatementAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterStatementAnalysisInterface.php
@@ -22,5 +22,5 @@ interface AfterStatementAnalysisInterface
         StatementsSource $statements_source,
         Codebase $codebase,
         array &$file_replacements = []
-    ): ?bool;
+    );
 }

--- a/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
@@ -20,5 +20,5 @@ interface FunctionExistenceProviderInterface
     public static function doesFunctionExist(
         StatementsSource $statements_source,
         string $function_id
-    );
+    ): ?bool;
 }

--- a/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
@@ -15,7 +15,6 @@ interface FunctionExistenceProviderInterface
      * not exist, return false. If you aren't sure if it exists or not, return null and the default analysis
      * will continue to determine if the function actually exists.
      *
-     * @return ?bool
      */
     public static function doesFunctionExist(
         StatementsSource $statements_source,

--- a/src/Psalm/Plugin/Hook/FunctionParamsProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionParamsProviderInterface.php
@@ -24,5 +24,5 @@ interface FunctionParamsProviderInterface
         array $call_args,
         ?Context $context = null,
         ?CodeLocation $code_location = null
-    );
+    ): ?array;
 }

--- a/src/Psalm/Plugin/Hook/PropertyExistenceProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/PropertyExistenceProviderInterface.php
@@ -26,5 +26,5 @@ interface PropertyExistenceProviderInterface
         ?StatementsSource $source = null,
         ?Context $context = null,
         ?CodeLocation $code_location = null
-    );
+    ): ?bool;
 }

--- a/src/Psalm/Plugin/Hook/PropertyExistenceProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/PropertyExistenceProviderInterface.php
@@ -17,7 +17,6 @@ interface PropertyExistenceProviderInterface
      * not exist, return false. If you aren't sure if it exists or not, return null and the default analysis will
      * continue to determine if the property actually exists.
      *
-     * @return ?bool
      */
     public static function doesPropertyExist(
         string $fq_classlike_name,

--- a/src/Psalm/Plugin/Hook/PropertyTypeProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/PropertyTypeProviderInterface.php
@@ -16,7 +16,6 @@ interface PropertyTypeProviderInterface
     /**
      * @param  array<PhpParser\Node\Arg>    $call_args
      *
-     * @return ?Type\Union
      */
     public static function getPropertyType(
         string $fq_classlike_name,

--- a/src/Psalm/Plugin/Hook/PropertyTypeProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/PropertyTypeProviderInterface.php
@@ -24,5 +24,5 @@ interface PropertyTypeProviderInterface
         bool $read_mode,
         ?StatementsSource $source = null,
         ?Context $context = null
-    );
+    ): ?Type\Union;
 }

--- a/src/Psalm/Plugin/Hook/PropertyVisibilityProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/PropertyVisibilityProviderInterface.php
@@ -12,9 +12,6 @@ interface PropertyVisibilityProviderInterface
      */
     public static function getClassLikeNames() : array;
 
-    /**
-     * @return ?bool
-     */
     public static function isPropertyVisible(
         StatementsSource $source,
         string $fq_classlike_name,

--- a/src/Psalm/Plugin/Hook/PropertyVisibilityProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/PropertyVisibilityProviderInterface.php
@@ -22,5 +22,5 @@ interface PropertyVisibilityProviderInterface
         bool $read_mode,
         Context $context,
         CodeLocation $code_location
-    );
+    ): ?bool;
 }

--- a/src/Psalm/Type/Algebra.php
+++ b/src/Psalm/Type/Algebra.php
@@ -91,7 +91,7 @@ class Algebra
         ?Codebase $codebase = null,
         bool $inside_negation = false,
         bool $cache = true
-    ) {
+    ): array {
         if ($conditional instanceof PhpParser\Node\Expr\BinaryOp\BooleanAnd ||
             $conditional instanceof PhpParser\Node\Expr\BinaryOp\LogicalAnd
         ) {
@@ -417,7 +417,7 @@ class Algebra
      *
      * @psalm-pure
      */
-    public static function simplifyCNF(array $clauses)
+    public static function simplifyCNF(array $clauses): array
     {
         $cloned_clauses = [];
 
@@ -455,7 +455,7 @@ class Algebra
                             /**
                              * @return bool
                              */
-                            function (string $possible_type) use ($negated_clause_type) {
+                            function (string $possible_type) use ($negated_clause_type): bool {
                                 return $possible_type !== $negated_clause_type;
                             }
                         )
@@ -803,7 +803,7 @@ class Algebra
      *
      * @return non-empty-list<Clause>
      */
-    public static function negateFormula(array $clauses)
+    public static function negateFormula(array $clauses): array
     {
         if (!$clauses) {
             $cond_id = \mt_rand(0, 100000000);

--- a/src/Psalm/Type/Algebra.php
+++ b/src/Psalm/Type/Algebra.php
@@ -452,9 +452,6 @@ class Algebra
                     $clause_var_possibilities = array_values(
                         array_filter(
                             $clause_b->possibilities[$clause_var],
-                            /**
-                             * @return bool
-                             */
                             function (string $possible_type) use ($negated_clause_type): bool {
                                 return $possible_type !== $negated_clause_type;
                             }

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -541,9 +541,6 @@ abstract class Atomic implements TypeNode
         }
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         return $this->__toString();
@@ -580,9 +577,6 @@ abstract class Atomic implements TypeNode
         int $php_minor_version
     );
 
-    /**
-     * @return bool
-     */
     abstract public function canBeFullyExpressedInPhp(): bool;
 
     public function replaceTemplateTypesWithStandins(

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -544,7 +544,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         return $this->__toString();
     }
@@ -583,7 +583,7 @@ abstract class Atomic implements TypeNode
     /**
      * @return bool
      */
-    abstract public function canBeFullyExpressedInPhp();
+    abstract public function canBeFullyExpressedInPhp(): bool;
 
     public function replaceTemplateTypesWithStandins(
         TemplateResult $template_result,

--- a/src/Psalm/Type/Atomic/CallableTrait.php
+++ b/src/Psalm/Type/Atomic/CallableTrait.php
@@ -92,7 +92,7 @@ trait CallableTrait
                     /**
                      * @return string
                      */
-                    function (FunctionLikeParameter $param) use ($namespace, $aliased_classes, $this_class) {
+                    function (FunctionLikeParameter $param) use ($namespace, $aliased_classes, $this_class): string {
                         if (!$param->type) {
                             $type_string = 'mixed';
                         } else {

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -115,7 +115,7 @@ trait GenericTrait
                     /**
                      * @return string
                      */
-                    function (Atomic $extra_type) use ($namespace, $aliased_classes, $this_class) {
+                    function (Atomic $extra_type) use ($namespace, $aliased_classes, $this_class): string {
                         return $extra_type->toNamespacedString($namespace, $aliased_classes, $this_class, false);
                     },
                     $this->extra_types
@@ -131,7 +131,7 @@ trait GenericTrait
                         /**
                          * @return string
                          */
-                        function (Union $type_param) use ($namespace, $aliased_classes, $this_class) {
+                        function (Union $type_param) use ($namespace, $aliased_classes, $this_class): string {
                             return $type_param->toNamespacedString($namespace, $aliased_classes, $this_class, false);
                         },
                         $this->type_params

--- a/src/Psalm/Type/Atomic/HasIntersectionTrait.php
+++ b/src/Psalm/Type/Atomic/HasIntersectionTrait.php
@@ -43,7 +43,7 @@ trait HasIntersectionTrait
                     $aliased_classes,
                     $this_class,
                     $use_phpdoc_format
-                ) {
+                ): string {
                     return $extra_type->toNamespacedString(
                         $namespace,
                         $aliased_classes,

--- a/src/Psalm/Type/Atomic/Scalar.php
+++ b/src/Psalm/Type/Atomic/Scalar.php
@@ -19,7 +19,7 @@ abstract class Scalar extends \Psalm\Type\Atomic
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return true;
     }

--- a/src/Psalm/Type/Atomic/Scalar.php
+++ b/src/Psalm/Type/Atomic/Scalar.php
@@ -16,9 +16,6 @@ abstract class Scalar extends \Psalm\Type\Atomic
         return $php_major_version >= 7 ? $this->getKey() : null;
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return true;

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -162,7 +162,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
                             $aliased_classes,
                             $this_class,
                             $use_phpdoc_format
-                        ): string{
+                        ): string {
                             if (\is_string($name) && \preg_match('/[ "\'\\\\.\n:]/', $name)) {
                                 $name = '\'' . \str_replace("\n", '\n', \addslashes($name)) . '\'';
                             }
@@ -245,9 +245,6 @@ class TKeyedArray extends \Psalm\Type\Atomic
         return $value_type;
     }
 
-    /**
-     * @return Type\Atomic\TArray
-     */
     public function getGenericArrayType(): TArray
     {
         $key_types = [];

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -162,7 +162,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
                             $aliased_classes,
                             $this_class,
                             $use_phpdoc_format
-                        ) {
+                        ): string{
                             if (\is_string($name) && \preg_match('/[ "\'\\\\.\n:]/', $name)) {
                                 $name = '\'' . \str_replace("\n", '\n', \addslashes($name)) . '\'';
                             }
@@ -248,7 +248,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
     /**
      * @return Type\Atomic\TArray
      */
-    public function getGenericArrayType()
+    public function getGenericArrayType(): TArray
     {
         $key_types = [];
         $value_type = null;

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -25,9 +25,6 @@ class TLiteralString extends TString
         return 'string';
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = false): string
     {
         $no_newline_value = preg_replace("/\n/m", '\n', $this->value);

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -28,7 +28,7 @@ class TLiteralString extends TString
     /**
      * @return string
      */
-    public function getId(bool $nested = false)
+    public function getId(bool $nested = false): string
     {
         $no_newline_value = preg_replace("/\n/m", '\n', $this->value);
         if (strlen($this->value) > 80) {

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -158,7 +158,7 @@ class TObjectWithProperties extends TObject
                             $aliased_classes,
                             $this_class,
                             $use_phpdoc_format
-                        ) {
+                        ): string {
                             return $name . ($type->possibly_undefined ? '?' : '') . ':' . $type->toNamespacedString(
                                 $namespace,
                                 $aliased_classes,

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -810,7 +810,6 @@ class Reconciler
     /**
      * @param  string[]     $suppressed_issues
      *
-     * @return void
      */
     protected static function triggerIssueForImpossible(
         Union $existing_var_type,

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -820,7 +820,7 @@ class Reconciler
         bool $redundant,
         CodeLocation $code_location,
         array $suppressed_issues
-    ) {
+    ): void {
         $never = $assertion[0] === '!';
 
         if ($never) {

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -226,9 +226,6 @@ class Union implements TypeNode
         return $this->types;
     }
 
-    /**
-     * @return void
-     */
     public function addType(Atomic $type): void
     {
         $this->types[$type->getKey()] = $type;
@@ -562,9 +559,6 @@ class Union implements TypeNode
         return false;
     }
 
-    /**
-     * @return void
-     */
     public function bustCache(): void
     {
         $this->id = null;
@@ -1549,7 +1543,6 @@ class Union implements TypeNode
     /**
      * @param  array<string, mixed> $phantom_classes
      *
-     * @return void
      */
     public function queueClassLikesForScanning(
         Codebase $codebase,
@@ -1589,9 +1582,6 @@ class Union implements TypeNode
         return $template_type_collector->getTemplateTypes();
     }
 
-    /**
-     * @return void
-     */
     public function setFromDocblock(): void
     {
         $this->from_docblock = true;

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -229,7 +229,7 @@ class Union implements TypeNode
     /**
      * @return void
      */
-    public function addType(Atomic $type)
+    public function addType(Atomic $type): void
     {
         $this->types[$type->getKey()] = $type;
 
@@ -565,7 +565,7 @@ class Union implements TypeNode
     /**
      * @return void
      */
-    public function bustCache()
+    public function bustCache(): void
     {
         $this->id = null;
     }
@@ -1393,7 +1393,7 @@ class Union implements TypeNode
         return count(
             array_filter(
                 $this->types,
-                function ($type) use ($check_templates) {
+                function ($type) use ($check_templates): bool {
                     return $type instanceof TInt
                         || ($check_templates
                             && $type instanceof TTemplateParam
@@ -1424,7 +1424,7 @@ class Union implements TypeNode
         return count(
             array_filter(
                 $this->types,
-                function ($type) use ($check_templates) {
+                function ($type) use ($check_templates): bool {
                     return $type instanceof TString
                         || ($check_templates
                             && $type instanceof TTemplateParam
@@ -1448,7 +1448,7 @@ class Union implements TypeNode
      *
      * @return TLiteralString the only string literal represented by this union type
      */
-    public function getSingleStringLiteral()
+    public function getSingleStringLiteral(): TLiteralString
     {
         if (count($this->types) !== 1 || count($this->literal_string_types) !== 1) {
             throw new \InvalidArgumentException('Not a string literal');
@@ -1500,7 +1500,7 @@ class Union implements TypeNode
      *
      * @return TLiteralInt the only int literal represented by this union type
      */
-    public function getSingleIntLiteral()
+    public function getSingleIntLiteral(): TLiteralInt
     {
         if (count($this->types) !== 1 || count($this->literal_int_types) !== 1) {
             throw new \InvalidArgumentException('Not an int literal');
@@ -1555,7 +1555,7 @@ class Union implements TypeNode
         Codebase $codebase,
         ?FileStorage $file_storage = null,
         array $phantom_classes = []
-    ) {
+    ): void {
         $scanner_visitor = new \Psalm\Internal\TypeVisitor\TypeScanner(
             $codebase->scanner,
             $file_storage,
@@ -1580,7 +1580,7 @@ class Union implements TypeNode
     /**
      * @return list<TTemplateParam>
      */
-    public function getTemplateTypes()
+    public function getTemplateTypes(): array
     {
         $template_type_collector = new \Psalm\Internal\TypeVisitor\TemplateTypeCollector();
 
@@ -1592,7 +1592,7 @@ class Union implements TypeNode
     /**
      * @return void
      */
-    public function setFromDocblock()
+    public function setFromDocblock(): void
     {
         $this->from_docblock = true;
 

--- a/src/psalm-language-server.php
+++ b/src/psalm-language-server.php
@@ -210,7 +210,7 @@ require_once __DIR__ . '/Psalm/Internal/IncludeCollector.php';
 $include_collector = new IncludeCollector();
 
 $first_autoloader = $include_collector->runAndCollect(
-    function () use ($current_dir, $options, $vendor_dir) {
+    function () use ($current_dir, $options, $vendor_dir): ?\Composer\Autoload\ClassLoader {
         return \Psalm\requireAutoloaders($current_dir, isset($options['r']), $vendor_dir);
     }
 );

--- a/src/psalm-refactor.php
+++ b/src/psalm-refactor.php
@@ -159,7 +159,7 @@ $vendor_dir = \Psalm\getVendorDir($current_dir);
 require_once __DIR__ . '/Psalm/Internal/IncludeCollector.php';
 $include_collector = new IncludeCollector();
 $first_autoloader = $include_collector->runAndCollect(
-    function () use ($current_dir, $options, $vendor_dir) {
+    function () use ($current_dir, $options, $vendor_dir): ?\Composer\Autoload\ClassLoader {
         return requireAutoloaders($current_dir, isset($options['r']), $vendor_dir);
     }
 );

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -277,7 +277,7 @@ require_once __DIR__ . '/' . 'Psalm/Internal/IncludeCollector.php';
 
 $include_collector = new IncludeCollector();
 $first_autoloader = $include_collector->runAndCollect(
-    function () use ($current_dir, $options, $vendor_dir) {
+    function () use ($current_dir, $options, $vendor_dir): ?\Composer\Autoload\ClassLoader {
         return requireAutoloaders($current_dir, isset($options['r']), $vendor_dir);
     }
 );

--- a/src/psalter.php
+++ b/src/psalter.php
@@ -219,7 +219,7 @@ $vendor_dir = \Psalm\getVendorDir($current_dir);
 require_once __DIR__ . '/Psalm/Internal/IncludeCollector.php';
 $include_collector = new IncludeCollector();
 $first_autoloader = $include_collector->runAndCollect(
-    function () use ($current_dir, $options, $vendor_dir) {
+    function () use ($current_dir, $options, $vendor_dir): ?\Composer\Autoload\ClassLoader {
         return requireAutoloaders($current_dir, isset($options['r']), $vendor_dir);
     }
 );

--- a/tests/AlgebraTest.php
+++ b/tests/AlgebraTest.php
@@ -15,9 +15,6 @@ use Psalm\Type\Reconciler;
 
 class AlgebraTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testNegateFormula(): void
     {
         $formula = [
@@ -61,9 +58,6 @@ class AlgebraTest extends TestCase
         $this->assertSame(['$b' => ['falsy']], $negated_formula[2]->possibilities);
     }
 
-    /**
-     * @return void
-     */
     public function testCombinatorialExpansion(): void
     {
         $dnf = '<?php ($b0 === true && $b4 === true && $b8 === true)
@@ -98,9 +92,6 @@ class AlgebraTest extends TestCase
         $this->assertCount(23, $simplified_dnf_clauses);
     }
 
-    /**
-     * @return void
-     */
     public function testContainsClause(): void
     {
         $this->assertTrue(
@@ -142,9 +133,6 @@ class AlgebraTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testSimplifyCNF(): void
     {
         $formula = [

--- a/tests/AlgebraTest.php
+++ b/tests/AlgebraTest.php
@@ -18,7 +18,7 @@ class AlgebraTest extends TestCase
     /**
      * @return void
      */
-    public function testNegateFormula()
+    public function testNegateFormula(): void
     {
         $formula = [
             new Clause(['$a' => ['!falsy']], 1, 1),
@@ -64,7 +64,7 @@ class AlgebraTest extends TestCase
     /**
      * @return void
      */
-    public function testCombinatorialExpansion()
+    public function testCombinatorialExpansion(): void
     {
         $dnf = '<?php ($b0 === true && $b4 === true && $b8 === true)
                   || ($b0 === true && $b1 === true && $b2 === true)
@@ -101,7 +101,7 @@ class AlgebraTest extends TestCase
     /**
      * @return void
      */
-    public function testContainsClause()
+    public function testContainsClause(): void
     {
         $this->assertTrue(
             (new Clause(
@@ -145,7 +145,7 @@ class AlgebraTest extends TestCase
     /**
      * @return void
      */
-    public function testSimplifyCNF()
+    public function testSimplifyCNF(): void
     {
         $formula = [
             new Clause(['$a' => ['!falsy']], 1, 1),

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -10,9 +10,6 @@ class AnnotationTest extends TestCase
     use Traits\InvalidCodeAnalysisTestTrait;
     use Traits\ValidCodeAnalysisTestTrait;
 
-    /**
-     * @return void
-     */
     public function testPhpStormGenericsWithValidArrayIteratorArgument(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
@@ -36,9 +33,6 @@ class AnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPhpStormGenericsWithValidTraversableArgument(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
@@ -59,9 +53,6 @@ class AnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPhpStormGenericsWithClassProperty(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
@@ -86,9 +77,6 @@ class AnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPhpStormGenericsWithGeneratorArray(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
@@ -110,9 +98,6 @@ class AnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPhpStormGenericsWithValidIterableArgument(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
@@ -133,9 +118,6 @@ class AnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPhpStormGenericsInvalidArgument(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -158,9 +140,6 @@ class AnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPhpStormGenericsNoTypehint(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -180,9 +159,6 @@ class AnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testInvalidParamDefault(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -201,9 +177,6 @@ class AnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testInvalidParamDefaultButAllowedInConfig(): void
     {
         Config::getInstance()->add_param_default_to_docblock_type = true;
@@ -223,9 +196,6 @@ class AnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testInvalidTypehintParamDefaultButAllowedInConfig(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -13,7 +13,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpStormGenericsWithValidArrayIteratorArgument()
+    public function testPhpStormGenericsWithValidArrayIteratorArgument(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
 
@@ -39,7 +39,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpStormGenericsWithValidTraversableArgument()
+    public function testPhpStormGenericsWithValidTraversableArgument(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
 
@@ -62,7 +62,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpStormGenericsWithClassProperty()
+    public function testPhpStormGenericsWithClassProperty(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
 
@@ -89,7 +89,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpStormGenericsWithGeneratorArray()
+    public function testPhpStormGenericsWithGeneratorArray(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
 
@@ -113,7 +113,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpStormGenericsWithValidIterableArgument()
+    public function testPhpStormGenericsWithValidIterableArgument(): void
     {
         Config::getInstance()->allow_phpstorm_generics = true;
 
@@ -136,7 +136,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpStormGenericsInvalidArgument()
+    public function testPhpStormGenericsInvalidArgument(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('InvalidScalarArgument');
@@ -161,7 +161,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpStormGenericsNoTypehint()
+    public function testPhpStormGenericsNoTypehint(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('PossiblyInvalidMethodCall');
@@ -183,7 +183,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testInvalidParamDefault()
+    public function testInvalidParamDefault(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('InvalidParamDefault');
@@ -204,7 +204,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testInvalidParamDefaultButAllowedInConfig()
+    public function testInvalidParamDefaultButAllowedInConfig(): void
     {
         Config::getInstance()->add_param_default_to_docblock_type = true;
 
@@ -226,7 +226,7 @@ class AnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testInvalidTypehintParamDefaultButAllowedInConfig()
+    public function testInvalidTypehintParamDefaultButAllowedInConfig(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('InvalidParamDefault');
@@ -245,7 +245,7 @@ class AnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'nopType' => [
@@ -1179,7 +1179,7 @@ class AnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidClassMethodReturn' => [

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -9,7 +9,7 @@ class ArgTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'callMapClassOptionalArg' => [
@@ -127,7 +127,7 @@ class ArgTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'possiblyInvalidArgument' => [

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -11,7 +11,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testEnsureArrayOffsetsExist()
+    public function testEnsureArrayOffsetsExist(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('PossiblyUndefinedStringArrayOffset');
@@ -35,7 +35,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testEnsureArrayOffsetsExistWithIssetCheck()
+    public function testEnsureArrayOffsetsExistWithIssetCheck(): void
     {
         \Psalm\Config::getInstance()->ensure_array_string_offsets_exist = true;
 
@@ -58,7 +58,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testDontEnsureArrayOffsetsExist()
+    public function testDontEnsureArrayOffsetsExist(): void
     {
         \Psalm\Config::getInstance()->ensure_array_string_offsets_exist = false;
 
@@ -79,7 +79,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testEnsureArrayOffsetsExistWithIssetCheckFollowedByIsArray()
+    public function testEnsureArrayOffsetsExistWithIssetCheckFollowedByIsArray(): void
     {
         \Psalm\Config::getInstance()->ensure_array_string_offsets_exist = true;
 
@@ -98,7 +98,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testComplainAfterFirstIsset()
+    public function testComplainAfterFirstIsset(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('PossiblyUndefinedStringArrayOffset');
@@ -119,7 +119,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testEnsureArrayIntOffsetsExist()
+    public function testEnsureArrayIntOffsetsExist(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('PossiblyUndefinedIntArrayOffset');
@@ -143,7 +143,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testNoIssueWhenUsingArrayValuesOnNonEmptyArray()
+    public function testNoIssueWhenUsingArrayValuesOnNonEmptyArray(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
 
@@ -185,7 +185,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testEnsureListOffsetExistsNotEmpty()
+    public function testEnsureListOffsetExistsNotEmpty(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
 
@@ -206,7 +206,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testEnsureListOffsetExistsAfterArrayPop()
+    public function testEnsureListOffsetExistsAfterArrayPop(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
 
@@ -246,7 +246,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testEnsureListOffsetExistsAfterCountValueInRange()
+    public function testEnsureListOffsetExistsAfterCountValueInRange(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
 
@@ -299,7 +299,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testEnsureListOffsetExistsAfterCountValueOutOfRange()
+    public function testEnsureListOffsetExistsAfterCountValueOutOfRange(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
 
@@ -325,7 +325,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return void
      */
-    public function testEnsureListOffsetExistsAfterCountValueOutOfRangeSmallerThan()
+    public function testEnsureListOffsetExistsAfterCountValueOutOfRangeSmallerThan(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
 
@@ -351,7 +351,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'instanceOfStringOffset' => [
@@ -1006,7 +1006,7 @@ class ArrayAccessTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidArrayAccess' => [

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -8,9 +8,6 @@ class ArrayAccessTest extends TestCase
     use Traits\InvalidCodeAnalysisTestTrait;
     use Traits\ValidCodeAnalysisTestTrait;
 
-    /**
-     * @return void
-     */
     public function testEnsureArrayOffsetsExist(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -32,9 +29,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEnsureArrayOffsetsExistWithIssetCheck(): void
     {
         \Psalm\Config::getInstance()->ensure_array_string_offsets_exist = true;
@@ -55,9 +49,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testDontEnsureArrayOffsetsExist(): void
     {
         \Psalm\Config::getInstance()->ensure_array_string_offsets_exist = false;
@@ -76,9 +67,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEnsureArrayOffsetsExistWithIssetCheckFollowedByIsArray(): void
     {
         \Psalm\Config::getInstance()->ensure_array_string_offsets_exist = true;
@@ -95,9 +83,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testComplainAfterFirstIsset(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -116,9 +101,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEnsureArrayIntOffsetsExist(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -140,9 +122,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testNoIssueWhenUsingArrayValuesOnNonEmptyArray(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
@@ -182,9 +161,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEnsureListOffsetExistsNotEmpty(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
@@ -203,9 +179,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEnsureListOffsetExistsAfterArrayPop(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
@@ -243,9 +216,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEnsureListOffsetExistsAfterCountValueInRange(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
@@ -296,9 +266,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEnsureListOffsetExistsAfterCountValueOutOfRange(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;
@@ -322,9 +289,6 @@ class ArrayAccessTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEnsureListOffsetExistsAfterCountValueOutOfRangeSmallerThan(): void
     {
         \Psalm\Config::getInstance()->ensure_array_int_offsets_exist = true;

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -8,9 +8,6 @@ class ArrayAssignmentTest extends TestCase
     use Traits\InvalidCodeAnalysisTestTrait;
     use Traits\ValidCodeAnalysisTestTrait;
 
-    /**
-     * @return void
-     */
     public function testConditionalAssignment(): void
     {
         $this->addFile(

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -11,7 +11,7 @@ class ArrayAssignmentTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalAssignment()
+    public function testConditionalAssignment(): void
     {
         $this->addFile(
             'somefile.php',
@@ -33,7 +33,7 @@ class ArrayAssignmentTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'genericArrayCreationWithSingleIntValue' => [
@@ -1534,7 +1534,7 @@ class ArrayAssignmentTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'objectAssignment' => [

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -11,7 +11,7 @@ class ArrayFunctionCallTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'arrayFilter' => [
@@ -1707,7 +1707,7 @@ class ArrayFunctionCallTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'arrayFilterWithoutTypes' => [

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -11,7 +11,7 @@ class AssertAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'implictAssertInstanceOfB' => [
@@ -1272,7 +1272,7 @@ class AssertAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'assertInstanceOfMultipleInterfaces' => [

--- a/tests/AssignmentTest.php
+++ b/tests/AssignmentTest.php
@@ -9,7 +9,7 @@ class AssignmentTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'nestedAssignment' => [
@@ -95,7 +95,7 @@ class AssignmentTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'mixedAssignment' => [

--- a/tests/BadFormatTest.php
+++ b/tests/BadFormatTest.php
@@ -5,9 +5,6 @@ use Psalm\Context;
 
 class BadFormatTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testMissingSemicolon(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:9');
@@ -29,9 +26,6 @@ class BadFormatTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testClassMethodWithNoStmts(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:3');
@@ -47,9 +41,6 @@ class BadFormatTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testInterfaceWithProperties(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:3');
@@ -65,9 +56,6 @@ class BadFormatTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testTypingReturnType(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:5');
@@ -87,9 +75,6 @@ class BadFormatTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testOverriddenUse(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:6');

--- a/tests/BadFormatTest.php
+++ b/tests/BadFormatTest.php
@@ -8,7 +8,7 @@ class BadFormatTest extends TestCase
     /**
      * @return void
      */
-    public function testMissingSemicolon()
+    public function testMissingSemicolon(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:9');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -32,7 +32,7 @@ class BadFormatTest extends TestCase
     /**
      * @return void
      */
-    public function testClassMethodWithNoStmts()
+    public function testClassMethodWithNoStmts(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:3');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -50,7 +50,7 @@ class BadFormatTest extends TestCase
     /**
      * @return void
      */
-    public function testInterfaceWithProperties()
+    public function testInterfaceWithProperties(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:3');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -68,7 +68,7 @@ class BadFormatTest extends TestCase
     /**
      * @return void
      */
-    public function testTypingReturnType()
+    public function testTypingReturnType(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:5');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -90,7 +90,7 @@ class BadFormatTest extends TestCase
     /**
      * @return void
      */
-    public function testOverriddenUse()
+    public function testOverriddenUse(): void
     {
         $this->expectExceptionMessage('ParseError - somefile.php:6');
         $this->expectException(\Psalm\Exception\CodeException::class);

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -86,7 +86,7 @@ class BinaryOperationTest extends TestCase
     /**
      * @return void
      */
-    public function testStrictTrueEquivalence()
+    public function testStrictTrueEquivalence(): void
     {
         $config = \Psalm\Config::getInstance();
         $config->strict_binary_operands = true;
@@ -112,7 +112,7 @@ class BinaryOperationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'regularAddition' => [
@@ -305,7 +305,7 @@ class BinaryOperationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'badAddition' => [

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -83,9 +83,6 @@ class BinaryOperationTest extends TestCase
         $this->assertSame($assertions, $actual_vars);
     }
 
-    /**
-     * @return void
-     */
     public function testStrictTrueEquivalence(): void
     {
         $config = \Psalm\Config::getInstance();

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -9,7 +9,7 @@ class CallableTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'byRefUseVar' => [
@@ -854,7 +854,7 @@ class CallableTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'undefinedCallableClass' => [

--- a/tests/ClassLoadOrderTest.php
+++ b/tests/ClassLoadOrderTest.php
@@ -9,7 +9,7 @@ class ClassLoadOrderTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'singleFileInheritance' => [
@@ -121,7 +121,7 @@ class ClassLoadOrderTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'inheritanceLoopOne' => [

--- a/tests/ClassScopeTest.php
+++ b/tests/ClassScopeTest.php
@@ -9,7 +9,7 @@ class ClassScopeTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'accessiblePrivateMethodFromSubclass' => [
@@ -138,7 +138,7 @@ class ClassScopeTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'inaccessiblePrivateMethod' => [

--- a/tests/ClassStringTest.php
+++ b/tests/ClassStringTest.php
@@ -9,9 +9,6 @@ class ClassStringTest extends TestCase
     use Traits\InvalidCodeAnalysisTestTrait;
     use Traits\ValidCodeAnalysisTestTrait;
 
-    /**
-     * @return void
-     */
     public function testDontAllowStringStandInForNewClass(): void
     {
         $this->expectExceptionMessage('InvalidStringClass');
@@ -31,9 +28,6 @@ class ClassStringTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testDontAllowStringStandInForStaticMethodCall(): void
     {
         $this->expectExceptionMessage('InvalidStringClass');

--- a/tests/ClassStringTest.php
+++ b/tests/ClassStringTest.php
@@ -12,7 +12,7 @@ class ClassStringTest extends TestCase
     /**
      * @return void
      */
-    public function testDontAllowStringStandInForNewClass()
+    public function testDontAllowStringStandInForNewClass(): void
     {
         $this->expectExceptionMessage('InvalidStringClass');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -34,7 +34,7 @@ class ClassStringTest extends TestCase
     /**
      * @return void
      */
-    public function testDontAllowStringStandInForStaticMethodCall()
+    public function testDontAllowStringStandInForStaticMethodCall(): void
     {
         $this->expectExceptionMessage('InvalidStringClass');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -58,7 +58,7 @@ class ClassStringTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'arrayOfClassConstants' => [
@@ -779,7 +779,7 @@ class ClassStringTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'arrayOfStringClasses' => [

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -49,7 +49,7 @@ class ClassTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'overrideProtectedAccessLevelToPublic' => [
@@ -594,7 +594,7 @@ class ClassTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'undefinedClass' => [

--- a/tests/CloneTest.php
+++ b/tests/CloneTest.php
@@ -12,7 +12,7 @@ class CloneTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'cloneCorrect' => [
@@ -48,7 +48,7 @@ class CloneTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidIntClone' => [

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -11,7 +11,7 @@ class ClosureTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'byRefUseVar' => [
@@ -516,7 +516,7 @@ class ClosureTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'wrongArg' => [

--- a/tests/CodebaseTest.php
+++ b/tests/CodebaseTest.php
@@ -31,7 +31,7 @@ class CodebaseTest extends TestCase
      *
      * @return void
      */
-    public function isTypeContainedByType(string $input, string $container, bool $expected)
+    public function isTypeContainedByType(string $input, string $container, bool $expected): void
     {
         $input = Type::parseString($input);
         $container = Type::parseString($container);
@@ -62,7 +62,7 @@ class CodebaseTest extends TestCase
      *
      * @return void
      */
-    public function canTypeBeContainedByType(string $input, string $container, bool $expected)
+    public function canTypeBeContainedByType(string $input, string $container, bool $expected): void
     {
         $input = Type::parseString($input);
         $container = Type::parseString($container);
@@ -93,7 +93,7 @@ class CodebaseTest extends TestCase
      *
      * @return void
      */
-    public function getKeyValueParamsForTraversableObject(string $input, array $expected)
+    public function getKeyValueParamsForTraversableObject(string $input, array $expected): void
     {
         [$input] = array_values(Type::parseString($input)->getAtomicTypes());
 
@@ -127,7 +127,7 @@ class CodebaseTest extends TestCase
      *
      * @return void
      */
-    public function customMetadataIsPersisted()
+    public function customMetadataIsPersisted(): void
     {
         $this->addFile(
             'somefile.php',
@@ -187,7 +187,7 @@ class CodebaseTest extends TestCase
      *
      * @return void
      */
-    public function classExtendsRejectsUnpopulatedClasslikes()
+    public function classExtendsRejectsUnpopulatedClasslikes(): void
     {
         $this->codebase->classlike_storage_provider->create('A');
         $this->codebase->classlike_storage_provider->create('B');

--- a/tests/CodebaseTest.php
+++ b/tests/CodebaseTest.php
@@ -29,7 +29,6 @@ class CodebaseTest extends TestCase
      * @test
      * @dataProvider typeContainments
      *
-     * @return void
      */
     public function isTypeContainedByType(string $input, string $container, bool $expected): void
     {
@@ -60,7 +59,6 @@ class CodebaseTest extends TestCase
      * @test
      * @dataProvider typeIntersections
      *
-     * @return void
      */
     public function canTypeBeContainedByType(string $input, string $container, bool $expected): void
     {
@@ -91,7 +89,6 @@ class CodebaseTest extends TestCase
      *
      * @param array{string,string} $expected
      *
-     * @return void
      */
     public function getKeyValueParamsForTraversableObject(string $input, array $expected): void
     {
@@ -125,7 +122,6 @@ class CodebaseTest extends TestCase
     /**
      * @test
      *
-     * @return void
      */
     public function customMetadataIsPersisted(): void
     {
@@ -185,7 +181,6 @@ class CodebaseTest extends TestCase
     /**
      * @test
      *
-     * @return void
      */
     public function classExtendsRejectsUnpopulatedClasslikes(): void
     {

--- a/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
+++ b/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
@@ -62,7 +62,7 @@ class GetMemoryLimitInBytesTest extends \Psalm\Tests\TestCase
     public function testGetMemoryLimitInBytes(
         $setting,
         $expectedBytes
-    ) {
+    ): void {
         ini_set('memory_limit', (string)$setting);
         $this->assertSame($expectedBytes, getMemoryLimitInBytes(), 'Memory limit in bytes does not fit setting');
     }

--- a/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
+++ b/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
@@ -57,7 +57,6 @@ class GetMemoryLimitInBytesTest extends \Psalm\Tests\TestCase
      * @param int|string $setting
      * @param int|string $expectedBytes
      *
-     * @return void
      */
     public function testGetMemoryLimitInBytes(
         $setting,

--- a/tests/ComposerLockTest.php
+++ b/tests/ComposerLockTest.php
@@ -8,7 +8,6 @@ use Psalm\Internal\PluginManager\ComposerLock;
 class ComposerLockTest extends TestCase
 {
     /**
-     * @return void
      * @test
      */
     public function pluginIsPackageOfTypePsalmPlugin(): void
@@ -31,7 +30,6 @@ class ComposerLockTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function seesNonDevPlugins(): void
@@ -49,7 +47,6 @@ class ComposerLockTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function seesDevPlugins(): void
@@ -67,7 +64,6 @@ class ComposerLockTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function skipsNonPlugins(): void
@@ -85,7 +81,6 @@ class ComposerLockTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function failsOnInvalidJson(): void
@@ -97,7 +92,6 @@ class ComposerLockTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function failsOnNonObjectJson(): void
@@ -109,7 +103,6 @@ class ComposerLockTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function failsOnMissingPackagesEntry(): void
@@ -123,7 +116,6 @@ class ComposerLockTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function failsOnMissingPackagesDevEntry(): void

--- a/tests/ComposerLockTest.php
+++ b/tests/ComposerLockTest.php
@@ -11,7 +11,7 @@ class ComposerLockTest extends TestCase
      * @return void
      * @test
      */
-    public function pluginIsPackageOfTypePsalmPlugin()
+    public function pluginIsPackageOfTypePsalmPlugin(): void
     {
         $lock = new ComposerLock([$this->jsonFile((object)[])]);
         $this->assertTrue($lock->isPlugin($this->pluginEntry('vendor/package', 'Some\Class')));
@@ -34,7 +34,7 @@ class ComposerLockTest extends TestCase
      * @return void
      * @test
      */
-    public function seesNonDevPlugins()
+    public function seesNonDevPlugins(): void
     {
         $lock = new ComposerLock([$this->jsonFile((object)[
             'packages' => [
@@ -52,7 +52,7 @@ class ComposerLockTest extends TestCase
      * @return void
      * @test
      */
-    public function seesDevPlugins()
+    public function seesDevPlugins(): void
     {
         $lock = new ComposerLock([$this->jsonFile((object)[
             'packages' => [],
@@ -70,7 +70,7 @@ class ComposerLockTest extends TestCase
      * @return void
      * @test
      */
-    public function skipsNonPlugins()
+    public function skipsNonPlugins(): void
     {
         $nonPlugin = (object)[
             'name' => 'vendor/package',
@@ -88,7 +88,7 @@ class ComposerLockTest extends TestCase
      * @return void
      * @test
      */
-    public function failsOnInvalidJson()
+    public function failsOnInvalidJson(): void
     {
         $lock = new ComposerLock(['data:application/json,[']);
 
@@ -100,7 +100,7 @@ class ComposerLockTest extends TestCase
      * @return void
      * @test
      */
-    public function failsOnNonObjectJson()
+    public function failsOnNonObjectJson(): void
     {
         $lock = new ComposerLock(['data:application/json,null']);
 
@@ -112,7 +112,7 @@ class ComposerLockTest extends TestCase
      * @return void
      * @test
      */
-    public function failsOnMissingPackagesEntry()
+    public function failsOnMissingPackagesEntry(): void
     {
         $noPackagesFile = $this->jsonFile((object)[
             'packages-dev' => [],
@@ -126,7 +126,7 @@ class ComposerLockTest extends TestCase
      * @return void
      * @test
      */
-    public function failsOnMissingPackagesDevEntry()
+    public function failsOnMissingPackagesDevEntry(): void
     {
         $noPackagesDevFile = $this->jsonFile((object)[
             'packages' => [],

--- a/tests/Config/ConfigFileTest.php
+++ b/tests/Config/ConfigFileTest.php
@@ -32,7 +32,6 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function canCreateConfigObject(): void
@@ -47,7 +46,6 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function addCanAddPluginClassToExistingPluginsNode(): void
@@ -77,7 +75,6 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function addCanCreateMissingPluginsNode(): void
@@ -99,7 +96,6 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function removeDoesNothingWhenThereIsNoPluginsNode(): void
@@ -119,7 +115,6 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function removeKillsEmptyPluginsNode(): void
@@ -144,7 +139,6 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function removeKillsSpecifiedPlugin(): void
@@ -171,7 +165,6 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function removeKillsSpecifiedPluginWithOneRemaining(): void
@@ -214,7 +207,6 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
      * @param string $expected_template
      * @param string $contents
      *
-     * @return bool
      *
      * @psalm-pure
      */

--- a/tests/Config/ConfigFileTest.php
+++ b/tests/Config/ConfigFileTest.php
@@ -35,7 +35,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function canCreateConfigObject()
+    public function canCreateConfigObject(): void
     {
         file_put_contents($this->file_path, trim('
             <?xml version="1.0"?>
@@ -50,7 +50,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function addCanAddPluginClassToExistingPluginsNode()
+    public function addCanAddPluginClassToExistingPluginsNode(): void
     {
         file_put_contents(
             $this->file_path,
@@ -80,7 +80,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function addCanCreateMissingPluginsNode()
+    public function addCanCreateMissingPluginsNode(): void
     {
         file_put_contents(
             $this->file_path,
@@ -102,7 +102,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function removeDoesNothingWhenThereIsNoPluginsNode()
+    public function removeDoesNothingWhenThereIsNoPluginsNode(): void
     {
         $noPlugins = '<?xml version="1.0"?>
             <psalm></psalm>' . PHP_EOL;
@@ -122,7 +122,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function removeKillsEmptyPluginsNode()
+    public function removeKillsEmptyPluginsNode(): void
     {
         $noPlugins = '<?xml version="1.0" encoding="UTF-8"?>
             <psalm/>' . PHP_EOL;
@@ -147,7 +147,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function removeKillsSpecifiedPlugin()
+    public function removeKillsSpecifiedPlugin(): void
     {
         $noPlugins = trim('
             <?xml version="1.0"?>
@@ -174,7 +174,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function removeKillsSpecifiedPluginWithOneRemaining()
+    public function removeKillsSpecifiedPluginWithOneRemaining(): void
     {
         $noPlugins = trim('
             <?xml version="1.0"?>
@@ -218,7 +218,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
      *
      * @psalm-pure
      */
-    protected static function compareContentWithTemplateAndTrailingLineEnding($expected_template, $contents)
+    protected static function compareContentWithTemplateAndTrailingLineEnding($expected_template, $contents): bool
     {
         $passed = false;
 

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -53,7 +53,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
      *
      * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
      */
-    private function getProjectAnalyzerWithConfig(Config $config)
+    private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $p = new \Psalm\Internal\Analyzer\ProjectAnalyzer(
             $config,
@@ -71,7 +71,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testBarebonesConfig()
+    public function testBarebonesConfig(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -94,7 +94,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testIgnoreProjectDirectory()
+    public function testIgnoreProjectDirectory(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -121,7 +121,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testIgnoreMissingProjectDirectory()
+    public function testIgnoreMissingProjectDirectory(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -219,7 +219,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testIgnoreWildcardProjectDirectory()
+    public function testIgnoreWildcardProjectDirectory(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -247,7 +247,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testIgnoreWildcardFiles()
+    public function testIgnoreWildcardFiles(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -275,7 +275,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testIgnoreWildcardFilesInWildcardFolder()
+    public function testIgnoreWildcardFilesInWildcardFolder(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -306,7 +306,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testIgnoreWildcardFilesInAllPossibleWildcardFolders()
+    public function testIgnoreWildcardFilesInAllPossibleWildcardFolders(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -337,7 +337,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testIssueHandler()
+    public function testIssueHandler(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -365,7 +365,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testIssueHandlerWithCustomErrorLevels()
+    public function testIssueHandlerWithCustomErrorLevels(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -576,7 +576,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testAllPossibleIssues()
+    public function testAllPossibleIssues(): void
     {
         $all_possible_handlers = implode(
             ' ',
@@ -586,7 +586,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
                  *
                  * @return string
                  */
-                function ($issue_name) {
+                function ($issue_name): string {
                     return '<' . $issue_name . ' errorLevel="suppress" />' . "\n";
                 },
                 \Psalm\Config\IssueHandler::getAllIssueTypes()
@@ -613,7 +613,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testImpossibleIssue()
+    public function testImpossibleIssue(): void
     {
         $this->expectExceptionMessage('This element is not expected');
         $this->expectException(\Psalm\Exception\ConfigException::class);
@@ -637,7 +637,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testRequireVoidReturnTypeExists()
+    public function testRequireVoidReturnTypeExists(): void
     {
         $this->expectExceptionMessage('MissingReturnType');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -668,7 +668,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testDoNotRequireVoidReturnTypeExists()
+    public function testDoNotRequireVoidReturnTypeExists(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -697,7 +697,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testThing()
+    public function testThing(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -732,7 +732,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testExitFunctions()
+    public function testExitFunctions(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -802,7 +802,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testAllowedEchoFunction()
+    public function testAllowedEchoFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -826,7 +826,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testForbiddenEchoFunctionViaFunctions()
+    public function testForbiddenEchoFunctionViaFunctions(): void
     {
         $this->expectExceptionMessage('ForbiddenCode');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -856,7 +856,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testForbiddenEchoFunctionViaFlag()
+    public function testForbiddenEchoFunctionViaFlag(): void
     {
         $this->expectExceptionMessage('ForbiddenEcho');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -882,7 +882,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testAllowedPrintFunction()
+    public function testAllowedPrintFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -906,7 +906,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testForbiddenPrintFunction()
+    public function testForbiddenPrintFunction(): void
     {
         $this->expectExceptionMessage('ForbiddenCode');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -936,7 +936,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testAllowedVarExportFunction()
+    public function testAllowedVarExportFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -961,7 +961,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testForbiddenVarExportFunction()
+    public function testForbiddenVarExportFunction(): void
     {
         $this->expectExceptionMessage('ForbiddenCode');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -992,7 +992,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testValidThrowInvalidCatch()
+    public function testValidThrowInvalidCatch(): void
     {
         $this->expectExceptionMessage('InvalidCatch');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -1043,7 +1043,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testInvalidThrowValidCatch()
+    public function testInvalidThrowValidCatch(): void
     {
         $this->expectExceptionMessage('InvalidThrow');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -1094,7 +1094,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testValidThrowValidCatch()
+    public function testValidThrowValidCatch(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -1146,7 +1146,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     }
 
     /** @return void */
-    public function testModularConfig()
+    public function testModularConfig(): void
     {
         $root = __DIR__ . '/../fixtures/ModularConfig';
         $config = Config::loadFromXMLFile($root . '/psalm.xml', $root);
@@ -1174,7 +1174,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testGlobals()
+    public function testGlobals(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -1272,7 +1272,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testIgnoreExceptions()
+    public function testIgnoreExceptions(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -1351,7 +1351,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testGetPossiblePsr4Path()
+    public function testGetPossiblePsr4Path(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -1405,7 +1405,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testTakesPhpVersionFromConfigFile()
+    public function testTakesPhpVersionFromConfigFile(): void
     {
         $cfg = Config::loadFromXML(
             dirname(__DIR__, 2),
@@ -1417,7 +1417,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testReadsComposerJsonForPhpVersion()
+    public function testReadsComposerJsonForPhpVersion(): void
     {
 
         $root = __DIR__ . '/../fixtures/ComposerPhpVersion';
@@ -1429,7 +1429,7 @@ class ConfigTest extends \Psalm\Tests\TestCase
     }
 
     /** @return void */
-    public function testSetsUsePhpStormMetaPath()
+    public function testSetsUsePhpStormMetaPath(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -48,11 +48,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->file_provider = new Provider\FakeFileProvider();
     }
 
-    /**
-     * @param  Config $config
-     *
-     * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
-     */
     private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $p = new \Psalm\Internal\Analyzer\ProjectAnalyzer(
@@ -68,9 +63,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         return $p;
     }
 
-    /**
-     * @return void
-     */
     public function testBarebonesConfig(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -91,9 +83,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->assertFalse($config->isInProjectDirs(realpath('examples/StringAnalyzer.php')));
     }
 
-    /**
-     * @return void
-     */
     public function testIgnoreProjectDirectory(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -118,9 +107,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->assertFalse($config->isInProjectDirs(realpath('examples/StringAnalyzer.php')));
     }
 
-    /**
-     * @return void
-     */
     public function testIgnoreMissingProjectDirectory(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -216,9 +202,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function testIgnoreWildcardProjectDirectory(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -244,9 +227,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->assertFalse($config->isInProjectDirs(realpath('examples/StringAnalyzer.php')));
     }
 
-    /**
-     * @return void
-     */
     public function testIgnoreWildcardFiles(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -272,9 +252,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->assertFalse($config->isInProjectDirs(realpath('examples/StringAnalyzer.php')));
     }
 
-    /**
-     * @return void
-     */
     public function testIgnoreWildcardFilesInWildcardFolder(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -303,9 +280,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->assertTrue($config->isInProjectDirs(realpath('examples/plugins/StringChecker.php')));
     }
 
-    /**
-     * @return void
-     */
     public function testIgnoreWildcardFilesInAllPossibleWildcardFolders(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -334,9 +308,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->assertFalse($config->isInProjectDirs(realpath('examples/StringAnalyzer.php')));
     }
 
-    /**
-     * @return void
-     */
     public function testIssueHandler(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -362,9 +333,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->assertFalse($config->reportIssueInFile('MissingReturnType', realpath('src/Psalm/Type.php')));
     }
 
-    /**
-     * @return void
-     */
     public function testIssueHandlerWithCustomErrorLevels(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -573,9 +541,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testAllPossibleIssues(): void
     {
         $all_possible_handlers = implode(
@@ -610,9 +575,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testImpossibleIssue(): void
     {
         $this->expectExceptionMessage('This element is not expected');
@@ -634,9 +596,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testRequireVoidReturnTypeExists(): void
     {
         $this->expectExceptionMessage('MissingReturnType');
@@ -665,9 +624,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testDoNotRequireVoidReturnTypeExists(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -694,9 +650,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testThing(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -729,9 +682,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testExitFunctions(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -799,9 +749,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testAllowedEchoFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -823,9 +770,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testForbiddenEchoFunctionViaFunctions(): void
     {
         $this->expectExceptionMessage('ForbiddenCode');
@@ -853,9 +797,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testForbiddenEchoFunctionViaFlag(): void
     {
         $this->expectExceptionMessage('ForbiddenEcho');
@@ -879,9 +820,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testAllowedPrintFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -903,9 +841,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testForbiddenPrintFunction(): void
     {
         $this->expectExceptionMessage('ForbiddenCode');
@@ -933,9 +868,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testAllowedVarExportFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -958,9 +890,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testForbiddenVarExportFunction(): void
     {
         $this->expectExceptionMessage('ForbiddenCode');
@@ -989,9 +918,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testValidThrowInvalidCatch(): void
     {
         $this->expectExceptionMessage('InvalidCatch');
@@ -1040,9 +966,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testInvalidThrowValidCatch(): void
     {
         $this->expectExceptionMessage('InvalidThrow');
@@ -1091,9 +1014,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testValidThrowValidCatch(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -1145,7 +1065,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /** @return void */
     public function testModularConfig(): void
     {
         $root = __DIR__ . '/../fixtures/ModularConfig';
@@ -1171,9 +1090,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function testGlobals(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -1269,9 +1185,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testIgnoreExceptions(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -1348,9 +1261,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testGetPossiblePsr4Path(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -1402,9 +1312,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testTakesPhpVersionFromConfigFile(): void
     {
         $cfg = Config::loadFromXML(
@@ -1414,9 +1321,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->assertSame('7.1', $cfg->getPhpVersion());
     }
 
-    /**
-     * @return void
-     */
     public function testReadsComposerJsonForPhpVersion(): void
     {
 
@@ -1428,7 +1332,6 @@ class ConfigTest extends \Psalm\Tests\TestCase
         $this->assertSame('8.0', $cfg->getPhpVersion());
     }
 
-    /** @return void */
     public function testSetsUsePhpStormMetaPath(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(

--- a/tests/Config/CreatorTest.php
+++ b/tests/Config/CreatorTest.php
@@ -15,9 +15,6 @@ class CreatorTest extends \Psalm\Tests\TestCase
     {
     }
 
-    /**
-     * @return void
-     */
     public function testDiscoverLibDirectory(): void
     {
         $lib_contents = Creator::getContents(

--- a/tests/Config/CreatorTest.php
+++ b/tests/Config/CreatorTest.php
@@ -18,7 +18,7 @@ class CreatorTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testDiscoverLibDirectory()
+    public function testDiscoverLibDirectory(): void
     {
         $lib_contents = Creator::getContents(
             dirname(__DIR__, 1)

--- a/tests/Config/Plugin/Hook/FooMethodProvider.php
+++ b/tests/Config/Plugin/Hook/FooMethodProvider.php
@@ -59,7 +59,6 @@ class FooMethodProvider implements
     /**
      * @param  array<PhpParser\Node\Arg>    $call_args
      *
-     * @return ?Type\Union
      */
     public static function getMethodReturnType(
         StatementsSource $source,

--- a/tests/Config/Plugin/Hook/FooMethodProvider.php
+++ b/tests/Config/Plugin/Hook/FooMethodProvider.php
@@ -71,7 +71,7 @@ class FooMethodProvider implements
         ?array $template_type_parameters = null,
         ?string $called_fq_classlike_name = null,
         ?string $called_method_name_lowercase = null
-    ) {
+    ): ?Type\Union {
         if ($method_name_lowercase == 'magicmethod') {
             return Type::getString();
         } else {

--- a/tests/Config/Plugin/Hook/FooPropertyProvider.php
+++ b/tests/Config/Plugin/Hook/FooPropertyProvider.php
@@ -33,7 +33,7 @@ class FooPropertyProvider implements
         ?StatementsSource $source = null,
         ?Context $context = null,
         ?CodeLocation $code_location = null
-    ) {
+    ): ?bool {
         return $property_name === 'magic_property';
     }
 
@@ -47,7 +47,7 @@ class FooPropertyProvider implements
         bool $read_mode,
         ?Context $context = null,
         ?CodeLocation $code_location = null
-    ) {
+    ): ?bool {
         return true;
     }
 
@@ -62,7 +62,7 @@ class FooPropertyProvider implements
         bool $read_mode,
         ?StatementsSource $source = null,
         ?Context $context = null
-    ) {
+    ): ?Type\Union {
         return Type::getString();
     }
 }

--- a/tests/Config/Plugin/Hook/FooPropertyProvider.php
+++ b/tests/Config/Plugin/Hook/FooPropertyProvider.php
@@ -23,9 +23,6 @@ class FooPropertyProvider implements
         return ['Ns\Foo'];
     }
 
-    /**
-     * @return ?bool
-     */
     public static function doesPropertyExist(
         string $fq_classlike_name,
         string $property_name,
@@ -37,9 +34,6 @@ class FooPropertyProvider implements
         return $property_name === 'magic_property';
     }
 
-    /**
-     * @return ?bool
-     */
     public static function isPropertyVisible(
         StatementsSource $source,
         string $fq_classlike_name,
@@ -54,7 +48,6 @@ class FooPropertyProvider implements
     /**
      * @param  array<PhpParser\Node\Arg>    $call_args
      *
-     * @return ?Type\Union
      */
     public static function getPropertyType(
         string $fq_classlike_name,

--- a/tests/Config/Plugin/Hook/MagicFunctionProvider.php
+++ b/tests/Config/Plugin/Hook/MagicFunctionProvider.php
@@ -30,7 +30,7 @@ class MagicFunctionProvider implements
         StatementsSource $statements_source,
         string $function_id,
         ?CodeLocation $code_location = null
-    ) {
+    ): ?bool {
         return $function_id === 'magicfunction';
     }
 
@@ -45,7 +45,7 @@ class MagicFunctionProvider implements
         array $call_args,
         ?Context $context = null,
         ?CodeLocation $code_location = null
-    ) {
+    ): ?array {
         return [new \Psalm\Storage\FunctionLikeParameter('first', false, Type::getString())];
     }
 
@@ -60,7 +60,7 @@ class MagicFunctionProvider implements
         array $call_args,
         Context $context,
         CodeLocation $code_location
-    ) {
+    ): ?Type\Union {
         return Type::getString();
     }
 }

--- a/tests/Config/Plugin/Hook/MagicFunctionProvider.php
+++ b/tests/Config/Plugin/Hook/MagicFunctionProvider.php
@@ -23,9 +23,6 @@ class MagicFunctionProvider implements
         return ['magicfunction'];
     }
 
-    /**
-     * @return ?bool
-     */
     public static function doesFunctionExist(
         StatementsSource $statements_source,
         string $function_id,
@@ -52,7 +49,6 @@ class MagicFunctionProvider implements
     /**
      * @param  array<PhpParser\Node\Arg>    $call_args
      *
-     * @return ?Type\Union
      */
     public static function getFunctionReturnType(
         StatementsSource $statements_source,

--- a/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
+++ b/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
@@ -11,7 +11,7 @@ class TSqlSelectString extends \Psalm\Type\Atomic\TLiteralString
     /**
      * @return string
      */
-    public function getId(bool $nested = true)
+    public function getId(bool $nested = true): string
     {
         return 'sql-select-string(' . $this->value . ')';
     }
@@ -19,7 +19,7 @@ class TSqlSelectString extends \Psalm\Type\Atomic\TLiteralString
     /**
      * @return bool
      */
-    public function canBeFullyExpressedInPhp()
+    public function canBeFullyExpressedInPhp(): bool
     {
         return false;
     }

--- a/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
+++ b/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
@@ -8,17 +8,11 @@ class TSqlSelectString extends \Psalm\Type\Atomic\TLiteralString
         return 'sql-select-string';
     }
 
-    /**
-     * @return string
-     */
     public function getId(bool $nested = true): string
     {
         return 'sql-select-string(' . $this->value . ')';
     }
 
-    /**
-     * @return bool
-     */
     public function canBeFullyExpressedInPhp(): bool
     {
         return false;

--- a/tests/Config/PluginListTest.php
+++ b/tests/Config/PluginListTest.php
@@ -41,7 +41,7 @@ class PluginListTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function pluginsPresentInConfigAreEnabled()
+    public function pluginsPresentInConfigAreEnabled(): void
     {
         $this->config->getPluginClasses()->willReturn([
             ['class' => 'a\b\c', 'config' => null],
@@ -60,7 +60,7 @@ class PluginListTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function pluginsPresentInPackageLockOnlyAreAvailable()
+    public function pluginsPresentInPackageLockOnlyAreAvailable(): void
     {
         $this->config->getPluginClasses()->willReturn([
             ['class' => 'a\b\c', 'config' => null],
@@ -82,7 +82,7 @@ class PluginListTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function pluginsPresentInPackageLockAndConfigHavePluginPackageName()
+    public function pluginsPresentInPackageLockAndConfigHavePluginPackageName(): void
     {
         $this->config->getPluginClasses()->willReturn([
             ['class' => 'a\b\c', 'config' => null],
@@ -103,7 +103,7 @@ class PluginListTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function canFindPluginClassByClassName()
+    public function canFindPluginClassByClassName(): void
     {
         $plugin_list = new PluginList($this->config_file->reveal(), $this->composer_lock->reveal());
         $this->assertSame('a\b\c', $plugin_list->resolvePluginClass('a\b\c'));
@@ -113,7 +113,7 @@ class PluginListTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function canFindPluginClassByPackageName()
+    public function canFindPluginClassByPackageName(): void
     {
         $this->composer_lock->getPlugins()->willReturn([
             'vendor/package' => 'a\b\c',
@@ -127,7 +127,7 @@ class PluginListTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function enabledPackageIsEnabled()
+    public function enabledPackageIsEnabled(): void
     {
         $this->config->getPluginClasses()->willReturn([
             ['class' => 'a\b\c', 'config' => null],
@@ -142,7 +142,7 @@ class PluginListTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function errorsOutWhenTryingToResolveUnknownPlugin()
+    public function errorsOutWhenTryingToResolveUnknownPlugin(): void
     {
         $plugin_list = new PluginList($this->config_file->reveal(), $this->composer_lock->reveal());
         $this->expectException(\InvalidArgumentException::class);
@@ -154,7 +154,7 @@ class PluginListTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function pluginsAreEnabledInConfigFile()
+    public function pluginsAreEnabledInConfigFile(): void
     {
         $plugin_list = new PluginList($this->config_file->reveal(), $this->composer_lock->reveal());
 
@@ -167,7 +167,7 @@ class PluginListTest extends \Psalm\Tests\TestCase
      * @return void
      * @test
      */
-    public function pluginsAreDisabledInConfigFile()
+    public function pluginsAreDisabledInConfigFile(): void
     {
         $plugin_list = new PluginList($this->config_file->reveal(), $this->composer_lock->reveal());
 

--- a/tests/Config/PluginListTest.php
+++ b/tests/Config/PluginListTest.php
@@ -38,7 +38,6 @@ class PluginListTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function pluginsPresentInConfigAreEnabled(): void
@@ -57,7 +56,6 @@ class PluginListTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function pluginsPresentInPackageLockOnlyAreAvailable(): void
@@ -79,7 +77,6 @@ class PluginListTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function pluginsPresentInPackageLockAndConfigHavePluginPackageName(): void
@@ -100,7 +97,6 @@ class PluginListTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function canFindPluginClassByClassName(): void
@@ -110,7 +106,6 @@ class PluginListTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function canFindPluginClassByPackageName(): void
@@ -124,7 +119,6 @@ class PluginListTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function enabledPackageIsEnabled(): void
@@ -139,7 +133,6 @@ class PluginListTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function errorsOutWhenTryingToResolveUnknownPlugin(): void
@@ -151,7 +144,6 @@ class PluginListTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function pluginsAreEnabledInConfigFile(): void
@@ -164,7 +156,6 @@ class PluginListTest extends \Psalm\Tests\TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function pluginsAreDisabledInConfigFile(): void

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -58,7 +58,7 @@ class PluginTest extends \Psalm\Tests\TestCase
      *
      * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
      */
-    private function getProjectAnalyzerWithConfig(Config $config)
+    private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $config->setIncludeCollector(new IncludeCollector());
         return new \Psalm\Internal\Analyzer\ProjectAnalyzer(
@@ -74,7 +74,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testStringAnalyzerPlugin()
+    public function testStringAnalyzerPlugin(): void
     {
         $this->expectExceptionMessage('InvalidClass');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -111,7 +111,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testStringAnalyzerPluginWithClassConstant()
+    public function testStringAnalyzerPluginWithClassConstant(): void
     {
         $this->expectExceptionMessage('InvalidClass');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -152,7 +152,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testStringAnalyzerPluginWithClassConstantConcat()
+    public function testStringAnalyzerPluginWithClassConstantConcat(): void
     {
         $this->expectExceptionMessage('UndefinedMethod');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -195,7 +195,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testEchoAnalyzerPluginWithJustHtml()
+    public function testEchoAnalyzerPluginWithJustHtml(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -229,7 +229,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testEchoAnalyzerPluginWithUnescapedConcatenatedString()
+    public function testEchoAnalyzerPluginWithUnescapedConcatenatedString(): void
     {
         $this->expectExceptionMessage('TypeCoercion');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -270,7 +270,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testEchoAnalyzerPluginWithUnescapedString()
+    public function testEchoAnalyzerPluginWithUnescapedString(): void
     {
         $this->expectExceptionMessage('TypeCoercion');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -310,7 +310,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testEchoAnalyzerPluginWithEscapedString()
+    public function testEchoAnalyzerPluginWithEscapedString(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -362,7 +362,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testFileAnalyzerPlugin()
+    public function testFileAnalyzerPlugin(): void
     {
         require_once __DIR__ . '/Plugin/FilePlugin.php';
 
@@ -413,7 +413,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testFloatCheckerPlugin()
+    public function testFloatCheckerPlugin(): void
     {
         $this->expectExceptionMessage('NoFloatAssignment');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -451,7 +451,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testFloatCheckerPluginIssueSuppressionByConfig()
+    public function testFloatCheckerPluginIssueSuppressionByConfig(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -492,7 +492,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testFloatCheckerPluginIssueSuppressionByDocblock()
+    public function testFloatCheckerPluginIssueSuppressionByDocblock(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -527,7 +527,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     }
 
     /** @return void */
-    public function testInheritedHookHandlersAreCalled()
+    public function testInheritedHookHandlersAreCalled(): void
     {
         require_once dirname(__DIR__) . '/fixtures/stubs/extending_plugin_entrypoint.php';
 
@@ -556,7 +556,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     }
 
     /** @return void */
-    public function testAfterCodebasePopulatedHookIsLoaded()
+    public function testAfterCodebasePopulatedHookIsLoaded(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -592,7 +592,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     }
 
     /** @return void */
-    public function testPropertyProviderHooks()
+    public function testPropertyProviderHooks(): void
     {
         require_once __DIR__ . '/Plugin/PropertyPlugin.php';
 
@@ -632,7 +632,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     }
 
     /** @return void */
-    public function testMethodProviderHooksValidArg()
+    public function testMethodProviderHooksValidArg(): void
     {
         require_once __DIR__ . '/Plugin/MethodPlugin.php';
 
@@ -694,7 +694,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     }
 
     /** @return void */
-    public function testFunctionProviderHooks()
+    public function testFunctionProviderHooks(): void
     {
         require_once __DIR__ . '/Plugin/FunctionPlugin.php';
 
@@ -729,7 +729,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     }
 
     /** @return void */
-    public function testSqlStringProviderHooks()
+    public function testSqlStringProviderHooks(): void
     {
         require_once __DIR__ . '/Plugin/SqlStringProviderPlugin.php';
 
@@ -773,7 +773,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testPropertyProviderHooksInvalidAssignment()
+    public function testPropertyProviderHooksInvalidAssignment(): void
     {
         $this->expectExceptionMessage('InvalidPropertyAssignmentValue');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -817,7 +817,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testMethodProviderHooksInvalidArg()
+    public function testMethodProviderHooksInvalidArg(): void
     {
         $this->expectExceptionMessage('InvalidScalarArgument');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -863,7 +863,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testFunctionProviderHooksInvalidArg()
+    public function testFunctionProviderHooksInvalidArg(): void
     {
         $this->expectExceptionMessage('InvalidScalarArgument');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -902,7 +902,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testAfterAnalysisHooks()
+    public function testAfterAnalysisHooks(): void
     {
         require_once __DIR__ . '/Plugin/AfterAnalysisPlugin.php';
 
@@ -938,7 +938,7 @@ class PluginTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testPluginFilenameCanBeAbsolute()
+    public function testPluginFilenameCanBeAbsolute(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -53,11 +53,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->file_provider = new Provider\FakeFileProvider();
     }
 
-    /**
-     * @param  Config $config
-     *
-     * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
-     */
     private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $config->setIncludeCollector(new IncludeCollector());
@@ -71,9 +66,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testStringAnalyzerPlugin(): void
     {
         $this->expectExceptionMessage('InvalidClass');
@@ -108,9 +100,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStringAnalyzerPluginWithClassConstant(): void
     {
         $this->expectExceptionMessage('InvalidClass');
@@ -149,9 +138,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStringAnalyzerPluginWithClassConstantConcat(): void
     {
         $this->expectExceptionMessage('UndefinedMethod');
@@ -192,9 +178,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEchoAnalyzerPluginWithJustHtml(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -226,9 +209,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEchoAnalyzerPluginWithUnescapedConcatenatedString(): void
     {
         $this->expectExceptionMessage('TypeCoercion');
@@ -267,9 +247,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEchoAnalyzerPluginWithUnescapedString(): void
     {
         $this->expectExceptionMessage('TypeCoercion');
@@ -307,9 +284,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testEchoAnalyzerPluginWithEscapedString(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -359,9 +333,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testFileAnalyzerPlugin(): void
     {
         require_once __DIR__ . '/Plugin/FilePlugin.php';
@@ -410,9 +381,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testFloatCheckerPlugin(): void
     {
         $this->expectExceptionMessage('NoFloatAssignment');
@@ -448,9 +416,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testFloatCheckerPluginIssueSuppressionByConfig(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -489,9 +454,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testFloatCheckerPluginIssueSuppressionByDocblock(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -526,7 +488,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /** @return void */
     public function testInheritedHookHandlersAreCalled(): void
     {
         require_once dirname(__DIR__) . '/fixtures/stubs/extending_plugin_entrypoint.php';
@@ -555,7 +516,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         );
     }
 
-    /** @return void */
     public function testAfterCodebasePopulatedHookIsLoaded(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -591,7 +551,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         );
     }
 
-    /** @return void */
     public function testPropertyProviderHooks(): void
     {
         require_once __DIR__ . '/Plugin/PropertyPlugin.php';
@@ -631,7 +590,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /** @return void */
     public function testMethodProviderHooksValidArg(): void
     {
         require_once __DIR__ . '/Plugin/MethodPlugin.php';
@@ -693,7 +651,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /** @return void */
     public function testFunctionProviderHooks(): void
     {
         require_once __DIR__ . '/Plugin/FunctionPlugin.php';
@@ -728,7 +685,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /** @return void */
     public function testSqlStringProviderHooks(): void
     {
         require_once __DIR__ . '/Plugin/SqlStringProviderPlugin.php';
@@ -770,9 +726,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function testPropertyProviderHooksInvalidAssignment(): void
     {
         $this->expectExceptionMessage('InvalidPropertyAssignmentValue');
@@ -814,9 +767,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testMethodProviderHooksInvalidArg(): void
     {
         $this->expectExceptionMessage('InvalidScalarArgument');
@@ -860,9 +810,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testFunctionProviderHooksInvalidArg(): void
     {
         $this->expectExceptionMessage('InvalidScalarArgument');
@@ -899,9 +846,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testAfterAnalysisHooks(): void
     {
         require_once __DIR__ . '/Plugin/AfterAnalysisPlugin.php';
@@ -935,9 +879,6 @@ class PluginTest extends \Psalm\Tests\TestCase
         ob_end_clean();
     }
 
-    /**
-     * @return void
-     */
     public function testPluginFilenameCanBeAbsolute(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -9,7 +9,7 @@ class ConstantTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'constantInFunction' => [
@@ -985,7 +985,7 @@ class ConstantTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'constantDefinedInFunctionButNotCalled' => [

--- a/tests/DeprecatedAnnotationTest.php
+++ b/tests/DeprecatedAnnotationTest.php
@@ -9,7 +9,7 @@ class DeprecatedAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'deprecatedMethod' => [
@@ -94,7 +94,7 @@ class DeprecatedAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'deprecatedMethodWithCall' => [

--- a/tests/DocblockInheritanceTest.php
+++ b/tests/DocblockInheritanceTest.php
@@ -13,7 +13,7 @@ class DocblockInheritanceTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'inheritParentReturnDocbblock' => [
@@ -110,7 +110,7 @@ class DocblockInheritanceTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'automaticInheritDoc' => [

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -117,9 +117,6 @@ class DocumentationTest extends TestCase
         $this->assertSame(implode("\n", $all_issues), implode("\n", $handler_types));
     }
 
-    /**
-     * @return void
-     */
     public function testAllIssuesCovered(): void
     {
         $all_issues = \Psalm\Config\IssueHandler::getAllIssueTypes();
@@ -151,7 +148,6 @@ class DocumentationTest extends TestCase
      * @param array<string> $error_levels
      * @param bool $check_references
      *
-     * @return void
      */
     public function testInvalidCode($code, $error_message, $error_levels = [], $check_references = false): void
     {

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -38,7 +38,7 @@ class DocumentationTest extends TestCase
     /**
      * @return array<string, array<int, string>>
      */
-    private static function getCodeBlocksFromDocs()
+    private static function getCodeBlocksFromDocs(): array
     {
         $issues_dir = dirname(dirname(__FILE__)) . DIRECTORY_SEPARATOR . 'docs' . DIRECTORY_SEPARATOR . 'running_psalm' . DIRECTORY_SEPARATOR . 'issues';
 
@@ -120,7 +120,7 @@ class DocumentationTest extends TestCase
     /**
      * @return void
      */
-    public function testAllIssuesCovered()
+    public function testAllIssuesCovered(): void
     {
         $all_issues = \Psalm\Config\IssueHandler::getAllIssueTypes();
         $all_issues[] = 'ParseError';
@@ -153,7 +153,7 @@ class DocumentationTest extends TestCase
      *
      * @return void
      */
-    public function testInvalidCode($code, $error_message, $error_levels = [], $check_references = false)
+    public function testInvalidCode($code, $error_message, $error_levels = [], $check_references = false): void
     {
         if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
@@ -190,7 +190,7 @@ class DocumentationTest extends TestCase
     /**
      * @return array<string,array{string,string,string[],bool}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): array
     {
         $invalid_code_data = [];
 
@@ -274,7 +274,7 @@ class DocumentationTest extends TestCase
 
         $duplicate_shortcodes = array_filter(
             $all_shortcodes,
-            function ($issues) {
+            function ($issues): bool {
                 return count($issues) > 1;
             }
         );

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -9,7 +9,7 @@ class EnumTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'enumStringOrEnumIntCorrect' => [
@@ -107,7 +107,7 @@ class EnumTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'enumStringOrEnumIntIncorrectString' => [

--- a/tests/ExtendsFinalClassTest.php
+++ b/tests/ExtendsFinalClassTest.php
@@ -10,7 +10,7 @@ class ExtendsFinalClassTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'suppressingIssueWhenUsedWithKeyword' => [
@@ -42,7 +42,7 @@ class ExtendsFinalClassTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidExtendsFinalClass' => [

--- a/tests/FileDiffTest.php
+++ b/tests/FileDiffTest.php
@@ -26,7 +26,7 @@ class FileDiffTest extends TestCase
         array $same_signatures,
         array $changed_methods,
         array $diff_map_offsets
-    ) {
+    ): void {
         if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
         }
@@ -59,7 +59,7 @@ class FileDiffTest extends TestCase
              *
              * @return array{0: int, 1: int}
              */
-            function (array $arr) {
+            function (array $arr): array {
                 return [$arr[2], $arr[3]];
             },
             $diff[3]
@@ -87,7 +87,7 @@ class FileDiffTest extends TestCase
         array $same_signatures,
         array $changed_methods,
         array $diff_map_offsets
-    ) {
+    ): void {
         if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
         }
@@ -134,7 +134,7 @@ class FileDiffTest extends TestCase
              *
              * @return array{0: int, 1: int}
              */
-            function (array $arr) {
+            function (array $arr): array {
                 return [$arr[2], $arr[3]];
             },
             $diff[3]
@@ -149,7 +149,7 @@ class FileDiffTest extends TestCase
      *
      * @return void
      */
-    private function assertTreesEqual(array $a, array $b)
+    private function assertTreesEqual(array $a, array $b): void
     {
         $this->assertSame(count($a), count($b));
 
@@ -204,7 +204,7 @@ class FileDiffTest extends TestCase
     /**
      * @return array<string,array{string,string,string[],string[],string[],array<array-key,array{int,int}>}>
      */
-    public function getChanges()
+    public function getChanges(): array
     {
         return [
             'sameFile' => [

--- a/tests/FileDiffTest.php
+++ b/tests/FileDiffTest.php
@@ -13,11 +13,8 @@ class FileDiffTest extends TestCase
     /**
      * @dataProvider getChanges
      *
-     * @param string $a
-     * @param string $b
      * @param string[] $same_methods
      *
-     * @return void
      */
     public function testCode(
         string $a,
@@ -71,14 +68,11 @@ class FileDiffTest extends TestCase
     /**
      * @dataProvider getChanges
      *
-     * @param string $a
-     * @param string $b
      * @param string[] $same_methods
      * @param string[] $same_signatures
      * @param string[] $changed_methods
      * @param array<array-key,array{int,int}> $diff_map_offsets
      *
-     * @return void
      */
     public function testPartialAstDiff(
         string $a,
@@ -147,7 +141,6 @@ class FileDiffTest extends TestCase
      * @param  array<int, PhpParser\Node\Stmt>  $a
      * @param  array<int, PhpParser\Node\Stmt>  $b
      *
-     * @return void
      */
     private function assertTreesEqual(array $a, array $b): void
     {

--- a/tests/FileManipulation/ClassConstantMoveTest.php
+++ b/tests/FileManipulation/ClassConstantMoveTest.php
@@ -23,12 +23,9 @@ class ClassConstantMoveTest extends \Psalm\Tests\TestCase
     /**
      * @dataProvider providerValidCodeParse
      *
-     * @param string $input_code
-     * @param string $output_code
      * @param array<string, string> $constants_to_move
      * @param array<string, string> $call_transforms
      *
-     * @return void
      */
     public function testValidCode(
         string $input_code,

--- a/tests/FileManipulation/ClassConstantMoveTest.php
+++ b/tests/FileManipulation/ClassConstantMoveTest.php
@@ -34,7 +34,7 @@ class ClassConstantMoveTest extends \Psalm\Tests\TestCase
         string $input_code,
         string $output_code,
         array $constants_to_move
-    ) {
+    ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
@@ -77,7 +77,7 @@ class ClassConstantMoveTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{string,string,array<string, string>}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'moveSimpleClassConstant' => [

--- a/tests/FileManipulation/ClassMoveTest.php
+++ b/tests/FileManipulation/ClassMoveTest.php
@@ -34,7 +34,7 @@ class ClassMoveTest extends \Psalm\Tests\TestCase
         string $input_code,
         string $output_code,
         array $constants_to_move
-    ) {
+    ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
@@ -77,7 +77,7 @@ class ClassMoveTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{string,string,array<string, string>}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'renameEmptyClass' => [

--- a/tests/FileManipulation/ClassMoveTest.php
+++ b/tests/FileManipulation/ClassMoveTest.php
@@ -23,12 +23,9 @@ class ClassMoveTest extends \Psalm\Tests\TestCase
     /**
      * @dataProvider providerValidCodeParse
      *
-     * @param string $input_code
-     * @param string $output_code
      * @param array<string, string> $constants_to_move
      * @param array<string, string> $call_transforms
      *
-     * @return void
      */
     public function testValidCode(
         string $input_code,

--- a/tests/FileManipulation/FileManipulationTest.php
+++ b/tests/FileManipulation/FileManipulationTest.php
@@ -28,9 +28,7 @@ abstract class FileManipulationTest extends \Psalm\Tests\TestCase
      * @param string $php_version
      * @param string[] $issues_to_fix
      * @param bool $safe_types
-     * @param bool $allow_backwards_incompatible_changes
      *
-     * @return void
      */
     public function testValidCode(
         $input_code,

--- a/tests/FileManipulation/FileManipulationTest.php
+++ b/tests/FileManipulation/FileManipulationTest.php
@@ -39,7 +39,7 @@ abstract class FileManipulationTest extends \Psalm\Tests\TestCase
         array $issues_to_fix,
         $safe_types,
         bool $allow_backwards_incompatible_changes = true
-    ) {
+    ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
@@ -97,5 +97,5 @@ abstract class FileManipulationTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{string,string,string,string[],bool}>
      */
-    abstract public function providerValidCodeParse();
+    abstract public function providerValidCodeParse(): array;
 }

--- a/tests/FileManipulation/ImmutableAnnotationAdditionTest.php
+++ b/tests/FileManipulation/ImmutableAnnotationAdditionTest.php
@@ -6,7 +6,7 @@ class ImmutableAnnotationAdditionTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'addPureAnnotationToFunction' => [

--- a/tests/FileManipulation/MethodMoveTest.php
+++ b/tests/FileManipulation/MethodMoveTest.php
@@ -34,7 +34,7 @@ class MethodMoveTest extends \Psalm\Tests\TestCase
         string $input_code,
         string $output_code,
         array $methods_to_move
-    ) {
+    ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
@@ -77,7 +77,7 @@ class MethodMoveTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{string,string,array<string, string>}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'moveSimpleStaticMethodWithForeachIterator' => [

--- a/tests/FileManipulation/MethodMoveTest.php
+++ b/tests/FileManipulation/MethodMoveTest.php
@@ -23,12 +23,9 @@ class MethodMoveTest extends \Psalm\Tests\TestCase
     /**
      * @dataProvider providerValidCodeParse
      *
-     * @param string $input_code
-     * @param string $output_code
      * @param array<string, string> $methods_to_move
      * @param array<string, string> $call_transforms
      *
-     * @return void
      */
     public function testValidCode(
         string $input_code,

--- a/tests/FileManipulation/MissingPropertyTypeTest.php
+++ b/tests/FileManipulation/MissingPropertyTypeTest.php
@@ -6,7 +6,7 @@ class MissingPropertyTypeTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool,5?:bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'addMissingUnionType56' => [

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -6,7 +6,7 @@ class MissingReturnTypeTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool,5?:bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'addMissingVoidReturnType56' => [

--- a/tests/FileManipulation/NamespaceMoveTest.php
+++ b/tests/FileManipulation/NamespaceMoveTest.php
@@ -34,7 +34,7 @@ class NamespaceMoveTest extends \Psalm\Tests\TestCase
         string $input_code,
         string $output_code,
         array $namespaces_to_move
-    ) {
+    ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
@@ -77,7 +77,7 @@ class NamespaceMoveTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{string,string,array<string, string>}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'moveClassesIntoNamespace' => [

--- a/tests/FileManipulation/NamespaceMoveTest.php
+++ b/tests/FileManipulation/NamespaceMoveTest.php
@@ -23,12 +23,9 @@ class NamespaceMoveTest extends \Psalm\Tests\TestCase
     /**
      * @dataProvider providerValidCodeParse
      *
-     * @param string $input_code
-     * @param string $output_code
      * @param array<string, string> $namespaces_to_move
      * @param array<string, string> $call_transforms
      *
-     * @return void
      */
     public function testValidCode(
         string $input_code,

--- a/tests/FileManipulation/ParamNameMismatchTest.php
+++ b/tests/FileManipulation/ParamNameMismatchTest.php
@@ -6,7 +6,7 @@ class ParamNameMismatchTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'fixMismatchingParamName74' => [

--- a/tests/FileManipulation/ParamTypeManipulationTest.php
+++ b/tests/FileManipulation/ParamTypeManipulationTest.php
@@ -6,7 +6,7 @@ class ParamTypeManipulationTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'fixMismatchingDocblockParamType70' => [

--- a/tests/FileManipulation/PropertyMoveTest.php
+++ b/tests/FileManipulation/PropertyMoveTest.php
@@ -23,12 +23,9 @@ class PropertyMoveTest extends \Psalm\Tests\TestCase
     /**
      * @dataProvider providerValidCodeParse
      *
-     * @param string $input_code
-     * @param string $output_code
      * @param array<string, string> $properties_to_move
      * @param array<string, string> $call_transforms
      *
-     * @return void
      */
     public function testValidCode(
         string $input_code,

--- a/tests/FileManipulation/PropertyMoveTest.php
+++ b/tests/FileManipulation/PropertyMoveTest.php
@@ -34,7 +34,7 @@ class PropertyMoveTest extends \Psalm\Tests\TestCase
         string $input_code,
         string $output_code,
         array $properties_to_move
-    ) {
+    ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
@@ -77,7 +77,7 @@ class PropertyMoveTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{string,string,array<string, string>}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'moveSimpleStaticProperty' => [

--- a/tests/FileManipulation/PureAnnotationAdditionTest.php
+++ b/tests/FileManipulation/PureAnnotationAdditionTest.php
@@ -6,7 +6,7 @@ class PureAnnotationAdditionTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'addPureAnnotationToFunction' => [

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -6,7 +6,7 @@ class ReturnTypeManipulationTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool,5?:bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'addMissingClosureStringReturnType56' => [

--- a/tests/FileManipulation/UndefinedVariableManipulationTest.php
+++ b/tests/FileManipulation/UndefinedVariableManipulationTest.php
@@ -8,7 +8,7 @@ class UndefinedVariableManipulationTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'possiblyUndefinedVariable' => [

--- a/tests/FileManipulation/UnnecessaryVarAnnotationManipulationTest.php
+++ b/tests/FileManipulation/UnnecessaryVarAnnotationManipulationTest.php
@@ -6,7 +6,7 @@ class UnnecessaryVarAnnotationManipulationTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'removeSingleLineVarAnnotation' => [

--- a/tests/FileManipulation/UnusedCodeManipulationTest.php
+++ b/tests/FileManipulation/UnusedCodeManipulationTest.php
@@ -6,7 +6,7 @@ class UnusedCodeManipulationTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'removePossiblyUnusedMethod' => [

--- a/tests/FileManipulation/UnusedVariableManipulationTest.php
+++ b/tests/FileManipulation/UnusedVariableManipulationTest.php
@@ -6,7 +6,7 @@ class UnusedVariableManipulationTest extends FileManipulationTest
     /**
      * @return array<string,array{string,string,string,string[],bool}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'removeUnusedVariableSimple' => [

--- a/tests/FileReferenceTest.php
+++ b/tests/FileReferenceTest.php
@@ -40,7 +40,7 @@ class FileReferenceTest extends TestCase
      *
      * @return void
      */
-    public function testReferenceLocations($input_code, $symbol, $expected_locations)
+    public function testReferenceLocations($input_code, $symbol, $expected_locations): void
     {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
@@ -91,7 +91,7 @@ class FileReferenceTest extends TestCase
         array $expected_method_references_to_missing_members,
         array $expected_file_references_to_members,
         array $expected_file_references_to_missing_members
-    ) {
+    ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
@@ -125,7 +125,7 @@ class FileReferenceTest extends TestCase
     /**
      * @return array<string,array{string,string,array<int,string>}>
      */
-    public function providerReferenceLocations()
+    public function providerReferenceLocations(): array
     {
         return [
             'getClassLocation' => [
@@ -158,7 +158,7 @@ class FileReferenceTest extends TestCase
      *              4: array<string,array<string,bool>>
      * }>
      */
-    public function providerReferencedMethods()
+    public function providerReferencedMethods(): array
     {
         return [
             'getClassReferences' => [

--- a/tests/FileReferenceTest.php
+++ b/tests/FileReferenceTest.php
@@ -38,7 +38,6 @@ class FileReferenceTest extends TestCase
      * @param string $symbol
      * @param array<int, string> $expected_locations
      *
-     * @return void
      */
     public function testReferenceLocations($input_code, $symbol, $expected_locations): void
     {
@@ -77,13 +76,11 @@ class FileReferenceTest extends TestCase
     /**
      * @dataProvider providerReferencedMethods
      *
-     * @param string $input_code
      * @param array<string,array<string,bool>> $expected_method_references_to_members
      * @param array<string,array<string,bool>> $expected_file_references_to_members
      * @param array<string,array<string,bool>> $expected_method_references_to_missing_members
      * @param array<string,array<string,bool>> $expected_file_references_to_missing_members
      *
-     * @return void
      */
     public function testReferencedMethods(
         string $input_code,

--- a/tests/FileUpdates/AnalyzedMethodTest.php
+++ b/tests/FileUpdates/AnalyzedMethodTest.php
@@ -44,7 +44,6 @@ class AnalyzedMethodTest extends \Psalm\Tests\TestCase
      * @param array<string, string> $end_files
      * @param array<string, string> $error_levels
      *
-     * @return void
      */
     public function testValidInclude(
         array $start_files,

--- a/tests/FileUpdates/AnalyzedMethodTest.php
+++ b/tests/FileUpdates/AnalyzedMethodTest.php
@@ -52,7 +52,7 @@ class AnalyzedMethodTest extends \Psalm\Tests\TestCase
         array $initial_analyzed_methods,
         array $unaffected_analyzed_methods,
         array $error_levels = []
-    ) {
+    ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
@@ -104,7 +104,7 @@ class AnalyzedMethodTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{start_files:array<string,string>,end_files:array<string,string>,initial_analyzed_methods:array<string,array<string,int>>,unaffected_analyzed_methods:array<string,array<string,int>>,4?:array<string,string>}>
      */
-    public function providerTestValidUpdates()
+    public function providerTestValidUpdates(): array
     {
         return [
             'basicRequire' => [

--- a/tests/FileUpdates/CachedStorageTest.php
+++ b/tests/FileUpdates/CachedStorageTest.php
@@ -37,9 +37,6 @@ class CachedStorageTest extends \Psalm\Tests\TestCase
         $this->project_analyzer->setPhpVersion('7.3');
     }
 
-    /**
-     * @return void
-     */
     public function testValidInclude(): void
     {
         $test_name = $this->getTestName();

--- a/tests/FileUpdates/CachedStorageTest.php
+++ b/tests/FileUpdates/CachedStorageTest.php
@@ -40,7 +40,7 @@ class CachedStorageTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testValidInclude()
+    public function testValidInclude(): void
     {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {

--- a/tests/FileUpdates/ErrorAfterUpdateTest.php
+++ b/tests/FileUpdates/ErrorAfterUpdateTest.php
@@ -44,7 +44,6 @@ class ErrorAfterUpdateTest extends \Psalm\Tests\TestCase
      * @param array<int, array<string, string>> $file_stages
      * @param array<string, string> $error_levels
      *
-     * @return void
      */
     public function testErrorAfterUpdate(
         array $file_stages,

--- a/tests/FileUpdates/ErrorAfterUpdateTest.php
+++ b/tests/FileUpdates/ErrorAfterUpdateTest.php
@@ -50,7 +50,7 @@ class ErrorAfterUpdateTest extends \Psalm\Tests\TestCase
         array $file_stages,
         string $error_message,
         array $error_levels = []
-    ) {
+    ): void {
         $this->project_analyzer->getCodebase()->diff_methods = true;
         $this->project_analyzer->getCodebase()->reportUnusedCode();
 
@@ -97,7 +97,7 @@ class ErrorAfterUpdateTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{file_stages:array<int,array<string,string>>,error_message:string}>
      */
-    public function providerTestInvalidUpdates()
+    public function providerTestInvalidUpdates(): array
     {
         return [
             'invalidateParentCaller' => [

--- a/tests/FileUpdates/ErrorFixTest.php
+++ b/tests/FileUpdates/ErrorFixTest.php
@@ -45,7 +45,6 @@ class ErrorFixTest extends \Psalm\Tests\TestCase
      * @param array<int, int> $error_counts
      * @param array<string, string> $error_levels
      *
-     * @return void
      */
     public function testErrorFix(
         array $files,

--- a/tests/FileUpdates/ErrorFixTest.php
+++ b/tests/FileUpdates/ErrorFixTest.php
@@ -51,7 +51,7 @@ class ErrorFixTest extends \Psalm\Tests\TestCase
         array $files,
         array $error_counts,
         array $error_levels = []
-    ) {
+    ): void {
         $this->project_analyzer->getCodebase()->diff_methods = true;
 
         $codebase = $this->project_analyzer->getCodebase();
@@ -99,7 +99,7 @@ class ErrorFixTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{files: array<int, array<string,string>>,error_counts:array<int,int>,error_levels?:array<string,string>}>
      */
-    public function providerTestErrorFix()
+    public function providerTestErrorFix(): array
     {
         return [
             'fixMissingColonSyntaxError' => [

--- a/tests/FileUpdates/TemporaryUpdateTest.php
+++ b/tests/FileUpdates/TemporaryUpdateTest.php
@@ -56,7 +56,7 @@ class TemporaryUpdateTest extends \Psalm\Tests\TestCase
         array $error_levels = [],
         bool $test_save = true,
         bool $check_unused_code = false
-    ) {
+    ): void {
         $codebase = $this->project_analyzer->getCodebase();
         $codebase->diff_methods = true;
 
@@ -157,7 +157,7 @@ class TemporaryUpdateTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{array<int, array<string, string>>,error_positions:array<int, array<int>>, error_levels?:array<string, string>, test_save?:bool}>
      */
-    public function providerTestErrorFix()
+    public function providerTestErrorFix(): array
     {
         return [
             'fixMissingColonSyntaxError' => [

--- a/tests/FileUpdates/TemporaryUpdateTest.php
+++ b/tests/FileUpdates/TemporaryUpdateTest.php
@@ -48,7 +48,6 @@ class TemporaryUpdateTest extends \Psalm\Tests\TestCase
      * @param array<int, array<int>> $error_positions
      * @param array<string, string> $error_levels
      *
-     * @return void
      */
     public function testErrorFix(
         array $file_stages,

--- a/tests/ForbiddenCodeTest.php
+++ b/tests/ForbiddenCodeTest.php
@@ -9,7 +9,7 @@ class ForbiddenCodeTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'varDump' => [
@@ -43,7 +43,7 @@ class ForbiddenCodeTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'execWithSuppression' => [

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -11,7 +11,7 @@ class FunctionCallTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'preg_grep' => [
@@ -1347,7 +1347,7 @@ class FunctionCallTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidScalarArgument' => [

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -9,7 +9,7 @@ class GeneratorTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'generator' => [
@@ -258,7 +258,7 @@ class GeneratorTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'shouldWarnAboutNoGeneratorReturn' => [

--- a/tests/ImmutableAnnotationTest.php
+++ b/tests/ImmutableAnnotationTest.php
@@ -11,7 +11,7 @@ class ImmutableAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'immutableClassGenerating' => [
@@ -530,7 +530,7 @@ class ImmutableAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'immutablePropertyAssignmentInternally' => [

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -17,7 +17,6 @@ class IncludeTest extends TestCase
      * @param bool $hoist_constants
      * @param array<string, string> $error_levels
      *
-     * @return void
      */
     public function testValidInclude(
         array $files,
@@ -61,7 +60,6 @@ class IncludeTest extends TestCase
      * @param string $error_message
      * @param bool $hoist_constants
      *
-     * @return void
      */
     public function testInvalidInclude(
         array $files,

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -24,7 +24,7 @@ class IncludeTest extends TestCase
         array $files_to_check,
         $hoist_constants = false,
         array $error_levels = []
-    ) {
+    ): void {
         $codebase = $this->project_analyzer->getCodebase();
 
         foreach ($files as $file_path => $contents) {
@@ -67,7 +67,7 @@ class IncludeTest extends TestCase
         array $files,
         array $files_to_check,
         $error_message
-    ) {
+    ): void {
         if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
         }
@@ -100,7 +100,7 @@ class IncludeTest extends TestCase
     /**
      * @return array<string,array{files:array<string,string>,files_to_check:array<int,string>}>
      */
-    public function providerTestValidIncludes()
+    public function providerTestValidIncludes(): array
     {
         return [
             'basicRequire' => [
@@ -607,7 +607,7 @@ class IncludeTest extends TestCase
     /**
      * @return array<string,array{files:array<string,string>,files_to_check:array<int,string>,error_message:string}>
      */
-    public function providerTestInvalidIncludes()
+    public function providerTestInvalidIncludes(): array
     {
         return [
             'undefinedMethodInRequire' => [

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -9,7 +9,7 @@ class InterfaceTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'extendsAndImplements' => [
@@ -707,7 +707,7 @@ class InterfaceTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidInterface' => [

--- a/tests/Internal/Provider/ClassLikeStorageInstanceCacheProvider.php
+++ b/tests/Internal/Provider/ClassLikeStorageInstanceCacheProvider.php
@@ -32,7 +32,7 @@ class ClassLikeStorageInstanceCacheProvider extends \Psalm\Internal\Provider\Cla
      *
      * @return ClassLikeStorage
      */
-    public function getLatestFromCache(string $fq_classlike_name_lc, ?string $file_path, ?string $file_contents)
+    public function getLatestFromCache(string $fq_classlike_name_lc, ?string $file_path, ?string $file_contents): ClassLikeStorage
     {
         $cached_value = $this->loadFromCache($fq_classlike_name_lc);
 
@@ -48,7 +48,7 @@ class ClassLikeStorageInstanceCacheProvider extends \Psalm\Internal\Provider\Cla
      *
      * @return ClassLikeStorage|null
      */
-    private function loadFromCache($fq_classlike_name_lc)
+    private function loadFromCache($fq_classlike_name_lc): ?ClassLikeStorage
     {
         return $this->cache[$fq_classlike_name_lc] ?? null;
     }

--- a/tests/Internal/Provider/ClassLikeStorageInstanceCacheProvider.php
+++ b/tests/Internal/Provider/ClassLikeStorageInstanceCacheProvider.php
@@ -14,9 +14,6 @@ class ClassLikeStorageInstanceCacheProvider extends \Psalm\Internal\Provider\Cla
     }
 
     /**
-     * @param  string|null $file_path
-     * @param  string|null $file_contents
-     *
      * @return void
      */
     public function writeToCache(ClassLikeStorage $storage, ?string $file_path, ?string $file_contents)
@@ -25,13 +22,6 @@ class ClassLikeStorageInstanceCacheProvider extends \Psalm\Internal\Provider\Cla
         $this->cache[$fq_classlike_name_lc] = $storage;
     }
 
-    /**
-     * @param  string  $fq_classlike_name_lc
-     * @param  string|null $file_path
-     * @param  string|null $file_contents
-     *
-     * @return ClassLikeStorage
-     */
     public function getLatestFromCache(string $fq_classlike_name_lc, ?string $file_path, ?string $file_contents): ClassLikeStorage
     {
         $cached_value = $this->loadFromCache($fq_classlike_name_lc);
@@ -46,7 +36,6 @@ class ClassLikeStorageInstanceCacheProvider extends \Psalm\Internal\Provider\Cla
     /**
      * @param  string  $fq_classlike_name_lc
      *
-     * @return ClassLikeStorage|null
      */
     private function loadFromCache($fq_classlike_name_lc): ?ClassLikeStorage
     {

--- a/tests/Internal/Provider/FakeFileProvider.php
+++ b/tests/Internal/Provider/FakeFileProvider.php
@@ -53,7 +53,6 @@ class FakeFileProvider extends \Psalm\Internal\Provider\FileProvider
     }
 
     /**
-     * @return void
      * @psalm-suppress InvalidPropertyAssignmentValue because microtime is needed for cache busting
      */
     public function registerFile(string $file_path, string $file_contents): void

--- a/tests/Internal/Provider/FakeFileProvider.php
+++ b/tests/Internal/Provider/FakeFileProvider.php
@@ -56,7 +56,7 @@ class FakeFileProvider extends \Psalm\Internal\Provider\FileProvider
      * @return void
      * @psalm-suppress InvalidPropertyAssignmentValue because microtime is needed for cache busting
      */
-    public function registerFile(string $file_path, string $file_contents)
+    public function registerFile(string $file_path, string $file_contents): void
     {
         $this->fake_files[$file_path] = $file_contents;
         $this->fake_file_times[$file_path] = microtime(true);

--- a/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
+++ b/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
@@ -206,7 +206,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     /**
      * @return array<string, array<string, int>>
      */
-    public function getAnalyzedMethodCache()
+    public function getAnalyzedMethodCache(): array
     {
         return $this->cached_correct_methods;
     }
@@ -231,7 +231,7 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
      *      }
      *  >
      */
-    public function getFileMapCache()
+    public function getFileMapCache(): array
     {
         return $this->cached_file_maps;
     }

--- a/tests/Internal/Provider/FakeParserCacheProvider.php
+++ b/tests/Internal/Provider/FakeParserCacheProvider.php
@@ -17,16 +17,16 @@ class FakeParserCacheProvider extends \Psalm\Internal\Provider\ParserCacheProvid
         return null;
     }
 
-    public function saveStatementsToCache(string $file_path, string $file_content_hash, array $stmts, bool $touch_only)
+    public function saveStatementsToCache(string $file_path, string $file_content_hash, array $stmts, bool $touch_only): void
     {
     }
 
-    public function loadExistingFileContentsFromCache(string $file_path)
+    public function loadExistingFileContentsFromCache(string $file_path): ?string
     {
         return null;
     }
 
-    public function cacheFileContents(string $file_path, string $file_contents)
+    public function cacheFileContents(string $file_path, string $file_contents): void
     {
     }
 }

--- a/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
+++ b/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
@@ -44,7 +44,7 @@ class FileStorageInstanceCacheProvider extends \Psalm\Internal\Provider\FileStor
     /**
      * @return FileStorage|null
      */
-    private function loadFromCache(string $file_path)
+    private function loadFromCache(string $file_path): ?FileStorage
     {
         return $this->cache[strtolower($file_path)] ?? null;
     }

--- a/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
+++ b/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
@@ -41,9 +41,6 @@ class FileStorageInstanceCacheProvider extends \Psalm\Internal\Provider\FileStor
         unset($this->cache[strtolower($file_path)]);
     }
 
-    /**
-     * @return FileStorage|null
-     */
     private function loadFromCache(string $file_path): ?FileStorage
     {
         return $this->cache[strtolower($file_path)] ?? null;

--- a/tests/Internal/Provider/ParserInstanceCacheProvider.php
+++ b/tests/Internal/Provider/ParserInstanceCacheProvider.php
@@ -30,7 +30,7 @@ class ParserInstanceCacheProvider extends \Psalm\Internal\Provider\ParserCachePr
     {
     }
 
-    public function loadStatementsFromCache(string $file_path, int $file_modified_time, string $file_content_hash)
+    public function loadStatementsFromCache(string $file_path, int $file_modified_time, string $file_content_hash): ?array
     {
         if (isset($this->statements_cache[$file_path])
             && $this->statements_cache_time[$file_path] >= $file_modified_time
@@ -45,7 +45,7 @@ class ParserInstanceCacheProvider extends \Psalm\Internal\Provider\ParserCachePr
     /**
      * @return list<PhpParser\Node\Stmt>|null
      */
-    public function loadExistingStatementsFromCache(string $file_path)
+    public function loadExistingStatementsFromCache(string $file_path): ?array
     {
         if (isset($this->statements_cache[$file_path])) {
             return $this->statements_cache[$file_path];
@@ -59,7 +59,7 @@ class ParserInstanceCacheProvider extends \Psalm\Internal\Provider\ParserCachePr
      *
      * @return void
      */
-    public function saveStatementsToCache(string $file_path, string $file_content_hash, array $stmts, bool $touch_only)
+    public function saveStatementsToCache(string $file_path, string $file_content_hash, array $stmts, bool $touch_only): void
     {
         $this->statements_cache[$file_path] = $stmts;
         $this->statements_cache_time[$file_path] = microtime(true);
@@ -69,7 +69,7 @@ class ParserInstanceCacheProvider extends \Psalm\Internal\Provider\ParserCachePr
     /**
      * @return string|null
      */
-    public function loadExistingFileContentsFromCache(string $file_path)
+    public function loadExistingFileContentsFromCache(string $file_path): ?string
     {
         if (isset($this->file_contents_cache[$file_path])) {
             return $this->file_contents_cache[$file_path];
@@ -81,12 +81,12 @@ class ParserInstanceCacheProvider extends \Psalm\Internal\Provider\ParserCachePr
     /**
      * @return void
      */
-    public function cacheFileContents(string $file_path, string $file_contents)
+    public function cacheFileContents(string $file_path, string $file_contents): void
     {
         $this->file_contents_cache[$file_path] = $file_contents;
     }
 
-    public function saveFileContentHashes()
+    public function saveFileContentHashes(): void
     {
     }
 }

--- a/tests/Internal/Provider/ParserInstanceCacheProvider.php
+++ b/tests/Internal/Provider/ParserInstanceCacheProvider.php
@@ -57,7 +57,6 @@ class ParserInstanceCacheProvider extends \Psalm\Internal\Provider\ParserCachePr
     /**
      * @param  list<PhpParser\Node\Stmt>        $stmts
      *
-     * @return void
      */
     public function saveStatementsToCache(string $file_path, string $file_content_hash, array $stmts, bool $touch_only): void
     {
@@ -66,9 +65,6 @@ class ParserInstanceCacheProvider extends \Psalm\Internal\Provider\ParserCachePr
         $this->file_content_hash[$file_path] = $file_content_hash;
     }
 
-    /**
-     * @return string|null
-     */
     public function loadExistingFileContentsFromCache(string $file_path): ?string
     {
         if (isset($this->file_contents_cache[$file_path])) {
@@ -78,9 +74,6 @@ class ParserInstanceCacheProvider extends \Psalm\Internal\Provider\ParserCachePr
         return null;
     }
 
-    /**
-     * @return void
-     */
     public function cacheFileContents(string $file_path, string $file_contents): void
     {
         $this->file_contents_cache[$file_path] = $file_contents;

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -9,7 +9,7 @@ class InternalAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'internalMethodWithCall' => [
@@ -526,7 +526,7 @@ class InternalAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'internalMethodWithCall' => [

--- a/tests/IssueBufferTest.php
+++ b/tests/IssueBufferTest.php
@@ -12,9 +12,6 @@ use Psalm\Report\ReportOptions;
 class IssueBufferTest extends TestCase
 {
 
-    /**
-     * @return void
-     */
     public function testFinishDoesNotCorruptInternalState(): void
     {
         IssueBuffer::clear();

--- a/tests/IssueBufferTest.php
+++ b/tests/IssueBufferTest.php
@@ -15,7 +15,7 @@ class IssueBufferTest extends TestCase
     /**
      * @return void
      */
-    public function testFinishDoesNotCorruptInternalState()
+    public function testFinishDoesNotCorruptInternalState(): void
     {
         IssueBuffer::clear();
         IssueBuffer::addIssues([

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -10,9 +10,6 @@ class IssueSuppressionTest extends TestCase
     use Traits\ValidCodeAnalysisTestTrait;
     use Traits\InvalidCodeAnalysisTestTrait;
 
-    /**
-     * @return void
-     */
     public function testIssueSuppressedOnFunction(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -37,9 +34,6 @@ class IssueSuppressionTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testIssueSuppressedOnStatement(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -55,9 +49,6 @@ class IssueSuppressionTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testUnusedSuppressAllOnFunction(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -75,9 +66,6 @@ class IssueSuppressionTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testUnusedSuppressAllOnStatement(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -93,9 +81,6 @@ class IssueSuppressionTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testMissingThrowsDocblockSuppressed(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -121,9 +106,6 @@ class IssueSuppressionTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testMissingThrowsDocblockSuppressedWithoutThrow(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -144,9 +126,6 @@ class IssueSuppressionTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testMissingThrowsDocblockSuppressedDuplicate(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -168,9 +147,6 @@ class IssueSuppressionTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtThrowInGlobalScopeSuppressed(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
@@ -197,9 +173,6 @@ class IssueSuppressionTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtThrowInGlobalScopeSuppressedWithoutThrow(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -13,7 +13,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
-    public function testIssueSuppressedOnFunction()
+    public function testIssueSuppressedOnFunction(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UnusedPsalmSuppress');
@@ -40,7 +40,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
-    public function testIssueSuppressedOnStatement()
+    public function testIssueSuppressedOnStatement(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UnusedPsalmSuppress');
@@ -58,7 +58,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
-    public function testUnusedSuppressAllOnFunction()
+    public function testUnusedSuppressAllOnFunction(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UnusedPsalmSuppress');
@@ -78,7 +78,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
-    public function testUnusedSuppressAllOnStatement()
+    public function testUnusedSuppressAllOnStatement(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UnusedPsalmSuppress');
@@ -96,7 +96,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
-    public function testMissingThrowsDocblockSuppressed()
+    public function testMissingThrowsDocblockSuppressed(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -124,7 +124,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
-    public function testMissingThrowsDocblockSuppressedWithoutThrow()
+    public function testMissingThrowsDocblockSuppressedWithoutThrow(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UnusedPsalmSuppress');
@@ -147,7 +147,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
-    public function testMissingThrowsDocblockSuppressedDuplicate()
+    public function testMissingThrowsDocblockSuppressedDuplicate(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UnusedPsalmSuppress');
@@ -171,7 +171,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtThrowInGlobalScopeSuppressed()
+    public function testUncaughtThrowInGlobalScopeSuppressed(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
 
@@ -200,7 +200,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtThrowInGlobalScopeSuppressedWithoutThrow()
+    public function testUncaughtThrowInGlobalScopeSuppressedWithoutThrow(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UnusedPsalmSuppress');
@@ -221,7 +221,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'undefinedClassSimple' => [
@@ -299,7 +299,7 @@ class IssueSuppressionTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'undefinedClassOneLineWithLineAfter' => [

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -46,7 +46,7 @@ class JsonOutputTest extends TestCase
      *
      * @return void
      */
-    public function testJsonOutputErrors($code, $message, $line_number, $error)
+    public function testJsonOutputErrors($code, $message, $line_number, $error): void
     {
         $this->addFile('somefile.php', $code);
         $this->analyzeFile('somefile.php', new Context());
@@ -65,7 +65,7 @@ class JsonOutputTest extends TestCase
     /**
      * @return array<string,array{string,message:string,line:int,error:string}>
      */
-    public function providerTestJsonOutputErrors()
+    public function providerTestJsonOutputErrors(): array
     {
         return [
             'returnTypeError' => [

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -44,7 +44,6 @@ class JsonOutputTest extends TestCase
      * @param int $line_number
      * @param string $error
      *
-     * @return void
      */
     public function testJsonOutputErrors($code, $message, $line_number, $error): void
     {

--- a/tests/LanguageServer/CompletionTest.php
+++ b/tests/LanguageServer/CompletionTest.php
@@ -40,7 +40,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnThisWithNoAssignment()
+    public function testCompletionOnThisWithNoAssignment(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -71,7 +71,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnThisWithAssignmentBelow()
+    public function testCompletionOnThisWithAssignmentBelow(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -104,7 +104,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnThisWithIfBelow()
+    public function testCompletionOnThisWithIfBelow(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -156,7 +156,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnThisProperty()
+    public function testCompletionOnThisProperty(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -197,7 +197,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnThisPropertyWithCharacter()
+    public function testCompletionOnThisPropertyWithCharacter(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -238,7 +238,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnThisPropertyWithAnotherCharacter()
+    public function testCompletionOnThisPropertyWithAnotherCharacter(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -279,7 +279,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnTemplatedThisProperty()
+    public function testCompletionOnTemplatedThisProperty(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -335,7 +335,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnMethodReturnValue()
+    public function testCompletionOnMethodReturnValue(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -367,7 +367,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnMethodArgument()
+    public function testCompletionOnMethodArgument(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -401,7 +401,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnMethodReturnValueWithArgument()
+    public function testCompletionOnMethodReturnValueWithArgument(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -435,7 +435,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnVariableWithWhitespace()
+    public function testCompletionOnVariableWithWhitespace(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -463,7 +463,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnVariableWithWhitespaceAndReturn()
+    public function testCompletionOnVariableWithWhitespaceAndReturn(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -493,7 +493,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnMethodReturnValueWithWhitespace()
+    public function testCompletionOnMethodReturnValueWithWhitespace(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -526,7 +526,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnMethodReturnValueWithWhitespaceAndReturn()
+    public function testCompletionOnMethodReturnValueWithWhitespaceAndReturn(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -560,7 +560,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnMethodReturnValueWhereParamIsClosure()
+    public function testCompletionOnMethodReturnValueWhereParamIsClosure(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -592,7 +592,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnMethodReturnValueWhereParamIsClosureWithStmt()
+    public function testCompletionOnMethodReturnValueWhereParamIsClosureWithStmt(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -661,7 +661,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnNewExceptionWithoutNamespace()
+    public function testCompletionOnNewExceptionWithoutNamespace(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -685,7 +685,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnNewExceptionWithNamespaceNoUse()
+    public function testCompletionOnNewExceptionWithNamespaceNoUse(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -735,7 +735,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnNewExceptionWithNamespaceAndUse()
+    public function testCompletionOnNewExceptionWithNamespaceAndUse(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -787,7 +787,7 @@ class CompletionTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testCompletionOnInstanceofWithNamespaceAndUse()
+    public function testCompletionOnInstanceofWithNamespaceAndUse(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;

--- a/tests/LanguageServer/CompletionTest.php
+++ b/tests/LanguageServer/CompletionTest.php
@@ -37,9 +37,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->project_analyzer->getCodebase()->store_node_types = true;
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnThisWithNoAssignment(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -68,9 +65,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\A&static', '->', 213], $codebase->getCompletionDataAtPosition('somefile.php', new Position(8, 31)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnThisWithAssignmentBelow(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -101,9 +95,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\A&static', '->', 220], $codebase->getCompletionDataAtPosition('somefile.php', new Position(8, 31)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnThisWithIfBelow(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -153,9 +144,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\A&static', '->', 220], $codebase->getCompletionDataAtPosition('somefile.php', new Position(8, 31)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnThisProperty(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -194,9 +182,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\C', '->', 454], $codebase->getCompletionDataAtPosition('somefile.php', new Position(16, 39)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnThisPropertyWithCharacter(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -235,9 +220,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\C', '->', 455], $codebase->getCompletionDataAtPosition('somefile.php', new Position(16, 40)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnThisPropertyWithAnotherCharacter(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -276,9 +258,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertNull($codebase->getCompletionDataAtPosition('somefile.php', new Position(16, 41)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnTemplatedThisProperty(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -332,9 +311,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertCount(3, $completion_items);
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnMethodReturnValue(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -364,9 +340,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\A', '->', 259], $codebase->getCompletionDataAtPosition('somefile.php', new Position(9, 31)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnMethodArgument(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -398,9 +371,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\C', '->', 298], $codebase->getCompletionDataAtPosition('somefile.php', new Position(11, 32)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnMethodReturnValueWithArgument(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -432,9 +402,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\A', '->', 299], $codebase->getCompletionDataAtPosition('somefile.php', new Position(11, 33)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnVariableWithWhitespace(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -460,9 +427,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\A', '->', 126], $codebase->getCompletionDataAtPosition('somefile.php', new Position(6, 25)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnVariableWithWhitespaceAndReturn(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -490,9 +454,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\A', '->', 150], $codebase->getCompletionDataAtPosition('somefile.php', new Position(7, 26)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnMethodReturnValueWithWhitespace(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -523,9 +484,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\A', '->', 261], $codebase->getCompletionDataAtPosition('somefile.php', new Position(10, 32)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnMethodReturnValueWithWhitespaceAndReturn(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -557,9 +515,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\A', '->', 285], $codebase->getCompletionDataAtPosition('somefile.php', new Position(11, 26)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnMethodReturnValueWhereParamIsClosure(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -589,9 +544,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['B\Collection', '->', 312], $codebase->getCompletionDataAtPosition('somefile.php', new Position(10, 49)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnMethodReturnValueWhereParamIsClosureWithStmt(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -658,9 +610,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame('baz()', $completion_items[1]->insertText);
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnNewExceptionWithoutNamespace(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -682,9 +631,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(['*Ex', 'symbol', 78], $codebase->getCompletionDataAtPosition('somefile.php', new Position(2, 32)));
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnNewExceptionWithNamespaceNoUse(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -732,9 +678,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(16, $completion_items[0]->additionalTextEdits[0]->range->end->character);
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnNewExceptionWithNamespaceAndUse(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -784,9 +727,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->assertSame(44, $completion_items[0]->additionalTextEdits[0]->range->end->character);
     }
 
-    /**
-     * @return void
-     */
     public function testCompletionOnInstanceofWithNamespaceAndUse(): void
     {
         $codebase = $this->project_analyzer->getCodebase();

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -41,7 +41,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testSimpleSymbolLookup()
+    public function testSimpleSymbolLookup(): void
     {
         $this->addFile(
             'somefile.php',
@@ -90,7 +90,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testSimpleSymbolLocation()
+    public function testSimpleSymbolLocation(): void
     {
         $this->addFile(
             'somefile.php',
@@ -154,7 +154,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testSymbolLookupAfterAlteration()
+    public function testSymbolLookupAfterAlteration(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -238,7 +238,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testGetSymbolPositionMissingArg()
+    public function testGetSymbolPositionMissingArg(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -274,7 +274,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testGetSymbolPositionNullableArg()
+    public function testGetSymbolPositionNullableArg(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -303,7 +303,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testGetSymbolPositionMethodWrongReturnType()
+    public function testGetSymbolPositionMethodWrongReturnType(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -336,7 +336,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testGetSymbolPositionUseStatement()
+    public function testGetSymbolPositionUseStatement(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -363,7 +363,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testGetSymbolPositionRange()
+    public function testGetSymbolPositionRange(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
@@ -396,7 +396,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
     /**
      * @return void
      */
-    public function testGetTypeInDocblock()
+    public function testGetTypeInDocblock(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -38,9 +38,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->project_analyzer->getCodebase()->store_node_types = true;
     }
 
-    /**
-     * @return void
-     */
     public function testSimpleSymbolLookup(): void
     {
         $this->addFile(
@@ -87,9 +84,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame("<?php function B\qux(\n    int \$a,\n    int \$b\n) : int", $codebase->getSymbolInformation('somefile.php', 'B\qux()'));
     }
 
-    /**
-     * @return void
-     */
     public function testSimpleSymbolLocation(): void
     {
         $this->addFile(
@@ -151,9 +145,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame(25, $function_symbol_location->getColumn());
     }
 
-    /**
-     * @return void
-     */
     public function testSymbolLookupAfterAlteration(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -235,9 +226,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame('425-426:int(2)', $symbol_at_position[0]);
     }
 
-    /**
-     * @return void
-     */
     public function testGetSymbolPositionMissingArg(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -271,9 +259,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame('B\A::foo()', $symbol_at_position[0]);
     }
 
-    /**
-     * @return void
-     */
     public function testGetSymbolPositionNullableArg(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -300,9 +285,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame('B\AClass', $symbol_at_position[0]);
     }
 
-    /**
-     * @return void
-     */
     public function testGetSymbolPositionMethodWrongReturnType(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -333,9 +315,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame('B\AClass', $symbol_at_position[0]);
     }
 
-    /**
-     * @return void
-     */
     public function testGetSymbolPositionUseStatement(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -360,9 +339,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame('StreamWrapper', $symbol_at_position[0]);
     }
 
-    /**
-     * @return void
-     */
     public function testGetSymbolPositionRange(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -393,9 +369,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame(30, $symbol_at_position[1]->end->character);
     }
 
-    /**
-     * @return void
-     */
     public function testGetTypeInDocblock(): void
     {
         $codebase = $this->project_analyzer->getCodebase();

--- a/tests/ListTest.php
+++ b/tests/ListTest.php
@@ -11,7 +11,7 @@ class ListTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'simpleVars' => [
@@ -78,7 +78,7 @@ class ListTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'thisVarWithBadType' => [

--- a/tests/Loop/DoTest.php
+++ b/tests/Loop/DoTest.php
@@ -12,7 +12,7 @@ class DoTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'doWhileVar' => [
@@ -349,7 +349,7 @@ class DoTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'doWhileVarWithPossibleBreakWithoutDefining' => [

--- a/tests/Loop/ForTest.php
+++ b/tests/Loop/ForTest.php
@@ -12,7 +12,7 @@ class ForTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'implicitFourthLoop' => [
@@ -140,7 +140,7 @@ class ForTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'possiblyUndefinedArrayInWhileAndForeach' => [

--- a/tests/Loop/ForeachTest.php
+++ b/tests/Loop/ForeachTest.php
@@ -12,7 +12,7 @@ class ForeachTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'switchVariableWithContinue' => [
@@ -1063,7 +1063,7 @@ class ForeachTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'switchVariableWithContinueOnce' => [

--- a/tests/Loop/WhileTest.php
+++ b/tests/Loop/WhileTest.php
@@ -11,7 +11,7 @@ class WhileTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'whileVar' => [
@@ -470,7 +470,7 @@ class WhileTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'whileTrueNoBreak' => [

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -10,9 +10,6 @@ class MagicMethodAnnotationTest extends TestCase
     use Traits\InvalidCodeAnalysisTestTrait;
     use Traits\ValidCodeAnalysisTestTrait;
 
-    /**
-     * @return void
-     */
     public function testPhpDocMethodWhenUndefined(): void
     {
         Config::getInstance()->use_phpdoc_method_without_magic_or_parent = true;
@@ -44,9 +41,6 @@ class MagicMethodAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPhpDocMethodWhenTemplated(): void
     {
         Config::getInstance()->use_phpdoc_method_without_magic_or_parent = true;
@@ -73,9 +67,6 @@ class MagicMethodAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testAnnotationWithoutCallConfig(): void
     {
         $this->expectExceptionMessage('UndefinedMethod');
@@ -100,9 +91,6 @@ class MagicMethodAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testOverrideParentClassRetunType(): void
     {
         Config::getInstance()->use_phpdoc_method_without_magic_or_parent = true;
@@ -892,9 +880,6 @@ class MagicMethodAnnotationTest extends TestCase
         ];
     }
 
-    /**
-     * @return void
-     */
     public function testSealAllMethodsWithoutFoo(): void
     {
         Config::getInstance()->seal_all_methods = true;
@@ -919,9 +904,6 @@ class MagicMethodAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testSealAllMethodsWithFoo(): void
     {
         Config::getInstance()->seal_all_methods = true;
@@ -944,9 +926,6 @@ class MagicMethodAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testSealAllMethodsWithFooInSubclass(): void
     {
         Config::getInstance()->seal_all_methods = true;
@@ -970,9 +949,6 @@ class MagicMethodAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testSealAllMethodsWithFooAnnotated(): void
     {
         Config::getInstance()->seal_all_methods = true;
@@ -995,9 +971,6 @@ class MagicMethodAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testSealAllMethodsSetToFalse(): void
     {
         Config::getInstance()->seal_all_methods = false;

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -13,7 +13,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocMethodWhenUndefined()
+    public function testPhpDocMethodWhenUndefined(): void
     {
         Config::getInstance()->use_phpdoc_method_without_magic_or_parent = true;
 
@@ -47,7 +47,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocMethodWhenTemplated()
+    public function testPhpDocMethodWhenTemplated(): void
     {
         Config::getInstance()->use_phpdoc_method_without_magic_or_parent = true;
 
@@ -76,7 +76,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testAnnotationWithoutCallConfig()
+    public function testAnnotationWithoutCallConfig(): void
     {
         $this->expectExceptionMessage('UndefinedMethod');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -103,7 +103,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testOverrideParentClassRetunType()
+    public function testOverrideParentClassRetunType(): void
     {
         Config::getInstance()->use_phpdoc_method_without_magic_or_parent = true;
 
@@ -156,7 +156,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'validSimpleAnnotations' => [
@@ -715,7 +715,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'annotationWithBadDocblock' => [
@@ -895,7 +895,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testSealAllMethodsWithoutFoo()
+    public function testSealAllMethodsWithoutFoo(): void
     {
         Config::getInstance()->seal_all_methods = true;
 
@@ -922,7 +922,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testSealAllMethodsWithFoo()
+    public function testSealAllMethodsWithFoo(): void
     {
         Config::getInstance()->seal_all_methods = true;
 
@@ -947,7 +947,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testSealAllMethodsWithFooInSubclass()
+    public function testSealAllMethodsWithFooInSubclass(): void
     {
         Config::getInstance()->seal_all_methods = true;
 
@@ -973,7 +973,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testSealAllMethodsWithFooAnnotated()
+    public function testSealAllMethodsWithFooAnnotated(): void
     {
         Config::getInstance()->seal_all_methods = true;
 
@@ -998,7 +998,7 @@ class MagicMethodAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testSealAllMethodsSetToFalse()
+    public function testSealAllMethodsSetToFalse(): void
     {
         Config::getInstance()->seal_all_methods = false;
 

--- a/tests/MagicPropertyTest.php
+++ b/tests/MagicPropertyTest.php
@@ -13,7 +13,7 @@ class MagicPropertyTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocPropertyWithoutGet()
+    public function testPhpDocPropertyWithoutGet(): void
     {
         Config::getInstance()->use_phpdoc_property_without_magic_or_parent = true;
 
@@ -36,7 +36,7 @@ class MagicPropertyTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'propertyDocblock' => [
@@ -703,7 +703,7 @@ class MagicPropertyTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'annotationWithoutGetter' => [

--- a/tests/MagicPropertyTest.php
+++ b/tests/MagicPropertyTest.php
@@ -10,9 +10,6 @@ class MagicPropertyTest extends TestCase
     use Traits\InvalidCodeAnalysisTestTrait;
     use Traits\ValidCodeAnalysisTestTrait;
 
-    /**
-     * @return void
-     */
     public function testPhpDocPropertyWithoutGet(): void
     {
         Config::getInstance()->use_phpdoc_property_without_magic_or_parent = true;

--- a/tests/MatchTest.php
+++ b/tests/MatchTest.php
@@ -9,7 +9,7 @@ class MatchTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'switchTruthy' => [
@@ -62,7 +62,7 @@ class MatchTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'getClassArgWrongClass' => [

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -32,7 +32,7 @@ class MethodCallTest extends TestCase
     /**
      * @return void
      */
-    public function testMethodCallMemoize()
+    public function testMethodCallMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;
 
@@ -68,7 +68,7 @@ class MethodCallTest extends TestCase
     /**
      * @return void
      */
-    public function testPropertyMethodCallMemoize()
+    public function testPropertyMethodCallMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;
 
@@ -103,7 +103,7 @@ class MethodCallTest extends TestCase
     /**
      * @return void
      */
-    public function testPropertyMethodCallMutationFreeMemoize()
+    public function testPropertyMethodCallMutationFreeMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;
 
@@ -141,7 +141,7 @@ class MethodCallTest extends TestCase
     /**
      * @return void
      */
-    public function testUnchainedMethodCallMemoize()
+    public function testUnchainedMethodCallMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;
 
@@ -177,7 +177,7 @@ class MethodCallTest extends TestCase
     /**
      * @return void
      */
-    public function testUnchainedMutationFreeMethodCallMemoize()
+    public function testUnchainedMutationFreeMethodCallMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;
 
@@ -216,7 +216,7 @@ class MethodCallTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'notInCallMapTest' => [
@@ -942,7 +942,7 @@ class MethodCallTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'staticInvocation' => [

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -29,9 +29,6 @@ class MethodCallTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testMethodCallMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;
@@ -65,9 +62,6 @@ class MethodCallTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPropertyMethodCallMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;
@@ -100,9 +94,6 @@ class MethodCallTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPropertyMethodCallMutationFreeMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;
@@ -138,9 +129,6 @@ class MethodCallTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testUnchainedMethodCallMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;
@@ -174,9 +162,6 @@ class MethodCallTest extends TestCase
         $this->analyzeFile('somefile.php', new \Psalm\Context());
     }
 
-    /**
-     * @return void
-     */
     public function testUnchainedMutationFreeMethodCallMemoize(): void
     {
         $this->project_analyzer->getConfig()->memoize_method_calls = true;

--- a/tests/MethodMutationTest.php
+++ b/tests/MethodMutationTest.php
@@ -9,7 +9,7 @@ class MethodMutationTest extends TestCase
     /**
      * @return void
      */
-    public function testControllerMutation()
+    public function testControllerMutation(): void
     {
         $this->addFile(
             'somefile.php',
@@ -108,7 +108,7 @@ class MethodMutationTest extends TestCase
     /**
      * @return void
      */
-    public function testNotSettingUser()
+    public function testNotSettingUser(): void
     {
         $this->addFile(
             'somefile.php',
@@ -153,7 +153,7 @@ class MethodMutationTest extends TestCase
     /**
      * @return void
      */
-    public function testParentControllerSet()
+    public function testParentControllerSet(): void
     {
         $this->addFile(
             'somefile.php',
@@ -193,7 +193,7 @@ class MethodMutationTest extends TestCase
     /**
      * @return void
      */
-    public function testTraitMethod()
+    public function testTraitMethod(): void
     {
         $this->addFile(
             'somefile.php',

--- a/tests/MethodMutationTest.php
+++ b/tests/MethodMutationTest.php
@@ -6,9 +6,6 @@ use Psalm\Internal\Analyzer\FileAnalyzer;
 
 class MethodMutationTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testControllerMutation(): void
     {
         $this->addFile(
@@ -105,9 +102,6 @@ class MethodMutationTest extends TestCase
         $this->assertTrue($method_context->vars_possibly_in_scope['$this->title']);
     }
 
-    /**
-     * @return void
-     */
     public function testNotSettingUser(): void
     {
         $this->addFile(
@@ -150,9 +144,6 @@ class MethodMutationTest extends TestCase
         $this->assertSame('User|null', (string)$method_context->vars_in_scope['$this->user']);
     }
 
-    /**
-     * @return void
-     */
     public function testParentControllerSet(): void
     {
         $this->addFile(
@@ -190,9 +181,6 @@ class MethodMutationTest extends TestCase
         $this->assertSame('Foo', (string)$method_context->vars_in_scope['$this->foo']);
     }
 
-    /**
-     * @return void
-     */
     public function testTraitMethod(): void
     {
         $this->addFile(

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -111,9 +111,6 @@ class MethodSignatureTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testMismatchingCovariantReturnIn73(): void
     {
         $this->expectExceptionMessage('MethodSignatureMismatch');
@@ -141,9 +138,6 @@ class MethodSignatureTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testMismatchingCovariantReturnIn74(): void
     {
         $this->project_analyzer->setPhpVersion('7.4');
@@ -168,9 +162,6 @@ class MethodSignatureTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testMismatchingCovariantReturnIn73WithSelf(): void
     {
         $this->expectExceptionMessage('MethodSignatureMismatch');
@@ -196,9 +187,6 @@ class MethodSignatureTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testMismatchingCovariantReturnIn74WithSelf(): void
     {
         $this->project_analyzer->setPhpVersion('7.4');
@@ -221,9 +209,6 @@ class MethodSignatureTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testMismatchingCovariantParamIn73(): void
     {
         $this->expectExceptionMessage('MethodSignatureMismatch');
@@ -248,9 +233,6 @@ class MethodSignatureTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testMismatchingCovariantParamIn74(): void
     {
         $this->project_analyzer->setPhpVersion('7.4');

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -114,7 +114,7 @@ class MethodSignatureTest extends TestCase
     /**
      * @return void
      */
-    public function testMismatchingCovariantReturnIn73()
+    public function testMismatchingCovariantReturnIn73(): void
     {
         $this->expectExceptionMessage('MethodSignatureMismatch');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -144,7 +144,7 @@ class MethodSignatureTest extends TestCase
     /**
      * @return void
      */
-    public function testMismatchingCovariantReturnIn74()
+    public function testMismatchingCovariantReturnIn74(): void
     {
         $this->project_analyzer->setPhpVersion('7.4');
 
@@ -171,7 +171,7 @@ class MethodSignatureTest extends TestCase
     /**
      * @return void
      */
-    public function testMismatchingCovariantReturnIn73WithSelf()
+    public function testMismatchingCovariantReturnIn73WithSelf(): void
     {
         $this->expectExceptionMessage('MethodSignatureMismatch');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -199,7 +199,7 @@ class MethodSignatureTest extends TestCase
     /**
      * @return void
      */
-    public function testMismatchingCovariantReturnIn74WithSelf()
+    public function testMismatchingCovariantReturnIn74WithSelf(): void
     {
         $this->project_analyzer->setPhpVersion('7.4');
 
@@ -224,7 +224,7 @@ class MethodSignatureTest extends TestCase
     /**
      * @return void
      */
-    public function testMismatchingCovariantParamIn73()
+    public function testMismatchingCovariantParamIn73(): void
     {
         $this->expectExceptionMessage('MethodSignatureMismatch');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -251,7 +251,7 @@ class MethodSignatureTest extends TestCase
     /**
      * @return void
      */
-    public function testMismatchingCovariantParamIn74()
+    public function testMismatchingCovariantParamIn74(): void
     {
         $this->project_analyzer->setPhpVersion('7.4');
 
@@ -347,7 +347,7 @@ class MethodSignatureTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'privateArgs' => [
@@ -836,7 +836,7 @@ class MethodSignatureTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'moreArguments' => [

--- a/tests/MixinAnnotationTest.php
+++ b/tests/MixinAnnotationTest.php
@@ -13,7 +13,7 @@ class MixinAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'validSimpleAnnotations' => [
@@ -571,7 +571,7 @@ class MixinAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'undefinedMixinClass' => [

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -9,7 +9,7 @@ class NamespaceTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'emptyNamespace' => [
@@ -73,7 +73,7 @@ class NamespaceTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'callNamespacedFunctionFromEmptyNamespace' => [

--- a/tests/Php40Test.php
+++ b/tests/Php40Test.php
@@ -8,7 +8,7 @@ class Php40Test extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'extendOldStyleConstructor' => [

--- a/tests/Php55Test.php
+++ b/tests/Php55Test.php
@@ -8,7 +8,7 @@ class Php55Test extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'finally' => [

--- a/tests/Php56Test.php
+++ b/tests/Php56Test.php
@@ -9,7 +9,7 @@ class Php56Test extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'constArray' => [
@@ -255,7 +255,7 @@ class Php56Test extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'arrayPushArgumentUnpackingWithBadArg' => [

--- a/tests/Php70Test.php
+++ b/tests/Php70Test.php
@@ -9,7 +9,7 @@ class Php70Test extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'functionTypeHints' => [
@@ -213,7 +213,7 @@ class Php70Test extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'anonymousClassWithBadStatement' => [

--- a/tests/Php71Test.php
+++ b/tests/Php71Test.php
@@ -9,7 +9,7 @@ class Php71Test extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'nullableReturnType' => [
@@ -258,7 +258,7 @@ class Php71Test extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidPrivateClassConstFetch' => [

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -52,7 +52,7 @@ class ProjectCheckerTest extends TestCase
      *
      * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
      */
-    private function getProjectAnalyzerWithConfig(Config $config)
+    private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $config->setIncludeCollector(new IncludeCollector());
         return new \Psalm\Internal\Analyzer\ProjectAnalyzer(
@@ -72,7 +72,7 @@ class ProjectCheckerTest extends TestCase
     /**
      * @return void
      */
-    public function testCheck()
+    public function testCheck(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -111,7 +111,7 @@ class ProjectCheckerTest extends TestCase
     /**
      * @return void
      */
-    public function testAfterCodebasePopulatedIsInvoked()
+    public function testAfterCodebasePopulatedIsInvoked(): void
     {
         $hook = new class implements AfterCodebasePopulatedInterface {
             /** @var bool */
@@ -150,7 +150,7 @@ class ProjectCheckerTest extends TestCase
     /**
      * @return void
      */
-    public function testCheckAfterNoChange()
+    public function testCheckAfterNoChange(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -197,7 +197,7 @@ class ProjectCheckerTest extends TestCase
     /**
      * @return void
      */
-    public function testCheckAfterFileChange()
+    public function testCheckAfterFileChange(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -265,7 +265,7 @@ class Bat
     /**
      * @return void
      */
-    public function testCheckDir()
+    public function testCheckDir(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -300,7 +300,7 @@ class Bat
     /**
      * @return void
      */
-    public function testCheckPaths()
+    public function testCheckPaths(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(
@@ -340,7 +340,7 @@ class Bat
     /**
      * @return void
      */
-    public function testCheckFile()
+    public function testCheckFile(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             Config::loadFromXML(

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -47,11 +47,6 @@ class ProjectCheckerTest extends TestCase
         $this->file_provider = new Provider\FakeFileProvider();
     }
 
-    /**
-     * @param  Config $config
-     *
-     * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
-     */
     private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $config->setIncludeCollector(new IncludeCollector());
@@ -69,9 +64,6 @@ class ProjectCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCheck(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -108,9 +100,6 @@ class ProjectCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testAfterCodebasePopulatedIsInvoked(): void
     {
         $hook = new class implements AfterCodebasePopulatedInterface {
@@ -147,9 +136,6 @@ class ProjectCheckerTest extends TestCase
         $this->assertTrue($hook::$called);
     }
 
-    /**
-     * @return void
-     */
     public function testCheckAfterNoChange(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -194,9 +180,6 @@ class ProjectCheckerTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCheckAfterFileChange(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -262,9 +245,6 @@ class Bat
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCheckDir(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -297,9 +277,6 @@ class Bat
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCheckPaths(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -337,9 +314,6 @@ class Bat
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCheckFile(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -10,9 +10,6 @@ class PropertyTypeTest extends TestCase
     use Traits\InvalidCodeAnalysisTestTrait;
     use Traits\ValidCodeAnalysisTestTrait;
 
-    /**
-     * @return void
-     */
     public function testForgetPropertyAssignments(): void
     {
         $this->expectExceptionMessage('NullableReturnStatement');
@@ -50,9 +47,6 @@ class PropertyTypeTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testForgetPropertyAssignmentsPassesNormally(): void
     {
         $this->addFile(
@@ -86,9 +80,6 @@ class PropertyTypeTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testForgetPropertyAssignmentsInBranchWithThrow(): void
     {
         Config::getInstance()->remember_property_assignments_after_call = false;
@@ -127,9 +118,6 @@ class PropertyTypeTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testForgetPropertyAssignmentsInBranchWithThrowNormally(): void
     {
         $this->addFile(

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -13,7 +13,7 @@ class PropertyTypeTest extends TestCase
     /**
      * @return void
      */
-    public function testForgetPropertyAssignments()
+    public function testForgetPropertyAssignments(): void
     {
         $this->expectExceptionMessage('NullableReturnStatement');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -53,7 +53,7 @@ class PropertyTypeTest extends TestCase
     /**
      * @return void
      */
-    public function testForgetPropertyAssignmentsPassesNormally()
+    public function testForgetPropertyAssignmentsPassesNormally(): void
     {
         $this->addFile(
             'somefile.php',
@@ -89,7 +89,7 @@ class PropertyTypeTest extends TestCase
     /**
      * @return void
      */
-    public function testForgetPropertyAssignmentsInBranchWithThrow()
+    public function testForgetPropertyAssignmentsInBranchWithThrow(): void
     {
         Config::getInstance()->remember_property_assignments_after_call = false;
 
@@ -130,7 +130,7 @@ class PropertyTypeTest extends TestCase
     /**
      * @return void
      */
-    public function testForgetPropertyAssignmentsInBranchWithThrowNormally()
+    public function testForgetPropertyAssignmentsInBranchWithThrowNormally(): void
     {
         $this->addFile(
             'somefile.php',
@@ -169,7 +169,7 @@ class PropertyTypeTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'newVarInIf' => [
@@ -2081,7 +2081,7 @@ class PropertyTypeTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'undefinedPropertyAssignment' => [

--- a/tests/PsalmPluginTest.php
+++ b/tests/PsalmPluginTest.php
@@ -55,7 +55,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function showsNoticesWhenTheresNoPlugins(): void
@@ -69,7 +68,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function showsEnabledPlugins(): void
@@ -85,7 +83,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function showsAvailablePlugins(): void
@@ -101,7 +98,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function passesExplicitConfigToPluginListFactory(): void
@@ -115,7 +111,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function showsColumnHeaders(): void
@@ -133,7 +128,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @dataProvider commands
      * @test
      */
@@ -146,7 +140,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @dataProvider commands
      * @test
      */
@@ -159,7 +152,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function requiresPluginNameToEnable(): void
@@ -170,7 +162,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function enableComplainsWhenPassedUnresolvablePlugin(): void
@@ -188,7 +179,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function enableComplainsWhenPassedAlreadyEnabledPlugin(): void
@@ -210,7 +200,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function enableReportsSuccessWhenItEnablesPlugin(): void
@@ -234,7 +223,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function requiresPluginNameToDisable(): void
@@ -245,7 +233,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function disableComplainsWhenPassedUnresolvablePlugin(): void
@@ -263,7 +250,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function disableComplainsWhenPassedNotEnabledPlugin(): void
@@ -285,7 +271,6 @@ class PsalmPluginTest extends TestCase
     }
 
     /**
-     * @return void
      * @test
      */
     public function disableReportsSuccessWhenItDisablesPlugin(): void

--- a/tests/PsalmPluginTest.php
+++ b/tests/PsalmPluginTest.php
@@ -58,7 +58,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function showsNoticesWhenTheresNoPlugins()
+    public function showsNoticesWhenTheresNoPlugins(): void
     {
         $show_command = new CommandTester($this->app->find('show'));
         $show_command->execute([]);
@@ -72,7 +72,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function showsEnabledPlugins()
+    public function showsEnabledPlugins(): void
     {
         $this->plugin_list->getEnabled()->willReturn(['a\b\c' => 'vendor/package']);
 
@@ -88,7 +88,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function showsAvailablePlugins()
+    public function showsAvailablePlugins(): void
     {
         $this->plugin_list->getAvailable()->willReturn(['a\b\c' => 'vendor/package']);
 
@@ -104,7 +104,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function passesExplicitConfigToPluginListFactory()
+    public function passesExplicitConfigToPluginListFactory(): void
     {
         $this->plugin_list_factory->__invoke(Argument::any(), '/a/b/c')->willReturn($this->plugin_list->reveal());
 
@@ -118,7 +118,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function showsColumnHeaders()
+    public function showsColumnHeaders(): void
     {
         $this->plugin_list->getAvailable()->willReturn(['a\b\c' => 'vendor/package']);
         $this->plugin_list->getAvailable()->willReturn(['c\d\e' => 'another-vendor/package']);
@@ -137,7 +137,7 @@ class PsalmPluginTest extends TestCase
      * @dataProvider commands
      * @test
      */
-    public function listsCommands(string $command)
+    public function listsCommands(string $command): void
     {
         $list_command = new CommandTester($this->app->find('list'));
         $list_command->execute([]);
@@ -150,7 +150,7 @@ class PsalmPluginTest extends TestCase
      * @dataProvider commands
      * @test
      */
-    public function showsHelpForCommand(string $command)
+    public function showsHelpForCommand(string $command): void
     {
         $help_command = new CommandTester($this->app->find('help'));
         $help_command->execute(['command_name' => $command]);
@@ -162,7 +162,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function requiresPluginNameToEnable()
+    public function requiresPluginNameToEnable(): void
     {
         $enable_command = new CommandTester($this->app->find('enable'));
         $this->expectExceptionMessage('missing: "pluginName"');
@@ -173,7 +173,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function enableComplainsWhenPassedUnresolvablePlugin()
+    public function enableComplainsWhenPassedUnresolvablePlugin(): void
     {
         $this->plugin_list->resolvePluginClass(Argument::any())->willThrow(new \InvalidArgumentException);
 
@@ -191,7 +191,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function enableComplainsWhenPassedAlreadyEnabledPlugin()
+    public function enableComplainsWhenPassedAlreadyEnabledPlugin(): void
     {
         $this->plugin_list->resolvePluginClass('vendor/package')->will(
             function (array $_args, ObjectProphecy $plugin_list): string {
@@ -213,7 +213,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function enableReportsSuccessWhenItEnablesPlugin()
+    public function enableReportsSuccessWhenItEnablesPlugin(): void
     {
         $this->plugin_list->resolvePluginClass('vendor/package')->will(
             function (array $_args, ObjectProphecy $plugin_list): string {
@@ -237,7 +237,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function requiresPluginNameToDisable()
+    public function requiresPluginNameToDisable(): void
     {
         $disable_command = new CommandTester($this->app->find('disable'));
         $this->expectExceptionMessage('missing: "pluginName"');
@@ -248,7 +248,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function disableComplainsWhenPassedUnresolvablePlugin()
+    public function disableComplainsWhenPassedUnresolvablePlugin(): void
     {
         $this->plugin_list->resolvePluginClass(Argument::any())->willThrow(new \InvalidArgumentException);
 
@@ -266,7 +266,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function disableComplainsWhenPassedNotEnabledPlugin()
+    public function disableComplainsWhenPassedNotEnabledPlugin(): void
     {
         $this->plugin_list->resolvePluginClass('vendor/package')->will(
             function (array $_args, ObjectProphecy $plugin_list): string {
@@ -288,7 +288,7 @@ class PsalmPluginTest extends TestCase
      * @return void
      * @test
      */
-    public function disableReportsSuccessWhenItDisablesPlugin()
+    public function disableReportsSuccessWhenItDisablesPlugin(): void
     {
         $this->plugin_list->resolvePluginClass('vendor/package')->will(
             function (array $_args, ObjectProphecy $plugin_list): string {

--- a/tests/PureAnnotationTest.php
+++ b/tests/PureAnnotationTest.php
@@ -11,7 +11,7 @@ class PureAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'simplePureFunction' => [
@@ -414,7 +414,7 @@ class PureAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'impurePropertyAssignment' => [

--- a/tests/PureCallableTest.php
+++ b/tests/PureCallableTest.php
@@ -9,7 +9,7 @@ class PureCallableTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'varCallableParamReturnType' => [
@@ -236,7 +236,7 @@ class PureCallableTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'impureCallableArgument' => [

--- a/tests/ReferenceConstraintTest.php
+++ b/tests/ReferenceConstraintTest.php
@@ -9,7 +9,7 @@ class ReferenceConstraintTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'functionParameterNoViolation' => [
@@ -163,7 +163,7 @@ class ReferenceConstraintTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'functionParameterViolation' => [

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -49,7 +49,7 @@ class ReportOutputTest extends TestCase
     /**
      * @return void
      */
-    public function testReportFormatValid()
+    public function testReportFormatValid(): void
     {
         $config = new TestConfig();
         $config->throw_exception = false;
@@ -63,7 +63,7 @@ class ReportOutputTest extends TestCase
     /**
      * @return void
      */
-    public function testReportFormatException()
+    public function testReportFormatException(): void
     {
         $this->expectException(\UnexpectedValueException::class);
         $config = new TestConfig();
@@ -101,7 +101,7 @@ echo $a;';
     /**
      * @return void
      */
-    public function testJsonReport()
+    public function testJsonReport(): void
     {
         $this->analyzeFileForReport();
 
@@ -257,7 +257,7 @@ echo $a;';
     /**
      * @return void
      */
-    public function testSonarqubeReport()
+    public function testSonarqubeReport(): void
     {
         $this->analyzeFileForReport();
 
@@ -358,7 +358,7 @@ echo $a;';
     /**
      * @return void
      */
-    public function testEmacsReport()
+    public function testEmacsReport(): void
     {
         $this->analyzeFileForReport();
 
@@ -378,7 +378,7 @@ somefile.php:15:6:warning - Possibly undefined global variable $a, first seen on
     /**
      * @return void
      */
-    public function testPylintReport()
+    public function testPylintReport(): void
     {
         $this->analyzeFileForReport();
 
@@ -398,7 +398,7 @@ somefile.php:15: [W0001] PossiblyUndefinedGlobalVariable: Possibly undefined glo
     /**
      * @return void
      */
-    public function testConsoleReport()
+    public function testConsoleReport(): void
     {
         $this->analyzeFileForReport();
 
@@ -429,7 +429,7 @@ echo $a
     /**
      * @return void
      */
-    public function testConsoleReportNoInfo()
+    public function testConsoleReportNoInfo(): void
     {
         $this->analyzeFileForReport();
 
@@ -458,7 +458,7 @@ echo CHANGE_ME;
     /**
      * @return void
      */
-    public function testConsoleReportNoSnippet()
+    public function testConsoleReportNoSnippet(): void
     {
         $this->analyzeFileForReport();
 
@@ -490,7 +490,7 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:15:6 - Possibly undefined g
     /**
      * @return void
      */
-    public function testCompactReport()
+    public function testCompactReport(): void
     {
         $this->analyzeFileForReport();
 
@@ -517,7 +517,7 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:15:6 - Possibly undefined g
     /**
      * @return void
      */
-    public function testCheckstyleReport()
+    public function testCheckstyleReport(): void
     {
         $this->analyzeFileForReport();
 
@@ -556,7 +556,7 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:15:6 - Possibly undefined g
     /**
      * @return void
      */
-    public function testJunitReport()
+    public function testJunitReport(): void
     {
         $this->analyzeFileForReport();
 
@@ -643,7 +643,7 @@ column_to: 8
     /**
      * @return void
      */
-    public function testEmptyReportIfNotError()
+    public function testEmptyReportIfNotError(): void
     {
         $this->addFile(
             'somefile.php',

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -46,9 +46,6 @@ class ReportOutputTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testReportFormatValid(): void
     {
         $config = new TestConfig();
@@ -60,9 +57,6 @@ class ReportOutputTest extends TestCase
         }
     }
 
-    /**
-     * @return void
-     */
     public function testReportFormatException(): void
     {
         $this->expectException(\UnexpectedValueException::class);
@@ -98,9 +92,6 @@ echo $a;';
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testJsonReport(): void
     {
         $this->analyzeFileForReport();
@@ -254,9 +245,6 @@ echo $a;';
         $this->assertIsArray(json_decode($report->create()));
     }
 
-    /**
-     * @return void
-     */
     public function testSonarqubeReport(): void
     {
         $this->analyzeFileForReport();
@@ -355,9 +343,6 @@ echo $a;';
         );
     }
 
-    /**
-     * @return void
-     */
     public function testEmacsReport(): void
     {
         $this->analyzeFileForReport();
@@ -375,9 +360,6 @@ somefile.php:15:6:warning - Possibly undefined global variable $a, first seen on
         );
     }
 
-    /**
-     * @return void
-     */
     public function testPylintReport(): void
     {
         $this->analyzeFileForReport();
@@ -395,9 +377,6 @@ somefile.php:15: [W0001] PossiblyUndefinedGlobalVariable: Possibly undefined glo
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConsoleReport(): void
     {
         $this->analyzeFileForReport();
@@ -426,9 +405,6 @@ echo $a
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConsoleReportNoInfo(): void
     {
         $this->analyzeFileForReport();
@@ -455,9 +431,6 @@ echo CHANGE_ME;
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConsoleReportNoSnippet(): void
     {
         $this->analyzeFileForReport();
@@ -487,9 +460,6 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:15:6 - Possibly undefined g
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCompactReport(): void
     {
         $this->analyzeFileForReport();
@@ -514,9 +484,6 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:15:6 - Possibly undefined g
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCheckstyleReport(): void
     {
         $this->analyzeFileForReport();
@@ -553,9 +520,6 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:15:6 - Possibly undefined g
         //);
     }
 
-    /**
-     * @return void
-     */
     public function testJunitReport(): void
     {
         $this->analyzeFileForReport();
@@ -640,9 +604,6 @@ column_to: 8
         //);
     }
 
-    /**
-     * @return void
-     */
     public function testEmptyReportIfNotError(): void
     {
         $this->addFile(

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -11,7 +11,7 @@ class ReturnTypeTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'returnTypeAfterUselessNullCheck' => [
@@ -898,7 +898,7 @@ class ReturnTypeTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'wrongReturnType1' => [

--- a/tests/SelfOutTest.php
+++ b/tests/SelfOutTest.php
@@ -8,7 +8,7 @@ class SelfOutTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'changeInterface' => [

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -44,7 +44,7 @@ class StubTest extends TestCase
      *
      * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
      */
-    private function getProjectAnalyzerWithConfig(Config $config)
+    private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $project_analyzer = new \Psalm\Internal\Analyzer\ProjectAnalyzer(
             $config,
@@ -64,7 +64,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testNonexistentStubFile()
+    public function testNonexistentStubFile(): void
     {
         $this->expectException(\Psalm\Exception\ConfigException::class);
         $this->expectExceptionMessage('Cannot resolve stubfile path');
@@ -90,7 +90,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubFileClass()
+    public function testStubFileClass(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -141,7 +141,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testLoadStubFileWithRelativePath()
+    public function testLoadStubFileWithRelativePath(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -165,7 +165,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testLoadStubFileWithAbsolutePath()
+    public function testLoadStubFileWithAbsolutePath(): void
     {
         $runDir = dirname(__DIR__);
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -190,7 +190,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubFileConstant()
+    public function testStubFileConstant(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -229,7 +229,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpStormMetaParsingFile()
+    public function testPhpStormMetaParsingFile(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -319,7 +319,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testNamespacedStubClass()
+    public function testNamespacedStubClass(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -359,7 +359,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubRegularFunction()
+    public function testStubRegularFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -393,7 +393,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubVariadicFunction()
+    public function testStubVariadicFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -427,7 +427,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubVariadicFunctionWrongArgType()
+    public function testStubVariadicFunctionWrongArgType(): void
     {
         $this->expectExceptionMessage('InvalidScalarArgument');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -463,7 +463,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testUserVariadicWithFalseVariadic()
+    public function testUserVariadicWithFalseVariadic(): void
     {
         $this->expectExceptionMessage('TooManyArguments');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -500,7 +500,7 @@ class StubTest extends TestCase
      * @return void
      * @runInSeparateProcess
      */
-    public function testPolyfilledFunction()
+    public function testPolyfilledFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -533,7 +533,7 @@ class StubTest extends TestCase
      * @return void
      * @runInSeparateProcess
      */
-    public function testConditionalConstantDefined()
+    public function testConditionalConstantDefined(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -565,7 +565,7 @@ class StubTest extends TestCase
      * @return void
      * @runInSeparateProcess
      */
-    public function testClassAlias()
+    public function testClassAlias(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -626,7 +626,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubFunctionWithFunctionExists()
+    public function testStubFunctionWithFunctionExists(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -661,7 +661,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testNamespacedStubFunctionWithFunctionExists()
+    public function testNamespacedStubFunctionWithFunctionExists(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -697,7 +697,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testNoStubFunction()
+    public function testNoStubFunction(): void
     {
         $this->expectExceptionMessage('UndefinedFunction - /src/somefile.php:2:22 - Function barBar does not exist');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -729,7 +729,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testNamespacedStubFunction()
+    public function testNamespacedStubFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -763,7 +763,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalNamespacedStubFunction()
+    public function testConditionalNamespacedStubFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -797,7 +797,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionallyExtendingInterface()
+    public function testConditionallyExtendingInterface(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -847,7 +847,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubFileWithExistingClassDefinition()
+    public function testStubFileWithExistingClassDefinition(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -881,7 +881,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubFileWithPartialClassDefinitionWithMoreMethods()
+    public function testStubFileWithPartialClassDefinitionWithMoreMethods(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -932,7 +932,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testExtendOnlyStubbedClass()
+    public function testExtendOnlyStubbedClass(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -970,7 +970,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubFileWithExtendedStubbedClass()
+    public function testStubFileWithExtendedStubbedClass(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -1008,7 +1008,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubFileWithPartialClassDefinitionWithCoercion()
+    public function testStubFileWithPartialClassDefinitionWithCoercion(): void
     {
         $this->expectExceptionMessage('TypeCoercion');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -1056,7 +1056,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubFileWithPartialClassDefinitionGeneralReturnType()
+    public function testStubFileWithPartialClassDefinitionGeneralReturnType(): void
     {
         $this->expectExceptionMessage('InvalidReturnStatement');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -1102,7 +1102,7 @@ class StubTest extends TestCase
     /**
      * @return void
      */
-    public function testStubFileWithTemplatedClassDefinitionAndMagicMethodOverride()
+    public function testStubFileWithTemplatedClassDefinitionAndMagicMethodOverride(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -39,11 +39,6 @@ class StubTest extends TestCase
         $this->file_provider = new Provider\FakeFileProvider();
     }
 
-    /**
-     * @param  Config $config
-     *
-     * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
-     */
     private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $project_analyzer = new \Psalm\Internal\Analyzer\ProjectAnalyzer(
@@ -61,9 +56,6 @@ class StubTest extends TestCase
         return $project_analyzer;
     }
 
-    /**
-     * @return void
-     */
     public function testNonexistentStubFile(): void
     {
         $this->expectException(\Psalm\Exception\ConfigException::class);
@@ -87,9 +79,6 @@ class StubTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testStubFileClass(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -127,10 +116,6 @@ class StubTest extends TestCase
     }
 
     /**
-     * @param string $file
-     *
-     * @return string
-     *
      * @psalm-pure
      */
     private function getOperatingSystemStyledPath(string $file): string
@@ -138,9 +123,6 @@ class StubTest extends TestCase
         return implode(DIRECTORY_SEPARATOR, explode('/', $file));
     }
 
-    /**
-     * @return void
-     */
     public function testLoadStubFileWithRelativePath(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -162,9 +144,6 @@ class StubTest extends TestCase
         $this->assertStringContainsString($path, \reset($stub_files));
     }
 
-    /**
-     * @return void
-     */
     public function testLoadStubFileWithAbsolutePath(): void
     {
         $runDir = dirname(__DIR__);
@@ -187,9 +166,6 @@ class StubTest extends TestCase
         $this->assertStringContainsString($path, \reset($stub_files));
     }
 
-    /**
-     * @return void
-     */
     public function testStubFileConstant(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -226,9 +202,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testPhpStormMetaParsingFile(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -316,9 +289,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, $context);
     }
 
-    /**
-     * @return void
-     */
     public function testNamespacedStubClass(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -356,9 +326,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubRegularFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -390,9 +357,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubVariadicFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -424,9 +388,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubVariadicFunctionWrongArgType(): void
     {
         $this->expectExceptionMessage('InvalidScalarArgument');
@@ -460,9 +421,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testUserVariadicWithFalseVariadic(): void
     {
         $this->expectExceptionMessage('TooManyArguments');
@@ -497,7 +455,6 @@ class StubTest extends TestCase
     }
 
     /**
-     * @return void
      * @runInSeparateProcess
      */
     public function testPolyfilledFunction(): void
@@ -530,7 +487,6 @@ class StubTest extends TestCase
     }
 
     /**
-     * @return void
      * @runInSeparateProcess
      */
     public function testConditionalConstantDefined(): void
@@ -562,7 +518,6 @@ class StubTest extends TestCase
     }
 
     /**
-     * @return void
      * @runInSeparateProcess
      */
     public function testClassAlias(): void
@@ -623,9 +578,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubFunctionWithFunctionExists(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -658,9 +610,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testNamespacedStubFunctionWithFunctionExists(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -694,9 +643,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testNoStubFunction(): void
     {
         $this->expectExceptionMessage('UndefinedFunction - /src/somefile.php:2:22 - Function barBar does not exist');
@@ -726,9 +672,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testNamespacedStubFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -760,9 +703,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testConditionalNamespacedStubFunction(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -794,9 +734,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testConditionallyExtendingInterface(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -844,9 +781,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubFileWithExistingClassDefinition(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -878,9 +812,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubFileWithPartialClassDefinitionWithMoreMethods(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -929,9 +860,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testExtendOnlyStubbedClass(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -967,9 +895,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubFileWithExtendedStubbedClass(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
@@ -1005,9 +930,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubFileWithPartialClassDefinitionWithCoercion(): void
     {
         $this->expectExceptionMessage('TypeCoercion');
@@ -1053,9 +975,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubFileWithPartialClassDefinitionGeneralReturnType(): void
     {
         $this->expectExceptionMessage('InvalidReturnStatement');
@@ -1099,9 +1018,6 @@ class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
-    /**
-     * @return void
-     */
     public function testStubFileWithTemplatedClassDefinitionAndMagicMethodOverride(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(

--- a/tests/SwitchTypeTest.php
+++ b/tests/SwitchTypeTest.php
@@ -11,7 +11,7 @@ class SwitchTypeTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'getClassConstArg' => [
@@ -990,7 +990,7 @@ class SwitchTypeTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'switchReturnTypeWithFallthroughAndBreak' => [

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -14,7 +14,7 @@ class TaintTest extends TestCase
      *
      * @return void
      */
-    public function testValidCode(string $code)
+    public function testValidCode(string $code): void
     {
         $test_name = $this->getTestName();
         if (\strpos($test_name, 'SKIPPED-') !== false) {
@@ -45,7 +45,7 @@ class TaintTest extends TestCase
      *
      * @return void
      */
-    public function testInvalidCode(string $code, string $error_message)
+    public function testInvalidCode(string $code, string $error_message): void
     {
         if (\strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
@@ -73,7 +73,7 @@ class TaintTest extends TestCase
     /**
      * @return array<string, array{string}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'taintedInputInCreatedArrayNotEchoed' => [
@@ -493,7 +493,7 @@ class TaintTest extends TestCase
     /**
      * @return array<string, array{0: string, error_message: string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): array
     {
         return [
             'taintedInputFromMethodReturnTypeSimple' => [

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -10,9 +10,7 @@ class TaintTest extends TestCase
     /**
      * @dataProvider providerValidCodeParse
      *
-     * @param string $code
      *
-     * @return void
      */
     public function testValidCode(string $code): void
     {
@@ -40,10 +38,7 @@ class TaintTest extends TestCase
     /**
      * @dataProvider providerInvalidCodeParse
      *
-     * @param string $code
-     * @param string $error_message
      *
-     * @return void
      */
     public function testInvalidCode(string $code, string $error_message): void
     {

--- a/tests/Template/ClassStringMapTest.php
+++ b/tests/Template/ClassStringMapTest.php
@@ -13,7 +13,7 @@ class ClassStringMapTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'basicClassStringMap' => [
@@ -78,7 +78,7 @@ class ClassStringMapTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'assignInvalidClass' => [

--- a/tests/Template/ClassTemplateCovarianceTest.php
+++ b/tests/Template/ClassTemplateCovarianceTest.php
@@ -13,7 +13,7 @@ class ClassTemplateCovarianceTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'allowBoundedType' => [
@@ -562,7 +562,7 @@ class ClassTemplateCovarianceTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'preventCovariantParamUsage' => [

--- a/tests/Template/ClassTemplateExtendsTest.php
+++ b/tests/Template/ClassTemplateExtendsTest.php
@@ -13,7 +13,7 @@ class ClassTemplateExtendsTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'phanTuple' => [
@@ -4474,7 +4474,7 @@ class ClassTemplateExtendsTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'extendsWithUnfulfilledNonTemplate' => [

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -13,7 +13,7 @@ class ClassTemplateTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'classTemplate' => [
@@ -2931,7 +2931,7 @@ class ClassTemplateTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'restrictTemplateInputWithClassString' => [

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -12,7 +12,7 @@ class ConditionalReturnTypeTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'conditionalReturnType' => [

--- a/tests/Template/FunctionClassStringTemplateTest.php
+++ b/tests/Template/FunctionClassStringTemplateTest.php
@@ -12,7 +12,7 @@ class FunctionClassStringTemplateTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'callStaticMethodOnTemplatedClassName' => [
@@ -704,7 +704,7 @@ class FunctionClassStringTemplateTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'copyScopedClassInFunction' => [

--- a/tests/Template/FunctionTemplateAssertTest.php
+++ b/tests/Template/FunctionTemplateAssertTest.php
@@ -12,7 +12,7 @@ class FunctionTemplateAssertTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'assertTemplatedType' => [
@@ -721,7 +721,7 @@ class FunctionTemplateAssertTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'detectRedundantCondition' => [

--- a/tests/Template/FunctionTemplateTest.php
+++ b/tests/Template/FunctionTemplateTest.php
@@ -12,7 +12,7 @@ class FunctionTemplateTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'validTemplatedType' => [
@@ -1408,7 +1408,7 @@ class FunctionTemplateTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidTemplatedType' => [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -82,7 +82,6 @@ class TestCase extends BaseTestCase
      * @param string $file_path
      * @param string $contents
      *
-     * @return void
      */
     public function addFile($file_path, $contents): void
     {
@@ -92,9 +91,7 @@ class TestCase extends BaseTestCase
 
     /**
      * @param  string         $file_path
-     * @param  \Psalm\Context $context
      *
-     * @return void
      */
     public function analyzeFile($file_path, \Psalm\Context $context, bool $track_unused_suppressions = true): void
     {
@@ -130,7 +127,6 @@ class TestCase extends BaseTestCase
     /**
      * @param  bool $withDataSet
      *
-     * @return string
      */
     protected function getTestName($withDataSet = true): string
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -84,7 +84,7 @@ class TestCase extends BaseTestCase
      *
      * @return void
      */
-    public function addFile($file_path, $contents)
+    public function addFile($file_path, $contents): void
     {
         $this->file_provider->registerFile($file_path, $contents);
         $this->project_analyzer->getCodebase()->scanner->addFileToShallowScan($file_path);
@@ -96,7 +96,7 @@ class TestCase extends BaseTestCase
      *
      * @return void
      */
-    public function analyzeFile($file_path, \Psalm\Context $context, bool $track_unused_suppressions = true)
+    public function analyzeFile($file_path, \Psalm\Context $context, bool $track_unused_suppressions = true): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $codebase->addFilesToAnalyze([$file_path => $file_path]);
@@ -132,7 +132,7 @@ class TestCase extends BaseTestCase
      *
      * @return string
      */
-    protected function getTestName($withDataSet = true)
+    protected function getTestName($withDataSet = true): string
     {
         $name = parent::getName($withDataSet);
         /**

--- a/tests/ThrowsAnnotationTest.php
+++ b/tests/ThrowsAnnotationTest.php
@@ -66,9 +66,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testUndocumentedThrow(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');
@@ -96,9 +93,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedThrow(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -128,9 +122,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedParentThrow(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -159,9 +150,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testThrowableInherited(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -186,9 +174,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testUndocumentedThrowInFunctionCall(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');
@@ -224,9 +209,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedThrowInFunctionCallWithThrow(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -264,9 +246,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedThrowInFunctionCallWithoutThrow(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -304,9 +283,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testCaughtThrowInFunctionCall(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -344,9 +320,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtThrowInFunctionCall(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');
@@ -386,9 +359,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testEmptyThrows(): void
     {
         $this->expectExceptionMessage('MissingDocblockType');
@@ -409,9 +379,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testCaughtAllThrowInFunctionCall(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -447,9 +414,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedThrowInInterfaceWithInheritDocblock(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -483,9 +447,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedThrowInInterfaceWithoutInheritDocblock(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -516,9 +477,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedThrowInSubclassWithExtendedInheritDocblock(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -553,9 +511,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedThrowInInterfaceWithExtendedInheritDocblock(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -590,9 +545,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedThrowInInterfaceWithOverriddenDocblock(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');
@@ -628,9 +580,6 @@ class ThrowsAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testDocumentedThrowInsideCatch(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');

--- a/tests/ThrowsAnnotationTest.php
+++ b/tests/ThrowsAnnotationTest.php
@@ -69,7 +69,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testUndocumentedThrow()
+    public function testUndocumentedThrow(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -99,7 +99,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedThrow()
+    public function testDocumentedThrow(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -131,7 +131,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedParentThrow()
+    public function testDocumentedParentThrow(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -162,7 +162,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testThrowableInherited()
+    public function testThrowableInherited(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -189,7 +189,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testUndocumentedThrowInFunctionCall()
+    public function testUndocumentedThrowInFunctionCall(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -227,7 +227,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedThrowInFunctionCallWithThrow()
+    public function testDocumentedThrowInFunctionCallWithThrow(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -267,7 +267,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedThrowInFunctionCallWithoutThrow()
+    public function testDocumentedThrowInFunctionCallWithoutThrow(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -307,7 +307,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testCaughtThrowInFunctionCall()
+    public function testCaughtThrowInFunctionCall(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -347,7 +347,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtThrowInFunctionCall()
+    public function testUncaughtThrowInFunctionCall(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -389,7 +389,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testEmptyThrows()
+    public function testEmptyThrows(): void
     {
         $this->expectExceptionMessage('MissingDocblockType');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -412,7 +412,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testCaughtAllThrowInFunctionCall()
+    public function testCaughtAllThrowInFunctionCall(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -450,7 +450,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedThrowInInterfaceWithInheritDocblock()
+    public function testDocumentedThrowInInterfaceWithInheritDocblock(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -486,7 +486,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedThrowInInterfaceWithoutInheritDocblock()
+    public function testDocumentedThrowInInterfaceWithoutInheritDocblock(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -519,7 +519,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedThrowInSubclassWithExtendedInheritDocblock()
+    public function testDocumentedThrowInSubclassWithExtendedInheritDocblock(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -556,7 +556,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedThrowInInterfaceWithExtendedInheritDocblock()
+    public function testDocumentedThrowInInterfaceWithExtendedInheritDocblock(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
 
@@ -593,7 +593,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedThrowInInterfaceWithOverriddenDocblock()
+    public function testDocumentedThrowInInterfaceWithOverriddenDocblock(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -631,7 +631,7 @@ class ThrowsAnnotationTest extends TestCase
     /**
      * @return void
      */
-    public function testDocumentedThrowInsideCatch()
+    public function testDocumentedThrowInsideCatch(): void
     {
         $this->expectExceptionMessage('MissingThrowsDocblock');
         $this->expectException(\Psalm\Exception\CodeException::class);

--- a/tests/ThrowsInGlobalScopeTest.php
+++ b/tests/ThrowsInGlobalScopeTest.php
@@ -9,7 +9,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtDocumentedThrowCall()
+    public function testUncaughtDocumentedThrowCall(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UncaughtThrowInGlobalScope');
@@ -45,7 +45,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testCaughtDocumentedThrowCall()
+    public function testCaughtDocumentedThrowCall(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
         Config::getInstance()->check_for_throws_in_global_scope = true;
@@ -82,7 +82,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtUndocumentedThrowCall()
+    public function testUncaughtUndocumentedThrowCall(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
 
@@ -112,7 +112,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtDocumentedThrowCallInNamespace()
+    public function testUncaughtDocumentedThrowCallInNamespace(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UncaughtThrowInGlobalScope');
@@ -149,7 +149,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtThrow()
+    public function testUncaughtThrow(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
         $this->expectExceptionMessage('UncaughtThrowInGlobalScope');
@@ -170,7 +170,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testCaughtThrow()
+    public function testCaughtThrow(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
 
@@ -190,7 +190,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtThrowWhenSuppressing()
+    public function testUncaughtThrowWhenSuppressing(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
 
@@ -209,7 +209,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtThrowInNamespaceWhenSuppressing()
+    public function testUncaughtThrowInNamespaceWhenSuppressing(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
 
@@ -229,7 +229,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtDocumentedThrowCallWhenSuppressing()
+    public function testUncaughtDocumentedThrowCallWhenSuppressing(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
 
@@ -264,7 +264,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtDocumentedThrowCallInNamespaceWhenSuppressing()
+    public function testUncaughtDocumentedThrowCallInNamespaceWhenSuppressing(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
 
@@ -300,7 +300,7 @@ class ThrowsInGlobalScopeTest extends TestCase
     /**
      * @return void
      */
-    public function testUncaughtDocumentedThrowCallWhenSuppressingFirst()
+    public function testUncaughtDocumentedThrowCallWhenSuppressingFirst(): void
     {
         $this->expectExceptionMessage('UncaughtThrowInGlobalScope');
         $this->expectException(\Psalm\Exception\CodeException::class);

--- a/tests/ThrowsInGlobalScopeTest.php
+++ b/tests/ThrowsInGlobalScopeTest.php
@@ -6,9 +6,6 @@ use Psalm\Context;
 
 class ThrowsInGlobalScopeTest extends TestCase
 {
-    /**
-     * @return void
-     */
     public function testUncaughtDocumentedThrowCall(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -42,9 +39,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testCaughtDocumentedThrowCall(): void
     {
         Config::getInstance()->check_for_throws_docblock = true;
@@ -79,9 +73,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtUndocumentedThrowCall(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
@@ -109,9 +100,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtDocumentedThrowCallInNamespace(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -146,9 +134,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtThrow(): void
     {
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -167,9 +152,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testCaughtThrow(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
@@ -187,9 +169,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtThrowWhenSuppressing(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
@@ -206,9 +185,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context, false);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtThrowInNamespaceWhenSuppressing(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
@@ -226,9 +202,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context, false);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtDocumentedThrowCallWhenSuppressing(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
@@ -261,9 +234,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context, false);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtDocumentedThrowCallInNamespaceWhenSuppressing(): void
     {
         Config::getInstance()->check_for_throws_in_global_scope = true;
@@ -297,9 +267,6 @@ class ThrowsInGlobalScopeTest extends TestCase
         $this->analyzeFile('somefile.php', $context, false);
     }
 
-    /**
-     * @return void
-     */
     public function testUncaughtDocumentedThrowCallWhenSuppressingFirst(): void
     {
         $this->expectExceptionMessage('UncaughtThrowInGlobalScope');

--- a/tests/ToStringTest.php
+++ b/tests/ToStringTest.php
@@ -9,7 +9,7 @@ class ToStringTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'validToString' => [
@@ -154,7 +154,7 @@ class ToStringTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'echoClass' => [

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -8,7 +8,7 @@ class TraceTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'traceVariable' => [

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -11,7 +11,7 @@ class TraitTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'accessiblePrivateMethodFromTrait' => [
@@ -979,7 +979,7 @@ class TraitTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'inaccessiblePrivateMethodFromInheritedTrait' => [

--- a/tests/Traits/InvalidCodeAnalysisTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisTestTrait.php
@@ -15,7 +15,7 @@ trait InvalidCodeAnalysisTestTrait
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    abstract public function providerInvalidCodeParse();
+    abstract public function providerInvalidCodeParse(): iterable;
 
     /**
      * @dataProvider providerInvalidCodeParse

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -15,7 +15,7 @@ trait ValidCodeAnalysisTestTrait
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    abstract public function providerValidCodeParse();
+    abstract public function providerValidCodeParse(): iterable;
 
     /**
      * @dataProvider providerValidCodeParse

--- a/tests/TryCatchTest.php
+++ b/tests/TryCatchTest.php
@@ -9,7 +9,7 @@ class TryCatchTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'addThrowableInterfaceType' => [
@@ -357,7 +357,7 @@ class TryCatchTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidCatchClass' => [

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -9,7 +9,7 @@ class TypeAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'typeAliasBeforeClass' => [
@@ -342,7 +342,7 @@ class TypeAnnotationTest extends TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'invalidTypeAlias' => [

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -15,7 +15,6 @@ class TypeCombinationTest extends TestCase
      * @param string $expected
      * @param non-empty-list<string> $types
      *
-     * @return void
      */
     public function testValidTypeCombination($expected, $types): void
     {
@@ -636,7 +635,6 @@ class TypeCombinationTest extends TestCase
     /**
      * @param  string $string
      *
-     * @return Type\Atomic
      */
     private static function getAtomic($string): Type\Atomic
     {

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -17,7 +17,7 @@ class TypeCombinationTest extends TestCase
      *
      * @return void
      */
-    public function testValidTypeCombination($expected, $types)
+    public function testValidTypeCombination($expected, $types): void
     {
         $converted_types = [];
 
@@ -36,7 +36,7 @@ class TypeCombinationTest extends TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'multipleValuedArray' => [
@@ -62,7 +62,7 @@ class TypeCombinationTest extends TestCase
     /**
      * @return array<string,array{string,non-empty-list<string>}>
      */
-    public function providerTestValidTypeCombination()
+    public function providerTestValidTypeCombination(): array
     {
         return [
             'intOrString' => [
@@ -638,7 +638,7 @@ class TypeCombinationTest extends TestCase
      *
      * @return Type\Atomic
      */
-    private static function getAtomic($string)
+    private static function getAtomic($string): Type\Atomic
     {
         return array_values(Type::parseString($string)->getAtomicTypes())[0];
     }

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -28,196 +28,124 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testThisToStatic(): void
     {
         $this->assertSame('static', (string) Type::parseString('$this'));
     }
 
-    /**
-     * @return void
-     */
     public function testThisToStaticUnion(): void
     {
         $this->assertSame('A|static', (string) Type::parseString('$this|A'));
     }
 
-    /**
-     * @return void
-     */
     public function testIntOrString(): void
     {
         $this->assertSame('int|string', (string) Type::parseString('int|string'));
     }
 
-    /**
-     * @return void
-     */
     public function testBracketedIntOrString(): void
     {
         $this->assertSame('int|string', (string) Type::parseString('(int|string)'));
     }
 
-    /**
-     * @return void
-     */
     public function testBoolOrIntOrString(): void
     {
         $this->assertSame('bool|int|string', (string) Type::parseString('bool|int|string'));
     }
 
-    /**
-     * @return void
-     */
     public function testNullable(): void
     {
         $this->assertSame('null|string', (string) Type::parseString('?string'));
     }
 
-    /**
-     * @return void
-     */
     public function testNullableUnion(): void
     {
         $this->assertSame('int|null|string', (string) Type::parseString('?(string|int)'));
     }
 
-    /**
-     * @return void
-     */
     public function testNullableFullyQualified(): void
     {
         $this->assertSame('null|stdClass', (string) Type::parseString('?\\stdClass'));
     }
 
-    /**
-     * @return void
-     */
     public function testNullableOrNullable(): void
     {
         $this->assertSame('int|null|string', (string) Type::parseString('?string|?int'));
     }
 
-    /**
-     * @return void
-     */
     public function testBadNullableCharacterInUnion(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('int|array|?');
     }
 
-    /**
-     * @return void
-     */
     public function testBadNullableCharacterInUnionWithFollowing(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('int|array|?|bool');
     }
 
-    /**
-     * @return void
-     */
     public function testArrayWithClosingBracket(): void
     {
         $this->assertSame('array<int, int>', (string) Type::parseString('array<int, int>'));
     }
 
-    /**
-     * @return void
-     */
     public function testArrayWithoutClosingBracket(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array<int, int');
     }
 
-    /**
-     * @return void
-     */
     public function testArrayWithSingleArg(): void
     {
         $this->assertSame('array<array-key, int>', (string) Type::parseString('array<int>'));
     }
 
-    /**
-     * @return void
-     */
     public function testArrayWithNestedSingleArg(): void
     {
         $this->assertSame('array<array-key, array<array-key, int>>', (string) Type::parseString('array<array<int>>'));
     }
 
-    /**
-     * @return void
-     */
     public function testArrayWithUnion(): void
     {
         $this->assertSame('array<int|string, string>', (string) Type::parseString('array<int|string, string>'));
     }
 
-    /**
-     * @return void
-     */
     public function testNonEmptyArrray(): void
     {
         $this->assertSame('non-empty-array<array-key, int>', (string) Type::parseString('non-empty-array<int>'));
     }
 
-    /**
-     * @return void
-     */
     public function testGeneric(): void
     {
         $this->assertSame('B<int>', (string) Type::parseString('B<int>'));
     }
 
-    /**
-     * @return void
-     */
     public function testIntersection(): void
     {
         $this->assertSame('I1&I2&I3', (string) Type::parseString('I1&I2&I3'));
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionOrNull(): void
     {
         $this->assertSame('I1&I2|null', (string) Type::parseString('I1&I2|null'));
     }
 
-    /**
-     * @return void
-     */
     public function testNullOrIntersection(): void
     {
         $this->assertSame('I1&I2|null', (string) Type::parseString('null|I1&I2'));
     }
 
-    /**
-     * @return void
-     */
     public function testInteratorAndTraversable(): void
     {
         $this->assertSame('Iterator<mixed, int>&Traversable', (string) Type::parseString('Iterator<int>&Traversable'));
     }
 
-    /**
-     * @return void
-     */
     public function testStaticAndStatic(): void
     {
         $this->assertSame('static', (string) Type::parseString('static&static'));
     }
 
-    /**
-     * @return void
-     */
     public function testTraversableAndIteratorOrNull(): void
     {
         $this->assertSame(
@@ -226,9 +154,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testIteratorAndTraversableOrNull(): void
     {
         $this->assertSame(
@@ -237,76 +162,49 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionAfterGeneric(): void
     {
         $this->assertSame('Countable&iterable<mixed, int>&I', (string) Type::parseString('Countable&iterable<int>&I'));
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionOfIterables(): void
     {
         $this->assertSame('iterable<mixed, A>&iterable<mixed, B>', (string) Type::parseString('iterable<A>&iterable<B>'));
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionOfTKeyedArray(): void
     {
         $this->assertSame('array{a: int, b: int}', (string) Type::parseString('array{a: int}&array{b: int}'));
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionOfTKeyedArrayWithMergedProperties(): void
     {
         $this->assertSame('array{a: int}', (string) Type::parseString('array{a: int}&array{a: mixed}'));
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionOfTKeyedArrayWithPossiblyUndefinedMergedProperties(): void
     {
         $this->assertSame('array{a: int}', (string) Type::parseString('array{a: int}&array{a?: int}'));
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionOfTKeyedArrayWithConflictingProperties(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{a: string}&array{a: int}');
     }
 
-    /**
-     * @return void
-     */
     public function testUnionOfIntersectionOfTKeyedArray(): void
     {
         $this->assertSame('array{a: int|string, b?: int}', (string) Type::parseString('array{a: int}|array{a: string}&array{b: int}'));
         $this->assertSame('array{a: int|string, b?: int}', (string) Type::parseString('array{b: int}&array{a: string}|array{a: int}'));
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionOfUnionOfTKeyedArray(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{a: int}&array{a: string}|array{b: int}');
     }
 
-    /**
-     * @return void
-     */
     public function testIntersectionOfTKeyedArrayAndObject(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
@@ -318,41 +216,26 @@ class TypeParseTest extends TestCase
         $this->assertSame('iterable<string, array{int}>', Type::parseString('iterable<string, array{int}>')->getId());
     }
 
-    /**
-     * @return void
-     */
     public function testPhpDocSimpleArray(): void
     {
         $this->assertSame('array<array-key, A>', (string) Type::parseString('A[]'));
     }
 
-    /**
-     * @return void
-     */
     public function testPhpDocUnionArray(): void
     {
         $this->assertSame('array<array-key, A|B>', (string) Type::parseString('(A|B)[]'));
     }
 
-    /**
-     * @return void
-     */
     public function testPhpDocMultiDimensionalArray(): void
     {
         $this->assertSame('array<array-key, array<array-key, A>>', (string) Type::parseString('A[][]'));
     }
 
-    /**
-     * @return void
-     */
     public function testPhpDocMultidimensionalUnionArray(): void
     {
         $this->assertSame('array<array-key, array<array-key, A|B>>', (string) Type::parseString('(A|B)[][]'));
     }
 
-    /**
-     * @return void
-     */
     public function testPhpDocTKeyedArray(): void
     {
         $this->assertSame(
@@ -361,151 +244,97 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testPhpDocUnionOfArrays(): void
     {
         $this->assertSame('array<array-key, A|B>', (string) Type::parseString('A[]|B[]'));
     }
 
-    /**
-     * @return void
-     */
     public function testPhpDocUnionOfArraysOrObject(): void
     {
         $this->assertSame('C|array<array-key, A|B>', (string) Type::parseString('A[]|B[]|C'));
     }
 
-    /**
-     * @return void
-     */
     public function testPsalmOnlyAtomic(): void
     {
         $this->assertSame('class-string', (string) Type::parseString('class-string'));
     }
 
-    /**
-     * @return void
-     */
     public function testParameterizedClassString(): void
     {
         $this->assertSame('class-string<A>', (string) Type::parseString('class-string<A>'));
     }
 
-    /**
-     * @return void
-     */
     public function testParameterizedClassStringUnion(): void
     {
         $this->assertSame('class-string<A>|class-string<B>', (string) Type::parseString('class-string<A>|class-string<B>'));
     }
 
-    /**
-     * @return void
-     */
     public function testInvalidType(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array(A)');
     }
 
-    /**
-     * @return void
-     */
     public function testBracketedUnionAndIntersection(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('(A|B)&C');
     }
 
-    /**
-     * @return void
-     */
     public function testBracketInUnion(): void
     {
         Type::parseString('null|(scalar|array|object)');
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithSimpleArgs(): void
     {
         $this->assertSame('array{a: int, b: string}', (string) Type:: parseString('array{a: int, b: string}'));
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithSpace(): void
     {
         $this->assertSame('array{\'a \': int, \'b  \': string}', (string) Type:: parseString('array{\'a \': int, \'b  \': string}'));
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithQuotedKeys(): void
     {
         $this->assertSame('array{\'\\"\': int, \'\\\'\': string}', (string) Type:: parseString('array{\'"\': int, \'\\\'\': string}'));
         $this->assertSame('array{\'\\"\': int, \'\\\'\': string}', (string) Type:: parseString('array{"\\"": int, "\\\'": string}'));
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithClassConstantKey(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{self::FOO: string}');
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithQuotedClassConstantKey(): void
     {
         $this->assertSame('array{\'self::FOO\': string}', (string) Type:: parseString('array{"self::FOO": string}'));
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithoutClosingBracket(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{a: int, b: string');
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayInType(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{a:[]}');
     }
 
-    /**
-     * @return void
-     */
     public function testObjectWithSimpleArgs(): void
     {
         $this->assertSame('object{a:int, b:string}', (string) Type::parseString('object{a:int, b:string}'));
     }
 
-    /**
-     * @return void
-     */
     public function testObjectWithDollarArgs(): void
     {
         $this->assertSame('object{a:int, $b:string}', (string) Type::parseString('object{a:int, $b:string}'));
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithUnionArgs(): void
     {
         $this->assertSame(
@@ -514,9 +343,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithGenericArgs(): void
     {
         $this->assertSame(
@@ -525,9 +351,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithIntKeysAndUnionArgs(): void
     {
         $this->assertSame(
@@ -536,9 +359,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayWithIntKeysAndGenericArgs(): void
     {
         $this->assertSame(
@@ -552,9 +372,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testTKeyedArrayOptional(): void
     {
         $this->assertSame(
@@ -563,9 +380,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testSimpleCallable(): void
     {
         $this->assertSame(
@@ -574,18 +388,12 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithoutClosingBracket(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('callable(int, string');
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithParamNames(): void
     {
         $this->assertSame(
@@ -594,9 +402,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableReturningIntersection(): void
     {
         $this->assertSame(
@@ -605,9 +410,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testEmptyCallable(): void
     {
         $this->assertSame(
@@ -616,9 +418,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithUnionLastType(): void
     {
         $this->assertSame(
@@ -627,9 +426,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithVariadic(): void
     {
         $this->assertSame(
@@ -638,9 +434,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableThatReturnsACallable(): void
     {
         $this->assertSame(
@@ -649,9 +442,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableThatReturnsACallableThatReturnsACallable(): void
     {
         $this->assertSame(
@@ -660,9 +450,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableOrInt(): void
     {
         $this->assertSame(
@@ -671,18 +458,12 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithGoodVariadic(): void
     {
         Type::parseString('callable(int, string...) : void');
         Type::parseString('callable(int,string...) : void');
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithSpreadBefore(): void
     {
         $this->assertSame(
@@ -691,9 +472,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConditionalTypeWithSpaces(): void
     {
         $this->assertSame(
@@ -702,9 +480,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConditionalTypeWithUnion(): void
     {
         $this->assertSame(
@@ -713,9 +488,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConditionalTypeWithTKeyedArray(): void
     {
         $this->assertSame(
@@ -724,9 +496,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConditionalTypeWithGenericIs(): void
     {
         $this->assertSame(
@@ -735,9 +504,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConditionalTypeWithIntersection(): void
     {
         $this->assertSame(
@@ -746,9 +512,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConditionalTypeWithoutSpaces(): void
     {
         $this->assertSame(
@@ -757,18 +520,12 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testConditionalTypeWithCallableElseBool(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('(T is string ? callable() : bool)', null, ['T' => ['' => [Type::getArray()]]]);
     }
 
-    /**
-     * @return void
-     */
     public function testConditionalTypeWithCallableReturningBoolElseBool(): void
     {
         $this->assertSame(
@@ -813,153 +570,102 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithTrailingColon(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('callable(int):');
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithAnotherBadVariadic(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('callable(int, string..) : void');
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithVariadicAndDefault(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('callable(int, string...=) : void');
     }
 
-    /**
-     * @return void
-     */
     public function testBadVariadic(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('string...');
     }
 
-    /**
-     * @return void
-     */
     public function testBadFullStop(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('string.');
     }
 
-    /**
-     * @return void
-     */
     public function testBadSemicolon(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('string;');
     }
 
-    /**
-     * @return void
-     */
     public function testBadGenericString(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('string<T>');
     }
 
-    /**
-     * @return void
-     */
     public function testBadAmpersand(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('&array');
     }
 
-    /**
-     * @return void
-     */
     public function testBadColon(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString(':array');
     }
 
-    /**
-     * @return void
-     */
     public function testBadBrackets(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('max(a)');
     }
 
-    /**
-     * @return void
-     */
     public function testMoreBadBrackets(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('max(a):void');
     }
 
-    /**
-     * @return void
-     */
     public function testGeneratorWithWBadBrackets(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('Generator{string, A}');
     }
 
-    /**
-     * @return void
-     */
     public function testBadEquals(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('=array');
     }
 
-    /**
-     * @return void
-     */
     public function testBadBar(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('|array');
     }
 
-    /**
-     * @return void
-     */
     public function testBadColonDash(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array|string:-');
     }
 
-    /**
-     * @return void
-     */
     public function testDoubleBar(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('PDO||Closure|numeric');
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithDefault(): void
     {
         $this->assertSame(
@@ -968,9 +674,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testNestedCallable(): void
     {
         $this->assertSame(
@@ -979,9 +682,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCallableWithoutReturn(): void
     {
         $this->assertSame(
@@ -990,9 +690,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCombineLiteralStringWithClassString(): void
     {
         $this->assertSame(
@@ -1001,9 +698,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testCombineLiteralClassStringWithClassString(): void
     {
         $this->assertSame(
@@ -1012,9 +706,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testKeyOfClassConstant(): void
     {
         $this->assertSame(
@@ -1023,9 +714,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testKeyOfTemplate(): void
     {
         $this->assertSame(
@@ -1034,9 +722,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testIndexedAccess(): void
     {
         $this->assertSame(
@@ -1054,9 +739,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testValueOfClassConstant(): void
     {
         $this->assertSame(
@@ -1073,9 +755,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testVeryLargeType(): void
     {
         $very_large_type = 'array{a: Closure():(array<array-key, mixed>|null), b?: Closure():array<array-key, mixed>, c?: Closure():array<array-key, mixed>, d?: Closure():array<array-key, mixed>, e?: Closure():(array{f: null|string, g: null|string, h: null|string, i: string, j: mixed, k: mixed, l: mixed, m: mixed, n: bool, o?: array{0: string}}|null), p?: Closure():(array{f: null|string, g: null|string, h: null|string, i: string, j: mixed, k: mixed, l: mixed, m: mixed, n: bool, o?: array{0: string}}|null), q: string, r?: Closure():(array<array-key, mixed>|null), s: array<array-key, mixed>}|null';
@@ -1086,9 +765,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testEnum(): void
     {
         $docblock_type = Type::parseString('( \'foo\\\'with\' | "bar\"bar" | "baz" | "bat\\\\" | \'bang bang\' | 1 | 2 | 3 | 4.5)');
@@ -1141,9 +817,6 @@ class TypeParseTest extends TestCase
         $this->assertSame($resolved_type->getId(), $docblock_type->getId());
     }
 
-    /**
-     * @return void
-     */
     public function testEnumWithoutSpaces(): void
     {
         $docblock_type = Type::parseString('\'foo\\\'with\'|"bar\"bar"|"baz"|"bat\\\\"|\'bang bang\'|1|2|3|4.5');
@@ -1163,9 +836,6 @@ class TypeParseTest extends TestCase
         $this->assertSame($resolved_type->getId(), $docblock_type->getId());
     }
 
-    /**
-     * @return void
-     */
     public function testSingleLiteralString(): void
     {
         $this->assertSame(
@@ -1174,9 +844,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testSingleLiteralInt(): void
     {
         $this->assertSame(
@@ -1185,9 +852,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testSingleLiteralFloat(): void
     {
         $this->assertSame(
@@ -1196,9 +860,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testEnumWithClassConstants(): void
     {
         $docblock_type = Type::parseString('("baz" | One2::TWO_THREE | Foo::BAR_BAR | Bat\Bar::BAZ_BAM)');
@@ -1213,9 +874,6 @@ class TypeParseTest extends TestCase
         $this->assertSame($resolved_type->getId(), $docblock_type->getId());
     }
 
-    /**
-     * @return void
-     */
     public function testReflectionTypeParse(): void
     {
         if (!function_exists('Psalm\Tests\someFunction')) {
@@ -1250,9 +908,6 @@ class TypeParseTest extends TestCase
         );
     }
 
-    /**
-     * @return void
-     */
     public function testValidCallMapType(): void
     {
         $callmap_types = \Psalm\Internal\Codebase\InternalCallMapHandler::getCallMap();

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -31,7 +31,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testThisToStatic()
+    public function testThisToStatic(): void
     {
         $this->assertSame('static', (string) Type::parseString('$this'));
     }
@@ -39,7 +39,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testThisToStaticUnion()
+    public function testThisToStaticUnion(): void
     {
         $this->assertSame('A|static', (string) Type::parseString('$this|A'));
     }
@@ -47,7 +47,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntOrString()
+    public function testIntOrString(): void
     {
         $this->assertSame('int|string', (string) Type::parseString('int|string'));
     }
@@ -55,7 +55,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBracketedIntOrString()
+    public function testBracketedIntOrString(): void
     {
         $this->assertSame('int|string', (string) Type::parseString('(int|string)'));
     }
@@ -63,7 +63,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBoolOrIntOrString()
+    public function testBoolOrIntOrString(): void
     {
         $this->assertSame('bool|int|string', (string) Type::parseString('bool|int|string'));
     }
@@ -71,7 +71,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testNullable()
+    public function testNullable(): void
     {
         $this->assertSame('null|string', (string) Type::parseString('?string'));
     }
@@ -79,7 +79,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testNullableUnion()
+    public function testNullableUnion(): void
     {
         $this->assertSame('int|null|string', (string) Type::parseString('?(string|int)'));
     }
@@ -87,7 +87,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testNullableFullyQualified()
+    public function testNullableFullyQualified(): void
     {
         $this->assertSame('null|stdClass', (string) Type::parseString('?\\stdClass'));
     }
@@ -95,7 +95,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testNullableOrNullable()
+    public function testNullableOrNullable(): void
     {
         $this->assertSame('int|null|string', (string) Type::parseString('?string|?int'));
     }
@@ -103,7 +103,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadNullableCharacterInUnion()
+    public function testBadNullableCharacterInUnion(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('int|array|?');
@@ -112,7 +112,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadNullableCharacterInUnionWithFollowing()
+    public function testBadNullableCharacterInUnionWithFollowing(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('int|array|?|bool');
@@ -121,7 +121,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testArrayWithClosingBracket()
+    public function testArrayWithClosingBracket(): void
     {
         $this->assertSame('array<int, int>', (string) Type::parseString('array<int, int>'));
     }
@@ -129,7 +129,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testArrayWithoutClosingBracket()
+    public function testArrayWithoutClosingBracket(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array<int, int');
@@ -138,7 +138,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testArrayWithSingleArg()
+    public function testArrayWithSingleArg(): void
     {
         $this->assertSame('array<array-key, int>', (string) Type::parseString('array<int>'));
     }
@@ -146,7 +146,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testArrayWithNestedSingleArg()
+    public function testArrayWithNestedSingleArg(): void
     {
         $this->assertSame('array<array-key, array<array-key, int>>', (string) Type::parseString('array<array<int>>'));
     }
@@ -154,7 +154,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testArrayWithUnion()
+    public function testArrayWithUnion(): void
     {
         $this->assertSame('array<int|string, string>', (string) Type::parseString('array<int|string, string>'));
     }
@@ -162,7 +162,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testNonEmptyArrray()
+    public function testNonEmptyArrray(): void
     {
         $this->assertSame('non-empty-array<array-key, int>', (string) Type::parseString('non-empty-array<int>'));
     }
@@ -170,7 +170,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testGeneric()
+    public function testGeneric(): void
     {
         $this->assertSame('B<int>', (string) Type::parseString('B<int>'));
     }
@@ -178,7 +178,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersection()
+    public function testIntersection(): void
     {
         $this->assertSame('I1&I2&I3', (string) Type::parseString('I1&I2&I3'));
     }
@@ -186,7 +186,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersectionOrNull()
+    public function testIntersectionOrNull(): void
     {
         $this->assertSame('I1&I2|null', (string) Type::parseString('I1&I2|null'));
     }
@@ -194,7 +194,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testNullOrIntersection()
+    public function testNullOrIntersection(): void
     {
         $this->assertSame('I1&I2|null', (string) Type::parseString('null|I1&I2'));
     }
@@ -202,7 +202,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testInteratorAndTraversable()
+    public function testInteratorAndTraversable(): void
     {
         $this->assertSame('Iterator<mixed, int>&Traversable', (string) Type::parseString('Iterator<int>&Traversable'));
     }
@@ -210,7 +210,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testStaticAndStatic()
+    public function testStaticAndStatic(): void
     {
         $this->assertSame('static', (string) Type::parseString('static&static'));
     }
@@ -218,7 +218,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTraversableAndIteratorOrNull()
+    public function testTraversableAndIteratorOrNull(): void
     {
         $this->assertSame(
             'Traversable&Iterator<mixed, int>|null',
@@ -229,7 +229,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIteratorAndTraversableOrNull()
+    public function testIteratorAndTraversableOrNull(): void
     {
         $this->assertSame(
             'Iterator<mixed, int>&Traversable|null',
@@ -240,7 +240,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersectionAfterGeneric()
+    public function testIntersectionAfterGeneric(): void
     {
         $this->assertSame('Countable&iterable<mixed, int>&I', (string) Type::parseString('Countable&iterable<int>&I'));
     }
@@ -248,7 +248,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersectionOfIterables()
+    public function testIntersectionOfIterables(): void
     {
         $this->assertSame('iterable<mixed, A>&iterable<mixed, B>', (string) Type::parseString('iterable<A>&iterable<B>'));
     }
@@ -256,7 +256,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersectionOfTKeyedArray()
+    public function testIntersectionOfTKeyedArray(): void
     {
         $this->assertSame('array{a: int, b: int}', (string) Type::parseString('array{a: int}&array{b: int}'));
     }
@@ -264,7 +264,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersectionOfTKeyedArrayWithMergedProperties()
+    public function testIntersectionOfTKeyedArrayWithMergedProperties(): void
     {
         $this->assertSame('array{a: int}', (string) Type::parseString('array{a: int}&array{a: mixed}'));
     }
@@ -272,7 +272,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersectionOfTKeyedArrayWithPossiblyUndefinedMergedProperties()
+    public function testIntersectionOfTKeyedArrayWithPossiblyUndefinedMergedProperties(): void
     {
         $this->assertSame('array{a: int}', (string) Type::parseString('array{a: int}&array{a?: int}'));
     }
@@ -280,7 +280,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersectionOfTKeyedArrayWithConflictingProperties()
+    public function testIntersectionOfTKeyedArrayWithConflictingProperties(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{a: string}&array{a: int}');
@@ -289,7 +289,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testUnionOfIntersectionOfTKeyedArray()
+    public function testUnionOfIntersectionOfTKeyedArray(): void
     {
         $this->assertSame('array{a: int|string, b?: int}', (string) Type::parseString('array{a: int}|array{a: string}&array{b: int}'));
         $this->assertSame('array{a: int|string, b?: int}', (string) Type::parseString('array{b: int}&array{a: string}|array{a: int}'));
@@ -298,7 +298,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersectionOfUnionOfTKeyedArray()
+    public function testIntersectionOfUnionOfTKeyedArray(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{a: int}&array{a: string}|array{b: int}');
@@ -307,7 +307,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIntersectionOfTKeyedArrayAndObject()
+    public function testIntersectionOfTKeyedArrayAndObject(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{a: int}&T1');
@@ -321,7 +321,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocSimpleArray()
+    public function testPhpDocSimpleArray(): void
     {
         $this->assertSame('array<array-key, A>', (string) Type::parseString('A[]'));
     }
@@ -329,7 +329,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocUnionArray()
+    public function testPhpDocUnionArray(): void
     {
         $this->assertSame('array<array-key, A|B>', (string) Type::parseString('(A|B)[]'));
     }
@@ -337,7 +337,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocMultiDimensionalArray()
+    public function testPhpDocMultiDimensionalArray(): void
     {
         $this->assertSame('array<array-key, array<array-key, A>>', (string) Type::parseString('A[][]'));
     }
@@ -345,7 +345,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocMultidimensionalUnionArray()
+    public function testPhpDocMultidimensionalUnionArray(): void
     {
         $this->assertSame('array<array-key, array<array-key, A|B>>', (string) Type::parseString('(A|B)[][]'));
     }
@@ -353,7 +353,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocTKeyedArray()
+    public function testPhpDocTKeyedArray(): void
     {
         $this->assertSame(
             'array<array-key, array{b: bool, d: string}>',
@@ -364,7 +364,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocUnionOfArrays()
+    public function testPhpDocUnionOfArrays(): void
     {
         $this->assertSame('array<array-key, A|B>', (string) Type::parseString('A[]|B[]'));
     }
@@ -372,7 +372,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testPhpDocUnionOfArraysOrObject()
+    public function testPhpDocUnionOfArraysOrObject(): void
     {
         $this->assertSame('C|array<array-key, A|B>', (string) Type::parseString('A[]|B[]|C'));
     }
@@ -380,7 +380,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testPsalmOnlyAtomic()
+    public function testPsalmOnlyAtomic(): void
     {
         $this->assertSame('class-string', (string) Type::parseString('class-string'));
     }
@@ -388,7 +388,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testParameterizedClassString()
+    public function testParameterizedClassString(): void
     {
         $this->assertSame('class-string<A>', (string) Type::parseString('class-string<A>'));
     }
@@ -396,7 +396,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testParameterizedClassStringUnion()
+    public function testParameterizedClassStringUnion(): void
     {
         $this->assertSame('class-string<A>|class-string<B>', (string) Type::parseString('class-string<A>|class-string<B>'));
     }
@@ -404,7 +404,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testInvalidType()
+    public function testInvalidType(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array(A)');
@@ -413,7 +413,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBracketedUnionAndIntersection()
+    public function testBracketedUnionAndIntersection(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('(A|B)&C');
@@ -422,7 +422,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBracketInUnion()
+    public function testBracketInUnion(): void
     {
         Type::parseString('null|(scalar|array|object)');
     }
@@ -430,7 +430,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithSimpleArgs()
+    public function testTKeyedArrayWithSimpleArgs(): void
     {
         $this->assertSame('array{a: int, b: string}', (string) Type:: parseString('array{a: int, b: string}'));
     }
@@ -438,7 +438,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithSpace()
+    public function testTKeyedArrayWithSpace(): void
     {
         $this->assertSame('array{\'a \': int, \'b  \': string}', (string) Type:: parseString('array{\'a \': int, \'b  \': string}'));
     }
@@ -446,7 +446,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithQuotedKeys()
+    public function testTKeyedArrayWithQuotedKeys(): void
     {
         $this->assertSame('array{\'\\"\': int, \'\\\'\': string}', (string) Type:: parseString('array{\'"\': int, \'\\\'\': string}'));
         $this->assertSame('array{\'\\"\': int, \'\\\'\': string}', (string) Type:: parseString('array{"\\"": int, "\\\'": string}'));
@@ -455,7 +455,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithClassConstantKey()
+    public function testTKeyedArrayWithClassConstantKey(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{self::FOO: string}');
@@ -464,7 +464,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithQuotedClassConstantKey()
+    public function testTKeyedArrayWithQuotedClassConstantKey(): void
     {
         $this->assertSame('array{\'self::FOO\': string}', (string) Type:: parseString('array{"self::FOO": string}'));
     }
@@ -472,7 +472,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithoutClosingBracket()
+    public function testTKeyedArrayWithoutClosingBracket(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{a: int, b: string');
@@ -481,7 +481,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayInType()
+    public function testTKeyedArrayInType(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array{a:[]}');
@@ -490,7 +490,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testObjectWithSimpleArgs()
+    public function testObjectWithSimpleArgs(): void
     {
         $this->assertSame('object{a:int, b:string}', (string) Type::parseString('object{a:int, b:string}'));
     }
@@ -498,7 +498,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testObjectWithDollarArgs()
+    public function testObjectWithDollarArgs(): void
     {
         $this->assertSame('object{a:int, $b:string}', (string) Type::parseString('object{a:int, $b:string}'));
     }
@@ -506,7 +506,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithUnionArgs()
+    public function testTKeyedArrayWithUnionArgs(): void
     {
         $this->assertSame(
             'array{a: int|string, b: string}',
@@ -517,7 +517,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithGenericArgs()
+    public function testTKeyedArrayWithGenericArgs(): void
     {
         $this->assertSame(
             'array{a: array<int, int|string>, b: string}',
@@ -528,7 +528,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithIntKeysAndUnionArgs()
+    public function testTKeyedArrayWithIntKeysAndUnionArgs(): void
     {
         $this->assertSame(
             'array{null|stdClass}',
@@ -539,7 +539,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayWithIntKeysAndGenericArgs()
+    public function testTKeyedArrayWithIntKeysAndGenericArgs(): void
     {
         $this->assertSame(
             'array{array<array-key, mixed>}',
@@ -555,7 +555,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testTKeyedArrayOptional()
+    public function testTKeyedArrayOptional(): void
     {
         $this->assertSame(
             'array{a: int, b?: int}',
@@ -566,7 +566,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testSimpleCallable()
+    public function testSimpleCallable(): void
     {
         $this->assertSame(
             'callable(int, string):void',
@@ -577,7 +577,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithoutClosingBracket()
+    public function testCallableWithoutClosingBracket(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('callable(int, string');
@@ -586,7 +586,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithParamNames()
+    public function testCallableWithParamNames(): void
     {
         $this->assertSame(
             'callable(int, string):void',
@@ -597,7 +597,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableReturningIntersection()
+    public function testCallableReturningIntersection(): void
     {
         $this->assertSame(
             'callable(int, string):I1&I2',
@@ -608,7 +608,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testEmptyCallable()
+    public function testEmptyCallable(): void
     {
         $this->assertSame(
             'callable():void',
@@ -619,7 +619,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithUnionLastType()
+    public function testCallableWithUnionLastType(): void
     {
         $this->assertSame(
             'callable(int, int|string):void',
@@ -630,7 +630,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithVariadic()
+    public function testCallableWithVariadic(): void
     {
         $this->assertSame(
             'callable(int, string...):void',
@@ -641,7 +641,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableThatReturnsACallable()
+    public function testCallableThatReturnsACallable(): void
     {
         $this->assertSame(
             'callable():callable():string',
@@ -652,7 +652,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableThatReturnsACallableThatReturnsACallable()
+    public function testCallableThatReturnsACallableThatReturnsACallable(): void
     {
         $this->assertSame(
             'callable():callable():callable():string',
@@ -663,7 +663,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableOrInt()
+    public function testCallableOrInt(): void
     {
         $this->assertSame(
             'callable(string):void|int',
@@ -674,7 +674,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithGoodVariadic()
+    public function testCallableWithGoodVariadic(): void
     {
         Type::parseString('callable(int, string...) : void');
         Type::parseString('callable(int,string...) : void');
@@ -683,7 +683,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithSpreadBefore()
+    public function testCallableWithSpreadBefore(): void
     {
         $this->assertSame(
             'callable(int, string...):void',
@@ -694,7 +694,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalTypeWithSpaces()
+    public function testConditionalTypeWithSpaces(): void
     {
         $this->assertSame(
             '(T is string ? string : int)',
@@ -705,7 +705,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalTypeWithUnion()
+    public function testConditionalTypeWithUnion(): void
     {
         $this->assertSame(
             '(T is string|true ? int|string : int)',
@@ -716,7 +716,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalTypeWithTKeyedArray()
+    public function testConditionalTypeWithTKeyedArray(): void
     {
         $this->assertSame(
             '(T is array{a: string} ? string : int)',
@@ -727,7 +727,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalTypeWithGenericIs()
+    public function testConditionalTypeWithGenericIs(): void
     {
         $this->assertSame(
             '(T is array<array-key, string> ? string : int)',
@@ -738,7 +738,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalTypeWithIntersection()
+    public function testConditionalTypeWithIntersection(): void
     {
         $this->assertSame(
             '(T is A&B ? string : int)',
@@ -749,7 +749,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalTypeWithoutSpaces()
+    public function testConditionalTypeWithoutSpaces(): void
     {
         $this->assertSame(
             '(T is string ? string : int)',
@@ -760,7 +760,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalTypeWithCallableElseBool()
+    public function testConditionalTypeWithCallableElseBool(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('(T is string ? callable() : bool)', null, ['T' => ['' => [Type::getArray()]]]);
@@ -769,7 +769,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testConditionalTypeWithCallableReturningBoolElseBool()
+    public function testConditionalTypeWithCallableReturningBoolElseBool(): void
     {
         $this->assertSame(
             '(T is string ? callable():bool : bool)',
@@ -816,7 +816,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithTrailingColon()
+    public function testCallableWithTrailingColon(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('callable(int):');
@@ -825,7 +825,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithAnotherBadVariadic()
+    public function testCallableWithAnotherBadVariadic(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('callable(int, string..) : void');
@@ -834,7 +834,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithVariadicAndDefault()
+    public function testCallableWithVariadicAndDefault(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('callable(int, string...=) : void');
@@ -843,7 +843,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadVariadic()
+    public function testBadVariadic(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('string...');
@@ -852,7 +852,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadFullStop()
+    public function testBadFullStop(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('string.');
@@ -861,7 +861,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadSemicolon()
+    public function testBadSemicolon(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('string;');
@@ -870,7 +870,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadGenericString()
+    public function testBadGenericString(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('string<T>');
@@ -879,7 +879,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadAmpersand()
+    public function testBadAmpersand(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('&array');
@@ -888,7 +888,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadColon()
+    public function testBadColon(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString(':array');
@@ -897,7 +897,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadBrackets()
+    public function testBadBrackets(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('max(a)');
@@ -906,7 +906,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testMoreBadBrackets()
+    public function testMoreBadBrackets(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('max(a):void');
@@ -915,7 +915,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testGeneratorWithWBadBrackets()
+    public function testGeneratorWithWBadBrackets(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('Generator{string, A}');
@@ -924,7 +924,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadEquals()
+    public function testBadEquals(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('=array');
@@ -933,7 +933,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadBar()
+    public function testBadBar(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('|array');
@@ -942,7 +942,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testBadColonDash()
+    public function testBadColonDash(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('array|string:-');
@@ -951,7 +951,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testDoubleBar()
+    public function testDoubleBar(): void
     {
         $this->expectException(\Psalm\Exception\TypeParseTreeException::class);
         Type::parseString('PDO||Closure|numeric');
@@ -960,7 +960,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithDefault()
+    public function testCallableWithDefault(): void
     {
         $this->assertSame(
             'callable(int, string=):void',
@@ -971,7 +971,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testNestedCallable()
+    public function testNestedCallable(): void
     {
         $this->assertSame(
             'callable(callable(A):B):C',
@@ -982,7 +982,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCallableWithoutReturn()
+    public function testCallableWithoutReturn(): void
     {
         $this->assertSame(
             'callable(int, string)',
@@ -993,7 +993,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCombineLiteralStringWithClassString()
+    public function testCombineLiteralStringWithClassString(): void
     {
         $this->assertSame(
             'class-string|string(array)',
@@ -1004,7 +1004,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testCombineLiteralClassStringWithClassString()
+    public function testCombineLiteralClassStringWithClassString(): void
     {
         $this->assertSame(
             'class-string',
@@ -1015,7 +1015,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testKeyOfClassConstant()
+    public function testKeyOfClassConstant(): void
     {
         $this->assertSame(
             'key-of<Foo\Baz::BAR>',
@@ -1026,7 +1026,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testKeyOfTemplate()
+    public function testKeyOfTemplate(): void
     {
         $this->assertSame(
             'key-of<T>',
@@ -1037,7 +1037,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testIndexedAccess()
+    public function testIndexedAccess(): void
     {
         $this->assertSame(
             'T[K]',
@@ -1057,7 +1057,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testValueOfClassConstant()
+    public function testValueOfClassConstant(): void
     {
         $this->assertSame(
             'value-of<Foo\Baz::BAR>',
@@ -1076,7 +1076,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testVeryLargeType()
+    public function testVeryLargeType(): void
     {
         $very_large_type = 'array{a: Closure():(array<array-key, mixed>|null), b?: Closure():array<array-key, mixed>, c?: Closure():array<array-key, mixed>, d?: Closure():array<array-key, mixed>, e?: Closure():(array{f: null|string, g: null|string, h: null|string, i: string, j: mixed, k: mixed, l: mixed, m: mixed, n: bool, o?: array{0: string}}|null), p?: Closure():(array{f: null|string, g: null|string, h: null|string, i: string, j: mixed, k: mixed, l: mixed, m: mixed, n: bool, o?: array{0: string}}|null), q: string, r?: Closure():(array<array-key, mixed>|null), s: array<array-key, mixed>}|null';
 
@@ -1089,7 +1089,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testEnum()
+    public function testEnum(): void
     {
         $docblock_type = Type::parseString('( \'foo\\\'with\' | "bar\"bar" | "baz" | "bat\\\\" | \'bang bang\' | 1 | 2 | 3 | 4.5)');
 
@@ -1144,7 +1144,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testEnumWithoutSpaces()
+    public function testEnumWithoutSpaces(): void
     {
         $docblock_type = Type::parseString('\'foo\\\'with\'|"bar\"bar"|"baz"|"bat\\\\"|\'bang bang\'|1|2|3|4.5');
 
@@ -1166,7 +1166,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testSingleLiteralString()
+    public function testSingleLiteralString(): void
     {
         $this->assertSame(
             'string',
@@ -1177,7 +1177,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testSingleLiteralInt()
+    public function testSingleLiteralInt(): void
     {
         $this->assertSame(
             'int',
@@ -1188,7 +1188,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testSingleLiteralFloat()
+    public function testSingleLiteralFloat(): void
     {
         $this->assertSame(
             'float',
@@ -1199,7 +1199,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testEnumWithClassConstants()
+    public function testEnumWithClassConstants(): void
     {
         $docblock_type = Type::parseString('("baz" | One2::TWO_THREE | Foo::BAR_BAR | Bat\Bar::BAZ_BAM)');
 
@@ -1216,7 +1216,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testReflectionTypeParse()
+    public function testReflectionTypeParse(): void
     {
         if (!function_exists('Psalm\Tests\someFunction')) {
             /** @psalm-suppress UnusedParam */
@@ -1253,7 +1253,7 @@ class TypeParseTest extends TestCase
     /**
      * @return void
      */
-    public function testValidCallMapType()
+    public function testValidCallMapType(): void
     {
         $callmap_types = \Psalm\Internal\Codebase\InternalCallMapHandler::getCallMap();
 

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -19,7 +19,7 @@ class ConditionalTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'intIsMixed' => [
@@ -2838,7 +2838,7 @@ class ConditionalTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'makeNonNullableNull' => [

--- a/tests/TypeReconciliation/EmptyTest.php
+++ b/tests/TypeReconciliation/EmptyTest.php
@@ -9,7 +9,7 @@ class EmptyTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'ifNotUndefinedAndEmpty' => [
@@ -381,7 +381,7 @@ class EmptyTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'preventImpossibleEmpty' => [

--- a/tests/TypeReconciliation/IssetTest.php
+++ b/tests/TypeReconciliation/IssetTest.php
@@ -9,7 +9,7 @@ class IssetTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'issetWithSimpleAssignment' => [
@@ -972,7 +972,7 @@ class IssetTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'complainAboutBadCallInIsset' => [

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -45,7 +45,6 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
      * @param string $type
      * @param string $string
      *
-     * @return void
      */
     public function testReconcilation($expected, $type, $string): void
     {
@@ -72,7 +71,6 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
      * @param string $input
      * @param string $container
      *
-     * @return void
      */
     public function testTypeIsContainedBy($input, $container): void
     {

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -47,7 +47,7 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
      *
      * @return void
      */
-    public function testReconcilation($expected, $type, $string)
+    public function testReconcilation($expected, $type, $string): void
     {
         $reconciled = \Psalm\Internal\Type\AssertionReconciler::reconcile(
             $type,
@@ -74,7 +74,7 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
      *
      * @return void
      */
-    public function testTypeIsContainedBy($input, $container)
+    public function testTypeIsContainedBy($input, $container): void
     {
         $this->assertTrue(
             UnionTypeComparator::isContainedBy(
@@ -88,7 +88,7 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{string,string,string}>
      */
-    public function providerTestReconcilation()
+    public function providerTestReconcilation(): array
     {
         return [
             'notNullWithObject' => ['MyObject', '!null', 'MyObject'],
@@ -146,7 +146,7 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
     /**
      * @return array<string,array{string,string}>
      */
-    public function providerTestTypeIsContainedBy()
+    public function providerTestTypeIsContainedBy(): array
     {
         return [
             'arrayContainsWithArrayOfStrings' => ['array<string>', 'array'],

--- a/tests/TypeReconciliation/RedundantConditionTest.php
+++ b/tests/TypeReconciliation/RedundantConditionTest.php
@@ -11,7 +11,7 @@ class RedundantConditionTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'ignoreIssueAndAssign' => [
@@ -806,7 +806,7 @@ class RedundantConditionTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'ifFalse' => [

--- a/tests/TypeReconciliation/ScopeTest.php
+++ b/tests/TypeReconciliation/ScopeTest.php
@@ -11,7 +11,7 @@ class ScopeTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'newVarInIf' => [
@@ -275,7 +275,7 @@ class ScopeTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'possiblyUndefinedVarInIf' => [

--- a/tests/TypeReconciliation/TypeAlgebraTest.php
+++ b/tests/TypeReconciliation/TypeAlgebraTest.php
@@ -9,7 +9,7 @@ class TypeAlgebraTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'twoVarLogicSimple' => [
@@ -1045,7 +1045,7 @@ class TypeAlgebraTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'threeVarLogicWithChange' => [

--- a/tests/TypeReconciliation/TypeTest.php
+++ b/tests/TypeReconciliation/TypeTest.php
@@ -11,7 +11,7 @@ class TypeTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'nullableMethodWithTernaryGuard' => [
@@ -1063,7 +1063,7 @@ class TypeTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'possiblyUndefinedVariable' => [

--- a/tests/TypeReconciliation/ValueTest.php
+++ b/tests/TypeReconciliation/ValueTest.php
@@ -29,7 +29,7 @@ class ValueTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'whileCountUpdate' => [
@@ -772,7 +772,7 @@ class ValueTest extends \Psalm\Tests\TestCase
     /**
      * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): iterable
     {
         return [
             'neverEqualsType' => [

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -36,7 +36,6 @@ class UnusedCodeTest extends TestCase
      * @param string $code
      * @param array<string> $error_levels
      *
-     * @return void
      */
     public function testValidCode($code, array $error_levels = []): void
     {
@@ -70,7 +69,6 @@ class UnusedCodeTest extends TestCase
      * @param string $error_message
      * @param array<string> $error_levels
      *
-     * @return void
      */
     public function testInvalidCode($code, $error_message, $error_levels = []): void
     {

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -38,7 +38,7 @@ class UnusedCodeTest extends TestCase
      *
      * @return void
      */
-    public function testValidCode($code, array $error_levels = [])
+    public function testValidCode($code, array $error_levels = []): void
     {
         $test_name = $this->getTestName();
         if (\strpos($test_name, 'SKIPPED-') !== false) {
@@ -72,7 +72,7 @@ class UnusedCodeTest extends TestCase
      *
      * @return void
      */
-    public function testInvalidCode($code, $error_message, $error_levels = [])
+    public function testInvalidCode($code, $error_message, $error_levels = []): void
     {
         if (\strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
@@ -102,7 +102,7 @@ class UnusedCodeTest extends TestCase
     /**
      * @return array<string, array{string}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'magicCall' => [
@@ -734,7 +734,7 @@ class UnusedCodeTest extends TestCase
     /**
      * @return array<string,array{string,error_message:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): array
     {
         return [
             'unusedClass' => [

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -40,7 +40,7 @@ class UnusedVariableTest extends TestCase
      *
      * @return void
      */
-    public function testValidCode($code, array $error_levels = [])
+    public function testValidCode($code, array $error_levels = []): void
     {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'SKIPPED-') !== false) {
@@ -70,7 +70,7 @@ class UnusedVariableTest extends TestCase
      *
      * @return void
      */
-    public function testInvalidCode($code, $error_message, $error_levels = [])
+    public function testInvalidCode($code, $error_message, $error_levels = []): void
     {
         if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
@@ -96,7 +96,7 @@ class UnusedVariableTest extends TestCase
     /**
      * @return array<string, array{string,error_levels?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): array
     {
         return [
             'arrayOffset' => [
@@ -1482,7 +1482,7 @@ class UnusedVariableTest extends TestCase
     /**
      * @return array<string,array{string,error_message:string}>
      */
-    public function providerInvalidCodeParse()
+    public function providerInvalidCodeParse(): array
     {
         return [
             'simpleUnusedVariable' => [

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -38,7 +38,6 @@ class UnusedVariableTest extends TestCase
      * @param string $code
      * @param array<string> $error_levels
      *
-     * @return void
      */
     public function testValidCode($code, array $error_levels = []): void
     {
@@ -68,7 +67,6 @@ class UnusedVariableTest extends TestCase
      * @param string $error_message
      * @param array<string> $error_levels
      *
-     * @return void
      */
     public function testInvalidCode($code, $error_message, $error_levels = []): void
     {

--- a/tests/VariadicTest.php
+++ b/tests/VariadicTest.php
@@ -12,9 +12,6 @@ class VariadicTest extends TestCase
 {
     use Traits\ValidCodeAnalysisTestTrait;
 
-    /**
-     * @return                   void
-     */
     public function testVariadicArrayBadParam(): void
     {
         $this->expectExceptionMessage('InvalidScalarArgument');
@@ -36,7 +33,6 @@ class VariadicTest extends TestCase
 
     /**
      * @throws \Psalm\Exception\ConfigException
-     * @return void
      * @runInSeparateProcess
      */
     public function testVariadicFunctionFromAutoloadFile(): void
@@ -130,11 +126,6 @@ class VariadicTest extends TestCase
         ];
     }
 
-    /**
-     * @param  Config $config
-     *
-     * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
-     */
     private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $project_analyzer = new \Psalm\Internal\Analyzer\ProjectAnalyzer(

--- a/tests/VariadicTest.php
+++ b/tests/VariadicTest.php
@@ -15,7 +15,7 @@ class VariadicTest extends TestCase
     /**
      * @return                   void
      */
-    public function testVariadicArrayBadParam()
+    public function testVariadicArrayBadParam(): void
     {
         $this->expectExceptionMessage('InvalidScalarArgument');
         $this->expectException(\Psalm\Exception\CodeException::class);
@@ -39,7 +39,7 @@ class VariadicTest extends TestCase
      * @return void
      * @runInSeparateProcess
      */
-    public function testVariadicFunctionFromAutoloadFile()
+    public function testVariadicFunctionFromAutoloadFile(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
@@ -70,7 +70,7 @@ class VariadicTest extends TestCase
     /**
      * @return iterable<string,array{string,1?:array<string,string>,2?:string[]}>
      */
-    public function providerValidCodeParse()
+    public function providerValidCodeParse(): iterable
     {
         return [
             'variadic' => [
@@ -135,7 +135,7 @@ class VariadicTest extends TestCase
      *
      * @return \Psalm\Internal\Analyzer\ProjectAnalyzer
      */
-    private function getProjectAnalyzerWithConfig(Config $config)
+    private function getProjectAnalyzerWithConfig(Config $config): \Psalm\Internal\Analyzer\ProjectAnalyzer
     {
         $project_analyzer = new \Psalm\Internal\Analyzer\ProjectAnalyzer(
             $config,

--- a/tests/fixtures/stubs/namespaced_class.php
+++ b/tests/fixtures/stubs/namespaced_class.php
@@ -11,7 +11,6 @@ class SystemClass
      * @param int       $a
      * @param string    $b
      *
-     * @return string
      */
     public function foo($a, $b): string
     {
@@ -21,7 +20,6 @@ class SystemClass
      * @param int       $a
      * @param string    $b
      *
-     * @return string
      */
     public static function bar($a, $b): string
     {

--- a/tests/fixtures/stubs/namespaced_class.php
+++ b/tests/fixtures/stubs/namespaced_class.php
@@ -13,7 +13,7 @@ class SystemClass
      *
      * @return string
      */
-    public function foo($a, $b)
+    public function foo($a, $b): string
     {
     }
 
@@ -23,7 +23,7 @@ class SystemClass
      *
      * @return string
      */
-    public static function bar($a, $b)
+    public static function bar($a, $b): string
     {
     }
 }

--- a/tests/fixtures/stubs/partial_class.php
+++ b/tests/fixtures/stubs/partial_class.php
@@ -8,7 +8,7 @@ class PartiallyStubbedClass
      *
      * @return PartiallyStubbedClass
      */
-    public function foo($a)
+    public function foo($a): PartiallyStubbedClass
     {
     }
 }

--- a/tests/fixtures/stubs/partial_class.php
+++ b/tests/fixtures/stubs/partial_class.php
@@ -6,7 +6,6 @@ class PartiallyStubbedClass
     /**
      * @param class-string    $a
      *
-     * @return PartiallyStubbedClass
      */
     public function foo($a): PartiallyStubbedClass
     {

--- a/tests/fixtures/stubs/polyfill.php
+++ b/tests/fixtures/stubs/polyfill.php
@@ -17,7 +17,7 @@ if (!function_exists('new_random_bytes')) {
      *
      * @return int
      */
-    function new_random_bytes($bytes)
+    function new_random_bytes($bytes): int
     {
         return 5;
     }

--- a/tests/fixtures/stubs/polyfill.php
+++ b/tests/fixtures/stubs/polyfill.php
@@ -15,7 +15,6 @@ if (!function_exists('new_random_bytes')) {
     /**
      * @param int $bytes
      *
-     * @return int
      */
     function new_random_bytes($bytes): int
     {

--- a/tests/fixtures/stubs/systemclass.php
+++ b/tests/fixtures/stubs/systemclass.php
@@ -11,7 +11,6 @@ class SystemClass
      * @param int       $a
      * @param string    $b
      *
-     * @return string
      */
     public function foo($a, $b): string
     {
@@ -21,7 +20,6 @@ class SystemClass
      * @param int       $a
      * @param string    $b
      *
-     * @return string
      */
     public static function bar($a, $b): string
     {

--- a/tests/fixtures/stubs/systemclass.php
+++ b/tests/fixtures/stubs/systemclass.php
@@ -13,7 +13,7 @@ class SystemClass
      *
      * @return string
      */
-    public function foo($a, $b)
+    public function foo($a, $b): string
     {
     }
 
@@ -23,7 +23,7 @@ class SystemClass
      *
      * @return string
      */
-    public static function bar($a, $b)
+    public static function bar($a, $b): string
     {
     }
 }


### PR DESCRIPTION
Hi,

This PR propose adding yet more native return types in Psalm. This time, I mainly added them through Psalter and refine with Psalm and PHPStorm.

There are still many cases where return types could theoretically be added but there are some code constructs that gets in the way for that (for example `return;` is not a valid return for a method that should return null), so I'll push a future PR that addresses that.

Before beginning a review to propose cases I missed, be aware that I had to rollback a lot of return types because there was incompatibility between hierarchy or with some issue Psalm detected. I'm totally open to try to put some back, but this may be wasted time