### PR TITLE
add analysis execution depending on PHP version in userland

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1774,6 +1774,7 @@ return [
 'DateTime::add' => ['static', 'interval'=>'DateInterval'],
 'DateTime::createFromFormat' => ['static|false', 'format'=>'string', 'time'=>'string', 'timezone='=>'?DateTimeZone'],
 'DateTime::createFromImmutable' => ['static', 'datetTimeImmutable'=>'DateTimeImmutable'],
+'DateTime::createFromInterface' => ['static', 'object'=>'DateTimeInterface'],
 'DateTime::diff' => ['DateInterval|false', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTime::format' => ['string|false', 'format'=>'string'],
 'DateTime::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -61,6 +61,7 @@ return [
 'date_time_set' => ['DateTime', 'object'=>'DateTime', 'hour'=>'int', 'minute'=>'int', 'second='=>'int', 'microseconds='=>'int'],
 'date_timestamp_set' => ['DateTime', 'object'=>'DateTime', 'unixtimestamp'=>'int'],
 'date_timezone_set' => ['DateTime', 'object'=>'DateTime', 'timezone'=>'DateTimeZone'],
+'DateTime::createFromInterface' => ['static', 'object'=>'DateTimeInterface'],
 'explode' => ['array<int,string>', 'separator'=>'string', 'str'=>'string', 'limit='=>'int'],
 'fdiv' => ['float', 'dividend'=>'float', 'divisor'=>'float'],
 'get_debug_type' => ['string', 'var'=>'mixed'],

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
@@ -240,36 +240,34 @@ class ExpressionResolver
             return $enter_conditional_left !== false || $enter_conditional_right !== false;
         }
 
-        if ($codebase->register_autoload_files) {
-            if ((
-                    $expr instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
-                    || $expr instanceof PhpParser\Node\Expr\BinaryOp\Greater
-                    || $expr instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
-                    || $expr instanceof PhpParser\Node\Expr\BinaryOp\Smaller
-                ) && (
-                    (
-                        $expr->left instanceof PhpParser\Node\Expr\ConstFetch
-                        && $expr->left->name->parts === ['PHP_VERSION_ID']
-                        && $expr->right instanceof PhpParser\Node\Scalar\LNumber
-                    ) || (
-                        $expr->right instanceof PhpParser\Node\Expr\ConstFetch
-                        && $expr->right->name->parts === ['PHP_VERSION_ID']
-                        && $expr->left instanceof PhpParser\Node\Scalar\LNumber
-                    )
+        if ((
+                $expr instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
+                || $expr instanceof PhpParser\Node\Expr\BinaryOp\Greater
+                || $expr instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
+                || $expr instanceof PhpParser\Node\Expr\BinaryOp\Smaller
+            ) && (
+                (
+                    $expr->left instanceof PhpParser\Node\Expr\ConstFetch
+                    && $expr->left->name->parts === ['PHP_VERSION_ID']
+                    && $expr->right instanceof PhpParser\Node\Scalar\LNumber
+                ) || (
+                    $expr->right instanceof PhpParser\Node\Expr\ConstFetch
+                    && $expr->right->name->parts === ['PHP_VERSION_ID']
+                    && $expr->left instanceof PhpParser\Node\Scalar\LNumber
                 )
-            ) {
-                $php_version_id = $codebase->php_major_version * 10000 + $codebase->php_minor_version * 100;
-                $evaluator = new ConstExprEvaluator(function (Expr $expr) use ($php_version_id) {
-                    if ($expr instanceof ConstFetch && $expr->name->parts === ['PHP_VERSION_ID']) {
-                        return $php_version_id;
-                    }
-                    throw new ConstExprEvaluationException('unexpected');
-                });
-                try {
-                    return (bool) $evaluator->evaluateSilently($expr);
-                } catch (ConstExprEvaluationException $e) {
-                    return null;
+            )
+        ) {
+            $php_version_id = $codebase->php_major_version * 10000 + $codebase->php_minor_version * 100;
+            $evaluator = new ConstExprEvaluator(function (Expr $expr) use ($php_version_id) {
+                if ($expr instanceof ConstFetch && $expr->name->parts === ['PHP_VERSION_ID']) {
+                    return $php_version_id;
                 }
+                throw new ConstExprEvaluationException('unexpected');
+            });
+            try {
+                return (bool) $evaluator->evaluateSilently($expr);
+            } catch (ConstExprEvaluationException $e) {
+                return null;
             }
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
@@ -240,36 +240,34 @@ class ExpressionResolver
             return $enter_conditional_left !== false || $enter_conditional_right !== false;
         }
 
-        if ($codebase->register_autoload_files) {
-            if ((
-                    $expr instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
-                    || $expr instanceof PhpParser\Node\Expr\BinaryOp\Greater
-                    || $expr instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
-                    || $expr instanceof PhpParser\Node\Expr\BinaryOp\Smaller
-                ) && (
-                    (
-                        $expr->left instanceof PhpParser\Node\Expr\ConstFetch
-                        && $expr->left->name->parts === ['PHP_VERSION_ID']
-                        && $expr->right instanceof PhpParser\Node\Scalar\LNumber
-                    ) || (
-                        $expr->right instanceof PhpParser\Node\Expr\ConstFetch
-                        && $expr->right->name->parts === ['PHP_VERSION_ID']
-                        && $expr->left instanceof PhpParser\Node\Scalar\LNumber
-                    )
+        if ((
+                $expr instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
+                || $expr instanceof PhpParser\Node\Expr\BinaryOp\Greater
+                || $expr instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
+                || $expr instanceof PhpParser\Node\Expr\BinaryOp\Smaller
+            ) && (
+                (
+                    $expr->left instanceof PhpParser\Node\Expr\ConstFetch
+                    && $expr->left->name->parts === ['PHP_VERSION_ID']
+                    && $expr->right instanceof PhpParser\Node\Scalar\LNumber
+                ) || (
+                    $expr->right instanceof PhpParser\Node\Expr\ConstFetch
+                    && $expr->right->name->parts === ['PHP_VERSION_ID']
+                    && $expr->left instanceof PhpParser\Node\Scalar\LNumber
                 )
-            ) {
-                $php_version_id = $codebase->php_major_version * 10000 + $codebase->php_minor_version * 100;
-                $evaluator = new ConstExprEvaluator(function (Expr $expr) use ($php_version_id) {
-                    if ($expr instanceof ConstFetch && $expr->name->parts === ['PHP_VERSION_ID']) {
-                        return $php_version_id;
-                    }
-                    throw new ConstExprEvaluationException('unexpected');
-                });
-                try {
-                    return (bool)$evaluator->evaluateSilently($expr);
-                } catch (ConstExprEvaluationException $e) {
-                    return null;
+            )
+        ) {
+            $php_version_id = $codebase->php_major_version * 10000 + $codebase->php_minor_version * 100;
+            $evaluator = new ConstExprEvaluator(function (Expr $expr) use ($php_version_id) {
+                if ($expr instanceof ConstFetch && $expr->name->parts === ['PHP_VERSION_ID']) {
+                    return $php_version_id;
                 }
+                throw new ConstExprEvaluationException('unexpected');
+            });
+            try {
+                return (bool) $evaluator->evaluateSilently($expr);
+            } catch (ConstExprEvaluationException $e) {
+                return null;
             }
         }
 

--- a/tests/ConditionalExecution.php
+++ b/tests/ConditionalExecution.php
@@ -1,0 +1,97 @@
+<?php
+namespace Psalm\Tests;
+
+use UnexpectedValueException;
+use function preg_quote;
+use Psalm\Config;
+use Psalm\Context;
+use Psalm\Internal\RuntimeCaches;
+use Psalm\Tests\Internal\Provider;
+use function strpos;
+use function substr;
+
+class ConditionalExecution extends TestCase
+{
+    /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
+    protected $project_analyzer;
+
+    public function setUp() : void
+    {
+        RuntimeCaches::clearAll();
+
+        $this->file_provider = new Provider\FakeFileProvider();
+
+        $this->project_analyzer = new \Psalm\Internal\Analyzer\ProjectAnalyzer(
+            new TestConfig(),
+            new \Psalm\Internal\Provider\Providers(
+                $this->file_provider,
+                new Provider\FakeParserCacheProvider()
+            )
+        );
+    }
+
+    /**
+     * @dataProvider providerValidCodeParse
+     *
+     * @param string $code
+     * @param array<string> $error_levels
+     */
+    public function testValidCode($code, array $error_levels = []): void
+    {
+        $test_name = $this->getTestName();
+        if (strpos($test_name, 'SKIPPED-') !== false) {
+            $this->markTestSkipped('Skipped due to a bug.');
+        }
+
+        $version_position = strpos($test_name, 'PHP-');
+        if ($version_position === false) {
+            throw new UnexpectedValueException('No PHPVersion in test name');
+        }
+
+        $version = substr($test_name, $version_position + 4, 3);
+        $this->project_analyzer->setPhpVersion($version);
+
+        $file_path = self::$src_dir_path . 'somefile.php';
+
+        $this->addFile(
+            $file_path,
+            $code
+        );
+
+        foreach ($error_levels as $error_level) {
+            $this->project_analyzer->getCodebase()->config->setCustomErrorLevel($error_level, Config::REPORT_SUPPRESS);
+        }
+
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    /**
+     * @return array<string, array{string,error_levels?:string[]}>
+     */
+    public function providerValidCodeParse(): array
+    {
+        return [
+            'PHP-7.2-hrtime' => [
+                '<?php
+                    $_startTime = \PHP_VERSION_ID >= 70300 ? \hrtime(false)[0] : \time();'
+            ],
+            'PHP-7.4-DateTimeCreateFromInterface' => [
+                '<?php
+                    namespace FooBar;
+
+                    class Datetime extends \DateTime
+                    {
+                        /**
+                         * @return \DateTime
+                         */
+                        public static function createFromInterface(\DatetimeInterface $datetime)
+                        {
+                            if (\PHP_VERSION_ID >= 80000) {
+                                return parent::createFromInterface($datetime);
+                            }
+                        }
+                    }'
+            ],
+        ];
+    }
+}

--- a/tests/ConditionalExecutionTest.php
+++ b/tests/ConditionalExecutionTest.php
@@ -2,7 +2,6 @@
 namespace Psalm\Tests;
 
 use UnexpectedValueException;
-use function preg_quote;
 use Psalm\Config;
 use Psalm\Context;
 use Psalm\Internal\RuntimeCaches;
@@ -10,7 +9,7 @@ use Psalm\Tests\Internal\Provider;
 use function strpos;
 use function substr;
 
-class ConditionalExecution extends TestCase
+class ConditionalExecutionTest extends TestCase
 {
     /** @var \Psalm\Internal\Analyzer\ProjectAnalyzer */
     protected $project_analyzer;


### PR DESCRIPTION
This PR aims to implement conditional analysis in userland code.

For example, it would allow using a syntax from PHP 8 even when phpVersion=PHP 7.4 as long as there is a PHP_VERSION_ID check.

EDIT: it also adds DateTime::createFromInterface in PHP8 callmap

EDIT: forgot to say, it should fix https://github.com/vimeo/psalm/issues/2809 and fix https://github.com/vimeo/psalm/issues/5033