### PR TITLE
Prevent throwing a division by zero when encountering a literal division by zero

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -326,12 +326,16 @@ class NonDivArithmeticOpAnalyzer
             } elseif ($parent instanceof PhpParser\Node\Expr\BinaryOp\ShiftRight) {
                 $calculated_type = Type::getInt(false, $left_type_part->value >> $right_type_part->value);
             } elseif ($parent instanceof PhpParser\Node\Expr\BinaryOp\Div) {
-                $value = $left_type_part->value / $right_type_part->value;
-
-                if (is_int($value)) {
-                    $calculated_type = Type::getInt(false, $value);
+                if ($right_type_part->value === 0) {
+                    $calculated_type = Type::getEmpty();
                 } else {
-                    $calculated_type = Type::getFloat($value);
+                    $value = $left_type_part->value / $right_type_part->value;
+
+                    if (is_int($value)) {
+                        $calculated_type = Type::getInt(false, $value);
+                    } else {
+                        $calculated_type = Type::getFloat($value);
+                    }
                 }
             }
 


### PR DESCRIPTION
This should fix #5157. When there is a literal `1/0` in code (for example in tests). Psalm attempt to calculate the result of the division and throw an error.

I used the TEmpty type for this but I'm not sure I should have 