### PR TITLE
Keep method nodeTypeProviders at class level

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -7,6 +7,7 @@ use Psalm\DocComment;
 use Psalm\Exception\DocblockParseException;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\ClassTemplateParamCollector;
 use Psalm\Internal\FileManipulation\PropertyDocblockManipulator;
+use Psalm\Internal\Provider\NodeDataProvider;
 use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Codebase;
@@ -67,6 +68,11 @@ class ClassAnalyzer extends ClassLikeAnalyzer
      * @var array<string, Type\Union>
      */
     public $inferred_property_types = [];
+
+    /**
+     * @var array<lowercase-string, NodeDataProvider>
+     */
+    public $type_providers = [];
 
     public function __construct(PhpParser\Node\Stmt\Class_ $class, SourceAnalyzer $source, ?string $fq_class_name)
     {
@@ -1985,6 +1991,8 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         $method_context->collect_exceptions = $config->check_for_throws_docblock;
 
         $type_provider = new \Psalm\Internal\Provider\NodeDataProvider();
+
+        $this->type_providers[$actual_method_id->method_name] = $type_provider;
 
         $method_analyzer->analyze(
             $method_context,


### PR DESCRIPTION
Closely related to https://github.com/vimeo/psalm/issues/4820

This PR propose saving method NodeDataProviders on class Analyzer.

This is needed to allow access to method Node types when using the `afterAnalyzeFile` hook.

This should not affect memory much, this only keeps the Nodes until destruction of ClassAnalyzer, which happens after each file analysis.