### PR TITLE
Fix windows builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,7 +14,7 @@ init:
 environment:
   SSL_CERT_FILE: "C:\\tools\\php\\cacert.pem"
   matrix:
-    - php_ver_target: 7.4
+    - php_ver_target: 8.0
       DEPS: 'high'
 
 cache:

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "phpspec/prophecy": ">=1.9.0",
         "phpunit/phpunit": "^9.0",
         "psalm/plugin-phpunit": "^0.13",
-        "slevomat/coding-standard": "^5.0",
+        "slevomat/coding-standard": "^6.3.11",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/process": "^4.3",
         "weirdan/prophecy-shim": "^1.0 || ^2.0"

--- a/composer.json
+++ b/composer.json
@@ -44,16 +44,16 @@
         "ext-curl": "*",
         "amphp/amp": "^2.4.2",
         "bamarni/composer-bin-plugin": "^1.2",
-        "brianium/paratest": "^4.0.0",
+        "brianium/paratest": "^4.0||^6.0",
         "phpdocumentor/reflection-docblock": "^5",
-        "phpmyadmin/sql-parser": "5.1.0",
+        "phpmyadmin/sql-parser": "5.1.0||dev-master",
         "phpspec/prophecy": ">=1.9.0",
         "phpunit/phpunit": "^9.0",
         "psalm/plugin-phpunit": "^0.13",
-        "weirdan/prophecy-shim": "^1.0 || ^2.0",
         "slevomat/coding-standard": "^5.0",
         "squizlabs/php_codesniffer": "^3.5",
-        "symfony/process": "^4.3"
+        "symfony/process": "^4.3",
+        "weirdan/prophecy-shim": "^1.0 || ^2.0"
     },
     "suggest": {
         "ext-igbinary": "^2.0.5"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -38,8 +38,8 @@
             <file>src/Psalm/Internal/Provider/ParserCacheProvider.php</file>
         </exclude>
         <report>
-            <clover outputFile="build/logs/clover.xml"/>
-            <html outputDirectory="build/logs/phpunit-html/"/>
+            <!-- <clover outputFile="build/logs/clover.xml"/> -->
+            <!-- <html outputDirectory="build/logs/phpunit-html/"/> -->
         </report>
     </coverage>
 

--- a/tests/fixtures/DummyProjectWithErrors/composer.json
+++ b/tests/fixtures/DummyProjectWithErrors/composer.json
@@ -3,7 +3,7 @@
     "description": "A sample project to be used when testing Psalm",
     "type": "project",
     "require": {
-        "vimeo/psalm": "^3.11"
+        "vimeo/psalm": "^4.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This fixes the issue that appeared on AppVeyor about a week ago, where PHP could not be installed. Turned out the reason was that PHP 7.4 is no longer available in Chocolatey repos.

Note that tests still fail, but it's no longer a build setup issue. Rather there seems to be an issue analyzing PHP 7.4 code (Psalm sees methods on `ReflectionClass` that were absent in PHP 7.4) when running on PHP 8