### PR TITLE
Pass CodeLocation to FunctionParamsProviderInterface interface

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -236,7 +236,9 @@ class FunctionCallAnalyzer extends CallAnalyzer
                     $function_params = $codebase->functions->params_provider->getFunctionParams(
                         $statements_analyzer,
                         $function_id,
-                        $stmt->args
+                        $stmt->args,
+                        null,
+                        $code_location
                     );
                 }
 


### PR DESCRIPTION
Currently the `getFunctionParams()` method of the `FunctionParamsProviderInterface` is never passed the CodeLocation of the analyzed function call. As this is in-scope in the only call site, we can pass the CodeLocation. This means the `getFunctionParams()` is able to issue it's own Issues (which required the code location to attached the Issue to)