### PR TITLE
ambiguous php version checks

### DIFF
--- a/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
+++ b/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
@@ -10,7 +10,9 @@ class TAnonymousClassInstance extends TNamedObject
         int $php_major_version,
         int $php_minor_version
     ): ?string {
-        return $php_major_version >= 7 && $php_minor_version >= 2 ? 'object' : null;
+        return $php_major_version > 7
+            || ($php_major_version === 7 && $php_minor_version >= 2)
+            ? 'object' : null;
     }
 
     /**

--- a/src/Psalm/Type/Atomic/TCallableObject.php
+++ b/src/Psalm/Type/Atomic/TCallableObject.php
@@ -23,7 +23,9 @@ class TCallableObject extends TObject
         int $php_major_version,
         int $php_minor_version
     ): ?string {
-        return $php_major_version >= 7 && $php_minor_version >= 2 ? 'object' : null;
+        return $php_major_version > 7
+            || ($php_major_version === 7 && $php_minor_version >= 2)
+            ? 'object' : null;
     }
 
     public function canBeFullyExpressedInPhp(): bool

--- a/src/Psalm/Type/Atomic/TVoid.php
+++ b/src/Psalm/Type/Atomic/TVoid.php
@@ -23,7 +23,9 @@ class TVoid extends \Psalm\Type\Atomic
         int $php_major_version,
         int $php_minor_version
     ): ?string {
-        return $php_major_version >= 7 && $php_minor_version >= 1 ? $this->getKey() : null;
+        return $php_major_version > 7
+            || ($php_major_version === 7 && $php_minor_version >= 1)
+            ? $this->getKey() : null;
     }
 
     public function canBeFullyExpressedInPhp(): bool

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -452,7 +452,7 @@ class Union implements TypeNode
 
         if (!$this->isSingleAndMaybeNullable()
             || $php_major_version < 7
-            || (isset($this->types['null']) && $php_minor_version < 1)
+            || (isset($this->types['null']) && $php_major_version === 7 && $php_minor_version < 1)
         ) {
             return null;
         }


### PR DESCRIPTION
This PR aims to fix some case where the PHP version checks are ambiguous and could lead to regressions when the php_minor_version start from 0 again in PHP 8.0