### PR TITLE
add CodeClimate output format

### DIFF
--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -25,6 +25,7 @@ use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Issue\CodeIssue;
 use Psalm\Issue\UnusedPsalmSuppress;
 use Psalm\Report\CheckstyleReport;
+use Psalm\Report\CodeClimateReport;
 use Psalm\Report\CompactReport;
 use Psalm\Report\ConsoleReport;
 use Psalm\Report\EmacsReport;
@@ -764,6 +765,9 @@ class IssueBuffer
 
             case Report::TYPE_SARIF:
                 $output = new SarifReport($normalized_data, self::$fixable_issue_counts, $report_options);
+
+            case Report::TYPE_CODECLIMATE:
+                $output = new CodeClimateReport($normalized_data, self::$fixable_issue_counts, $report_options);
                 break;
         }
 

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -20,6 +20,7 @@ abstract class Report
     public const TYPE_GITHUB_ACTIONS = 'github';
     public const TYPE_PHP_STORM = 'phpstorm';
     public const TYPE_SARIF = 'sarif';
+    public const TYPE_CODECLIMATE = 'codeclimate';
 
     public const SUPPORTED_OUTPUT_TYPES = [
         self::TYPE_COMPACT,
@@ -36,6 +37,7 @@ abstract class Report
         self::TYPE_GITHUB_ACTIONS,
         self::TYPE_PHP_STORM,
         self::TYPE_SARIF,
+        self::TYPE_CODECLIMATE,
     ];
 
     /**

--- a/src/Psalm/Report/CodeClimateReport.php
+++ b/src/Psalm/Report/CodeClimateReport.php
@@ -8,14 +8,15 @@ use Psalm\Report;
 use Psalm\Internal\Analyzer\IssueData;
 
 use function array_values;
+use function md5;
 
 /**
  * CodeClimate format
  * This is the format used by Gitlab for CodeQuality
- * 
+ *
  * @see https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html
  * @see https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
- * 
+ *
  * @author Olivier Doucet <webmaster@ajeux.com>
  */
 class CodeClimateReport extends Report
@@ -27,8 +28,8 @@ class CodeClimateReport extends Report
         $issues_data = \array_map(
             function (IssueData $issue): array {
                 /**
-                 * map fields to new structure. 
-                 * Expected fields: 
+                 * map fields to new structure.
+                 * Expected fields:
                  * - type
                  * - check_name
                  * - description*
@@ -70,9 +71,15 @@ class CodeClimateReport extends Report
      */
     protected function convertSeverity(string $input): string
     {
-        if (Config::REPORT_INFO === $input) return 'info';
-        if (Config::REPORT_ERROR === $input) return 'critical';
-        if (Config::REPORT_SUPPRESS === $input) return 'minor';
+        if (Config::REPORT_INFO === $input) {
+            return 'info';
+        }
+        if (Config::REPORT_ERROR === $input) {
+            return 'critical';
+        }
+        if (Config::REPORT_SUPPRESS === $input) {
+            return 'minor';
+        }
 
         // unknown cases ? fallback
         return 'critical';

--- a/src/Psalm/Report/CodeClimateReport.php
+++ b/src/Psalm/Report/CodeClimateReport.php
@@ -38,11 +38,10 @@ class CodeClimateReport extends Report
                  * - fingerprint*
                  * - location.path*
                  * - location.lines.begin*
-                 * 
+                 *
                  * Fields with * are the one used by Gitlab for Code Quality
-                 */ 
-                // expected fields: 
-                $new = [
+                 */
+                return [
                     'type' => 'issue',
                     'check_name' => $issue->type,
                     'description' => $issue->message,
@@ -57,8 +56,6 @@ class CodeClimateReport extends Report
                         ],
                     ],
                 ];
-
-                return $new;
             },
             $this->issues_data
         );

--- a/src/Psalm/Report/CodeClimateReport.php
+++ b/src/Psalm/Report/CodeClimateReport.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Psalm\Report;
+
+use Psalm\Config;
+use Psalm\Internal\Json\Json;
+use Psalm\Report;
+use Psalm\Internal\Analyzer\IssueData;
+
+use function array_values;
+
+/**
+ * CodeClimate format
+ * This is the format used by Gitlab for CodeQuality
+ * 
+ * @see https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html
+ * @see https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types
+ * 
+ * @author Olivier Doucet <webmaster@ajeux.com>
+ */
+class CodeClimateReport extends Report
+{
+    public function create(): string
+    {
+        $options = $this->pretty ? Json::PRETTY : Json::DEFAULT;
+
+        $issues_data = \array_map(
+            function (IssueData $issue): array {
+                /**
+                 * map fields to new structure. 
+                 * Expected fields: 
+                 * - type
+                 * - check_name
+                 * - description*
+                 * - content
+                 * - categories[]
+                 * - severity
+                 * - fingerprint*
+                 * - location.path*
+                 * - location.lines.begin*
+                 * 
+                 * Fields with * are the one used by Gitlab for Code Quality
+                 */ 
+                // expected fields: 
+                $new = [
+                    'type' => 'issue',
+                    'check_name' => $issue->type,
+                    'description' => $issue->message,
+                    'categories' => [$issue->type],
+                    'severity' => $this->convertSeverity($issue->severity),
+                    'fingerprint' => $this->calculateFingerprint($issue),
+                    'location' => [
+                        'path' => $issue->file_path,
+                        'lines' => [
+                            'begin' => $issue->from,
+                            'end' => $issue->to,
+                        ],
+                    ],
+                ];
+
+                return $new;
+            },
+            $this->issues_data
+        );
+
+        return Json::encode(array_values($issues_data), $options) . "\n";
+    }
+
+    /**
+     * convert our own severity to CodeClimate format
+     * Values can be : info, minor, major, critical, or blocker
+     * @return string
+     */
+    protected function convertSeverity(string $input): string
+    {
+        if (Config::REPORT_INFO === $input) return 'info';
+        if (Config::REPORT_ERROR === $input) return 'critical';
+        if (Config::REPORT_SUPPRESS === $input) return 'minor';
+
+        // unknown cases ? fallback
+        return 'critical';
+    }
+
+    /**
+     * calculate a unique fingerprint for a given issue
+     */
+    protected function calculateFingerprint(IssueData $issue): string
+    {
+        return md5($issue->type.$issue->message.$issue->file_path.$issue->from.$issue->to);
+    }
+}

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -372,7 +372,7 @@ Output:
     --output-format=console
         Changes the output format.
         Available formats: compact, console, text, emacs, json, pylint, xml, checkstyle, junit, sonarqube, github,
-                           phpstorm
+                           phpstorm, codeclimate
 
     --no-progress
         Disable the progress indicator


### PR DESCRIPTION
This PR adds CodeClimate json format to output. 
CodeClimate is the format used by Gitlab to generate Code Quality reports.

See https://docs.gitlab.com/ee/user/project/merge_requests/code_quality.html

Format spec : https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types