### PR TITLE
Allow Attribute::IS_REPEATABLE

### DIFF
--- a/stubs/Php80.php
+++ b/stubs/Php80.php
@@ -57,9 +57,10 @@ class Attribute
     public const TARGET_CLASS_CONSTANT = 16;
     public const TARGET_PARAMETER = 32;
     public const TARGET_ALL = 63;
+    public const IS_REPEATABLE = 64;
 
     /**
-     * @param 1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23|24|25|26|27|28|29|30|31|32|33|34|35|36|37|38|39|40|41|42|43|44|45|46|47|48|49|50|51|52|53|54|55|56|57|58|59|60|61|62|63 $flags
+     * @param int-mask-of<self::*> $flags
      */
     public function __construct(int $flags = self::TARGET_ALL)
     {

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -117,6 +117,15 @@ class AttributeTest extends TestCase
                 [],
                 '8.0'
             ],
+            'allowsRepeatableFlag' => [
+                '<?php
+                    #[Attribute(Attribute::TARGET_ALL|Attribute::IS_REPEATABLE)] // results in int(127)
+                    class A {}
+                ',
+                [],
+                [],
+                '8.0'
+            ],
         ];
     }
 


### PR DESCRIPTION
This allows Attribute::IS_REPEATABLE to be specified as attribute flag.

Fixes vimeo/psalm#4892, vimeo/psalm#4970