### PR TITLE
Invalid syntax for PHP v7.2, psalm v4.3.0

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -248,7 +248,7 @@ class ExistingAtomicStaticCallAnalyzer
                             } elseif ($template_type->param_name === 'TPhpMajorVersion') {
                                 $template_result->upper_bounds[$template_type->param_name] = [
                                     'fn-' . strtolower((string) $method_id) => new TemplateBound(
-                                        Type::getInt(false, $codebase->php_major_version),
+                                        Type::getInt(false, $codebase->php_major_version)
                                     )
                                 ];
                             } else {


### PR DESCRIPTION
Hi,

I'm trying to use psalm v4.3.0 + PHP 7.2.33 

According `composer.json`, it should work with v7.1+
 https://github.com/vimeo/psalm/blob/master/composer.json#L17 

I found invalid syntax here
https://github.com/vimeo/psalm/blob/master/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php#L251

`Type::getInt(false, $codebase->php_major_version),`

I guess it should be 
`Type::getInt(false, $codebase->php_major_version)`


