### PR TITLE
Fix type inference when unpacking typed iterables

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -106,7 +106,12 @@ class ArrayAnalyzer
                     } else {
                         $can_create_objectlike = false;
 
-                        if ($unpacked_atomic_type instanceof Type\Atomic\TArray) {
+                        if ($unpacked_atomic_type instanceof Type\Atomic\TArray
+                            || $unpacked_atomic_type instanceof Type\Atomic\TIterable
+                            || (
+                                $unpacked_atomic_type instanceof Type\Atomic\TGenericObject
+                                && $unpacked_atomic_type->hasTraversableInterface($codebase)
+                        )) {
                             if ($unpacked_atomic_type->type_params[0]->hasString()) {
                                 if (IssueBuffer::accepts(
                                     new DuplicateArrayKey(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -128,7 +128,11 @@ class ArrayAnalyzer
 
                             $item_value_atomic_types = array_merge(
                                 $item_value_atomic_types,
-                                array_values($unpacked_atomic_type->type_params[1]->getAtomicTypes())
+                                array_values(
+                                    isset($unpacked_atomic_type->type_params[1])
+                                        ? $unpacked_atomic_type->type_params[1]->getAtomicTypes()
+                                        : [new Type\Atomic\TMixed()]
+                                )
                             );
                         } elseif ($unpacked_atomic_type instanceof Type\Atomic\TList) {
                             $item_key_atomic_types[] = new Type\Atomic\TInt();

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1525,6 +1525,30 @@ class ArrayAssignmentTest extends TestCase
                         return $l;
                     }'
             ],
+            'unpackTypedIterableIntoArray' => [
+                '<?php
+
+                /**
+                 * @param iterable<int, string> $data
+                 * @return list<string>
+                 */
+                function unpackIterable(iterable $data): array
+                {
+                    return [...$data];
+                }'
+            ],
+            'unpackTypedTraversableIntoArray' => [
+                '<?php
+
+                /**
+                 * @param Traversable<int, string> $data
+                 * @return list<string>
+                 */
+                function unpackIterable(Traversable $data): array
+                {
+                    return [...$data];
+                }'
+            ]
         ];
     }
 
@@ -1802,6 +1826,32 @@ class ArrayAssignmentTest extends TestCase
                     }',
                 'error_message' => 'NullableReturnStatement',
             ],
+            'unpackTypedIterableWithStringKeysIntoArray' => [
+                '<?php
+
+                /**
+                 * @param iterable<string, string> $data
+                 * @return list<string>
+                 */
+                function unpackIterable(iterable $data): array
+                {
+                    return [...$data];
+                }',
+                'error_message' => 'DuplicateArrayKey'
+            ],
+            'unpackTypedTraversableWithStringKeysIntoArray' => [
+                '<?php
+
+                /**
+                 * @param Traversable<string, string> $data
+                 * @return list<string>
+                 */
+                function unpackIterable(Traversable $data): array
+                {
+                    return [...$data];
+                }',
+                'error_message' => 'DuplicateArrayKey'
+            ]
         ];
     }
 }


### PR DESCRIPTION
This attempts to fix issue  #3113

When a typed iterable is unpacked into an array, it's template types are discarted and `list<mixed>` is assumed.