### PR TITLE
[WIP] Add basic support for PHP 8 union types

### DIFF
--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -406,13 +406,22 @@ class Reflection
             return Type::getMixed();
         }
 
-        $suffix = '';
 
-        if ($reflection_type->allowsNull()) {
-            $suffix = '|null';
+        if ($reflection_type instanceof \ReflectionNamedType) {
+            $type = $reflection_type->getName();
+        } elseif ($reflection_type instanceof \ReflectionUnionType) {
+            $type = implode('|', array_map(function (\ReflectionNamedType $reflection) {
+                return $reflection->getName();
+            }, $reflection_type->getTypes()));
+        } else {
+            throw new \LogicException('Unexpected reflection class ' . \get_class($reflection_type) . ' found.');
         }
 
-        return Type::parseString($reflection_type->getName() . $suffix);
+        if ($reflection_type->allowsNull()) {
+            $type .= '|null';
+        }
+
+        return Type::parseString($type);
     }
 
     private function registerInheritedMethods(


### PR DESCRIPTION
I noticed that running Psalm on PHP 8 results in [an error in my build](https://github.com/wouterj/WouterJEloquentBundle/runs/1368129901):

> Uncaught Error: Call to undefined method ReflectionUnionType::getName() in /home/runner/work/WouterJEloquentBundle/WouterJEloquentBundle/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Reflection.php:415

The patch in this PR fixes the build, but more work needs to be done. (I'm also unsure about the policy of this package to unstable PHP versions)

I'm very very new with the Psalm codebase, so I'm unsure how to continue. I'm happy to finish this PR if there is some guidance, but also please feel free to take over this PR if that's easier for you :) A list of things I'm stuck with atm:

* Psalm doesn't yet know about the `ReflectionUnionType` class, so the analysis errors. I found `stubs/Php80.php` and `dictionaries/CallMap_80_deta.php`. Am I supposed this add that class somewhere? (I've tried doing so, but it didn't seem to do much) For reference, this is the `ReflectionUnionType` structure: https://wiki.php.net/rfc/union_types_v2#reflection
* Psalm incorrectly thinks `getName()` is part of `ReflectionType`, it's part of `ReflectionNamedType` instead. I couldn't find a way to tell Psalm this.
* I also get another Psalm error with this patch: `Could not verify return type 'Psalm\Type\Union' for Psalm\Internal\Codebase\Reflection::getPsalmTypeFromReflectionType` I'm unsure why that is, as this method is always returning `Type\Union` as far as I can see.
* This surely needs a test. I couldn't find tests directly for `Reflection` or `php8`. Can you guide my to which test class I should add a new test to cover this?