### PR TITLE
Ds\Queue & Ds\Set implement ArrayAccess as well

### DIFF
--- a/stubs/ext-ds.php
+++ b/stubs/ext-ds.php
@@ -730,8 +730,9 @@ final class Vector implements Sequence
 /**
  * @template TValue
  * @implements Collection<int, TValue>
+ * @implements ArrayAccess<int, TValue>
  */
-final class Set implements Collection
+final class Set implements Collection, ArrayAccess
 {
     /**
      * @param iterable<TValue> $values
@@ -937,8 +938,9 @@ final class Stack implements Collection, ArrayAccess
 /**
  * @template TValue
  * @implements Collection<int, TValue>
+ * @implements ArrayAccess<int, TValue>
  */
-final class Queue implements Collection
+final class Queue implements Collection, ArrayAccess
 {
     /**
      * @param iterable<TValue> $values


### PR DESCRIPTION
Forgot these in #4401.

See [Queue](https://github.com/php-ds/polyfill/blob/master/src/Queue.php) & [Set](https://github.com/php-ds/polyfill/blob/master/src/Set.php) in the polyfill.

See also https://github.com/php-ds/ext-ds/pull/163.