### PR TITLE
Added test to enforce that all supported annotations are documented

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -475,6 +475,38 @@ class User {
 }
 ```
 
+### `@psalm-require-extends`
+
+The @psalm-require-extends-annotation allows you to define a requirements that a trait imposes on the using class.
+
+```php
+abstract class DatabaseModel {
+  // methods, properties, etc.
+}
+
+/**
+ * @psalm-require-extends DatabaseModel
+ */
+trait SoftDeletingTrait {
+  // useful but scoped functionality, that depends on methods/properties from DatabaseModel
+}
+
+
+class MyModel extends DatabaseModel {
+  // valid
+  use SoftDeletingTrait;
+}
+
+class NormalClass {
+  // triggers an error
+  use SoftDeletingTrait;
+}
+```
+
+### `@psalm-require-implements`
+
+Behaves the same way as `@psalm-require-extends`, but for interfaces.
+
 ## Type Syntax
 
 Psalm supports PHPDoc’s [type syntax](https://docs.phpdoc.org/latest/guides/types.html), and also the [proposed PHPDoc PSR type syntax](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types).

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -7,7 +7,7 @@ Psalm supports a wide range of docblock annotations.
 Psalm uses the following PHPDoc tags to understand your code:
 
 - [`@var`](https://docs.phpdoc.org/latest/references/phpdoc/tags/var.html)
-  Used for specifying the types of properties and variables
+  Used for specifying the types of properties and variables@
 - [`@return`](https://docs.phpdoc.org/latest/references/phpdoc/tags/return.html)
   Used for specifying the return types of functions, methods and closures
 - [`@param`](https://docs.phpdoc.org/latest/references/phpdoc/tags/param.html)
@@ -68,7 +68,7 @@ function addFoo(?string &$s) : void {
 }
 ```
 
