### PR TITLE
replace deprecated methods with their equivalent

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -51,8 +51,6 @@
         <DeprecatedMethod>
             <errorLevel type="suppress">
                 <directory name="tests" />
-                <referencedMethod name="PhpParser\Comment::getFilePos" />
-                <referencedMethod name="PhpParser\Comment::getLine" />
             </errorLevel>
         </DeprecatedMethod>
         <DeprecatedClass>

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -122,9 +122,9 @@ class CodeLocation
 
         $doc_comment = $stmt->getDocComment();
 
-        $this->docblock_start = $doc_comment ? $doc_comment->getFilePos() : null;
+        $this->docblock_start = $doc_comment ? $doc_comment->getStartFilePos() : null;
         $this->docblock_end = $doc_comment ? $this->file_start : null;
-        $this->docblock_start_line_number = $doc_comment ? $doc_comment->getLine() : null;
+        $this->docblock_start_line_number = $doc_comment ? $doc_comment->getStartLine() : null;
 
         $this->preview_start = $this->docblock_start ?: $this->file_start;
 

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1281,8 +1281,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                     function (FunctionLikeParameter $param) : PhpParser\Node\Param {
                         $fake_param = (new PhpParser\Builder\Param($param->name));
                         if ($param->signature_type) {
-                            /** @psalm-suppress DeprecatedMethod */
-                            $fake_param->setTypeHint((string)$param->signature_type);
+                            $fake_param->setType((string)$param->signature_type);
                         }
 
                         return $fake_param->getNode();
@@ -1853,7 +1852,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         $comments = $stmt->getComments();
 
         if ($comments) {
-            $start = $comments[0]->getFilePos();
+            $start = $comments[0]->getStartFilePos();
         }
 
         if ($codebase->diff_methods

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -100,7 +100,7 @@ class CommentAnalyzer
 
         $comment_text = $comment->getText();
 
-        $var_line_number = $comment->getLine();
+        $var_line_number = $comment->getStartLine();
 
         if (isset($parsed_docblock->combined_tags['var'])) {
             foreach ($parsed_docblock->combined_tags['var'] as $offset => $var_line) {
@@ -115,10 +115,10 @@ class CommentAnalyzer
 
                 $line_parts = self::splitDocLine($var_line);
 
-                $line_number = $comment->getLine() + substr_count($comment_text, "\n", 0, $offset);
+                $line_number = $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset);
 
                 if ($line_parts && $line_parts[0]) {
-                    $type_start = $offset + $comment->getFilePos();
+                    $type_start = $offset + $comment->getStartFilePos();
                     $type_end = $type_start + strlen($line_parts[0]);
 
                     $line_parts[0] = self::sanitizeDocblockType($line_parts[0]);
@@ -168,7 +168,7 @@ class CommentAnalyzer
                         ' (from ' .
                         $source->getFilePath() .
                         ':' .
-                        $comment->getLine() .
+                        $comment->getStartLine() .
                         ')'
                     );
                 }
@@ -393,7 +393,7 @@ class CommentAnalyzer
 
                         $line_parts[1] = preg_replace('/,$/', '', $line_parts[1]);
 
-                        $start = $offset + $comment->getFilePos();
+                        $start = $offset + $comment->getStartFilePos();
                         $end = $start + strlen($line_parts[0]);
 
                         $line_parts[0] = self::sanitizeDocblockType($line_parts[0]);
@@ -408,7 +408,7 @@ class CommentAnalyzer
                         $info->params[] = [
                             'name' => trim($line_parts[1]),
                             'type' => $line_parts[0],
-                            'line_number' => $comment->getLine() + substr_count($comment_text, "\n", 0, $offset),
+                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset),
                             'start' => $start,
                             'end' => $end,
                         ];
@@ -450,7 +450,7 @@ class CommentAnalyzer
                         $info->params_out[] = [
                             'name' => trim($line_parts[1]),
                             'type' => str_replace("\n", '', $line_parts[0]),
-                            'line_number' => $comment->getLine() + substr_count($comment_text, "\n", 0, $offset),
+                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset),
                         ];
                     }
                 } else {
@@ -468,7 +468,7 @@ class CommentAnalyzer
 
                     $info->self_out = [
                         'type' => str_replace("\n", '', $line_parts[0]),
-                        'line_number' => $comment->getLine() + substr_count($comment_text, "\n", 0, $offset),
+                        'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset),
                     ];
                 }
             }
