### PR TITLE
Fix preg_match_all stub

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -761,6 +761,7 @@ function preg_replace_callback($search, $replace, $subject, int $limit = -1, &$c
  *          )
  *        ) $matches
  * @return int|false
+ * @psalm-ignore-falsable-return
  */
 function preg_match_all($pattern, $replace, &$matches = [], int $flags = 1, int $offset = 0) {}
 

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -760,7 +760,7 @@ function preg_replace_callback($search, $replace, $subject, int $limit = -1, &$c
  *              )
  *          )
  *        ) $matches
- * @return int
+ * @return int|false
  */
 function preg_match_all($pattern, $replace, &$matches = [], int $flags = 1, int $offset = 0) {}
 

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1341,6 +1341,15 @@ class FunctionCallTest extends TestCase
                         return $matches[0];
                     }'
             ],
+            'pregMatchAllReturnsFalse' => [
+                '<?php
+                    /**
+                     * @return int|false
+                     */
+                    function badpattern(): array {
+                        return @preg_match_all("foo", "foo", $matches);
+                    }'
+            ],
             'strposAllowDictionary' => [
                 '<?php
                     function sayHello(string $format): void {

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1346,7 +1346,7 @@ class FunctionCallTest extends TestCase
                     /**
                      * @return int|false
                      */
-                    function badpattern(): array {
+                    function badpattern() {
                         return @preg_match_all("foo", "foo", $matches);
                     }'
             ],


### PR DESCRIPTION
[`preg_match_all`](https://www.php.net/preg_match_all) can return false given a bad pattern.

This PR fixes the stub, and adds a test for it. The test triggers a warning, so I suppress that since we're only interested in the `false` return value.