### PR TITLE
Stub for preg_filter

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -664,6 +664,19 @@ function str_replace($search, $replace, $subject, &$count = null) {}
 /**
  * @psalm-pure
  *
+ * @param string|string[] $pattern
+ * @param string|array<string|int|float> $replacement
+ * @param string|array<string|int|float> $subject
+ * @param int $count
+ * @return ($subject is array ? array<string> : string)
+ *
+ * @psalm-flow ($replacement, $subject) -> return
+ */
+function preg_filter($pattern, $replacement, $subject, int $limit = -1, &$count = null) {}
+
+/**
+ * @psalm-pure
+ *
  * @param string|string[] $search
  * @param string|array<string|int|float> $replace
  * @param string|array<string|int|float> $subject


### PR DESCRIPTION
As suggested here is a pull request for issue #4561. It seems to work for me.

However, a few notes from my side:
* According to the documentation, preg_filter returns an array if $subject is an array. If $subject is a string, it returns a string _or null_ in case of error. The null case is missing from the `@return` annotation. However, `preg_replace` can also return null in case of error, so I assumed the author of `preg_replace` stub knows better than I and left it this way.
* I have no idea what `@psalm-flow` does and could not find documentation.