### PR TITLE
add stub with conditionnal return for is_a

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -779,3 +779,14 @@ function random_int(int $min, int $max): int {}
  * @psalm-pure
  */
 function array_count_values(array $array): array {}
+
+/**
+ * @template T of object
+ * @template U of object
+ * @param class-string<T>|T $object
+ * @param class-string<U> $class_name
+ * @return ($allow_string is false ? ($object is class-string ? false : (T is U ? true : bool)) : (T is U ? true : bool))
+ */
+function is_a($object, $class_name, $allow_string = false): bool{
+    return false;
+}


### PR DESCRIPTION
This PR propose adding a stub for is_a with a conditionnal return to try to fix #4439 

I made some tests here and it seems to work well:
https://psalm.dev/r/d5f0c18633

If we try with the example of the issue, it outputs:
https://psalm.dev/r/5eb4292c0b

Which may not be the result expected in the issue, but it makes the function always return false when called with a class-string when not allowed by $allow_string