### PR TITLE
Fix whitespace in help output

### DIFF
--- a/src/psalm-language-server.php
+++ b/src/psalm-language-server.php
@@ -168,6 +168,7 @@ Options:
 
     --verbose
         Will send log messages to the client with information.
+
 HELP;
 
     exit;

--- a/src/psalter.php
+++ b/src/psalter.php
@@ -125,7 +125,7 @@ if (isset($options['c']) && is_array($options['c'])) {
 }
 
 if (array_key_exists('h', $options)) {
-    echo <<< HELP
+    echo <<<HELP
 Usage:
     psalter [options] [file...]
 
@@ -161,7 +161,7 @@ Options:
         If any issues can be fixed automatically, Psalm will update the codebase. To fix as many issues as possible,
         use --issues=all
 
-     --list-supported-issues
+    --list-supported-issues
         Display the list of issues that psalter knows how to fix
 
     --find-unused-code
@@ -181,6 +181,7 @@ Options:
 
     --no-cache
         Runs Psalm without using cache
+
 HELP;
 
     exit;


### PR DESCRIPTION
The help output needs an extra newline at the end so the shell prompt clears properly.
