### PR TITLE
Don't add link if the issue doesn't have a shortcode

### DIFF
--- a/src/Psalm/Internal/Analyzer/IssueData.php
+++ b/src/Psalm/Internal/Analyzer/IssueData.php
@@ -162,7 +162,7 @@ class IssueData
         $this->column_to = $column_to;
         $this->shortcode = $shortcode;
         $this->error_level = $error_level;
-        $this->link = 'https://psalm.dev/' . \str_pad((string) $shortcode, 3, "0", \STR_PAD_LEFT);
+        $this->link = $shortcode ? 'https://psalm.dev/' . \str_pad((string) $shortcode, 3, "0", \STR_PAD_LEFT) : '';
         $this->taint_trace = $taint_trace;
         $this->dupe_key = $dupe_key;
     }

--- a/src/Psalm/Report/ConsoleReport.php
+++ b/src/Psalm/Report/ConsoleReport.php
@@ -30,7 +30,7 @@ class ConsoleReport extends Report
             $issue_string .= 'INFO';
         }
 
-        $issue_reference = ' (see ' . $issue_data->link . ')';
+        $issue_reference = $issue_data->link ? ' (see ' . $issue_data->link . ')' : '';
 
         $issue_string .= ': ' . $issue_data->type
             . ' - ' . $issue_data->file_name . ':' . $issue_data->line_from . ':' . $issue_data->column_from

--- a/src/Psalm/Report/PhpStormReport.php
+++ b/src/Psalm/Report/PhpStormReport.php
@@ -30,7 +30,7 @@ class PhpStormReport extends Report
             $issue_string .= 'INFO';
         }
 
-        $issue_reference = ' (see ' . $issue_data->link . ')';
+        $issue_reference = $issue_data->link ? ' (see ' . $issue_data->link . ')' : '';
 
         $issue_string .= ': ' . $issue_data->type
             . "\nat " . $issue_data->file_path . ':' . $issue_data->line_from . ':' . $issue_data->column_from


### PR DESCRIPTION
This avoids the link `(see https://psalm.dev/000)` at the end of plugin issues