### PR TITLE
Enforce property type invariance

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -312,6 +312,7 @@
             <xs:element name="NoInterfaceProperties" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="NonStaticSelfCall" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NoValue" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NonInvariantPropertyType" type="MethodIssueHandlerType" minOccurs="0" />
             <xs:element name="NullableReturnStatement" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NullArgument" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="NullArrayAccess" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/issues/NonInvariantPropertyType.md
+++ b/docs/running_psalm/issues/NonInvariantPropertyType.md
@@ -1,0 +1,26 @@
+# NonInvariantPropertyType
+
+Emitted when a public or protected class property has a different type to the matching property in the parent class.
+
+```php
+<?php
+
+class A {
+    /** @var string */
+    public $foo = 'hello';
+}
+
+class B extends A {
+    /** @var null|string */
+    public $foo;
+}
+
+```
+
+## Why this is bad
+
+For typed properties, this can cause a compile error. For non-typed
+properties, it can cause a type system violation when code written against the parent class reads or writes a value on an object of the child class.
+
+If the child class widens the type then reading the value may return unexpected value that client code cannot deal with. If the child class narrows the type then code setting the value may set
+it to an invalid value.

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -30,6 +30,7 @@ use Psalm\Issue\MissingImmutableAnnotation;
 use Psalm\Issue\MissingPropertyType;
 use Psalm\Issue\MissingTemplateParam;
 use Psalm\Issue\MutableDependency;
+use Psalm\Issue\NonInvariantPropertyType;
 use Psalm\Issue\OverriddenPropertyAccess;
 use Psalm\Issue\PropertyNotSetInConstructor;
 use Psalm\Issue\ReservedWord;
@@ -651,7 +652,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                     ) {
                         if (IssueBuffer::accepts(
                             new OverriddenPropertyAccess(
-                                'Property ' . $guide_class_storage->name . '::$' . $property_name
+                                'Property ' . $fq_class_name . '::$' . $property_name
                                     . ' has different access level than '
                                     . $storage->name . '::$' . $property_name,
                                 $property_storage->location
@@ -659,8 +660,22 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                         )) {
                             // fall through
                         }
+                    }
 
-                        continue;
+                    if ($property_storage->type && $guide_property_storage->type && $property_storage->location &&
+                        !$property_storage->type->equals($guide_property_storage->type)) {
+                        if (IssueBuffer::accepts(
+                            new NonInvariantPropertyType(
+                                'Property ' . $fq_class_name . '::$' . $property_name
+                                . ' has type ' . $property_storage->type->getId()
+                                . ", not invariant with " . $guide_class_name . '::$' . $property_name . ' of type ' .
+                                $guide_property_storage->type->getId(),
+                                $property_storage->location
+                            ),
+                            $property_storage->suppressed_issues
+                        )) {
+                            // fall through
+                        }
                     }
                 }
             }

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -72,6 +72,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
     protected $class;
 
     /**
+     * @psalm-suppress NonInvariantPropertyType
      * @var StatementsSource
      */
     protected $source;

--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -24,6 +24,7 @@ use function preg_match;
 class ClosureAnalyzer extends FunctionLikeAnalyzer
 {
     /**
+     * @psalm-suppress NonInvariantPropertyType
      * @var PhpParser\Node\Expr\Closure|PhpParser\Node\Expr\ArrowFunction
      */
     protected $function;

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -225,6 +225,10 @@ class CommentAnalyzer
             $var_comment->psalm_internal = reset($parsed_docblock->tags['psalm-internal']);
             $var_comment->internal = true;
         }
+
+        if (isset($parsed_docblock->tags['psalm-suppress'])) {
+            $var_comment->suppressed_issues = $parsed_docblock->tags['psalm-suppress'];
+        }
     }
 
     /**

--- a/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
@@ -13,6 +13,7 @@ class FunctionAnalyzer extends FunctionLikeAnalyzer
 {
     /**
      * @var PhpParser\Node\Stmt\Function_
+     * @psalm-suppress NonInvariantPropertyType
      */
     protected $function;
 

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -71,6 +71,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
 
     /**
      * @var StatementsSource
+     * @psalm-suppress NonInvariantPropertyType
      */
     protected $source;
 

