### PR TITLE
Add a `proxy` capability to the flow annotation

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -507,27 +507,33 @@ class FunctionLikeDocblockScanner
                     }
                 }
 
-                if (isset($flow_parts[0]) && \strpos(trim($flow_parts[0]), 'passthru') === 0) {
-                    $passthru_call = trim(substr($flow_parts[0], strlen('passthru')));
-                    list($fully_qualified_name, $source_param_string) = explode('(', $passthru_call, 2);
+                if (isset($flow_parts[0]) && \strpos(trim($flow_parts[0]), 'proxy') === 0) {
+                    $proxy_call = trim(substr($flow_parts[0], strlen('proxy')));
+                    list($fully_qualified_name, $source_param_string) = explode('(', $proxy_call, 2);
 
-                    $source_params = preg_split('/, ?/', substr($source_param_string, 0, -1)) ?: [];
-                    $call_params = [];
-                    foreach ($source_params as $source_param) {
-                        $source_param = substr($source_param, 1);
+                    if (!empty($fully_qualified_name) && !empty($source_param_string)) {
+                        $source_params = preg_split('/, ?/', substr($source_param_string, 0, -1)) ?: [];
+                        $call_params = [];
+                        foreach ($source_params as $source_param) {
+                            $source_param = substr($source_param, 1);
 
-                        foreach ($storage->params as $i => $param_storage) {
-                            if ($param_storage->name === $source_param) {
-                                $call_params[] = $i;
+                            foreach ($storage->params as $i => $param_storage) {
+                                if ($param_storage->name === $source_param) {
+                                    $call_params[] = $i;
+                                }
                             }
                         }
-                    }
 
-                    $storage->passthru_calls[] = [
-                        'fqcn' => $fully_qualified_name,
-                        'params' => $call_params,
-                        'return' => isset($flow_parts[1]) && trim($flow_parts[1]) === 'return'
-                    ];
+                        if ($storage->proxy_calls === null) {
+                            $storage->proxy_calls = [];
+                        }
+
+                        $storage->proxy_calls[] = [
+                            'fqcn' => $fully_qualified_name,
+                            'params' => $call_params,
+                            'return' => isset($flow_parts[1]) && trim($flow_parts[1]) === 'return'
+                        ];
+                    }
                 }
             }
         }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -506,6 +506,29 @@ class FunctionLikeDocblockScanner
                         }
                     }
                 }
+
+                if (isset($flow_parts[0]) && \strpos(trim($flow_parts[0]), 'passthru') === 0) {
+                    $passthru_call = trim(substr($flow_parts[0], strlen('passthru')));
+                    list($fully_qualified_name, $source_param_string) = explode('(', $passthru_call, 2);
+
+                    $source_params = preg_split('/, ?/', substr($source_param_string, 0, -1)) ?: [];
+                    $call_params = [];
+                    foreach ($source_params as $source_param) {
+                        $source_param = substr($source_param, 1);
+
+                        foreach ($storage->params as $i => $param_storage) {
+                            if ($param_storage->name === $source_param) {
+                                $call_params[] = $i;
+                            }
+                        }
+                    }
+
+                    $storage->passthru_calls[] = [
+                        'fqcn' => $fully_qualified_name,
+                        'params' => $call_params,
+                        'return' => isset($flow_parts[1]) && trim($flow_parts[1]) === 'return'
+                    ];
+                }
             }
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -529,7 +529,7 @@ class FunctionLikeDocblockScanner
                         }
 
                         $storage->proxy_calls[] = [
-                            'fqcn' => $fully_qualified_name,
+                            'fqn' => $fully_qualified_name,
                             'params' => $call_params,
                             'return' => isset($flow_parts[1]) && trim($flow_parts[1]) === 'return'
                         ];

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -210,7 +210,7 @@ abstract class FunctionLikeStorage
     public $attributes = [];
 
     /**
-     * @var list<array{fqcn: string, params: array<int>, return: bool}>|null
+     * @var list<array{fqn: string, params: array<int>, return: bool}>|null
      */
     public $proxy_calls = [];
 

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -210,9 +210,9 @@ abstract class FunctionLikeStorage
     public $attributes = [];
 
     /**
-     * @var list<array{fqcn: string, params: array<int>, return: bool}>
+     * @var list<array{fqcn: string, params: array<int>, return: bool}>|null
      */
