### PR TITLE
Check if included files are listed in mustBeIgnored

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -143,6 +143,9 @@ class IncludeAnalyzer
                 ) {
                     return true;
                 }
+                if ($config->mustBeIgnored($path_to_file)) {
+                    return true;
+                }
 
                 $current_file_analyzer->addRequiredFilePath($path_to_file);
 


### PR DESCRIPTION
Previously, when a file was included in `include()`, it was not subject
to ignoreFiles

Related to #4876