### PR TITLE
align default value with documentation

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -146,7 +146,7 @@ class Config
      *
      * @var bool
      */
-    public $use_docblock_property_types = true;
+    public $use_docblock_property_types = false;
 
     /**
      * Whether or not to throw an exception on first error


### PR DESCRIPTION
If you take this code
```php
class A{
    /** @var string */
    private $b;
    
    public function getB(){
        return $this->b;
    }
}
```
and process it through psalter `--issues=MissingReturnType` with `useDocblockTypes=false`, it will add a `: string` return type anyway. This is due to the property docblock which can be disabled with `useDocblockPropertyTypes=false`. However, the [documentation](https://psalm.dev/docs/running_psalm/configuration/#usedocblockpropertytypes) states:

> If not using all docblock types, you can still use docblock property types. Defaults to false (though only relevant if useDocblockTypes is false.

This is not the case. The example above shows that the real default is true. This is due to a difference between the default declared in xsd specifications and the Config class.

This PR resolves the difference by changing the Config value. (I assumed that someone who want to disable docblock will likely want to disable them in property too).

Interesting note: using `useDocblockTypes=false` AND  `useDocblockPropertyTypes=false` will not totally suppress docblock reading. Any `/** @var type $variable */ ` directly in the code will still be read.