### PR TITLE
Document lowercase-string when possible

### DIFF
--- a/src/Psalm/Aliases.php
+++ b/src/Psalm/Aliases.php
@@ -4,22 +4,22 @@ namespace Psalm;
 class Aliases
 {
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     public $uses;
 
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     public $uses_flipped;
 
     /**
-     * @var array<string, non-empty-string>
+     * @var array<lowercase-string, non-empty-string>
      */
     public $functions;
 
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     public $functions_flipped;
 
@@ -46,11 +46,11 @@ class Aliases
     public $uses_end;
 
     /**
-     * @param array<string, string> $uses
-     * @param array<string, non-empty-string> $functions
+     * @param array<lowercase-string, string> $uses
+     * @param array<lowercase-string, non-empty-string> $functions
      * @param array<string, string> $constants
-     * @param array<string, string> $uses_flipped
-     * @param array<string, string> $functions_flipped
+     * @param array<lowercase-string, string> $uses_flipped
+     * @param array<lowercase-string, string> $functions_flipped
      * @param array<string, string> $constants_flipped
      */
     public function __construct(

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -51,7 +51,7 @@ class Codebase
      * A map of fully-qualified use declarations to the files
      * that reference them (keyed by filename)
      *
-     * @var array<string, array<int, \Psalm\CodeLocation>>
+     * @var array<lowercase-string, array<int, \Psalm\CodeLocation>>
      */
     public $use_referencing_locations = [];
 
@@ -59,7 +59,7 @@ class Codebase
      * A map of file names to the classes that they contain explicit references to
      * used in collaboration with use_referencing_locations
      *
-     * @var array<string, array<string, bool>>
+     * @var array<string, array<lowercase-string, bool>>
      */
     public $use_referencing_files = [];
 
@@ -235,7 +235,7 @@ class Codebase
     public $classes_to_move = [];
 
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     public $call_transforms = [];
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -397,7 +397,7 @@ class Config
     public $ensure_array_int_offsets_exist = false;
 
     /**
-     * @var array<string, bool>
+     * @var array<lowercase-string, bool>
      */
     public $forbidden_functions = [];
 
@@ -591,7 +591,7 @@ class Config
     /**
      * Custom functions that always exit
      *
-     * @var array<string, bool>
+     * @var array<lowercase-string, bool>
      */
     public $exit_functions = [];
 

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -142,7 +142,7 @@ class Context
     /**
      * A list of classes checked with class_exists
      *
-     * @var array<string,bool>
+     * @var array<lowercase-string,bool>
      */
     public $phantom_classes = [];
 

--- a/src/Psalm/Internal/Analyzer/CanAlias.php
+++ b/src/Psalm/Internal/Analyzer/CanAlias.php
@@ -11,27 +11,27 @@ use function strtolower;
 trait CanAlias
 {
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     private $aliased_classes = [];
 
     /**
-     * @var array<string, CodeLocation>
+     * @var array<lowercase-string, CodeLocation>
      */
     private $aliased_class_locations = [];
 
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     private $aliased_classes_flipped = [];
 
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     private $aliased_classes_flipped_replaceable = [];
 
     /**
-     * @var array<string, non-empty-string>
+     * @var array<lowercase-string, non-empty-string>
      */
     private $aliased_functions = [];
 
@@ -132,7 +132,7 @@ trait CanAlias
     }
 
     /**
-     * @return array<string, string>
+     * @return array<lowercase-string, string>
      */
     public function getAliasedClassesFlipped(): array
     {

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -421,7 +421,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
     }
 
     /**
-     * @return array<string, string>
+     * @return array<lowercase-string, string>
      */
     public function getAliasedClassesFlipped(): array
     {

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -351,7 +351,7 @@ class FileAnalyzer extends SourceAnalyzer
 
             $fq_class_name = $class_analyzer->getFQCLN();
 
-            $this->interface_analyzers_to_analyze[$fq_class_name] = $class_analyzer;
+            $this->interface_analyzers_to_analyze[strtolower($fq_class_name)] = $class_analyzer;
         }
     }
 

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -67,7 +67,7 @@ class FileAnalyzer extends SourceAnalyzer
     private $namespace_aliased_classes = [];
 
     /**
-     * @var array<string, array<string, string>>
+     * @var array<string, array<lowercase-string, string>>
      */
     private $namespace_aliased_classes_flipped = [];
 
@@ -77,7 +77,7 @@ class FileAnalyzer extends SourceAnalyzer
     private $namespace_aliased_classes_flipped_replaceable = [];
 
     /**
-     * @var array<string, InterfaceAnalyzer>
+     * @var array<lowercase-string, InterfaceAnalyzer>
      */
     public $interface_analyzers_to_analyze = [];
 
@@ -448,7 +448,7 @@ class FileAnalyzer extends SourceAnalyzer
     }
 
     /**
-     * @return array<string, string>
+     * @return array<lowercase-string, string>
      */
     public function getAliasedClassesFlipped(?string $namespace_name = null): array
     {

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1765,7 +1765,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     }
 
     /**
-     * @return array<string, string>
+     * @return array<lowercase-string, string>
      */
     public function getAliasedClassesFlipped(): array
     {

--- a/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
@@ -61,11 +61,12 @@ class ScopeAnalyzer
     }
 
     /**
-     * @param   array<PhpParser\Node> $stmts
-     * @param   bool $return_is_exit Exit and Throw statements are treated differently from return if this is false
-     * @param   list<'loop'|'switch'> $break_types
+     * @param array<PhpParser\Node> $stmts
+     * @param array<lowercase-string, bool> $exit_functions
+     * @param list<'loop'|'switch'> $break_types
+     * @param bool $return_is_exit Exit and Throw statements are treated differently from return if this is false
      *
-     * @return  list<self::ACTION_*>
+     * @return list<self::ACTION_*>
      */
     public static function getControlActions(
         array $stmts,

--- a/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/SourceAnalyzer.php
@@ -27,7 +27,7 @@ abstract class SourceAnalyzer implements StatementsSource
     }
 
     /**
-     * @return array<string, string>
+     * @return array<lowercase-string, string>
      */
     public function getAliasedClassesFlipped(): array
     {

--- a/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
@@ -41,7 +41,7 @@ class TraitAnalyzer extends ClassLikeAnalyzer
     }
 
     /**
-     * @return array<string, string>
+     * @return array<lowercase-string, string>
      */
     public function getAliasedClassesFlipped(): array
     {

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -93,7 +93,7 @@ class ClassLikes
     private $existing_traits = [];
 
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     private $classlike_aliases = [];
 
@@ -557,7 +557,7 @@ class ClassLikes
     }
 
     /**
-     * @return array<string, string>   all interfaces extended by $interface_name
+     * @return array<lowercase-string, string>   all interfaces extended by $interface_name
      */
     public function getParentInterfaces(string $fq_interface_name): array
     {

--- a/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
+++ b/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
@@ -38,7 +38,7 @@ class InternalCallMapHandler
     private static $loaded_php_minor_version = null;
 
     /**
-     * @var array<array<int|string,string>>|null
+     * @var array<lowercase-string, array<int|string,string>>|null
      */
     private static $call_map = null;
 

--- a/src/Psalm/Internal/Codebase/PropertyMap.php
+++ b/src/Psalm/Internal/Codebase/PropertyMap.php
@@ -9,14 +9,14 @@ use function strtolower;
 class PropertyMap
 {
     /**
-     * @var array<string, array<string, string>>|null
+     * @var array<lowercase-string, array<string, string>>|null
      */
     private static $property_map;
 
     /**
      * Gets the method/function call map
      *
-     * @return array<string, array<string, string>>
+     * @return array<lowercase-string, array<string, string>>
      */
     public static function getPropertyMap(): array
     {

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -53,7 +53,7 @@ use function substr;
  *     unchanged_signature_members:array<string, array<string, bool>>,
  *     diff_map:array<string, array<int, array{0:int, 1:int, 2:int, 3:int}>>,
  *     classlike_storage:array<string, \Psalm\Storage\ClassLikeStorage>,
- *     file_storage:array<string, \Psalm\Storage\FileStorage>,
+ *     file_storage:array<lowercase-string, \Psalm\Storage\FileStorage>,
  *     new_file_content_hashes: array<string, string>,
  *     taint_data: ?TaintFlowGraph
  * }

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -12,12 +12,12 @@ use function strtolower;
 class FileProvider
 {
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     protected $temp_files = [];
 
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     protected $open_files = [];
 

--- a/src/Psalm/Internal/Provider/FileStorageProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageProvider.php
@@ -14,7 +14,7 @@ class FileStorageProvider
      * A list of data useful to analyse files
      * Storing this statically is much faster (at least in PHP 7.2.1)
      *
-     * @var array<string, FileStorage>
+     * @var array<lowercase-string, FileStorage>
      */
     private static $storage = [];
 
@@ -81,7 +81,7 @@ class FileStorageProvider
     }
 
     /**
-     * @return array<string, FileStorage>
+     * @return array<lowercase-string, FileStorage>
      */
     public function getAll(): array
     {
@@ -97,8 +97,7 @@ class FileStorageProvider
     }
 
     /**
-     * @param array<string, FileStorage> $more
-     *
+     * @param array<lowercase-string, FileStorage> $more
      */
     public function addMore(array $more): void
     {

--- a/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
@@ -10,7 +10,7 @@ class FunctionExistenceProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     StatementsSource,
      *     string
@@ -38,7 +38,7 @@ class FunctionExistenceProvider
     }
 
     /**
-     * /**
+     * @param lowercase-string $function_id
      * @param \Closure(
      *     StatementsSource,
      *     string

--- a/src/Psalm/Internal/Provider/FunctionParamsProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionParamsProvider.php
@@ -12,7 +12,7 @@ class FunctionParamsProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     StatementsSource,
      *     string,

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -13,7 +13,7 @@ class FunctionReturnTypeProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     StatementsSource,
      *     non-empty-string,
@@ -72,7 +72,7 @@ class FunctionReturnTypeProvider
     }
 
     /**
-     * /**
+     * @param lowercase-string $function_id
      * @param \Closure(
      *     StatementsSource,
      *     non-empty-string,

--- a/src/Psalm/Internal/Provider/MethodExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/MethodExistenceProvider.php
@@ -11,7 +11,7 @@ class MethodExistenceProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     string,
      *     string,

--- a/src/Psalm/Internal/Provider/MethodParamsProvider.php
+++ b/src/Psalm/Internal/Provider/MethodParamsProvider.php
@@ -12,7 +12,7 @@ class MethodParamsProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     string,
      *     string,

--- a/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
@@ -13,7 +13,7 @@ class MethodReturnTypeProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     StatementsSource,
      *     string,

--- a/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
@@ -12,7 +12,7 @@ class MethodVisibilityProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     StatementsSource,
      *     string,

--- a/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
@@ -12,7 +12,7 @@ class PropertyExistenceProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     string,
      *     string,

--- a/src/Psalm/Internal/Provider/PropertyTypeProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyTypeProvider.php
@@ -12,7 +12,7 @@ class PropertyTypeProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     string,
      *     string,

--- a/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
@@ -12,7 +12,7 @@ class PropertyVisibilityProvider
 {
     /**
      * @var array<
-     *   string,
+     *   lowercase-string,
      *   array<\Closure(
      *     StatementsSource,
      *     string,

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayChunkReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayChunkReturnTypeProvider.php
@@ -11,6 +11,9 @@ use Psalm\Type;
 
 class ArrayChunkReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds(): array
     {
         return ['array_chunk'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ArrayColumnReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_column'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFillReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFillReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ArrayFillReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_fill'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -18,6 +18,9 @@ use Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer;
 
 class ArrayFilterReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_filter'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
@@ -17,6 +17,9 @@ use Psalm\Internal\Analyzer\Statements\Expression\AssertionFinder;
 
 class ArrayMapReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_map'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMergeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMergeReturnTypeProvider.php
@@ -12,6 +12,9 @@ use Psalm\Type;
 
 class ArrayMergeReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_merge', 'array_replace'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPadReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPadReturnTypeProvider.php
@@ -11,6 +11,9 @@ use Psalm\Type;
 
 class ArrayPadReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds(): array
     {
         return ['array_pad'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPointerAdjustmentReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPointerAdjustmentReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ArrayPointerAdjustmentReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['current', 'next', 'prev', 'reset', 'end'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPopReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPopReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ArrayPopReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_pop', 'array_shift'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayRandReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayRandReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ArrayRandReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_rand'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
@@ -19,6 +19,9 @@ use function strtolower;
 
 class ArrayReduceReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_reduce'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReverseReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReverseReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ArrayReverseReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_reverse'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySliceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySliceReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ArraySliceReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_slice'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayUniqueReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayUniqueReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ArrayUniqueReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_unique'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayValuesReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayValuesReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ArrayValuesReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['array_values'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ExplodeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ExplodeReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class ExplodeReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['explode'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterVarReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterVarReturnTypeProvider.php
@@ -10,6 +10,9 @@ use Psalm\Internal\DataFlow\DataFlowNode;
 
 class FilterVarReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['filter_var'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FirstArgStringReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FirstArgStringReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class FirstArgStringReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return [

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetClassMethodsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetClassMethodsReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class GetClassMethodsReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return [

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class GetObjectVarsReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return [

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/HexdecReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/HexdecReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class HexdecReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['hexdec'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
@@ -13,6 +13,9 @@ use Psalm\Type;
 
 class IteratorToArrayReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return [

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/MktimeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/MktimeReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 
 class MktimeReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return [

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ParseUrlReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ParseUrlReturnTypeProvider.php
@@ -19,6 +19,9 @@ use Psalm\Type;
 
 class ParseUrlReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['parse_url'];

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/StrReplaceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/StrReplaceReturnTypeProvider.php
@@ -10,6 +10,9 @@ use Psalm\Type;
 
 class StrReplaceReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return [

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/StrTrReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/StrTrReturnTypeProvider.php
@@ -10,6 +10,9 @@ use Psalm\Internal\DataFlow\DataFlowNode;
 
 class StrTrReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return [
@@ -41,7 +44,7 @@ class StrTrReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypePr
                 null,
                 $code_location
             );
-            
+
             $statements_source->data_flow_graph->addNode($function_return_sink);
             foreach ($call_args as $i => $_) {
                 $function_param_sink = DataFlowNode::getForMethodArgument(

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/VersionCompareReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/VersionCompareReturnTypeProvider.php
@@ -11,6 +11,9 @@ use Psalm\Type;
 
 class VersionCompareReturnTypeProvider implements \Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface
 {
+    /**
+     * @return array<lowercase-string>
+     */
     public static function getFunctionIds() : array
     {
         return ['version_compare'];

--- a/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
+++ b/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
@@ -241,7 +241,7 @@ class PhpStormMetaScanner
             && $identifier->args
             && $identifier->args[0]->value instanceof PhpParser\Node\Scalar\LNumber
         ) {
-            $function_id = implode('\\', $identifier->name->parts);
+            $function_id = strtolower(implode('\\', $identifier->name->parts));
 
             if ($map) {
                 $offset = $identifier->args[0]->value->value;

--- a/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionExistenceProviderInterface.php
@@ -6,7 +6,7 @@ use Psalm\StatementsSource;
 interface FunctionExistenceProviderInterface
 {
     /**
-     * @return array<string>
+     * @return array<lowercase-string>
      */
     public static function getFunctionIds() : array;
 

--- a/src/Psalm/Plugin/Hook/FunctionParamsProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionParamsProviderInterface.php
@@ -9,7 +9,7 @@ use Psalm\StatementsSource;
 interface FunctionParamsProviderInterface
 {
     /**
-     * @return array<string>
+     * @return array<lowercase-string>
      */
     public static function getFunctionIds() : array;
 

--- a/src/Psalm/Plugin/Hook/FunctionReturnTypeProviderInterface.php
+++ b/src/Psalm/Plugin/Hook/FunctionReturnTypeProviderInterface.php
@@ -10,7 +10,7 @@ use Psalm\Type;
 interface FunctionReturnTypeProviderInterface
 {
     /**
-     * @return array<string>
+     * @return array<lowercase-string>
      */
     public static function getFunctionIds() : array;
 

--- a/src/Psalm/StatementsSource.php
+++ b/src/Psalm/StatementsSource.php
@@ -6,7 +6,7 @@ interface StatementsSource extends FileSource
     public function getNamespace(): ?string;
 
     /**
-     * @return array<string, string>
+     * @return array<lowercase-string, string>
      */
     public function getAliasedClassesFlipped(): array;
 

--- a/src/Psalm/Storage/FileStorage.php
+++ b/src/Psalm/Storage/FileStorage.php
@@ -13,17 +13,17 @@ class FileStorage
     public $classlikes_in_file = [];
 
     /**
-     * @var array<string>
+     * @var array<lowercase-string, string>
      */
     public $referenced_classlikes = [];
 
     /**
-     * @var array<string>
+     * @var array<lowercase-string, string>
      */
     public $required_classes = [];
 
     /**
-     * @var array<string>
+     * @var array<lowercase-string, string>
      */
     public $required_interfaces = [];
 
@@ -51,10 +51,10 @@ class FileStorage
     /** @var array<string, string> */
     public $declaring_constants = [];
 
-    /** @var array<string, string> */
+    /** @var array<lowercase-string, string> */
     public $required_file_paths = [];
 
-    /** @var array<string, string> */
+    /** @var array<lowercase-string, string> */
     public $required_by_file_paths = [];
 
     /** @var bool */

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -101,7 +101,7 @@ abstract class Type
     }
 
     /**
-     * @param array<string, string> $aliased_classes
+     * @param array<lowercase-string, string> $aliased_classes
      *
      * @psalm-pure
      */

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -548,8 +548,7 @@ abstract class Atomic implements TypeNode
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
-     *
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -561,7 +560,7 @@ abstract class Atomic implements TypeNode
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     abstract public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/CallableTrait.php
+++ b/src/Psalm/Type/Atomic/CallableTrait.php
@@ -64,7 +64,7 @@ trait CallableTrait
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -129,7 +129,7 @@ trait CallableTrait
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -61,7 +61,7 @@ trait GenericTrait
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/HasIntersectionTrait.php
+++ b/src/Psalm/Type/Atomic/HasIntersectionTrait.php
@@ -16,7 +16,7 @@ trait HasIntersectionTrait
     public $extra_types;
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     private function getNamespacedIntersectionTypes(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
+++ b/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
@@ -19,7 +19,7 @@ class TAnonymousClassInstance extends TNamedObject
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TArray.php
+++ b/src/Psalm/Type/Atomic/TArray.php
@@ -38,7 +38,7 @@ class TArray extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TArrayKey.php
+++ b/src/Psalm/Type/Atomic/TArrayKey.php
@@ -17,7 +17,7 @@ class TArrayKey extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -35,7 +35,7 @@ class TArrayKey extends Scalar
     }
 
     /**
-     * @param array<string> $aliased_classes
+     * @param array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TAssertionFalsy.php
+++ b/src/Psalm/Type/Atomic/TAssertionFalsy.php
@@ -22,7 +22,7 @@ class TAssertionFalsy extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TBool.php
+++ b/src/Psalm/Type/Atomic/TBool.php
@@ -17,7 +17,7 @@ class TBool extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TCallable.php
+++ b/src/Psalm/Type/Atomic/TCallable.php
@@ -14,7 +14,7 @@ class TCallable extends \Psalm\Type\Atomic
     public $value;
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TCallableObject.php
+++ b/src/Psalm/Type/Atomic/TCallableObject.php
@@ -17,7 +17,7 @@ class TCallableObject extends TObject
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TClassString.php
+++ b/src/Psalm/Type/Atomic/TClassString.php
@@ -55,7 +55,7 @@ class TClassString extends TString
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -68,8 +68,7 @@ class TClassString extends TString
     }
 
     /**
-     * @param  array<string> $aliased_classes
-     *
+     * @param array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TClassStringMap.php
+++ b/src/Psalm/Type/Atomic/TClassStringMap.php
@@ -76,7 +76,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(
@@ -111,7 +111,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TClosedResource.php
+++ b/src/Psalm/Type/Atomic/TClosedResource.php
@@ -22,7 +22,7 @@ class TClosedResource extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TConditional.php
+++ b/src/Psalm/Type/Atomic/TConditional.php
@@ -96,7 +96,7 @@ class TConditional extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      * @return null
      */
@@ -111,7 +111,7 @@ class TConditional extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TEmpty.php
+++ b/src/Psalm/Type/Atomic/TEmpty.php
@@ -18,7 +18,7 @@ class TEmpty extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TFloat.php
+++ b/src/Psalm/Type/Atomic/TFloat.php
@@ -17,7 +17,7 @@ class TFloat extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TGenericObject.php
+++ b/src/Psalm/Type/Atomic/TGenericObject.php
@@ -54,7 +54,7 @@ class TGenericObject extends TNamedObject
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TInt.php
+++ b/src/Psalm/Type/Atomic/TInt.php
@@ -17,7 +17,7 @@ class TInt extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TIntMask.php
+++ b/src/Psalm/Type/Atomic/TIntMask.php
@@ -35,7 +35,7 @@ class TIntMask extends TInt
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -48,7 +48,7 @@ class TIntMask extends TInt
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TIntMaskOf.php
+++ b/src/Psalm/Type/Atomic/TIntMaskOf.php
@@ -30,7 +30,7 @@ class TIntMaskOf extends TInt
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -43,8 +43,7 @@ class TIntMaskOf extends TInt
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
-     *
+     * @param array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TIterable.php
+++ b/src/Psalm/Type/Atomic/TIterable.php
@@ -79,7 +79,7 @@ class TIterable extends Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
@@ -40,7 +40,7 @@ class TKeyOfClassConstant extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -58,8 +58,7 @@ class TKeyOfClassConstant extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
-     *
+     * @param array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -132,7 +132,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(
@@ -183,7 +183,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -52,7 +52,7 @@ class TList extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(
@@ -84,7 +84,7 @@ class TList extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TLiteralClassString.php
+++ b/src/Psalm/Type/Atomic/TLiteralClassString.php
@@ -31,7 +31,7 @@ class TLiteralClassString extends TLiteralString
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -59,8 +59,7 @@ class TLiteralClassString extends TLiteralString
     }
 
     /**
-     * @param  array<string> $aliased_classes
-     *
+     * @param array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -25,7 +25,7 @@ class TLiteralFloat extends TFloat
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -38,7 +38,7 @@ class TLiteralFloat extends TFloat
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TLiteralInt.php
@@ -25,7 +25,7 @@ class TLiteralInt extends TInt
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -38,7 +38,7 @@ class TLiteralInt extends TInt
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -39,7 +39,7 @@ class TLiteralString extends TString
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -52,7 +52,7 @@ class TLiteralString extends TString
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TMixed.php
+++ b/src/Psalm/Type/Atomic/TMixed.php
@@ -25,7 +25,7 @@ class TMixed extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -71,7 +71,7 @@ class TNamedObject extends Atomic
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(
@@ -102,7 +102,7 @@ class TNamedObject extends Atomic
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TNever.php
+++ b/src/Psalm/Type/Atomic/TNever.php
@@ -18,7 +18,7 @@ class TNever extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TNull.php
+++ b/src/Psalm/Type/Atomic/TNull.php
@@ -17,7 +17,7 @@ class TNull extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TNumeric.php
+++ b/src/Psalm/Type/Atomic/TNumeric.php
@@ -17,7 +17,7 @@ class TNumeric extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TObject.php
+++ b/src/Psalm/Type/Atomic/TObject.php
@@ -17,7 +17,7 @@ class TObject extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -121,7 +121,7 @@ class TObjectWithProperties extends TObject
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(
@@ -165,7 +165,7 @@ class TObjectWithProperties extends TObject
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TPositiveInt.php
+++ b/src/Psalm/Type/Atomic/TPositiveInt.php
@@ -25,7 +25,7 @@ class TPositiveInt extends TInt
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TResource.php
+++ b/src/Psalm/Type/Atomic/TResource.php
@@ -17,7 +17,7 @@ class TResource extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TScalar.php
+++ b/src/Psalm/Type/Atomic/TScalar.php
@@ -18,7 +18,7 @@ class TScalar extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TScalarClassConstant.php
+++ b/src/Psalm/Type/Atomic/TScalarClassConstant.php
@@ -34,7 +34,7 @@ class TScalarClassConstant extends Scalar
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -52,7 +52,7 @@ class TScalarClassConstant extends Scalar
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TString.php
+++ b/src/Psalm/Type/Atomic/TString.php
@@ -7,7 +7,7 @@ namespace Psalm\Type\Atomic;
 class TString extends Scalar
 {
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
+++ b/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
@@ -44,7 +44,7 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -62,7 +62,7 @@ class TTemplateIndexedAccess extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TTemplateKeyOf.php
+++ b/src/Psalm/Type/Atomic/TTemplateKeyOf.php
@@ -49,7 +49,7 @@ class TTemplateKeyOf extends TArrayKey
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -70,7 +70,7 @@ class TTemplateKeyOf extends TArrayKey
     }
 
     /**
-     * @param array<string> $aliased_classes
+     * @param array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TTemplateParam.php
+++ b/src/Psalm/Type/Atomic/TTemplateParam.php
@@ -70,7 +70,7 @@ class TTemplateParam extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      * @return null
      */
@@ -85,7 +85,7 @@ class TTemplateParam extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TTemplateParamClass.php
+++ b/src/Psalm/Type/Atomic/TTemplateParamClass.php
@@ -49,7 +49,7 @@ class TTemplateParamClass extends TClassString
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -67,7 +67,7 @@ class TTemplateParamClass extends TClassString
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TTraitString.php
+++ b/src/Psalm/Type/Atomic/TTraitString.php
@@ -22,7 +22,7 @@ class TTraitString extends TString
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -35,7 +35,7 @@ class TTraitString extends TString
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TTypeAlias.php
+++ b/src/Psalm/Type/Atomic/TTypeAlias.php
@@ -61,7 +61,7 @@ class TTypeAlias extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -79,7 +79,7 @@ class TTypeAlias extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(

--- a/src/Psalm/Type/Atomic/TValueOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TValueOfClassConstant.php
@@ -34,7 +34,7 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,
@@ -52,8 +52,7 @@ class TValueOfClassConstant extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
-     *
+     * @param array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,

--- a/src/Psalm/Type/Atomic/TVoid.php
+++ b/src/Psalm/Type/Atomic/TVoid.php
@@ -17,7 +17,7 @@ class TVoid extends \Psalm\Type\Atomic
     }
 
     /**
-     * @param  array<string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -413,7 +413,7 @@ class Union implements TypeNode
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      *
      */
     public function toNamespacedString(
@@ -448,7 +448,7 @@ class Union implements TypeNode
     }
 
     /**
-     * @param  array<string, string> $aliased_classes
+     * @param  array<lowercase-string, string> $aliased_classes
      */
     public function toPhpString(
         ?string $namespace,

--- a/tests/Config/Plugin/Hook/MagicFunctionProvider.php
+++ b/tests/Config/Plugin/Hook/MagicFunctionProvider.php
@@ -16,7 +16,7 @@ class MagicFunctionProvider implements
     FunctionReturnTypeProviderInterface
 {
     /**
-     * @return array<string>
+     * @return array<lowercase-string>
      */
     public static function getFunctionIds() : array
     {

--- a/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
+++ b/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
@@ -6,7 +6,7 @@ use function strtolower;
 
 class FileStorageInstanceCacheProvider extends \Psalm\Internal\Provider\FileStorageCacheProvider
 {
-    /** @var array<string, FileStorage> */
+    /** @var array<lowercase-string, FileStorage> */
     private $cache = [];
 
     public function __construct()


### PR DESCRIPTION
I made a blackfire profiling on psalm today and I was surprised to see that the most called function and the one that takes the longer is `strtolower`. I wanted to see if there wasn't some redundant functions so I documented lowercase-string where I could.

Psalm didn't report any redundant strtolower :( Worse, I found two places where there was a missing strtolower(cf commit 2)