### PR TITLE
psalm annotations of extends/implements

### DIFF
--- a/stubs/CoreGenericIterators.phpstub
+++ b/stubs/CoreGenericIterators.phpstub
@@ -405,7 +405,7 @@ class CallbackFilterIterator extends FilterIterator implements OuterIterator  {
 }
 
 /**
- * @psalm-implements SeekableIterator<int, DirectoryIterator>
+ * @template-implements SeekableIterator<int, DirectoryIterator>
  */
 class DirectoryIterator extends SplFileInfo implements SeekableIterator {
 
@@ -469,7 +469,7 @@ class EmptyIterator implements Iterator {
 }
 
 /**
- * @psalm-extends SeekableIterator<string, FilesystemIterator|SplFileInfo|string>
+ * @template-extends SeekableIterator<string, FilesystemIterator|SplFileInfo|string>
  */
 class FilesystemIterator extends DirectoryIterator
 {
@@ -515,7 +515,7 @@ class FilesystemIterator extends DirectoryIterator
 
 
 /**
- * @psalm-extends SeekableIterator<string, GlobIterator|SplFileInfo|string>
+ * @template-extends SeekableIterator<string, GlobIterator|SplFileInfo|string>
  */
 class GlobIterator extends FilesystemIterator implements Countable {
     /**


### PR DESCRIPTION
This PR change some annotations as the rest of the file. It was not coherent and those two annotations are not even authorized in userland because they're not here: https://github.com/vimeo/psalm/blob/ab5ddb1514f7de0976b964e92e9bf51138aa1496/src/Psalm/DocComment.php#L25

