### PR TITLE
Fix ImagickPixel::getColor()

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -5875,7 +5875,7 @@ return [
 'ImagickPixel::clear' => ['bool'],
 'ImagickPixel::clone' => ['void'],
 'ImagickPixel::destroy' => ['bool'],
-'ImagickPixel::getColor' => ['array{r: int|float, g: int|float, b: int|float, a: int|float}', 'normalized='=>'bool'],
+'ImagickPixel::getColor' => ['array{r: int|float, g: int|float, b: int|float, a: int|float}', 'normalized='=>'int'],
 'ImagickPixel::getColorAsString' => ['string'],
 'ImagickPixel::getColorCount' => ['int'],
 'ImagickPixel::getColorQuantum' => ['mixed'],


### PR DESCRIPTION
`ImagickPixel::getColor()` takes an int, not a bool:

https://www.php.net/manual/en/imagickpixel.getcolor.php
https://github.com/Imagick/imagick/blob/06116aa24b76edaf6b1693198f79e6c295eda8a9/imagickpixel_class.c#L605