### PR TITLE
#4997 added more precise type inference for `count()` returning `0` or `positive-int` on known arrays

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -300,7 +300,7 @@ class FunctionCallReturnTypeFetcher
                                     return new Type\Union([
                                         $atomic_types['array']->count !== null
                                             ? new Type\Atomic\TLiteralInt($atomic_types['array']->count)
-                                            : new Type\Atomic\TInt
+                                            : new Type\Atomic\TPositiveInt
                                     ]);
                                 }
 
@@ -308,7 +308,7 @@ class FunctionCallReturnTypeFetcher
                                     return new Type\Union([
                                         $atomic_types['array']->count !== null
                                             ? new Type\Atomic\TLiteralInt($atomic_types['array']->count)
-                                            : new Type\Atomic\TInt
+                                            : new Type\Atomic\TPositiveInt
                                     ]);
                                 }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -319,6 +319,11 @@ class FunctionCallReturnTypeFetcher
                                         new Type\Atomic\TLiteralInt(count($atomic_types['array']->properties))
                                     ]);
                                 }
+
+                                return new Type\Union([
+                                    new Type\Atomic\TLiteralInt(0),
+                                    new Type\Atomic\TPositiveInt
+                                ]);
                             }
                         }
                     }

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1087,6 +1087,28 @@ function chunk_split(string $str, int $chunklen = 76, string $end= ''): string
 }
 
 /**
+ * @template TInput as \Countable|array
+ *
+ * @param TInput $value
+ * @param \COUNT_NORMAL|\COUNT_RECURSIVE $mode
+ *
+ * @return (
+ *          TInput is array<empty, empty>
+ *          ? 0
+ *          : (TInput is non-empty-array
+ *              ? positive-int
+ *              : (TInput is array
+ *                  ? positive-int|0
+ *                  : int
+ *              )
+ *          )
+ * )
+ */
+function count(\Countable|array $value, int $mode = \COUNT_NORMAL): int
+{
+}
+
+/**
  * @psalm-pure
  *
  * @psalm-flow ($data) -> return

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1087,24 +1087,27 @@ function chunk_split(string $str, int $chunklen = 76, string $end= ''): string
 }
 
 /**
- * @template TInput as \Countable|array
+ * @template TInput as \Countable|\SimpleXMLElement|\ResourceBundle|array
  *
  * @param TInput $value
- * @param \COUNT_NORMAL|\COUNT_RECURSIVE $mode
+ * @param 0|1 $mode
  *
  * @return (
  *          TInput is array<empty, empty>
  *          ? 0
- *          : (TInput is non-empty-array
- *              ? positive-int
- *              : (TInput is array
- *                  ? positive-int|0
- *                  : int
+ *          : (TInput is array{0: mixed, 1: mixed}
+ *              ? 2
+ *              : (TInput is non-empty-array
+ *                  ? positive-int
+ *                  : (TInput is array
+ *                      ? positive-int|0
+ *                      : int
+ *                  )
  *              )
  *          )
  * )
  */
