### PR TITLE
--report=codeclimate.json

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -360,6 +360,7 @@ class ProjectAnalyzer
         $mapping = [
             'checkstyle.xml' => Report::TYPE_CHECKSTYLE,
             'sonarqube.json' => Report::TYPE_SONARQUBE,
+            'codeclimate.json' => Report::TYPE_CODECLIMATE,
             'summary.json' => Report::TYPE_JSON_SUMMARY,
             'junit.xml' => Report::TYPE_JUNIT,
             '.xml' => Report::TYPE_XML,

--- a/src/command_functions.php
+++ b/src/command_functions.php
@@ -388,7 +388,7 @@ Reports:
     --report=PATH
         The path where to output report file. The output format is based on the file extension.
         (Currently supported formats: ".json", ".xml", ".txt", ".emacs", ".pylint", ".console",
-        ".sarif", "checkstyle.xml", "sonarqube.json", "summary.json", "junit.xml")
+        ".sarif", "checkstyle.xml", "sonarqube.json", "codeclimate.json", "summary.json", "junit.xml")
 
     --report-show-info[=BOOLEAN]
         Whether the report should include non-errors in its output (defaults to true)


### PR DESCRIPTION
Currently it's possible to generate a [codeclimate JSON](https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#data-types) output with the `--output-format=codeclimate` flag, but it's impossible to generate directly a report (you must redirect the output because if you use `--report=codeclimate.json` psalm creates a standard JSON).
With these changes it is now possible to generate directly a `codeclimate.json` report with a flag like `--report=codeclimate.json` or `--report=foo.codeclimate.json`.