### PR TITLE
Migrate PHPUnit configuration

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,43 +11,41 @@
          verbose="true"
          executionOrder="random"
 >
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">src/Psalm/Issue/</directory>
+            <directory suffix=".php">src/Psalm/Internal/Stubs/</directory>
+            <directory suffix=".php">src/Psalm/Internal/LanguageServer/</directory>
+            <directory suffix=".php">src/Psalm/Internal/ExecutionEnvironment/</directory>
+            <directory suffix=".php">src/Psalm/SourceControl/</directory>
+            <file>src/command_functions.php</file>
+            <file>src/psalm.php</file>
+            <file>src/psalm-language-server.php</file>
+            <file>src/psalter.php</file>
+            <file>src/psalm_plugin.php</file>
+            <file>src/psalm-refactor.php</file>
+            <file>src/Psalm/Plugin/Shepherd.php</file>
+            <file>src/Psalm/Internal/CallMap.php</file>
+            <file>src/Psalm/Internal/Fork/Pool.php</file>
+            <file>src/Psalm/Internal/Fork/Restarter.php</file>
+            <file>src/Psalm/Internal/PropertyMap.php</file>
+            <file>src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php</file>
+            <file>src/Psalm/Internal/Provider/FileReferenceCacheProvider.php</file>
+            <file>src/Psalm/Internal/Provider/FileStorageCacheProvider.php</file>
+            <file>src/Psalm/Internal/Provider/ParserCacheProvider.php</file>
+        </exclude>
+        <report>
+            <clover outputFile="build/logs/clover.xml"/>
+            <html outputDirectory="build/logs/phpunit-html/"/>
+        </report>
+    </coverage>
+
     <testsuites>
         <testsuite name="psalm">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-            <exclude>
-                <directory suffix=".php">src/Psalm/Issue/</directory>
-                <directory suffix=".php">src/Psalm/Internal/Stubs/</directory>
-                <directory suffix=".php">src/Psalm/Internal/LanguageServer/</directory>
-                <directory suffix=".php">src/Psalm/Internal/ExecutionEnvironment/</directory>
-                <directory suffix=".php">src/Psalm/SourceControl/</directory>
-                <file>src/command_functions.php</file>
-                <file>src/psalm.php</file>
-                <file>src/psalm-language-server.php</file>
-                <file>src/psalter.php</file>
-                <file>src/psalm_plugin.php</file>
-                <file>src/psalm-refactor.php</file>
-                <file>src/Psalm/Plugin/Shepherd.php</file>
-                <file>src/Psalm/Internal/CallMap.php</file>
-                <file>src/Psalm/Internal/Fork/Pool.php</file>
-                <file>src/Psalm/Internal/Fork/Restarter.php</file>
-                <file>src/Psalm/Internal/PropertyMap.php</file>
-                <file>src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php</file>
-                <file>src/Psalm/Internal/Provider/FileReferenceCacheProvider.php</file>
-                <file>src/Psalm/Internal/Provider/FileStorageCacheProvider.php</file>
-                <file>src/Psalm/Internal/Provider/ParserCacheProvider.php</file>
-            </exclude>
-        </whitelist>
-    </filter>
-
-    <logging>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-        <log type="coverage-html" target="build/logs/phpunit-html/"/>
-    </logging>
 </phpunit>
-


### PR DESCRIPTION
While running some tests I noticed this warning:

```
PHPUnit 9.4.3 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.12 with Xdebug 2.9.8
Configuration: /opt/project/phpunit.xml.dist
Random Seed:   1606407050
Warning:       Your XML configuration validates against a deprecated schema.
Suggestion:    Migrate your XML configuration using "--migrate-configuration"!
```

As suggested, I used `vendor/bin/phpunit --migrate-configuration` to perform the migration, followed by some manual reformatting.

The migration refactored `xsi:noNamespaceSchemaLocation` to point to `https://schema.phpunit.de/9.3/phpunit.xsd`. I reverted that to `./vendor/phpunit/phpunit/phpunit.xsd` but if you want I can change it to point to schema.phpunit.de