### PR TITLE
Memoize private inferred mutation-free methods

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -2,6 +2,7 @@
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use PhpParser;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Codebase;
 use Psalm\CodeLocation;
@@ -79,7 +80,8 @@ class MethodCallPurityAnalyzer
         ) {
             if ($method_storage->mutation_free
                 && (!$method_storage->mutation_free_inferred
-                    || $method_storage->final)
+                    || $method_storage->final
+                    || $method_storage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE)
                 && ($method_storage->immutable || $config->remember_property_assignments_after_call)
             ) {
                 if ($context->inside_conditional

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -857,6 +857,27 @@ class MethodCallTest extends TestCase
                         printInt($obj->getInt());
                     }',
             ],
+            'privateInferredMutationFreeMethodCallMemoize' => [
+                '<?php
+                    class PropertyClass {
+                        public function test() : void {
+                            echo "test";
+                        }
+                    }
+                    class SomeClass {
+                        private ?PropertyClass $property = null;
+
+                        private function getProperty(): ?PropertyClass {
+                            return $this->property;
+                        }
+
+                        public function test(int $int): void {
+                            if ($this->getProperty() !== null) {
+                                $this->getProperty()->test();
+                            }
+                        }
+                    }',
+            ],
             'inferredFinalMethod' => [
                 '<?php
                     class PropertyClass {


### PR DESCRIPTION
More relaxed modification from the rejected [approach](https://github.com/vimeo/psalm/pull/4808): given an inferred mutation-free behaviour, if final methods are memoized because they cannot be overridden, private methods cannot be overridden as well, hence it's logical to memoize them too.

https://psalm.dev/r/91cfaaafb0