@@ -596,7 +596,7 @@ class CommentAnalyzer
                         $info->globals[] = [
                             'name' => $line_parts[1],
                             'type' => $line_parts[0],
-                            'line_number' => $comment->getLine() + substr_count($comment_text, "\n", 0, $offset),
+                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset),
                         ];
                     }
                 } else {
@@ -627,7 +627,7 @@ class CommentAnalyzer
         if (isset($parsed_docblock->tags['psalm-suppress'])) {
             foreach ($parsed_docblock->tags['psalm-suppress'] as $offset => $suppress_entry) {
                 foreach (DocComment::parseSuppressList($suppress_entry) as $issue_offset => $suppressed_issue) {
-                    $info->suppressed_issues[$issue_offset + $offset + $comment->getFilePos()] = $suppressed_issue;
+                    $info->suppressed_issues[$issue_offset + $offset + $comment->getStartFilePos()] = $suppressed_issue;
                 }
             }
         }
@@ -642,8 +642,8 @@ class CommentAnalyzer
 
                 $info->throws[] = [
                     $throws_class,
-                    $offset + $comment->getFilePos(),
-                    $comment->getLine() + substr_count($comment->getText(), "\n", 0, $offset)
+                    $offset + $comment->getStartFilePos(),
+                    $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset)
                 ];
             }
         }
@@ -780,7 +780,7 @@ class CommentAnalyzer
                     throw new IncorrectDocblockException('Misplaced variable');
                 }
 
-                $start = $offset + $comment->getFilePos();
+                $start = $offset + $comment->getStartFilePos();
                 $end = $start + strlen($line_parts[0]);
 
                 $line_parts[0] = self::sanitizeDocblockType($line_parts[0]);
@@ -789,7 +789,7 @@ class CommentAnalyzer
                 $info->return_type_description = $line_parts ? implode(' ', $line_parts) : null;
 
                 $info->return_type_line_number
-                    = $comment->getLine() + substr_count($comment->getText(), "\n", 0, $offset);
+                    = $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset);
                 $info->return_type_start = $start;
                 $info->return_type_end = $end;
             } else {
@@ -970,7 +970,7 @@ class CommentAnalyzer
         if (isset($parsed_docblock->tags['psalm-suppress'])) {
             foreach ($parsed_docblock->tags['psalm-suppress'] as $offset => $suppress_entry) {
                 foreach (DocComment::parseSuppressList($suppress_entry) as $issue_offset => $suppressed_issue) {
-                    $info->suppressed_issues[$issue_offset + $offset + $comment->getFilePos()] = $suppressed_issue;
+                    $info->suppressed_issues[$issue_offset + $offset + $comment->getStartFilePos()] = $suppressed_issue;
                 }
             }
         }
@@ -978,9 +978,9 @@ class CommentAnalyzer
         if (isset($parsed_docblock->tags['psalm-import-type'])) {
             foreach ($parsed_docblock->tags['psalm-import-type'] as $offset => $imported_type_entry) {
                 $info->imported_types[] = [
-                    'line_number' => $comment->getLine() + substr_count($comment->getText(), "\n", 0, $offset),
-                    'start_offset' => $comment->getFilePos() + $offset,
-                    'end_offset' => $comment->getFilePos() + $offset + strlen($imported_type_entry),
+                    'line_number' => $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset),
+                    'start_offset' => $comment->getStartFilePos() + $offset,
+                    'end_offset' => $comment->getStartFilePos() + $offset + strlen($imported_type_entry),
                     'parts' => self::splitDocLine($imported_type_entry) ?: []
                 ];
             }
@@ -1129,16 +1129,16 @@ class CommentAnalyzer
                 /** @var \PhpParser\Comment\Doc */
                 $node_doc_comment = $node->getDocComment();
 
-                $statements[0]->stmts[0]->setAttribute('startLine', $node_doc_comment->getLine());
-                $statements[0]->stmts[0]->setAttribute('startFilePos', $node_doc_comment->getFilePos());
+                $statements[0]->stmts[0]->setAttribute('startLine', $node_doc_comment->getStartLine());
+                $statements[0]->stmts[0]->setAttribute('startFilePos', $node_doc_comment->getStartFilePos());
                 $statements[0]->stmts[0]->setAttribute('endFilePos', $node->getAttribute('startFilePos'));
 
                 if ($doc_comment = $statements[0]->stmts[0]->getDocComment()) {
                     $statements[0]->stmts[0]->setDocComment(
                         new \PhpParser\Comment\Doc(
                             $doc_comment->getText(),
-                            $comment->getLine() + substr_count($comment->getText(), "\n", 0, $offset),
-                            $node_doc_comment->getFilePos()
+                            $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset),
+                            $node_doc_comment->getStartFilePos()
                         )
                     );
                 }
