### PR TITLE
allow psalter to use static return type in PHP8

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1819,7 +1819,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                 $source->getFQCLN(),
                 true
             ),
-            $inferred_type->canBeFullyExpressedInPhp()
+            $inferred_type->canBeFullyExpressedInPhp($codebase->php_major_version, $codebase->php_minor_version)
         );
     }
 

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -900,7 +900,7 @@ class ReturnTypeAnalyzer
                 $source->getFQCLN(),
                 true
             ),
-            $inferred_return_type->canBeFullyExpressedInPhp(),
+            $inferred_return_type->canBeFullyExpressedInPhp($codebase->php_major_version, $codebase->php_minor_version),
             $function_like_storage ? $function_like_storage->return_type_description : null
         );
     }

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -571,7 +571,7 @@ abstract class Atomic implements TypeNode
         int $php_minor_version
     ): ?string;
 
-    abstract public function canBeFullyExpressedInPhp(): bool;
+    abstract public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool;
 
     public function replaceTemplateTypesWithStandins(
         TemplateResult $template_result,

--- a/src/Psalm/Type/Atomic/Scalar.php
+++ b/src/Psalm/Type/Atomic/Scalar.php
@@ -3,7 +3,7 @@ namespace Psalm\Type\Atomic;
 
 abstract class Scalar extends \Psalm\Type\Atomic
 {
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return true;
     }

--- a/src/Psalm/Type/Atomic/TArray.php
+++ b/src/Psalm/Type/Atomic/TArray.php
@@ -50,7 +50,7 @@ class TArray extends \Psalm\Type\Atomic
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return $this->type_params[0]->isArrayKey() && $this->type_params[1]->isMixed();
     }

--- a/src/Psalm/Type/Atomic/TArrayKey.php
+++ b/src/Psalm/Type/Atomic/TArrayKey.php
@@ -26,7 +26,7 @@ class TArrayKey extends Scalar
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TAssertionFalsy.php
+++ b/src/Psalm/Type/Atomic/TAssertionFalsy.php
@@ -31,7 +31,7 @@ class TAssertionFalsy extends \Psalm\Type\Atomic
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TCallable.php
+++ b/src/Psalm/Type/Atomic/TCallable.php
@@ -23,7 +23,7 @@ class TCallable extends \Psalm\Type\Atomic
         return 'callable';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return $this->params === null && $this->return_type === null;
     }

--- a/src/Psalm/Type/Atomic/TCallableObject.php
+++ b/src/Psalm/Type/Atomic/TCallableObject.php
@@ -28,7 +28,7 @@ class TCallableObject extends TObject
             ? 'object' : null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TCallableString.php
+++ b/src/Psalm/Type/Atomic/TCallableString.php
@@ -14,7 +14,7 @@ class TCallableString extends TString
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClassString.php
+++ b/src/Psalm/Type/Atomic/TClassString.php
@@ -96,7 +96,7 @@ class TClassString extends TString
         return 'class-string<\\' . $this->as . '>';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClassStringMap.php
+++ b/src/Psalm/Type/Atomic/TClassStringMap.php
@@ -122,7 +122,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
         return 'array';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClosedResource.php
+++ b/src/Psalm/Type/Atomic/TClosedResource.php
@@ -31,7 +31,7 @@ class TClosedResource extends \Psalm\Type\Atomic
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClosure.php
+++ b/src/Psalm/Type/Atomic/TClosure.php
@@ -11,7 +11,7 @@ class TClosure extends TNamedObject
     /** @var array<string, bool> */
     public $byref_uses = [];
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TConditional.php
+++ b/src/Psalm/Type/Atomic/TConditional.php
@@ -124,7 +124,7 @@ class TConditional extends \Psalm\Type\Atomic
         return [$this->conditional_type, $this->if_type, $this->else_type];
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TDependentGetClass.php
+++ b/src/Psalm/Type/Atomic/TDependentGetClass.php
@@ -37,7 +37,7 @@ class TDependentGetClass extends TString
             : 'class-string<' . $this->as_type->getId() . '>';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TDependentGetDebugType.php
+++ b/src/Psalm/Type/Atomic/TDependentGetDebugType.php
@@ -21,7 +21,7 @@ class TDependentGetDebugType extends TString
         $this->typeof = $typeof;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TDependentGetType.php
+++ b/src/Psalm/Type/Atomic/TDependentGetType.php
@@ -21,7 +21,7 @@ class TDependentGetType extends TString
         $this->typeof = $typeof;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TFalse.php
