### PR TITLE
Add missing param for constructor arguments in PDOStatement#fetchObject

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -9884,7 +9884,7 @@ return [
 'PDOStatement::fetch' => ['mixed', 'how='=>'int', 'orientation='=>'int', 'offset='=>'int'],
 'PDOStatement::fetchAll' => ['array|false', 'how='=>'int', 'fetch_argument='=>'int|string|callable', 'ctor_args='=>'?array'],
 'PDOStatement::fetchColumn' => ['string|int|float|bool|null', 'column_number='=>'int'],
-'PDOStatement::fetchObject' => ['object|false', 'class_name='=>'string', 'ctor_args='=>'?array'],
+'PDOStatement::fetchObject' => ['object|false', 'class_name='=>'string', 'ctor_args='=>'array'],
 'PDOStatement::getAttribute' => ['mixed', 'attribute'=>'int'],
 'PDOStatement::getColumnMeta' => ['array|false', 'column'=>'int'],
 'PDOStatement::nextRowset' => ['bool'],

--- a/stubs/pdo.php
+++ b/stubs/pdo.php
@@ -6,7 +6,8 @@ class PdoStatement {
      *
      * @template T
      * @param class-string<T> $class
+     * @param array $ctorArgs
      * @return false|T
      */
-    public function fetchObject($class = "stdclass") {}
+    public function fetchObject($class = "stdclass", array $ctorArgs = array()) {}
 }


### PR DESCRIPTION
`PDOStatement#fetchObject` allows a second, optional parameter for constructor arguments, which - if given - will be passed to the given class' constructor.
See: https://www.php.net/manual/de/pdostatement.fetchobject.php

Also see the PhpStorm stubs: https://github.com/JetBrains/phpstorm-stubs/blob/master/PDO/PDO.php#L1441

Currently psalm reports a `TooManyArguments` error for code like this:

```php
<?php

class MyClass {}

/** @var PDO $pdo */
$pdo->query('some-query')->fetchObject(MyClass::class, ['ctor', 'args']);
``` 

See: https://psalm.dev/r/9426558ef1