### PR TITLE
Declare PdoStatement->fetchObject($class_name) a taint sink

### DIFF
--- a/stubs/pdo.php
+++ b/stubs/pdo.php
@@ -2,6 +2,8 @@
 
 class PdoStatement {
     /**
+     * @psalm-taint-sink text $class
+     *
      * @template T
      * @param class-string<T> $class
      * @return false|T

--- a/stubs/pdo.php
+++ b/stubs/pdo.php
@@ -2,7 +2,7 @@
 
 class PdoStatement {
     /**
-     * @psalm-taint-sink text $class
+     * @psalm-taint-sink callable $class
      *
      * @template T
      * @param class-string<T> $class


### PR DESCRIPTION
IMO a string used by the engine to construct a object should never be end-user-controlled