### PR TITLE
change label

### DIFF
--- a/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
@@ -93,7 +93,7 @@ class PropertyDocblockManipulator
         $file_contents = $codebase->getFileContents($file_path);
 
         if (count($stmt->props) > 1) {
-            throw new \UnexpectedValueException('Cannot replace multiple properties');
+            throw new \UnexpectedValueException('Cannot replace multiple inline properties in ' . $file_path);
         }
 
         $prop = $stmt->props[0];


### PR DESCRIPTION
This PR propose to change the wording of an error that I came across at work today.

This is caused when Psalter try to change this code

```php
class A{
   private $a, $b;
}
```
When it tries to add the type in properties (in my case, the --isssues was MissingPropertyType) it stops with an error.

The error was not really enough and I had no idea what file caused it. I had to run with --debug multiple times to understand what was going on. This should help clarify the issue.