### PR TITLE
Emit an issue when returning a Stringable object when a string is expected

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -844,7 +844,9 @@ class Codebase
      */
     public function getDeclaringMethodId($method_id): ?string
     {
-        return $this->methods->getDeclaringMethodId(Internal\MethodIdentifier::wrap($method_id));
+        $new_method_id = $this->methods->getDeclaringMethodId(Internal\MethodIdentifier::wrap($method_id));
+
+        return $new_method_id ? (string) $new_method_id : null;
     }
 
     /**
@@ -855,7 +857,9 @@ class Codebase
      */
     public function getAppearingMethodId($method_id): ?string
     {
-        return $this->methods->getAppearingMethodId(Internal\MethodIdentifier::wrap($method_id));
+        $new_method_id = $this->methods->getAppearingMethodId(Internal\MethodIdentifier::wrap($method_id));
+
+        return $new_method_id ? (string) $new_method_id : null;
     }
 
     /**

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -18,6 +18,7 @@ use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\Internal\FileManipulation\FunctionDocblockManipulator;
+use Psalm\Issue\ImplicitToStringCast;
 use Psalm\Issue\InvalidFalsableReturnType;
 use Psalm\Issue\InvalidNullableReturnType;
 use Psalm\Issue\InvalidParent;
@@ -588,6 +589,20 @@ class ReturnTypeAnalyzer
                             return false;
                         }
                     }
+                }
+            }
+
+            if ($union_comparison_results->to_string_cast) {
+                if (IssueBuffer::accepts(
+                    new ImplicitToStringCast(
+                        'The declared return type for ' . $cased_method_id . ' expects \'' .
+                        $declared_return_type . '\', ' . '\'' . $inferred_return_type .
+                        '\' provided with a __toString method',
+                        $return_type_location
+                    ),
+                    $suppressed_issues
+                )) {
+                    // fall through
                 }
             }
 

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -1040,7 +1040,7 @@ class Methods
         $method_id = $this->getDeclaringMethodId($original_method_id);
 
         if ($method_id === null) {
-            return $original_method_id;
+            return (string) $original_method_id;
         }
 
         $fq_class_name = $method_id->fq_class_name;


### PR DESCRIPTION
This PR fix partially https://github.com/vimeo/psalm/issues/4235

It emits an ImplicitToStringCast when returning a Stringable object instead of a string to a method.

The other part of https://github.com/vimeo/psalm/issues/4235 was to do the same on property assignment but it seems more complicated.