### PR TITLE
Use composer autoloader during init

### DIFF
--- a/src/psalm.php
+++ b/src/psalm.php
@@ -337,6 +337,7 @@ if (isset($options['i'])) {
         echo "Calculating best config level based on project files\n";
         \Psalm\Config\Creator::createBareConfig($current_dir, $init_source_dir, $vendor_dir);
         $config = \Psalm\Config::getInstance();
+        $config->setComposerClassLoader($first_autoloader);
     } else {
         try {
             $template_contents = \Psalm\Config\Creator::getContents(


### PR DESCRIPTION
Fixes vimeo/psalm#5048

The issue was caused by missing dependency of a class that Psalm tried to inspect through reflection. Fixed by using composer autoloader which avoids the need to use reflection.