### PR TITLE
Track references on global variables

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -21,6 +21,7 @@ use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Analyzer\NamespaceAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Block\ForeachAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ConstFetchAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\Fetch\VariableFetchAnalyzer;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Codebase\InternalCallMapHandler;
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
@@ -1002,6 +1003,13 @@ class Codebase
 
                 $function = $this->functions->getStorage(null, $function_id);
                 return '<?php ' . $function->getSignature(true);
+            }
+
+            if (strpos($symbol, '$') === 0) {
+                $type = VariableFetchAnalyzer::getGlobalType($symbol);
+                if (!$type->isMixed()) {
+                    return '<?php ' . $type;
+                }
             }
 
             try {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -165,6 +165,12 @@ class VariableFetchAnalyzer
             $context->vars_in_scope[$var_name] = clone $type;
             $context->vars_possibly_in_scope[$var_name] = true;
 
+            $codebase->analyzer->addNodeReference(
+                $statements_analyzer->getFilePath(),
+                $stmt,
+                $var_name
+            );
+
             return true;
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
@@ -5,6 +5,7 @@ use PhpParser;
 use Psalm\Internal\Analyzer\FunctionLikeAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Fetch\VariableFetchAnalyzer;
+use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\Issue\InvalidGlobal;
@@ -56,6 +57,23 @@ class GlobalAnalyzer
 
                         $context->byref_constraints[$var_id] = new \Psalm\Internal\ReferenceConstraint();
                     }
+                    $assignment_node = DataFlowNode::getForAssignment(
+                        $var_id,
+                        new CodeLocation($statements_analyzer, $var)
+                    );
+                    $context->vars_in_scope[$var_id]->parent_nodes = [
+                        $assignment_node->id => $assignment_node,
+                    ];
+                    $statements_analyzer->registerVariable(
+                        $var_id,
+                        new CodeLocation($statements_analyzer, $var),
+                        $context->branch_point
+                    );
+                    $statements_analyzer->getCodebase()->analyzer->addNodeReference(
+                        $statements_analyzer->getFilePath(),
+                        $var,
+                        $var_id
+                    );
                 }
             }
         }

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -300,7 +300,6 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
                     global $my_global;
                     echo $my_global;
                 }'
-
         );
 
         $codebase->file_provider->openFile('somefile.php');

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -308,9 +308,11 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         $this->analyzeFile('somefile.php', new Context());
 
         $symbol_at_position = $codebase->getReferenceAtPosition('somefile.php', new Position(2, 31));
+        $this->assertNotNull($symbol_at_position);
         $this->assertSame('$my_global', $symbol_at_position[0]);
 
         $symbol_at_position = $codebase->getReferenceAtPosition('somefile.php', new Position(3, 28));
+        $this->assertNotNull($symbol_at_position);
         $this->assertSame('73-82:string', $symbol_at_position[0]);
     }
 

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -3114,6 +3114,15 @@ class UnusedVariableTest extends TestCase
                     };',
                 'error_message' => 'UnusedVariable',
             ],
+            'globalVariableUsage' => [
+                '<?php
+                    $a = "hello";
+                    function example() : void {
+                        global $a;
+                    }
+                    example();',
+                'error_message' => 'UnusedVariable',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Add global type references to the type map, and fix up unused detection on global variables. To do this I had to also register the globals in the var maps when you do `global $x`. I think this makes sense -- in doing so I also had to add the Node references to satisfy the unused variable detection.