### PR TITLE
Fix #4549 Better intersection between parent types

### DIFF
--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -779,11 +779,19 @@ class Methods
                 if ((!$old_contained_by_new && !$new_contained_by_old)
                     || ($old_contained_by_new && $new_contained_by_old)
                 ) {
-                    $attempted_intersection = Type::intersectUnionTypes(
-                        $overridden_storage->return_type,
-                        $candidate_type,
-                        $source_analyzer->getCodebase()
-                    );
+                    if ($old_contained_by_new && $new_contained_by_old) {
+                        $attempted_intersection = Type::intersectUnionTypes(
+                            $candidate_type,
+                            $overridden_storage->return_type,
+                            $source_analyzer->getCodebase()
+                        );
+                    } else {
+                        $attempted_intersection = Type::intersectUnionTypes(
+                            $overridden_storage->return_type,
+                            $candidate_type,
+                            $source_analyzer->getCodebase()
+                        );
+                    }
 
                     if ($attempted_intersection) {
                         $self_class = $overridden_method_id->fq_class_name;


### PR DESCRIPTION
This fix #4549 doing a better intersection, getting the most specific type.

The problem occurs with stubs, when we have something like this:

```php
interface Either
{
    /**
     * @param callable $left
     * @param callable $right
     * @return mixed
     */
    public function either(callable $left, callable $right);
}
```

and we have a tow stubs, one for the interface and another for an implementation that override the interface method types:


```php
/**
 * @template E
 * @template A
 */
interface Either
{
    /**
     * @template TE
     * @template TA
     * @param callable(E): TE $left
     * @param callable(A): TA $right
     * @return TE|TA
     */
    public function either(callable $left, callable $right);
}

/**
 * @template E
 * @template A
 * @template-implements Either<E, A>
 */
class Right
{
    /**
     * @template TE
     * @template TA
     * @param callable(E): TE $left
     * @param callable(A): TA $right
     * @return TA
     */
    public function either(callable $left, callable $right);
}
```

Without this change, the intersection will take type references from the stubbed interface and not from the implementation, breaking the template_type inference.

Sorry, I wasn't able to reproduce it in a test.