-### `@psalm-var`, `@psalm-param`, `@psalm-return`, `@psalm-property`, `@psalm-property-read`, `@psalm-property-write`
+### `@psalm-var`, `@psalm-param`, `@psalm-return`, `@psalm-property`, `@psalm-property-read`, `@psalm-property-write`, `@psalm-method`
 
 When specifying types in a format not supported by phpDocumentor ([but supported by Psalm](#type-syntax)) you may wish to prepend `@psalm-` to the PHPDoc tag, so as to avoid confusing your IDE. If a `@psalm`-prefixed tag is given, Psalm will use it in place of its non-prefixed counterpart.
 

--- a/docs/annotating_code/templated_annotations.md
+++ b/docs/annotating_code/templated_annotations.md
@@ -68,9 +68,9 @@ class One_off_instance_of_MyContainer {
 
 This pattern can be used in large number of different situations like mocking, collections, iterators and loading arbitrary objects. Psalm has a large number of annotations to make it easy to use templated types in your codebase.
 
-## `@template`
+## `@template`, `@psalm-template`
 
-The `@template` tag allows classes and functions to declare a generic type parameter.
+The `@template`/`@psalm-template` tag allows classes and functions to declare a generic type parameter.
 
 As a very simple example, this function returns whatever is passed in:
 

--- a/docs/annotating_code/templated_annotations.md
+++ b/docs/annotating_code/templated_annotations.md
@@ -380,7 +380,7 @@ function takesDogList(Collection $dog_collection) : void {
 
 Here we're not doing anything bad – we're just iterating over an array of objects. But Psalm still gives that same basic error – "getNoises expects a `Collection<Animal>`, but `Collection<Dog>` was passed".
 
-We can tell Psalm that it's safe to pass subtypes for the templated param `T` by using the annotation `@template-covariant T`:
+We can tell Psalm that it's safe to pass subtypes for the templated param `T` by using the annotation `@template-covariant T` (or `@psalm-template-covariant T`):
 
 ```php
 <?php

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -22,7 +22,7 @@ use function strspn;
 
 class DocComment
 {
-    private const PSALM_ANNOTATIONS = [
+    public const PSALM_ANNOTATIONS = [
         'return', 'param', 'template', 'var', 'type',
         'template-covariant', 'property', 'property-read', 'property-write', 'method',
         'assert', 'assert-if-true', 'assert-if-false', 'suppress',

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -298,6 +298,7 @@ class DocumentationTest extends TestCase
         );
     }
 
+    /** @var list<string> */
     private static $annotationDocs = [
         'docs/annotating_code/supported_annotations.md',
         'docs/annotating_code/templated_annotations.md',
@@ -305,6 +306,7 @@ class DocumentationTest extends TestCase
         'docs/security_analysis/annotations.md',
     ];
 
+    /** @var string */
     private static $docContents = '';
 
     /** @dataProvider knownAnnotations */
@@ -328,11 +330,12 @@ class DocumentationTest extends TestCase
         );
     }
 
+    /** @var list<string> */
     private static $intentionallyUndocumentedAnnotations = [
         'self-out', // I'm fairly sure it's intentionally undocumented, but can't find the reference
     ];
 
-    /** @return iterable<int, string> */
+    /** @return iterable<string, array{string}> */
     public function knownAnnotations(): iterable
     {
         foreach (DocComment::PSALM_ANNOTATIONS as $annotation) {

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -332,11 +332,7 @@ class DocumentationTest extends TestCase
 
         $this->assertThat(
             self::$docContents,
-            $this->conciseExpected(
-                $this->logicalOr(
-                    $this->stringContains('@psalm-' . $annotation)
-                )
-            ),
+            $this->conciseExpected($this->stringContains('@psalm-' . $annotation)),
             "'@psalm-$annotation' is not present in the docs"
         );
     }

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -1,35 +1,38 @@
 <?php
+
 namespace Psalm\Tests;
 
+use DOMAttr;
+use DOMDocument;
+use DOMXPath;
+use PHPUnit\Framework\Constraint\Constraint;
+use Psalm\Config;
+use Psalm\Context;
+use Psalm\DocComment;
+use Psalm\Internal\RuntimeCaches;
+use Psalm\Tests\Internal\Provider;
+
+use function array_filter;
 use function array_keys;
+use function array_shift;
 use function count;
-use const DIRECTORY_SEPARATOR;
-use const LIBXML_NONET;
 use function dirname;
 use function explode;
 use function file_exists;
 use function file_get_contents;
+use function glob;
 use function implode;
+use function in_array;
 use function preg_quote;
-use Psalm\Config;
-use Psalm\Context;
-use Psalm\Tests\Internal\Provider;
 use function sort;
 use function strpos;
+use function str_replace;
 use function substr;
 use function trim;
-use function glob;
-use function str_replace;
-use function array_shift;
-use DOMDocument;
-use DOMXPath;
-use DOMAttr;
-use PHPUnit\Framework\Constraint\Constraint;
-use Psalm\DocComment;
-use Psalm\Internal\RuntimeCaches;
-
-use function array_filter;
 use function var_export;
+
+use const DIRECTORY_SEPARATOR;
+use const LIBXML_NONET;
 
 class DocumentationTest extends TestCase
 {

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -53,6 +53,25 @@ class DocumentationTest extends TestCase
         '@psalm-self-out', // I'm fairly sure it's intentionally undocumented, but can't find the reference
         '@psalm-variadic',
     ];
+    
+    /**
+     * These should be documented
+     */
+    private const WALL_OF_SHAME = [
+        '@psalm-assert-untainted',
+        '@psalm-consistent-constructor',
+        '@psalm-flow',
+        '@psalm-generator-return',
+        '@psalm-ignore-variable-method',
+        '@psalm-ignore-variable-property',
+        '@psalm-override-method-visibility',
+        '@psalm-override-property-visibility',
+        '@psalm-scope-this',
+        '@psalm-seal-methods',
+        '@psalm-stub-override',
+        '@psalm-taint-unescape',
+        '@psalm-yield',
+    ];
 
     /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
     protected $project_analyzer;
@@ -345,6 +364,11 @@ class DocumentationTest extends TestCase
             if (in_array('@psalm-' . $annotation, self::INTENTIONALLY_UNDOCUMENTED_ANNOTATIONS, true)) {
                 continue;
             }
+
+            if (in_array('@psalm-' . $annotation, self::WALL_OF_SHAME, true)) {
+                continue;
+            }
+
             yield $annotation => [$annotation];
         }
     }

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -50,7 +50,8 @@ class DocumentationTest extends TestCase
      * annotations that we don’t want documented
      */
     private const INTENTIONALLY_UNDOCUMENTED_ANNOTATIONS = [
-        'self-out', // I'm fairly sure it's intentionally undocumented, but can't find the reference
+        '@psalm-self-out', // I'm fairly sure it's intentionally undocumented, but can't find the reference
+        '@psalm-variadic',
     ];
 
     /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
@@ -341,7 +342,7 @@ class DocumentationTest extends TestCase
     public function knownAnnotations(): iterable
     {
         foreach (DocComment::PSALM_ANNOTATIONS as $annotation) {
-            if (in_array($annotation, self::INTENTIONALLY_UNDOCUMENTED_ANNOTATIONS, true)) {
+            if (in_array('@psalm-' . $annotation, self::INTENTIONALLY_UNDOCUMENTED_ANNOTATIONS, true)) {
                 continue;
             }
             yield $annotation => [$annotation];


### PR DESCRIPTION
Well, at least mentioned.

Refs vimeo/psalm#3816

The output looks like this:
```
There were 13 failures:

1) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "consistent-constructor" ('consistent-constructor')
'@psalm-consistent-constructor' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-consistent-constructor".

/home/docker/project/tests/DocumentationTest.php:337

2) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "generator-return" ('generator-return')
'@psalm-generator-return' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-generator-return".

/home/docker/project/tests/DocumentationTest.php:337

3) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "flow" ('flow')
'@psalm-flow' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-flow".

/home/docker/project/tests/DocumentationTest.php:337

4) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "override-method-visibility" ('override-method-visibility')
'@psalm-override-method-visibility' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-override-method-visibility".

