### PR TITLE
Remove the trailing comma for function call as minimum support version is 7.1

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1631,7 +1631,7 @@ class Codebase
                         null,
                         null,
                         null,
-                        $property_name,
+                        $property_name
                     );
                 }
             } elseif ($atomic_type instanceof Type\Atomic\TLiteralString) {
@@ -1642,7 +1642,7 @@ class Codebase
                     null,
                     null,
                     null,
-                    "'$atomic_type->value'",
+                    "'$atomic_type->value'"
                 );
             } elseif ($atomic_type instanceof Type\Atomic\TLiteralInt) {
                 $completion_items[] = new \LanguageServerProtocol\CompletionItem(
@@ -1652,7 +1652,7 @@ class Codebase
                     null,
                     null,
                     null,
-                    (string) $atomic_type->value,
+                    (string) $atomic_type->value
                 );
             } elseif ($atomic_type instanceof Type\Atomic\TScalarClassConstant) {
                 $const = $atomic_type->fq_classlike_name . '::' . $atomic_type->const_name;
@@ -1663,7 +1663,7 @@ class Codebase
                     null,
                     null,
                     null,
-                    $const,
+                    $const
                 );
             }
         }
@@ -1688,7 +1688,7 @@ class Codebase
                         null,
                         null,
                         null,
-                        "'$property_name'",
+                        "'$property_name'"
                     );
                 }
             }


### PR DESCRIPTION
The new version, 4.5.*, fails on PHP 7.1 and 7.2 with:
```
Uncaught ParseError: syntax error, unexpected ')' in ...../vendor/vimeo/psalm/src/Psalm/Codebase.php:1635
```

I'm guessing this will require a new bug patch release after merge.