### PR TITLE
push original statements list to file plugin

### DIFF
--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -271,7 +271,7 @@ class FileAnalyzer extends SourceAnalyzer
             }
         }
 
-        $event = new AfterFileAnalysisEvent($this, $this->context, $file_storage, $codebase);
+        $event = new AfterFileAnalysisEvent($this, $this->context, $file_storage, $codebase, $stmts);
         $codebase->config->eventDispatcher->dispatchAfterFileAnalysis($event);
 
         $this->class_analyzers_to_analyze = [];

--- a/src/Psalm/Plugin/EventHandler/Event/AfterFileAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterFileAnalysisEvent.php
@@ -3,6 +3,7 @@
 
 namespace Psalm\Plugin\EventHandler\Event;
 
+use PhpParser\Node\Stmt;
 use Psalm\Codebase;
 use Psalm\Context;
 use Psalm\StatementsSource;
@@ -26,20 +27,28 @@ class AfterFileAnalysisEvent
      * @var Codebase
      */
     private $codebase;
+    /**
+     * @var Stmt[]
+     */
+    private $stmts;
 
     /**
      * Called after a file has been checked
+     *
+     * @param array<Stmt> $stmts
      */
     public function __construct(
         StatementsSource $statements_source,
         Context $file_context,
         FileStorage $file_storage,
-        Codebase $codebase
+        Codebase $codebase,
+        array $stmts
     ) {
         $this->statements_source = $statements_source;
         $this->file_context = $file_context;
         $this->file_storage = $file_storage;
         $this->codebase = $codebase;
+        $this->stmts = $stmts;
     }
 
     public function getStatementsSource(): StatementsSource
@@ -60,5 +69,13 @@ class AfterFileAnalysisEvent
     public function getCodebase(): Codebase
     {
         return $this->codebase;
+    }
+
+    /**
+     * @return Stmt[]
+     */
+    public function getStmts(): array
+    {
+        return $this->stmts;
     }
 }


### PR DESCRIPTION
This PR propose adding the list of statements directly to the hook for AfterFileAnalysis.

This should fix https://github.com/vimeo/psalm/issues/4820. After hours of tweaking, I came to the conclusion that I couldn't get types in the plugin because I didn't retrieved the original list of statement when I used this syntax:
`$stmts = $codebase->getStatementsForFile($file_storage->file_path);`
I think the cache is causing them to be recreated between the analysis and the plugin hook. This makes it impossible to fetch the types through this syntax:
`$type = $statement_source->getNodeTypeProvider()->getType($stmt->expr);`
It returns null because the new nodes created by cache fetching weren't analyzed and stored here.

Unfortunately, this PR is a BC break. It adds a new parameter to the hook so it will probably break every AfterFileAnalysis plugin.

I searched on GitHub and I could only find one usage of this hook (except mine) here:
https://github.com/omegaup/omegaup/blob/df92883630bd6c1efa42905985337ab535b392aa/frontend/server/src/Psalm/TranslationStringChecker.php#L109 (and it's still in Psalm V3)
But I can't be sure there isn't private usage not published somewhere...