### PR TITLE
Handling isset on non-nullable properties

### DIFF
--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -89,29 +89,31 @@ class NegatedAssertionReconciler extends Reconciler
                             $failed_reconciliation = 2;
 
                             if ($code_location) {
-                                if ($existing_var_type->from_docblock) {
-                                    if (IssueBuffer::accepts(
-                                        new DocblockTypeContradiction(
-                                            'Cannot resolve types for ' . $key . ' with docblock-defined type '
+                                if (strpos($key, '$this->')) {
+                                    if ($existing_var_type->from_docblock) {
+                                        if (IssueBuffer::accepts(
+                                            new DocblockTypeContradiction(
+                                                'Cannot resolve types for ' . $key . ' with docblock-defined type '
                                                 . $existing_var_type . ' and !isset assertion',
-                                            $code_location,
-                                            null
-                                        ),
-                                        $suppressed_issues
-                                    )) {
-                                        // fall through
-                                    }
-                                } else {
-                                    if (IssueBuffer::accepts(
-                                        new TypeDoesNotContainType(
-                                            'Cannot resolve types for ' . $key . ' with type '
+                                                $code_location,
+                                                null
+                                            ),
+                                            $suppressed_issues
+                                        )) {
+                                            // fall through
+                                        }
+                                    } else {
+                                        if (IssueBuffer::accepts(
+                                            new TypeDoesNotContainType(
+                                                'Cannot resolve types for ' . $key . ' with type '
                                                 . $existing_var_type . ' and !isset assertion',
-                                            $code_location,
-                                            null
-                                        ),
-                                        $suppressed_issues
-                                    )) {
-                                        // fall through
+                                                $code_location,
+                                                null
+                                            ),
+                                            $suppressed_issues
+                                        )) {
+                                            // fall through
+                                        }
                                     }
                                 }
                             }

--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -89,12 +89,12 @@ class NegatedAssertionReconciler extends Reconciler
                             $failed_reconciliation = 2;
 
                             if ($code_location) {
-                                if (strpos($key, '$this->')) {
+                                if (strpos($key, '$this->') !== 0) {
                                     if ($existing_var_type->from_docblock) {
                                         if (IssueBuffer::accepts(
                                             new DocblockTypeContradiction(
                                                 'Cannot resolve types for ' . $key . ' with docblock-defined type '
-                                                . $existing_var_type . ' and !isset assertion',
+                                                    . $existing_var_type . ' and !isset assertion',
                                                 $code_location,
                                                 null
                                             ),
@@ -106,7 +106,7 @@ class NegatedAssertionReconciler extends Reconciler
                                         if (IssueBuffer::accepts(
                                             new TypeDoesNotContainType(
                                                 'Cannot resolve types for ' . $key . ' with type '
-                                                . $existing_var_type . ' and !isset assertion',
+                                                    . $existing_var_type . ' and !isset assertion',
                                                 $code_location,
                                                 null
                                             ),


### PR DESCRIPTION
Following discussion on https://github.com/vimeo/psalm/issues/4726#issuecomment-735253394 about isset on non-nullable properties to check initialisation, I made this small PR just to show what I had in mind instead of trying to explain it badly

This successfully remove the issue and it doesn't seem like a big deal. Maybe we could couple this with a config "allowIssetChecksOnNonNullableProperties" for old projects? Or we could emit another Issue type in this case, just for easy suppression for old projects

What do you think about this?