### PR TITLE
Remove all (but one) properity declarations that needed NonInvariantDocblockPropertyType suppressed

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -71,12 +71,6 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
      */
     protected $class;
 
-    /**
-     * @psalm-suppress NonInvariantDocblockPropertyType
-     * @var StatementsSource
-     */
-    protected $source;
-
     /** @var FileAnalyzer */
     public $file_analyzer;
 

--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -24,12 +24,6 @@ use function preg_match;
 class ClosureAnalyzer extends FunctionLikeAnalyzer
 {
     /**
-     * @psalm-suppress NonInvariantDocblockPropertyType
-     * @var PhpParser\Node\Expr\Closure|PhpParser\Node\Expr\ArrowFunction
-     */
-    protected $function;
-
-    /**
      * @param PhpParser\Node\Expr\Closure|PhpParser\Node\Expr\ArrowFunction $function
      */
     public function __construct(PhpParser\Node\FunctionLike $function, SourceAnalyzer $source)

--- a/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionAnalyzer.php
@@ -2,6 +2,7 @@
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;
+use PhpParser\Node\Expr\ArrowFunction;
 use Psalm\Context;
 use function strtolower;
 use function is_string;
@@ -11,12 +12,6 @@ use function is_string;
  */
 class FunctionAnalyzer extends FunctionLikeAnalyzer
 {
-    /**
-     * @var PhpParser\Node\Stmt\Function_
-     * @psalm-suppress NonInvariantDocblockPropertyType
-     */
-    protected $function;
-
     public function __construct(PhpParser\Node\Stmt\Function_ $function, SourceAnalyzer $source)
     {
         $codebase = $source->getCodebase();
@@ -42,9 +37,14 @@ class FunctionAnalyzer extends FunctionLikeAnalyzer
 
     /**
      * @return non-empty-lowercase-string
+     * @throws \UnexpectedValueException if function is closure or arrow function.
      */
     public function getFunctionId(): string
     {
+        if ($this->function instanceof PhpParser\Node\Expr\Closure || $this->function instanceof ArrowFunction) {
+            throw new \UnexpectedValueException("Can't get ID for a closure or arrow function");
+        }
+
         $namespace = $this->source->getNamespace();
 
         /** @var non-empty-lowercase-string */

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -70,12 +70,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     protected $is_static = false;
 
     /**
-     * @var StatementsSource
-     * @psalm-suppress NonInvariantDocblockPropertyType
-     */
-    protected $source;
-
-    /**
      * @var ?array<string, Type\Union>
      */
     protected $return_vars_in_scope = [];
@@ -1624,11 +1618,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
     public function isStatic(): bool
     {
         return $this->is_static;
-    }
-
-    public function getSource(): StatementsSource
-    {
-        return $this->source;
     }
 
     public function getCodebase() : Codebase

--- a/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
@@ -2,6 +2,7 @@
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;
+use PhpParser\Node\Expr\ArrowFunction;
 use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\Context;
@@ -21,11 +22,6 @@ use function in_array;
  */
 class MethodAnalyzer extends FunctionLikeAnalyzer
 {
-    /**
-     * @psalm-suppress NonInvariantDocblockPropertyType
-     * @var PhpParser\Node\Stmt\ClassMethod
-     */
-    protected $function;
 
     public function __construct(
         PhpParser\Node\Stmt\ClassMethod $function,
@@ -281,6 +277,10 @@ class MethodAnalyzer extends FunctionLikeAnalyzer
 
     public function getMethodId(?string $context_self = null): \Psalm\Internal\MethodIdentifier
     {
+        if ($this->function instanceof PhpParser\Node\Expr\Closure || $this->function instanceof ArrowFunction) {
+            throw new \UnexpectedValueException("Can't get ID for a closure or arrow function");
+        }
+
         $function_name = (string)$this->function->name;
 
         return new \Psalm\Internal\MethodIdentifier(

--- a/src/Psalm/Type/Atomic/TArray.php
+++ b/src/Psalm/Type/Atomic/TArray.php
@@ -13,12 +13,6 @@ class TArray extends \Psalm\Type\Atomic
     use GenericTrait;
 
     /**
-     * @var array{\Psalm\Type\Union, \Psalm\Type\Union}
-     * @psalm-suppress NonInvariantDocblockPropertyType
-     */
-    public $type_params;
-
-    /**
      * @var string
      */
     public $value = 'array';

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -38,12 +38,6 @@ class PluginTest extends \Psalm\Tests\TestCase
     /** @var TestConfig */
     protected static $config;
 
-    /**
-     * @var ?\Psalm\Internal\Analyzer\ProjectAnalyzer
-     * @psalm-suppress NonInvariantDocblockPropertyType
-     */
-    protected $project_analyzer;
-
     public static function setUpBeforeClass() : void
     {
         self::$config = new TestConfig();


### PR DESCRIPTION
The remaining property
\Psalm\Internal\Analyzer\NamespaceAnalyzer::$source seems a bit harder
to fix