### PR TITLE
Fix PdoStatementReturnTypeProvider

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
@@ -37,20 +37,26 @@ class PdoStatementReturnTypeProvider implements \Psalm\Plugin\Hook\MethodReturnT
             $fetch_mode = $first_arg_type->getSingleIntLiteral()->value;
 
             switch ($fetch_mode) {
-                case \PDO::FETCH_ASSOC: // array<string,scalar>|false
+                case \PDO::FETCH_ASSOC: // array<string,scalar|null>|false
                     return new Type\Union([
                         new Type\Atomic\TArray([
                             Type::getString(),
-                            Type::getScalar(),
+                            new Type\Union([
+                                new Type\Atomic\TScalar(),
+                                new Type\Atomic\TNull()
+                            ])
                         ]),
                         new Type\Atomic\TFalse(),
                     ]);
 
-                case \PDO::FETCH_BOTH: // array<array-key,scalar>|false
+                case \PDO::FETCH_BOTH: // array<array-key,scalar|null>|false
                     return new Type\Union([
                         new Type\Atomic\TArray([
                             Type::getArrayKey(),
-                            Type::getScalar()
+                            new Type\Union([
+                                new Type\Atomic\TScalar(),
+                                new Type\Atomic\TNull()
+                            ])
                         ]),
                         new Type\Atomic\TFalse(),
                     ]);
@@ -84,9 +90,14 @@ class PdoStatementReturnTypeProvider implements \Psalm\Plugin\Hook\MethodReturnT
                         new Type\Atomic\TFalse(),
                     ]);
 
-                case \PDO::FETCH_NUM: // list<scalar>|false
+                case \PDO::FETCH_NUM: // list<scalar|null>|false
                     return new Type\Union([
-                        new Type\Atomic\TList(Type::getScalar()),
+                        new Type\Atomic\TList(
+                            new Type\Union([
+                                new Type\Atomic\TScalar(),
+                                new Type\Atomic\TNull()
+                            ])
+                        ),
                         new Type\Atomic\TFalse(),
                     ]);
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -603,7 +603,7 @@ class MethodCallTest extends TestCase
             ],
             'pdoStatementFetchAssoc' => [
                 '<?php
-                    /** @return array<string,scalar>|false */
+                    /** @return array<string,null|scalar>|false */
                     function fetch_assoc() {
                         $p = new PDO("sqlite::memory:");
                         $sth = $p->prepare("SELECT 1");
@@ -613,7 +613,7 @@ class MethodCallTest extends TestCase
             ],
             'pdoStatementFetchBoth' => [
                 '<?php
-                    /** @return array<scalar>|false */
+                    /** @return array<null|scalar>|false */
                     function fetch_both() {
                         $p = new PDO("sqlite::memory:");
                         $sth = $p->prepare("SELECT 1");
@@ -663,7 +663,7 @@ class MethodCallTest extends TestCase
             ],
             'pdoStatementFetchNum' => [
                 '<?php
-                    /** @return list<scalar>|false */
+                    /** @return list<null|scalar>|false */
                     function fetch_named() {
                         $p = new PDO("sqlite::memory:");
                         $sth = $p->prepare("SELECT 1");


### PR DESCRIPTION
Methods returning scalars may return `null` as well.

May fix #4382, although at first glance it looks like this provider only applies to `PDOStatement::fetch()`, unless I missed something?