### PR TITLE
Added GHA workflow to build phars

### DIFF
--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -1,0 +1,53 @@
+name: Build phar
+
+on: 
+  release:
+    types:
+      - published
+
+jobs:
+  build-phar:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer:v2
+
+      - uses: actions/checkout@v2
+
+      - name: Get Composer Cache Directories
+        id: composer-cache
+        run: |
+          echo "::set-output name=files_cache::$(composer config cache-files-dir)"
+          echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+
+      - name: Cache composer cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.composer-cache.outputs.files_cache }}
+            ${{ steps.composer-cache.outputs.vcs_cache }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Run composer install
+        run: composer install -o
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
+
+      - run: bin/build-phar.sh
+        env:
+          GPG_ENCRYPTION: ${{ secrets.GPG_ENCRYPTION }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
+
+      - name: Upload release assets
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: build/psalm.phar*
+          file_glob: true
+          tag: ${{ github.ref }}

--- a/bin/build-phar.sh
+++ b/bin/build-phar.sh
@@ -10,8 +10,10 @@ php $DIR/improve_class_alias.php
 
 vendor/bin/box compile
 
+SIGNING_KEY_ID=${SIGNING_KEY_ID:-8A03EA3B385DBAA1}
+
 if [[ "$GPG_ENCRYPTION" != '' ]] ; then
-    echo $GPG_ENCRYPTION | gpg --passphrase-fd 0 keys.asc.gpg
+    echo "$GPG_ENCRYPTION" | gpg --batch --passphrase-fd 0 keys.asc.gpg
     gpg --batch --yes --import keys.asc
-    echo $SIGNING_KEY | gpg --passphrase-fd 0 -u 8A03EA3B385DBAA1 --armor --detach-sig build/psalm.phar
+    echo "$SIGNING_KEY" | gpg --batch --passphrase-fd 0 --pinentry-mode loopback -u "$SIGNING_KEY_ID" --armor --detach-sig build/psalm.phar
 fi


### PR DESCRIPTION
Required setup:
On `Settings / Secrets` add three secrets:
* `GPG_ENCRYPTION` - passphrase used to encrypt `keys.asc.gpg`
* `SIGNING_KEY` - passphrase for actual signing key
* `SIGNING_KEY_ID` - key ID used to sign phar with (use `8A03EA3B385DBAA1` to use the same key Travis currently uses).