### PR TITLE
handle concatenation with int parts

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -209,7 +209,7 @@ class ConcatAnalyzer
                 if ($left_type_part instanceof Type\Atomic\TTemplateParam) {
                     if (IssueBuffer::accepts(
                         new MixedOperand(
-                            'Left operand cannot be mixed',
+                            'Left operand cannot be a template param',
                             new CodeLocation($statements_analyzer->getSource(), $left)
                         ),
                         $statements_analyzer->getSuppressedIssues()
@@ -449,9 +449,20 @@ class ConcatAnalyzer
         if ($left_type && $right_type && $left_type->isSingleStringLiteral() && $right_type->isSingleStringLiteral()) {
             $literal = $left_type->getSingleStringLiteral()->value . $right_type->getSingleStringLiteral()->value;
             if (strlen($literal) <= 1000) {
-                // Limit these to 10000 bytes to avoid extremely large union types from repeated concatenations, etc
+                // Limit these to 1000 bytes to avoid extremely large union types from repeated concatenations, etc
                 $result_type = Type::getString($literal);
             }
+        } elseif ($left_type && $right_type && $left_type->isSingleIntLiteral() && $right_type->isSingleIntLiteral()) {
+            $literal = $left_type->getSingleIntLiteral()->value . $right_type->getSingleIntLiteral()->value;
+            if (strlen($literal) <= 1000) {
+                // Limit these to 1000 bytes to avoid extremely large union types from repeated concatenations, etc
+                $result_type = Type::getString($literal);
+            }
+        } elseif ($left_type && $right_type &&
+            $left_type->isSingle() && $right_type->isSingle() &&
+            $left_type->isInt() && $right_type->isInt()
+        ) {
+            $result_type = Type::getNumericString();
         } else {
             if ($left_type
                 && $right_type

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -31,6 +31,7 @@ use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TNumeric;
+use Psalm\Type\Atomic\TNumericString;
 use Psalm\Type\Atomic\TObject;
 use Psalm\Type\Atomic\TObjectWithProperties;
 use Psalm\Type\Atomic\TResource;
@@ -183,6 +184,13 @@ abstract class Type
     public static function getNumeric(): Union
     {
         $type = new TNumeric;
+
+        return new Union([$type]);
+    }
+
+    public static function getNumericString(): Union
+    {
+        $type = new TNumericString;
 
         return new Union([$type]);
     }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -155,6 +155,20 @@ class BinaryOperationTest extends TestCase
                 '<?php
                     $a = "hi" . 5;',
             ],
+            'concatenationWithTwoLiteralInt' => [
+                '<?php
+                    $a = 7 . 5;',
+                'assertions' => [
+                    '$a' => 'string',//will contain "75"
+                ]
+            ],
+            'concatenationWithTwoInt' => [
+                '<?php
+                    /** @return numeric-string */
+                    function scope(int $a, int $b): string{
+                        return $a . $b;
+                    }',
+            ],
             'possiblyInvalidAdditionOnBothSides' => [
                 '<?php
                     function foo(string $s) : int {


### PR DESCRIPTION
This PR handles some concatenation cases with int parts.
When two int are concatened, it results in numeric-string. When two literal ints are concatened, we can infer the resulting string.

This is useful for example when using this plugin: https://github.com/orklah/psalm-strict-numeric-cast who require having a numeric-string before casting to int. There are cases in Psalm itself where we concat two ints (php major/minor version) where this can help

I also fixed a comment and an error message I saw
