### PR TITLE
Remove file map cache when re-analyzing files

### DIFF
--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -576,6 +576,11 @@ class Analyzer
             $i = 0;
 
             foreach ($this->files_to_analyze as $file_path => $_) {
+                // Remove all current maps for the file, so new analysis doesn't
+                // only append to existing data.
+                unset($this->reference_map[$file_path]);
+                unset($this->type_map[$file_path]);
+                unset($this->argument_map[$file_path]);
                 $analysis_worker($i, $file_path);
                 ++$i;
 

--- a/tests/FileUpdates/AnalyzedMethodTest.php
+++ b/tests/FileUpdates/AnalyzedMethodTest.php
@@ -1318,4 +1318,39 @@ class AnalyzedMethodTest extends \Psalm\Tests\TestCase
             ],
         ];
     }
+
+    public function testFileMapsUpdated(): void {
+        $codebase = $this->project_analyzer->getCodebase();
+
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->file_provider->registerFile('somefile.php', '
+            <?php
+
+            function foo() : void {
+            }
+
+            foo();
+        ');
+
+        $codebase->addFilesToAnalyze( ['somefile.php' => 'somefile.php']);
+        $codebase->scanFiles();
+        $codebase->analyzer->analyzeFiles($this->project_analyzer, 1, false);
+
+        $maps = $codebase->analyzer->getMapsForFile( 'somefile.php' );
+
+        $this->assertNotEmpty( $maps[0] );
+
+        $this->file_provider->setOpenContents('somefile.php', '');
+
+        $codebase->reloadFiles($this->project_analyzer, ['somefile.php']);
+        $codebase->analyzer->analyzeFiles($this->project_analyzer, 1, false);
+
+        $updated_maps = $codebase->analyzer->getMapsForFile( 'somefile.php' );
+
+        $this->assertSame( [], $updated_maps[0] );
+        $this->assertSame( [], $updated_maps[1] );
+        $this->assertSame( [], $updated_maps[2] );
+    }
 }

--- a/tests/FileUpdates/AnalyzedMethodTest.php
+++ b/tests/FileUpdates/AnalyzedMethodTest.php
@@ -1319,7 +1319,8 @@ class AnalyzedMethodTest extends \Psalm\Tests\TestCase
         ];
     }
 
-    public function testFileMapsUpdated(): void {
+    public function testFileMapsUpdated(): void
+    {
         $codebase = $this->project_analyzer->getCodebase();
 
         $config = $codebase->config;

--- a/tests/FileUpdates/AnalyzedMethodTest.php
+++ b/tests/FileUpdates/AnalyzedMethodTest.php
@@ -1334,23 +1334,23 @@ class AnalyzedMethodTest extends \Psalm\Tests\TestCase
             foo();
         ');
 
-        $codebase->addFilesToAnalyze( ['somefile.php' => 'somefile.php']);
+        $codebase->addFilesToAnalyze(['somefile.php' => 'somefile.php']);
         $codebase->scanFiles();
         $codebase->analyzer->analyzeFiles($this->project_analyzer, 1, false);
 
-        $maps = $codebase->analyzer->getMapsForFile( 'somefile.php' );
+        $maps = $codebase->analyzer->getMapsForFile('somefile.php');
 
-        $this->assertNotEmpty( $maps[0] );
+        $this->assertNotEmpty($maps[0]);
 
         $this->file_provider->setOpenContents('somefile.php', '');
 
         $codebase->reloadFiles($this->project_analyzer, ['somefile.php']);
         $codebase->analyzer->analyzeFiles($this->project_analyzer, 1, false);
 
-        $updated_maps = $codebase->analyzer->getMapsForFile( 'somefile.php' );
+        $updated_maps = $codebase->analyzer->getMapsForFile('somefile.php');
 
-        $this->assertSame( [], $updated_maps[0] );
-        $this->assertSame( [], $updated_maps[1] );
-        $this->assertSame( [], $updated_maps[2] );
+        $this->assertSame([], $updated_maps[0]);
+        $this->assertSame([], $updated_maps[1]);
+        $this->assertSame([], $updated_maps[2]);
     }
 }

--- a/tests/Internal/Provider/FakeFileProvider.php
+++ b/tests/Internal/Provider/FakeFileProvider.php
@@ -40,6 +40,13 @@ class FakeFileProvider extends \Psalm\Internal\Provider\FileProvider
         $this->fake_files[$file_path] = $file_contents;
     }
 
