### PR TITLE
restore str_split as a list

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -749,7 +749,7 @@ function str_shuffle(string $str): string {}
 
 /**
  * @psalm-pure
- * @return array<string>
+ * @return list<string>
  *
  * @psalm-flow ($string) -> return
  */


### PR DESCRIPTION
As I reported here: https://github.com/vimeo/psalm/pull/4591#issuecomment-732769280 there were at least 3 false positives introduced in the PR.

I saw you fixed two of them earlier, this PR should fix the third one