### PR TITLE
Illegal offsets access

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
@@ -110,7 +110,7 @@ class SwitchCaseAnalyzer
             if ($fake_switch_condition) {
                 $statements_analyzer->node_data->setType(
                     $switch_condition,
-                    $case_context->vars_in_scope[$switch_var_id] ?? Type::getMixed()
+                    $case_context->vars_in_scope[(string)$switch_var_id] ?? Type::getMixed()
                 );
             }
 
@@ -183,7 +183,7 @@ class SwitchCaseAnalyzer
                     if ($fake_switch_condition) {
                         $statements_analyzer->node_data->setType(
                             $switch_condition,
-                            $case_context->vars_in_scope[$switch_var_id] ?? Type::getMixed()
+                            $case_context->vars_in_scope[(string)$switch_var_id] ?? Type::getMixed()
                         );
                     }
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -1261,8 +1261,8 @@ class InstancePropertyAssignmentAnalyzer
             if (!$property_storage->readonly
                 && !$context->collect_mutations
                 && !$context->collect_initializations
-                && isset($context->vars_in_scope[$lhs_var_id])
-                && !$context->vars_in_scope[$lhs_var_id]->allow_mutations
+                && isset($context->vars_in_scope[(string)$lhs_var_id])
+                && !$context->vars_in_scope[(string)$lhs_var_id]->allow_mutations
             ) {
                 if ($context->mutation_free) {
                     if (IssueBuffer::accepts(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -398,7 +398,7 @@ class AssignmentAnalyzer
             return false;
         }
 
-        if (isset($context->protected_var_ids[$var_id])
+        if (isset($context->protected_var_ids[(string)$var_id])
             && $assign_value_type->hasLiteralInt()
         ) {
             if (IssueBuffer::accepts(
@@ -817,7 +817,7 @@ class AssignmentAnalyzer
             && !$context->collect_initializations
             && $stmt->var instanceof PhpParser\Node\Expr\PropertyFetch
         ) {
-            $lhs_var_id = ExpressionIdentifier::getArrayVarId(
+            $lhs_var_id = (string)ExpressionIdentifier::getArrayVarId(
                 $stmt->var->var,
                 $statements_analyzer->getFQCLN(),
                 $statements_analyzer

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -194,10 +194,10 @@ class MethodCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\
                 $lhs_var_id,
                 $result
             );
-            if (isset($context->vars_in_scope[$lhs_var_id])
-                && ($possible_new_class_type = $context->vars_in_scope[$lhs_var_id]) instanceof Type\Union
+            if (isset($context->vars_in_scope[(string)$lhs_var_id])
+                && ($possible_new_class_type = $context->vars_in_scope[(string)$lhs_var_id]) instanceof Type\Union
                 && !$possible_new_class_type->equals($class_type)) {
-                $possible_new_class_types[] = $context->vars_in_scope[$lhs_var_id];
+                $possible_new_class_types[] = $context->vars_in_scope[(string)$lhs_var_id];
             }
         }
         if (!$stmt->args && $lhs_var_id && $stmt->name instanceof PhpParser\Node\Identifier) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -691,6 +691,8 @@ class CallAnalyzer
                     $rule = substr($rule, 1);
                 }
 
+                \assert($rule !== false);
+
                 if (isset($inferred_upper_bounds[$rule])) {
                     foreach ($inferred_upper_bounds[$rule] as $template_map) {
                         if ($template_map->type->hasMixed()) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -122,6 +122,7 @@ class ArrayFetchAnalyzer
                         && !$atomic_key_type instanceof Type\Atomic\TInt
                         && !$atomic_key_type instanceof Type\Atomic\TArrayKey
                         && !$atomic_key_type instanceof Type\Atomic\TMixed
+                        && !$atomic_key_type instanceof Type\Atomic\TNull
                         && !(
                             $atomic_key_type instanceof Type\Atomic\TObjectWithProperties
                             && isset($atomic_key_type->methods['__toString'])

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -711,7 +711,7 @@ class Analyzer
                     $method_param_uses[$member_id]
                 );
 
-                $member_stub = preg_replace('/::.*$/', '::*', $member_id);
+                $member_stub = (string)preg_replace('/::.*$/', '::*', $member_id);
 
                 if (isset($all_referencing_methods[$member_stub])) {
                     $newly_invalidated_methods = array_merge(

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -70,6 +70,7 @@ class Functions
     ) : FunctionStorage {
         if ($function_id[0] === '\\') {
             $function_id = substr($function_id, 1);
+            \assert($function_id !== false);
         }
 
         if (isset(self::$stubbed_functions[$function_id])) {

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -624,7 +624,7 @@ class Scanner
     ): FileScanner {
         $path_parts = explode(DIRECTORY_SEPARATOR, $file_path);
         $file_name_parts = explode('.', array_pop($path_parts));
-        $extension = count($file_name_parts) > 1 ? array_pop($file_name_parts) : null;
+        $extension = count($file_name_parts) > 1 ? array_pop($file_name_parts) : '';
 
         $file_name = $this->config->shortenFileName($file_path);
 

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1235,6 +1235,8 @@ class AssertionReconciler extends \Psalm\Type\Reconciler
             $allow_string_comparison = true;
         }
 
+        \assert($assertion !== false);
+
         if ($existing_var_type->hasMixed()) {
             $type = new Type\Union([
                 new Type\Atomic\TNamedObject($assertion),

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -408,7 +408,7 @@ class TypeTokenizer
                 continue;
             }
 
-            if (isset(self::PSALM_RESERVED_WORDS[$string_type_token[0]])) {
+            if (isset(self::PSALM_RESERVED_WORDS[(string)$string_type_token[0]])) {
                 continue;
             }
 
@@ -459,7 +459,7 @@ class TypeTokenizer
             $type_tokens[$i][2] = $string_type_token[0];
 
             if (isset($type_aliases[$string_type_token[0]])) {
-                $type_alias = $type_aliases[$string_type_token[0]];
+                $type_alias = $type_aliases[(string)$string_type_token[0]];
 
                 if ($type_alias instanceof TypeAlias\InlineTypeAlias) {
                     $replacement_tokens = $type_alias->replacement_tokens;

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -537,7 +537,7 @@ class Reconciler
             return isset($existing_keys[$key_parts[0]]) ? clone $existing_keys[$key_parts[0]] : null;
         }
 
-        $base_key = array_shift($key_parts);
+        $base_key = (string)array_shift($key_parts);
 
         if ($base_key === 'C::A' && isset($existing_keys[$base_key]) && $existing_keys[$base_key]->isMixed()) {
             throw new \Exception("Error Processing Request", 1);
@@ -882,6 +882,7 @@ class Reconciler
 
         if ($not) {
             $assertion = substr($assertion, 1);
+            \assert($assertion !== false);
         }
 
         if ($negated) {

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1801,6 +1801,7 @@ class ArrayAssignmentTest extends TestCase
             ],
             'ArrayDimOffsetObject' => [
                 '<?php
+                    $_a = [];
                     $_a[new stdClass] = "a";
                 ',
                 'error_message' => 'InvalidArrayOffset'
@@ -1813,6 +1814,7 @@ class ArrayAssignmentTest extends TestCase
             ],
             'ArrayDimOffsetResource' => [
                 '<?php
+                    $_a = [];
                     $_a[fopen("", "")] = "a";
                 ',
                 'error_message' => 'InvalidArrayOffset'
@@ -1825,6 +1827,7 @@ class ArrayAssignmentTest extends TestCase
             ],
             'ArrayDimOffsetBool' => [
                 '<?php
+                    $_a = [];
                     $_a[true] = "a";
                 ',
                 'error_message' => 'InvalidArrayOffset'
@@ -1837,6 +1840,7 @@ class ArrayAssignmentTest extends TestCase
             ],
             'ArrayDimOffsetStringable' => [
                 '<?php
+                    $_a = [];
                     $a = new class{public function __toString(){return "";}};
                     $_a[$a] = "a";',
                 'error_message' => 'InvalidArrayOffset',

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1799,9 +1799,21 @@ class ArrayAssignmentTest extends TestCase
                 ',
                 'error_message' => 'InvalidArrayOffset'
             ],
+            'ArrayDimOffsetObject' => [
+                '<?php
+                    $_a[new stdClass] = "a";
+                ',
+                'error_message' => 'InvalidArrayOffset'
+            ],
             'ArrayCreateOffsetResource' => [
                 '<?php
                     $_a = [fopen("", "") => "a"];
+                ',
+                'error_message' => 'InvalidArrayOffset'
+            ],
+            'ArrayDimOffsetResource' => [
+                '<?php
+                    $_a[fopen("", "")] = "a";
                 ',
                 'error_message' => 'InvalidArrayOffset'
             ],
@@ -1811,10 +1823,22 @@ class ArrayAssignmentTest extends TestCase
                 ',
                 'error_message' => 'InvalidArrayOffset'
             ],
+            'ArrayDimOffsetBool' => [
+                '<?php
+                    $_a[true] = "a";
+                ',
+                'error_message' => 'InvalidArrayOffset'
+            ],
             'ArrayCreateOffsetStringable' => [
                 '<?php
                     $a = new class{public function __toString(){return "";}};
                     $_a = [$a => "a"];',
+                'error_message' => 'InvalidArrayOffset',
+            ],
+            'ArrayDimOffsetStringable' => [
+                '<?php
+                    $a = new class{public function __toString(){return "";}};
+                    $_a[$a] = "a";',
                 'error_message' => 'InvalidArrayOffset',
             ],
             'coerceListToArray' => [

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -90,6 +90,7 @@ trait ValidCodeAnalysisTestTrait
 
             if ($var && strpos($var, '===') === strlen($var) - 3) {
                 $var = substr($var, 0, -3);
+                \assert($var !== false);
                 $exact = true;
             }
 


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/4857 and https://github.com/vimeo/psalm/issues/4858

Basically, this checks that every ArrayDimFetch is used with a valid offset.

This was not my first goal. At first, I just wanted to forbid the syntax `$a[1.1] = ''` but this went to forbid `$a[1.1]` altogether because this was simpler and still a correct issue. We could be less strict by checking that at least one type in the union is array-key compatible instead of checking that all the types should.