+    public function setOpenContents(string $file_path, string $file_contents): void
+    {
+        if (isset($this->fake_files[strtolower($file_path)])) {
+            $this->fake_files[strtolower($file_path)] = $file_contents;
+        }
+    }
+
     public function getModifiedTime(string $file_path): int
     {
         if (isset($this->fake_file_times[$file_path])) {

--- a/tests/LanguageServer/FileMapTest.php
+++ b/tests/LanguageServer/FileMapTest.php
@@ -8,7 +8,7 @@ use Psalm\Internal\Provider\Providers;
 use Psalm\Tests\Internal\Provider;
 use Psalm\Tests\TestConfig;
 
-class MapTest extends \Psalm\Tests\TestCase
+class FileMapTest extends \Psalm\Tests\TestCase
 {
     public function setUp() : void
     {
@@ -35,8 +35,6 @@ class MapTest extends \Psalm\Tests\TestCase
         $this->project_analyzer->getCodebase()->store_node_types = true;
     }
 
-
-
     public function testMapIsUpdatedOnReloadFiles(): void
     {
         $codebase = $this->project_analyzer->getCodebase();
@@ -58,12 +56,13 @@ class MapTest extends \Psalm\Tests\TestCase
         $this->analyzeFile('somefile.php', new Context());
         [ $type_map ] = $codebase->analyzer->getMapsForFile('somefile.php');
 
-        $this->assertTrue( ! empty( $type_map ) );
+        $this->assertTrue(!empty($type_map));
 
         $codebase->file_provider->setOpenContents('somefile.php', '');
         $codebase->reloadFiles( $this->project_analyzer, [ 'somefile.php'] );
-        $map = $codebase->analyzer->getMapsForFile('somefile.php');
-        var_dump( $map );
+        [ $type_map ] = $codebase->analyzer->getMapsForFile('somefile.php');
+
+        $this->assertSame([], $type_map);
     }
 
     public function testGetTypeMap(): void

--- a/tests/LanguageServer/FileMapTest.php
+++ b/tests/LanguageServer/FileMapTest.php
@@ -59,7 +59,7 @@ class FileMapTest extends \Psalm\Tests\TestCase
         $this->assertTrue(!empty($type_map));
 
         $codebase->file_provider->setOpenContents('somefile.php', '');
-        $codebase->reloadFiles( $this->project_analyzer, [ 'somefile.php'] );
+        $codebase->reloadFiles($this->project_analyzer, ['somefile.php']);
         [ $type_map ] = $codebase->analyzer->getMapsForFile('somefile.php');
 
         $this->assertSame([], $type_map);

--- a/tests/LanguageServer/MapTest.php
+++ b/tests/LanguageServer/MapTest.php
@@ -1,0 +1,104 @@
+<?php
+namespace Psalm\Tests\LanguageServer;
+
+use LanguageServerProtocol\Position;
+use Psalm\Context;
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\Internal\Provider\Providers;
+use Psalm\Tests\Internal\Provider;
+use Psalm\Tests\TestConfig;
+
+class MapTest extends \Psalm\Tests\TestCase
+{
+    public function setUp() : void
+    {
+        parent::setUp();
+
+        $this->file_provider = new \Psalm\Tests\Internal\Provider\FakeFileProvider();
+
+        $config = new TestConfig();
+
+        $providers = new Providers(
+            $this->file_provider,
+            new \Psalm\Tests\Internal\Provider\ParserInstanceCacheProvider(),
+            null,
+            null,
+            new Provider\FakeFileReferenceCacheProvider(),
+            new \Psalm\Tests\Internal\Provider\ProjectCacheProvider()
+        );
+
+        $this->project_analyzer = new ProjectAnalyzer(
+            $config,
+            $providers
+        );
+        $this->project_analyzer->setPhpVersion('7.3');
+        $this->project_analyzer->getCodebase()->store_node_types = true;
+    }
+
+
+
+    public function testMapIsUpdatedOnReloadFiles(): void
+    {
+        $codebase = $this->project_analyzer->getCodebase();
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                class A {
+                    function __construct( string $var ) {
+                    }
+                }
+                $a = new A( "foo" );'
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+        $this->analyzeFile('somefile.php', new Context());
+        [ $type_map ] = $codebase->analyzer->getMapsForFile('somefile.php');
+
+        $this->assertTrue( ! empty( $type_map ) );
+
+        $codebase->file_provider->setOpenContents('somefile.php', '');
+        $codebase->reloadFiles( $this->project_analyzer, [ 'somefile.php'] );
+        $map = $codebase->analyzer->getMapsForFile('somefile.php');
+        var_dump( $map );
+    }
+
+    public function testGetTypeMap(): void
+    {
+        $codebase = $this->project_analyzer->getCodebase();
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                class A {
+                    function __construct( string $var ) {
+                    }
+                }
+                $a = new A( "foo" );'
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+        $this->analyzeFile('somefile.php', new Context());
+        [ $type_map ] = $codebase->analyzer->getMapsForFile('somefile.php');
+
+        $this->assertSame(
+            [
+                155 => [
+                    156,
+                    'A',
+                ],
+                146 => [
+                    148,
+                    '146-147:A',
+                ],
+            ],
+            $type_map
+        );
+    }
+}


### PR DESCRIPTION
When the project is re-analyzed under the single thread condition (not using a process pool), the filemaps are not cleared before re-analyzing files. This means that file maps only get appended to. If you delete the contents of a file via the LSP, the file map will still be populated with all the old values for example.
