### PR TITLE
$expr->name is not prefixed with $

### DIFF
--- a/docs/security_analysis/custom_taint_sources.md
+++ b/docs/security_analysis/custom_taint_sources.md
@@ -53,7 +53,7 @@ class BadSqlTainter implements AfterExpressionAnalysisInterface
         array &$file_replacements = []
     ) {
         if ($expr instanceof PhpParser\Node\Expr\Variable
-            && $expr->name === '$bad_data'
+            && $expr->name === 'bad_data'
         ) {
             $expr_type = $statements_source->getNodeTypeProvider()->getType($expr);
 


### PR DESCRIPTION
The example as-is would currently not flag the following code:

```
	public function foo() {
		$foo = $bad_data;
		\shell_exec($foo);
        } 
```

Switching it to `bad_data` made it work.