### PR TITLE
Fix support of extraFiles

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1149,6 +1149,8 @@ class ProjectAnalyzer
     public function checkPaths(array $paths_to_check): void
     {
         $this->visitAutoloadFiles();
+        
+        $this->codebase->scanner->addFilesToShallowScan($this->extra_files);
 
         foreach ($paths_to_check as $path) {
             $this->progress->debug('Checking ' . $path . "\n");


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/4756

By debugging on my project, reading the code and making some try with dump, i discovered that
- Running `vendor/bin/psalm` use ProjectAnalyser::check
- Running `vendor/bin/psalm foo.php` use ProjectAnalyser::checkPaths
- ProjectAnalyser::check use 
```
$this->visitAutoloadFiles();
$this->codebase->scanner->addFilesToShallowScan($this->extra_files);
$this->codebase->scanner->addFilesToDeepScan($this->project_files);
$this->codebase->analyzer->addFilesToAnalyze($this->project_files);
```
- ProjectAnalyser::checkPaths use 
```
$this->visitAutoloadFiles();
```

I think the call
```
$this->codebase->scanner->addFilesToShallowScan($this->extra_files);
```
Should be added too.

I tried on my project and it fixed my issues. @muglug 