-function count(\Countable|array $value, int $mode = \COUNT_NORMAL): int
+function count(\Countable|\SimpleXMLElement|\ResourceBundle|array $value, int $mode = 0): int
 {
 }
 

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1087,31 +1087,6 @@ function chunk_split(string $str, int $chunklen = 76, string $end= ''): string
 }
 
 /**
- * @template TInput as \Countable|\SimpleXMLElement|\ResourceBundle|array
- *
- * @param TInput $value
- * @param 0|1 $mode
- *
- * @return (
- *          TInput is array<empty, empty>
- *          ? 0
- *          : (TInput is array{0: mixed, 1: mixed}
- *              ? 2
- *              : (TInput is non-empty-array
- *                  ? positive-int
- *                  : (TInput is array
- *                      ? positive-int|0
- *                      : int
- *                  )
- *              )
- *          )
- * )
- */
-function count(\Countable|\SimpleXMLElement|\ResourceBundle|array $value, int $mode = 0): int
-{
-}
-
-/**
  * @psalm-pure
  *
  * @psalm-flow ($data) -> return

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1818,7 +1818,7 @@ class FunctionCallTest extends TestCase
                             if ($c !== 2) {}
                         }
                     }',
-                'error_message' => 'TypeDoesNotContainType',
+                'error_message' => 'DocblockTypeContradiction',
             ],
             'coerceCallMapArgsInStrictMode' => [
                 '<?php

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1054,6 +1054,83 @@ class FunctionCallTest extends TestCase
                         }
                     }'
             ],
+            'countNonEmptyArrayShouldBePositiveInt' => [
+                '<?php
+                    /**
+                     * @psalm-pure
+                     * @param non-empty-list $x
+                     * @return positive-int
+                     */
+                    function example($x) : int {
+                        return count($x);
+                    }',
+            ],
+            'countListShouldBeZeroOrPositive' => [
+                '<?php
+                    /**
+                     * @psalm-pure
+                     * @param list $x
+                     * @return positive-int|0
+                     */
+                    function example($x) : int {
+                        return count($x);
+                    }',
+            ],
+            'countArrayShouldBeZeroOrPositive' => [
+                '<?php
+                    /**
+                     * @psalm-pure
+                     * @param array $x
+                     * @return positive-int|0
+                     */
+                    function example($x) : int {
+                        return count($x);
+                    }',
+            ],
+            'countEmptyArrayShouldBeZero' => [
+                '<?php
+                    /**
+                     * @psalm-pure
+                     * @param array<empty, empty> $x
+                     * @return 0
+                     */
+                    function example($x) : int {
+                        return count($x);
+                    }',
+            ],
+            'countConstantSizeArrayShouldBeConstantInteger' => [
+                '<?php
+                    /**
+                     * @psalm-pure
+                     * @param array{int, int, string} $x
+                     * @return 3
+                     */
+                    function example($x) : int {
+                        return count($x);
+                    }',
+            ],
+            'countCallableArrayShouldBe2' => [
+                '<?php
+                    /**
+                     * @psalm-pure
+                     * @return 2
+                     */
+                    function example(callable $x) : int {
+                        assert(is_array($x));
+                        return count($x);
+                    }',
+            ],
+            'countOnPureObjectIsPure' => [
+                '<?php
+                    class PureCountable implements \Countable {
+                        /** @psalm-pure */
+                        public function count(): int { return 1; }
+                    }
+                    /** @psalm-pure */
+                    function example(PureCountable $x) : int {
+                        return count($x);
+                    }',
+            ],
             'refineWithTraitExists' => [
                 '<?php
                     function foo(string $s) : void {
@@ -1818,7 +1895,23 @@ class FunctionCallTest extends TestCase
                             if ($c !== 2) {}
                         }
                     }',
-                'error_message' => 'DocblockTypeContradiction',
+                'error_message' => 'TypeDoesNotContainType',
+            ],
+            'countOnObjectCannotBePositive' => [
+                '<?php
+                    /** @return positive-int|0 */
+                    function example(\Countable $x) : int {
+                        return count($x);
+                    }',
+                'error_message' => 'LessSpecificReturnStatement',
+            ],
+            'countOnUnknownObjectCannotBePure' => [
+                '<?php
+                    /** @psalm-pure */
+                    function example(\Countable $x) : int {
+                        return count($x);
+                    }',
+                'error_message' => 'ImpureFunctionCall',
             ],
             'coerceCallMapArgsInStrictMode' => [
                 '<?php


### PR DESCRIPTION
Fixes #4997

~~Note: I only provided the stub, but am unsure about where tests for stubs (if there are any) are applicable.~~

Questions open:

 * [x] `@psalm-flow` - unclear whether this is needed, seems related to taint analysis, so probably not necessary
 * [x] `@psalm-pure` - unclear whether this is to be declared. Purity depends on the given argument: perhaps @azjezz knows more here? See https://github.com/vimeo/psalm/pull/4999#issuecomment-759444684