### PR TITLE
return static instead of self when static context detected

### DIFF
--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -115,7 +115,7 @@ abstract class Type
     ) : string {
         if ($allow_self && $value === $this_class) {
             if ($was_static) {
-                return '$this';
+                return 'static';
             }
             return 'self';
         }

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -110,9 +110,13 @@ abstract class Type
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        bool $allow_self = false
+        bool $allow_self = false,
+        bool $was_static = false
     ) : string {
         if ($allow_self && $value === $this_class) {
+            if ($was_static) {
+                return '$this';
+            }
             return 'self';
         }
 

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -88,8 +88,14 @@ class TNamedObject extends Atomic
             $use_phpdoc_format
         );
 
-        return Type::getStringFromFQCLN($this->value, $namespace, $aliased_classes, $this_class, true)
-            . $intersection_types;
+        return Type::getStringFromFQCLN(
+            $this->value,
+            $namespace,
+            $aliased_classes,
+            $this_class,
+            true,
+            $this->was_static
+        ) . $intersection_types;
     }
 
     /**
@@ -106,12 +112,16 @@ class TNamedObject extends Atomic
             return null;
         }
 
+        if ($this->was_static) {
+            return 'self';
+        }
+
         return $this->toNamespacedString($namespace, $aliased_classes, $this_class, false);
     }
 
     public function canBeFullyExpressedInPhp(): bool
     {
-        return $this->value !== 'static';
+        return $this->value !== 'static' && $this->was_static === false;
     }
 
     public function replaceTemplateTypesWithArgTypes(

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -448,6 +448,9 @@ class MissingReturnTypeTest extends FileManipulationTest
                     }',
                 '<?php
                     class A {
+                        /**
+                         * @return $this
+                         */
                         public function foo(): self {
                             return $this;
                         }
@@ -650,7 +653,7 @@ class MissingReturnTypeTest extends FileManipulationTest
                 '<?php
                     class A {
                         /**
-                         * @return self
+                         * @return $this
                          */
                         public function foo() {
                             return $this;
@@ -659,7 +662,7 @@ class MissingReturnTypeTest extends FileManipulationTest
 
                     class B extends A {
                         /**
-                         * @return self
+                         * @return $this
                          */
                         public function foo() {
                             return $this;
@@ -687,7 +690,7 @@ class MissingReturnTypeTest extends FileManipulationTest
                 '<?php
                     class A {
                         /**
-                         * @return self
+                         * @return $this
                          */
                         public function foo() {
                             return $this;
@@ -698,7 +701,7 @@ class MissingReturnTypeTest extends FileManipulationTest
 
                     class C extends B {
                         /**
-                         * @return self
+                         * @return $this
                          */
                         public function foo() {
                             return $this;

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -449,7 +449,7 @@ class MissingReturnTypeTest extends FileManipulationTest
                 '<?php
                     class A {
                         /**
-                         * @return $this
+                         * @return static
                          */
                         public function foo(): self {
                             return $this;
@@ -653,7 +653,7 @@ class MissingReturnTypeTest extends FileManipulationTest
                 '<?php
                     class A {
                         /**
-                         * @return $this
+                         * @return static
                          */
                         public function foo() {
                             return $this;
@@ -662,7 +662,7 @@ class MissingReturnTypeTest extends FileManipulationTest
 
                     class B extends A {
                         /**
-                         * @return $this
+                         * @return static
                          */
                         public function foo() {
                             return $this;
@@ -690,7 +690,7 @@ class MissingReturnTypeTest extends FileManipulationTest
                 '<?php
                     class A {
                         /**
-                         * @return $this
+                         * @return static
                          */
                         public function foo() {
                             return $this;
@@ -701,7 +701,7 @@ class MissingReturnTypeTest extends FileManipulationTest
 
                     class C extends B {
                         /**
-                         * @return $this
+                         * @return static
                          */
                         public function foo() {
                             return $this;

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -557,7 +557,7 @@ class ReturnTypeManipulationTest extends FileManipulationTest
                 '<?php
                     class A {
                         /**
-                         * @return self
+                         * @return $this
                          */
                         public function getMe() {
                             return $this;

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -557,7 +557,7 @@ class ReturnTypeManipulationTest extends FileManipulationTest
                 '<?php
                     class A {
                         /**
-                         * @return $this
+                         * @return static
                          */
                         public function getMe() {
                             return $this;


### PR DESCRIPTION
This PR propose improving the handling of functions that return $this.

The goal is to transform this code:
```php
class HelloWorld
{
    public function sayHello()
    {
        return $this;
    }
}
```
into:

```php
class HelloWorld
{
    /**
     * @return $this
     */
    public function sayHello(): self
    {
        return $this;
    }
}
```

Bonus points: I want to propose another PR so that this example return `static` instead of `self` in PHP8 but I'm not sure how I'm supposed to access to the php version inside an Atomic. Can you give me a hint?