### PR TITLE
allow passing mixed in is_a

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -6426,7 +6426,7 @@ return [
 'ip2long' => ['int|false', 'ip'=>'string'],
 'iptcembed' => ['string|bool', 'iptc_data'=>'string', 'filename'=>'string', 'spool='=>'int'],
 'iptcparse' => ['array|false', 'iptc_block'=>'string'],
-'is_a' => ['bool', 'object_or_class'=>'object|string', 'class'=>'string', 'allow_string='=>'bool'],
+'is_a' => ['bool', 'object_or_class'=>'mixed', 'class'=>'string', 'allow_string='=>'bool'],
 'is_array' => ['bool', 'value'=>'mixed'],
 'is_bool' => ['bool', 'value'=>'mixed'],
 'is_callable' => ['bool', 'value'=>'callable|mixed', 'syntax_only='=>'bool', '&w_callable_name='=>'string'],


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/4776

rationale: you may want to pass anything in is_a for example to split an union object|array ;
```php
$test = rand(1, 4) > 2 ? [] : new stdClass;

if(is_a($test, stdClass::class)) {
    echo 'object';
}
else{
    echo 'array';
}
```