### PR TITLE
docs: Update config of vim-lsp in language_server.md

### DIFF
--- a/docs/running_psalm/language_server.md
+++ b/docs/running_psalm/language_server.md
@@ -79,7 +79,7 @@ This is the config I used (for Vim):
 au User lsp_setup call lsp#register_server({
      \ 'name': 'psalm-language-server',
      \ 'cmd': {server_info->[expand('vendor/bin/psalm-language-server')]},
-     \ 'whitelist': ['php'],
+     \ 'allowlist': ['php'],
      \ })
 ```
 


### PR DESCRIPTION
## Description

This is about the "vim-lsp" configuration.

It has now been changed from the `whitelist` to the `allowlist`.

The old settings may not be available in the future, so we have changed the documentation.

## REF

https://github.com/prabirshrestha/vim-lsp/commit/32fae1f0e9c0c2c21361d0bb94f119f9ae65a118