/home/docker/project/tests/DocumentationTest.php:337

5) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "override-property-visibility" ('override-property-visibility')
'@psalm-override-property-visibility' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-override-property-visibility".

/home/docker/project/tests/DocumentationTest.php:337

6) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "taint-unescape" ('taint-unescape')
'@psalm-taint-unescape' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-taint-unescape".

/home/docker/project/tests/DocumentationTest.php:337

7) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "yield" ('yield')
'@psalm-yield' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-yield".

/home/docker/project/tests/DocumentationTest.php:337

8) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "scope-this" ('scope-this')
'@psalm-scope-this' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-scope-this".

/home/docker/project/tests/DocumentationTest.php:337

9) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "ignore-variable-property" ('ignore-variable-property')
'@psalm-ignore-variable-property' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-ignore-variable-property".

/home/docker/project/tests/DocumentationTest.php:337

10) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "stub-override" ('stub-override')
'@psalm-stub-override' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-stub-override".

/home/docker/project/tests/DocumentationTest.php:337

11) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "ignore-variable-method" ('ignore-variable-method')
'@psalm-ignore-variable-method' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-ignore-variable-method".

/home/docker/project/tests/DocumentationTest.php:337

12) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "assert-untainted" ('assert-untainted')
'@psalm-assert-untainted' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-assert-untainted".

/home/docker/project/tests/DocumentationTest.php:337

13) Psalm\Tests\DocumentationTest::testAllAnnotationsAreDocumented with data set "seal-methods" ('seal-methods')
'@psalm-seal-methods' is not present in the docs
Failed asserting that '# Supported docblock annotati...es).\n' contains "@psalm-seal-methods".

/home/docker/project/tests/DocumentationTest.php:337
```