-    public $passthru_calls = [];
+    public $proxy_calls = [];
 
     public function __toString(): string
     {

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -209,6 +209,11 @@ abstract class FunctionLikeStorage
      */
     public $attributes = [];
 
+    /**
+     * @var array{fqcn: string, params: array<int>, return: bool}
+     */
+    public $passthru_calls = [];
+
     public function __toString(): string
     {
         return $this->getSignature(false);

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -210,7 +210,7 @@ abstract class FunctionLikeStorage
     public $attributes = [];
 
     /**
-     * @var array{fqcn: string, params: array<int>, return: bool}
+     * @var list<array{fqcn: string, params: array<int>, return: bool}>
      */
     public $passthru_calls = [];
 

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -1596,6 +1596,25 @@ class TaintTest extends TestCase
 
                 echo some_stub($r);',
                 'error_message' => 'TaintedInput',
+            ],
+            'taintFlowMethodProxyAndReturn' => [
+                '<?php
+
+                class dummy {
+                    public function taintable(string $in): string {
+                        return $in;
+                    }
+                }
+
+                /**
+                 * @psalm-flow proxy dummy::taintable($r) -> return
+                 */
+                function some_stub(string $r): string {}
+
+                $r = $_GET["untrusted"];
+
+                echo some_stub($r);',
+                'error_message' => 'TaintedInput',
             ]
             /*
             // TODO: Stubs do not support this type of inference even with $this->message = $message.

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -1549,6 +1549,54 @@ class TaintTest extends TestCase
                     echo $params["foo"];',
                 'error_message' => 'TaintedInput',
             ],
+            'taintFlow' => [
+                '<?php
+
+                /**
+                 * @psalm-flow ($r) -> return
+                 */
+                function some_stub(string $r): string {}
+
+                $r = $_GET["untrusted"];
+
+                echo some_stub($r);',
+                'error_message' => 'TaintedInput',
+            ],
+            'taintFlowPassthru' => [
+                '<?php
+
+                /**
+                 * @psalm-taint-sink text $in
+                 */
+                function dummy_taint_sink(string $in): void {}
+
+                /**
+                 * @psalm-flow passthru dummy_taint_sink($r)
+                 */
+                function some_stub(string $r): string {}
+
+                $r = $_GET["untrusted"];
+
+                some_stub($r);',
+                'error_message' => 'TaintedInput',
+            ],
+            'taintFlowPassthruAndReturn' => [
+                '<?php
+
+                function dummy_taintable(string $in): string {
+                    return $in;
+                }
+
+                /**
+                 * @psalm-flow passthru dummy_taintable($r) -> return
+                 */
+                function some_stub(string $r): string {}
+
+                $r = $_GET["untrusted"];
+
+                echo some_stub($r);',
+                'error_message' => 'TaintedInput',
+            ]
             /*
             // TODO: Stubs do not support this type of inference even with $this->message = $message.
             // Most uses of getMessage() would be with caught exceptions, so this is not representative of real code.

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -1562,7 +1562,7 @@ class TaintTest extends TestCase
                 echo some_stub($r);',
                 'error_message' => 'TaintedInput',
             ],
-            'taintFlowPassthru' => [
+            'taintFlowProxy' => [
                 '<?php
 
                 /**
@@ -1571,7 +1571,7 @@ class TaintTest extends TestCase
                 function dummy_taint_sink(string $in): void {}
 
                 /**
-                 * @psalm-flow passthru dummy_taint_sink($r)
+                 * @psalm-flow proxy dummy_taint_sink($r)
                  */
                 function some_stub(string $r): string {}
 
@@ -1580,7 +1580,7 @@ class TaintTest extends TestCase
                 some_stub($r);',
                 'error_message' => 'TaintedInput',
             ],
-            'taintFlowPassthruAndReturn' => [
+            'taintFlowProxyAndReturn' => [
                 '<?php
 
                 function dummy_taintable(string $in): string {
@@ -1588,7 +1588,7 @@ class TaintTest extends TestCase
                 }
 
                 /**
-                 * @psalm-flow passthru dummy_taintable($r) -> return
+                 * @psalm-flow proxy dummy_taintable($r) -> return
                  */
                 function some_stub(string $r): string {}
 


### PR DESCRIPTION
The idea is to be able to add control flow nodes using the `@psalm-flow` annotation.
You could want to : 
 - indicate that a call to a certain stubbed method is "actually" a call to another stubbed method. In the case of Doctrine stubs, we could indicate that a call to `Doctrine\DBAL\Connexion::insert` is in fact a call to `Doctrine\DBAL\Connexion::executeStatement` which is really a call to `Doctrine\DBAL\Connexion::prepare` which is a taint sink.
 - indicate that a call to a certain stubbed method is a call to another totally different method and that you want it analysed and have its return type taints be wired to the taint of the actual call. In the case of Symfony, we could indicate that a call to  `Symfony\Bundle\FrameworkBundle\Controller\AbstractController::renderView` is a call to `Twig\Environment::render` which could have a taint sink (or not depending on the template analysis).

What do you think ?