### PR TITLE
Allow session_name to also return false

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -11928,7 +11928,7 @@ return [
 'session_id' => ['string', 'id='=>'string'],
 'session_is_registered' => ['bool', 'name'=>'string'],
 'session_module_name' => ['string', 'module='=>'string'],
-'session_name' => ['string', 'name='=>'string'],
+'session_name' => ['string|false', 'name='=>'string'],
 'session_pgsql_add_error' => ['bool', 'error_level'=>'int', 'error_message='=>'string'],
 'session_pgsql_get_error' => ['array', 'with_error_message='=>'bool'],
 'session_pgsql_get_field' => ['string'],


### PR DESCRIPTION
According to the PHP docs the [session_name](https://php.net/session_name) signature is:

    session_name ([ string|null $name = null ] ) : string|false

Resolves Possibly incorrect handling of session_name() #4854.