### PR TITLE
don't throw InvalidArrayOffset when dealing with templates

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -154,6 +154,7 @@ class ArrayAnalyzer
                     && !$atomic_key_type instanceof Type\Atomic\TInt
                     && !$atomic_key_type instanceof Type\Atomic\TArrayKey
                     && !$atomic_key_type instanceof Type\Atomic\TMixed
+                    && !$atomic_key_type instanceof Type\Atomic\TTemplateParam
                     && !(
                         $atomic_key_type instanceof Type\Atomic\TObjectWithProperties
                         && isset($atomic_key_type->methods['__toString'])

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1506,6 +1506,16 @@ class ArrayAssignmentTest extends TestCase
                         return $list;
                     }'
             ],
+            'ArrayCreateTemplateArrayKey' => [
+                '/**
+                  * @template K of array-key
+                  * @param K $key
+                  */
+                function with($key): void
+                {
+                    [$key => 123];
+                }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR aims to fix https://github.com/vimeo/psalm/issues/5016

This is probably not fixed the best possible way (I can imagine we could infer template type and check if it's a subtype of array-key) but I'm not quite ready to enter this module in psalm!