### PR TITLE
Allow @psalm-type and @psalm-import-type to be used in extends/implements

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -40,6 +40,11 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements FileSour
     private $aliases;
 
     /**
+     * @var string[]
+     */
+    private $fq_classlike_names = [];
+
+    /**
      * @var FileScanner
      */
     private $file_scanner;
@@ -122,7 +127,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements FileSour
         foreach ($node->getComments() as $comment) {
             if ($comment instanceof PhpParser\Comment\Doc && !$node instanceof PhpParser\Node\Stmt\ClassLike) {
                 $self_fqcln = $node instanceof PhpParser\Node\Stmt\ClassLike
-                && $node->name !== null
+                    && $node->name !== null
                     ? ($this->aliases->namespace ? $this->aliases->namespace . '\\' : '') . $node->name->name
                     : null;
 
@@ -180,7 +185,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements FileSour
                 return PhpParser\NodeTraverser::DONT_TRAVERSE_CHILDREN;
             }
 
-            $this->type_aliases = $this->type_aliases + $classlike_node_scanner->type_aliases;
+            $this->type_aliases += $classlike_node_scanner->type_aliases;
         } elseif ($node instanceof PhpParser\Node\Stmt\TryCatch) {
             foreach ($node->catches as $catch) {
                 foreach ($catch->types as $catch_type) {
@@ -293,7 +298,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements FileSour
                 $this->file_storage->declaring_constants[$fq_const_name] = $this->file_path;
             }
         } elseif ($node instanceof PhpParser\Node\Stmt\If_ && !$this->skip_if_descendants) {
-            if (!$this->functionlike_node_scanners) {
+            if (!$this->fq_classlike_names && !$this->functionlike_node_scanners) {
                 $this->exists_cond_expr = $node->cond;
 
                 if (Reflector\ExpressionResolver::enterConditional(
@@ -584,10 +589,10 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements FileSour
 
                         throw new \Psalm\Exception\CodeException(
                             'Error with core stub file docblocks: '
-                            . $issue_type
-                            . ' - ' . $e->getShortLocationWithPrevious()
-                            . ':' . $e->code_location->getColumn()
-                            . ' - ' . $message
+                                . $issue_type
+                                . ' - ' . $e->getShortLocationWithPrevious()
+                                . ':' . $e->code_location->getColumn()
+                                . ' - ' . $message
                         );
                     }
                 }

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -319,10 +319,10 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements FileSour
                 $this->exists_cond_expr = $node->cond;
 
                 if (Reflector\ExpressionResolver::enterConditional(
-                        $this->codebase,
-                        $this->file_path,
-                        $this->exists_cond_expr
-                    ) === false
+                    $this->codebase,
+                    $this->file_path,
+                    $this->exists_cond_expr
+                ) === false
                 ) {
                     // the else node should terminate the agreement
                     $this->skip_if_descendants = $node->else ? $node->else->getLine() : $node->getLine();

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -506,6 +506,38 @@ class TypeAnnotationTest extends TestCase
                      */
                     class C extends A {}',
             ],
+            'importedTypeInsideLocalTypeAliasUsedAsTypeParameter' => [
+                '<?php
+                    /** @template T */
+                    abstract class A {
+                        /** @var T */
+                        public $value;
+
+                        /** @param T $value */
+                        public function __construct($value) {
+                            $this->value = $value;
+                        }
+                    }
+
+                    /**
+                     * @psalm-type Foo=string
+                     */
+                    class B {}
+
+                    /**
+                     * @psalm-import-type Foo from B
+                     * @psalm-type Baz=Foo
+                     *
+                     * @extends A<Baz>
+                     */
+                    class C extends A {}
+
+                    $instance = new C("hello");
+                    $output = $instance->value;',
+                [
+                    '$output' => 'string',
+                ],
+            ],
         ];
     }
 
@@ -702,6 +734,35 @@ class TypeAnnotationTest extends TestCase
                      */
                     function test(array $input):void {}',
                 'error_message' => 'InvalidDocblock',
+            ],
+            'invalidTypeWhenNotImported' => [
+                '<?php
+
+                    /** @psalm-type Foo = string */
+                    class A {}
+
+                    /** @template T */
+                    interface B {}
+
+                    /** @implements B<Foo> */
+                    class C implements B {}',
+                'error_message' => 'UndefinedDocblockClass',
+            ],
+            'invalidTypeWhenNotImportedInsideAnotherTypeAlias' => [
+                '<?php
+
+                    /** @psalm-type Foo = string */
+                    class A {}
+
+                    /** @template T */
+                    interface B {}
+
+                    /**
+                     * @psalm-type Baz=Foo
+                     * @implements B<Baz>
+                     */
+                    class C implements B {}',
+                'error_message' => 'UndefinedDocblockClass',
             ],
         ];
     }

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -336,6 +336,176 @@ class TypeAnnotationTest extends TestCase
                         }
                     }'
             ],
