### PR TITLE
SARIF report: Include help links

### DIFF
--- a/src/Psalm/Report/SarifReport.php
+++ b/src/Psalm/Report/SarifReport.php
@@ -23,6 +23,7 @@ class SarifReport extends Report
                     'tool' => [
                         'driver' => [
                             'name' => 'Psalm',
+                            'informationUri' => 'https://psalm.dev',
                             'version' => PSALM_VERSION,
                         ],
                     ],
@@ -45,6 +46,7 @@ class SarifReport extends Report
                         (\substr($issue_data->type, 0, 7) === 'Tainted') ? 'security' : 'maintainability',
                     ],
                 ],
+                'helpUri' => $issue_data->link,
             ];
 
             $markdown_documentation_path = __DIR__ . '/../../../docs/running_psalm/issues/' . $issue_data->type . '.md';

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -98,6 +98,7 @@ echo "Successfully executed the command: " . $prefixedData;';
                     'tool' => [
                         'driver' => [
                             'name' => 'Psalm',
+                            'informationUri' => 'https://psalm.dev',
                             'version' => '2.0.0',
                             'rules' => [
                                 [
@@ -111,6 +112,7 @@ echo "Successfully executed the command: " . $prefixedData;';
                                             'security'
                                         ],
                                     ],
+                                    'helpUri' => 'https://psalm.dev/246',
                                     'help' => [
                                         'markdown' => file_get_contents(__DIR__ . '/../docs/running_psalm/issues/TaintedShell.md'),
                                         'text' => file_get_contents(__DIR__ . '/../docs/running_psalm/issues/TaintedShell.md'),
@@ -127,6 +129,7 @@ echo "Successfully executed the command: " . $prefixedData;';
                                             'security'
                                         ],
                                     ],
+                                    'helpUri' => 'https://psalm.dev/245',
                                     'help' => [
                                         'markdown' => file_get_contents(__DIR__ . '/../docs/running_psalm/issues/TaintedHtml.md'),
                                         'text' => file_get_contents(__DIR__ . '/../docs/running_psalm/issues/TaintedHtml.md'),


### PR DESCRIPTION
This will make it quicker for users to access the help as tools can directly print the link in the issue details.