### PR TITLE
remove test namespace from autoload-dev to allow usage outside of Psalm (e.g. for plugins)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,17 +72,13 @@
     },
     "autoload": {
         "psr-4": {
-            "Psalm\\": "src/Psalm/"
+            "Psalm\\": "src/Psalm/",
+            "Psalm\\Tests\\": "tests/"
         },
         "files": [
             "src/functions.php",
             "src/spl_object_id.php"
         ]
-    },
-    "autoload-dev": {
-        "psr-4": {
-            "Psalm\\Tests\\": "tests/"
-        }
     },
     "repositories": [
         {


### PR DESCRIPTION
I started a discussion on this subject here: https://github.com/vimeo/psalm/discussions/4887