### PR TITLE
Trigger dispatch even when only legacy hooks

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -370,7 +370,7 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             }
         }
 
-        if ($config->eventDispatcher->after_method_checks) {
+        if ($config->eventDispatcher->hasAfterMethodCallAnalysisHandlers()) {
             $file_manipulations = [];
 
             $appearing_method_id = $codebase->methods->getAppearingMethodId($method_id);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -469,7 +469,7 @@ class ExistingAtomicStaticCallAnalyzer
             }
         }
 
-        if ($config->eventDispatcher->after_method_checks) {
+        if ($config->eventDispatcher->hasAfterMethodCallAnalysisHandlers()) {
             $file_manipulations = [];
 
             $appearing_method_id = $codebase->methods->getAppearingMethodId($method_id);

--- a/src/Psalm/Internal/EventDispatcher.php
+++ b/src/Psalm/Internal/EventDispatcher.php
@@ -6,6 +6,7 @@ use Psalm\Plugin\Hook;
 use Psalm\Plugin\EventHandler;
 use Psalm\Plugin\EventHandler\Event;
 use Psalm\Type\Atomic\TLiteralString;
+use function count;
 use function is_subclass_of;
 
 
@@ -16,9 +17,9 @@ class EventDispatcher
      *
      * @var list<class-string<EventHandler\AfterMethodCallAnalysisInterface>>
      */
-    public $after_method_checks = [];
+    private $after_method_checks = [];
     /** @var list<class-string<Hook\AfterMethodCallAnalysisInterface>> */
-    public $legacy_after_method_checks = [];
+    private $legacy_after_method_checks = [];
 
     /**
      * Static methods to be called after project function checks have completed
@@ -96,9 +97,9 @@ class EventDispatcher
      *
      * @var list<class-string<EventHandler\AfterClassLikeVisitInterface>>
      */
-    public $after_visit_classlikes = [];
+    private $after_visit_classlikes = [];
     /** @var list<class-string<Hook\AfterClassLikeVisitInterface>> */
-    public $legacy_after_visit_classlikes = [];
+    private $legacy_after_visit_classlikes = [];
 
     /**
      * Static methods to be called after codebase has been populated
@@ -233,6 +234,11 @@ class EventDispatcher
         } elseif (is_subclass_of($class, EventHandler\AfterFunctionLikeAnalysisInterface::class)) {
             $this->after_functionlike_checks[] = $class;
         }
+    }
+
+    public function hasAfterMethodCallAnalysisHandlers(): bool
+    {
+        return count($this->after_method_checks) || count($this->legacy_after_method_checks);
     }
 
     public function dispatchAfterMethodCallAnalysis(Event\AfterMethodCallAnalysisEvent $event): void
@@ -407,6 +413,11 @@ class EventDispatcher
         }
 
         return null;
+    }
+
+    public function hasAfterClassLikeVisitHandlers(): bool
+    {
+        return count($this->after_visit_classlikes) || count($this->legacy_after_visit_classlikes);
     }
 
     public function dispatchAfterClassLikeVisit(Event\AfterClassLikeVisitEvent $event): void

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -51,7 +51,7 @@ class ClassLikeStorageCacheProvider
             $storage_dir . 'MethodStorage.php',
         ];
 
-        if ($config->eventDispatcher->after_visit_classlikes) {
+        if ($config->eventDispatcher->hasAfterClassLikeVisitHandlers()) {
             $dependent_files = array_merge($dependent_files, $config->plugin_paths);
         }
 

--- a/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
@@ -52,7 +52,7 @@ class FileStorageCacheProvider
             $storage_dir . 'FunctionLikeParameter.php',
         ];
 
-        if ($config->eventDispatcher->after_visit_classlikes) {
+        if ($config->eventDispatcher->hasAfterClassLikeVisitHandlers()) {
             $dependent_files = array_merge($dependent_files, $config->plugin_paths);
         }
 


### PR DESCRIPTION
Hey ! With the new `EventDispatcher` mechanism there is an issue when there are only legacy hooks registered for the `AfterMethodCallAnalysis` and `AfterClassLikeVisit` handlers : the dispatch does not occur.

