### PR TITLE
remove incorrect inheritDoc

### DIFF
--- a/src/Psalm/Report/CheckstyleReport.php
+++ b/src/Psalm/Report/CheckstyleReport.php
@@ -7,9 +7,6 @@ use function sprintf;
 
 class CheckstyleReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $output = '<?xml version="1.0" encoding="UTF-8"?>' . "\n";

--- a/src/Psalm/Report/CompactReport.php
+++ b/src/Psalm/Report/CompactReport.php
@@ -14,8 +14,6 @@ use Symfony\Component\Console\Output\BufferedOutput;
 class CompactReport extends Report
 {
     /**
-     * {@inheritdoc}
-     *
      * @psalm-suppress PossiblyNullReference
      */
     public function create(): string

--- a/src/Psalm/Report/ConsoleReport.php
+++ b/src/Psalm/Report/ConsoleReport.php
@@ -8,9 +8,6 @@ use function substr;
 
 class ConsoleReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $output = '';

--- a/src/Psalm/Report/EmacsReport.php
+++ b/src/Psalm/Report/EmacsReport.php
@@ -7,9 +7,6 @@ use function sprintf;
 
 class EmacsReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $output = '';

--- a/src/Psalm/Report/GithubActionsReport.php
+++ b/src/Psalm/Report/GithubActionsReport.php
@@ -7,9 +7,6 @@ use function sprintf;
 
 class GithubActionsReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $output = '';

--- a/src/Psalm/Report/JsonReport.php
+++ b/src/Psalm/Report/JsonReport.php
@@ -9,9 +9,6 @@ use function array_values;
 
 class JsonReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $options = $this->pretty ? Json::PRETTY : Json::DEFAULT;

--- a/src/Psalm/Report/JsonSummaryReport.php
+++ b/src/Psalm/Report/JsonSummaryReport.php
@@ -6,9 +6,6 @@ use Psalm\Report;
 
 class JsonSummaryReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $type_counts = [];

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -20,9 +20,6 @@ use function trim;
  */
 class JunitReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $errors = 0;

--- a/src/Psalm/Report/PhpStormReport.php
+++ b/src/Psalm/Report/PhpStormReport.php
@@ -8,9 +8,6 @@ use function substr;
 
 class PhpStormReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $output = '';

--- a/src/Psalm/Report/PylintReport.php
+++ b/src/Psalm/Report/PylintReport.php
@@ -7,9 +7,6 @@ use function sprintf;
 
 class PylintReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $output = '';

--- a/src/Psalm/Report/SonarqubeReport.php
+++ b/src/Psalm/Report/SonarqubeReport.php
@@ -14,9 +14,6 @@ use Psalm\Report;
  */
 class SonarqubeReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $report = ['issues' => []];

--- a/src/Psalm/Report/TextReport.php
+++ b/src/Psalm/Report/TextReport.php
@@ -7,9 +7,6 @@ use function sprintf;
 
 class TextReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $output = '';

--- a/src/Psalm/Report/XmlReport.php
+++ b/src/Psalm/Report/XmlReport.php
@@ -8,9 +8,6 @@ use function array_map;
 
 class XmlReport extends Report
 {
-    /**
-     * {@inheritdoc}
-     */
     public function create(): string
     {
         $xml = Array2XML::createXML(


### PR DESCRIPTION
This PR remove incorrect inheritDoc. I think they were useful before I added return types and deleted phpdoc but not anymore