### PR TITLE
Add default to 3rd argument of get_headers and thus not ask to use all 3 arguments

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1194,11 +1194,11 @@ function base64_encode(string $data) : string {}
 /**
  * @psalm-pure
  *
- * @param resource $context
+ * @param resource|null $context
  *
  * @psalm-taint-sink ssrf $url
  */
-function get_headers(string $url, int $format = 0, $context) : array {}
+function get_headers(string $url, int $format = 0, $context = null) : array {}
 
 /**
  * @psalm-pure


### PR DESCRIPTION
closes #4772 

There is no documentation that `$context` is nullable but it’s better to mark is nullable and use default value so psalm will not ask to use all 3 parameters.

official docs: https://www.php.net/manual/en/function.get-headers.php

## php-src stub
https://github.com/php/php-src/blob/bb1dd83af393a701cc82f32c4f919e15595a28f5/ext/standard/basic_functions.stub.php#L1441-L1442

```php
/** @param resource $context */
function get_headers(string $url, bool $associative = false, $context = null): array|false {}
```

## phpstorm stubs
https://github.com/JetBrains/phpstorm-stubs/blob/c433ad857bd77831e79432a92255659715e3c703/standard/standard_6.php#L1044-L1060
```php
/**
 * Fetches all the headers sent by the server in response to an HTTP request
 * @link https://php.net/manual/en/function.get-headers.php
 * @param string $url <p>
 * The target URL.
 * </p>
 * @param int $associative [optional] <p>
 * If the optional format parameter is set to non-zero,
 * get_headers parses the response and sets the
 * array's keys.
 * </p>
 * @param resource $context [optional]
 * @return array|false an indexed or associative array with the headers, or false on
 * failure.
 */
#[Pure]
function get_headers (string $url, bool $associative, $context): array|false
{}
```
