### PR TITLE
preserve analyzers until the end of file

### DIFF
--- a/examples/TemplateChecker.php
+++ b/examples/TemplateChecker.php
@@ -18,7 +18,7 @@ class TemplateAnalyzer extends Psalm\Internal\Analyzer\FileAnalyzer
 {
     const VIEW_CLASS = 'Your\\View\\Class';
 
-    public function analyze(?Context $file_context = null, bool $preserve_analyzers = false, ?Context $global_context = null): void
+    public function analyze(?Context $file_context = null, ?Context $global_context = null): void
     {
         $codebase = $this->project_analyzer->getCodebase();
         $stmts = $codebase->getStatementsForFile($this->file_path);

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -123,7 +123,6 @@ class FileAnalyzer extends SourceAnalyzer
 
     public function analyze(
         ?Context $file_context = null,
-        bool $preserve_analyzers = false,
         ?Context $global_context = null
     ): void {
         $codebase = $this->project_analyzer->getCodebase();
@@ -211,11 +210,6 @@ class FileAnalyzer extends SourceAnalyzer
             $class_analyzer->analyze(null, $this->context);
         }
 
-        if (!$preserve_analyzers) {
-            $this->class_analyzers_to_analyze = [];
-            $this->interface_analyzers_to_analyze = [];
-        }
-
         if ($codebase->config->check_for_throws_in_global_scope) {
             $uncaught_throws = $statements_analyzer->getUncaughtThrows($this->context);
             foreach ($uncaught_throws as $possibly_thrown_exception => $codelocations) {
@@ -277,6 +271,9 @@ class FileAnalyzer extends SourceAnalyzer
         foreach ($codebase->config->after_file_checks as $plugin_class) {
             $plugin_class::afterAnalyzeFile($this, $this->context, $file_storage, $codebase);
         }
+
+        $this->class_analyzers_to_analyze = [];
+        $this->interface_analyzers_to_analyze = [];
     }
 
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -178,7 +178,6 @@ class IncludeAnalyzer
                 try {
                     $include_file_analyzer->analyze(
                         $context,
-                        false,
                         $global_context
                     );
                 } catch (\Psalm\Exception\UnpreparedAnalysisException $e) {


### PR DESCRIPTION
Related to https://github.com/vimeo/psalm/issues/4820

This drops the $preserve_analyzers that was always false and move the removal of analyzers below the call to the File plugin hook