### PR TITLE
allow libraries to provide psalm plugins

### DIFF
--- a/src/Psalm/Internal/PluginManager/ComposerLock.php
+++ b/src/Psalm/Internal/PluginManager/ComposerLock.php
@@ -31,11 +31,8 @@ class ComposerLock
     public function isPlugin($package): bool
     {
         return is_array($package)
-            && isset($package['name'])
+            && isset($package['name'], $package['extra']['psalm']['pluginClass'])
             && is_string($package['name'])
-            && isset($package['type'])
-            && $package['type'] === 'psalm-plugin'
-            && isset($package['extra']['psalm']['pluginClass'])
             && is_array($package['extra'])
             && is_array($package['extra']['psalm'])
             && is_string($package['extra']['psalm']['pluginClass']);
@@ -71,7 +68,7 @@ class ComposerLock
     }
 
     /**
-     * @return list<array{type:string,name:string,extra:array{psalm:array{pluginClass:string}}}>
+     * @return list<array{name:string,extra:array{psalm:array{pluginClass:string}}}>
      */
     private function getAllPluginPackages(): array
     {
@@ -80,7 +77,7 @@ class ComposerLock
         /** @psalm-suppress MixedAssignment */
         foreach ($packages as $package) {
             if ($this->isPlugin($package)) {
-                /** @var array{type:'psalm-plugin',name:string,extra:array{psalm:array{pluginClass:string}}} */
+                /** @var array{name:string,extra:array{psalm:array{pluginClass:string}}} */
                 $ret[] = $package;
             }
         }

--- a/tests/ComposerLockTest.php
+++ b/tests/ComposerLockTest.php
@@ -10,10 +10,39 @@ class ComposerLockTest extends TestCase
     /**
      * @test
      */
-    public function pluginIsPackageOfTypePsalmPlugin(): void
+    public function packageIsPsalmPlugin(): void
     {
         $lock = new ComposerLock([$this->jsonFile((object)[])]);
-        $this->assertTrue($lock->isPlugin($this->pluginEntry('vendor/package', 'Some\Class')));
+
+        $this->assertTrue($lock->isPlugin([
+            'name' => 'vendor/package',
+            'type' => 'psalm-plugin',
+            'extra' => [
+                'psalm' => [
+                    'pluginClass' => 'Some\Class'
+                ]
+            ]
+        ]), 'Non-plugin should not be considered a plugin');
+
+        $this->assertTrue($lock->isPlugin([
+            'name' => 'vendor/package',
+            'type' => 'library',
+            'extra' => [
+                'psalm' => [
+                    'pluginClass' => 'Some\Class'
+                ]
+            ]
+        ]), 'Non-plugin should not be considered a plugin');
+
+        $this->assertTrue($lock->isPlugin([
+            'name' => 'vendor/package',
+            'extra' => [
+                'psalm' => [
+                    'pluginClass' => 'Some\Class'
+                ]
+            ]
+        ]), 'Non-plugin should not be considered a plugin');
+
         // counterexamples
 
         $this->assertFalse($lock->isPlugin([]), 'Non-package should not be considered a plugin');


### PR DESCRIPTION
In `azjezz/psl`, i want to provide a plugin with the library, however, i don't want to change the package type, as it is still a library, even tho it defines an optional psalm-plugin, this restriction ( of requiring the package to be of `psalm-plugin` type ), is currently stopping `vendor/bin/psalm-plugin` from discovering the plugin within PSL, even tho the plugin class is declared.

see https://github.com/azjezz/psl/pull/119/files#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R65