### PR TITLE
Add undocumented properties in SoapFault

### DIFF
--- a/dictionaries/PropertyMap.php
+++ b/dictionaries/PropertyMap.php
@@ -527,4 +527,12 @@ return [
         'timestamp' => 'int',
         'headers' => 'array<string, string>|null',
     ],
+    'soapfault' => [
+        'faultcode' => 'string',
+        'faultstring' => 'string',
+        'faultactor' => 'string',
+        'detail' => 'string',
+        '_name' => 'string',
+        'headerfault' => 'string',
+    ],
 ];


### PR DESCRIPTION
This PR propose adding undocumented properties in SoapFault.

This can be checked by running this code on a PHP install with Soap extension:
```php
try {
    throw new SoapFault('code', 'string', 'actor', 'detail', 'name', 'header');
} catch (Exception $ex) {
    var_dump($ex->faultcode, $ex->faultstring, $ex->faultactor, $ex->detail, $ex->_name, $ex->headerfault);
}
```

And it's explained here:
https://www.php.net/manual/fr/class.soapfault.php#97875
