### PR TITLE
better fix for reconciling iterable and object

### DIFF
--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1213,7 +1213,7 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
 
                 self::refineArrayKey($clone_type->type_params[0]);
 
-                $object_types[] = new Type\Atomic\TGenericObject('ArrayAccess', $clone_type->type_params);
+                $object_types[] = new Type\Atomic\TGenericObject('Traversable', $clone_type->type_params);
 
                 $did_remove_type = true;
             } else {

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -130,7 +130,7 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
             'traversableToIntersection' => ['Countable&Traversable', 'Traversable', 'Countable'],
             'iterableWithoutParamsToTraversableWithoutParams' => ['Traversable', '!array', 'iterable'],
             'iterableWithParamsToTraversableWithParams' => ['Traversable<int, string>', '!array', 'iterable<int, string>'],
-            'iterableAndObject' => ['ArrayAccess<int, string>', 'object', 'iterable<int, string>'],
+            'iterableAndObject' => ['Traversable<int, string>', 'object', 'iterable<int, string>'],
             'iterableAndNotObject' => ['array<int, string>', '!object', 'iterable<int, string>'],
         ];
     }


### PR DESCRIPTION
As @weirdan noted, an iterable without array becomes a Traversable, not ArrayAccess