### PR TITLE
Infer result of modulo 1 operation statically

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -674,9 +674,18 @@ class NonDivArithmeticOpAnalyzer
                     }
 
                     if ($parent instanceof PhpParser\Node\Expr\BinaryOp\Mod) {
-                        $result_type = $always_positive
-                            ? new Type\Union([new Type\Atomic\TPositiveInt(), new TLiteralInt(0)])
-                            : Type::getInt();
+                        if ($always_positive) {
+                            if ($right_type_part instanceof TLiteralInt && $right_type_part->value === 1) {
+                                $result_type = Type::getInt(true, 0);
+                            } else {
+                                $result_type = new Type\Union([
+                                    new Type\Atomic\TPositiveInt(),
+                                    new TLiteralInt(0)
+                                ]);
+                            }
+                        } else {
+                            $result_type = Type::getInt();
+                        }
                     } elseif (!$result_type) {
                         $result_type = $always_positive ? Type::getPositiveInt(true) : Type::getInt(true);
                     } else {

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -131,12 +131,14 @@ class BinaryOperationTest extends TestCase
                     $a = 25 % 2;
                     $b = 25.4 % 2;
                     $c = 25 % 2.5;
-                    $d = 25.5 % 2.5;',
+                    $d = 25.5 % 2.5;
+                    $e = 25 % 1;',
                 'assertions' => [
                     '$a' => 'int',
                     '$b' => 'int',
                     '$c' => 'int',
                     '$d' => 'int',
+                    '$e' => 'int',
                 ],
             ],
             'numericAddition' => [


### PR DESCRIPTION
This PR propose handling the case where the left part of a modulo was already inferred to 1. In this case, the result is always 0.

I added that to resolve an issue emitted in Doctrine:
https://github.com/doctrine/orm/blob/3ef5a30102905483c29a6849c8c4efb4dfbe97d6/lib/Doctrine/ORM/Query.php#L413

> ERROR: InvalidArrayOffset - lib/Doctrine/ORM/Query.php:416:49 - Cannot access value on variable $value using a int(0)|positive-int offset, expecting int(0) (see https://psalm.dev/115)
`                $sqlParams[$sqlPositions[$i]] = $value[($i % $countValue)];`

The modulo will always return 0 in this case(because the array has only 1 element) so there is no real issue.
