### PR TITLE
Change ReflectionUnionType::getTypes() return type

### DIFF
--- a/stubs/Php80.php
+++ b/stubs/Php80.php
@@ -68,7 +68,7 @@ class Attribute
 
 class ReflectionUnionType extends ReflectionType {
     /**
-     * @return non-empty-list<ReflectionType>
+     * @return non-empty-list<ReflectionNamedType>
      */
     public function getTypes() {}
 }


### PR DESCRIPTION
`ReflectionUnionType::getTypes()` can currently only return `ReflectionNamedType` instances.

The PHP docs currently document it as `ReflectionType[]`; I [opened a PR](https://github.com/php/doc-en/pull/291) to document it as `ReflectionNamedType[]` instead, but concerns have been raised that this could change in the future, which I believe is unlikely, at least in a near future.

PHPStorm already documents it as [ReflectionNamedType[]](https://github.com/JetBrains/phpstorm-stubs/blob/master/Reflection/ReflectionUnionType.php), and I believe this is the right thing to do in Psalm as well.

