### PR TITLE
Taint specialized calls even when not using a variable

### DIFF
--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -1591,6 +1591,32 @@ class TaintTest extends TestCase
                     echo $a->isUnsafe();',
                 'error_message' => 'TaintedHtml',
             ],
+            'taintSpecializedMethodForAnonymousInstance' => [
+                '<?php
+                    /** @psalm-taint-specialize */
+                    class Unsafe {
+                        public function isUnsafe() {
+                            return $_GET["unsafe"];
+                        }
+                    }
+                    echo (new Unsafe())->isUnsafe();',
+                'error_message' => 'TaintedHtml',
+            ],
+            'taintSpecializedMethodForStubMadeInstance' => [
+                '<?php
+                    /** @psalm-taint-specialize */
+                    class Unsafe {
+                        public function isUnsafe() {
+                            return $_GET["unsafe"];
+                        }
+                    }
+
+                    /** @psalm-suppress InvalidReturnType */
+                    function stub(): Unsafe { }
+
+                    echo stub()->isUnsafe();',
+                'error_message' => 'TaintedHtml',
+            ],
             'doTaintSpecializedInstanceProperty' => [
                 '<?php
                     /** @psalm-taint-specialize */


### PR DESCRIPTION
Hi there ! Happy new year !

I found a strange behaviour (possibly introduced by https://github.com/vimeo/psalm/commit/95de6cf177845976f10be22340eedfb593e0007c) : when having a specialized call, if the object instance is not stored in a variable, the taint does not _go out_ (not sure about the terminology here) of the call.

I added two test cases to prove the point, but the fix I introduced is really naive (only merge two `if`s) and I'm pretty sure it will not be sufficient. Let me know how, and I'll be happy to improve it :)
