### PR TITLE
Make sure uncached files are analyzed

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1076,7 +1076,7 @@ class ProjectAnalyzer
 
         foreach ($file_paths as $file_path) {
             if ($config->isInProjectDirs($file_path)) {
-                if ($this->file_provider->getModifiedTime($file_path) > $last_run
+                if ($this->file_provider->getModifiedTime($file_path) >= $last_run
                     && $this->parser_cache_provider->loadExistingFileContentsFromCache($file_path)
                         !== $this->file_provider->getContents($file_path)
                 ) {
@@ -1149,7 +1149,7 @@ class ProjectAnalyzer
     public function checkPaths(array $paths_to_check): void
     {
         $this->visitAutoloadFiles();
-        
+
         $this->codebase->scanner->addFilesToShallowScan($this->extra_files);
 
         foreach ($paths_to_check as $path) {


### PR DESCRIPTION
Previously Psalm would ignore any files that were created before or at the same time (second) as it had recorded as the last run.

This is problematic in these situations:

 * File is created the same second Psalm starts, but after it created the list of files to check
 * File is copied/moved from somewhere into the project folder with original timestamps preserved

Now Psalm will additionally check if it actually has the file cached before ignoring it.