### PR TITLE
Infer mutation-free on all non-overridden methods

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -80,7 +80,7 @@ class MethodCallPurityAnalyzer
         ) {
             if ($method_storage->mutation_free
                 && (!$method_storage->mutation_free_inferred
-                    || $method_storage->final)
+                    || !$method_storage->overridden_somewhere)
             ) {
                 if ($context->inside_conditional
                     && !$method_storage->assertions

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -833,7 +833,7 @@ class MethodCallTest extends TestCase
                         printInt($obj->getInt());
                     }',
             ],
-            'unchainedInferredInferredFinalMutationFreeMethodCallMemoize' => [
+            'unchainedInferredNonOverriddenMutationFreeMethodCallMemoize' => [
                 '<?php
                     class SomeClass {
                         private ?int $int;
@@ -842,7 +842,7 @@ class MethodCallTest extends TestCase
                             $this->int = 1;
                         }
 
-                        final public function getInt(): ?int {
+                        public function getInt(): ?int {
                             return $this->int;
                         }
                     }
@@ -1381,6 +1381,11 @@ class MethodCallTest extends TestCase
                         }
 
                         public function getInt(): ?int {
+                            return $this->int;
+                        }
+                    }
+                    class Child extends SomeClass {
+                        public function getInt(): ?int { // overridden
                             return $this->int;
                         }
                     }

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -1371,7 +1371,7 @@ class MethodCallTest extends TestCase
                     new Missing($class_arg);',
                 'error_message' => 'PossiblyUndefinedVariable',
             ],
-            'unchainedInferredInferredMutationFreeMethodCallDontMemoize' => [
+            'unchainedOverriddenInferredMutationFreeMethodCallDontMemoize' => [
                 '<?php
                     class SomeClass {
                         private ?int $int;


### PR DESCRIPTION
I doubted at first to do this implicitly but then I found that mutation-free property is already inferred for final methods.
Finality is only interesting to verify against class inheritors. What the mutation-free heuristics apparently wants to know is that there are no inheritors on the method.

This would allow wider acceptance of, for instance, `PossiblyNull*` issues while avoiding bending the code for Psalm with unnecessary `final` keywords or `@psalm-mutation-free` in the contexts where it's obvious to have no side effects.