@@ -1192,7 +1192,7 @@ class CommentAnalyzer
 
                     $line_parts[1] = preg_replace('/,$/', '', $line_parts[1]);
 
-                    $start = $offset + $comment->getFilePos();
+                    $start = $offset + $comment->getStartFilePos();
                     $end = $start + strlen($line_parts[0]);
 
                     $line_parts[0] = str_replace("\n", '', preg_replace('@^[ \t]*\*@m', '', $line_parts[0]));
@@ -1213,7 +1213,7 @@ class CommentAnalyzer
                     $info->properties[] = [
                         'name' => $name,
                         'type' => $line_parts[0],
-                        'line_number' => $comment->getLine() + substr_count($comment->getText(), "\n", 0, $offset),
+                        'line_number' => $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset),
                         'tag' => $property_tag,
                         'start' => $start,
                         'end' => $end,

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -349,7 +349,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
 
                     foreach ($suppressed as $offset => $suppress_entry) {
                         foreach (DocComment::parseSuppressList($suppress_entry) as $issue_offset => $issue_type) {
-                            $new_issues[$issue_offset + $offset + $docblock->getFilePos()] = $issue_type;
+                            $new_issues[$issue_offset + $offset + $docblock->getStartFilePos()] = $issue_type;
 
                             if ($issue_type === 'InaccessibleMethod') {
                                 continue;
@@ -358,7 +358,7 @@ class StatementsAnalyzer extends SourceAnalyzer implements StatementsSource
                             if ($codebase->track_unused_suppressions) {
                                 IssueBuffer::addUnusedSuppression(
                                     $statements_analyzer->getFilePath(),
-                                    $issue_offset + $offset + $docblock->getFilePos(),
+                                    $issue_offset + $offset + $docblock->getStartFilePos(),
                                     $issue_type
                                 );
                             }

--- a/src/Psalm/Internal/Diff/ClassStatementsDiffer.php
+++ b/src/Psalm/Internal/Diff/ClassStatementsDiffer.php
@@ -72,7 +72,7 @@ class ClassStatementsDiffer extends AstDiffer
                         $signature_change = true;
                     }
 
-                    $a_start = $a_comments[0]->getFilePos();
+                    $a_start = $a_comments[0]->getStartFilePos();
                 }
 
                 if ($b_comments) {
@@ -80,7 +80,7 @@ class ClassStatementsDiffer extends AstDiffer
                         $signature_change = true;
                     }
 
-                    $b_start = $b_comments[0]->getFilePos();
+                    $b_start = $b_comments[0]->getStartFilePos();
                 }
 
                 $a_size = $a_end - $a_start;
