### PR TITLE
add documentation for RedundantPropertyInitializationCheck

### DIFF
--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -199,6 +199,7 @@ These issues are treated as errors at level 4 and below.
  - [NoInterfaceProperties](issues/NoInterfaceProperties.md)
  - [PossibleRawObjectIteration](issues/PossibleRawObjectIteration.md)
  - [RedundantCondition](issues/RedundantCondition.md)
+ - [RedundantPropertyInitializationCheck](issues/RedundantPropertyInitializationCheck.md)
  - [StringIncrement](issues/StringIncrement.md)
  - [TooManyArguments](issues/TooManyArguments.md)
  - [TypeDoesNotContainNull](issues/TypeDoesNotContainNull.md)

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -178,6 +178,7 @@
  - [RedundantCondition](issues/RedundantCondition.md)
  - [RedundantConditionGivenDocblockType](issues/RedundantConditionGivenDocblockType.md)
  - [RedundantIdentityWithTrue](issues/RedundantIdentityWithTrue.md)
+ - [RedundantPropertyInitializationCheck](issues/RedundantPropertyInitializationCheck.md)
  - [ReferenceConstraintViolation](issues/ReferenceConstraintViolation.md)
  - [ReservedWord](issues/ReservedWord.md)
  - [StringIncrement](issues/StringIncrement.md)

--- a/docs/running_psalm/issues/RedundantPropertyInitializationCheck.md
+++ b/docs/running_psalm/issues/RedundantPropertyInitializationCheck.md
@@ -1,0 +1,16 @@
+# RedundantPropertyInitializationCheck
+
+Emitted when checking `isset()` on a non-nullable property. This issue indicate a redundant check for projects that initialize their properties in constructor.
+
+```php
+<?php
+    class A {
+        public string $bar;
+        public function getBar() : string {
+            if (isset($this->bar)) {
+                return $this->bar;
+            }
+            return "hello";
+        }
+    }
+```


### PR DESCRIPTION
This PR adds documentation for RedundantPropertyInitializationCheck

Thanks for adding this :)

I started looking at what you did, it's interesting to look at, I thought reinitializing the from_property would have to be dispersed everywhere, but it's quite localized in assignments, that's cool.

I'm not sure why you added the third param when creating a new instance of the issue. Isn't that used for custom suppression in issueHandler