### PR TITLE
Support completions on class references

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1286,6 +1286,12 @@ class Codebase
             if ($offset - $end_pos === 2 && substr($file_contents, $end_pos, 2) === '::') {
                 return [$possible_reference, '::', $offset];
             }
+
+            // Only continue for references that are partial / don't exist.
+            if ($possible_reference[0] !== '*') {
+                continue;
+            }
+
             if ($offset - $end_pos === 0) {
                 $recent_type = $possible_reference;
 

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1279,10 +1279,13 @@ class Codebase
         }
 
         foreach ($reference_map as $start_pos => [$end_pos, $possible_reference]) {
-            if ($offset < $start_pos || $possible_reference[0] !== '*') {
+            if ($offset < $start_pos) {
                 continue;
             }
-
+            // If the reference precedes a "::" then treat it as a class reference.
+            if ($offset - $end_pos === 2 && substr($file_contents, $end_pos, 2) === '::') {
+                return [$possible_reference, '::', $offset];
+            }
             if ($offset - $end_pos === 0) {
                 $recent_type = $possible_reference;
 

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -1168,7 +1168,7 @@ class Analyzer
     }
 
     /**
-     * @param string $reference The symbol name for the reference. Prepend with an asterisk (*) SOME REASON!.
+     * @param string $reference The symbol name for the reference. Prepend with an asterisk (*) to signify a reference that doesn't exist.
      */
     public function addNodeReference(string $file_path, PhpParser\Node $node, string $reference): void
     {

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -1167,6 +1167,9 @@ class Analyzer
         ];
     }
 
+    /**
+     * @param string $reference The symbol name for the reference. Prepend with an asterisk (*) SOME REASON!.
+     */
     public function addNodeReference(string $file_path, PhpParser\Node $node, string $reference): void
     {
         if (!$reference) {

--- a/tests/LanguageServer/CompletionTest.php
+++ b/tests/LanguageServer/CompletionTest.php
@@ -766,4 +766,36 @@ class CompletionTest extends \Psalm\Tests\TestCase
 
         $this->assertCount(2, $completion_items);
     }
+
+    public function testCompletionOnClassReference(): void
+    {
+
+        $codebase = $this->project_analyzer->getCodebase();
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace Bar;
+
+                class Alpha {
+                    const FOO = "123";
+                    static function add() : void {
+                    }
+                }
+                Alpha::'
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+        $this->analyzeFile('somefile.php', new Context());
+
+        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', new Position(8, 23));
+
+        $this->assertSame(['Bar\Alpha', '::', 221], $completion_data);
+
+        $completion_items = $codebase->getCompletionItemsForClassishThing($completion_data[0], $completion_data[1]);
+        $this->assertCount(2, $completion_items);
+    }
 }


### PR DESCRIPTION
This provides completions on class references (as opposed to initiated objects via the type map), so you can do `MyClass::` and get completitions for static methods and constants etc.

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2021-01-22-14-27-22.32-ynaLwxUWbtVWJoMM3GwwUr7mJnyQfRAIGDQ12Cd78JXNXVhFsRk48C51uakuMpKY8OMfdcjTDjYiRyS1doYqUcsHyRj7kpQw76aQ.png)