### PR TITLE
Use separate exit code to indicate Psalm finding issues

### DIFF
--- a/docs/running_psalm/command_line_usage.md
+++ b/docs/running_psalm/command_line_usage.md
@@ -16,6 +16,13 @@ If you want to run on specific files, use
 
 Run with `--help` to see a list of options that Psalm supports.
 
+## Exit status
+
+Psalm exits with status `0` when it successfully completed and found no issues,
+`1` when there was a problem running Psalm and `2` when it completed
+successfully but found some issues. Any exit status apart from those indicate
+some internal problem.
+
 ## Shepherd
 
 Psalm currently offers some GitHub integration with public projects.

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -686,7 +686,7 @@ class IssueBuffer
                 && $project_analyzer->generated_report_options
                 && isset($_SERVER['GITHUB_WORKFLOW']))
         ) {
-            exit(1);
+            exit(2);
         }
     }
 

--- a/tests/EndToEnd/PsalmEndToEndTest.php
+++ b/tests/EndToEnd/PsalmEndToEndTest.php
@@ -118,7 +118,7 @@ class PsalmEndToEndTest extends TestCase
         $this->assertStringContainsString('InvalidReturnType', $result['STDOUT']);
         $this->assertStringContainsString('InvalidReturnStatement', $result['STDOUT']);
         $this->assertStringContainsString('2 errors', $result['STDOUT']);
-        $this->assertSame(1, $result['CODE']);
+        $this->assertSame(2, $result['CODE']);
     }
 
     public function testPsalmDiff(): void
@@ -136,7 +136,7 @@ class PsalmEndToEndTest extends TestCase
         $this->assertStringContainsString('2 errors', $result['STDOUT']);
         $this->assertStringContainsString('E', $result['STDERR']);
 
-        $this->assertSame(1, $result['CODE']);
+        $this->assertSame(2, $result['CODE']);
 
         $result = $this->runPsalm(['--diff', '-m'], self::$tmpDir, true);
 
@@ -145,7 +145,7 @@ class PsalmEndToEndTest extends TestCase
         $this->assertStringContainsString('2 errors', $result['STDOUT']);
         $this->assertStringNotContainsString('E', $result['STDERR']);
 
-        $this->assertSame(1, $result['CODE']);
+        $this->assertSame(2, $result['CODE']);
 
         @unlink(self::$tmpDir . '/composer.lock');
     }
@@ -157,7 +157,7 @@ class PsalmEndToEndTest extends TestCase
 
         $this->assertStringContainsString('TaintedHtml', $result['STDOUT']);
         $this->assertStringContainsString('1 errors', $result['STDOUT']);
-        $this->assertSame(1, $result['CODE']);
+        $this->assertSame(2, $result['CODE']);
     }
 
     public function testTaintingWithoutInit(): void
@@ -166,7 +166,7 @@ class PsalmEndToEndTest extends TestCase
 
         $this->assertStringContainsString('TaintedHtml', $result['STDOUT']);
         $this->assertStringContainsString('1 errors', $result['STDOUT']);
-        $this->assertSame(1, $result['CODE']);
+        $this->assertSame(2, $result['CODE']);
     }
 
     public function testTaintGraphDumping(): void
@@ -181,7 +181,7 @@ class PsalmEndToEndTest extends TestCase
             true
         );
 
-        $this->assertSame(1, $result['CODE']);
+        $this->assertSame(2, $result['CODE']);
         $this->assertFileEquals(
             __DIR__ . '/../fixtures/expected_taint_graph.dot',
             self::$tmpDir.'/taints.dot'
@@ -200,7 +200,7 @@ class PsalmEndToEndTest extends TestCase
 
         $process = new Process(['php', $this->psalm, '--config=src/psalm.xml'], self::$tmpDir);
         $process->run();
-        $this->assertSame(1, $process->getExitCode());
+        $this->assertSame(2, $process->getExitCode());
         $this->assertStringContainsString('InvalidReturnType', $process->getOutput());
     }
 


### PR DESCRIPTION
This will allow to distinguish successful run that found some issues from crash (that results in exit code=1).