### PR TITLE
Allow by reference parameters in method docblock

### DIFF
--- a/src/Psalm/Internal/Type/ParseTreeCreator.php
+++ b/src/Psalm/Internal/Type/ParseTreeCreator.php
@@ -157,10 +157,10 @@ class ParseTreeCreator
         $default = '';
 
         if ($current_token[0] === '&') {
-            throw new TypeParseTreeException('Magic args cannot be passed by reference');
-        }
-
-        if ($current_token[0] === '...') {
+            $byref = true;
+            ++$this->t;
+            $current_token = $this->t < $this->type_token_count ? $this->type_tokens[$this->t] : null;
+        } elseif ($current_token[0] === '...') {
             $variadic = true;
 
             ++$this->t;
@@ -648,7 +648,7 @@ class ParseTreeCreator
 
         $current_parent = $this->current_leaf->parent;
 
-        if ($this->current_leaf instanceof ParseTree\MethodTree && $current_parent) {
+        if ($current_parent && $current_parent instanceof ParseTree\MethodTree) {
             $this->createMethodParam($this->type_tokens[$this->t], $current_parent);
             return;
         }

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -204,6 +204,26 @@ class MagicMethodAnnotationTest extends TestCase
                     $child->setArray(["boo"]);
                     $child->setArray(["boo"], 8);',
             ],
+            'validAnnotationWithByRefParam' => [
+                '<?php
+                    class ParentClass {
+                        public function __call(string $name, array $args) {}
+                    }
+
+                    /**
+                     * @template T
+                     * @method void configure(string $string, array &$arr)
+                     */
+                    class Child extends ParentClass
+                    {
+                        /** @psalm-param T $t */
+                        public function getChild($t): void {}
+                    }
+                    $child = new Child();
+
+                    $array = [];
+                    $child->configure("foo", $array);',
+            ],
             'validAnnotationWithNonEmptyDefaultArray' => [
                 '<?php
                     class ParentClass {


### PR DESCRIPTION
This tries to fix #4625, I've tried to imitate the variadic example.

Debugging this, the issue was that when interpreting the `&` it was creating a `IntersectionTree` instead of treating it as a part of the parameter. Tests pass, but not sure if this is the right fix 😬  

Fixes #4625 