### PR TITLE
Detect redundant cast

### DIFF
--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -104,7 +104,7 @@ class DocComment
                         $special[$type] = [];
                     }
 
-                    $line_number = $line_map && isset($line_map[$full_match]) ? $line_map[$full_match] : (int)$m;
+                    $line_number = $line_map && isset($line_map[$full_match]) ? $line_map[$full_match] : $m;
 
                     $special[$type][$line_number] = rtrim($data);
                 }
@@ -122,7 +122,7 @@ class DocComment
                         $special[$type] = [];
                     }
 
-                    $line_number = $line_map && isset($line_map[$_]) ? $line_map[$_] : (int)$m;
+                    $line_number = $line_map && isset($line_map[$_]) ? $line_map[$_] : $m;
 
                     $special[$type][$line_number] = $data;
                 }

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1502,7 +1502,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 $parent_fqcln = $this->getParentFQCLN();
 
                 if ($resolved_name === 'self' && $context->self) {
-                    $resolved_name = (string) $context->self;
+                    $resolved_name = $context->self;
                 } elseif ($resolved_name === 'parent' && $parent_fqcln) {
                     $resolved_name = $parent_fqcln;
                 }
@@ -1536,7 +1536,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 $parent_fqcln = $this->getParentFQCLN();
 
                 if ($resolved_name === 'self' && $context->self) {
-                    $resolved_name = (string) $context->self;
+                    $resolved_name = $context->self;
                 } elseif ($resolved_name === 'parent' && $parent_fqcln) {
                     $resolved_name = $parent_fqcln;
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -745,7 +745,7 @@ class ArrayAssignmentAnalyzer
                 $object_like = new TKeyedArray(
                     [$key_value->value => clone $current_type],
                     $key_value instanceof Type\Atomic\TLiteralClassString
-                        ? [(string) $key_value->value => true]
+                        ? [$key_value->value => true]
                         : null
                 );
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -9,6 +9,8 @@ use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\Issue\InvalidCast;
 use Psalm\Issue\PossiblyInvalidCast;
+use Psalm\Issue\RedundantCondition;
+use Psalm\Issue\RedundantConditionGivenDocblockType;
 use Psalm\Issue\UnrecognizedExpression;
 use Psalm\IssueBuffer;
 use Psalm\Type;
@@ -45,6 +47,26 @@ class CastAnalyzer
             $maybe_type = $statements_analyzer->node_data->getType($stmt->expr);
 
             if ($maybe_type) {
+                if ($maybe_type->isInt()) {
+                    if ($maybe_type->from_docblock) {
+                        $issue = new RedundantConditionGivenDocblockType(
+                            'Redundant cast to ' . $maybe_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $maybe_type->getKey()
+                        );
+                    } else {
+                        $issue = new RedundantCondition(
+                            'Redundant cast to ' . $maybe_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $maybe_type->getKey()
+                        );
+                    }
+
+                    if (IssueBuffer::accepts($issue, $statements_analyzer->getSuppressedIssues())) {
+                        // fall through
+                    }
+                }
+
                 $maybe = $maybe_type->getAtomicTypes();
 
                 if (count($maybe) === 1 && current($maybe) instanceof Type\Atomic\TBool) {
@@ -78,6 +100,28 @@ class CastAnalyzer
 
             $maybe_type = $statements_analyzer->node_data->getType($stmt->expr);
 
+            if ($maybe_type) {
+                if ($maybe_type->isFloat()) {
+                    if ($maybe_type->from_docblock) {
+                        $issue = new RedundantConditionGivenDocblockType(
+                            'Redundant cast to ' . $maybe_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $maybe_type->getKey()
+                        );
+                    } else {
+                        $issue = new RedundantCondition(
+                            'Redundant cast to ' . $maybe_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $maybe_type->getKey()
+                        );
+                    }
+
+                    if (IssueBuffer::accepts($issue, $statements_analyzer->getSuppressedIssues())) {
+                        // fall through
+                    }
+                }
+            }
+
             $type = Type::getFloat();
 
             if ($statements_analyzer->data_flow_graph
@@ -97,6 +141,28 @@ class CastAnalyzer
             }
 
             $maybe_type = $statements_analyzer->node_data->getType($stmt->expr);
+
+            if ($maybe_type) {
+                if ($maybe_type->isBool()) {
+                    if ($maybe_type->from_docblock) {
+                        $issue = new RedundantConditionGivenDocblockType(
+                            'Redundant cast to ' . $maybe_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $maybe_type->getKey()
+                        );
+                    } else {
+                        $issue = new RedundantCondition(
+                            'Redundant cast to ' . $maybe_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $maybe_type->getKey()
+                        );
+                    }
+
+                    if (IssueBuffer::accepts($issue, $statements_analyzer->getSuppressedIssues())) {
+                        // fall through
+                    }
+                }
+            }
 
             $type = Type::getBool();
 
@@ -119,6 +185,26 @@ class CastAnalyzer
             $stmt_expr_type = $statements_analyzer->node_data->getType($stmt->expr);
 
             if ($stmt_expr_type) {
+                if ($stmt_expr_type->isString()) {
+                    if ($stmt_expr_type->from_docblock) {
+                        $issue = new RedundantConditionGivenDocblockType(
+                            'Redundant cast to ' . $stmt_expr_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $stmt_expr_type->getKey()
+                        );
+                    } else {
+                        $issue = new RedundantCondition(
+                            'Redundant cast to ' . $stmt_expr_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $stmt_expr_type->getKey()
+                        );
+                    }
+
+                    if (IssueBuffer::accepts($issue, $statements_analyzer->getSuppressedIssues())) {
+                        // fall through
+                    }
+                }
+
                 $stmt_type = self::castStringAttempt(
                     $statements_analyzer,
                     $context,
@@ -170,6 +256,26 @@ class CastAnalyzer
             $all_permissible = false;
 
             if ($stmt_expr_type = $statements_analyzer->node_data->getType($stmt->expr)) {
+                if ($stmt_expr_type->isArray()) {
+                    if ($stmt_expr_type->from_docblock) {
+                        $issue = new RedundantConditionGivenDocblockType(
+                            'Redundant cast to ' . $stmt_expr_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $stmt_expr_type->getKey()
+                        );
+                    } else {
+                        $issue = new RedundantCondition(
+                            'Redundant cast to ' . $stmt_expr_type->getKey(),
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            $stmt_expr_type->getKey()
+                        );
+                    }
+
+                    if (IssueBuffer::accepts($issue, $statements_analyzer->getSuppressedIssues())) {
+                        // fall through
+                    }
+                }
+
                 $all_permissible = true;
 
                 foreach ($stmt_expr_type->getAtomicTypes() as $type) {

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -315,13 +315,13 @@ class Reflection
     private function getReflectionParamData(\ReflectionParameter $param): FunctionLikeParameter
     {
         $param_type = self::getPsalmTypeFromReflectionType($param->getType());
-        $param_name = (string)$param->getName();
+        $param_name = $param->getName();
 
-        $is_optional = (bool)$param->isOptional();
+        $is_optional = $param->isOptional();
 
         $parameter = new FunctionLikeParameter(
             $param_name,
-            (bool)$param->isPassedByReference(),
+            $param->isPassedByReference(),
             $param_type,
             null,
             null,

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -506,7 +506,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
             throw new \InvalidArgumentException("Not a valid file URI: $uri");
         }
 
-        $filepath = urldecode((string) $fragments['path']);
+        $filepath = urldecode($fragments['path']);
 
         if (strpos($filepath, ':') !== false) {
             if ($filepath[0] === '/') {

--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -92,7 +92,7 @@ class StatementsProvider
 
         $from_cache = false;
 
-        $version = (string) PHP_PARSER_VERSION . $this->this_modified_time;
+        $version = PHP_PARSER_VERSION . $this->this_modified_time;
 
         $file_contents = $this->file_provider->getContents($file_path);
         $modified_time = $this->file_provider->getModifiedTime($file_path);

--- a/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
@@ -166,8 +166,8 @@ class ObjectComparator
                     && $intersection_input_type instanceof TTemplateParam
                 ) {
                     if ($intersection_container_type->param_name !== $intersection_input_type->param_name
-                        || ((string)$intersection_container_type->defining_class
-                            !== (string)$intersection_input_type->defining_class
+                        || ($intersection_container_type->defining_class
+                            !== $intersection_input_type->defining_class
                             && \substr($intersection_input_type->defining_class, 0, 3) !== 'fn-'
                             && \substr($intersection_container_type->defining_class, 0, 3) !== 'fn-')
                     ) {

--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -569,7 +569,7 @@ class TypeCombiner
             }
 
             if (!$allow_mixed_union) {
-                return Type::getMixed((bool) $combination->mixed_from_loop_isset);
+                return Type::getMixed($combination->mixed_from_loop_isset);
             }
         }
 

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -891,7 +891,7 @@ class TypeParser
                 $offset_template_type = array_values($offset_template_data[''][0]->getAtomicTypes())[0];
 
                 if ($offset_template_type instanceof Atomic\TTemplateKeyOf) {
-                    $offset_defining_class = (string) $offset_template_type->defining_class;
+                    $offset_defining_class = $offset_template_type->defining_class;
                 }
             }
 

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1421,6 +1421,30 @@ class Union implements TypeNode
     }
 
     /**
+     * @return bool true if this is a boolean
+     */
+    public function isBool(): bool
+    {
+        if (!$this->isSingle()) {
+            return false;
+        }
+
+        return isset($this->types['bool']);
+    }
+
+    /**
+     * @return bool true if this is an array
+     */
+    public function isArray(): bool
+    {
+        if (!$this->isSingle()) {
+            return false;
+        }
+
+        return isset($this->types['array']);
+    }
+
+    /**
      * @return bool true if this is a string literal with only one possible value
      */
     public function isSingleStringLiteral(): bool

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -129,7 +129,7 @@ function requireAutoloaders(string $current_dir, bool $has_explicit_root, string
         exit(1);
     }
 
-    define('PSALM_VERSION', (string)\PackageVersions\Versions::getVersion('vimeo/psalm'));
+    define('PSALM_VERSION', \PackageVersions\Versions::getVersion('vimeo/psalm'));
     define('PHP_PARSER_VERSION', \PackageVersions\Versions::getVersion('nikic/php-parser'));
 
     return $first_autoloader;

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -821,7 +821,7 @@ if (!isset($options['i'])) {
 
         $init_level = \Psalm\Config\Creator::getLevel(
             array_merge(...array_values($issues_by_file)),
-            (int) array_sum($mixed_counts)
+            array_sum($mixed_counts)
         );
     }
 

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1032,18 +1032,6 @@ class ArrayAssignmentTest extends TestCase
                     '$b' => 'array<empty, empty>',
                 ],
             ],
-            'coerceListToArray' => [
-                '<?php
-                    /**
-                     * @param list<int> $_bar
-                     */
-                    function foo(array $_bar) : void {}
-
-                    /**
-                     * @param list<int> $bar
-                     */
-                    function baz(array $bar) : void { foo((array) $bar); }',
-            ],
             'getOnCoercedArray' => [
                 '<?php
                     function getArray() : array {
@@ -1883,6 +1871,19 @@ class ArrayAssignmentTest extends TestCase
                     $a = new class{public function __toString(){return "";}};
                     $_a = [$a => "a"];',
                 'error_message' => 'InvalidArrayOffset',
+            ],
+            'coerceListToArray' => [
+                '<?php
+                    /**
+                     * @param list<int> $_bar
+                     */
+                    function foo(array $_bar) : void {}
+
+                    /**
+                     * @param list<int> $bar
+                     */
+                    function baz(array $bar) : void { foo((array) $bar); }',
+                'error_message' => 'RedundantCondition',
             ],
         ];
     }

--- a/tests/ClassLoadOrderTest.php
+++ b/tests/ClassLoadOrderTest.php
@@ -107,7 +107,7 @@ class ClassLoadOrderTest extends TestCase
                     class B extends A {
                         /** @return void */
                         public function foo() {
-                            echo (string)(new C)->bar;
+                            echo (new C)->bar;
                         }
                     }
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -453,7 +453,7 @@ class MethodCallTest extends TestCase
             'defineVariableCreatedInArgToMixed' => [
                 '<?php
                     function bar($a) : void {
-                        if ($a->foo($b = (int) 5)) {
+                        if ($a->foo($b = (int) "5")) {
                             echo $b;
                         }
                     }',

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -496,7 +496,7 @@ class MethodSignatureTest extends TestCase
                         {
                             [
                                 $this->id,
-                            ] = (array) \unserialize((string) $serialized);
+                            ] = (array) \unserialize($serialized);
                         }
 
                         public function serialize() : string

--- a/tests/TypeReconciliation/AssignmentInConditionalTest.php
+++ b/tests/TypeReconciliation/AssignmentInConditionalTest.php
@@ -355,7 +355,7 @@ class AssignmentInConditionalTest extends \Psalm\Tests\TestCase
             'passedByRefInIf' => [
                 '<?php
                     if (preg_match("/bad/", "badger", $matches)) {
-                        echo (string)$matches[0];
+                        echo $matches[0];
                     }',
             ],
             'passByRefInIfCheckAfter' => [
@@ -363,13 +363,13 @@ class AssignmentInConditionalTest extends \Psalm\Tests\TestCase
                     if (!preg_match("/bad/", "badger", $matches)) {
                         exit();
                     }
-                    echo (string)$matches[0];',
+                    echo $matches[0];',
             ],
             'passByRefInIfWithBoolean' => [
                 '<?php
                     $a = (bool)rand(0, 1);
                     if ($a && preg_match("/bad/", "badger", $matches)) {
-                        echo (string)$matches[0];
+                        echo $matches[0];
                     }',
             ],
             'bleedElseifAssignedVarsIntoElseScope' => [

--- a/tests/TypeReconciliation/ScopeTest.php
+++ b/tests/TypeReconciliation/ScopeTest.php
@@ -40,7 +40,7 @@ class ScopeTest extends \Psalm\Tests\TestCase
                 '<?php
                     $a = preg_match("/bad/", "badger", $matches) > 0;
                     if ($a) {
-                        echo (string)$matches[1];
+                        echo $matches[1];
                     }',
             ],
             'functionExists' => [

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -147,10 +147,10 @@ class UnusedVariableTest extends TestCase
             ],
             'varRedefinedInIfWithReference' => [
                 '<?php
-                    $a = (string) "fdf";
+                    $a = (string) 5;
 
                     if (rand(0, 1)) {
-                        $a = (string) "ard";
+                        $a = (string) 6;
                     }
 
                     echo $a;',


### PR DESCRIPTION
This PR intends to fix https://github.com/vimeo/psalm/issues/1767

However, when I look at issues emitted in Psalm itself, I'm surprised to see this for example:
```
ERROR: RedundantConditionGivenDocblockType - src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php:1505:38 - Redundant cast to string (see https://psalm.dev/156)
                    $resolved_name = (string) $context->self;

```
This is a cast to string from a property defined as:
```
   /**
     * @var string|null
     */
    public $self;
```

This cast seems valid. That means, the detection of Union::isString() seems broken and don't see that the string is nullable. But I don't get it, it's used many times in the code and doesn't seem to cause issues. Am I missing something?