### PR TITLE
Fix missing bracket in docs

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -96,7 +96,7 @@ Whether or not to use types as defined in docblocks. Defaults to `true`.
   useDocblockPropertyTypes="[bool]"
 >
 ```
-If not using all docblock types, you can still use docblock property types. Defaults to `false` (though only relevant if `useDocblockTypes` is `false`.
+If not using all docblock types, you can still use docblock property types. Defaults to `false` (though only relevant if `useDocblockTypes` is `false`).
 
 #### usePhpDocMethodsWithoutMagicCall
 


### PR DESCRIPTION
Add bracket at end of the [configuration.md#useDocBlockPropertyTypes](https://github.com/vimeo/psalm/blob/d60abaf858a846766378d2328012bdfd0170dd00/docs/running_psalm/configuration.md#usedocblockpropertytypes) description.