--- a/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
@@ -22,6 +22,7 @@ use function in_array;
 class MethodAnalyzer extends FunctionLikeAnalyzer
 {
     /**
+     * @psalm-suppress NonInvariantPropertyType
      * @var PhpParser\Node\Stmt\ClassMethod
      */
     protected $function;

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -20,6 +20,7 @@ class NamespaceAnalyzer extends SourceAnalyzer
 
     /**
      * @var FileAnalyzer
+     * @psalm-suppress NonInvariantPropertyType
      */
     protected $source;
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -1349,6 +1349,7 @@ class ClassLikeNodeScanner
             $property_storage->stmt_location = new CodeLocation($this->file_scanner, $stmt);
             $property_storage->has_default = $property->default ? true : false;
             $property_storage->deprecated = $var_comment ? $var_comment->deprecated : false;
+            $property_storage->suppressed_issues = $var_comment ? $var_comment->suppressed_issues : [];
             $property_storage->internal = $var_comment ? $var_comment->psalm_internal ?? '' : '';
             if (! $property_storage->internal && $var_comment && $var_comment->internal) {
                 $property_storage->internal = NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name);

--- a/src/Psalm/Internal/Provider/PropertyTypeProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyTypeProvider.php
@@ -95,6 +95,11 @@ class PropertyTypeProvider
         ?StatementsSource $source = null,
         ?Context $context = null
     ): ?Type\Union {
+
+        if ($source) {
+            $source->addSuppressedIssues(['NonInvariantPropertyType']);
+        }
+
         foreach (self::$handlers[strtolower($fq_classlike_name)] ?? [] as $property_handler) {
             $event = new PropertyTypeProviderEvent(
                 $fq_classlike_name,

--- a/src/Psalm/Internal/Scanner/VarDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/VarDocblockComment.php
@@ -77,4 +77,9 @@ class VarDocblockComment
      * @var list<string>
      */
     public $removed_taints = [];
+
+    /**
+     * @var array<int, string>
+     */
+    public $suppressed_issues = [];
 }

--- a/src/Psalm/Issue/NonInvariantPropertyType.php
+++ b/src/Psalm/Issue/NonInvariantPropertyType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Issue;
+
+final class NonInvariantPropertyType extends CodeIssue
+{
+    public const ERROR_LEVEL = -1;
+    public const SHORTCODE = 235159;
+}

--- a/src/Psalm/Issue/NonInvariantPropertyType.php
+++ b/src/Psalm/Issue/NonInvariantPropertyType.php
@@ -7,5 +7,5 @@ namespace Psalm\Issue;
 final class NonInvariantPropertyType extends CodeIssue
 {
     public const ERROR_LEVEL = -1;
-    public const SHORTCODE = 235159;
+    public const SHORTCODE = 265;
 }

--- a/src/Psalm/Storage/PropertyStorage.php
+++ b/src/Psalm/Storage/PropertyStorage.php
@@ -96,6 +96,11 @@ class PropertyStorage
      */
     public $attributes = [];
 
+    /**
+     * @var array<int, string>
+     */
+    public $suppressed_issues = [];
+
     public function getInfo() : string
     {
         switch ($this->visibility) {

--- a/src/Psalm/Type/Atomic/TArray.php
+++ b/src/Psalm/Type/Atomic/TArray.php
@@ -14,6 +14,7 @@ class TArray extends \Psalm\Type\Atomic
 
     /**
      * @var array{\Psalm\Type\Union, \Psalm\Type\Union}
+     * @psalm-suppress NonInvariantPropertyType
      */
     public $type_params;
 

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -570,7 +570,6 @@ class ClassTest extends TestCase
             'extendException' => [
                 '<?php
                     class ME extends Exception {
-                        /** @var string */
                         protected $message = "hello";
                     }',
             ],

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -38,7 +38,10 @@ class PluginTest extends \Psalm\Tests\TestCase
     /** @var TestConfig */
     protected static $config;
 
-    /** @var ?\Psalm\Internal\Analyzer\ProjectAnalyzer */
+    /**
+     * @var ?\Psalm\Internal\Analyzer\ProjectAnalyzer
+     * @psalm-suppress NonInvariantPropertyType
+     */
     protected $project_analyzer;
 
     public static function setUpBeforeClass() : void

--- a/tests/PropertyTypeInvariance.php
+++ b/tests/PropertyTypeInvariance.php
@@ -1,0 +1,87 @@
+<?php
+namespace Psalm\Tests;
+
+class PropertyTypeInvariance extends TestCase
+{
+    use Traits\InvalidCodeAnalysisTestTrait;
+    use Traits\ValidCodeAnalysisTestTrait;
+
+    /**
+     * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
+     */
+    public function providerValidCodeParse(): iterable
+    {
+        return [
+            'validcode' =>
+                ['<?php
+
+                class ParentClass
+                {
+                    /** @var null|string */
+                    protected $mightExist;
+
+                    protected ?string $mightExistNative = null;
+
+                    /** @var string */
+                    protected $doesExist = "";
+
+                    protected string $doesExistNative = "";
+                }
+
+                class ChildClass extends ParentClass
+                {
+                    /** @var null|string */
+                    protected $mightExist = "";
+
+                    protected ?string $mightExistNative = null;
+
+                    /** @var string */
+                    protected $doesExist = "";
+
+                    protected string $doesExistNative = "";
+                }
+                '],
+        ];
+    }
+
+    /**
+     * @return iterable<string,array{string,error_message:string,2?:string[],3?:bool,4?:string}>
+     */
+    public function providerInvalidCodeParse(): iterable
+    {
+        return [
+            'variantProperties' => [
+                '
+                <?php
+
+                class ParentClass
+                {
+                    /** @var null|string */
+                    protected $mightExist;
+
+                    protected ?string $mightExistNative = null;
+
+                    /** @var string */
+                    protected $doesExist = "";
+
+                    protected string $doesExistNative = "";
+                }
+
+                class ChildClass extends ParentClass
+                {
+                    /** @var string */
+                    protected $mightExist = "";
+
+                    protected string $mightExistNative = "";
+
+                    /** @var null|string */
+                    protected $doesExist = "";
+
+                    protected ?string $doesExistNative = "";
+                }
+                ',
+                'error_message' => 'NonInvariantPropertyType',
+            ]
+        ];
+    }
+}

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -1724,34 +1724,6 @@ class PropertyTypeTest extends TestCase
 
                     class Bar extends Foo {}',
             ],
-            'parentSetsWiderTypeInConstructor' => [
-                '<?php
-                    interface Foo {}
-
-                    interface FooMore extends Foo {
-                        public function something(): void;
-                    }
-
-                    class Bar {
-                        /** @var Foo */
-                        protected $foo;
-
-                        public function __construct(Foo $foo) {
-                            $this->foo = $foo;
-                        }
-                    }
-
-
-                    class BarMore extends Bar {
-                        /** @var FooMore */
-                        protected $foo;
-
-                        public function __construct(FooMore $foo) {
-                            parent::__construct($foo);
-                            $this->foo->something();
-                        }
-                    }',
-            ],
             'inferPropertyTypesForSimpleConstructors' => [
                 '<?php
                     class A {
@@ -3259,32 +3231,6 @@ class PropertyTypeTest extends TestCase
                         }
                     }',
                 'error_message' => 'PropertyNotSetInConstructor',
-            ],
-            'parentSetsWiderTypeInConstructor' => [
-                '<?php
-                    interface Foo {}
-
-                    interface FooMore extends Foo {}
-
-                    class Bar {
-                        /** @var Foo */
-                        protected $foo;
-
-                        public function __construct(Foo $foo) {
-                            $this->foo = $foo;
-                        }
-                    }
-
-                    class BarMore extends Bar {
-                        /** @var FooMore */
-                        protected $foo;
-
-                        public function __construct(FooMore $foo) {
-                            parent::__construct($foo);
-                            $this->foo->something();
-                        }
-                    }',
-                'error_message' => 'UndefinedInterfaceMethod',
             ],
             'nullableTypedPropertyNoConstructor' => [
                 '<?php


### PR DESCRIPTION
This should be a fix for https://github.com/vimeo/psalm/issues/4184

Creates a new issue type **NonInvariantPropertyType** which is emitted when any property which exists in a parent class is redeclared in a child class with a different type.