### PR TITLE
Filter selected text to prevent invalid XML

### DIFF
--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -168,7 +168,7 @@ class JunitReport extends Report
         $ret = 'message: ' . htmlspecialchars(trim($data->message), ENT_XML1 | ENT_QUOTES) . "\n";
         $ret .= 'type: ' . trim($data->type) . "\n";
         $ret .= 'snippet: ' . htmlspecialchars(trim($data->snippet), ENT_XML1 | ENT_QUOTES) . "\n";
-        $ret .= 'selected_text: ' . trim($data->selected_text) . "\n";
+        $ret .= 'selected_text: ' . htmlspecialchars(trim($data->selected_text)) . "\n";
         $ret .= 'line: ' . $data->line_from . "\n";
         $ret .= 'column_from: ' . $data->column_from . "\n";
         $ret .= 'column_to: ' . $data->column_to . "\n";


### PR DESCRIPTION
The current JUnit formatter occasionally produces invalid XML.
This happens for code snippets that contain two ampersands "&&".
```$ xmllint psalm.junit.xml
psalm.junit.xml:19436: parser error : xmlParseEntityRef: no name
selected_text: if (!$request-&gt;isMethod(Request::METHOD_GET) & !$request->isMe
                                                                ^
````