### PR TITLE
add ArrayAccess to SimpleXmlElement

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -2215,7 +2215,7 @@ final class WeakReference
     public function get(): ?object;
 }
 
-class SimpleXMLElement implements \Stringable, \Countable, \RecursiveIterator
+class SimpleXMLElement implements \Stringable, \Countable, \RecursiveIterator, \ArrayAccess
 {
     /** @return array */
     public function getNamespaces(bool $recursive = false)
@@ -2282,6 +2282,22 @@ class SimpleXMLElement implements \Stringable, \Countable, \RecursiveIterator
     }
     /** @return SimpleXMLElement|null */
     public function getChildren()
+    {
+    }
+
+    public function offsetExists($offset)
+    {
+    }
+
+    public function offsetGet($offset)
+    {
+    }
+
+    public function offsetSet($offset, $value)
+    {
+    }
+
+    public function offsetUnset($offset)
     {
     }
 }

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -835,6 +835,14 @@ class ArrayAccessTest extends TestCase
                         return $s["a"];
                     }',
             ],
+            'simpleXmlArrayFetchChildren' => [
+                '<?php
+                    function iterator(SimpleXMLElement $xml): iterable {
+                        foreach ($xml->children() as $img) {
+                            yield $img["src"] ?? "";
+                        }
+                    }',
+            ],
             'assertOnArrayAccess' => [
                 '<?php
                     class A {


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/4933

However, I'm not sure this is the correct fix as https://github.com/vimeo/psalm/compare/master...orklah:ArrayAccess?expand=1#diff-ae46a3ded74600c7b71b7e92661c1427c514741f10191e1b9aa49c7a3e83c5afR835 already works somehow