### PR TITLE
avoid formating useless type

### DIFF
--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -410,14 +410,14 @@ class Union implements TypeNode
         $multi_floats = count($this->literal_float_types) > 1;
 
         foreach ($this->types as $type) {
-            $type_string = $type->toNamespacedString($namespace, $aliased_classes, $this_class, $use_phpdoc_format);
-
             if ($type instanceof TLiteralInt && !$multi_ints) {
                 $type_string = 'int';
             } elseif ($type instanceof TLiteralFloat && !$multi_floats) {
                 $type_string = 'float';
             } elseif ($type instanceof TLiteralString && !$multi_strings) {
                 $type_string = 'string';
+            } else {
+                $type_string = $type->toNamespacedString($namespace, $aliased_classes, $this_class, $use_phpdoc_format);
             }
 
             $types[] = $type_string;


### PR DESCRIPTION
This is a small PR to change a sub-optimal condition I encountered when reading the code.

The `$type_string` is first assigned with the return of a formatting function and possibly overrided by a litteral just below.