### PR TITLE
Narrow inference of $a <=> $b from "int" to "-1|0|1"

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -161,7 +161,16 @@ class BinaryOpAnalyzer
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Spaceship) {
-            $statements_analyzer->node_data->setType($stmt, Type::getInt());
+            $statements_analyzer->node_data->setType(
+                $stmt,
+                new Type\Union(
+                    [
+                        new Type\Atomic\TLiteralInt(-1),
+                        new Type\Atomic\TLiteralInt(0),
+                        new Type\Atomic\TLiteralInt(1)
+                    ]
+                )
+            );
 
             self::addDataFlow(
                 $statements_analyzer,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -100,7 +100,13 @@ class SimpleTypeInferer
             }
 
             if ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Spaceship) {
-                return Type::getInt();
+                return new Type\Union(
+                    [
+                        new Type\Atomic\TLiteralInt(-1),
+                        new Type\Atomic\TLiteralInt(0),
+                        new Type\Atomic\TLiteralInt(1)
+                    ]
+                );
             }
 
             $stmt_left_type = self::infer(

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -318,6 +318,23 @@ class BinaryOperationTest extends TestCase
                         func("asdasdasd $a");
                     }'
             ],
+            'spaceshipOpIsLiteralUnionType' => [
+                '<?php
+                    /**
+                     * @psalm-param -1|0|1 $i
+                     */
+                     function onlyZeroOrPlusMinusOne(int $i): int {
+                         return $i;
+                     }
+
+                     /**
+                      * @psalm-param mixed $a
+                      * @psalm-param mixed $b
+                      */
+                     function foo($a, $b): void {
+                         onlyZeroOrPlusMinusOne($a <=> $b);
+                     }'
+            ]
         ];
     }
 


### PR DESCRIPTION
Resolves #4478 

Included test covers change to `BinaryOpAnalyzer::analyze`. I'm not certain how to trigger the same change in `SimpleTypeInferer::infer`.