### PR TITLE
Add constant fetch to reference map

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -18,6 +18,7 @@ use const PHP_MINOR_VERSION;
 use PhpParser;
 use function preg_match;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\Internal\Analyzer\NamespaceAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Block\ForeachAnalyzer;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Codebase\InternalCallMapHandler;
@@ -1000,9 +1001,32 @@ class Codebase
                 return '<?php ' . $function->getSignature(true);
             }
 
-            $storage = $this->classlike_storage_provider->get($symbol);
+            try {
+                $storage = $this->classlike_storage_provider->get($symbol);
+                return '<?php ' . ($storage->abstract ? 'abstract ' : '') . 'class ' . $storage->name;
+            } catch (\InvalidArgumentException $e) {
+            }
 
-            return '<?php ' . ($storage->abstract ? 'abstract ' : '') . 'class ' . $storage->name;
+            if (strpos($symbol,'\\')) {
+                $const_name_parts = explode('\\', $symbol);
+                $const_name = array_pop($const_name_parts);
+                $namespace_name = implode('\\', $const_name_parts);
+
+                $namespace_constants = NamespaceAnalyzer::getConstantsForNamespace(
+                    $namespace_name,
+                    \ReflectionProperty::IS_PUBLIC
+                );
+                if (isset($namespace_constants[$const_name])) {
+                    $type = $namespace_constants[$const_name];
+                    return '<?php const ' . $symbol . ' ' . $type;
+                }
+            } else {
+                $constant = $this->getStubbedConstantType($symbol);
+                if ( $constant ) {
+                    return $constant;
+                }
+            }
+            return null;
         } catch (\Exception $e) {
             error_log($e->getMessage());
 

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -20,6 +20,7 @@ use function preg_match;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Analyzer\NamespaceAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Block\ForeachAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ConstFetchAnalyzer;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Codebase\InternalCallMapHandler;
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
@@ -1021,9 +1022,14 @@ class Codebase
                     return '<?php const ' . $symbol . ' ' . $type;
                 }
             } else {
-                $constant = $this->getStubbedConstantType($symbol);
-                if ( $constant ) {
-                    return $constant;
+                $file_storage = $this->file_storage_provider->get($file_path);
+                if (isset($file_storage->constants[$symbol])) {
+                    return '<?php const ' . $symbol . ' ' . $file_storage->constants[$symbol];
+                }
+                $constant = ConstFetchAnalyzer::getGlobalConstType($this, $symbol, $symbol);
+
+                if ($constant) {
+                    return '<?php const ' . $symbol . ' ' . $constant;
                 }
             }
             return null;

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -41,6 +41,8 @@ use function strrpos;
 use function strtolower;
 use function substr;
 use function substr_count;
+use function array_pop;
+use function implode;
 
 class Codebase
 {
@@ -1008,7 +1010,7 @@ class Codebase
             } catch (\InvalidArgumentException $e) {
             }
 
-            if (strpos($symbol,'\\')) {
+            if (strpos($symbol, '\\')) {
                 $const_name_parts = explode('\\', $symbol);
                 $const_name = array_pop($const_name_parts);
                 $namespace_name = implode('\\', $const_name_parts);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
@@ -58,6 +58,25 @@ class ConstFetchAnalyzer
                     $context
                 );
 
+                $codebase = $statements_analyzer->getCodebase();
+
+                $aliased_constants = $statements_analyzer->getAliases()->constants;
+                if (isset($aliased_constants[$const_name])) {
+                    $fq_const_name = $aliased_constants[$const_name];
+                } elseif ($stmt->name instanceof PhpParser\Node\Name\FullyQualified) {
+                    $fq_const_name = $const_name;
+                } else {
+                    $fq_const_name = Type::getFQCLNFromString($const_name, $statements_analyzer->getAliases());
+                }
+
+                $codebase->analyzer->addNodeReference(
+                    $statements_analyzer->getFilePath(),
+                    $stmt,
+                    $const_type
+                        ? $fq_const_name
+                        : '*' . $fq_const_name
+                );
+
                 if ($const_type) {
                     $statements_analyzer->node_data->setType($stmt, clone $const_type);
                 } elseif ($context->check_consts) {

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -44,6 +44,8 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
             '<?php
                 namespace B;
 
+                const APPLE = "🍏";
+
                 class A {
                     /** @var int|null */
                     protected $a;
@@ -81,6 +83,23 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->assertSame('<?php BANANA', $codebase->getSymbolInformation('somefile.php', 'B\A::BANANA'));
         $this->assertSame("<?php function B\baz(\n    int \$a\n) : int", $codebase->getSymbolInformation('somefile.php', 'B\baz()'));
         $this->assertSame("<?php function B\qux(\n    int \$a,\n    int \$b\n) : int", $codebase->getSymbolInformation('somefile.php', 'B\qux()'));
+        $this->assertSame("<?php const B\APPLE string", $codebase->getSymbolInformation('somefile.php', 'B\APPLE'));
+    }
+
+    public function testSimpleSymbolLookupGlobalConst(): void
+    {
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                const APPLE = "🍏";'
+        );
+
+        new FileAnalyzer($this->project_analyzer, 'somefile.php', 'somefile.php');
+
+        $codebase = $this->project_analyzer->getCodebase();
+
+        $this->analyzeFile('somefile.php', new Context());
+        $this->assertSame("<?php const APPLE string", $codebase->getSymbolInformation('somefile.php', 'APPLE'));
     }
 
     public function testSimpleSymbolLocation(): void

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -91,6 +91,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->addFile(
             'somefile.php',
             '<?php
+                define("BANANA", "🍌");
                 const APPLE = "🍏";'
         );
 
@@ -100,6 +101,7 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
 
         $this->analyzeFile('somefile.php', new Context());
         $this->assertSame("<?php const APPLE string", $codebase->getSymbolInformation('somefile.php', 'APPLE'));
+        $this->assertSame("<?php const BANANA string", $codebase->getSymbolInformation('somefile.php', 'BANANA'));
     }
 
     public function testSimpleSymbolLocation(): void


### PR DESCRIPTION
To support showing constant types on hover of constant references, we need to add them to the ref map.

I'm not sure on the best format for the Symbol Information, I went with `const APPLE string` but perhaps there's a better formula to use here?

For global constants (though not in a namespace), I wasn't yet able to see where they were stored (see the failing test). It looks like `Codebase::getStubbedConstantType()` doesn't have it.

I'm also adding this to support both constant compleitions, but also it will mean effectively any word in typing will become a `*unknown_const` reference.
