### PR TITLE
only transform a Keyed array into callable-array if there's two elements

### DIFF
--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -40,6 +40,7 @@ use Psalm\Type\Atomic\TString;
 use Psalm\Type\Atomic\TTemplateParam;
 use function strpos;
 use function substr;
+use function count;
 
 class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
 {
@@ -1988,7 +1989,7 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
                 $type = new TCallableList($type->type_param);
                 $callable_types[] = $type;
                 $did_remove_type = true;
-            } elseif ($type instanceof TKeyedArray) {
+            } elseif ($type instanceof TKeyedArray && count($type->properties) === 2) {
                 $type = clone $type;
                 $type = new TCallableKeyedArray($type->properties);
                 $callable_types[] = $type;

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -126,6 +126,8 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
             'iterableToArray' => ['array<int, int>', 'array', 'iterable<int, int>'],
             'iterableToTraversable' => ['Traversable<int, int>', 'Traversable', 'iterable<int, int>'],
             'callableToCallableArray' => ['callable-array{0: class-string|object, 1: string}', 'array', 'callable'],
+            'SmallKeyedArrayAndCallable' => ['array{test: string}', 'array{test: string}', 'callable'],
+            'BigKeyedArrayAndCallable' => ['array{foo: string, test: string, thing: string}', 'array{foo: string, test: string, thing: string}', 'callable'],
             'callableOrArrayToCallableArray' => ['array<array-key, mixed>', 'array', 'callable|array'],
             'traversableToIntersection' => ['Countable&Traversable', 'Traversable', 'Countable'],
             'iterableWithoutParamsToTraversableWithoutParams' => ['Traversable', '!array', 'iterable'],


### PR DESCRIPTION
This will prevent Psalm from transforming a random array into a callable-array. It does that by checking an array has exactly two elements

This will solve https://github.com/vimeo/psalm/issues/5082