### PR TITLE
Bump the CURRENT PHP TARGET VERSION to 8.0 in CallMap.php

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -2,7 +2,7 @@
 namespace Phan\Language\Internal;
 
 /**
- * CURRENT PHP TARGET VERSION: 7.4
+ * CURRENT PHP TARGET VERSION: 8.0
  * The version above has to match Psalm\Internal\Codebase\InternalCallMapHandler::PHP_(MAJOR|MINOR)_VERSION
  *
  * Format


### PR DESCRIPTION
Currently, Psalm\Internal\Codebase\InternalCallMapHandler::PHP_(MAJOR|MINOR)_VERSION indicates it's 8.0. https://github.com/vimeo/psalm/blob/09fb141e49ffc82c7f3551f283493dab51bc43f3/src/Psalm/Internal/Codebase/InternalCallMapHandler.php#L27-L28