### PR TITLE
CachingIterator - Add forgotten constructor parameter.

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -218,7 +218,7 @@ class CachingIterator extends IteratorIterator implements OuterIterator , ArrayA
     /**
      * @param Iterator<TKey, TValue> $iterator
      */
-    public function __construct(Iterator $iterator) {} 
+    public function __construct(Iterator $iterator, int $flags = self::CALL_TOSTRING) {} 
 
     /** @return bool */
     public function hasNext () {}


### PR DESCRIPTION
This PR:

* [x] Follows #4320 
* [x] Fix CachingIterator stub constructor - parameter `$flags` was missing