### PR TITLE
add strict_types declarations

### DIFF
--- a/src/Psalm/Aliases.php
+++ b/src/Psalm/Aliases.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 class Aliases

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use function explode;

--- a/src/Psalm/CodeLocation/DocblockTypeLocation.php
+++ b/src/Psalm/CodeLocation/DocblockTypeLocation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\CodeLocation;
 
 class DocblockTypeLocation extends \Psalm\CodeLocation

--- a/src/Psalm/CodeLocation/ParseErrorLocation.php
+++ b/src/Psalm/CodeLocation/ParseErrorLocation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\CodeLocation;
 
 use PhpParser;

--- a/src/Psalm/CodeLocation/Raw.php
+++ b/src/Psalm/CodeLocation/Raw.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\CodeLocation;
 
 use function substr;

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm;
 
 use Composer\Autoload\ClassLoader;

--- a/src/Psalm/Config/Creator.php
+++ b/src/Psalm/Config/Creator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Config;
 
 use function array_merge;

--- a/src/Psalm/Config/ErrorLevelFileFilter.php
+++ b/src/Psalm/Config/ErrorLevelFileFilter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Config;
 
 use function in_array;

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Config;
 
 use function array_filter;

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Config;
 
 use function array_filter;

--- a/src/Psalm/Config/ProjectFileFilter.php
+++ b/src/Psalm/Config/ProjectFileFilter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Config;
 
 use SimpleXMLElement;

--- a/src/Psalm/Config/TaintAnalysisFileFilter.php
+++ b/src/Psalm/Config/TaintAnalysisFileFilter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Config;
 
 use SimpleXMLElement;

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use function array_filter;

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use function array_filter;

--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use function array_filter;

--- a/src/Psalm/Exception/CircularReferenceException.php
+++ b/src/Psalm/Exception/CircularReferenceException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class CircularReferenceException extends \Exception

--- a/src/Psalm/Exception/CodeException.php
+++ b/src/Psalm/Exception/CodeException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class CodeException extends \Exception

--- a/src/Psalm/Exception/ComplicatedExpressionException.php
+++ b/src/Psalm/Exception/ComplicatedExpressionException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class ComplicatedExpressionException extends \Exception

--- a/src/Psalm/Exception/ConfigCreationException.php
+++ b/src/Psalm/Exception/ConfigCreationException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class ConfigCreationException extends \Exception

--- a/src/Psalm/Exception/ConfigException.php
+++ b/src/Psalm/Exception/ConfigException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class ConfigException extends \Exception

--- a/src/Psalm/Exception/DocblockParseException.php
+++ b/src/Psalm/Exception/DocblockParseException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class DocblockParseException extends \Exception

--- a/src/Psalm/Exception/FileIncludeException.php
+++ b/src/Psalm/Exception/FileIncludeException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class FileIncludeException extends \Exception

--- a/src/Psalm/Exception/IncorrectDocblockException.php
+++ b/src/Psalm/Exception/IncorrectDocblockException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class IncorrectDocblockException extends DocblockParseException

--- a/src/Psalm/Exception/InvalidClasslikeOverrideException.php
+++ b/src/Psalm/Exception/InvalidClasslikeOverrideException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class InvalidClasslikeOverrideException extends \Exception

--- a/src/Psalm/Exception/InvalidMethodOverrideException.php
+++ b/src/Psalm/Exception/InvalidMethodOverrideException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class InvalidMethodOverrideException extends \Exception

--- a/src/Psalm/Exception/RefactorException.php
+++ b/src/Psalm/Exception/RefactorException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class RefactorException extends \Exception

--- a/src/Psalm/Exception/ScopeAnalysisException.php
+++ b/src/Psalm/Exception/ScopeAnalysisException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class ScopeAnalysisException extends \Exception

--- a/src/Psalm/Exception/TypeParseTreeException.php
+++ b/src/Psalm/Exception/TypeParseTreeException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class TypeParseTreeException extends \Exception

--- a/src/Psalm/Exception/UnanalyzedFileException.php
+++ b/src/Psalm/Exception/UnanalyzedFileException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class UnanalyzedFileException extends \Exception

--- a/src/Psalm/Exception/UnpopulatedClasslikeException.php
+++ b/src/Psalm/Exception/UnpopulatedClasslikeException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class UnpopulatedClasslikeException extends \LogicException

--- a/src/Psalm/Exception/UnpreparedAnalysisException.php
+++ b/src/Psalm/Exception/UnpreparedAnalysisException.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class UnpreparedAnalysisException extends \Exception

--- a/src/Psalm/Exception/UnsupportedIssueToFixException.php
+++ b/src/Psalm/Exception/UnsupportedIssueToFixException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Exception;
 
 class UnsupportedIssueToFixException extends \Exception

--- a/src/Psalm/FileBasedPluginAdapter.php
+++ b/src/Psalm/FileBasedPluginAdapter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;

--- a/src/Psalm/FileManipulation.php
+++ b/src/Psalm/FileManipulation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use function sha1;

--- a/src/Psalm/FileSource.php
+++ b/src/Psalm/FileSource.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 interface FileSource

