### PR TITLE
Add psalm-mutation-free to ext-ds

### DIFF
--- a/stubs/ext-ds.php
+++ b/stubs/ext-ds.php
@@ -599,13 +599,13 @@ final class Pair implements JsonSerializable
 interface Sequence extends Collection, ArrayAccess
 {
     /**
-     * @return Sequence<TKey, TValue>
+     * @return Sequence<int, TValue>
      * @psalm-mutation-free
      */
     public function copy(): Sequence;
 
     /**
-     * @return array<TKey, TValue>
+     * @return array<int, TValue>
      * @psalm-mutation-free
      */
     public function toArray(): array;

--- a/stubs/ext-ds.php
+++ b/stubs/ext-ds.php
@@ -19,13 +19,25 @@ interface Collection extends Traversable, Countable, JsonSerializable
 {
     /**
      * @return Collection<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function copy(): Collection;
 
     /**
      * @return array<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function toArray(): array;
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool;
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function count(): int;
 }
 
 /**
@@ -155,7 +167,7 @@ final class Deque implements Sequence
 
     /**
      * @param (callable(TValue, TValue): int)|null $comparator
-     * @return Sequence<TValue>
+     * @return Deque<TValue>
      */
     public function sorted(callable $comparator = null): Deque
     {
@@ -178,6 +190,20 @@ final class Map implements Collection, ArrayAccess
     }
 
     /**
+     * @psalm-mutation-free
+     */
+    public function allocate(int $capacity): void
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function capacity(): int
+    {
+    }
+
+    /**
      * @return Map<TKey, TValue>
      */
     public function copy(): Map
@@ -194,6 +220,7 @@ final class Map implements Collection, ArrayAccess
     /**
      * @return Pair<TKey, TValue>
      * @throws UnderflowException
+     * @psalm-mutation-free
      */
     public function first(): Pair
     {
@@ -202,6 +229,7 @@ final class Map implements Collection, ArrayAccess
     /**
      * @return Pair<TKey, TValue>
      * @throws UnderflowException
+     * @psalm-mutation-free
      */
     public function last(): Pair
     {
@@ -210,6 +238,7 @@ final class Map implements Collection, ArrayAccess
     /**
      * @return Pair<TKey, TValue>
      * @throws OutOfRangeException
+     * @psalm-mutation-free
      */
     public function skip(int $position): Pair
     {
@@ -220,6 +249,7 @@ final class Map implements Collection, ArrayAccess
      * @template TValue2
      * @param iterable<TKey2, TValue2> $values
      * @return Map<TKey|TKey2, TValue|TValue2>
+     * @psalm-mutation-free
      */
     public function merge(iterable $values): Map
     {
@@ -230,6 +260,7 @@ final class Map implements Collection, ArrayAccess
      * @template TValue2
      * @param Map<TKey2, TValue2> $map
      * @return Map<TKey&TKey2, TValue>
+     * @psalm-mutation-free
      */
     public function intersect(Map $map): Map
     {
@@ -239,6 +270,7 @@ final class Map implements Collection, ArrayAccess
      * @template TValue2
      * @param Map<TKey, TValue2> $map
      * @return Map<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function diff(Map $map): Map
     {
@@ -246,6 +278,7 @@ final class Map implements Collection, ArrayAccess
 
     /**
      * @param TKey $key
+     * @psalm-mutation-free
      */
     public function hasKey($key): bool
     {
@@ -253,6 +286,7 @@ final class Map implements Collection, ArrayAccess
 
     /**
      * @param TValue $value
+     * @psalm-mutation-free
      */
     public function hasValue($value): bool
     {
@@ -261,6 +295,7 @@ final class Map implements Collection, ArrayAccess
     /**
      * @param (callable(TKey, TValue): bool)|null $callback
      * @return Map<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function filter(callable $callback = null): Map
     {
@@ -276,6 +311,7 @@ final class Map implements Collection, ArrayAccess
      *     : TValue|TDefault
      * )
      * @throws OutOfBoundsException
+     * @psalm-mutation-free
      */
     public function get($key, $default = null)
     {
@@ -283,6 +319,7 @@ final class Map implements Collection, ArrayAccess
 
     /**
      * @return Set<TKey>
+     * @psalm-mutation-free
      */
     public function keys(): Set
     {
@@ -292,6 +329,7 @@ final class Map implements Collection, ArrayAccess
      * @template TNewValue
      * @param callable(TKey, TValue): TNewValue $callback
      * @return Map<TKey, TNewValue>
+     * @psalm-mutation-free
      */
     public function map(callable $callback): Map
     {
@@ -299,6 +337,7 @@ final class Map implements Collection, ArrayAccess
 
     /**
      * @return Sequence<Pair<TKey, TValue>>
+     * @psalm-mutation-free
      */
     public function pairs(): Sequence
     {
@@ -324,6 +363,7 @@ final class Map implements Collection, ArrayAccess
      * @param callable(TCarry, TKey, TValue): TCarry $callback
      * @param TCarry $initial
      * @return TCarry
+     * @psalm-mutation-free
      */
     public function reduce(callable $callback, $initial = null)
     {
@@ -346,6 +386,7 @@ final class Map implements Collection, ArrayAccess
 
     /**
      * @return Map<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function reversed(): Map
     {
@@ -353,6 +394,7 @@ final class Map implements Collection, ArrayAccess
 
     /**
      * @return Map<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function slice(int $offset, ?int $length = null): Map
     {
@@ -368,6 +410,7 @@ final class Map implements Collection, ArrayAccess
     /**
      * @param (callable(TValue, TValue): int)|null $comparator
      * @return Map<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function sorted(callable $comparator = null): Map
     {
@@ -383,6 +426,7 @@ final class Map implements Collection, ArrayAccess
     /**
      * @param (callable(TKey, TKey): int)|null $comparator
      * @return Map<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function ksorted(callable $comparator = null): Map
     {
@@ -397,6 +441,7 @@ final class Map implements Collection, ArrayAccess
 
     /**
      * @return Sequence<TValue>
+     * @psalm-mutation-free
      */
     public function values(): Sequence
     {
@@ -407,6 +452,7 @@ final class Map implements Collection, ArrayAccess
      * @template TValue2
      * @param Map<TKey2, TValue2> $map
      * @return Map<TKey|TKey2, TValue|TValue2>
+     * @psalm-mutation-free
      */
     public function union(Map $map): Map
     {
@@ -417,6 +463,7 @@ final class Map implements Collection, ArrayAccess
      * @template TValue2
      * @param Map<TKey2, TValue2> $map
      * @return Map<TKey|TKey2, TValue|TValue2>
+     * @psalm-mutation-free
      */
     public function xor(Map $map): Map
     {
@@ -449,6 +496,7 @@ final class Pair implements JsonSerializable
 
     /**
      * @return Pair<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function copy(): Pair
     {
@@ -463,36 +511,57 @@ final class Pair implements JsonSerializable
 interface Sequence extends Collection, ArrayAccess
 {
     /**
+     * @psalm-mutation-free
+     */
+    public function allocate(int $capacity): void;
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function capacity(): int;
+
+    /**
+     * @return number
+     * @psalm-mutation-free
+     */
+    public function sum();
+
+    /**
      * @param callable(TValue): TValue $callback
      */
     public function apply(callable $callback): void;
 
     /**
      * @param TValue ...$values
+     * @psalm-mutation-free
      */
     public function contains(...$values): bool;
 
     /**
      * @param (callable(TValue): bool)|null $callback
      * @return Sequence<TValue>
+     * @psalm-mutation-free
      */
     public function filter(callable $callback = null): Sequence;
 
     /**
      * @param TValue $value
      * @return int|false
+     * @psalm-mutation-free
      */
     public function find($value);
 
     /**
      * @return TValue
      * @throws \UnderflowException
+     * @psalm-mutation-free
      */
     public function first();
 
     /**
      * @return TValue
      * @throws \OutOfRangeException
+     * @psalm-mutation-free
      */
     public function get(int $index);
 
@@ -505,12 +574,14 @@ interface Sequence extends Collection, ArrayAccess
     /**
      * @param string $glue
      * @return string
+     * @psalm-mutation-free
      */
     public function join(string $glue = null): string;
 
     /**
      * @return TValue
      * @throws \UnderflowException
+     * @psalm-mutation-free
      */
     public function last();
 
@@ -518,6 +589,7 @@ interface Sequence extends Collection, ArrayAccess
      * @template TNewValue
      * @param callable(TValue): TNewValue $callback
      * @return Sequence<TNewValue>
+     * @psalm-mutation-free
      */
     public function map(callable $callback): Sequence;
 
@@ -525,6 +597,7 @@ interface Sequence extends Collection, ArrayAccess
      * @template TValue2
      * @param iterable<TValue2> $values
      * @return Sequence<TValue|TValue2>
+     * @psalm-mutation-free
      */
     public function merge(iterable $values): Sequence;
 
@@ -544,6 +617,7 @@ interface Sequence extends Collection, ArrayAccess
      * @param callable(TCarry, TValue): TCarry $callback
      * @param TCarry $initial
      * @return TCarry
+     * @psalm-mutation-free
      */
     public function reduce(callable $callback, $initial = null);
 
@@ -555,6 +629,7 @@ interface Sequence extends Collection, ArrayAccess
 
     /**
      * @return Sequence<TValue>
+     * @psalm-mutation-free
      */
     public function reversed(): Sequence;
 
@@ -572,6 +647,7 @@ interface Sequence extends Collection, ArrayAccess
 
     /**
      * @return Sequence<TValue>
+     * @psalm-mutation-free
      */
     public function slice(int $index, ?int $length = null): Sequence;
 
@@ -583,6 +659,7 @@ interface Sequence extends Collection, ArrayAccess
     /**
      * @param (callable(TValue, TValue): int)|null $comparator
      * @return Sequence<TValue>
+     * @psalm-mutation-free
      */
     public function sorted(callable $comparator = null): Sequence;
 
@@ -742,6 +819,20 @@ final class Set implements Collection, ArrayAccess
     }
 
     /**
+     * @psalm-mutation-free
+     */
+    public function allocate(int $capacity): void
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function capacity(): int
+    {
+    }
+
+    /**
      * @param TValue ...$values
      */
     public function add(...$values): void
@@ -750,6 +841,7 @@ final class Set implements Collection, ArrayAccess
 
     /**
      * @param TValue ...$values
+     * @psalm-mutation-free
      */
     public function contains(...$values): bool
     {
@@ -766,6 +858,7 @@ final class Set implements Collection, ArrayAccess
      * @template TValue2
      * @param Set<TValue2> $set
      * @return Set<TValue>
+     * @psalm-mutation-free
      */
     public function diff(Set $set): Set
     {
@@ -774,6 +867,7 @@ final class Set implements Collection, ArrayAccess
     /**
      * @param (callable(TValue): bool)|null $callback
      * @return Set<TValue>
+     * @psalm-mutation-free
      */
     public function filter(callable $callback = null): Set
     {
@@ -782,6 +876,7 @@ final class Set implements Collection, ArrayAccess
     /**
      * @return TValue
      * @throws \UnderflowException
+     * @psalm-mutation-free
      */
     public function first()
     {
@@ -790,6 +885,7 @@ final class Set implements Collection, ArrayAccess
     /**
      * @return TValue
      * @throws \OutOfRangeException
+     * @psalm-mutation-free
      */
     public function get(int $index)
     {
@@ -799,6 +895,7 @@ final class Set implements Collection, ArrayAccess
      * @template TValue2
      * @param Set<TValue2> $set
      * @return Set<TValue&TValue2>
+     * @psalm-mutation-free
      */
     public function intersect(Set $set): Set
     {
@@ -807,6 +904,7 @@ final class Set implements Collection, ArrayAccess
     /**
      * @return TValue
      * @throws \UnderflowException
+     * @psalm-mutation-free
      */
     public function last()
     {
@@ -816,6 +914,7 @@ final class Set implements Collection, ArrayAccess
      * @template TValue2
      * @param iterable<TValue2> $values
      * @return Set<TValue|TValue2>
+     * @psalm-mutation-free
      */
     public function merge(iterable $values): Set
     {
@@ -830,6 +929,7 @@ final class Set implements Collection, ArrayAccess
 
     /**
      * @return Set<TValue>
+     * @psalm-mutation-free
      */
     public function reversed(): Set
     {
@@ -837,6 +937,7 @@ final class Set implements Collection, ArrayAccess
 
     /**
      * @return Set<TValue>
+     * @psalm-mutation-free
      */
     public function slice(int $index, ?int $length = null): Set
     {
@@ -852,6 +953,7 @@ final class Set implements Collection, ArrayAccess
     /**
      * @param (callable(TValue, TValue): int)|null $comparator
      * @return Set<TValue>
+     * @psalm-mutation-free
      */
     public function sorted(callable $comparator = null): Set
     {
@@ -868,6 +970,7 @@ final class Set implements Collection, ArrayAccess
      * @template TValue2
      * @param Set<TValue2> $set
      * @return Set<TValue|TValue2>
+     * @psalm-mutation-free
      */
     public function union(Set $set): Set
     {
@@ -877,6 +980,7 @@ final class Set implements Collection, ArrayAccess
      * @template TValue2
      * @param Set<TValue2> $set
      * @return Set<TValue|TValue2>
+     * @psalm-mutation-free
      */
     public function xor(Set $set): Set
     {
@@ -898,6 +1002,20 @@ final class Stack implements Collection, ArrayAccess
     }
 
     /**
+     * @psalm-mutation-free
+     */
+    public function allocate(int $capacity): void
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function capacity(): int
+    {
+    }
+
+    /**
      * @return Stack<TValue>
      */
     public function copy(): Stack
@@ -907,6 +1025,7 @@ final class Stack implements Collection, ArrayAccess
     /**
      * @return TValue
      * @throws UnderflowException
+     * @psalm-mutation-free
      */
     public function peek()
     {
@@ -950,6 +1069,20 @@ final class Queue implements Collection, ArrayAccess
     }
 
     /**
+     * @psalm-mutation-free
+     */
+    public function allocate(int $capacity): void
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function capacity(): int
+    {
+    }
+
+    /**
      * @return Queue<TValue>
      */
     public function copy(): Queue
@@ -959,6 +1092,7 @@ final class Queue implements Collection, ArrayAccess
     /**
      * @return TValue
      * @throws UnderflowException
+     * @psalm-mutation-free
      */
     public function peek()
     {
@@ -994,6 +1128,20 @@ final class Queue implements Collection, ArrayAccess
 final class PriorityQueue implements Collection
 {
     /**
+     * @psalm-mutation-free
+     */
+    public function allocate(int $capacity): void
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function capacity(): int
+    {
+    }
+
+    /**
      * @return PriorityQueue<TValue>
      */
     public function copy(): PriorityQueue
@@ -1003,6 +1151,7 @@ final class PriorityQueue implements Collection
     /**
      * @return TValue
      * @throws UnderflowException
+     * @psalm-mutation-free
      */
     public function peek()
     {

--- a/stubs/ext-ds.php
+++ b/stubs/ext-ds.php
@@ -55,6 +55,7 @@ final class Deque implements Sequence
 
     /**
      * @return Deque<TValue>
+     * @psalm-mutation-free
      */
     public function copy(): Deque
     {
@@ -62,14 +63,78 @@ final class Deque implements Sequence
 
     /**
      * @return list<TValue>
+     * @psalm-mutation-free
      */
     public function toArray(): array
     {
     }
 
     /**
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function count(): int
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function allocate(int $capacity): void
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function capacity(): int
+    {
+    }
+
+    /**
+     * @return number
+     * @psalm-mutation-free
+     */
+    public function sum()
+    {
+    }
+
+    /**
+     * @param TValue ...$values
+     * @psalm-mutation-free
+     */
+    public function contains(...$values): bool
+    {
+    }
+
+    /**
+     * @param (callable(TValue): bool)|null $callback
+     * @return Deque<TValue>
+     * @psalm-mutation-free
+     */
+    public function filter(callable $callback = null): Deque
+    {
+    }
+
+    /**
+     * @param TValue $value
+     * @return int|false
+     * @psalm-mutation-free
+     */
+    public function find($value)
+    {
+    }
+
+    /**
      * @return TValue
      * @throws \UnderflowException
+     * @psalm-mutation-free
      */
     public function first()
     {
@@ -78,16 +143,45 @@ final class Deque implements Sequence
     /**
      * @return TValue
      * @throws \OutOfRangeException
+     * @psalm-mutation-free
      */
     public function get(int $index)
     {
     }
 
     /**
+     * @psalm-mutation-free
+     */
+    public function join(?string $glue = null): string
+    {
+    }
+
+    /**
      * @return TValue
      * @throws \UnderflowException
+     * @psalm-mutation-free
      */
     public function last()
+    {
+    }
+
+    /**
+     * @template TNewValue
+     * @param callable(TValue): TNewValue $callback
+     * @return Deque<TNewValue>
+     * @psalm-mutation-free
+     */
+    public function map(callable $callback): Deque
+    {
+    }
+
+    /**
+     * @template TValue2
+     * @param iterable<TValue2> $values
+     * @return Deque<TValue|TValue2>
+     * @psalm-mutation-free
+     */
+    public function merge(iterable $values): Deque
     {
     }
 
@@ -104,6 +198,7 @@ final class Deque implements Sequence
      * @param callable(TCarry, TValue): TCarry $callback
      * @param TCarry $initial
      * @return TCarry
+     * @psalm-mutation-free
      */
     public function reduce(callable $callback, $initial = null)
     {
@@ -118,6 +213,14 @@ final class Deque implements Sequence
     }
 
     /**
+     * @return Deque<TValue>
+     * @psalm-mutation-free
+     */
+    public function reversed(): Deque
+    {
+    }
+
+    /**
      * @return TValue
      * @throws \UnderflowException
      */
@@ -126,40 +229,8 @@ final class Deque implements Sequence
     }
 
     /**
-     * @template TValue2
-     * @param iterable<TValue2> $values
-     * @return Deque<TValue|TValue2>
-     */
-    public function merge(iterable $values): Deque
-    {
-    }
-
-    /**
-     * @param (callable(TValue): bool)|null $callback
      * @return Deque<TValue>
-     */
-    public function filter(callable $callback = null): Deque
-    {
-    }
-
-    /**
-     * @template TNewValue
-     * @param callable(TValue): TNewValue $callback
-     * @return Deque<TNewValue>
-     */
-    public function map(callable $callback): Deque
-    {
-    }
-
-    /**
-     * @return Deque<TValue>
-     */
-    public function reversed(): Deque
-    {
-    }
-
-    /**
-     * @return Deque<TValue>
+     * @psalm-mutation-free
      */
     public function slice(int $offset, ?int $length = null): Deque
     {
@@ -168,6 +239,7 @@ final class Deque implements Sequence
     /**
      * @param (callable(TValue, TValue): int)|null $comparator
      * @return Deque<TValue>
+     * @psalm-mutation-free
      */
     public function sorted(callable $comparator = null): Deque
     {
@@ -205,8 +277,31 @@ final class Map implements Collection, ArrayAccess
 
     /**
      * @return Map<TKey, TValue>
+     * @psalm-mutation-free
      */
     public function copy(): Map
+    {
+    }
+
+    /**
+     * @return array<TKey, TValue>
+     * @psalm-mutation-free
+     */
+    public function toArray(): array
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function count(): int
     {
     }
 
@@ -433,13 +528,6 @@ final class Map implements Collection, ArrayAccess
     }
 
     /**
-     * @return array<TKey, TValue>
-     */
-    public function toArray(): array
-    {
-    }
-
-    /**
      * @return Sequence<TValue>
      * @psalm-mutation-free
      */
@@ -511,6 +599,28 @@ final class Pair implements JsonSerializable
 interface Sequence extends Collection, ArrayAccess
 {
     /**
+     * @return Sequence<TKey, TValue>
+     * @psalm-mutation-free
+     */
+    public function copy(): Sequence;
+
+    /**
+     * @return array<TKey, TValue>
+     * @psalm-mutation-free
+     */
+    public function toArray(): array;
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool;
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function count(): int;
+
+    /**
      * @psalm-mutation-free
      */
     public function allocate(int $capacity): void;
@@ -572,11 +682,9 @@ interface Sequence extends Collection, ArrayAccess
     public function insert(int $index, ...$values);
 
     /**
-     * @param string $glue
-     * @return string
      * @psalm-mutation-free
      */
-    public function join(string $glue = null): string;
+    public function join(?string $glue = null): string;
 
     /**
      * @return TValue
@@ -685,6 +793,7 @@ final class Vector implements Sequence
 
     /**
      * @return Vector<TValue>
+     * @psalm-mutation-free
      */
     public function copy(): Vector
     {
@@ -692,14 +801,78 @@ final class Vector implements Sequence
 
     /**
      * @return list<TValue>
+     * @psalm-mutation-free
      */
     public function toArray(): array
     {
     }
 
     /**
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function count(): int
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function allocate(int $capacity): void
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function capacity(): int
+    {
+    }
+
+    /**
+     * @return number
+     * @psalm-mutation-free
+     */
+    public function sum()
+    {
+    }
+
+    /**
+     * @param TValue ...$values
+     * @psalm-mutation-free
+     */
+    public function contains(...$values): bool
+    {
+    }
+
+    /**
+     * @param (callable(TValue): bool)|null $callback
+     * @return Vector<TValue>
+     * @psalm-mutation-free
+     */
+    public function filter(callable $callback = null): Vector
+    {
+    }
+
+    /**
+     * @param TValue $value
+     * @return int|false
+     * @psalm-mutation-free
+     */
+    public function find($value)
+    {
+    }
+
+    /**
      * @return TValue
      * @throws \UnderflowException
+     * @psalm-mutation-free
      */
     public function first()
     {
@@ -708,16 +881,45 @@ final class Vector implements Sequence
     /**
      * @return TValue
      * @throws \OutOfRangeException
+     * @psalm-mutation-free
      */
     public function get(int $index)
     {
     }
 
     /**
+     * @psalm-mutation-free
+     */
+    public function join(?string $glue = null): string
+    {
+    }
+
+    /**
      * @return TValue
      * @throws \UnderflowException
+     * @psalm-mutation-free
      */
     public function last()
+    {
+    }
+
+    /**
+     * @template TNewValue
+     * @param callable(TValue): TNewValue $callback
+     * @return Vector<TNewValue>
+     * @psalm-mutation-free
+     */
+    public function map(callable $callback): Vector
+    {
+    }
+
+    /**
+     * @template TValue2
+     * @param iterable<TValue2> $values
+     * @return Vector<TValue|TValue2>
+     * @psalm-mutation-free
+     */
+    public function merge(iterable $values): Sequence
     {
     }
 
@@ -734,6 +936,7 @@ final class Vector implements Sequence
      * @param callable(TCarry, TValue): TCarry $callback
      * @param TCarry $initial
      * @return TCarry
+     * @psalm-mutation-free
      */
     public function reduce(callable $callback, $initial = null)
     {
@@ -748,6 +951,14 @@ final class Vector implements Sequence
     }
 
     /**
+     * @return Vector<TValue>
+     * @psalm-mutation-free
+     */
+    public function reversed(): Vector
+    {
+    }
+
+    /**
      * @return TValue
      * @throws \UnderflowException
      */
@@ -757,13 +968,7 @@ final class Vector implements Sequence
 
     /**
      * @return Vector<TValue>
-     */
-    public function reversed(): Vector
-    {
-    }
-
-    /**
-     * @return Vector<TValue>
+     * @psalm-mutation-free
      */
     public function slice(int $offset, ?int $length = null): Vector
     {
@@ -772,34 +977,9 @@ final class Vector implements Sequence
     /**
      * @param (callable(TValue, TValue): int)|null $comparator
      * @return Vector<TValue>
+     * @psalm-mutation-free
      */
     public function sorted(callable $comparator = null): Vector
-    {
-    }
-
-    /**
-     * @param (callable(TValue): bool)|null $callback
-     * @return Vector<TValue>
-     */
-    public function filter(callable $callback = null): Vector
-    {
-    }
-
-    /**
-     * @template TNewValue
-     * @param callable(TValue): TNewValue $callback
-     * @return Vector<TNewValue>
-     */
-    public function map(callable $callback): Vector
-    {
-    }
-
-    /**
-     * @template TValue2
-     * @param iterable<TValue2> $values
-     * @return Vector<TValue|TValue2>
-     */
-    public function merge(iterable $values): Sequence
     {
     }
 }
@@ -815,6 +995,36 @@ final class Set implements Collection, ArrayAccess
      * @param iterable<TValue> $values
      */
     public function __construct(iterable $values = [])
+    {
+    }
+
+    /**
+     * @return Set<TValue>
+     * @psalm-mutation-free
+     */
+    public function copy(): Set
+    {
+    }
+
+    /**
+     * @return list<TValue>
+     * @psalm-mutation-free
+     */
+    public function toArray(): array
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function count(): int
     {
     }
 
@@ -844,13 +1054,6 @@ final class Set implements Collection, ArrayAccess
      * @psalm-mutation-free
      */
     public function contains(...$values): bool
-    {
-    }
-
-    /**
-     * @return Set<TValue>
-     */
-    public function copy(): Set
     {
     }
 
@@ -960,13 +1163,6 @@ final class Set implements Collection, ArrayAccess
     }
 
     /**
-     * @return list<TValue>
-     */
-    public function toArray(): array
-    {
-    }
-
-    /**
      * @template TValue2
      * @param Set<TValue2> $set
      * @return Set<TValue|TValue2>
@@ -1002,6 +1198,36 @@ final class Stack implements Collection, ArrayAccess
     }
 
     /**
+     * @return Stack<TValue>
+     * @psalm-mutation-free
+     */
+    public function copy(): Stack
+    {
+    }
+
+    /**
+     * @return list<TValue>
+     * @psalm-mutation-free
+     */
+    public function toArray(): array
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function count(): int
+    {
+    }
+
+    /**
      * @psalm-mutation-free
      */
     public function allocate(int $capacity): void
@@ -1012,13 +1238,6 @@ final class Stack implements Collection, ArrayAccess
      * @psalm-mutation-free
      */
     public function capacity(): int
-    {
-    }
-
-    /**
-     * @return Stack<TValue>
-     */
-    public function copy(): Stack
     {
     }
 
@@ -1043,13 +1262,6 @@ final class Stack implements Collection, ArrayAccess
      * @param TValue ...$values
      */
     public function push(...$values): void
-    {
-    }
-
-    /**
-     * @return list<TValue>
-     */
-    public function toArray(): array
     {
     }
 }
@@ -1069,6 +1281,36 @@ final class Queue implements Collection, ArrayAccess
     }
 
     /**
+     * @return Queue<TValue>
+     * @psalm-mutation-free
+     */
+    public function copy(): Queue
+    {
+    }
+
+    /**
+     * @return list<TValue>
+     * @psalm-mutation-free
+     */
+    public function toArray(): array
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function count(): int
+    {
+    }
+
+    /**
      * @psalm-mutation-free
      */
     public function allocate(int $capacity): void
@@ -1079,13 +1321,6 @@ final class Queue implements Collection, ArrayAccess
      * @psalm-mutation-free
      */
     public function capacity(): int
-    {
-    }
-
-    /**
-     * @return Queue<TValue>
-     */
-    public function copy(): Queue
     {
     }
 
@@ -1112,13 +1347,6 @@ final class Queue implements Collection, ArrayAccess
     public function push(...$values): void
     {
     }
-
-    /**
-     * @return list<TValue>
-     */
-    public function toArray(): array
-    {
-    }
 }
 
 /**
@@ -1127,6 +1355,36 @@ final class Queue implements Collection, ArrayAccess
  */
 final class PriorityQueue implements Collection
 {
+    /**
+     * @return PriorityQueue<TValue>
+     * @psalm-mutation-free
+     */
+    public function copy(): PriorityQueue
+    {
+    }
+
+    /**
+     * @return list<TValue>
+     * @psalm-mutation-free
+     */
+    public function toArray(): array
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function isEmpty(): bool
+    {
+    }
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function count(): int
+    {
+    }
+
     /**
      * @psalm-mutation-free
      */
@@ -1138,13 +1396,6 @@ final class PriorityQueue implements Collection
      * @psalm-mutation-free
      */
     public function capacity(): int
-    {
-    }
-
-    /**
-     * @return PriorityQueue<TValue>
-     */
-    public function copy(): PriorityQueue
     {
     }
 
@@ -1169,13 +1420,6 @@ final class PriorityQueue implements Collection
      * @param TValue $value
      */
     public function push($value, int $priority): void
-    {
-    }
-
-    /**
-     * @return list<TValue>
-     */
-    public function toArray(): array
     {
     }
 }


### PR DESCRIPTION
I noticed that adding `@psalm-mutation-free` to `Collection::isEmpty()` doesn't affect `Set::isEmpty()` even though `Set implements Collection`. Do I have to copy the methods in such cases or is there a way to make the inheritance work?