### PR TITLE
implicit int cast in array keys

### DIFF
--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -242,7 +242,7 @@ class Reconciler
                 ? clone $existing_types[$key]
                 : self::getValueForKey(
                     $codebase,
-                    $key,
+                    (string)$key,
                     $existing_types,
                     $new_types,
                     $code_location,


### PR DESCRIPTION
This code outputs a Type Error on strict_types=1

This is due to the infamous cast in array keys:
```php
$a = '12';
$b = [];
$b[$a] = 'a';
foreach($b as $key => $value){
    var_dump($key); // int(12)
}
```

This PR is more a discussion than an actual proposed fix.

Maybe we should have an issue in that sort of case at level 1 (alongside Mixed Issues) that only activates when the file is in strict_types and we use a string array-key where a string is expected?