### PR TITLE
store node type provider on functionlike level

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -738,7 +738,9 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $storage,
             $this,
             $codebase,
-            []
+            [],
+            $type_provider,
+            $context
         );
 
         if ($codebase->config->eventDispatcher->dispatchAfterFunctionLikeAnalysis($event) === false) {

--- a/src/Psalm/Plugin/EventHandler/Event/AfterFunctionLikeAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterFunctionLikeAnalysisEvent.php
@@ -5,7 +5,9 @@ namespace Psalm\Plugin\EventHandler\Event;
 
 use PhpParser\Node;
 use Psalm\Codebase;
+use Psalm\Context;
 use Psalm\FileManipulation;
+use Psalm\NodeTypeProvider;
 use Psalm\StatementsSource;
 use Psalm\Storage\FunctionLikeStorage;
 
@@ -31,6 +33,14 @@ class AfterFunctionLikeAnalysisEvent
      * @var FileManipulation[]
      */
     private $file_replacements;
+    /**
+     * @var NodeTypeProvider
+     */
+    private $node_type_provider;
+    /**
+     * @var Context
+     */
+    private $context;
 
     /**
      * Called after a statement has been checked
@@ -42,13 +52,17 @@ class AfterFunctionLikeAnalysisEvent
         FunctionLikeStorage $classlike_storage,
         StatementsSource $statements_source,
         Codebase $codebase,
-        array $file_replacements = []
+        array $file_replacements,
+        NodeTypeProvider $node_type_provider,
+        Context $context
     ) {
         $this->stmt = $stmt;
         $this->classlike_storage = $classlike_storage;
         $this->statements_source = $statements_source;
         $this->codebase = $codebase;
         $this->file_replacements = $file_replacements;
+        $this->node_type_provider = $node_type_provider;
+        $this->context = $context;
     }
 
     public function getStmt(): Node\FunctionLike
@@ -85,5 +99,15 @@ class AfterFunctionLikeAnalysisEvent
     public function setFileReplacements(array $file_replacements): void
     {
         $this->file_replacements = $file_replacements;
+    }
+
+    public function getNodeTypeProvider(): NodeTypeProvider
+    {
+        return $this->node_type_provider;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
     }
 }


### PR DESCRIPTION
This PR propose storing the node type provider on a property of FunctionLikeAnalyzer.

This is needed to retrieve the node type provider from AfterFunctionLikeAnalysis Hook.