### PR TITLE
fix wrong cast to int when string offset is a number > MAX INT

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -15,6 +15,7 @@ use function preg_match;
 use function array_merge;
 use function array_values;
 use function count;
+use const PHP_INT_MAX;
 
 /**
  * @internal
@@ -170,6 +171,7 @@ class ArrayAnalyzer
 
                     if ($item->key instanceof PhpParser\Node\Scalar\String_
                         && preg_match('/^(0|[1-9][0-9]*)$/', $item->key->value)
+                        && (int) $item->key->value <= PHP_INT_MAX
                     ) {
                         $key_type = Type::getInt(false, (int) $item->key->value);
                     }


### PR DESCRIPTION
This PR is an attempt to fix https://github.com/vimeo/psalm/issues/4698