### PR TITLE
use int|string in phpdoc format for array-key

### DIFF
--- a/src/Psalm/Type/Atomic/TArrayKey.php
+++ b/src/Psalm/Type/Atomic/TArrayKey.php
@@ -30,4 +30,16 @@ class TArrayKey extends Scalar
     {
         return false;
     }
+
+    /**
+     * @param array<string> $aliased_classes
+     */
+    public function toNamespacedString(
+        ?string $namespace,
+        array $aliased_classes,
+        ?string $this_class,
+        bool $use_phpdoc_format
+    ): string {
+        return $use_phpdoc_format ? '(int|string)' : 'array-key';
+    }
 }

--- a/src/Psalm/Type/Atomic/TTemplateKeyOf.php
+++ b/src/Psalm/Type/Atomic/TTemplateKeyOf.php
@@ -67,8 +67,7 @@ class TTemplateKeyOf extends TArrayKey
     }
 
     /**
-     * @param  array<string> $aliased_classes
-     *
+     * @param array<string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -965,6 +965,25 @@ class MissingReturnTypeTest extends FileManipulationTest
                 false,
                 true,
             ],
+            'arrayKeyReturn' => [
+                '<?php
+                    function scope(array $array) {
+                        return (array_keys($array))[0] ?? null;
+                    }',
+                '<?php
+                    /**
+                     * @return (int|string)|null
+                     *
+                     * @psalm-return array-key|null
+                     */
+                    function scope(array $array) {
+                        return (array_keys($array))[0] ?? null;
+                    }',
+                '7.1',
+                ['MissingReturnType'],
+                false,
+                true,
+            ],
         ];
     }
 }


### PR DESCRIPTION
This PR aims to fix https://github.com/vimeo/psalm/issues/4023

This is kind of a special case as array-key is in itself an union of two types. This means I had to add parenthesis to avoid errors in type construction. (For example, without them, we could get something like `int|string[]` to represent `array<array-key>`)

I also considered looking at $php_major_version to return int|string directly in return type but was confronted to an issue with nullable types: https://github.com/vimeo/psalm/issues/4643#issuecomment-731580141