### PR TITLE
Fix for #5049 removing `true` or `false` from a `Union` should turn `bool` into respectively `false` or `true`

### DIFF
--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -560,6 +560,12 @@ class Union implements TypeNode
                 unset($this->types[$literal_key]);
             }
             $this->literal_float_types = [];
+        } elseif ($type_string === 'false' && isset($this->types['bool'])) {
+            unset($this->types['bool']);
+            $this->addType(new Type\Atomic\TTrue());
+        } elseif ($type_string === 'true' && isset($this->types['bool'])) {
+            unset($this->types['bool']);
+            $this->addType(new Type\Atomic\TFalse());
         }
 
         return false;

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -1626,6 +1626,22 @@ class AssertAnnotationTest extends TestCase
                 'error_message' => 'RedundantConditionGivenDocblockType - src'
                                     . DIRECTORY_SEPARATOR . 'somefile.php:19:29',
             ],
+            'assertBooleanNotEmpty' => [
+                '<?php
+                     /**
+                      * @param mixed $value
+                      * @psalm-assert !empty $value
+                      */
+                    function assertNotEmpty($value) : void {}
+
+                    function foo(bool $bar) : void {
+                        assertNotEmpty($bar);
+
+                        if ($bar) {}
+                    }',
+                'error_message' => 'RedundantConditionGivenDocblockType - src'
+                    . DIRECTORY_SEPARATOR . 'somefile.php:11:29',
+            ],
             'assertOneOfStrings' => [
                 '<?php
                     /**

--- a/tests/Type/UnionTest.php
+++ b/tests/Type/UnionTest.php
@@ -1,0 +1,57 @@
+<?php
+namespace Psalm\Tests\Type;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\Type\Atomic\TBool;
+use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TTrue;
+use Psalm\Type\Union;
+
+/** @covers \Psalm\Type\Union */
+class UnionTest extends TestCase
+{
+    /** @dataProvider removedTypes */
+    public function testRemovingTypeFromUnion(Union $unionType, string $removedType, string $expectedType): void
+    {
+        $unionType->removeType($removedType);
+
+        self::assertSame($expectedType, $unionType->__toString());
+    }
+
+    /** @psalm-return non-empty-array<string, array{Union, string, string}> */
+    public function removedTypes(): array
+    {
+        return [
+            'true - true => ""' => [
+                new Union([new TTrue()]),
+                'true',
+                '',
+            ],
+            'true - false => false' => [
+                new Union([new TTrue()]),
+                'false',
+                'true',
+            ],
+            'bool - true => false' => [
+                new Union([new TBool()]),
+                'true',
+                'false',
+            ],
+            'false - false => ""' => [
+                new Union([new TTrue()]),
+                'true',
+                '',
+            ],
+            'false - true => false' => [
+                new Union([new TFalse()]),
+                'true',
+                'false',
+            ],
+            'bool \ false => true' => [
+                new Union([new TBool()]),
+                'false',
+                'true',
+            ],
+        ];
+    }
+}

--- a/tests/Type/UnionTest.php
+++ b/tests/Type/UnionTest.php
@@ -22,7 +22,7 @@ class UnionTest extends TestCase
     public function removedTypes(): array
     {
         return [
-            'true - true => ""' => [
+            'true - true => ∅' => [
                 new Union([new TTrue()]),
                 'true',
                 '',
@@ -37,7 +37,7 @@ class UnionTest extends TestCase
                 'true',
                 'false',
             ],
-            'false - false => ""' => [
+            'false - false => ∅' => [
                 new Union([new TTrue()]),
                 'true',
                 '',


### PR DESCRIPTION
Fixes #5049