### PR TITLE
Completions for array keys and type literals

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1273,7 +1273,7 @@ class Codebase
                         return null;
                     }
 
-                    return [$recent_type, '[', $offset];
+                    return [$recent_type, $gap, $offset];
                 }
             }
 

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -900,7 +900,8 @@ class Codebase
         $this->file_storage_provider->remove($file_path);
     }
 
-    public function getFunctionStorageForSymbol(string $file_path, string $symbol): ?FunctionLikeStorage {
+    public function getFunctionStorageForSymbol(string $file_path, string $symbol): ?FunctionLikeStorage
+    {
         if (strpos($symbol, '::')) {
             $symbol = substr($symbol, 0, -2);
             /** @psalm-suppress ArgumentTypeCoercion */
@@ -1366,7 +1367,7 @@ class Codebase
             }
             // First parameter to a function-like
             $function_storage = $this->getFunctionStorageForSymbol($file_path, $function . '()');
-            if (!$function_storage || !$function_storage->params){
+            if (!$function_storage || !$function_storage->params) {
                 return null;
             }
             $parameter = $function_storage->params[$argument_num];
@@ -1582,7 +1583,7 @@ class Codebase
         foreach ($type->getAtomicTypes() as $atomic_type) {
             if ($atomic_type instanceof Type\Atomic\TBool) {
                 $bools = (string) $atomic_type === 'bool' ? ['true', 'false'] : [(string) $atomic_type];
-                foreach( $bools as $property_name) {
+                foreach ($bools as $property_name) {
                     $completion_items[] = new \LanguageServerProtocol\CompletionItem(
                         $property_name,
                         \LanguageServerProtocol\CompletionItemKind::VALUE,
@@ -1603,7 +1604,9 @@ class Codebase
                     null,
                     "'$atomic_type->value'",
                 );
-            } elseif ($atomic_type instanceof Type\Atomic\TLiteralFloat || $atomic_type instanceof Type\Atomic\TLiteralInt) {
+            } elseif ($atomic_type instanceof Type\Atomic\TLiteralFloat
+                    || $atomic_type instanceof Type\Atomic\TLiteralInt
+                ) {
                 $completion_items[] = new \LanguageServerProtocol\CompletionItem(
                     (string) $atomic_type->value,
                     \LanguageServerProtocol\CompletionItemKind::VALUE,
@@ -1639,7 +1642,7 @@ class Codebase
         $type = Type::parseString($type_string);
         foreach ($type->getAtomicTypes() as $atomic_type) {
             if ($atomic_type instanceof Type\Atomic\TKeyedArray) {
-                foreach($atomic_type->properties as $property_name => $property ) {
+                foreach ($atomic_type->properties as $property_name => $property) {
                     $completion_items[] = new \LanguageServerProtocol\CompletionItem(
                         (string) $property_name,
                         \LanguageServerProtocol\CompletionItemKind::PROPERTY,
@@ -1650,7 +1653,6 @@ class Codebase
                         "'$property_name'",
                     );
                 }
-
             }
         }
         return $completion_items;

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1633,7 +1633,7 @@ class Codebase
      * @return list<\LanguageServerProtocol\CompletionItem>
      */
     public function getCompletionItemsForArrayKeys(
-        string $type_string,
+        string $type_string
     ) : array {
         $completion_items = [];
         $type = Type::parseString($type_string);

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1604,9 +1604,7 @@ class Codebase
                     null,
                     "'$atomic_type->value'",
                 );
-            } elseif ($atomic_type instanceof Type\Atomic\TLiteralFloat
-                    || $atomic_type instanceof Type\Atomic\TLiteralInt
-                ) {
+            } elseif ($atomic_type instanceof Type\Atomic\TLiteralInt) {
                 $completion_items[] = new \LanguageServerProtocol\CompletionItem(
                     (string) $atomic_type->value,
                     \LanguageServerProtocol\CompletionItemKind::VALUE,

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1279,7 +1279,7 @@ class Codebase
         $offset = $position->toOffset($file_contents);
 
         [$reference_map, $type_map] = $this->analyzer->getMapsForFile($file_path);
-        print_r([$reference_map, $type_map]);
+
         if (!$reference_map && !$type_map) {
             return null;
         }
@@ -1314,7 +1314,7 @@ class Codebase
             if ($offset - $end_pos === 2 || $offset - $end_pos === 3) {
                 $candidate_gap = substr($file_contents, $end_pos, 2);
 
-                if ($candidate_gap === '->' || $candidate_gap === '::' ) {
+                if ($candidate_gap === '->' || $candidate_gap === '::') {
                     $gap = $candidate_gap;
                     $recent_type = $possible_type;
 

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -247,7 +247,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 if ($this->project_analyzer->provide_completion) {
                     $serverCapabilities->completionProvider = new CompletionOptions();
                     $serverCapabilities->completionProvider->resolveProvider = false;
-                    $serverCapabilities->completionProvider->triggerCharacters = ['$', '>', ':'];
+                    $serverCapabilities->completionProvider->triggerCharacters = ['$', '>', ':',"["];
                 }
 
                 $serverCapabilities->signatureHelpProvider = new SignatureHelpOptions(['(', ',']);

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -247,7 +247,7 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
                 if ($this->project_analyzer->provide_completion) {
                     $serverCapabilities->completionProvider = new CompletionOptions();
                     $serverCapabilities->completionProvider->resolveProvider = false;
-                    $serverCapabilities->completionProvider->triggerCharacters = ['$', '>', ':',"["];
+                    $serverCapabilities->completionProvider->triggerCharacters = ['$', '>', ':',"[", "(", ",", " "];
                 }
 
                 $serverCapabilities->signatureHelpProvider = new SignatureHelpOptions(['(', ',']);

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -259,6 +259,8 @@ class TextDocument
 
         if ($gap === '->' || $gap === '::') {
             $completion_items = $this->codebase->getCompletionItemsForClassishThing($recent_type, $gap);
+        } else if ($gap === '[') {
+            $completion_items = $this->codebase->getCompletionItemsForArrayKeys($recent_type);
         } else {
             $completion_items = $this->codebase->getCompletionItemsForPartialSymbol($recent_type, $offset, $file_path);
         }

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -249,20 +249,26 @@ class TextDocument
             return new Success([]);
         }
 
-        if (!$completion_data) {
+        $type_context = $this->codebase->getTypeContextAtPosition($file_path, $position);
+
+        if (!$completion_data && !$type_context) {
             error_log('completion not found at ' . $position->line . ':' . $position->character);
 
             return new Success([]);
         }
 
-        [$recent_type, $gap, $offset] = $completion_data;
+        if ($completion_data) {
+            [$recent_type, $gap, $offset] = $completion_data;
 
-        if ($gap === '->' || $gap === '::') {
-            $completion_items = $this->codebase->getCompletionItemsForClassishThing($recent_type, $gap);
-        } else if ($gap === '[') {
-            $completion_items = $this->codebase->getCompletionItemsForArrayKeys($recent_type);
+            if ($gap === '->' || $gap === '::') {
+                $completion_items = $this->codebase->getCompletionItemsForClassishThing($recent_type, $gap);
+            } else if ($gap === '[') {
+                $completion_items = $this->codebase->getCompletionItemsForArrayKeys($recent_type);
+            } else {
+                $completion_items = $this->codebase->getCompletionItemsForPartialSymbol($recent_type, $offset, $file_path);
+            }
         } else {
-            $completion_items = $this->codebase->getCompletionItemsForPartialSymbol($recent_type, $offset, $file_path);
+            $completion_items = $this->codebase->getCompletionItemsForType($type_context);
         }
 
         return new Success(new CompletionList($completion_items, false));

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -262,10 +262,14 @@ class TextDocument
 
             if ($gap === '->' || $gap === '::') {
                 $completion_items = $this->codebase->getCompletionItemsForClassishThing($recent_type, $gap);
-            } else if ($gap === '[') {
+            } elseif ($gap === '[') {
                 $completion_items = $this->codebase->getCompletionItemsForArrayKeys($recent_type);
             } else {
-                $completion_items = $this->codebase->getCompletionItemsForPartialSymbol($recent_type, $offset, $file_path);
+                $completion_items = $this->codebase->getCompletionItemsForPartialSymbol(
+                    $recent_type,
+                    $offset,
+                    $file_path
+                );
             }
         } else {
             $completion_items = $this->codebase->getCompletionItemsForType($type_context);

--- a/src/Psalm/Internal/Type/ParseTreeCreator.php
+++ b/src/Psalm/Internal/Type/ParseTreeCreator.php
@@ -764,7 +764,7 @@ class ParseTreeCreator
                     );
                 } else {
                     throw new TypeParseTreeException(
-                        'Bracket must be preceded by “Closure”, “callable”, "pure-callable" or a valid @method name'
+                        'Paranthesis must be preceded by “Closure”, “callable”, "pure-callable" or a valid @method name'
                     );
                 }
 

--- a/tests/LanguageServer/CompletionTest.php
+++ b/tests/LanguageServer/CompletionTest.php
@@ -827,7 +827,6 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $this->addFile(
             'somefile.php',
             '<?php
-                /** @var array{ foo: int, bar: int } */
                 $my_array = ["foo" => 1, "bar" => 2];
                 $my_array[]
                 '
@@ -837,12 +836,12 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $codebase->scanFiles();
         $this->analyzeFile('somefile.php', new Context());
 
-        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', new Position(3, 26));
+        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', new Position(2, 26));
         $this->assertSame(
             [
-                'array{bar: int, foo: int}',
+                'array{bar: 2, foo: 1}',
                 '[',
-                142,
+                86,
             ],
             $completion_data
         );

--- a/tests/LanguageServer/CompletionTest.php
+++ b/tests/LanguageServer/CompletionTest.php
@@ -919,8 +919,9 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $completion_items = $codebase->getCompletionItemsForType(Type::parseString("1|2|3"));
         $this->assertCount(3, $completion_items);
 
+        // Floats not supported.
         $completion_items = $codebase->getCompletionItemsForType(Type::parseString("1.0"));
-        $this->assertCount(1, $completion_items);
+        $this->assertCount(0, $completion_items);
 
         $completion_items = $codebase->getCompletionItemsForType(Type::parseString("DateTime::RFC3339"));
         $this->assertCount(1, $completion_items);


### PR DESCRIPTION
This adds two new additions to completions support: known array-key string literals, and valid values as completions for argument types. For example, any parameter that has `bool`, ints, literal strings or constants will be provided as completions.

This requires broadening the completions triggers to `(`, `[` and ` `. From what I can see this is the same for TypeScript, which is what I've been using for completion comparisons.

For known-literals for types in arguments, it's show like so:

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2021-01-25-13-56-41.33-yVunadsIPQ3QjVFXBa2tdxRabBArFHtf6CYmz6VVdQcvcfdwlsgHluWg9lWetRw7aspBIiIZMEGtYqU5ETrSYypedbMdexfUD8px.png)

For known-array keys it's shown like so:

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2021-01-25-13-58-16.78-GXXyfuLoFY0sQ05KxBoLdwQH58AygSDBszPYZlo4lXqsKgkUinA7xH8yUTvJ3sGrkUt78ZzmDLQBanEdxtM7BgQh1HVkEfAr9SbZ.png)

This is still marked as draft as I have an issue with the array-key completion. Currently the reference map for the file will hold `array{bar: int(2), foo: int(1)}` for the above screenshot if the type annotation is not added. `array{bar: int(2), foo: int(1)}` is not a valid value for `Type::parseString()`, so I don't see a way to be able to reverse the type "annotation" in the reference map to a type object (and then be able to pull out the array-keys).

Perhaps `array{bar: int(2), foo: int(1)}` could become a valid type string, or perhaps it could make sense to change the format of `array{bar: int(2), foo: int(1)}` to something that's reversible to a type string too? Failing that, I think I'd need to track additional information in the reference map to be able to work back to a valid type object.