### PR TITLE
Add taint analysis to language server

### DIFF
--- a/src/psalm-language-server.php
+++ b/src/psalm-language-server.php
@@ -60,6 +60,9 @@ $valid_long_options = [
     'tcp-server',
     'disable-on-change::',
     'enable-autocomplete',
+    'track-tainted-input',
+    'taint-analysis',
+    'security-analysis',
     'use-extended-diagnostic-codes',
     'verbose'
 ];
@@ -215,6 +218,10 @@ $first_autoloader = $include_collector->runAndCollect(
     }
 );
 
+$run_taint_analysis = (isset($options['track-tainted-input'])
+    || isset($options['security-analysis'])
+    || isset($options['taint-analysis']));
+
 $ini_handler = new \Psalm\Internal\Fork\PsalmRestarter('PSALM');
 
 $ini_handler->disableExtension('grpc');
@@ -289,6 +296,11 @@ $config->visitComposerAutoloadFiles($project_analyzer);
 
 if ($find_unused_code) {
     $project_analyzer->getCodebase()->reportUnusedCode($find_unused_code);
+}
+
+if ($config->run_taint_analysis || $run_taint_analysis) {
+    $is_diff = false;
+    $project_analyzer->trackTaintedInputs();
 }
 
 if (isset($options['use-extended-diagnostic-codes'])) {

--- a/src/psalm-language-server.php
+++ b/src/psalm-language-server.php
@@ -299,7 +299,7 @@ if ($find_unused_code) {
 }
 
 if ($config->run_taint_analysis || $run_taint_analysis) {
-    $is_diff = false;
+    //$is_diff = false;
     $project_analyzer->trackTaintedInputs();
 }
 


### PR DESCRIPTION
When the taint analysis feature was added in b2c0993cdc023608c1ef7c4b010ae5a0354c6b8f and 23ab0f1ddb552347fffde0ff6da5a48fb70356f7 it was added only for the `psalm` executable, not for `psalm-language-server`.
Hence, IDE plugins were not able to display security alerts (see for example https://github.com/psalm/psalm-vscode-plugin/issues/25 ).

I this commit I have ported from [`psalm.php`](https://github.com/vimeo/psalm/blob/master/src/psalm.php) to [`psalm-language-server.php`](https://github.com/vimeo/psalm/blob/master/src/psalm-language-server.php) the lines which load the taint analysis configuration.

With these changes and [psalm-vscode-plugin](https://github.com/psalm/psalm-vscode-plugin) I have been able to display taint alerts on Visual Studio Code:
![immagine](https://user-images.githubusercontent.com/8406735/102689554-4a109a00-41ff-11eb-802f-6085483f85cc.png)
