### PR TITLE
Illegal offset

### DIFF
--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1799,9 +1799,23 @@ class ArrayAssignmentTest extends TestCase
                 ',
                 'error_message' => 'InvalidArrayOffset'
             ],
+            'ArrayDimOffsetObject' => [
+                '<?php
+                    $_a = [];
+                    $_a[new stdClass] = "a";
+                ',
+                'error_message' => 'InvalidArrayOffset'
+            ],
             'ArrayCreateOffsetResource' => [
                 '<?php
                     $_a = [fopen("", "") => "a"];
+                ',
+                'error_message' => 'InvalidArrayOffset'
+            ],
+            'ArrayDimOffsetResource' => [
+                '<?php
+                    $_a = [];
+                    $_a[fopen("", "")] = "a";
                 ',
                 'error_message' => 'InvalidArrayOffset'
             ],
@@ -1811,10 +1825,24 @@ class ArrayAssignmentTest extends TestCase
                 ',
                 'error_message' => 'InvalidArrayOffset'
             ],
+            'ArrayDimOffsetBool' => [
+                '<?php
+                    $_a = [];
+                    $_a[true] = "a";
+                ',
+                'error_message' => 'InvalidArrayOffset'
+            ],
             'ArrayCreateOffsetStringable' => [
                 '<?php
                     $a = new class{public function __toString(){return "";}};
                     $_a = [$a => "a"];',
+                'error_message' => 'InvalidArrayOffset',
+            ],
+            'ArrayDimOffsetStringable' => [
+                '<?php
+                    $_a = [];
+                    $a = new class{public function __toString(){return "";}};
+                    $_a[$a] = "a";',
                 'error_message' => 'InvalidArrayOffset',
             ],
             'coerceListToArray' => [

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1065,15 +1065,6 @@ class ArrayAssignmentTest extends TestCase
                         if (is_int($value["a"])) {}
                     }'
             ],
-            'falseArrayAssignment' => [
-                '<?php
-                    function foo(): array {
-                        $array = [];
-                        $array[false] = "";
-                        echo $array[0];
-                        return $array;
-                    }',
-            ],
             'coercePossiblyNullKeyToZero' => [
                 '<?php
                     function int_or_null(): ?int {
@@ -1904,7 +1895,17 @@ class ArrayAssignmentTest extends TestCase
                         return $arr;
                     }',
                 'error_message' => 'MixedArrayOffset'
-            ]
+            ],
+            'falseArrayAssignment' => [
+                '<?php
+                    function foo(): array {
+                        $array = [];
+                        $array[false] = "";
+                        echo $array[0];
+                        return $array;
+                    }',
+                'error_message' => 'InvalidArrayOffset'
+            ],
         ];
     }
 }


### PR DESCRIPTION
This should fix #4857 and #4858

There was already a check for offset type to verify this was coherent with expected type. I added a new variable to check the offset was coherent by itself