### PR TITLE
PHAR: Include issue docs for SARIF output

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -9,7 +9,12 @@
         "src/psalm-refactor.php"
     ],
     "files-bin": ["config.xsd"],
-    "directories-bin" : ["assets", "dictionaries", "stubs"],
+    "directories-bin" : [
+        "assets",
+        "dictionaries",
+        "docs/running_psalm/issues",
+        "stubs"
+    ],
     "compactors" : [
         "KevinGH\\Box\\Compactor\\PhpScoper"
     ]


### PR DESCRIPTION
The SARIF report uses the Markdown files inside `docs/running_psalm/issues` for its output, so the files should be included in the PHAR.