### PR TITLE
WIP: start working on array_intersect_ukey return type provider

### DIFF
--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -55,6 +55,7 @@ class FunctionReturnTypeProvider
         $this->registerClass(ReturnTypeProvider\GetClassMethodsReturnTypeProvider::class);
         $this->registerClass(ReturnTypeProvider\FirstArgStringReturnTypeProvider::class);
         $this->registerClass(ReturnTypeProvider\HexdecReturnTypeProvider::class);
+        $this->registerClass(ReturnTypeProvider\ArrayIntersectUKeyReturnTypeProvider::class);
     }
 
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayIntersectUKeyReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayIntersectUKeyReturnTypeProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Provider\ReturnTypeProvider;
+
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\Internal\Type\ArrayType;
+use Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface;
+use Psalm\StatementsSource;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+
+final class ArrayIntersectUKeyReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    public static function getFunctionIds(): array
+    {
+        return ['array_intersect_ukey'];
+    }
+
+    public static function getFunctionReturnType(
+        StatementsSource $statements_source,
+        string $function_id,
+        array $call_args,
+        Context $context,
+        CodeLocation $code_location
+    ): ?Type\Union {
+        if (count($call_args) >= 3
+            && ($array_arg_type = $statements_source->getNodeTypeProvider()->getType($call_args[0]->value))
+            && $array_arg_type->isSingle()
+            && $array_arg_type->hasArray()
+            && ($array_type = ArrayType::infer($array_arg_type->getAtomicTypes()['array']))
+            && ($callable_arg_type = $statements_source->getNodeTypeProvider()->getType(end($call_args)->value))
+            && $callable_arg_type->isSingle()
+            && $callable_arg_type->hasCallableType()
+            && ($callable_type = current($callable_arg_type->getAtomicTypes()))
+            && array_key_exists(0, $callable_type->params)
+            && ($callable_type->params[0] instanceof FunctionLikeParameter)
+            /** @var Type\Union $callable_param_type */
+            && ($callable_param_type = $callable_type->params[0]->type)
+            //&& $callable_param_type == $array_type->key
+            && ($callable_return_type = $callable_type->return_type)
+            && $callable_return_type->isSingle()
+            && $callable_return_type->hasInt()
+        ) {
+            var_dump($callable_type);die;
+
+            return new Type\Union([
+                new Type\Atomic\TArray([$array_type->key, $array_type->value])
+            ]);
+        }
+
+        return new Type\Union([Type::getArray()]);
+    }
+}

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -51,23 +51,6 @@ function array_intersect_key(array $arr, array $arr2, array ...$arr3)
  * @param array<TKey, TValue> $arr
  * @param array $arr2
  * @param array ...$arr3
- * @param callable(TKey): int $keyCompareFunc
- *
- * @return array<TKey, TValue>
- *
- * @psalm-pure
- */
-function array_intersect_ukey(array $arr, array $arr2, array ...$arr3, callable $keyCompareFunc): array
-{
-}
-
-/**
- * @psalm-template TKey as array-key
- * @psalm-template TValue
- *
- * @param array<TKey, TValue> $arr
- * @param array $arr2
- * @param array ...$arr3
  *
  * @return array<TKey, TValue>
  * @psalm-pure

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1250,6 +1250,18 @@ class ArrayFunctionCallTest extends TestCase
                     '$r' => 'array<string, int>',
                 ],
             ],
+            'arrayIntersectUKey' => [
+                '<?php
+                    /**
+                     * @var array<string, int> $a
+                     * @var array $b
+                     * @var callable(string): int $c
+                     */
+                    $r = array_intersect_ukey($a, $b, $c);',
+                'assertions' => [
+                    '$r' => 'array<string, int>'
+                ],
+            ],
             'arrayReduce' => [
                 '<?php
                     $arr = [2, 3, 4, 5];


### PR DESCRIPTION
I'm trying to create a return type provider for `array_intersect_ukey` since the stub does not work as expected.

I have some questions:
- is the idea of return type providers to check the requirements on the parameters and if they are satisfied, then return a precise type, and otherwise return a broad type?
- at line 42 of `ArrayIntersectUKeyReturnTypeProvider` I's like to assert that the first type of the callable is broaded than the type of the keys of the first array argument. How should I do this?