--- a/src/Psalm/Internal/Analyzer/AlgebraAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/AlgebraAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/CanAlias.php
+++ b/src/Psalm/Internal/Analyzer/CanAlias.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;
@@ -237,9 +240,9 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
         }
 
         if (preg_match(
-            '/(^|\\\)(int|float|bool|string|void|null|false|true|object|mixed)$/i',
-            $fq_class_name
-        ) || strtolower($fq_class_name) === 'resource'
+                '/(^|\\\)(int|float|bool|string|void|null|false|true|object|mixed)$/i',
+                $fq_class_name
+            ) || strtolower($fq_class_name) === 'resource'
         ) {
             $class_name_parts = explode('\\', $fq_class_name);
             $class_name = array_pop($class_name_parts);
@@ -336,7 +339,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
             if (IssueBuffer::accepts(
                 new MissingDependency(
                     $fq_class_name . ' depends on class or interface '
-                        . $dependency_class_name . ' that does not exist',
+                    . $dependency_class_name . ' that does not exist',
                     $code_location,
                     $fq_class_name
                 ),
@@ -579,12 +582,12 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
             case self::VISIBILITY_PRIVATE:
                 if (!$context->self || $appearing_property_class !== $context->self) {
                     if ($emit_issues && IssueBuffer::accepts(
-                        new InaccessibleProperty(
-                            'Cannot access private property ' . $property_id . ' from context ' . $context->self,
-                            $code_location
-                        ),
-                        $suppressed_issues
-                    )) {
+                            new InaccessibleProperty(
+                                'Cannot access private property ' . $property_id . ' from context ' . $context->self,
+                                $code_location
+                            ),
+                            $suppressed_issues
+                        )) {
                         // fall through
                     }
 
@@ -600,12 +603,12 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
 
                 if (!$context->self) {
                     if ($emit_issues && IssueBuffer::accepts(
-                        new InaccessibleProperty(
-                            'Cannot access protected property ' . $property_id,
-                            $code_location
-                        ),
-                        $suppressed_issues
-                    )) {
+                            new InaccessibleProperty(
+                                'Cannot access protected property ' . $property_id,
+                                $code_location
+                            ),
+                            $suppressed_issues
+                        )) {
                         // fall through
                     }
 
@@ -618,12 +621,12 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
 
                 if (!$codebase->classExtends($context->self, $appearing_property_class)) {
                     if ($emit_issues && IssueBuffer::accepts(
-                        new InaccessibleProperty(
-                            'Cannot access protected property ' . $property_id . ' from context ' . $context->self,
-                            $code_location
-                        ),
-                        $suppressed_issues
-                    )) {
+                            new InaccessibleProperty(
+                                'Cannot access protected property ' . $property_id . ' from context ' . $context->self,
+                                $code_location
+                            ),
+                            $suppressed_issues
+                        )) {
                         // fall through
                     }
 

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -240,9 +240,9 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
         }
 
         if (preg_match(
-                '/(^|\\\)(int|float|bool|string|void|null|false|true|object|mixed)$/i',
-                $fq_class_name
-            ) || strtolower($fq_class_name) === 'resource'
+            '/(^|\\\)(int|float|bool|string|void|null|false|true|object|mixed)$/i',
+            $fq_class_name
+        ) || strtolower($fq_class_name) === 'resource'
         ) {
             $class_name_parts = explode('\\', $fq_class_name);
             $class_name = array_pop($class_name_parts);
@@ -339,7 +339,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
             if (IssueBuffer::accepts(
                 new MissingDependency(
                     $fq_class_name . ' depends on class or interface '
-                    . $dependency_class_name . ' that does not exist',
+                        . $dependency_class_name . ' that does not exist',
                     $code_location,
                     $fq_class_name
                 ),
@@ -582,12 +582,12 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
             case self::VISIBILITY_PRIVATE:
                 if (!$context->self || $appearing_property_class !== $context->self) {
                     if ($emit_issues && IssueBuffer::accepts(
-                            new InaccessibleProperty(
-                                'Cannot access private property ' . $property_id . ' from context ' . $context->self,
-                                $code_location
-                            ),
-                            $suppressed_issues
-                        )) {
+                        new InaccessibleProperty(
+                            'Cannot access private property ' . $property_id . ' from context ' . $context->self,
+                            $code_location
+                        ),
+                        $suppressed_issues
+                    )) {
                         // fall through
                     }
 
@@ -603,12 +603,12 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
 
                 if (!$context->self) {
                     if ($emit_issues && IssueBuffer::accepts(
-                            new InaccessibleProperty(
-                                'Cannot access protected property ' . $property_id,
-                                $code_location
-                            ),
-                            $suppressed_issues
-                        )) {
+                        new InaccessibleProperty(
+                            'Cannot access protected property ' . $property_id,
+                            $code_location
+                        ),
+                        $suppressed_issues
+                    )) {
                         // fall through
                     }
 
@@ -621,12 +621,12 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer implements StatementsSou
 
                 if (!$codebase->classExtends($context->self, $appearing_property_class)) {
                     if ($emit_issues && IssueBuffer::accepts(
-                            new InaccessibleProperty(
-                                'Cannot access protected property ' . $property_id . ' from context ' . $context->self,
-                                $code_location
-                            ),
-                            $suppressed_issues
-                        )) {
+                        new InaccessibleProperty(
+                            'Cannot access protected property ' . $property_id . ' from context ' . $context->self,
+                            $code_location
+                        ),
+                        $suppressed_issues
+                    )) {
                         // fall through
                     }
 

--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\FunctionLike;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\FunctionLike;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/IssueData.php
+++ b/src/Psalm/Internal/Analyzer/IssueData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 class IssueData

--- a/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser\Node\Stmt\ClassMethod;

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use Psalm\Aliases;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/DoAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/DoAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Block;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Block;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Block;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Internal\Analyzer\Statements\Block;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Block;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Block;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Block;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Block;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/WhileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/WhileAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Block;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/BreakAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/BreakAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/ContinueAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ContinueAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/EchoAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/EchoAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Assignment;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Assignment;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Assignment;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\BinaryOp;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\BinaryOp;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\BinaryOp;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonComparisonOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonComparisonOpAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\BinaryOp;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\BinaryOp;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\BinaryOp;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BitwiseNotAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BitwiseNotAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BooleanNotAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BooleanNotAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentMapPopulator.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentMapPopulator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 
 use PhpParser\Node\Expr;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicCallContext.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicCallContext.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use Psalm\Internal\MethodIdentifier;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalysisResult.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalysisResult.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use Psalm\Type;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/EmptyAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/EmptyAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/EvalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/EvalAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ExitAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ExitAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Fetch;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Fetch;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Fetch;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Fetch;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Fetch;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression\Fetch;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/InstanceofAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/InstanceofAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/MagicConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/MagicConstAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/MatchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/MatchAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/PrintAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/PrintAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/TernaryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/TernaryAnalyzer.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/UnaryPlusMinusAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/UnaryPlusMinusAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/YieldFromAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/YieldFromAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/ThrowAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ThrowAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer\Statements;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/TaintNodeData.php
+++ b/src/Psalm/Internal/Analyzer/TaintNodeData.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 /**

--- a/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;

--- a/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TypeAnalyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Analyzer;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Clause.php
+++ b/src/Psalm/Internal/Clause.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal;
 
 use function array_diff;

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function array_filter;

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function array_merge;

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function array_shift;

--- a/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
+++ b/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function array_shift;

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function array_pop;

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function array_keys;

--- a/src/Psalm/Internal/Codebase/Properties.php
+++ b/src/Psalm/Internal/Codebase/Properties.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function explode;

--- a/src/Psalm/Internal/Codebase/PropertyMap.php
+++ b/src/Psalm/Internal/Codebase/PropertyMap.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function strtolower;

--- a/src/Psalm/Internal/Codebase/ReferenceMapGenerator.php
+++ b/src/Psalm/Internal/Codebase/ReferenceMapGenerator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 class ReferenceMapGenerator

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function array_merge;

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use function array_filter;

--- a/src/Psalm/Internal/Codebase/Taint.php
+++ b/src/Psalm/Internal/Codebase/Taint.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Codebase;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Internal/Diff/ClassStatementsDiffer.php
+++ b/src/Psalm/Internal/Diff/ClassStatementsDiffer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Diff;
 
 use function count;

--- a/src/Psalm/Internal/Diff/FileStatementsDiffer.php
+++ b/src/Psalm/Internal/Diff/FileStatementsDiffer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Diff;
 
 use function array_merge;

--- a/src/Psalm/Internal/Diff/NamespaceStatementsDiffer.php
+++ b/src/Psalm/Internal/Diff/NamespaceStatementsDiffer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Diff;
 
 use function array_merge;

--- a/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\ExecutionEnvironment;
 
 use Psalm\SourceControl\Git\CommitInfo;

--- a/src/Psalm/Internal/ExecutionEnvironment/GitInfoCollector.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/GitInfoCollector.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\ExecutionEnvironment;
 
 use function array_keys;

--- a/src/Psalm/Internal/ExecutionEnvironment/SystemCommandExecutor.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/SystemCommandExecutor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\ExecutionEnvironment;
 
 use function exec;

--- a/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/ClassDocblockManipulator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\FileManipulation;
 
 use function array_shift;

--- a/src/Psalm/Internal/FileManipulation/CodeMigration.php
+++ b/src/Psalm/Internal/FileManipulation/CodeMigration.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\FileManipulation;
 
 /**

--- a/src/Psalm/Internal/FileManipulation/FileManipulationBuffer.php
+++ b/src/Psalm/Internal/FileManipulation/FileManipulationBuffer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\FileManipulation;
 
 use function array_merge;

--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\FileManipulation;
 
 use PhpParser;

--- a/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\FileManipulation;
 
 use function array_shift;

--- a/src/Psalm/Internal/Fork/ForkMessage.php
+++ b/src/Psalm/Internal/Fork/ForkMessage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Fork;
 
 interface ForkMessage

--- a/src/Psalm/Internal/Fork/ForkProcessDoneMessage.php
+++ b/src/Psalm/Internal/Fork/ForkProcessDoneMessage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Fork;
 
 /**

--- a/src/Psalm/Internal/Fork/ForkProcessErrorMessage.php
+++ b/src/Psalm/Internal/Fork/ForkProcessErrorMessage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Fork;
 
 /**

--- a/src/Psalm/Internal/Fork/ForkTaskDoneMessage.php
+++ b/src/Psalm/Internal/Fork/ForkTaskDoneMessage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Fork;
 
 /**

--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Fork;
 
 use function array_fill_keys;

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Fork;
 
 use function array_filter;

--- a/src/Psalm/Internal/IncludeCollector.php
+++ b/src/Psalm/Internal/IncludeCollector.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal;
 
 use function array_diff;

--- a/src/Psalm/Internal/InternalTaintSinkMap.php
+++ b/src/Psalm/Internal/InternalTaintSinkMap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // This maps internal function names to sink types that we don’t want to end up there
 
 return [

--- a/src/Psalm/Internal/Json/Json.php
+++ b/src/Psalm/Internal/Json/Json.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Json;
 
 use RuntimeException;

--- a/src/Psalm/Internal/MethodIdentifier.php
+++ b/src/Psalm/Internal/MethodIdentifier.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal;
 
 /**

--- a/src/Psalm/Internal/PhpVisitor/AssignmentMapVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/AssignmentMapVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PhpVisitor;
 
 use PhpParser;

--- a/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PhpVisitor;
 
 use PhpParser;

--- a/src/Psalm/Internal/PhpVisitor/NodeCleanerVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/NodeCleanerVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PhpVisitor;
 
 use PhpParser;

--- a/src/Psalm/Internal/PhpVisitor/NodeCounterVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/NodeCounterVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PhpVisitor;
 
 use PhpParser;

--- a/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PhpVisitor;
 
 use PhpParser;

--- a/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PhpVisitor;
 
 use PhpParser;

--- a/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PhpVisitor;
 
 use function count;

--- a/src/Psalm/Internal/PhpVisitor/ShortClosureVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ShortClosureVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PhpVisitor;
 
 use PhpParser;

--- a/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 // based on PhpParser's builtin one
 namespace Psalm\Internal\PhpVisitor;
 

--- a/src/Psalm/Internal/PhpVisitor/TraitFinder.php
+++ b/src/Psalm/Internal/PhpVisitor/TraitFinder.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PhpVisitor;
 
 use PhpParser;

--- a/src/Psalm/Internal/PluginManager/Command/DisableCommand.php
+++ b/src/Psalm/Internal/PluginManager/Command/DisableCommand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PluginManager\Command;
 
 use function assert;

--- a/src/Psalm/Internal/PluginManager/Command/EnableCommand.php
+++ b/src/Psalm/Internal/PluginManager/Command/EnableCommand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PluginManager\Command;
 
 use function assert;

--- a/src/Psalm/Internal/PluginManager/Command/ShowCommand.php
+++ b/src/Psalm/Internal/PluginManager/Command/ShowCommand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PluginManager\Command;
 
 use function array_keys;

--- a/src/Psalm/Internal/PluginManager/ComposerLock.php
+++ b/src/Psalm/Internal/PluginManager/ComposerLock.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PluginManager;
 
 use function array_merge;

--- a/src/Psalm/Internal/PluginManager/ConfigFile.php
+++ b/src/Psalm/Internal/PluginManager/ConfigFile.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PluginManager;
 
 use DOMDocument;

--- a/src/Psalm/Internal/PluginManager/PluginList.php
+++ b/src/Psalm/Internal/PluginManager/PluginList.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PluginManager;
 
 use function array_diff_key;

--- a/src/Psalm/Internal/PluginManager/PluginListFactory.php
+++ b/src/Psalm/Internal/PluginManager/PluginListFactory.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\PluginManager;
 
 use function array_filter;

--- a/src/Psalm/Internal/PropertyMap.php
+++ b/src/Psalm/Internal/PropertyMap.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal;
 
 /**

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use Psalm\Config;

--- a/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use function array_merge;

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use function file_exists;

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use const DIRECTORY_SEPARATOR;

--- a/src/Psalm/Internal/Provider/FileReferenceProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use function array_filter;

--- a/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use function array_merge;

--- a/src/Psalm/Internal/Provider/FileStorageProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use function array_merge;

--- a/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/FunctionParamsProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionParamsProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/MethodExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/MethodExistenceProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/MethodParamsProvider.php
+++ b/src/Psalm/Internal/Provider/MethodParamsProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/NodeDataProvider.php
+++ b/src/Psalm/Internal/Provider/NodeDataProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ParserCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ParserCacheProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use const DIRECTORY_SEPARATOR;

--- a/src/Psalm/Internal/Provider/ProjectCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ProjectCacheProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use const DIRECTORY_SEPARATOR;

--- a/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/PropertyTypeProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/Providers.php
+++ b/src/Psalm/Internal/Provider/Providers.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFillReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFillReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use function array_map;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use function array_map;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMergeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMergeReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use function array_merge;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPointerAdjustmentReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPointerAdjustmentReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPopReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPopReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayRandReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayRandReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use function count;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReverseReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReverseReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySliceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySliceReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayUniqueReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayUniqueReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayValuesReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayValuesReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ClosureFromCallableReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ClosureFromCallableReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/DomNodeAppendChild.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/DomNodeAppendChild.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ExplodeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ExplodeReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterVarReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterVarReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FirstArgStringReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FirstArgStringReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetClassMethodsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetClassMethodsReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/HexdecReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/HexdecReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use function assert;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/MktimeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/MktimeReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ParseUrlReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ParseUrlReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use function count;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementSetFetchMode.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementSetFetchMode.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use PhpParser;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/SimpleXmlElementAsXml.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/SimpleXmlElementAsXml.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use function count;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/StrReplaceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/StrReplaceReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use function in_array;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/VersionCompareReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/VersionCompareReturnTypeProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use function count;

--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Provider;
 
 use function abs;

--- a/src/Psalm/Internal/ReferenceConstraint.php
+++ b/src/Psalm/Internal/ReferenceConstraint.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal;
 
 use Psalm\Type;

--- a/src/Psalm/Internal/RuntimeCaches.php
+++ b/src/Psalm/Internal/RuntimeCaches.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal;
 
 abstract class RuntimeCaches

--- a/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner;
 
 /**

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner;
 
 use const PREG_OFFSET_CAPTURE;

--- a/src/Psalm/Internal/Scanner/FileScanner.php
+++ b/src/Psalm/Internal/Scanner/FileScanner.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner;
 
 use PhpParser;

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner;
 
 /**

--- a/src/Psalm/Internal/Scanner/ParsedDocblock.php
+++ b/src/Psalm/Internal/Scanner/ParsedDocblock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner;
 
 use function trim;

--- a/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
+++ b/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner;
 
 use PhpParser;

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayOffsetFetch.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayOffsetFetch.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayValue.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ClassConstant.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ClassConstant.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/Constant.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/Constant.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/KeyValuePair.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/KeyValuePair.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ScalarValue.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ScalarValue.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedAdditionOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedAdditionOp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBinaryOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBinaryOp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBitwiseOr.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBitwiseOr.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedConcatOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedConcatOp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedDivisionOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedDivisionOp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedMultiplicationOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedMultiplicationOp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedSubtractionOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedSubtractionOp.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedTernary.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedTernary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;

--- a/src/Psalm/Internal/Scanner/UnresolvedConstantComponent.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstantComponent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner;
 
 /**

--- a/src/Psalm/Internal/Scanner/VarDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/VarDocblockComment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scanner;
 
 use Psalm\Type;

--- a/src/Psalm/Internal/Scope/CaseScope.php
+++ b/src/Psalm/Internal/Scope/CaseScope.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scope;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Internal/Scope/IfConditionalScope.php
+++ b/src/Psalm/Internal/Scope/IfConditionalScope.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scope;
 
 use Psalm\Context;

--- a/src/Psalm/Internal/Scope/IfScope.php
+++ b/src/Psalm/Internal/Scope/IfScope.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scope;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Internal/Scope/LoopScope.php
+++ b/src/Psalm/Internal/Scope/LoopScope.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scope;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Internal/Scope/SwitchScope.php
+++ b/src/Psalm/Internal/Scope/SwitchScope.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Scope;
 
 use PhpParser;

--- a/src/Psalm/Internal/Stubs/Generator/ClassLikeStubGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/ClassLikeStubGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Stubs\Generator;
 
 use PhpParser;

--- a/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Stubs\Generator;
 
 use PhpParser;

--- a/src/Psalm/Internal/Taint/Path.php
+++ b/src/Psalm/Internal/Taint/Path.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Taint;
 
 /**

--- a/src/Psalm/Internal/Taint/Sink.php
+++ b/src/Psalm/Internal/Taint/Sink.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Taint;
 
 class Sink extends Taintable

--- a/src/Psalm/Internal/Taint/Source.php
+++ b/src/Psalm/Internal/Taint/Source.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Taint;
 
 class Source extends Taintable

--- a/src/Psalm/Internal/Taint/TaintNode.php
+++ b/src/Psalm/Internal/Taint/TaintNode.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Taint;
 
 class TaintNode extends Taintable

--- a/src/Psalm/Internal/Taint/Taintable.php
+++ b/src/Psalm/Internal/Taint/Taintable.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Taint;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use function array_filter;

--- a/src/Psalm/Internal/Type/Comparator/ArrayTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ArrayTypeComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Internal\Analyzer\StatementsAnalyzer;

--- a/src/Psalm/Internal/Type/Comparator/ClassStringComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ClassStringComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Type/Comparator/KeyedArrayComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/KeyedArrayComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;

--- a/src/Psalm/Internal/Type/Comparator/TypeComparisonResult.php
+++ b/src/Psalm/Internal/Type/Comparator/TypeComparisonResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 class TypeComparisonResult

--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use function count;

--- a/src/Psalm/Internal/Type/ParseTree.php
+++ b/src/Psalm/Internal/Type/ParseTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/CallableParamTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/CallableParamTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/CallableTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/CallableTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/CallableWithReturnTypeTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/CallableWithReturnTypeTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/ConditionalTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/ConditionalTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/EncapsulationTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/EncapsulationTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/GenericTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/GenericTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/IndexedAccessTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/IndexedAccessTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/IntersectionTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/IntersectionTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/KeyedArrayPropertyTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/KeyedArrayPropertyTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/KeyedArrayTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/KeyedArrayTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/MethodParamTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/MethodParamTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/MethodTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/MethodTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/MethodWithReturnTypeTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/MethodWithReturnTypeTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/NullableTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/NullableTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/Root.php
+++ b/src/Psalm/Internal/Type/ParseTree/Root.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/TemplateAsTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/TemplateAsTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/TemplateIsTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/TemplateIsTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/UnionTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/UnionTree.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTree/Value.php
+++ b/src/Psalm/Internal/Type/ParseTree/Value.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\ParseTree;
 
 /**

--- a/src/Psalm/Internal/Type/ParseTreeCreator.php
+++ b/src/Psalm/Internal/Type/ParseTreeCreator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use function array_pop;

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use function array_filter;

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use function get_class;

--- a/src/Psalm/Internal/Type/TemplateResult.php
+++ b/src/Psalm/Internal/Type/TemplateResult.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use Psalm\Type\Union;

--- a/src/Psalm/Internal/Type/TypeAlias.php
+++ b/src/Psalm/Internal/Type/TypeAlias.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 interface TypeAlias

--- a/src/Psalm/Internal/Type/TypeAlias/ClassTypeAlias.php
+++ b/src/Psalm/Internal/Type/TypeAlias/ClassTypeAlias.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\TypeAlias;
 
 class ClassTypeAlias implements \Psalm\Internal\Type\TypeAlias

--- a/src/Psalm/Internal/Type/TypeAlias/InlineTypeAlias.php
+++ b/src/Psalm/Internal/Type/TypeAlias/InlineTypeAlias.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\TypeAlias;
 
 /**

--- a/src/Psalm/Internal/Type/TypeAlias/LinkableTypeAlias.php
+++ b/src/Psalm/Internal/Type/TypeAlias/LinkableTypeAlias.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type\TypeAlias;
 
 /**

--- a/src/Psalm/Internal/Type/TypeCombination.php
+++ b/src/Psalm/Internal/Type/TypeCombination.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use function array_filter;

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use function array_keys;

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use function array_push;

--- a/src/Psalm/Internal/Type/UnionTemplateHandler.php
+++ b/src/Psalm/Internal/Type/UnionTemplateHandler.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Internal\Type;
 
 use Psalm\Codebase;

--- a/src/Psalm/Internal/TypeVisitor/ContainsClassLikeVisitor.php
+++ b/src/Psalm/Internal/TypeVisitor/ContainsClassLikeVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\TypeVisitor;
 
 use Psalm\Type\Atomic\TLiteralClassString;

--- a/src/Psalm/Internal/TypeVisitor/FromDocblockSetter.php
+++ b/src/Psalm/Internal/TypeVisitor/FromDocblockSetter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\TypeVisitor;
 
 use Psalm\Type\TypeNode;

--- a/src/Psalm/Internal/TypeVisitor/TemplateTypeCollector.php
+++ b/src/Psalm/Internal/TypeVisitor/TemplateTypeCollector.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\TypeVisitor;
 
 use Psalm\Type\Atomic\TConditional;

--- a/src/Psalm/Internal/TypeVisitor/TypeChecker.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeChecker.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\TypeVisitor;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Internal/TypeVisitor/TypeScanner.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeScanner.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Internal\TypeVisitor;
 
 use Psalm\Internal\Codebase\Scanner;

--- a/src/Psalm/Internal/exception_handler.php
+++ b/src/Psalm/Internal/exception_handler.php
@@ -1,4 +1,6 @@
 <?php
+
+declare(strict_types=1);
 /**
  * If there is an uncaught exception,
  * then print more of the backtrace than is done by default to stderr,

--- a/src/Psalm/Issue/AbstractInstantiation.php
+++ b/src/Psalm/Issue/AbstractInstantiation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class AbstractInstantiation extends CodeIssue

--- a/src/Psalm/Issue/AbstractMethodCall.php
+++ b/src/Psalm/Issue/AbstractMethodCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class AbstractMethodCall extends CodeIssue

--- a/src/Psalm/Issue/ArgumentIssue.php
+++ b/src/Psalm/Issue/ArgumentIssue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 use function strtolower;

--- a/src/Psalm/Issue/ArgumentTypeCoercion.php
+++ b/src/Psalm/Issue/ArgumentTypeCoercion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ArgumentTypeCoercion extends ArgumentIssue

--- a/src/Psalm/Issue/AssignmentToVoid.php
+++ b/src/Psalm/Issue/AssignmentToVoid.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class AssignmentToVoid extends CodeIssue

--- a/src/Psalm/Issue/CircularReference.php
+++ b/src/Psalm/Issue/CircularReference.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class CircularReference extends CodeIssue

--- a/src/Psalm/Issue/ClassIssue.php
+++ b/src/Psalm/Issue/ClassIssue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 abstract class ClassIssue extends CodeIssue

--- a/src/Psalm/Issue/CodeIssue.php
+++ b/src/Psalm/Issue/CodeIssue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Issue/ConflictingReferenceConstraint.php
+++ b/src/Psalm/Issue/ConflictingReferenceConstraint.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ConflictingReferenceConstraint extends CodeIssue

--- a/src/Psalm/Issue/ConstructorSignatureMismatch.php
+++ b/src/Psalm/Issue/ConstructorSignatureMismatch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ConstructorSignatureMismatch extends CodeIssue

--- a/src/Psalm/Issue/ContinueOutsideLoop.php
+++ b/src/Psalm/Issue/ContinueOutsideLoop.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ContinueOutsideLoop extends CodeIssue

--- a/src/Psalm/Issue/DeprecatedClass.php
+++ b/src/Psalm/Issue/DeprecatedClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DeprecatedClass extends ClassIssue

--- a/src/Psalm/Issue/DeprecatedConstant.php
+++ b/src/Psalm/Issue/DeprecatedConstant.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DeprecatedConstant extends CodeIssue

--- a/src/Psalm/Issue/DeprecatedFunction.php
+++ b/src/Psalm/Issue/DeprecatedFunction.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DeprecatedFunction extends FunctionIssue

--- a/src/Psalm/Issue/DeprecatedInterface.php
+++ b/src/Psalm/Issue/DeprecatedInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DeprecatedInterface extends ClassIssue

--- a/src/Psalm/Issue/DeprecatedMethod.php
+++ b/src/Psalm/Issue/DeprecatedMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DeprecatedMethod extends MethodIssue

--- a/src/Psalm/Issue/DeprecatedProperty.php
+++ b/src/Psalm/Issue/DeprecatedProperty.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DeprecatedProperty extends PropertyIssue

--- a/src/Psalm/Issue/DeprecatedTrait.php
+++ b/src/Psalm/Issue/DeprecatedTrait.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DeprecatedTrait extends CodeIssue

--- a/src/Psalm/Issue/DocblockTypeContradiction.php
+++ b/src/Psalm/Issue/DocblockTypeContradiction.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DocblockTypeContradiction extends CodeIssue

--- a/src/Psalm/Issue/DuplicateArrayKey.php
+++ b/src/Psalm/Issue/DuplicateArrayKey.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DuplicateArrayKey extends CodeIssue

--- a/src/Psalm/Issue/DuplicateClass.php
+++ b/src/Psalm/Issue/DuplicateClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DuplicateClass extends CodeIssue

--- a/src/Psalm/Issue/DuplicateFunction.php
+++ b/src/Psalm/Issue/DuplicateFunction.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DuplicateFunction extends CodeIssue

--- a/src/Psalm/Issue/DuplicateMethod.php
+++ b/src/Psalm/Issue/DuplicateMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DuplicateMethod extends CodeIssue

--- a/src/Psalm/Issue/DuplicateParam.php
+++ b/src/Psalm/Issue/DuplicateParam.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class DuplicateParam extends CodeIssue

--- a/src/Psalm/Issue/EmptyArrayAccess.php
+++ b/src/Psalm/Issue/EmptyArrayAccess.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class EmptyArrayAccess extends CodeIssue

--- a/src/Psalm/Issue/FalsableReturnStatement.php
+++ b/src/Psalm/Issue/FalsableReturnStatement.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class FalsableReturnStatement extends CodeIssue

--- a/src/Psalm/Issue/FalseOperand.php
+++ b/src/Psalm/Issue/FalseOperand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class FalseOperand extends CodeIssue

--- a/src/Psalm/Issue/ForbiddenCode.php
+++ b/src/Psalm/Issue/ForbiddenCode.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ForbiddenCode extends CodeIssue

--- a/src/Psalm/Issue/ForbiddenEcho.php
+++ b/src/Psalm/Issue/ForbiddenEcho.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ForbiddenEcho extends CodeIssue

--- a/src/Psalm/Issue/FunctionIssue.php
+++ b/src/Psalm/Issue/FunctionIssue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 use function strtolower;

--- a/src/Psalm/Issue/ImplementedParamTypeMismatch.php
+++ b/src/Psalm/Issue/ImplementedParamTypeMismatch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImplementedParamTypeMismatch extends CodeIssue

--- a/src/Psalm/Issue/ImplementedReturnTypeMismatch.php
+++ b/src/Psalm/Issue/ImplementedReturnTypeMismatch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImplementedReturnTypeMismatch extends CodeIssue

--- a/src/Psalm/Issue/ImplicitToStringCast.php
+++ b/src/Psalm/Issue/ImplicitToStringCast.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImplicitToStringCast extends CodeIssue

--- a/src/Psalm/Issue/ImpureByReferenceAssignment.php
+++ b/src/Psalm/Issue/ImpureByReferenceAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImpureByReferenceAssignment extends CodeIssue

--- a/src/Psalm/Issue/ImpureFunctionCall.php
+++ b/src/Psalm/Issue/ImpureFunctionCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImpureFunctionCall extends CodeIssue

--- a/src/Psalm/Issue/ImpureMethodCall.php
+++ b/src/Psalm/Issue/ImpureMethodCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImpureMethodCall extends CodeIssue

--- a/src/Psalm/Issue/ImpurePropertyAssignment.php
+++ b/src/Psalm/Issue/ImpurePropertyAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImpurePropertyAssignment extends CodeIssue

--- a/src/Psalm/Issue/ImpurePropertyFetch.php
+++ b/src/Psalm/Issue/ImpurePropertyFetch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImpurePropertyFetch extends CodeIssue

--- a/src/Psalm/Issue/ImpureStaticProperty.php
+++ b/src/Psalm/Issue/ImpureStaticProperty.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImpureStaticProperty extends CodeIssue

--- a/src/Psalm/Issue/ImpureStaticVariable.php
+++ b/src/Psalm/Issue/ImpureStaticVariable.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImpureStaticVariable extends CodeIssue

--- a/src/Psalm/Issue/ImpureVariable.php
+++ b/src/Psalm/Issue/ImpureVariable.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ImpureVariable extends CodeIssue

--- a/src/Psalm/Issue/InaccessibleClassConstant.php
+++ b/src/Psalm/Issue/InaccessibleClassConstant.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InaccessibleClassConstant extends CodeIssue

--- a/src/Psalm/Issue/InaccessibleMethod.php
+++ b/src/Psalm/Issue/InaccessibleMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InaccessibleMethod extends CodeIssue

--- a/src/Psalm/Issue/InaccessibleProperty.php
+++ b/src/Psalm/Issue/InaccessibleProperty.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InaccessibleProperty extends CodeIssue

--- a/src/Psalm/Issue/InterfaceInstantiation.php
+++ b/src/Psalm/Issue/InterfaceInstantiation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InterfaceInstantiation extends CodeIssue

--- a/src/Psalm/Issue/InternalClass.php
+++ b/src/Psalm/Issue/InternalClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InternalClass extends ClassIssue

--- a/src/Psalm/Issue/InternalMethod.php
+++ b/src/Psalm/Issue/InternalMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InternalMethod extends MethodIssue

--- a/src/Psalm/Issue/InternalProperty.php
+++ b/src/Psalm/Issue/InternalProperty.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InternalProperty extends PropertyIssue

--- a/src/Psalm/Issue/InvalidArgument.php
+++ b/src/Psalm/Issue/InvalidArgument.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidArgument extends ArgumentIssue

--- a/src/Psalm/Issue/InvalidArrayAccess.php
+++ b/src/Psalm/Issue/InvalidArrayAccess.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidArrayAccess extends CodeIssue

--- a/src/Psalm/Issue/InvalidArrayAssignment.php
+++ b/src/Psalm/Issue/InvalidArrayAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidArrayAssignment extends CodeIssue

--- a/src/Psalm/Issue/InvalidArrayOffset.php
+++ b/src/Psalm/Issue/InvalidArrayOffset.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidArrayOffset extends CodeIssue

--- a/src/Psalm/Issue/InvalidCast.php
+++ b/src/Psalm/Issue/InvalidCast.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidCast extends CodeIssue

--- a/src/Psalm/Issue/InvalidCatch.php
+++ b/src/Psalm/Issue/InvalidCatch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidCatch extends ClassIssue

--- a/src/Psalm/Issue/InvalidClass.php
+++ b/src/Psalm/Issue/InvalidClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidClass extends ClassIssue

--- a/src/Psalm/Issue/InvalidClone.php
+++ b/src/Psalm/Issue/InvalidClone.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidClone extends CodeIssue

--- a/src/Psalm/Issue/InvalidDocblock.php
+++ b/src/Psalm/Issue/InvalidDocblock.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidDocblock extends CodeIssue

--- a/src/Psalm/Issue/InvalidDocblockParamName.php
+++ b/src/Psalm/Issue/InvalidDocblockParamName.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidDocblockParamName extends CodeIssue

--- a/src/Psalm/Issue/InvalidExtendClass.php
+++ b/src/Psalm/Issue/InvalidExtendClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidExtendClass extends ClassIssue

--- a/src/Psalm/Issue/InvalidFalsableReturnType.php
+++ b/src/Psalm/Issue/InvalidFalsableReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidFalsableReturnType extends CodeIssue

--- a/src/Psalm/Issue/InvalidFunctionCall.php
+++ b/src/Psalm/Issue/InvalidFunctionCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidFunctionCall extends CodeIssue

--- a/src/Psalm/Issue/InvalidGlobal.php
+++ b/src/Psalm/Issue/InvalidGlobal.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidGlobal extends CodeIssue

--- a/src/Psalm/Issue/InvalidIterator.php
+++ b/src/Psalm/Issue/InvalidIterator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidIterator extends CodeIssue

--- a/src/Psalm/Issue/InvalidLiteralArgument.php
+++ b/src/Psalm/Issue/InvalidLiteralArgument.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidLiteralArgument extends ArgumentIssue

--- a/src/Psalm/Issue/InvalidMethodCall.php
+++ b/src/Psalm/Issue/InvalidMethodCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidMethodCall extends CodeIssue

--- a/src/Psalm/Issue/InvalidNullableReturnType.php
+++ b/src/Psalm/Issue/InvalidNullableReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidNullableReturnType extends CodeIssue

--- a/src/Psalm/Issue/InvalidOperand.php
+++ b/src/Psalm/Issue/InvalidOperand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidOperand extends CodeIssue

--- a/src/Psalm/Issue/InvalidParamDefault.php
+++ b/src/Psalm/Issue/InvalidParamDefault.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidParamDefault extends CodeIssue

--- a/src/Psalm/Issue/InvalidParent.php
+++ b/src/Psalm/Issue/InvalidParent.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidParent extends CodeIssue

--- a/src/Psalm/Issue/InvalidPassByReference.php
+++ b/src/Psalm/Issue/InvalidPassByReference.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidPassByReference extends CodeIssue

--- a/src/Psalm/Issue/InvalidPropertyAssignment.php
+++ b/src/Psalm/Issue/InvalidPropertyAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidPropertyAssignment extends CodeIssue

--- a/src/Psalm/Issue/InvalidPropertyAssignmentValue.php
+++ b/src/Psalm/Issue/InvalidPropertyAssignmentValue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidPropertyAssignmentValue extends PropertyIssue

--- a/src/Psalm/Issue/InvalidPropertyFetch.php
+++ b/src/Psalm/Issue/InvalidPropertyFetch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidPropertyFetch extends CodeIssue

--- a/src/Psalm/Issue/InvalidReturnStatement.php
+++ b/src/Psalm/Issue/InvalidReturnStatement.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidReturnStatement extends CodeIssue

--- a/src/Psalm/Issue/InvalidReturnType.php
+++ b/src/Psalm/Issue/InvalidReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidReturnType extends CodeIssue

--- a/src/Psalm/Issue/InvalidScalarArgument.php
+++ b/src/Psalm/Issue/InvalidScalarArgument.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidScalarArgument extends ArgumentIssue

--- a/src/Psalm/Issue/InvalidScope.php
+++ b/src/Psalm/Issue/InvalidScope.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidScope extends CodeIssue

--- a/src/Psalm/Issue/InvalidStaticInvocation.php
+++ b/src/Psalm/Issue/InvalidStaticInvocation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidStaticInvocation extends CodeIssue

--- a/src/Psalm/Issue/InvalidStringClass.php
+++ b/src/Psalm/Issue/InvalidStringClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidStringClass extends CodeIssue

--- a/src/Psalm/Issue/InvalidTemplateParam.php
+++ b/src/Psalm/Issue/InvalidTemplateParam.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidTemplateParam extends CodeIssue

--- a/src/Psalm/Issue/InvalidThrow.php
+++ b/src/Psalm/Issue/InvalidThrow.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidThrow extends ClassIssue

--- a/src/Psalm/Issue/InvalidToString.php
+++ b/src/Psalm/Issue/InvalidToString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidToString extends CodeIssue

--- a/src/Psalm/Issue/InvalidTypeImport.php
+++ b/src/Psalm/Issue/InvalidTypeImport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class InvalidTypeImport extends CodeIssue

--- a/src/Psalm/Issue/LessSpecificImplementedReturnType.php
+++ b/src/Psalm/Issue/LessSpecificImplementedReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class LessSpecificImplementedReturnType extends CodeIssue

--- a/src/Psalm/Issue/LessSpecificReturnStatement.php
+++ b/src/Psalm/Issue/LessSpecificReturnStatement.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class LessSpecificReturnStatement extends CodeIssue

--- a/src/Psalm/Issue/LessSpecificReturnType.php
+++ b/src/Psalm/Issue/LessSpecificReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class LessSpecificReturnType extends CodeIssue

--- a/src/Psalm/Issue/LoopInvalidation.php
+++ b/src/Psalm/Issue/LoopInvalidation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class LoopInvalidation extends CodeIssue

--- a/src/Psalm/Issue/MethodIssue.php
+++ b/src/Psalm/Issue/MethodIssue.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Issue;
 
 use function strtolower;

--- a/src/Psalm/Issue/MethodSignatureMismatch.php
+++ b/src/Psalm/Issue/MethodSignatureMismatch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MethodSignatureMismatch extends CodeIssue

--- a/src/Psalm/Issue/MethodSignatureMustOmitReturnType.php
+++ b/src/Psalm/Issue/MethodSignatureMustOmitReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MethodSignatureMustOmitReturnType extends CodeIssue

--- a/src/Psalm/Issue/MismatchingDocblockParamType.php
+++ b/src/Psalm/Issue/MismatchingDocblockParamType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MismatchingDocblockParamType extends CodeIssue

--- a/src/Psalm/Issue/MismatchingDocblockReturnType.php
+++ b/src/Psalm/Issue/MismatchingDocblockReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MismatchingDocblockReturnType extends CodeIssue

--- a/src/Psalm/Issue/MissingClosureParamType.php
+++ b/src/Psalm/Issue/MissingClosureParamType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingClosureParamType extends CodeIssue

--- a/src/Psalm/Issue/MissingClosureReturnType.php
+++ b/src/Psalm/Issue/MissingClosureReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingClosureReturnType extends CodeIssue

--- a/src/Psalm/Issue/MissingConstructor.php
+++ b/src/Psalm/Issue/MissingConstructor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingConstructor extends CodeIssue

--- a/src/Psalm/Issue/MissingDependency.php
+++ b/src/Psalm/Issue/MissingDependency.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingDependency extends ClassIssue

--- a/src/Psalm/Issue/MissingDocblockType.php
+++ b/src/Psalm/Issue/MissingDocblockType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingDocblockType extends CodeIssue

--- a/src/Psalm/Issue/MissingFile.php
+++ b/src/Psalm/Issue/MissingFile.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingFile extends CodeIssue

--- a/src/Psalm/Issue/MissingImmutableAnnotation.php
+++ b/src/Psalm/Issue/MissingImmutableAnnotation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingImmutableAnnotation extends CodeIssue

--- a/src/Psalm/Issue/MissingParamType.php
+++ b/src/Psalm/Issue/MissingParamType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingParamType extends CodeIssue

--- a/src/Psalm/Issue/MissingPropertyType.php
+++ b/src/Psalm/Issue/MissingPropertyType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingPropertyType extends PropertyIssue

--- a/src/Psalm/Issue/MissingReturnType.php
+++ b/src/Psalm/Issue/MissingReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingReturnType extends CodeIssue

--- a/src/Psalm/Issue/MissingTemplateParam.php
+++ b/src/Psalm/Issue/MissingTemplateParam.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingTemplateParam extends CodeIssue

--- a/src/Psalm/Issue/MissingThrowsDocblock.php
+++ b/src/Psalm/Issue/MissingThrowsDocblock.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MissingThrowsDocblock extends CodeIssue

--- a/src/Psalm/Issue/MixedArgument.php
+++ b/src/Psalm/Issue/MixedArgument.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedArgument extends ArgumentIssue

--- a/src/Psalm/Issue/MixedArgumentTypeCoercion.php
+++ b/src/Psalm/Issue/MixedArgumentTypeCoercion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedArgumentTypeCoercion extends ArgumentIssue

--- a/src/Psalm/Issue/MixedArrayAccess.php
+++ b/src/Psalm/Issue/MixedArrayAccess.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedArrayAccess extends CodeIssue

--- a/src/Psalm/Issue/MixedArrayAssignment.php
+++ b/src/Psalm/Issue/MixedArrayAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedArrayAssignment extends CodeIssue

--- a/src/Psalm/Issue/MixedArrayOffset.php
+++ b/src/Psalm/Issue/MixedArrayOffset.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedArrayOffset extends CodeIssue

--- a/src/Psalm/Issue/MixedArrayTypeCoercion.php
+++ b/src/Psalm/Issue/MixedArrayTypeCoercion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedArrayTypeCoercion extends CodeIssue

--- a/src/Psalm/Issue/MixedAssignment.php
+++ b/src/Psalm/Issue/MixedAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedAssignment extends CodeIssue

--- a/src/Psalm/Issue/MixedClone.php
+++ b/src/Psalm/Issue/MixedClone.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedClone extends CodeIssue

--- a/src/Psalm/Issue/MixedFunctionCall.php
+++ b/src/Psalm/Issue/MixedFunctionCall.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedFunctionCall extends CodeIssue

--- a/src/Psalm/Issue/MixedInferredReturnType.php
+++ b/src/Psalm/Issue/MixedInferredReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedInferredReturnType extends CodeIssue

--- a/src/Psalm/Issue/MixedMethodCall.php
+++ b/src/Psalm/Issue/MixedMethodCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedMethodCall extends CodeIssue

--- a/src/Psalm/Issue/MixedOperand.php
+++ b/src/Psalm/Issue/MixedOperand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedOperand extends CodeIssue

--- a/src/Psalm/Issue/MixedPropertyAssignment.php
+++ b/src/Psalm/Issue/MixedPropertyAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedPropertyAssignment extends CodeIssue

--- a/src/Psalm/Issue/MixedPropertyFetch.php
+++ b/src/Psalm/Issue/MixedPropertyFetch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedPropertyFetch extends CodeIssue

--- a/src/Psalm/Issue/MixedPropertyTypeCoercion.php
+++ b/src/Psalm/Issue/MixedPropertyTypeCoercion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedPropertyTypeCoercion extends PropertyIssue

--- a/src/Psalm/Issue/MixedReturnStatement.php
+++ b/src/Psalm/Issue/MixedReturnStatement.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedReturnStatement extends CodeIssue

--- a/src/Psalm/Issue/MixedReturnTypeCoercion.php
+++ b/src/Psalm/Issue/MixedReturnTypeCoercion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedReturnTypeCoercion extends CodeIssue

--- a/src/Psalm/Issue/MixedStringOffsetAssignment.php
+++ b/src/Psalm/Issue/MixedStringOffsetAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MixedStringOffsetAssignment extends CodeIssue

--- a/src/Psalm/Issue/MoreSpecificImplementedParamType.php
+++ b/src/Psalm/Issue/MoreSpecificImplementedParamType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MoreSpecificImplementedParamType extends CodeIssue

--- a/src/Psalm/Issue/MoreSpecificReturnType.php
+++ b/src/Psalm/Issue/MoreSpecificReturnType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MoreSpecificReturnType extends CodeIssue

--- a/src/Psalm/Issue/MutableDependency.php
+++ b/src/Psalm/Issue/MutableDependency.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class MutableDependency extends CodeIssue

--- a/src/Psalm/Issue/NoInterfaceProperties.php
+++ b/src/Psalm/Issue/NoInterfaceProperties.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NoInterfaceProperties extends ClassIssue

--- a/src/Psalm/Issue/NoValue.php
+++ b/src/Psalm/Issue/NoValue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NoValue extends CodeIssue

--- a/src/Psalm/Issue/NonStaticSelfCall.php
+++ b/src/Psalm/Issue/NonStaticSelfCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NonStaticSelfCall extends CodeIssue

--- a/src/Psalm/Issue/NullArgument.php
+++ b/src/Psalm/Issue/NullArgument.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NullArgument extends ArgumentIssue

--- a/src/Psalm/Issue/NullArrayAccess.php
+++ b/src/Psalm/Issue/NullArrayAccess.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 /**

--- a/src/Psalm/Issue/NullArrayOffset.php
+++ b/src/Psalm/Issue/NullArrayOffset.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NullArrayOffset extends CodeIssue

--- a/src/Psalm/Issue/NullFunctionCall.php
+++ b/src/Psalm/Issue/NullFunctionCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NullFunctionCall extends CodeIssue

--- a/src/Psalm/Issue/NullIterator.php
+++ b/src/Psalm/Issue/NullIterator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NullIterator extends CodeIssue

--- a/src/Psalm/Issue/NullOperand.php
+++ b/src/Psalm/Issue/NullOperand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NullOperand extends CodeIssue

--- a/src/Psalm/Issue/NullPropertyAssignment.php
+++ b/src/Psalm/Issue/NullPropertyAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 /**

--- a/src/Psalm/Issue/NullPropertyFetch.php
+++ b/src/Psalm/Issue/NullPropertyFetch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 /**

--- a/src/Psalm/Issue/NullReference.php
+++ b/src/Psalm/Issue/NullReference.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NullReference extends CodeIssue

--- a/src/Psalm/Issue/NullableReturnStatement.php
+++ b/src/Psalm/Issue/NullableReturnStatement.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class NullableReturnStatement extends CodeIssue

--- a/src/Psalm/Issue/OverriddenMethodAccess.php
+++ b/src/Psalm/Issue/OverriddenMethodAccess.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class OverriddenMethodAccess extends CodeIssue

--- a/src/Psalm/Issue/OverriddenPropertyAccess.php
+++ b/src/Psalm/Issue/OverriddenPropertyAccess.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class OverriddenPropertyAccess extends CodeIssue

--- a/src/Psalm/Issue/ParadoxicalCondition.php
+++ b/src/Psalm/Issue/ParadoxicalCondition.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ParadoxicalCondition extends CodeIssue

--- a/src/Psalm/Issue/ParamNameMismatch.php
+++ b/src/Psalm/Issue/ParamNameMismatch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ParamNameMismatch extends CodeIssue

--- a/src/Psalm/Issue/ParentNotFound.php
+++ b/src/Psalm/Issue/ParentNotFound.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ParentNotFound extends CodeIssue

--- a/src/Psalm/Issue/ParseError.php
+++ b/src/Psalm/Issue/ParseError.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ParseError extends CodeIssue

--- a/src/Psalm/Issue/PluginIssue.php
+++ b/src/Psalm/Issue/PluginIssue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 abstract class PluginIssue extends CodeIssue

--- a/src/Psalm/Issue/PossibleRawObjectIteration.php
+++ b/src/Psalm/Issue/PossibleRawObjectIteration.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossibleRawObjectIteration extends CodeIssue

--- a/src/Psalm/Issue/PossiblyFalseArgument.php
+++ b/src/Psalm/Issue/PossiblyFalseArgument.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyFalseArgument extends ArgumentIssue

--- a/src/Psalm/Issue/PossiblyFalseIterator.php
+++ b/src/Psalm/Issue/PossiblyFalseIterator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyFalseIterator extends CodeIssue

--- a/src/Psalm/Issue/PossiblyFalseOperand.php
+++ b/src/Psalm/Issue/PossiblyFalseOperand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyFalseOperand extends CodeIssue

--- a/src/Psalm/Issue/PossiblyFalsePropertyAssignmentValue.php
+++ b/src/Psalm/Issue/PossiblyFalsePropertyAssignmentValue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyFalsePropertyAssignmentValue extends PropertyIssue

--- a/src/Psalm/Issue/PossiblyFalseReference.php
+++ b/src/Psalm/Issue/PossiblyFalseReference.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyFalseReference extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidArgument.php
+++ b/src/Psalm/Issue/PossiblyInvalidArgument.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidArgument extends ArgumentIssue

--- a/src/Psalm/Issue/PossiblyInvalidArrayAccess.php
+++ b/src/Psalm/Issue/PossiblyInvalidArrayAccess.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidArrayAccess extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidArrayAssignment.php
+++ b/src/Psalm/Issue/PossiblyInvalidArrayAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidArrayAssignment extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidArrayOffset.php
+++ b/src/Psalm/Issue/PossiblyInvalidArrayOffset.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidArrayOffset extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidCast.php
+++ b/src/Psalm/Issue/PossiblyInvalidCast.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidCast extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidClone.php
+++ b/src/Psalm/Issue/PossiblyInvalidClone.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidClone extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidFunctionCall.php
+++ b/src/Psalm/Issue/PossiblyInvalidFunctionCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidFunctionCall extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidIterator.php
+++ b/src/Psalm/Issue/PossiblyInvalidIterator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidIterator extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidMethodCall.php
+++ b/src/Psalm/Issue/PossiblyInvalidMethodCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidMethodCall extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidOperand.php
+++ b/src/Psalm/Issue/PossiblyInvalidOperand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidOperand extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidPropertyAssignment.php
+++ b/src/Psalm/Issue/PossiblyInvalidPropertyAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidPropertyAssignment extends CodeIssue

--- a/src/Psalm/Issue/PossiblyInvalidPropertyAssignmentValue.php
+++ b/src/Psalm/Issue/PossiblyInvalidPropertyAssignmentValue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidPropertyAssignmentValue extends PropertyIssue

--- a/src/Psalm/Issue/PossiblyInvalidPropertyFetch.php
+++ b/src/Psalm/Issue/PossiblyInvalidPropertyFetch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyInvalidPropertyFetch extends CodeIssue

--- a/src/Psalm/Issue/PossiblyNullArgument.php
+++ b/src/Psalm/Issue/PossiblyNullArgument.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyNullArgument extends ArgumentIssue

--- a/src/Psalm/Issue/PossiblyNullArrayAccess.php
+++ b/src/Psalm/Issue/PossiblyNullArrayAccess.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 /**

--- a/src/Psalm/Issue/PossiblyNullArrayAssignment.php
+++ b/src/Psalm/Issue/PossiblyNullArrayAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyNullArrayAssignment extends CodeIssue

--- a/src/Psalm/Issue/PossiblyNullArrayOffset.php
+++ b/src/Psalm/Issue/PossiblyNullArrayOffset.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyNullArrayOffset extends CodeIssue

--- a/src/Psalm/Issue/PossiblyNullFunctionCall.php
+++ b/src/Psalm/Issue/PossiblyNullFunctionCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyNullFunctionCall extends CodeIssue

--- a/src/Psalm/Issue/PossiblyNullIterator.php
+++ b/src/Psalm/Issue/PossiblyNullIterator.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyNullIterator extends CodeIssue

--- a/src/Psalm/Issue/PossiblyNullOperand.php
+++ b/src/Psalm/Issue/PossiblyNullOperand.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyNullOperand extends CodeIssue

--- a/src/Psalm/Issue/PossiblyNullPropertyAssignment.php
+++ b/src/Psalm/Issue/PossiblyNullPropertyAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 /**

--- a/src/Psalm/Issue/PossiblyNullPropertyAssignmentValue.php
+++ b/src/Psalm/Issue/PossiblyNullPropertyAssignmentValue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyNullPropertyAssignmentValue extends PropertyIssue

--- a/src/Psalm/Issue/PossiblyNullPropertyFetch.php
+++ b/src/Psalm/Issue/PossiblyNullPropertyFetch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 /**

--- a/src/Psalm/Issue/PossiblyNullReference.php
+++ b/src/Psalm/Issue/PossiblyNullReference.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyNullReference extends CodeIssue

--- a/src/Psalm/Issue/PossiblyUndefinedArrayOffset.php
+++ b/src/Psalm/Issue/PossiblyUndefinedArrayOffset.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyUndefinedArrayOffset extends CodeIssue

--- a/src/Psalm/Issue/PossiblyUndefinedGlobalVariable.php
+++ b/src/Psalm/Issue/PossiblyUndefinedGlobalVariable.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyUndefinedGlobalVariable extends VariableIssue

--- a/src/Psalm/Issue/PossiblyUndefinedIntArrayOffset.php
+++ b/src/Psalm/Issue/PossiblyUndefinedIntArrayOffset.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyUndefinedIntArrayOffset extends CodeIssue

--- a/src/Psalm/Issue/PossiblyUndefinedMethod.php
+++ b/src/Psalm/Issue/PossiblyUndefinedMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyUndefinedMethod extends MethodIssue

--- a/src/Psalm/Issue/PossiblyUndefinedStringArrayOffset.php
+++ b/src/Psalm/Issue/PossiblyUndefinedStringArrayOffset.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyUndefinedStringArrayOffset extends CodeIssue

--- a/src/Psalm/Issue/PossiblyUndefinedVariable.php
+++ b/src/Psalm/Issue/PossiblyUndefinedVariable.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyUndefinedVariable extends CodeIssue

--- a/src/Psalm/Issue/PossiblyUnusedMethod.php
+++ b/src/Psalm/Issue/PossiblyUnusedMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyUnusedMethod extends MethodIssue

--- a/src/Psalm/Issue/PossiblyUnusedParam.php
+++ b/src/Psalm/Issue/PossiblyUnusedParam.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyUnusedParam extends CodeIssue

--- a/src/Psalm/Issue/PossiblyUnusedProperty.php
+++ b/src/Psalm/Issue/PossiblyUnusedProperty.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PossiblyUnusedProperty extends CodeIssue

--- a/src/Psalm/Issue/PropertyIssue.php
+++ b/src/Psalm/Issue/PropertyIssue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 abstract class PropertyIssue extends CodeIssue

--- a/src/Psalm/Issue/PropertyNotSetInConstructor.php
+++ b/src/Psalm/Issue/PropertyNotSetInConstructor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PropertyNotSetInConstructor extends PropertyIssue

--- a/src/Psalm/Issue/PropertyTypeCoercion.php
+++ b/src/Psalm/Issue/PropertyTypeCoercion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PropertyTypeCoercion extends PropertyIssue

--- a/src/Psalm/Issue/PsalmInternalError.php
+++ b/src/Psalm/Issue/PsalmInternalError.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class PsalmInternalError extends CodeIssue

--- a/src/Psalm/Issue/RawObjectIteration.php
+++ b/src/Psalm/Issue/RawObjectIteration.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class RawObjectIteration extends CodeIssue

--- a/src/Psalm/Issue/RedundantCondition.php
+++ b/src/Psalm/Issue/RedundantCondition.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class RedundantCondition extends CodeIssue

--- a/src/Psalm/Issue/RedundantConditionGivenDocblockType.php
+++ b/src/Psalm/Issue/RedundantConditionGivenDocblockType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class RedundantConditionGivenDocblockType extends CodeIssue

--- a/src/Psalm/Issue/RedundantIdentityWithTrue.php
+++ b/src/Psalm/Issue/RedundantIdentityWithTrue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class RedundantIdentityWithTrue extends CodeIssue

--- a/src/Psalm/Issue/ReferenceConstraintViolation.php
+++ b/src/Psalm/Issue/ReferenceConstraintViolation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ReferenceConstraintViolation extends CodeIssue

--- a/src/Psalm/Issue/ReservedWord.php
+++ b/src/Psalm/Issue/ReservedWord.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class ReservedWord extends ClassIssue

--- a/src/Psalm/Issue/StringIncrement.php
+++ b/src/Psalm/Issue/StringIncrement.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class StringIncrement extends CodeIssue

--- a/src/Psalm/Issue/TaintedInput.php
+++ b/src/Psalm/Issue/TaintedInput.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 use Psalm\Internal\Analyzer\TaintNodeData;

--- a/src/Psalm/Issue/TooFewArguments.php
+++ b/src/Psalm/Issue/TooFewArguments.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class TooFewArguments extends ArgumentIssue

--- a/src/Psalm/Issue/TooManyArguments.php
+++ b/src/Psalm/Issue/TooManyArguments.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class TooManyArguments extends ArgumentIssue

--- a/src/Psalm/Issue/TooManyTemplateParams.php
+++ b/src/Psalm/Issue/TooManyTemplateParams.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class TooManyTemplateParams extends CodeIssue

--- a/src/Psalm/Issue/Trace.php
+++ b/src/Psalm/Issue/Trace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 
 namespace Psalm\Issue;
 

--- a/src/Psalm/Issue/TraitMethodSignatureMismatch.php
+++ b/src/Psalm/Issue/TraitMethodSignatureMismatch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class TraitMethodSignatureMismatch extends CodeIssue

--- a/src/Psalm/Issue/TypeDoesNotContainNull.php
+++ b/src/Psalm/Issue/TypeDoesNotContainNull.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class TypeDoesNotContainNull extends CodeIssue

--- a/src/Psalm/Issue/TypeDoesNotContainType.php
+++ b/src/Psalm/Issue/TypeDoesNotContainType.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class TypeDoesNotContainType extends CodeIssue

--- a/src/Psalm/Issue/UncaughtThrowInGlobalScope.php
+++ b/src/Psalm/Issue/UncaughtThrowInGlobalScope.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UncaughtThrowInGlobalScope extends CodeIssue

--- a/src/Psalm/Issue/UndefinedClass.php
+++ b/src/Psalm/Issue/UndefinedClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedClass extends ClassIssue

--- a/src/Psalm/Issue/UndefinedConstant.php
+++ b/src/Psalm/Issue/UndefinedConstant.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedConstant extends CodeIssue

--- a/src/Psalm/Issue/UndefinedDocblockClass.php
+++ b/src/Psalm/Issue/UndefinedDocblockClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedDocblockClass extends ClassIssue

--- a/src/Psalm/Issue/UndefinedFunction.php
+++ b/src/Psalm/Issue/UndefinedFunction.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedFunction extends FunctionIssue

--- a/src/Psalm/Issue/UndefinedGlobalVariable.php
+++ b/src/Psalm/Issue/UndefinedGlobalVariable.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedGlobalVariable extends VariableIssue

--- a/src/Psalm/Issue/UndefinedInterface.php
+++ b/src/Psalm/Issue/UndefinedInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedInterface extends ClassIssue

--- a/src/Psalm/Issue/UndefinedInterfaceMethod.php
+++ b/src/Psalm/Issue/UndefinedInterfaceMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedInterfaceMethod extends MethodIssue

--- a/src/Psalm/Issue/UndefinedMagicMethod.php
+++ b/src/Psalm/Issue/UndefinedMagicMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedMagicMethod extends MethodIssue

--- a/src/Psalm/Issue/UndefinedMagicPropertyAssignment.php
+++ b/src/Psalm/Issue/UndefinedMagicPropertyAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedMagicPropertyAssignment extends PropertyIssue

--- a/src/Psalm/Issue/UndefinedMagicPropertyFetch.php
+++ b/src/Psalm/Issue/UndefinedMagicPropertyFetch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedMagicPropertyFetch extends PropertyIssue

--- a/src/Psalm/Issue/UndefinedMethod.php
+++ b/src/Psalm/Issue/UndefinedMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedMethod extends MethodIssue

--- a/src/Psalm/Issue/UndefinedPropertyAssignment.php
+++ b/src/Psalm/Issue/UndefinedPropertyAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedPropertyAssignment extends PropertyIssue

--- a/src/Psalm/Issue/UndefinedPropertyFetch.php
+++ b/src/Psalm/Issue/UndefinedPropertyFetch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedPropertyFetch extends PropertyIssue

--- a/src/Psalm/Issue/UndefinedThisPropertyAssignment.php
+++ b/src/Psalm/Issue/UndefinedThisPropertyAssignment.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedThisPropertyAssignment extends PropertyIssue

--- a/src/Psalm/Issue/UndefinedThisPropertyFetch.php
+++ b/src/Psalm/Issue/UndefinedThisPropertyFetch.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedThisPropertyFetch extends PropertyIssue

--- a/src/Psalm/Issue/UndefinedTrace.php
+++ b/src/Psalm/Issue/UndefinedTrace.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 
 namespace Psalm\Issue;
 

--- a/src/Psalm/Issue/UndefinedTrait.php
+++ b/src/Psalm/Issue/UndefinedTrait.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedTrait extends CodeIssue

--- a/src/Psalm/Issue/UndefinedVariable.php
+++ b/src/Psalm/Issue/UndefinedVariable.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UndefinedVariable extends CodeIssue

--- a/src/Psalm/Issue/UnevaluatedCode.php
+++ b/src/Psalm/Issue/UnevaluatedCode.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnevaluatedCode extends CodeIssue

--- a/src/Psalm/Issue/UnhandledMatchCondition.php
+++ b/src/Psalm/Issue/UnhandledMatchCondition.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnhandledMatchCondition extends CodeIssue

--- a/src/Psalm/Issue/UnimplementedAbstractMethod.php
+++ b/src/Psalm/Issue/UnimplementedAbstractMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnimplementedAbstractMethod extends CodeIssue

--- a/src/Psalm/Issue/UnimplementedInterfaceMethod.php
+++ b/src/Psalm/Issue/UnimplementedInterfaceMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnimplementedInterfaceMethod extends CodeIssue

--- a/src/Psalm/Issue/UninitializedProperty.php
+++ b/src/Psalm/Issue/UninitializedProperty.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UninitializedProperty extends PropertyIssue

--- a/src/Psalm/Issue/UnnecessaryVarAnnotation.php
+++ b/src/Psalm/Issue/UnnecessaryVarAnnotation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnnecessaryVarAnnotation extends CodeIssue

--- a/src/Psalm/Issue/UnrecognizedExpression.php
+++ b/src/Psalm/Issue/UnrecognizedExpression.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnrecognizedExpression extends CodeIssue

--- a/src/Psalm/Issue/UnrecognizedStatement.php
+++ b/src/Psalm/Issue/UnrecognizedStatement.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnrecognizedStatement extends CodeIssue

--- a/src/Psalm/Issue/UnresolvableInclude.php
+++ b/src/Psalm/Issue/UnresolvableInclude.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnresolvableInclude extends CodeIssue

--- a/src/Psalm/Issue/UnsafeInstantiation.php
+++ b/src/Psalm/Issue/UnsafeInstantiation.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnsafeInstantiation extends CodeIssue

--- a/src/Psalm/Issue/UnusedClass.php
+++ b/src/Psalm/Issue/UnusedClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnusedClass extends ClassIssue

--- a/src/Psalm/Issue/UnusedClosureParam.php
+++ b/src/Psalm/Issue/UnusedClosureParam.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnusedClosureParam extends CodeIssue

--- a/src/Psalm/Issue/UnusedFunctionCall.php
+++ b/src/Psalm/Issue/UnusedFunctionCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnusedFunctionCall extends FunctionIssue

--- a/src/Psalm/Issue/UnusedMethod.php
+++ b/src/Psalm/Issue/UnusedMethod.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnusedMethod extends MethodIssue

--- a/src/Psalm/Issue/UnusedMethodCall.php
+++ b/src/Psalm/Issue/UnusedMethodCall.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnusedMethodCall extends MethodIssue

--- a/src/Psalm/Issue/UnusedParam.php
+++ b/src/Psalm/Issue/UnusedParam.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnusedParam extends CodeIssue

--- a/src/Psalm/Issue/UnusedProperty.php
+++ b/src/Psalm/Issue/UnusedProperty.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnusedProperty extends CodeIssue

--- a/src/Psalm/Issue/UnusedPsalmSuppress.php
+++ b/src/Psalm/Issue/UnusedPsalmSuppress.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnusedPsalmSuppress extends CodeIssue

--- a/src/Psalm/Issue/UnusedVariable.php
+++ b/src/Psalm/Issue/UnusedVariable.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 class UnusedVariable extends CodeIssue

--- a/src/Psalm/Issue/VariableIssue.php
+++ b/src/Psalm/Issue/VariableIssue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Issue;
 
 use function strtolower;

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use Psalm\Report\PhpStormReport;

--- a/src/Psalm/NodeTypeProvider.php
+++ b/src/Psalm/NodeTypeProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm;
 
 use PhpParser;

--- a/src/Psalm/Plugin/Hook/AfterAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\Internal\Analyzer\IssueData;

--- a/src/Psalm/Plugin/Hook/AfterClassLikeAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterClassLikeAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser\Node;

--- a/src/Psalm/Plugin/Hook/AfterClassLikeExistenceCheckInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterClassLikeExistenceCheckInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\Codebase;

--- a/src/Psalm/Plugin/Hook/AfterClassLikeVisitInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterClassLikeVisitInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser\Node\Stmt\ClassLike;

--- a/src/Psalm/Plugin/Hook/AfterCodebasePopulatedInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterCodebasePopulatedInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\Codebase;

--- a/src/Psalm/Plugin/Hook/AfterEveryFunctionCallAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterEveryFunctionCallAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser\Node\Expr\FuncCall;

--- a/src/Psalm/Plugin/Hook/AfterExpressionAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterExpressionAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser\Node\Expr;

--- a/src/Psalm/Plugin/Hook/AfterFileAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterFileAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\Codebase;

--- a/src/Psalm/Plugin/Hook/AfterFunctionCallAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterFunctionCallAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser\Node\Expr\FuncCall;

--- a/src/Psalm/Plugin/Hook/AfterFunctionLikeAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterFunctionLikeAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser\Node;

--- a/src/Psalm/Plugin/Hook/AfterMethodCallAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterMethodCallAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser\Node\Expr;

--- a/src/Psalm/Plugin/Hook/AfterStatementAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/AfterStatementAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser\Node\Stmt;

--- a/src/Psalm/Plugin/Hook/BeforeFileAnalysisInterface.php
+++ b/src/Psalm/Plugin/Hook/BeforeFileAnalysisInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\Codebase;

--- a/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\StatementsSource;

--- a/src/Psalm/Plugin/Hook/FunctionParamsProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionParamsProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser;

--- a/src/Psalm/Plugin/Hook/FunctionReturnTypeProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionReturnTypeProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser;

--- a/src/Psalm/Plugin/Hook/MethodExistenceProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/MethodExistenceProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Plugin/Hook/MethodParamsProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/MethodParamsProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser;

--- a/src/Psalm/Plugin/Hook/MethodReturnTypeProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/MethodReturnTypeProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser;

--- a/src/Psalm/Plugin/Hook/MethodVisibilityProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/MethodVisibilityProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Plugin/Hook/PropertyExistenceProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/PropertyExistenceProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Plugin/Hook/PropertyTypeProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/PropertyTypeProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use PhpParser;

--- a/src/Psalm/Plugin/Hook/PropertyVisibilityProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/PropertyVisibilityProviderInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Plugin/Hook/StringInterpreterInterface.php
+++ b/src/Psalm/Plugin/Hook/StringInterpreterInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin\Hook;
 
 use Psalm\Type;

--- a/src/Psalm/Plugin/PluginEntryPointInterface.php
+++ b/src/Psalm/Plugin/PluginEntryPointInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin;
 
 use SimpleXMLElement;

--- a/src/Psalm/Plugin/RegistrationInterface.php
+++ b/src/Psalm/Plugin/RegistrationInterface.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin;
 
 interface RegistrationInterface

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Plugin;
 
 use function array_filter;

--- a/src/Psalm/PluginRegistrationSocket.php
+++ b/src/Psalm/PluginRegistrationSocket.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use Psalm\Plugin\Hook;

--- a/src/Psalm/Progress/DebugProgress.php
+++ b/src/Psalm/Progress/DebugProgress.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Progress;
 
 use const E_ALL;

--- a/src/Psalm/Progress/DefaultProgress.php
+++ b/src/Psalm/Progress/DefaultProgress.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Progress;
 
 use function str_repeat;

--- a/src/Psalm/Progress/LongProgress.php
+++ b/src/Psalm/Progress/LongProgress.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Progress;
 
 use const PHP_EOL;

--- a/src/Psalm/Progress/Progress.php
+++ b/src/Psalm/Progress/Progress.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Progress;
 
 use const E_ERROR;

--- a/src/Psalm/Progress/VoidProgress.php
+++ b/src/Psalm/Progress/VoidProgress.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Progress;
 
 class VoidProgress extends Progress

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use function array_filter;

--- a/src/Psalm/Report/CheckstyleReport.php
+++ b/src/Psalm/Report/CheckstyleReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use function htmlspecialchars;

--- a/src/Psalm/Report/CompactReport.php
+++ b/src/Psalm/Report/CompactReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use function count;

--- a/src/Psalm/Report/ConsoleReport.php
+++ b/src/Psalm/Report/ConsoleReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Config;

--- a/src/Psalm/Report/EmacsReport.php
+++ b/src/Psalm/Report/EmacsReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Config;

--- a/src/Psalm/Report/GithubActionsReport.php
+++ b/src/Psalm/Report/GithubActionsReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Config;

--- a/src/Psalm/Report/JsonReport.php
+++ b/src/Psalm/Report/JsonReport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Internal\Json\Json;

--- a/src/Psalm/Report/JsonSummaryReport.php
+++ b/src/Psalm/Report/JsonSummaryReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Internal\Json\Json;

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use DOMDocument;

--- a/src/Psalm/Report/PhpStormReport.php
+++ b/src/Psalm/Report/PhpStormReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Config;

--- a/src/Psalm/Report/PylintReport.php
+++ b/src/Psalm/Report/PylintReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Config;

--- a/src/Psalm/Report/ReportOptions.php
+++ b/src/Psalm/Report/ReportOptions.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Report;

--- a/src/Psalm/Report/SonarqubeReport.php
+++ b/src/Psalm/Report/SonarqubeReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Internal\Json\Json;

--- a/src/Psalm/Report/TextReport.php
+++ b/src/Psalm/Report/TextReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use Psalm\Config;

--- a/src/Psalm/Report/XmlReport.php
+++ b/src/Psalm/Report/XmlReport.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Report;
 
 use LSS\Array2XML;

--- a/src/Psalm/SourceControl/Git/CommitInfo.php
+++ b/src/Psalm/SourceControl/Git/CommitInfo.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\SourceControl\Git;
 
 /**

--- a/src/Psalm/SourceControl/Git/GitInfo.php
+++ b/src/Psalm/SourceControl/Git/GitInfo.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\SourceControl\Git;
 
 use Psalm\SourceControl\SourceControlInfo;

--- a/src/Psalm/SourceControl/Git/RemoteInfo.php
+++ b/src/Psalm/SourceControl/Git/RemoteInfo.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\SourceControl\Git;
 
 /**

--- a/src/Psalm/SourceControl/SourceControlInfo.php
+++ b/src/Psalm/SourceControl/SourceControlInfo.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\SourceControl;
 
 abstract class SourceControlInfo

--- a/src/Psalm/StatementsSource.php
+++ b/src/Psalm/StatementsSource.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 interface StatementsSource extends FileSource

--- a/src/Psalm/Storage/Assertion.php
+++ b/src/Psalm/Storage/Assertion.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Storage;
 
 use function array_map;

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Storage;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Storage/CustomMetadataTrait.php
+++ b/src/Psalm/Storage/CustomMetadataTrait.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Storage;
 
 /**

--- a/src/Psalm/Storage/FileStorage.php
+++ b/src/Psalm/Storage/FileStorage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Storage;
 
 use Psalm\Aliases;

--- a/src/Psalm/Storage/FunctionLikeParameter.php
+++ b/src/Psalm/Storage/FunctionLikeParameter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Storage;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Storage;
 
 use function array_map;

--- a/src/Psalm/Storage/FunctionStorage.php
+++ b/src/Psalm/Storage/FunctionStorage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Storage;
 
 use function array_map;

--- a/src/Psalm/Storage/MethodStorage.php
+++ b/src/Psalm/Storage/MethodStorage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Storage;
 
 use Psalm\Type;

--- a/src/Psalm/Storage/PropertyStorage.php
+++ b/src/Psalm/Storage/PropertyStorage.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Storage;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm;
 
 use function array_merge;

--- a/src/Psalm/Type/Algebra.php
+++ b/src/Psalm/Type/Algebra.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type;
 
 use function array_filter;

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type;
 
 use function array_filter;

--- a/src/Psalm/Type/Atomic/CallableTrait.php
+++ b/src/Psalm/Type/Atomic/CallableTrait.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function array_map;

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function array_map;

--- a/src/Psalm/Type/Atomic/GetClassT.php
+++ b/src/Psalm/Type/Atomic/GetClassT.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function array_values;

--- a/src/Psalm/Type/Atomic/GetTypeT.php
+++ b/src/Psalm/Type/Atomic/GetTypeT.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 /**

--- a/src/Psalm/Type/Atomic/HasIntersectionTrait.php
+++ b/src/Psalm/Type/Atomic/HasIntersectionTrait.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function array_map;

--- a/src/Psalm/Type/Atomic/Scalar.php
+++ b/src/Psalm/Type/Atomic/Scalar.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 abstract class Scalar extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
+++ b/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TAnonymousClassInstance extends TNamedObject

--- a/src/Psalm/Type/Atomic/TArray.php
+++ b/src/Psalm/Type/Atomic/TArray.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function count;

--- a/src/Psalm/Type/Atomic/TArrayKey.php
+++ b/src/Psalm/Type/Atomic/TArrayKey.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TArrayKey extends Scalar

--- a/src/Psalm/Type/Atomic/TAssertionFalsy.php
+++ b/src/Psalm/Type/Atomic/TAssertionFalsy.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TAssertionFalsy extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/Atomic/TBool.php
+++ b/src/Psalm/Type/Atomic/TBool.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TBool extends Scalar

--- a/src/Psalm/Type/Atomic/TCallable.php
+++ b/src/Psalm/Type/Atomic/TCallable.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TCallable extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/Atomic/TCallableArray.php
+++ b/src/Psalm/Type/Atomic/TCallableArray.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 /**

--- a/src/Psalm/Type/Atomic/TCallableKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TCallableKeyedArray.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 /**

--- a/src/Psalm/Type/Atomic/TCallableList.php
+++ b/src/Psalm/Type/Atomic/TCallableList.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 /**

--- a/src/Psalm/Type/Atomic/TCallableObject.php
+++ b/src/Psalm/Type/Atomic/TCallableObject.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TCallableObject extends TObject

--- a/src/Psalm/Type/Atomic/TCallableString.php
+++ b/src/Psalm/Type/Atomic/TCallableString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TCallableString extends TString

--- a/src/Psalm/Type/Atomic/TClassString.php
+++ b/src/Psalm/Type/Atomic/TClassString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use Psalm\Codebase;

--- a/src/Psalm/Type/Atomic/TClassStringMap.php
+++ b/src/Psalm/Type/Atomic/TClassStringMap.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function get_class;

--- a/src/Psalm/Type/Atomic/TClosedResource.php
+++ b/src/Psalm/Type/Atomic/TClosedResource.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Type/Atomic/TConditional.php
+++ b/src/Psalm/Type/Atomic/TConditional.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function implode;

--- a/src/Psalm/Type/Atomic/TEmpty.php
+++ b/src/Psalm/Type/Atomic/TEmpty.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TEmpty extends Scalar

--- a/src/Psalm/Type/Atomic/TEmptyMixed.php
+++ b/src/Psalm/Type/Atomic/TEmptyMixed.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TEmptyMixed extends TMixed

--- a/src/Psalm/Type/Atomic/TEmptyNumeric.php
+++ b/src/Psalm/Type/Atomic/TEmptyNumeric.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TEmptyNumeric extends TNumeric

--- a/src/Psalm/Type/Atomic/TEmptyScalar.php
+++ b/src/Psalm/Type/Atomic/TEmptyScalar.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TEmptyScalar extends TScalar

--- a/src/Psalm/Type/Atomic/TFalse.php
+++ b/src/Psalm/Type/Atomic/TFalse.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TFalse extends TBool

--- a/src/Psalm/Type/Atomic/TFloat.php
+++ b/src/Psalm/Type/Atomic/TFloat.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TFloat extends Scalar

--- a/src/Psalm/Type/Atomic/TFn.php
+++ b/src/Psalm/Type/Atomic/TFn.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 /**

--- a/src/Psalm/Type/Atomic/TGenericObject.php
+++ b/src/Psalm/Type/Atomic/TGenericObject.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function count;

--- a/src/Psalm/Type/Atomic/THtmlEscapedString.php
+++ b/src/Psalm/Type/Atomic/THtmlEscapedString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class THtmlEscapedString extends TString

--- a/src/Psalm/Type/Atomic/TInt.php
+++ b/src/Psalm/Type/Atomic/TInt.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TInt extends Scalar

--- a/src/Psalm/Type/Atomic/TIterable.php
+++ b/src/Psalm/Type/Atomic/TIterable.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function count;

--- a/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function preg_quote;

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function array_keys;

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function get_class;

--- a/src/Psalm/Type/Atomic/TLiteralClassString.php
+++ b/src/Psalm/Type/Atomic/TLiteralClassString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TLiteralFloat extends TFloat

--- a/src/Psalm/Type/Atomic/TLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TLiteralInt.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TLiteralInt extends TInt

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function preg_replace;

--- a/src/Psalm/Type/Atomic/TLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TLowercaseString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TLowercaseString extends TString

--- a/src/Psalm/Type/Atomic/TMixed.php
+++ b/src/Psalm/Type/Atomic/TMixed.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TMixed extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function implode;

--- a/src/Psalm/Type/Atomic/TNever.php
+++ b/src/Psalm/Type/Atomic/TNever.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TNever extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/Atomic/TNonEmptyArray.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyArray.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 /**

--- a/src/Psalm/Type/Atomic/TNonEmptyList.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyList.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 /**

--- a/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TNonEmptyLowercaseString extends TNonEmptyString

--- a/src/Psalm/Type/Atomic/TNonEmptyMixed.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyMixed.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TNonEmptyMixed extends TMixed

--- a/src/Psalm/Type/Atomic/TNonEmptyScalar.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyScalar.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TNonEmptyScalar extends TScalar

--- a/src/Psalm/Type/Atomic/TNonEmptyString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 /**

--- a/src/Psalm/Type/Atomic/TNull.php
+++ b/src/Psalm/Type/Atomic/TNull.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TNull extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/Atomic/TNumeric.php
+++ b/src/Psalm/Type/Atomic/TNumeric.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TNumeric extends Scalar

--- a/src/Psalm/Type/Atomic/TNumericString.php
+++ b/src/Psalm/Type/Atomic/TNumericString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TNumericString extends TString

--- a/src/Psalm/Type/Atomic/TObject.php
+++ b/src/Psalm/Type/Atomic/TObject.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TObject extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function array_keys;

--- a/src/Psalm/Type/Atomic/TPositiveInt.php
+++ b/src/Psalm/Type/Atomic/TPositiveInt.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TPositiveInt extends TInt

--- a/src/Psalm/Type/Atomic/TResource.php
+++ b/src/Psalm/Type/Atomic/TResource.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Type/Atomic/TScalar.php
+++ b/src/Psalm/Type/Atomic/TScalar.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TScalar extends Scalar

--- a/src/Psalm/Type/Atomic/TScalarClassConstant.php
+++ b/src/Psalm/Type/Atomic/TScalarClassConstant.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Type/Atomic/TSingleLetter.php
+++ b/src/Psalm/Type/Atomic/TSingleLetter.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TSingleLetter extends TString

--- a/src/Psalm/Type/Atomic/TString.php
+++ b/src/Psalm/Type/Atomic/TString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TString extends Scalar

--- a/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
+++ b/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TTemplateIndexedAccess extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/Atomic/TTemplateKeyOf.php
+++ b/src/Psalm/Type/Atomic/TTemplateKeyOf.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use Psalm\Type\Union;

--- a/src/Psalm/Type/Atomic/TTemplateParam.php
+++ b/src/Psalm/Type/Atomic/TTemplateParam.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use function implode;

--- a/src/Psalm/Type/Atomic/TTemplateParamClass.php
+++ b/src/Psalm/Type/Atomic/TTemplateParamClass.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TTemplateParamClass extends TClassString

--- a/src/Psalm/Type/Atomic/TTraitString.php
+++ b/src/Psalm/Type/Atomic/TTraitString.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TTraitString extends TString

--- a/src/Psalm/Type/Atomic/TTrue.php
+++ b/src/Psalm/Type/Atomic/TTrue.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TTrue extends TBool

--- a/src/Psalm/Type/Atomic/TTypeAlias.php
+++ b/src/Psalm/Type/Atomic/TTypeAlias.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 use Psalm\CodeLocation;

--- a/src/Psalm/Type/Atomic/TValueOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TValueOfClassConstant.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TValueOfClassConstant extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/Atomic/TVoid.php
+++ b/src/Psalm/Type/Atomic/TVoid.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type\Atomic;
 
 class TVoid extends \Psalm\Type\Atomic

--- a/src/Psalm/Type/NodeVisitor.php
+++ b/src/Psalm/Type/NodeVisitor.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type;
 
 abstract class NodeVisitor

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Type;
 
 use function array_map;

--- a/src/Psalm/Type/TaintKind.php
+++ b/src/Psalm/Type/TaintKind.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Type;
 
 /**

--- a/src/Psalm/Type/TaintKindGroup.php
+++ b/src/Psalm/Type/TaintKindGroup.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Type;
 
 /**

--- a/src/Psalm/Type/TypeNode.php
+++ b/src/Psalm/Type/TypeNode.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type;
 
 interface TypeNode

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Psalm\Type;
 
 use function array_filter;

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm;
 
 use Composer\Autoload\ClassLoader;

--- a/src/psalm-language-server.php
+++ b/src/psalm-language-server.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm;
 
 use Psalm\Config;

--- a/src/psalm-refactor.php
+++ b/src/psalm-refactor.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm;
 
 require_once('command_functions.php');

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm;
 
 gc_collect_cycles();

--- a/src/psalm_plugin.php
+++ b/src/psalm_plugin.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm;
 
 require_once __DIR__ . '/command_functions.php';

--- a/src/psalter.php
+++ b/src/psalter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm;
 
 require_once('command_functions.php');


### PR DESCRIPTION
This PR propose adding strict_types everywhere it's possible.

I added them automatically in files in src/ . I just had to remove it from two files.

One of them does an implicit call to __toString that require not being in strict_types and the other one triggers a "redundant" error.
EDIT: I had to remove some more due to failing tests. I'll try to fix them one by one on a future PR.