### PR TITLE
Allow <false|T as object> to be falsy

### DIFF
--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -165,7 +165,8 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                 $suppressed_issues,
                 $failed_reconciliation,
                 $is_equality,
-                $is_strict_equality
+                $is_strict_equality,
+                false
             );
         }
 
@@ -540,7 +541,8 @@ class SimpleNegatedAssertionReconciler extends Reconciler
         array $suppressed_issues,
         int &$failed_reconciliation,
         bool $is_equality,
-        bool $is_strict_equality
+        bool $is_strict_equality,
+        bool $recursive_check
     ) : Type\Union {
         $old_var_type_string = $existing_var_type->getId();
         $existing_var_atomic_types = $existing_var_type->getAtomicTypes();
@@ -757,7 +759,8 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                         $suppressed_issues,
                         $template_did_fail,
                         $is_equality,
-                        $is_strict_equality
+                        $is_strict_equality,
+                        true
                     );
 
                     $did_remove_type = true;
@@ -777,7 +780,10 @@ class SimpleNegatedAssertionReconciler extends Reconciler
         $existing_var_type->possibly_undefined = false;
         $existing_var_type->possibly_undefined_from_try = false;
 
-        if ((!$did_remove_type || empty($existing_var_type->getAtomicTypes())) && !$existing_var_type->hasTemplate()) {
+        if ((!$did_remove_type || empty($existing_var_type->getAtomicTypes())) &&
+            !$existing_var_type->hasTemplate() &&
+            !$recursive_check //don't emit issue if we're checking a subtype
+        ) {
             if ($key && $code_location && !$is_equality) {
                 self::triggerIssueForImpossible(
                     $existing_var_type,


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/4359

The issue was that `reconcileFalsyOrEmpty` is recursive in case of templates. Unfortunately, reconciling the result of the template with the assertion can emit an issue by itself. I made it so recursive calls can't emit issues anymore.

Note: I wanted to add a test for that, but I'm not sure what notation should be used for representing templates in the tests