### PR TITLE
Fix PDOStatement::fetchObject() return type

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -9796,7 +9796,7 @@ return [
 'PDOStatement::fetch' => ['mixed', 'how='=>'int', 'orientation='=>'int', 'offset='=>'int'],
 'PDOStatement::fetchAll' => ['array|false', 'how='=>'int', 'fetch_argument='=>'int|string|callable', 'ctor_args='=>'?array'],
 'PDOStatement::fetchColumn' => ['string|int|float|bool|null', 'column_number='=>'int'],
-'PDOStatement::fetchObject' => ['mixed|false', 'class_name='=>'string', 'ctor_args='=>'?array'],
+'PDOStatement::fetchObject' => ['object|false', 'class_name='=>'string', 'ctor_args='=>'?array'],
 'PDOStatement::getAttribute' => ['mixed', 'attribute'=>'int'],
 'PDOStatement::getColumnMeta' => ['array|false', 'column'=>'int'],
 'PDOStatement::nextRowset' => ['bool'],


### PR DESCRIPTION
According to [the manual](https://www.php.net/manual/en/pdostatement.fetchobject.php):

> Returns an instance of the required class with property names that correspond to the column names or FALSE on failure.

So: `object|false`