### PR TITLE
Added initial support of asserting properties of objects out of scope

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -18,6 +18,7 @@ use Psalm\Issue\ArgumentTypeCoercion;
 use Psalm\Issue\UndefinedFunction;
 use Psalm\IssueBuffer;
 use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\PropertyStorage;
 use Psalm\Type;
 use Psalm\Type\Atomic\TNamedObject;
 use function strtolower;
@@ -677,6 +678,39 @@ class CallAnalyzer
                 $assertion_var_id = $assertion->var_id;
             } elseif (isset($context->vars_in_scope[$assertion->var_id])) {
                 $assertion_var_id = $assertion->var_id;
+            } elseif (str_contains($assertion->var_id, '->')) {
+                [$var_id, $property] = explode('->', $assertion->var_id);
+
+                if (!is_numeric($var_id) || !isset($args[$var_id])) {
+                    continue; // any chance to report malformed/not supported assertion?
+                }
+
+                $arg_value = $args[$var_id]->value;
+
+                $arg_var_id = ExpressionIdentifier::getArrayVarId($arg_value, null, $statements_analyzer); // $c
+
+                if (!$arg_var_id) {
+                    continue;
+                }
+
+                foreach ($context->vars_in_scope[$arg_var_id]->getAtomicTypes() as $type) {
+                    if (!$type instanceof TNamedObject) {
+                        continue 2;
+                    }
+
+                    $class_definition = $statements_analyzer->getCodebase()->classlike_storage_provider->get($type->value);
+                    $property_definition = $class_definition->properties[$property] ?? null;
+
+                    if (!$property_definition instanceof PropertyStorage) {
+                        continue 2; // incorrect/not-existing property mentioned in assert-annotation
+                    }
+
+                    if (!$property_definition->readonly) {
+                        continue 2;
+                    }
+                }
+
+                $assertion_var_id = str_replace($var_id, $arg_var_id, $assertion->var_id);
             }
 
             if ($assertion_var_id) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -1087,6 +1087,14 @@ class FunctionLikeDocblockScanner
                         );
                         continue 2;
                     }
+
+                    if (strpos($assertion['param_name'], $param->name.'->') === 0) {
+                        $storage->assertions[] = new \Psalm\Storage\Assertion(
+                            str_replace($param->name, $i, $assertion['param_name']),
+                            [$assertion_type_parts]
+                        );
+                        continue 2;
+                    }
                 }
 
                 $storage->assertions[] = new \Psalm\Storage\Assertion(

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -1414,6 +1414,27 @@ class AssertAnnotationTest extends TestCase
                     }
                 ?>'
             ],
+            'assertOnPropertyOfImmutableArgument' => [
+                '<?php
+                    /** @psalm-immutable */
+                    class Aclass {
+                        public ?string $b;
+                        public function __construct(?string $b) {
+                            $this->b = $b;
+                        }
+                    }
+
+                    /** @psalm-assert !null $item->b */
+                    function c(\Aclass $item): void {
+                        if (null === $item->b) {
+                            throw new \InvalidArgumentException("");
+                        }
+                    }
+
+                    /** @var \Aclass $a */
+                    c($a);
+                    echo strlen($a->b);',
+            ],
         ];
     }
 
@@ -1655,6 +1676,27 @@ class AssertAnnotationTest extends TestCase
                         public static function foo($value);
                     }',
                 'error_message' => 'InvalidDocblock',
+            ],
+            'assertOnPropertyOfMutableArgument' => [
+                '<?php
+                    class Aclass {
+                        public ?string $b;
+                        public function __construct(?string $b) {
+                            $this->b = $b;
+                        }
+                    }
+
+                    /** @psalm-assert !null $item->b */
+                    function c(\Aclass $item): void {
+                        if (null === $item->b) {
+                            throw new \InvalidArgumentException("");
+                        }
+                    }
+
+                    /** @var \Aclass $a */
+                    c($a);
+                    echo strlen($a->b);',
+                'error_message' => 'PossiblyNullArgument',
             ],
         ];
     }


### PR DESCRIPTION
Fixes #4619

[x]￼ Support for @psalm-assert + tests (both failed and )
[ ]￼ Support for @psalm-assert-if-true + tests
[ ] Support for @psalm-assert-if-false + tests

Adding support of additional `@psalm-assert-*` annotations looks pretty straightforward and will be added soon. Meanwhile I have a few questions to devs:

1. any additional use-cases to check?
2. any chance/way to log/report malformed annotation/incorrect properties/other checks I do before asserting?
3. any other types should have similar property assertion feature except `TNamedObject` in L697 (cannot find any in my mind)?
4. I limited to immutable objects only, but theoretically, objects having single reference are valid as well, but not sure how to implement reference-creation-listener  :(

It's my first PR so would appreciate any comments prior closing if I did something wrong.

Thanks in advance!