+            'sameDocBlockTypeAliasAsTypeParameterForInterface' => [
+                '<?php
+                    /** @template T */
+                    interface A {
+                        /** @return T */
+                        public function output();
+                    }
+
+                    /**
+                     * @psalm-type Foo=string
+                     * @implements A<Foo>
+                     */
+                    class C implements A {
+                        public function output() {
+                            return "hello";
+                        }
+                    }
+
+                    $instance = new C();
+                    $output = $instance->output();',
+                [
+                    '$output' => 'string',
+                ],
+            ],
+            'sameDocBlockTypeAliasAsTypeParameterForExtendedRegularClass' => [
+                '<?php
+                    /** @template T */
+                    class A {
+                        /** @var T */
+                        public $value;
+
+                        /** @param T $value */
+                        public function __construct($value) {
+                            $this->value = $value;
+                        }
+                    }
+
+                    /**
+                     * @psalm-type Foo=string
+                     * @extends A<Foo>
+                     */
+                    class C extends A {}
+
+                    $instance = new C("hello");
+                    $output = $instance->value;',
+                [
+                    '$output' => 'string',
+                ],
+            ],
+            'sameDocBlockTypeAliasAsTypeParameterForExtendedAbstractClass' => [
+                '<?php
+                    /** @template T */
+                    abstract class A {
+                        /** @var T */
+                        public $value;
+
+                        /** @param T $value */
+                        public function __construct($value) {
+                            $this->value = $value;
+                        }
+                    }
+
+                    /**
+                     * @psalm-type Foo=string
+                     * @extends A<Foo>
+                     */
+                    class C extends A {}
+
+                    $instance = new C("hello");
+                    $output = $instance->value;',
+                [
+                    '$output' => 'string',
+                ],
+            ],
+            'importedTypeAliasAsTypeParameterForImplementation' => [
+                '<?php
+                    namespace Bar;
+
+                    /** @template T */
+                    interface A {}
+
+                    /** @psalm-type Foo=string */
+                    class B {}
+
+                    /**
+                     * @psalm-import-type Foo from B
+                     * @implements A<Foo>
+                     */
+                    class C implements A {}',
+            ],
+            'importedTypeAliasAsTypeParameterForExtendedClass' => [
+                '<?php
+                    namespace Bar;
+
+                    /** @template T */
+                    class A {}
+
+                    /** @psalm-type Foo=string */
+                    class B {}
+
+                    /**
+                     * @psalm-import-type Foo from B
+                     * @extends A<Foo>
+                     */
+                    class C extends A {}',
+            ],
+            'importedTypeAliasAsTypeParameterForExtendedAbstractClass' => [
+                '<?php
+                    namespace Bar;
+
+                    /** @template T */
+                    abstract class A {}
+
+                    /** @psalm-type Foo=string */
+                    class B {}
+
+                    /**
+                     * @psalm-import-type Foo from B
+                     * @extends A<Foo>
+                     */
+                    class C extends A {}',
+            ],
+            'importedTypeAliasRenamedAsTypeParameterForImplementation' => [
+                '<?php
+                    namespace Bar;
+
+                    /** @template T */
+                    interface A {}
+
+                    /** @psalm-type Foo=string */
+                    class B {}
+
+                    /**
+                     * @psalm-import-type Foo from B as NewName
+                     * @implements A<NewName>
+                     */
+                    class C implements A {}',
+            ],
+            'importedTypeAliasRenamedAsTypeParameterForExtendedClass' => [
+                '<?php
+                    namespace Bar;
+
+                    /** @template T */
+                    class A {}
+
+                    /** @psalm-type Foo=string */
+                    class B {}
+
+                    /**
+                     * @psalm-import-type Foo from B as NewName
+                     * @extends A<NewName>
+                     */
+                    class C extends A {}',
+            ],
+            'importedTypeAliasRenamedAsTypeParameterForExtendedAbstractClass' => [
+                '<?php
+                    namespace Bar;
+
+                    /** @template T */
+                    abstract class A {}
+
+                    /** @psalm-type Foo=string */
+                    class B {}
+
+                    /**
+                     * @psalm-import-type Foo from B as NewName
+                     * @extends A<NewName>
+                     */
+                    class C extends A {}',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fix #4240

This fixes issues with not being able to use `@psalm-type`s in the same doc-block they're defined in, and allows them to be used for `@implements`/`@extends` type parameters as expected

It's mostly just moving some things around so that it gets the types from the node's comments before carrying on with the rest of the doc-block stuff, and pulls the resolving of imported types into a separate method