+++ b/src/Psalm/Type/Atomic/TFalse.php
@@ -7,13 +7,13 @@ class TFalse extends TBool
     {
         return 'false';
     }
-    
+
     public function getKey(bool $include_extra = true): string
     {
         return 'false';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TGenericObject.php
+++ b/src/Psalm/Type/Atomic/TGenericObject.php
@@ -45,7 +45,7 @@ class TGenericObject extends TNamedObject
         return $this->value . '<' . substr($s, 0, -2) . '>' . $extra_types;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/THtmlEscapedString.php
+++ b/src/Psalm/Type/Atomic/THtmlEscapedString.php
@@ -13,7 +13,7 @@ class THtmlEscapedString extends TString
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TIntMask.php
+++ b/src/Psalm/Type/Atomic/TIntMask.php
@@ -66,7 +66,7 @@ class TIntMask extends TInt
         return 'int-mask<' . substr($s, 0, -2) . '>';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TIntMaskOf.php
+++ b/src/Psalm/Type/Atomic/TIntMaskOf.php
@@ -56,7 +56,7 @@ class TIntMaskOf extends TInt
             . '>';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TIterable.php
+++ b/src/Psalm/Type/Atomic/TIterable.php
@@ -91,7 +91,7 @@ class TIterable extends Atomic
             : null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return $this->type_params[0]->isMixed() && $this->type_params[1]->isMixed();
     }

--- a/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
@@ -49,7 +49,7 @@ class TKeyOfClassConstant extends Scalar
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -194,7 +194,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -92,7 +92,7 @@ class TList extends \Psalm\Type\Atomic
         return 'array';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TLiteralClassString.php
+++ b/src/Psalm/Type/Atomic/TLiteralClassString.php
@@ -40,7 +40,7 @@ class TLiteralClassString extends TLiteralString
         return 'string';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TLowercaseString.php
@@ -13,7 +13,7 @@ class TLowercaseString extends TString
         return 'lowercase-string';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TMixed.php
+++ b/src/Psalm/Type/Atomic/TMixed.php
@@ -34,7 +34,7 @@ class TMixed extends \Psalm\Type\Atomic
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -109,19 +109,19 @@ class TNamedObject extends Atomic
         int $php_minor_version
     ): ?string {
         if ($this->value === 'static') {
-            return null;
+            return $php_major_version >= 8 ? 'static' : null;
         }
 
         if ($this->was_static) {
-            return 'self';
+            return $php_major_version >= 8 ? 'static' : 'self';
         }
 
         return $this->toNamespacedString($namespace, $aliased_classes, $this_class, false);
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
-        return $this->value !== 'static' && $this->was_static === false;
+        return ($this->value !== 'static' && $this->was_static === false) || $php_major_version >= 8;
     }
 
     public function replaceTemplateTypesWithArgTypes(

--- a/src/Psalm/Type/Atomic/TNever.php
+++ b/src/Psalm/Type/Atomic/TNever.php
@@ -26,7 +26,7 @@ class TNever extends \Psalm\Type\Atomic
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
@@ -16,7 +16,7 @@ class TNonEmptyLowercaseString extends TNonEmptyString
     /**
      * @return false
      */
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNull.php
+++ b/src/Psalm/Type/Atomic/TNull.php
@@ -26,7 +26,7 @@ class TNull extends \Psalm\Type\Atomic
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNumeric.php
+++ b/src/Psalm/Type/Atomic/TNumeric.php
@@ -26,7 +26,7 @@ class TNumeric extends Scalar
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNumericString.php
+++ b/src/Psalm/Type/Atomic/TNumericString.php
@@ -18,7 +18,7 @@ class TNumericString extends TString
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TObject.php
+++ b/src/Psalm/Type/Atomic/TObject.php
@@ -29,7 +29,7 @@ class TObject extends \Psalm\Type\Atomic
             : null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return true;
     }

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -173,7 +173,7 @@ class TObjectWithProperties extends TObject
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TPositiveInt.php
+++ b/src/Psalm/Type/Atomic/TPositiveInt.php
@@ -16,7 +16,7 @@ class TPositiveInt extends TInt
     /**
      * @return false
      */
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TResource.php
+++ b/src/Psalm/Type/Atomic/TResource.php
@@ -26,7 +26,7 @@ class TResource extends \Psalm\Type\Atomic
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TScalar.php
+++ b/src/Psalm/Type/Atomic/TScalar.php
@@ -26,7 +26,7 @@ class TScalar extends Scalar
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TScalarClassConstant.php
+++ b/src/Psalm/Type/Atomic/TScalarClassConstant.php
@@ -43,7 +43,7 @@ class TScalarClassConstant extends Scalar
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
+++ b/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
@@ -56,7 +56,7 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTemplateKeyOf.php
+++ b/src/Psalm/Type/Atomic/TTemplateKeyOf.php
@@ -61,7 +61,7 @@ class TTemplateKeyOf extends TArrayKey
     /**
      * @return false
      */
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTemplateParam.php
+++ b/src/Psalm/Type/Atomic/TTemplateParam.php
@@ -115,7 +115,7 @@ class TTemplateParam extends \Psalm\Type\Atomic
         return [$this->as];
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTemplateParamClass.php
+++ b/src/Psalm/Type/Atomic/TTemplateParamClass.php
@@ -58,7 +58,7 @@ class TTemplateParamClass extends TClassString
         return 'string';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTraitString.php
