### PR TITLE
fix array_column with possibly_undefined keys

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
@@ -92,10 +92,13 @@ class ArrayColumnReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturn
         // calculate results
         if ($row_shape instanceof Type\Atomic\TKeyedArray) {
             if ((null !== $value_column_name) && isset($row_shape->properties[$value_column_name])) {
-                if ($input_array_not_empty) {
+                $result_element_type = $row_shape->properties[$value_column_name];
+                // When the selected key is possibly_undefined, the resulting array can be empty
+                if ($input_array_not_empty && $result_element_type->possibly_undefined !== true) {
                     $have_at_least_one_res = true;
                 }
-                $result_element_type = $row_shape->properties[$value_column_name];
+                //array_column skips undefined elements so resulting type is necesseraly defined
+                $result_element_type->possibly_undefined = false;
             } else {
                 $result_element_type = Type::getMixed();
             }

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1151,6 +1151,8 @@ class ArrayFunctionCallTest extends TestCase
                     function makeShapeArray(): array { return []; }
                     /** @return array<array{0:string}|int> */
                     function makeUnionArray(): array { return []; }
+                    /** @return array<string, array{x?:int, y?:int, width?:int, height?:int}> */
+                    function makeKeyedArray(): array { return []; }
                     $a = array_column([[1], [2], [3]], 0);
                     $b = array_column([["a" => 1], ["a" => 2], ["a" => 3]], "a");
                     $c = array_column([["k" => "a", "v" => 1], ["k" => "b", "v" => 2]], "v", "k");
@@ -1162,6 +1164,10 @@ class ArrayFunctionCallTest extends TestCase
                     $i = array_column(makeShapeArray(), 0);
                     $j = array_column(makeUnionArray(), 0);
                     $k = array_column([[0 => "test"]], 0);
+                    $l = array_column(makeKeyedArray(), "y");
+                    $m_prepare = makeKeyedArray();
+                    assert($m_prepare !== []);
+                    $m = array_column($m_prepare, "y");
                 ',
                 'assertions' => [
                     '$a' => 'non-empty-list<int>',
@@ -1175,6 +1181,8 @@ class ArrayFunctionCallTest extends TestCase
                     '$i' => 'list<string>',
                     '$j' => 'list<mixed>',
                     '$k' => 'non-empty-list<string>',
+                    '$l' => 'list<int>',
+                    '$m' => 'list<int>',
                 ],
             ],
             'splatArrayIntersect' => [
@@ -1868,6 +1876,15 @@ class ArrayFunctionCallTest extends TestCase
                         if (count($list) === 2) {
                             foo($list);
                         }
+                    }'
+            ],
+            'arrayColumnwithKeyedArrayWithoutRedundantUnion' => [
+                '<?php
+                    /**
+                     * @param array<string, array{x?:int, y?:int, width?:int, height?:int}> $foos
+                     */
+                    function foo(array $foos): void {
+                        array_multisort($formLayoutFields, SORT_ASC, array_column($foos, "y"));
                     }'
             ],
         ];


### PR DESCRIPTION
This PR should really fix https://github.com/vimeo/psalm/issues/4285 this time!

The issue was that the provider for array_column didn't take into account the fact that the key could be possibly_undefined.

This allowed two bugs:
- The resulting type of array_column on a possibly_undefined key was a list<int> but with the possibly_undefined flag so it was not accepted by functions expecting a correct list
- When the initial array was a non-empty array, there was a special case to return a non-empty result. This is not always the case on possibly_undefined columns because if they're all undefined, it returns an empty result