### PR TITLE
mysqli::$insert_id can be a string

### DIFF
--- a/dictionaries/PropertyMap.php
+++ b/dictionaries/PropertyMap.php
@@ -260,7 +260,7 @@ return [
         'field_count' => 'int',
         'host_info' => 'string',
         'info' => 'string',
-        'insert_id' => 'int',
+        'insert_id' => 'int|string',
         'protocol_version' => 'string',
         'server_info' => 'string',
         'server_version' => 'int',


### PR DESCRIPTION
Source: https://www.php.net/manual/en/mysqli.insert-id.php

> Note:
> If the number is greater than maximal int value, mysqli_insert_id() will return a string.
