### PR TITLE
return string in phpdoc for a literal class-string

### DIFF
--- a/src/Psalm/Type/Atomic/TLiteralClassString.php
+++ b/src/Psalm/Type/Atomic/TLiteralClassString.php
@@ -65,6 +65,10 @@ class TLiteralClassString extends TLiteralString
         ?string $this_class,
         bool $use_phpdoc_format
     ): string {
+        if ($use_phpdoc_format) {
+            return 'string';
+        }
+
         if ($this->value === 'static') {
             return 'static::class';
         }


### PR DESCRIPTION
I don't think classname::class is valid phpdoc. It's not recognized by phpstorm either.

This PR format it as `string` in the `@return`. It will have no impact on `@psalm-return`