### PR TITLE
Detect trying to access to a list with a negative offset

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -797,9 +797,16 @@ class ArrayFetchAnalyzer
                                     $statements_analyzer
                                 );
                             }
+                            $has_valid_offset = true;
+                        } elseif (count($key_values) === 1
+                            && is_int($key_values[0])
+                            && $key_values[0] < 0
+                        ) {
+                            $expected_offset_types[] = Type::getPositiveInt();
+                            $has_valid_offset = false;
+                        } else {
+                            $has_valid_offset = true;
                         }
-
-                        $has_valid_offset = true;
                     }
 
                     if ($in_assignment && $type instanceof Type\Atomic\TNonEmptyList && $type->count !== null) {

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -1270,6 +1270,19 @@ class ArrayAccessTest extends TestCase
                     [$width, $height, $depth] = size();',
                 'error_message' => 'InvalidArrayOffset',
             ],
+            'negativeListAccess' => [
+                '<?php
+                    class HelloWorld
+                    {
+                        public function sayHello(): void
+                        {
+                            $a = explode("/", "a/b/c");
+                            $x = $a[-3];
+                            echo $x;
+                        }
+                    }',
+                'error_message' => 'InvalidArrayOffset'
+            ]
         ];
     }
 }


### PR DESCRIPTION
The goal of this PR is to fix #4551

It detects when the offset key is a negative int and flag the offset as invalid.

The error message is sub-optimal though. I wanted to display something like 
`Cannot access value on variable $a using offset value of -1, expecting positive-int|int(0)`

I saw two way of doing that:
- Adding an Union in $expected_offset_type => This fails and only displays `int`,
- Adding two types in $expected_offset_type => This fails because we take only the first in https://github.com/orklah/psalm/blob/1497cfb98c84f8487b7150593816e5f7baef907b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php#L1471

However, I think the current message is explicit enough given it will look like 
`Cannot access value on variable $a using offset value of -12, expecting positive-int`
It should be obvious that 0 is still an option for a list.