@@ -115,7 +115,7 @@ class ClassStatementsDiffer extends AstDiffer
                         $a_stmts_start = (int) $first_stmt->getAttribute('startFilePos');
 
                         if ($a_stmt_comments = $first_stmt->getComments()) {
-                            $a_stmts_start = $a_stmt_comments[0]->getFilePos();
+                            $a_stmts_start = $a_stmt_comments[0]->getStartFilePos();
                         }
                     } else {
                         $a_stmts_start = $a_end;
@@ -126,7 +126,7 @@ class ClassStatementsDiffer extends AstDiffer
                         $b_stmts_start = (int) $first_stmt->getAttribute('startFilePos');
 
                         if ($b_stmt_comments = $first_stmt->getComments()) {
-                            $b_stmts_start = $b_stmt_comments[0]->getFilePos();
+                            $b_stmts_start = $b_stmt_comments[0]->getStartFilePos();
                         }
                     } else {
                         $b_stmts_start = $b_end;

--- a/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
@@ -61,7 +61,7 @@ class ClassDocblockManipulator
     ) {
         $this->stmt = $stmt;
         $docblock = $stmt->getDocComment();
-        $this->docblock_start = $docblock ? $docblock->getFilePos() : (int)$stmt->getAttribute('startFilePos');
+        $this->docblock_start = $docblock ? $docblock->getStartFilePos() : (int)$stmt->getAttribute('startFilePos');
         $this->docblock_end = (int)$stmt->getAttribute('startFilePos');
 
         $codebase = $project_analyzer->getCodebase();

--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -119,7 +119,7 @@ class FunctionDocblockManipulator
     {
         $this->stmt = $stmt;
         $docblock = $stmt->getDocComment();
-        $this->docblock_start = $docblock ? $docblock->getFilePos() : (int)$stmt->getAttribute('startFilePos');
+        $this->docblock_start = $docblock ? $docblock->getStartFilePos() : (int)$stmt->getAttribute('startFilePos');
         $this->docblock_end = $function_start = (int)$stmt->getAttribute('startFilePos');
         $function_end = (int)$stmt->getAttribute('endFilePos');
 

--- a/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
@@ -85,7 +85,7 @@ class PropertyDocblockManipulator
     ) {
         $this->stmt = $stmt;
         $docblock = $stmt->getDocComment();
-        $this->docblock_start = $docblock ? $docblock->getFilePos() : (int)$stmt->getAttribute('startFilePos');
+        $this->docblock_start = $docblock ? $docblock->getStartFilePos() : (int)$stmt->getAttribute('startFilePos');
         $this->docblock_end = (int)$stmt->getAttribute('startFilePos');
 
         $codebase = $project_analyzer->getCodebase();

--- a/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
@@ -35,14 +35,14 @@ class OffsetShifterVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
                 if ($c instanceof PhpParser\Comment\Doc) {
                     $new_comments[] = new PhpParser\Comment\Doc(
                         $c->getText(),
-                        $c->getLine() + $this->line_offset,
-                        $c->getFilePos() + $this->file_offset
+                        $c->getStartLine() + $this->line_offset,
+                        $c->getStartFilePos() + $this->file_offset
                     );
                 } else {
                     $new_comments[] = new PhpParser\Comment(
                         $c->getText(),
-                        $c->getLine() + $this->line_offset,
-                        $c->getFilePos() + $this->file_offset
+                        $c->getStartLine() + $this->line_offset,
+                        $c->getStartFilePos() + $this->file_offset
                     );
                 }
             }

--- a/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
@@ -90,8 +90,8 @@ class ParamReplacementVisitor extends PhpParser\NodeVisitorAbstract implements P
 
             if ($replaced) {
                 $this->replacements[] = new FileManipulation(
-                    $docblock->getFilePos(),
-                    $docblock->getFilePos() + \strlen($docblock->getText()),
+                    $docblock->getStartFilePos(),
+                    $docblock->getStartFilePos() + \strlen($docblock->getText()),
                     \rtrim($parsed_docblock->render($parsed_docblock->first_line_padding)),
                     false,
                     false

--- a/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
@@ -69,7 +69,7 @@ class PartialParserVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
         $attrs = $node->getAttributes();
 
         if ($cs = $node->getComments()) {
-            $stmt_start_pos = $cs[0]->getFilePos();
+            $stmt_start_pos = $cs[0]->getStartFilePos();
         } else {
             $stmt_start_pos = $attrs['startFilePos'];
         }
@@ -283,14 +283,14 @@ class PartialParserVisitor extends PhpParser\NodeVisitorAbstract implements PhpP
                         if ($c instanceof PhpParser\Comment\Doc) {
                             $new_comments[] = new PhpParser\Comment\Doc(
                                 $c->getText(),
-                                $c->getLine() + $line_offset,
-                                $c->getFilePos() + $start_offset
+                                $c->getStartLine() + $line_offset,
+                                $c->getStartFilePos() + $start_offset
                             );
                         } else {
                             $new_comments[] = new PhpParser\Comment(
                                 $c->getText(),
-                                $c->getLine() + $line_offset,
-                                $c->getFilePos() + $start_offset
+                                $c->getStartLine() + $line_offset,
+                                $c->getStartFilePos() + $start_offset
                             );
                         }
                     }

--- a/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
@@ -83,7 +83,7 @@ class SimpleNameResolver extends NodeVisitorAbstract
             $attrs = $node->getAttributes();
 
             if ($cs = $node->getComments()) {
-                $attrs['startFilePos'] = $cs[0]->getFilePos();
+                $attrs['startFilePos'] = $cs[0]->getStartFilePos();
             }
 
             if ($attrs['endFilePos'] < $this->start_change

--- a/tests/FileDiffTest.php
+++ b/tests/FileDiffTest.php
@@ -166,7 +166,7 @@ class FileDiffTest extends TestCase
 
                 $this->assertNotSame($a_doc, $b_doc);
 
-                $this->assertSame($a_doc->getLine(), $b_doc->getLine());
+                $this->assertSame($a_doc->getStartLine(), $b_doc->getStartLine());
             }
 
             $this->assertSame(


### PR DESCRIPTION
This PR replaces deprecated methods in external libraries by their recommanded replacement. I checked that the new version was available in all the versions covered by Composer and that the new methods worked the same way as the old ones.