### PR TITLE
Added PDOStatement->fetchObject() stub

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1848,7 +1848,7 @@ class Config
             $xdebug_stub_path = dirname(__DIR__, 2) . '/stubs/Xdebug.php';
 
             if (!file_exists($xdebug_stub_path)) {
-                throw new \UnexpectedValueException('Cannot locate XDebug stub');
+                throw new \UnexpectedValueException('Cannot locate Xdebug stub');
             }
 
             $stub_files[] = $xdebug_stub_path;

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1822,6 +1822,16 @@ class Config
             $core_generic_files[] = $stringable_path;
         }
 
+        if (class_exists('PDO', false)) {
+            $ext_pdo_path = dirname(__DIR__, 2) . '/stubs/pdo.php';
+
+            if (!file_exists($ext_pdo_path)) {
+                throw new \UnexpectedValueException('Cannot locate pdo classes');
+            }
+
+            $core_generic_files[] = $ext_pdo_path;
+        }
+
         if (\extension_loaded('ds')) {
             $ext_ds_path = dirname(__DIR__, 2) . '/stubs/ext-ds.php';
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1822,7 +1822,7 @@ class Config
             $core_generic_files[] = $stringable_path;
         }
 
-        if (class_exists('PDO', false)) {
+        if (\extension_loaded('PDO')) {
             $ext_pdo_path = dirname(__DIR__, 2) . '/stubs/pdo.php';
 
             if (!file_exists($ext_pdo_path)) {

--- a/stubs/pdo.php
+++ b/stubs/pdo.php
@@ -1,0 +1,10 @@
+<?php
+
+class PdoStatement {
+    /**
+     * @template T
+     * @param T $class
+     * @return T
+     */
+    public function fetchObject($class = "stdclass") {}
+}

--- a/stubs/pdo.php
+++ b/stubs/pdo.php
@@ -3,8 +3,8 @@
 class PdoStatement {
     /**
      * @template T
-     * @param T $class
-     * @return T
+     * @param class-string<T> $class
+     * @return false|T
      */
     public function fetchObject($class = "stdclass") {}
 }


### PR DESCRIPTION
adding a PDO Stub as mentioned in the referenced issue.

closes https://github.com/vimeo/psalm/issues/4685

This turns unexpected error message of https://psalm.dev/r/6431cc5c64

from

> LessSpecificReturnStatement - 13:14 - The type 'false|object' is more general than the declared return type 'User' for User::load_by_id

into

> InvalidReturnStatement - test.php:16:16 - The inferred type 'User::class|false' does not match the declared return type 'User|false' for User::load_by_id (see https://psalm.dev/128)

so its obvious the new stubs are picked up, but it seems psalm is still not able to match the types as expected.
it doesn't realize that `User::class` is the same as `self` in this context?

my testfile:

```
<?php

class User {
    // Private properties
    private $id, $name;

    private function __construct () {}

    /**
     * @return false|self
     */
    public static function load_by_id ($id) {
        $pdo = new pdo("my-dsn");
        $stmt = $pdo->prepare('SELECT id, name FROM users WHERE id=?');
        $stmt->execute([$id]);
        return $stmt->fetchObject(__CLASS__);
    }

}

$user = User::load_by_id(1);
/** @psalm-trace $user */
```