### PR TITLE
Catch InvalidArgumentException

### DIFF
--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -118,7 +118,11 @@ class Populator
             }
 
             foreach ($class_storage->dependent_classlikes as $dependent_classlike_lc => $_) {
-                $dependee_storage = $this->classlike_storage_provider->get($dependent_classlike_lc);
+                try {
+                    $dependee_storage = $this->classlike_storage_provider->get($dependent_classlike_lc);
+                } catch (\InvalidArgumentException $exception) {
+                    continue;
+                }
 
                 $class_storage->dependent_classlikes += $dependee_storage->dependent_classlikes;
             }


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/5047

I tried in my project and it solves the issue.
I don't know why this invalidArgumentException is thrown but it works well if psalm ignores it.