### PR TITLE
changing the templates order to match existing stub in PHPStan

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -1546,8 +1546,8 @@ class SplMinHeap extends SplHeap {
  * The SplPriorityQueue class provides the main functionalities of a prioritized queue, implemented using a max heap.
  * @link https://php.net/manual/en/class.splpriorityqueue.php
  *
- * @template TValue
  * @template TPriority
+ * @template TValue
  * @template-implements Iterator<int, TValue>
  */
 class SplPriorityQueue implements Iterator, Countable {


### PR DESCRIPTION
This PR change the order of the templates in SplPriorityQueue to match those in PHPStan.

For reference, the original issue and discussion can be seen/continued here: https://github.com/phpDocumentor/phpDocumentor/pull/2625