### PR TITLE
Fix PHPMAXINT offset

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -171,7 +171,10 @@ class ArrayAnalyzer
 
                     if ($item->key instanceof PhpParser\Node\Scalar\String_
                         && preg_match('/^(0|[1-9][0-9]*)$/', $item->key->value)
-                        && (int) $item->key->value <= PHP_INT_MAX
+                        && (
+                            (int) $item->key->value < PHP_INT_MAX ||
+                            $item->key->value === (string) PHP_INT_MAX
+                        )
                     ) {
                         $key_type = Type::getInt(false, (int) $item->key->value);
                     }

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1545,6 +1545,14 @@ class ArrayAssignmentTest extends TestCase
                     $_a = [$b => "a"];
                 ',
             ],
+            'ArrayOffsetNumericSupPHPINTMAX' => [
+                '<?php
+                    $_a = [
+                        "9223372036854775808" => 1,
+                        "9223372036854775809" => 2
+                    ];
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
I messed up in https://github.com/vimeo/psalm/pull/4702. I must have left cache active while running my test file locally but the fix was not correct. Plus, I didn't add a unit test for it. This one should be better.

It fixes https://github.com/vimeo/psalm/issues/4698 once again :)