### PR TITLE
Allow reconciling between object and iterable

### DIFF
--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -941,6 +941,14 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                 ]);
                 $non_object_types[] = new Atomic\TCallableString();
                 $did_remove_type = true;
+            } elseif ($type instanceof Atomic\TIterable) {
+                $clone_type = clone $type;
+
+                self::refineArrayKey($clone_type->type_params[0]);
+
+                $non_object_types[] = new TArray($clone_type->type_params);
+
+                $did_remove_type = true;
             } elseif (!$type->isObjectType()) {
                 $non_object_types[] = $type;
             } else {

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -134,6 +134,8 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
             'traversableToIntersection' => ['Countable&Traversable', 'Traversable', 'Countable'],
             'iterableWithoutParamsToTraversableWithoutParams' => ['Traversable', '!array', 'iterable'],
             'iterableWithParamsToTraversableWithParams' => ['Traversable<int, string>', '!array', 'iterable<int, string>'],
+            'iterableAndObject' => ['ArrayAccess|array<int, string>', 'object', 'iterable<int, string>'],
+            'iterableAndNotObject' => ['array<int, string>', '!object', 'iterable<int, string>'],
         ];
     }
 


### PR DESCRIPTION
This is an attempt to fix https://github.com/vimeo/psalm/issues/4664

I wanted to reconcile:
- `iterable<TKey, TValue>` and `!object` to `array<Tkey, TValue>`
- `iterable<TKey, TValue>` and `object` to `ArrayAccess<Tkey, TValue>`, the closest I could find was an union `array<Tkey, TValue>` and `TNamedObject('ArrayAccess')`. I'm really not sur about this one

For this, I looked how we reconcile `TIterable` to array and we use a refineArrayKey method which wasn't in SimpleNegatedAssertionReconciler so I made it protected and moved it in Reconciler