### PR TITLE
respect static keyword in method access

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -459,7 +459,7 @@ class ArgumentsAnalyzer
             if ($function_storage) {
                 $is_variadic = $function_storage->variadic;
             } elseif (is_string($method_id)) {
-                $is_variadic = $codebase->functions->isVariadic(
+                $is_variadic = $codebase->functions::isVariadic(
                     $codebase,
                     strtolower($method_id),
                     $statements_analyzer->getRootFilePath()

--- a/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
@@ -76,7 +76,7 @@ class UnusedAssignmentRemover
 
             if ($treat_as_expr) {
                 $is_assign_ref = $assign_exp instanceof PhpParser\Node\Expr\AssignRef;
-                $new_file_manipulation = self::getPartialRemovalBounds(
+                $new_file_manipulation = $this->getPartialRemovalBounds(
                     $codebase,
                     $original_location,
                     $assign_stmt->getEndFilePos(),
@@ -104,7 +104,7 @@ class UnusedAssignmentRemover
             FileManipulationBuffer::add($original_location->file_path, [$new_file_manipulation]);
         } elseif (!is_null($assign_exp)) {
             $is_assign_ref = $assign_exp instanceof PhpParser\Node\Expr\AssignRef;
-            $new_file_manipulation = self::getPartialRemovalBounds(
+            $new_file_manipulation = $this->getPartialRemovalBounds(
                 $codebase,
                 $original_location,
                 $assign_exp->getEndFilePos(),

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -731,7 +731,7 @@ class ClassLikes
                                     && \strtolower((string) $stmt->name . '\\' . (string) $namespace_stmt->name)
                                         === $fq_class_name_lc
                                 ) {
-                                    self::makeImmutable(
+                                    $this->makeImmutable(
                                         $namespace_stmt,
                                         $project_analyzer,
                                         $classlike_storage->location->file_path
@@ -741,7 +741,7 @@ class ClassLikes
                         } elseif ($stmt instanceof PhpParser\Node\Stmt\Class_
                             && \strtolower((string) $stmt->name) === $fq_class_name_lc
                         ) {
-                            self::makeImmutable(
+                            $this->makeImmutable(
                                 $stmt,
                                 $project_analyzer,
                                 $classlike_storage->location->file_path

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -144,8 +144,8 @@ class Populator
 
         $this->progress->debug('FileStorage is populated' . "\n");
 
-        $this->classlike_storage_provider->populated();
-        $this->file_storage_provider->populated();
+        $this->classlike_storage_provider::populated();
+        $this->file_storage_provider::populated();
     }
 
     /**

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -358,8 +358,8 @@ class Scanner
                     $statements_provider = $codebase->statements_provider;
 
                     $codebase->scanner->isForked();
-                    $codebase->file_storage_provider->deleteAll();
-                    $codebase->classlike_storage_provider->deleteAll();
+                    $codebase->file_storage_provider::deleteAll();
+                    $codebase->classlike_storage_provider::deleteAll();
 
                     $statements_provider->resetDiffs();
 

--- a/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
@@ -167,7 +167,7 @@ class PartialParserVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
                             || !$replacement_stmts[0] instanceof PhpParser\Node\Stmt\ClassLike
                             || count($replacement_stmts[0]->stmts) !== 1
                         ) {
-                            $hacky_class_fix = self::balanceBrackets($fake_class);
+                            $hacky_class_fix = $this->balanceBrackets($fake_class);
 
                             if ($replacement_stmts
                                 && $replacement_stmts[0] instanceof PhpParser\Node\Stmt\ClassLike

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -3764,7 +3764,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements PhpParse
                     $const
                 );
             } else {
-                $unresolved_const_expr = self::getUnresolvedClassConstExpr(
+                $unresolved_const_expr = $this->getUnresolvedClassConstExpr(
                     $const->value,
                     $this->aliases,
                     $fq_classlike_name

--- a/src/Psalm/Internal/Provider/FileReferenceProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceProvider.php
@@ -335,7 +335,7 @@ class FileReferenceProvider
 
     public function removeDeletedFilesFromReferences(): void
     {
-        $deleted_files = self::getDeletedReferencedFiles();
+        $deleted_files = $this->getDeletedReferencedFiles();
 
         if ($deleted_files) {
             foreach ($deleted_files as $file) {

--- a/src/Psalm/Internal/Provider/NodeDataProvider.php
+++ b/src/Psalm/Internal/Provider/NodeDataProvider.php
@@ -113,7 +113,7 @@ class NodeDataProvider implements \Psalm\NodeTypeProvider
 
     public function isPureCompatible(PhpParser\Node\Expr $node) : bool
     {
-        $node_type = self::getType($node);
+        $node_type = $this->getType($node);
 
         return ($node_type && $node_type->reference_free) || isset($node->pure);
     }

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -453,7 +453,7 @@ if (isset($options['generate-stubs']) && is_string($options['generate-stubs'])) 
 // If Xdebug is enabled, restart without it
 $ini_handler->check();
 
-if (is_null($config->load_xdebug_stub) && '' !== $ini_handler->getSkippedVersion()) {
+if (is_null($config->load_xdebug_stub) && '' !== $ini_handler::getSkippedVersion()) {
     $config->load_xdebug_stub = true;
 }
 


### PR DESCRIPTION
Hi,

Some static methods were called through `->` and some dynamic method through `::`. This PR propose to replace those with the normal syntax for each.