+++ b/src/Psalm/Type/Atomic/TTraitString.php
@@ -44,7 +44,7 @@ class TTraitString extends TString
         return 'trait-string';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTrue.php
+++ b/src/Psalm/Type/Atomic/TTrue.php
@@ -13,7 +13,7 @@ class TTrue extends TBool
         return 'true';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTypeAlias.php
+++ b/src/Psalm/Type/Atomic/TTypeAlias.php
@@ -73,7 +73,7 @@ class TTypeAlias extends \Psalm\Type\Atomic
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TValueOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TValueOfClassConstant.php
@@ -43,7 +43,7 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TVoid.php
+++ b/src/Psalm/Type/Atomic/TVoid.php
@@ -28,7 +28,7 @@ class TVoid extends \Psalm\Type\Atomic
             ? $this->getKey() : null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return true;
     }

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -475,7 +475,7 @@ class Union implements TypeNode
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         if (!$this->isSingleAndMaybeNullable()) {
             return false;
@@ -493,7 +493,7 @@ class Union implements TypeNode
 
         $atomic_type = array_values($types)[0];
 
-        return $atomic_type->canBeFullyExpressedInPhp();
+        return $atomic_type->canBeFullyExpressedInPhp($php_major_version, $php_minor_version);
     }
 
     public function removeType(string $type_string): bool

--- a/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
+++ b/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
@@ -13,7 +13,7 @@ class TSqlSelectString extends \Psalm\Type\Atomic\TLiteralString
         return 'sql-select-string(' . $this->value . ')';
     }
 
-    public function canBeFullyExpressedInPhp(): bool
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
     {
         return false;
     }

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -893,6 +893,78 @@ class MissingReturnTypeTest extends FileManipulationTest
                 ['MissingReturnType'],
                 false,
             ],
+            'staticReturn5.6' => [
+                '<?php
+                    class HelloWorld
+                    {
+                        public function sayHello()
+                        {
+                            return $this;
+                        }
+                    }',
+                '<?php
+                    class HelloWorld
+                    {
+                        /**
+                         * @return static
+                         */
+                        public function sayHello()
+                        {
+                            return $this;
+                        }
+                    }',
+                '5.6',
+                ['MissingReturnType'],
+                false,
+                true,
+            ],
+            'staticReturn7.0' => [
+                '<?php
+                    class HelloWorld
+                    {
+                        public function sayHello()
+                        {
+                            return $this;
+                        }
+                    }',
+                '<?php
+                    class HelloWorld
+                    {
+                        /**
+                         * @return static
+                         */
+                        public function sayHello(): self
+                        {
+                            return $this;
+                        }
+                    }',
+                '7.0',
+                ['MissingReturnType'],
+                false,
+                true,
+            ],
+            'staticReturn8.0' => [
+                '<?php
+                    class HelloWorld
+                    {
+                        public function sayHello()
+                        {
+                            return $this;
+                        }
+                    }',
+                '<?php
+                    class HelloWorld
+                    {
+                        public function sayHello(): static
+                        {
+                            return $this;
+                        }
+                    }',
+                '8.0',
+                ['MissingReturnType'],
+                false,
+                true,
+            ],
         ];
     }
 }


### PR DESCRIPTION
This PR propose allowing `static` return type when using Psalter starting from PHP8.

I had to change the signature of `canBeFullyExpressedInPhp` to add major and minor php version in order to remove the return phpdoc when it was identical to the return type