### PR TITLE
Fix errors in return types

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1490,8 +1490,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
 
     /**
      * @param array<PhpParser\Node\Stmt> $function_stmts
-     *
-     * @return  false|null
      */
     public function verifyReturnType(
         array $function_stmts,
@@ -1501,7 +1499,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         ?CodeLocation $return_type_location = null,
         bool $did_explicitly_return = false,
         bool $closure_inside_call = false
-    ) {
+    ): void {
         ReturnTypeAnalyzer::verifyReturnType(
             $this->function,
             $function_stmts,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -37,7 +37,7 @@ class AssertionFinder
     /**
      * Gets all the type assertions in a conditional
      *
-     * @return array<string, non-empty-list<non-empty-list<string>>>|null
+     * @return array<string, non-empty-list<non-empty-list<string>>>
      */
     public static function scrapeAssertions(
         PhpParser\Node\Expr $conditional,
@@ -47,7 +47,7 @@ class AssertionFinder
         bool $inside_negation = false,
         bool $cache = true,
         bool $inside_conditional = true
-    ) {
+    ): array {
         $if_types = [];
 
         if ($conditional instanceof PhpParser\Node\Expr\Instanceof_) {
@@ -193,10 +193,6 @@ class AssertionFinder
                 if ($cache && $source instanceof StatementsAnalyzer) {
                     $source->node_data->setAssertions($conditional->expr, $expr_assertions);
                 }
-            }
-
-            if ($expr_assertions === null) {
-                throw new \UnexpectedValueException('Assertions should be set');
             }
 
             if (count($expr_assertions) !== 1) {
@@ -699,10 +695,6 @@ class AssertionFinder
                         }
                     }
 
-                    if ($base_assertions === null) {
-                        throw new \UnexpectedValueException('Assertions should be set');
-                    }
-
                     $if_types = $base_assertions;
                 }
             }
@@ -818,10 +810,6 @@ class AssertionFinder
                         if ($source instanceof StatementsAnalyzer && $cache) {
                             $source->node_data->setAssertions($base_conditional, $base_assertions);
                         }
-                    }
-
-                    if ($base_assertions === null) {
-                        throw new \UnexpectedValueException('Assertions should be set');
                     }
 
                     $notif_types = $base_assertions;
@@ -1338,10 +1326,6 @@ class AssertionFinder
                     }
                 }
 
-                if ($base_assertions === null) {
-                    throw new \UnexpectedValueException('Assertions should be set');
-                }
-
                 $notif_types = $base_assertions;
 
                 if (count($notif_types) === 1) {
@@ -1446,10 +1430,6 @@ class AssertionFinder
                         if ($source instanceof StatementsAnalyzer && $cache) {
                             $source->node_data->setAssertions($base_conditional, $base_assertions);
                         }
-                    }
-
-                    if ($base_assertions === null) {
-                        throw new \UnexpectedValueException('Assertions should be set');
                     }
 
                     $notif_types = $base_assertions;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -705,16 +705,13 @@ class ArgumentsAnalyzer
                 }
             }
 
-            if (ArrayFunctionArgumentsAnalyzer::checkArgumentsMatch(
+            ArrayFunctionArgumentsAnalyzer::checkArgumentsMatch(
                 $statements_analyzer,
                 $context,
                 $args,
                 $method_id,
                 $context->check_functions
-            ) === false
-            ) {
-                return false;
-            }
+            );
 
             return null;
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
@@ -44,7 +44,6 @@ class ArrayFunctionArgumentsAnalyzer
 {
     /**
      * @param   array<int, PhpParser\Node\Arg> $args
-     * @return  false|null
      */
     public static function checkArgumentsMatch(
         StatementsAnalyzer $statements_analyzer,
@@ -52,7 +51,7 @@ class ArrayFunctionArgumentsAnalyzer
         array $args,
         string $method_id,
         bool $check_functions
-    ) {
+    ): void {
         $closure_index = $method_id === 'array_map' ? 0 : 1;
 
         $array_arg_types = [];

--- a/src/Psalm/Type/Algebra.php
+++ b/src/Psalm/Type/Algebra.php
@@ -201,37 +201,35 @@ class Algebra
                     }
                 }
 
-                if ($assertions !== null) {
-                    $clauses = [];
+                $clauses = [];
 
-                    foreach ($assertions as $var => $anded_types) {
-                        $redefined = false;
+                foreach ($assertions as $var => $anded_types) {
+                    $redefined = false;
 
-                        if ($var[0] === '=') {
-                            /** @var string */
-                            $var = substr($var, 1);
-                            $redefined = true;
-                        }
-
-                        foreach ($anded_types as $orred_types) {
-                            $clauses[] = new Clause(
-                                [$var => $orred_types],
-                                $conditional_object_id,
-                                \spl_object_id($conditional->expr),
-                                false,
-                                true,
-                                $orred_types[0][0] === '='
-                                    || $orred_types[0][0] === '~'
-                                    || (strlen($orred_types[0]) > 1
-                                        && ($orred_types[0][1] === '='
-                                            || $orred_types[0][1] === '~')),
-                                $redefined ? [$var => true] : []
-                            );
-                        }
+                    if ($var[0] === '=') {
+                        /** @var string */
+                        $var = substr($var, 1);
+                        $redefined = true;
                     }
 
-                    return self::negateFormula($clauses);
+                    foreach ($anded_types as $orred_types) {
+                        $clauses[] = new Clause(
+                            [$var => $orred_types],
+                            $conditional_object_id,
+                            \spl_object_id($conditional->expr),
+                            false,
+                            true,
+                            $orred_types[0][0] === '='
+                                || $orred_types[0][0] === '~'
+                                || (strlen($orred_types[0]) > 1
+                                    && ($orred_types[0][1] === '='
+                                        || $orred_types[0][1] === '~')),
+                            $redefined ? [$var => true] : []
+                        );
+                    }
                 }
+
+                return self::negateFormula($clauses);
             }
 
             if ($conditional->expr instanceof PhpParser\Node\Expr\BinaryOp\BooleanAnd) {


### PR DESCRIPTION
While adding return types in Psalm, I found some cases where declared return types didn't match with the code.

This PR contains 3 commits, each one fix a specific issue and it's consequences if any.