### PR TITLE
Introduce Virtual Nodes in order to differentiate real nodes in plugins

### DIFF
--- a/examples/TemplateChecker.php
+++ b/examples/TemplateChecker.php
@@ -11,6 +11,8 @@ use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\DocComment;
+use Psalm\Node\Stmt\VirtualClass;
+use Psalm\Node\Stmt\VirtualClassMethod;
 use Psalm\Storage\MethodStorage;
 use Psalm\Type;
 
@@ -147,9 +149,9 @@ class TemplateAnalyzer extends Psalm\Internal\Analyzer\FileAnalyzer
 
         $pseudo_method_name = preg_replace('/[^a-zA-Z0-9_]+/', '_', $this->file_name);
 
-        $class_method = new PhpParser\Node\Stmt\ClassMethod($pseudo_method_name, ['stmts' => []]);
+        $class_method = new VirtualClassMethod($pseudo_method_name, ['stmts' => []]);
 
-        $class = new PhpParser\Node\Stmt\Class_(self::VIEW_CLASS);
+        $class = new VirtualClass(self::VIEW_CLASS);
 
         $class_analyzer = new ClassAnalyzer($class, $this, self::VIEW_CLASS);
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -73,6 +73,7 @@
             <errorLevel type="suppress">
                 <directory name="examples"/>
                 <directory name="src/Psalm/Internal/Fork" />
+                <directory name="src/Psalm/Node" />
                 <file name="src/Psalm/Plugin/Shepherd.php" />
                 <file name="src/Psalm/Plugin/Hook/MethodReturnTypeProviderInterface.php"/>
             </errorLevel>
@@ -131,5 +132,23 @@
                 <directory name="tests"/>
             </errorLevel>
         </PossiblyUndefinedStringArrayOffset>
+
+        <MixedPropertyTypeCoercion>
+            <errorLevel type="suppress">
+                <directory name="vendor/nikic/php-parser" />
+            </errorLevel>
+        </MixedPropertyTypeCoercion>
+
+        <PropertyTypeCoercion>
+            <errorLevel type="suppress">
+                <directory name="vendor/nikic/php-parser" />
+            </errorLevel>
+        </PropertyTypeCoercion>
+
+        <MixedAssignment>
+            <errorLevel type="suppress">
+                <directory name="vendor/nikic/php-parser" />
+            </errorLevel>
+        </MixedAssignment>
     </issueHandlers>
 </psalm>

--- a/src/Psalm/Internal/Algebra/FormulaGenerator.php
+++ b/src/Psalm/Internal/Algebra/FormulaGenerator.php
@@ -7,6 +7,9 @@ use Psalm\FileSource;
 use Psalm\Internal\Algebra;
 use Psalm\Internal\Analyzer\Statements\Expression\AssertionFinder;
 use Psalm\Internal\Clause;
+use Psalm\Node\Expr\BinaryOp\VirtualBooleanAnd;
+use Psalm\Node\Expr\BinaryOp\VirtualBooleanOr;
+use Psalm\Node\Expr\VirtualBooleanNot;
 use function array_merge;
 use function count;
 use function strlen;
@@ -88,12 +91,12 @@ class FormulaGenerator
 
         if ($conditional instanceof PhpParser\Node\Expr\BooleanNot) {
             if ($conditional->expr instanceof PhpParser\Node\Expr\BinaryOp\BooleanOr) {
-                $and_expr = new PhpParser\Node\Expr\BinaryOp\BooleanAnd(
-                    new PhpParser\Node\Expr\BooleanNot(
+                $and_expr = new VirtualBooleanAnd(
+                    new VirtualBooleanNot(
                         $conditional->expr->left,
                         $conditional->getAttributes()
                     ),
-                    new PhpParser\Node\Expr\BooleanNot(
+                    new VirtualBooleanNot(
                         $conditional->expr->right,
                         $conditional->getAttributes()
                     ),
@@ -170,12 +173,12 @@ class FormulaGenerator
             }
 
             if ($conditional->expr instanceof PhpParser\Node\Expr\BinaryOp\BooleanAnd) {
-                $and_expr = new PhpParser\Node\Expr\BinaryOp\BooleanOr(
-                    new PhpParser\Node\Expr\BooleanNot(
+                $and_expr = new VirtualBooleanOr(
+                    new VirtualBooleanNot(
                         $conditional->expr->left,
                         $conditional->getAttributes()
                     ),
-                    new PhpParser\Node\Expr\BooleanNot(
+                    new VirtualBooleanNot(
                         $conditional->expr->right,
                         $conditional->getAttributes()
                     ),

--- a/src/Psalm/Internal/Analyzer/AttributeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/AttributeAnalyzer.php
@@ -2,6 +2,11 @@
 namespace Psalm\Internal\Analyzer;
 
 use PhpParser;
+use Psalm\Node\Expr\VirtualNew;
+use Psalm\Node\Name\VirtualFullyQualified;
+use Psalm\Node\Stmt\VirtualExpression;
+use Psalm\Node\VirtualArg;
+use Psalm\Node\VirtualIdentifier;
 use Psalm\Storage\AttributeStorage;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;
@@ -123,13 +128,13 @@ class AttributeAnalyzer
 
             $type_expr->setAttributes($arg_attributes);
 
-            $node_args[] = new PhpParser\Node\Arg(
+            $node_args[] = new VirtualArg(
                 $type_expr,
                 false,
                 false,
                 $arg_attributes,
                 $storage_arg->name
-                    ? new PhpParser\Node\Identifier(
+                    ? new VirtualIdentifier(
                         $storage_arg->name,
                         $arg_attributes
                     )
@@ -137,8 +142,8 @@ class AttributeAnalyzer
             );
         }
 
-        $new_stmt = new PhpParser\Node\Expr\New_(
-            new PhpParser\Node\Name\FullyQualified(
+        $new_stmt = new VirtualNew(
+            new VirtualFullyQualified(
                 $attribute->fq_class_name,
                 [
                     'startFilePos' => $attribute->name_location->raw_file_start,
@@ -160,7 +165,7 @@ class AttributeAnalyzer
         );
 
         $statements_analyzer->analyze(
-            [new PhpParser\Node\Stmt\Expression($new_stmt)],
+            [new VirtualExpression($new_stmt)],
             new \Psalm\Context()
         );
     }

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -43,6 +43,14 @@ use Psalm\Issue\UndefinedTrait;
 use Psalm\Issue\UnimplementedAbstractMethod;
 use Psalm\Issue\UnimplementedInterfaceMethod;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualStaticCall;
+use Psalm\Node\Expr\VirtualVariable;
+use Psalm\Node\Name\VirtualFullyQualified;
+use Psalm\Node\Stmt\VirtualClassMethod;
+use Psalm\Node\Stmt\VirtualExpression;
+use Psalm\Node\VirtualArg;
+use Psalm\Node\VirtualIdentifier;
+use Psalm\Node\VirtualParam;
 use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
 use Psalm\StatementsSource;
 use Psalm\Storage\ClassLikeStorage;
@@ -1042,8 +1050,8 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                             ]
                             : [];
 
-                        return new PhpParser\Node\Arg(
-                            new PhpParser\Node\Expr\Variable($param->name, $attributes),
+                        return new VirtualArg(
+                            new VirtualVariable($param->name, $attributes),
                             false,
                             $param->is_variadic,
                             $attributes
@@ -1068,10 +1076,10 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                     ];
 
                 $fake_constructor_stmts = [
-                    new PhpParser\Node\Stmt\Expression(
-                        new PhpParser\Node\Expr\StaticCall(
-                            new PhpParser\Node\Name\FullyQualified($constructor_declaring_fqcln),
-                            new PhpParser\Node\Identifier('__construct', $fake_constructor_attributes),
+                    new VirtualExpression(
+                        new VirtualStaticCall(
+                            new VirtualFullyQualified($constructor_declaring_fqcln),
+                            new VirtualIdentifier('__construct', $fake_constructor_attributes),
                             $fake_constructor_stmt_args,
                             $fake_call_attributes
                         ),
@@ -1079,8 +1087,8 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                     ),
                 ];
 
-                $fake_stmt = new PhpParser\Node\Stmt\ClassMethod(
-                    new PhpParser\Node\Identifier('__construct'),
+                $fake_stmt = new VirtualClassMethod(
+                    new VirtualIdentifier('__construct'),
                     [
                         'type' => PhpParser\Node\Stmt\Class_::MODIFIER_PUBLIC,
                         'params' => $fake_constructor_params,

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -28,6 +28,8 @@ use Psalm\Issue\RawObjectIteration;
 use Psalm\Issue\UnnecessaryVarAnnotation;
 use Psalm\IssueBuffer;
 use Psalm\Internal\Scope\LoopScope;
+use Psalm\Node\Expr\VirtualMethodCall;
+use Psalm\Node\VirtualIdentifier;
 use Psalm\Type;
 use function is_string;
 use function in_array;
@@ -777,9 +779,9 @@ class ForeachAnalyzer
 
                     $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-                    $fake_method_call = new PhpParser\Node\Expr\MethodCall(
+                    $fake_method_call = new VirtualMethodCall(
                         $foreach_expr,
-                        new PhpParser\Node\Identifier('getIterator', $foreach_expr->getAttributes())
+                        new VirtualIdentifier('getIterator', $foreach_expr->getAttributes())
                     );
 
                     $suppressed_issues = $statements_analyzer->getSuppressedIssues();
@@ -1061,9 +1063,9 @@ class ForeachAnalyzer
 
         $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-        $fake_method_call = new PhpParser\Node\Expr\MethodCall(
+        $fake_method_call = new VirtualMethodCall(
             $foreach_expr,
-            new PhpParser\Node\Identifier($method_name, $foreach_expr->getAttributes())
+            new VirtualIdentifier($method_name, $foreach_expr->getAttributes())
         );
 
         $suppressed_issues = $statements_analyzer->getSuppressedIssues();

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
@@ -13,6 +13,11 @@ use Psalm\Issue\ConflictingReferenceConstraint;
 use Psalm\IssueBuffer;
 use Psalm\Internal\Scope\IfScope;
 use Psalm\Internal\Scope\IfConditionalScope;
+use Psalm\Node\Expr\BinaryOp\VirtualBooleanOr;
+use Psalm\Node\Expr\VirtualBooleanNot;
+use Psalm\Node\Expr\VirtualFuncCall;
+use Psalm\Node\Name\VirtualFullyQualified;
+use Psalm\Node\VirtualArg;
 use Psalm\Type;
 use Psalm\Internal\Algebra;
 use Psalm\Type\Reconciler;
@@ -356,7 +361,7 @@ class IfAnalyzer
 
         foreach ($exprs as $expr) {
             if ($expr instanceof PhpParser\Node\Expr\BinaryOp\BooleanAnd) {
-                $fake_not = new PhpParser\Node\Expr\BinaryOp\BooleanOr(
+                $fake_not = new VirtualBooleanOr(
                     self::negateExpr($expr->left),
                     self::negateExpr($expr->right),
                     $expr->getAttributes()
@@ -365,9 +370,9 @@ class IfAnalyzer
                 $fake_not = self::negateExpr($expr);
             }
 
-            $fake_negated_expr = new PhpParser\Node\Expr\FuncCall(
-                new PhpParser\Node\Name\FullyQualified('assert'),
-                [new PhpParser\Node\Arg(
+            $fake_negated_expr = new VirtualFuncCall(
+                new VirtualFullyQualified('assert'),
+                [new VirtualArg(
                     $fake_not,
                     false,
                     false,
@@ -424,7 +429,7 @@ class IfAnalyzer
             return $expr->expr;
         }
 
-        return new PhpParser\Node\Expr\BooleanNot($expr, $expr->getAttributes());
+        return new VirtualBooleanNot($expr, $expr->getAttributes());
     }
 
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
@@ -10,6 +10,7 @@ use Psalm\Internal\Clause;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\Internal\Scope\IfScope;
+use Psalm\Node\Expr\VirtualBooleanNot;
 use Psalm\Type;
 use Psalm\Internal\Algebra;
 use Psalm\Type\Reconciler;
@@ -204,7 +205,7 @@ class IfElseAnalyzer
                 $if_scope->negated_clauses = FormulaGenerator::getFormula(
                     $cond_object_id,
                     $cond_object_id,
-                    new PhpParser\Node\Expr\BooleanNot($stmt->cond),
+                    new VirtualBooleanNot($stmt->cond),
                     $context->self,
                     $statements_analyzer,
                     $codebase,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -42,6 +42,10 @@ use Psalm\Issue\UndefinedPropertyAssignment;
 use Psalm\Issue\UndefinedMagicPropertyAssignment;
 use Psalm\Issue\UndefinedThisPropertyAssignment;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualMethodCall;
+use Psalm\Node\Scalar\VirtualString;
+use Psalm\Node\VirtualArg;
+use Psalm\Node\VirtualIdentifier;
 use Psalm\Type;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNull;
@@ -995,17 +999,17 @@ class InstancePropertyAssignmentAnalyzer
 
                 $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-                $fake_method_call = new PhpParser\Node\Expr\MethodCall(
+                $fake_method_call = new VirtualMethodCall(
                     $stmt->var,
-                    new PhpParser\Node\Identifier('__set', $stmt->name->getAttributes()),
+                    new VirtualIdentifier('__set', $stmt->name->getAttributes()),
                     [
-                        new PhpParser\Node\Arg(
-                            new PhpParser\Node\Scalar\String_(
+                        new VirtualArg(
+                            new VirtualString(
                                 $prop_name,
                                 $stmt->name->getAttributes()
                             )
                         ),
-                        new PhpParser\Node\Arg(
+                        new VirtualArg(
                             $assignment_value
                         )
                     ]

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -39,6 +39,7 @@ use Psalm\Issue\PossiblyUndefinedArrayOffset;
 use Psalm\Issue\ReferenceConstraintViolation;
 use Psalm\Issue\UnnecessaryVarAnnotation;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\BinaryOp\VirtualCoalesce;
 use Psalm\Type;
 use function is_string;
 use function strpos;
@@ -738,7 +739,7 @@ class AssignmentAnalyzer
 
             $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-            $fake_coalesce_expr = new PhpParser\Node\Expr\BinaryOp\Coalesce(
+            $fake_coalesce_expr = new VirtualCoalesce(
                 $stmt->var,
                 $stmt->expr,
                 $stmt->getAttributes()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
@@ -9,6 +9,8 @@ use Psalm\Internal\Analyzer\Statements\Block\IfElseAnalyzer;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\Internal\Algebra;
+use Psalm\Node\Stmt\VirtualExpression;
+use Psalm\Node\Stmt\VirtualIf;
 use Psalm\Type\Reconciler;
 use function array_merge;
 use function array_diff_key;
@@ -28,11 +30,11 @@ class AndAnalyzer
         bool $from_stmt = false
     ) : bool {
         if ($from_stmt) {
-            $fake_if_stmt = new PhpParser\Node\Stmt\If_(
+            $fake_if_stmt = new VirtualIf(
                 $stmt->left,
                 [
                     'stmts' => [
-                        new PhpParser\Node\Stmt\Expression(
+                        new VirtualExpression(
                             $stmt->right
                         )
                     ]

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
@@ -5,6 +5,9 @@ use PhpParser;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Context;
+use Psalm\Node\Expr\VirtualIsset;
+use Psalm\Node\Expr\VirtualTernary;
+use Psalm\Node\Expr\VirtualVariable;
 use Psalm\Type;
 use function substr;
 
@@ -50,14 +53,14 @@ class CoalesceAnalyzer
 
             $context->vars_in_scope[$left_var_id] = $condition_type;
 
-            $left_expr = new PhpParser\Node\Expr\Variable(
+            $left_expr = new VirtualVariable(
                 substr($left_var_id, 1),
                 $left_expr->getAttributes()
             );
         }
 
-        $ternary = new PhpParser\Node\Expr\Ternary(
-            new PhpParser\Node\Expr\Isset_(
+        $ternary = new VirtualTernary(
+            new VirtualIsset(
                 [$left_expr],
                 $stmt->left->getAttributes()
             ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
@@ -11,6 +11,9 @@ use Psalm\Internal\Analyzer\Statements\Block\IfElse\IfAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Block\IfConditionalAnalyzer;
 use Psalm\CodeLocation;
 use Psalm\Context;
+use Psalm\Node\Expr\VirtualBooleanNot;
+use Psalm\Node\Stmt\VirtualExpression;
+use Psalm\Node\Stmt\VirtualIf;
 use Psalm\Type;
 use Psalm\Internal\Algebra;
 use Psalm\Type\Reconciler;
@@ -33,11 +36,11 @@ class OrAnalyzer
         bool $from_stmt = false
     ) : bool {
         if ($from_stmt) {
-            $fake_if_stmt = new PhpParser\Node\Stmt\If_(
-                new PhpParser\Node\Expr\BooleanNot($stmt->left, $stmt->left->getAttributes()),
+            $fake_if_stmt = new VirtualIf(
+                new VirtualBooleanNot($stmt->left, $stmt->left->getAttributes()),
                 [
                     'stmts' => [
-                        new PhpParser\Node\Stmt\Expression(
+                        new VirtualExpression(
                             $stmt->right
                         )
                     ]
@@ -137,7 +140,7 @@ class OrAnalyzer
                 $negated_left_clauses = FormulaGenerator::getFormula(
                     $left_cond_id,
                     $left_cond_id,
-                    new PhpParser\Node\Expr\BooleanNot($stmt->left),
+                    new VirtualBooleanNot($stmt->left),
                     $context->self,
                     $statements_analyzer,
                     $codebase,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -26,6 +26,7 @@ use Psalm\Issue\PossiblyUndefinedVariable;
 use Psalm\Issue\TooFewArguments;
 use Psalm\Issue\TooManyArguments;
 use Psalm\IssueBuffer;
+use Psalm\Node\VirtualArg;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Storage\FunctionLikeStorage;
@@ -603,7 +604,7 @@ class ArgumentsAnalyzer
                         $i,
                         $i,
                         $function_storage ? $function_storage->allow_named_arg_calls : true,
-                        new PhpParser\Node\Arg(
+                        new VirtualArg(
                             StubsGenerator::getExpressionFromType($function_params[$i]->default_type)
                         ),
                         $function_params[$i]->default_type,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
@@ -22,6 +22,7 @@ use Psalm\Issue\TooFewArguments;
 use Psalm\Issue\TooManyArguments;
 use Psalm\Issue\ArgumentTypeCoercion;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualArrayDimFetch;
 use Psalm\Type;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TArray;
@@ -159,7 +160,7 @@ class ArrayFunctionArgumentsAnalyzer
 
                 ArrayAssignmentAnalyzer::analyze(
                     $statements_analyzer,
-                    new PhpParser\Node\Expr\ArrayDimFetch(
+                    new VirtualArrayDimFetch(
                         $args[0]->value,
                         null,
                         $args[$i]->value->getAttributes()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -20,6 +20,11 @@ use Psalm\Issue\PossiblyInvalidFunctionCall;
 use Psalm\Issue\PossiblyNullFunctionCall;
 use Psalm\Issue\UnusedFunctionCall;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualFuncCall;
+use Psalm\Node\Expr\VirtualMethodCall;
+use Psalm\Node\Name\VirtualFullyQualified;
+use Psalm\Node\VirtualArg;
+use Psalm\Node\VirtualIdentifier;
 use Psalm\Plugin\EventHandler\Event\AfterEveryFunctionCallAnalysisEvent;
 use Psalm\Storage\Assertion;
 use Psalm\Type;
@@ -75,7 +80,7 @@ class FunctionCallAnalyzer extends CallAnalyzer
 
                 $function_name = $stmt->args[0]->value;
 
-                $stmt = new PhpParser\Node\Expr\FuncCall(
+                $stmt = new VirtualFuncCall(
                     $function_name,
                     $other_args,
                     $stmt->getAttributes()
@@ -85,9 +90,9 @@ class FunctionCallAnalyzer extends CallAnalyzer
             if ($original_function_id === 'call_user_func_array' && isset($stmt->args[1])) {
                 $function_name = $stmt->args[0]->value;
 
-                $stmt = new PhpParser\Node\Expr\FuncCall(
+                $stmt = new VirtualFuncCall(
                     $function_name,
-                    [new PhpParser\Node\Arg($stmt->args[1]->value, false, true)],
+                    [new VirtualArg($stmt->args[1]->value, false, true)],
                     $stmt->getAttributes()
                 );
             }
@@ -653,7 +658,7 @@ class FunctionCallAnalyzer extends CallAnalyzer
                             $fq_class_name = \preg_replace('/^\\\\/', '', $fq_class_name);
                             $potential_method_id = new \Psalm\Internal\MethodIdentifier($fq_class_name, $parts[1]);
                         } else {
-                            $function_call_info->new_function_name = new PhpParser\Node\Name\FullyQualified(
+                            $function_call_info->new_function_name = new VirtualFullyQualified(
                                 $var_type_part->value,
                                 $function_name->getAttributes()
                             );
@@ -768,9 +773,9 @@ class FunctionCallAnalyzer extends CallAnalyzer
 
         $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-        $fake_method_call = new PhpParser\Node\Expr\MethodCall(
+        $fake_method_call = new VirtualMethodCall(
             $function_name,
-            new PhpParser\Node\Identifier('__invoke', $function_name->getAttributes()),
+            new VirtualIdentifier('__invoke', $function_name->getAttributes()),
             $stmt->args
         );
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -23,6 +23,7 @@ use Psalm\Issue\PropertyTypeCoercion;
 use Psalm\Issue\UndefinedThisPropertyAssignment;
 use Psalm\Issue\UndefinedThisPropertyFetch;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualFuncCall;
 use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
 use Psalm\Storage\Assertion;
 use Psalm\Type;
@@ -88,7 +89,7 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
         if ($fq_class_name === 'Closure' && $method_name_lc === '__invoke') {
             $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-            $fake_function_call = new PhpParser\Node\Expr\FuncCall(
+            $fake_function_call = new VirtualFuncCall(
                 $stmt->var,
                 $args,
                 $stmt->getAttributes()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -9,6 +9,10 @@ use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Node\Expr\VirtualArray;
+use Psalm\Node\Expr\VirtualArrayItem;
+use Psalm\Node\Scalar\VirtualString;
+use Psalm\Node\VirtualArg;
 use Psalm\Type;
 use function array_map;
 use function array_merge;
@@ -154,7 +158,7 @@ class MissingMethodCallHandler
              * @return PhpParser\Node\Expr\ArrayItem
              */
             function (PhpParser\Node\Arg $arg): PhpParser\Node\Expr\ArrayItem {
-                return new PhpParser\Node\Expr\ArrayItem(
+                return new VirtualArrayItem(
                     $arg->value,
                     null,
                     false,
@@ -170,14 +174,14 @@ class MissingMethodCallHandler
         return new AtomicCallContext(
             new MethodIdentifier($fq_class_name, '__call'),
             [
-                new PhpParser\Node\Arg(
-                    new PhpParser\Node\Scalar\String_($method_name_lc),
+                new VirtualArg(
+                    new VirtualString($method_name_lc),
                     false,
                     false,
                     $stmt->getAttributes()
                 ),
-                new PhpParser\Node\Arg(
-                    new PhpParser\Node\Expr\Array_(
+                new VirtualArg(
+                    new VirtualArray(
                         $array_values,
                         $stmt->getAttributes()
                     ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NamedFunctionCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NamedFunctionCallHandler.php
@@ -13,6 +13,10 @@ use Psalm\Context;
 use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\Issue\ForbiddenCode;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualArray;
+use Psalm\Node\Expr\VirtualArrayItem;
+use Psalm\Node\Expr\VirtualVariable;
+use Psalm\Node\Scalar\VirtualString;
 use Psalm\Type;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Reconciler;
@@ -188,16 +192,16 @@ class NamedFunctionCallHandler
 
                 $var_name = $arg_type->getSingleStringLiteral()->value;
 
-                $new_items[] = new PhpParser\Node\Expr\ArrayItem(
-                    new PhpParser\Node\Expr\Variable($var_name, $arg->value->getAttributes()),
-                    new PhpParser\Node\Scalar\String_($var_name, $arg->value->getAttributes()),
+                $new_items[] = new VirtualArrayItem(
+                    new VirtualVariable($var_name, $arg->value->getAttributes()),
+                    new VirtualString($var_name, $arg->value->getAttributes()),
                     false,
                     $arg->getAttributes()
                 );
             }
 
             if ($all_args_string_literals) {
-                $arr = new PhpParser\Node\Expr\Array_($new_items, $stmt->getAttributes());
+                $arr = new VirtualArray($new_items, $stmt->getAttributes());
                 $old_node_data = $statements_analyzer->node_data;
                 $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -21,6 +21,12 @@ use Psalm\Issue\InternalClass;
 use Psalm\Issue\MixedMethodCall;
 use Psalm\Issue\UndefinedClass;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualArray;
+use Psalm\Node\Expr\VirtualArrayItem;
+use Psalm\Node\Expr\VirtualMethodCall;
+use Psalm\Node\Expr\VirtualVariable;
+use Psalm\Node\Scalar\VirtualString;
+use Psalm\Node\VirtualArg;
 use Psalm\Type;
 use Psalm\Type\Atomic\TNamedObject;
 use function count;
@@ -394,8 +400,8 @@ class AtomicStaticCallAnalyzer
 
                     $context->vars_in_scope['$tmp_mixin_var'] = $new_lhs_type;
 
-                    $fake_method_call_expr = new PhpParser\Node\Expr\MethodCall(
-                        new PhpParser\Node\Expr\Variable(
+                    $fake_method_call_expr = new VirtualMethodCall(
+                        new VirtualVariable(
                             'tmp_mixin_var',
                             $stmt->class->getAttributes()
                         ),
@@ -516,7 +522,7 @@ class AtomicStaticCallAnalyzer
 
                 $array_values = array_map(
                     function (PhpParser\Node\Arg $arg): PhpParser\Node\Expr\ArrayItem {
-                        return new PhpParser\Node\Expr\ArrayItem(
+                        return new VirtualArrayItem(
                             $arg->value,
                             null,
                             false,
@@ -527,14 +533,14 @@ class AtomicStaticCallAnalyzer
                 );
 
                 $args = [
-                    new PhpParser\Node\Arg(
-                        new PhpParser\Node\Scalar\String_((string) $method_id, $stmt_name->getAttributes()),
+                    new VirtualArg(
+                        new VirtualString((string) $method_id, $stmt_name->getAttributes()),
                         false,
                         false,
                         $stmt_name->getAttributes()
                     ),
-                    new PhpParser\Node\Arg(
-                        new PhpParser\Node\Expr\Array_($array_values, $stmt->getAttributes()),
+                    new VirtualArg(
+                        new VirtualArray($array_values, $stmt->getAttributes()),
                         false,
                         false,
                         $stmt->getAttributes()
@@ -685,8 +691,8 @@ class AtomicStaticCallAnalyzer
 
                 $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-                $fake_method_call_expr = new PhpParser\Node\Expr\MethodCall(
-                    new PhpParser\Node\Expr\Variable(
+                $fake_method_call_expr = new VirtualMethodCall(
+                    new VirtualVariable(
                         'this',
                         $stmt->class->getAttributes()
                     ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -17,6 +17,9 @@ use Psalm\Issue\MixedArgumentTypeCoercion;
 use Psalm\Issue\ArgumentTypeCoercion;
 use Psalm\Issue\UndefinedFunction;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\BinaryOp\VirtualIdentical;
+use Psalm\Node\Expr\VirtualConstFetch;
+use Psalm\Node\VirtualName;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Type;
 use Psalm\Type\Atomic\TNamedObject;
@@ -733,9 +736,9 @@ class CallAnalyzer
                 }
             } elseif ($arg_value && ($assertion->rule === [['!falsy']] || $assertion->rule === [['true']])) {
                 if ($assertion->rule === [['true']]) {
-                    $conditional = new PhpParser\Node\Expr\BinaryOp\Identical(
+                    $conditional = new VirtualIdentical(
                         $arg_value,
-                        new PhpParser\Node\Expr\ConstFetch(new PhpParser\Node\Name('true'))
+                        new VirtualConstFetch(new VirtualName('true'))
                     );
 
                     $assert_clauses = FormulaGenerator::getFormula(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -32,6 +32,11 @@ use Psalm\Issue\PossiblyUndefinedArrayOffset;
 use Psalm\Issue\PossiblyUndefinedIntArrayOffset;
 use Psalm\Issue\PossiblyUndefinedStringArrayOffset;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualConstFetch;
+use Psalm\Node\Expr\VirtualMethodCall;
+use Psalm\Node\VirtualArg;
+use Psalm\Node\VirtualIdentifier;
+use Psalm\Node\VirtualName;
 use Psalm\Type;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TArray;
@@ -1741,11 +1746,11 @@ class ArrayFetchAnalyzer
 
             $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-            $fake_method_call = new PhpParser\Node\Expr\MethodCall(
+            $fake_method_call = new VirtualMethodCall(
                 $stmt->var,
-                new PhpParser\Node\Identifier('item', $stmt->var->getAttributes()),
+                new VirtualIdentifier('item', $stmt->var->getAttributes()),
                 [
-                    new PhpParser\Node\Arg($stmt->dim)
+                    new VirtualArg($stmt->dim)
                 ]
             );
 
@@ -1794,22 +1799,22 @@ class ArrayFetchAnalyzer
 
                 $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-                $fake_set_method_call = new PhpParser\Node\Expr\MethodCall(
+                $fake_set_method_call = new VirtualMethodCall(
                     $stmt->var,
-                    new PhpParser\Node\Identifier('offsetSet', $stmt->var->getAttributes()),
+                    new VirtualIdentifier('offsetSet', $stmt->var->getAttributes()),
                     [
-                        new PhpParser\Node\Arg(
+                        new VirtualArg(
                             $stmt->dim
                                 ? $stmt->dim
-                                : new PhpParser\Node\Expr\ConstFetch(
-                                    new PhpParser\Node\Name('null'),
+                                : new VirtualConstFetch(
+                                    new VirtualName('null'),
                                     $stmt->var->getAttributes()
                                 )
                         ),
-                        new PhpParser\Node\Arg(
+                        new VirtualArg(
                             $assign_value
-                                ?: new PhpParser\Node\Expr\ConstFetch(
-                                    new PhpParser\Node\Name('null'),
+                                ?: new VirtualConstFetch(
+                                    new VirtualName('null'),
                                     $stmt->var->getAttributes()
                                 )
                         ),
@@ -1830,11 +1835,11 @@ class ArrayFetchAnalyzer
 
                 $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-                $fake_get_method_call = new PhpParser\Node\Expr\MethodCall(
+                $fake_get_method_call = new VirtualMethodCall(
                     $stmt->var,
-                    new PhpParser\Node\Identifier('offsetGet', $stmt->var->getAttributes()),
+                    new VirtualIdentifier('offsetGet', $stmt->var->getAttributes()),
                     [
-                        new PhpParser\Node\Arg(
+                        new VirtualArg(
                             $stmt->dim
                         )
                     ]

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -25,6 +25,10 @@ use Psalm\Issue\UndefinedMagicPropertyFetch;
 use Psalm\Issue\UndefinedPropertyFetch;
 use Psalm\Issue\UndefinedThisPropertyFetch;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualMethodCall;
+use Psalm\Node\Scalar\VirtualString;
+use Psalm\Node\VirtualArg;
+use Psalm\Node\VirtualIdentifier;
 use Psalm\Type;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Type\Atomic\TGenericObject;
@@ -517,12 +521,12 @@ class AtomicPropertyFetchAnalyzer
 
             $statements_analyzer->node_data->setType($stmt->var, new Type\Union([$lhs_type_part]));
 
-            $fake_method_call = new PhpParser\Node\Expr\MethodCall(
+            $fake_method_call = new VirtualMethodCall(
                 $stmt->var,
-                new PhpParser\Node\Identifier('__get', $stmt->name->getAttributes()),
+                new VirtualIdentifier('__get', $stmt->name->getAttributes()),
                 [
-                    new PhpParser\Node\Arg(
-                        new PhpParser\Node\Scalar\String_(
+                    new VirtualArg(
+                        new VirtualString(
                             $prop_name,
                             $stmt->name->getAttributes()
                         )

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
@@ -12,6 +12,10 @@ use Psalm\Context;
 use Psalm\Issue\ParentNotFound;
 use Psalm\Issue\UndefinedPropertyFetch;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualPropertyFetch;
+use Psalm\Node\Expr\VirtualStaticPropertyFetch;
+use Psalm\Node\Expr\VirtualVariable;
+use Psalm\Node\Name\VirtualFullyQualified;
 use Psalm\Type;
 use Psalm\Type\Atomic\TNamedObject;
 use function strtolower;
@@ -387,12 +391,12 @@ class StaticPropertyFetchAnalyzer
                     : null);
 
             if ($string_type) {
-                $new_stmt_name = new PhpParser\Node\Name\FullyQualified(
+                $new_stmt_name = new VirtualFullyQualified(
                     $string_type,
                     $stmt_class->getAttributes()
                 );
 
-                $fake_static_property = new PhpParser\Node\Expr\StaticPropertyFetch(
+                $fake_static_property = new VirtualStaticPropertyFetch(
                     $new_stmt_name,
                     $stmt->name,
                     $stmt->getAttributes()
@@ -405,14 +409,14 @@ class StaticPropertyFetchAnalyzer
             } else {
                 $fake_var_name = '__fake_var_' . (string) $stmt->getAttribute('startFilePos');
 
-                $fake_var = new PhpParser\Node\Expr\Variable(
+                $fake_var = new VirtualVariable(
                     $fake_var_name,
                     $stmt_class->getAttributes()
                 );
 
                 $context->vars_in_scope['$' . $fake_var_name] = new Type\Union([$class_atomic_type]);
 
-                $fake_instance_property = new PhpParser\Node\Expr\PropertyFetch(
+                $fake_instance_property = new VirtualPropertyFetch(
                     $fake_var,
                     $stmt->name,
                     $stmt->getAttributes()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
@@ -9,6 +9,10 @@ use PhpParser\Node\Expr\PreDec;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Context;
+use Psalm\Node\Expr\BinaryOp\VirtualMinus;
+use Psalm\Node\Expr\BinaryOp\VirtualPlus;
+use Psalm\Node\Expr\VirtualAssign;
+use Psalm\Node\Scalar\VirtualLNumber;
 use Psalm\Type;
 
 class IncDecExpressionAnalyzer
@@ -47,7 +51,7 @@ class IncDecExpressionAnalyzer
         ) {
             $return_type = null;
 
-            $fake_right_expr = new PhpParser\Node\Scalar\LNumber(1, $stmt->getAttributes());
+            $fake_right_expr = new VirtualLNumber(1, $stmt->getAttributes());
             $statements_analyzer->node_data->setType($fake_right_expr, Type::getInt());
 
             BinaryOp\NonDivArithmeticOpAnalyzer::analyze(
@@ -93,21 +97,21 @@ class IncDecExpressionAnalyzer
                 );
             }
         } else {
-            $fake_right_expr = new PhpParser\Node\Scalar\LNumber(1, $stmt->getAttributes());
+            $fake_right_expr = new VirtualLNumber(1, $stmt->getAttributes());
 
             $operation = $stmt instanceof PostInc || $stmt instanceof PreInc
-                ? new PhpParser\Node\Expr\BinaryOp\Plus(
+                ? new VirtualPlus(
                     $stmt->var,
                     $fake_right_expr,
                     $stmt->var->getAttributes()
                 )
-                : new PhpParser\Node\Expr\BinaryOp\Minus(
+                : new VirtualMinus(
                     $stmt->var,
                     $fake_right_expr,
                     $stmt->var->getAttributes()
                 );
 
-            $fake_assignment = new PhpParser\Node\Expr\Assign(
+            $fake_assignment = new VirtualAssign(
                 $stmt->var,
                 $operation,
                 $stmt->getAttributes()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/NullsafeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/NullsafeAnalyzer.php
@@ -5,6 +5,13 @@ use PhpParser;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Context;
+use Psalm\Node\Expr\BinaryOp\VirtualIdentical;
+use Psalm\Node\Expr\VirtualConstFetch;
+use Psalm\Node\Expr\VirtualMethodCall;
+use Psalm\Node\Expr\VirtualPropertyFetch;
+use Psalm\Node\Expr\VirtualTernary;
+use Psalm\Node\Expr\VirtualVariable;
+use Psalm\Node\VirtualName;
 use Psalm\Type;
 
 /**
@@ -30,7 +37,7 @@ class NullsafeAnalyzer
             if ($condition_type) {
                 $context->vars_in_scope['$' . $tmp_name] = $condition_type;
 
-                $tmp_var = new PhpParser\Node\Expr\Variable($tmp_name, $stmt->var->getAttributes());
+                $tmp_var = new VirtualVariable($tmp_name, $stmt->var->getAttributes());
             } else {
                 $tmp_var = $stmt->var;
             }
@@ -41,34 +48,34 @@ class NullsafeAnalyzer
         $old_node_data = $statements_analyzer->node_data;
         $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 
-        $null_value1 = new PhpParser\Node\Expr\ConstFetch(
-            new PhpParser\Node\Name('null'),
+        $null_value1 = new VirtualConstFetch(
+            new VirtualName('null'),
             $stmt->var->getAttributes()
         );
 
-        $null_comparison = new PhpParser\Node\Expr\BinaryOp\Identical(
+        $null_comparison = new VirtualIdentical(
             $tmp_var,
             $null_value1,
             $stmt->var->getAttributes()
         );
 
-        $null_value2 = new PhpParser\Node\Expr\ConstFetch(
-            new PhpParser\Node\Name('null'),
+        $null_value2 = new VirtualConstFetch(
+            new VirtualName('null'),
             $stmt->var->getAttributes()
         );
 
         if ($stmt instanceof PhpParser\Node\Expr\NullsafePropertyFetch) {
-            $ternary = new PhpParser\Node\Expr\Ternary(
+            $ternary = new VirtualTernary(
                 $null_comparison,
                 $null_value2,
-                new PhpParser\Node\Expr\PropertyFetch($tmp_var, $stmt->name, $stmt->getAttributes()),
+                new VirtualPropertyFetch($tmp_var, $stmt->name, $stmt->getAttributes()),
                 $stmt->getAttributes()
             );
         } else {
-            $ternary = new PhpParser\Node\Expr\Ternary(
+            $ternary = new VirtualTernary(
                 $null_comparison,
                 $null_value2,
-                new PhpParser\Node\Expr\MethodCall($tmp_var, $stmt->name, $stmt->args, $stmt->getAttributes()),
+                new VirtualMethodCall($tmp_var, $stmt->name, $stmt->args, $stmt->getAttributes()),
                 $stmt->getAttributes()
             );
         }

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
@@ -1,6 +1,14 @@
 <?php
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
+use Psalm\Node\Expr\VirtualArrayDimFetch;
+use Psalm\Node\Expr\VirtualFuncCall;
+use Psalm\Node\Expr\VirtualMethodCall;
+use Psalm\Node\Expr\VirtualStaticCall;
+use Psalm\Node\Expr\VirtualVariable;
+use Psalm\Node\Name\VirtualFullyQualified;
+use Psalm\Node\VirtualArg;
+use Psalm\Node\VirtualIdentifier;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use function array_map;
 use function count;
@@ -133,13 +141,13 @@ class ArrayMapReturnTypeProvider implements \Psalm\Plugin\EventHandler\FunctionR
                         if ($variable_atomic_type instanceof Type\Atomic\TTemplateParam
                             || $variable_atomic_type instanceof Type\Atomic\TTemplateParamClass
                         ) {
-                            $fake_method_call = new PhpParser\Node\Expr\StaticCall(
+                            $fake_method_call = new VirtualStaticCall(
                                 $function_call_arg->value->items[0]->value,
                                 $function_call_arg->value->items[1]->value->value,
                                 []
                             );
                         } elseif ($variable_atomic_type instanceof Type\Atomic\TTemplateParamClass) {
-                            $fake_method_call = new PhpParser\Node\Expr\StaticCall(
+                            $fake_method_call = new VirtualStaticCall(
                                 $function_call_arg->value->items[0]->value,
                                 $function_call_arg->value->items[1]->value->value,
                                 []
@@ -329,10 +337,10 @@ class ArrayMapReturnTypeProvider implements \Psalm\Plugin\EventHandler\FunctionR
                 $fake_args = [];
 
                 foreach ($array_args as $array_arg) {
-                    $fake_args[] = new PhpParser\Node\Arg(
-                        new PhpParser\Node\Expr\ArrayDimFetch(
+                    $fake_args[] = new VirtualArg(
+                        new VirtualArrayDimFetch(
                             $array_arg->value,
-                            new PhpParser\Node\Expr\Variable(
+                            new VirtualVariable(
                                 '__fake_offset_var__',
                                 $array_arg->value->getAttributes()
                             ),
@@ -356,12 +364,12 @@ class ArrayMapReturnTypeProvider implements \Psalm\Plugin\EventHandler\FunctionR
                     [$callable_fq_class_name, $callable_method_name] = $method_id_parts;
 
                     if ($is_instance) {
-                        $fake_method_call = new PhpParser\Node\Expr\MethodCall(
-                            new PhpParser\Node\Expr\Variable(
+                        $fake_method_call = new VirtualMethodCall(
+                            new VirtualVariable(
                                 '__fake_method_call_var__',
                                 $function_call_arg->getAttributes()
                             ),
-                            new PhpParser\Node\Identifier(
+                            new VirtualIdentifier(
                                 $callable_method_name,
                                 $function_call_arg->getAttributes()
                             ),
@@ -400,12 +408,12 @@ class ArrayMapReturnTypeProvider implements \Psalm\Plugin\EventHandler\FunctionR
                         unset($context->vars_in_scope['$__fake_offset_var__']);
                         unset($context->vars_in_scope['$__method_call_var__']);
                     } else {
-                        $fake_method_call = new PhpParser\Node\Expr\StaticCall(
-                            new PhpParser\Node\Name\FullyQualified(
+                        $fake_method_call = new VirtualStaticCall(
+                            new VirtualFullyQualified(
                                 $callable_fq_class_name,
                                 $function_call_arg->getAttributes()
                             ),
-                            new PhpParser\Node\Identifier(
+                            new VirtualIdentifier(
                                 $callable_method_name,
                                 $function_call_arg->getAttributes()
                             ),
@@ -427,8 +435,8 @@ class ArrayMapReturnTypeProvider implements \Psalm\Plugin\EventHandler\FunctionR
 
                     $function_id_return_type = $fake_method_return_type ?: Type::getMixed();
                 } else {
-                    $fake_function_call = new PhpParser\Node\Expr\FuncCall(
-                        new PhpParser\Node\Name\FullyQualified(
+                    $fake_function_call = new VirtualFuncCall(
+                        new VirtualFullyQualified(
                             $mapping_function_id_part,
                             $function_call_arg->getAttributes()
                         ),

--- a/src/Psalm/Internal/Stubs/Generator/ClassLikeStubGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/ClassLikeStubGenerator.php
@@ -3,6 +3,15 @@
 namespace Psalm\Internal\Stubs\Generator;
 
 use PhpParser;
+use Psalm\Node\Name\VirtualFullyQualified;
+use Psalm\Node\Stmt\VirtualClass;
+use Psalm\Node\Stmt\VirtualClassConst;
+use Psalm\Node\Stmt\VirtualClassMethod;
+use Psalm\Node\Stmt\VirtualInterface;
+use Psalm\Node\Stmt\VirtualProperty;
+use Psalm\Node\Stmt\VirtualPropertyProperty;
+use Psalm\Node\Stmt\VirtualTrait;
+use Psalm\Node\VirtualConst;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Scanner\ParsedDocblock;
@@ -60,11 +69,11 @@ class ClassLikeStubGenerator
                 $subnodes['extends'] = [];
 
                 foreach ($storage->direct_interface_parents as $direct_interface_parent) {
-                    $subnodes['extends'][] = new PhpParser\Node\Name\FullyQualified($direct_interface_parent);
+                    $subnodes['extends'][] = new VirtualFullyQualified($direct_interface_parent);
                 }
             }
 
-            return new PhpParser\Node\Stmt\Interface_(
+            return new VirtualInterface(
                 $classlike_name,
                 $subnodes,
                 $attrs
@@ -72,7 +81,7 @@ class ClassLikeStubGenerator
         }
 
         if ($storage->is_trait) {
-            return new PhpParser\Node\Stmt\Trait_(
+            return new VirtualTrait(
                 $classlike_name,
                 $subnodes,
                 $attrs
@@ -80,17 +89,17 @@ class ClassLikeStubGenerator
         }
 
         if ($storage->parent_class) {
-            $subnodes['extends'] = new PhpParser\Node\Name\FullyQualified($storage->parent_class);
+            $subnodes['extends'] = new VirtualFullyQualified($storage->parent_class);
         } else
 
         if ($storage->direct_class_interfaces) {
             $subnodes['implements'] = [];
             foreach ($storage->direct_class_interfaces as $direct_class_interface) {
-                $subnodes['implements'][] = new PhpParser\Node\Name\FullyQualified($direct_class_interface);
+                $subnodes['implements'][] = new VirtualFullyQualified($direct_class_interface);
             }
         }
 
-        return new PhpParser\Node\Stmt\Class_(
+        return new VirtualClass(
             $classlike_name,
             $subnodes,
             $attrs
@@ -118,9 +127,9 @@ class ClassLikeStubGenerator
                 throw new \UnexpectedValueException('bad');
             }
 
-            $constant_nodes[] = new PhpParser\Node\Stmt\ClassConst(
+            $constant_nodes[] = new VirtualClassConst(
                 [
-                    new PhpParser\Node\Const_(
+                    new VirtualConst(
                         $constant_name,
                         StubsGenerator::getExpressionFromType($type)
                     )
@@ -171,10 +180,10 @@ class ClassLikeStubGenerator
                 );
             }
 
-            $property_nodes[] = new PhpParser\Node\Stmt\Property(
+            $property_nodes[] = new VirtualProperty(
                 $flag | ($property_storage->is_static ? PhpParser\Node\Stmt\Class_::MODIFIER_STATIC : 0),
                 [
-                    new PhpParser\Node\Stmt\PropertyProperty(
+                    new VirtualPropertyProperty(
                         $property_name,
                         $property_storage->suggested_type
                             ? StubsGenerator::getExpressionFromType($property_storage->suggested_type)
@@ -268,7 +277,7 @@ class ClassLikeStubGenerator
                 );
             }
 
-            $method_nodes[] = new PhpParser\Node\Stmt\ClassMethod(
+            $method_nodes[] = new VirtualClassMethod(
                 $method_storage->cased_name,
                 [
                     'flags' => $flag

--- a/src/Psalm/Node/Expr/AssignOp/VirtualBitwiseAnd.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualBitwiseAnd.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\BitwiseAnd;
+use Psalm\Node\VirtualNode;
+
+class VirtualBitwiseAnd extends BitwiseAnd implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualBitwiseOr.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualBitwiseOr.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\BitwiseOr;
+use Psalm\Node\VirtualNode;
+
+class VirtualBitwiseOr extends BitwiseOr implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualBitwiseXor.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualBitwiseXor.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\BitwiseXor;
+use Psalm\Node\VirtualNode;
+
+class VirtualBitwiseXor extends BitwiseXor implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualCoalesce.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualCoalesce.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\Coalesce;
+use Psalm\Node\VirtualNode;
+
+class VirtualCoalesce extends Coalesce implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualConcat.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualConcat.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\Concat;
+use Psalm\Node\VirtualNode;
+
+class VirtualConcat extends Concat implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualDiv.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualDiv.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\Div;
+use Psalm\Node\VirtualNode;
+
+class VirtualDiv extends Div implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualMinus.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualMinus.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\Minus;
+use Psalm\Node\VirtualNode;
+
+class VirtualMinus extends Minus implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualMod.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualMod.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\Mod;
+use Psalm\Node\VirtualNode;
+
+class VirtualMod extends Mod implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualMul.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualMul.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\Mul;
+use Psalm\Node\VirtualNode;
+
+class VirtualMul extends Mul implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualPlus.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualPlus.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\Plus;
+use Psalm\Node\VirtualNode;
+
+class VirtualPlus extends Plus implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualPow.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualPow.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\Pow;
+use Psalm\Node\VirtualNode;
+
+class VirtualPow extends Pow implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualShiftLeft.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualShiftLeft.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\ShiftLeft;
+use Psalm\Node\VirtualNode;
+
+class VirtualShiftLeft extends ShiftLeft implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/AssignOp/VirtualShiftRight.php
+++ b/src/Psalm/Node/Expr/AssignOp/VirtualShiftRight.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\AssignOp;
+
+use PhpParser\Node\Expr\AssignOp\ShiftRight;
+use Psalm\Node\VirtualNode;
+
+class VirtualShiftRight extends ShiftRight implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualBitwiseAnd.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualBitwiseAnd.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\BitwiseAnd;
+use Psalm\Node\VirtualNode;
+
+class VirtualBitwiseAnd extends BitwiseAnd implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualBitwiseOr.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualBitwiseOr.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\BitwiseOr;
+use Psalm\Node\VirtualNode;
+
+class VirtualBitwiseOr extends BitwiseOr implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualBitwiseXor.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualBitwiseXor.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\BitwiseXor;
+use Psalm\Node\VirtualNode;
+
+class VirtualBitwiseXor extends BitwiseXor implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualBooleanAnd.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualBooleanAnd.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\BooleanAnd;
+use Psalm\Node\VirtualNode;
+
+class VirtualBooleanAnd extends BooleanAnd implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualBooleanOr.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualBooleanOr.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\BooleanOr;
+use Psalm\Node\VirtualNode;
+
+class VirtualBooleanOr extends BooleanOr implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualCoalesce.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualCoalesce.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Coalesce;
+use Psalm\Node\VirtualNode;
+
+class VirtualCoalesce extends Coalesce implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualConcat.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualConcat.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Concat;
+use Psalm\Node\VirtualNode;
+
+class VirtualConcat extends Concat implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualDiv.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualDiv.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Div;
+use Psalm\Node\VirtualNode;
+
+class VirtualDiv extends Div implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualEqual.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualEqual.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Equal;
+use Psalm\Node\VirtualNode;
+
+class VirtualEqual extends Equal implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualGreater.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualGreater.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Greater;
+use Psalm\Node\VirtualNode;
+
+class VirtualGreater extends Greater implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualGreaterOrEqual.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualGreaterOrEqual.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\GreaterOrEqual;
+use Psalm\Node\VirtualNode;
+
+class VirtualGreaterOrEqual extends GreaterOrEqual implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualIdentical.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualIdentical.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Identical;
+use Psalm\Node\VirtualNode;
+
+class VirtualIdentical extends Identical implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualLogicalAnd.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualLogicalAnd.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\LogicalAnd;
+use Psalm\Node\VirtualNode;
+
+class VirtualLogicalAnd extends LogicalAnd implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualLogicalOr.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualLogicalOr.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\LogicalOr;
+use Psalm\Node\VirtualNode;
+
+class VirtualLogicalOr extends LogicalOr implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualLogicalXor.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualLogicalXor.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\LogicalXor;
+use Psalm\Node\VirtualNode;
+
+class VirtualLogicalXor extends LogicalXor implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualMinus.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualMinus.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Minus;
+use Psalm\Node\VirtualNode;
+
+class VirtualMinus extends Minus implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualMod.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualMod.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Mod;
+use Psalm\Node\VirtualNode;
+
+class VirtualMod extends Mod implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualMul.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualMul.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Mul;
+use Psalm\Node\VirtualNode;
+
+class VirtualMul extends Mul implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualNotEqual.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualNotEqual.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\NotEqual;
+use Psalm\Node\VirtualNode;
+
+class VirtualNotEqual extends NotEqual implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualNotIdentical.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualNotIdentical.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\NotIdentical;
+use Psalm\Node\VirtualNode;
+
+class VirtualNotIdentical extends NotIdentical implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualPlus.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualPlus.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Plus;
+use Psalm\Node\VirtualNode;
+
+class VirtualPlus extends Plus implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualPow.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualPow.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Pow;
+use Psalm\Node\VirtualNode;
+
+class VirtualPow extends Pow implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualShiftLeft.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualShiftLeft.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\ShiftLeft;
+use Psalm\Node\VirtualNode;
+
+class VirtualShiftLeft extends ShiftLeft implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualShiftRight.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualShiftRight.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\ShiftRight;
+use Psalm\Node\VirtualNode;
+
+class VirtualShiftRight extends ShiftRight implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualSmaller.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualSmaller.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Smaller;
+use Psalm\Node\VirtualNode;
+
+class VirtualSmaller extends Smaller implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualSmallerOrEqual.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualSmallerOrEqual.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\SmallerOrEqual;
+use Psalm\Node\VirtualNode;
+
+class VirtualSmallerOrEqual extends SmallerOrEqual implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/BinaryOp/VirtualSpaceship.php
+++ b/src/Psalm/Node/Expr/BinaryOp/VirtualSpaceship.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\BinaryOp;
+
+use PhpParser\Node\Expr\BinaryOp\Spaceship;
+use Psalm\Node\VirtualNode;
+
+class VirtualSpaceship extends Spaceship implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/Cast/VirtualArray.php
+++ b/src/Psalm/Node/Expr/Cast/VirtualArray.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\Cast;
+
+use PhpParser\Node\Expr\Cast\Array_;
+use Psalm\Node\VirtualNode;
+
+class VirtualArray extends Array_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/Cast/VirtualBool.php
+++ b/src/Psalm/Node/Expr/Cast/VirtualBool.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\Cast;
+
+use PhpParser\Node\Expr\Cast\Bool_;
+use Psalm\Node\VirtualNode;
+
+class VirtualBool extends Bool_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/Cast/VirtualDouble.php
+++ b/src/Psalm/Node/Expr/Cast/VirtualDouble.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\Cast;
+
+use PhpParser\Node\Expr\Cast\Double;
+use Psalm\Node\VirtualNode;
+
+class VirtualDouble extends Double implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/Cast/VirtualInt.php
+++ b/src/Psalm/Node/Expr/Cast/VirtualInt.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\Cast;
+
+use PhpParser\Node\Expr\Cast\Int_;
+use Psalm\Node\VirtualNode;
+
+class VirtualInt extends Int_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/Cast/VirtualObject.php
+++ b/src/Psalm/Node/Expr/Cast/VirtualObject.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\Cast;
+
+use PhpParser\Node\Expr\Cast\Object_;
+use Psalm\Node\VirtualNode;
+
+class VirtualObject extends Object_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/Cast/VirtualString.php
+++ b/src/Psalm/Node/Expr/Cast/VirtualString.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\Cast;
+
+use PhpParser\Node\Expr\Cast\String_;
+use Psalm\Node\VirtualNode;
+
+class VirtualString extends String_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/Cast/VirtualUnset.php
+++ b/src/Psalm/Node/Expr/Cast/VirtualUnset.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr\Cast;
+
+use PhpParser\Node\Expr\Cast\Unset_;
+use Psalm\Node\VirtualNode;
+
+class VirtualUnset extends Unset_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualArray.php
+++ b/src/Psalm/Node/Expr/VirtualArray.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Array_;
+use Psalm\Node\VirtualNode;
+
+class VirtualArray extends Array_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualArrayDimFetch.php
+++ b/src/Psalm/Node/Expr/VirtualArrayDimFetch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\ArrayDimFetch;
+use Psalm\Node\VirtualNode;
+
+class VirtualArrayDimFetch extends ArrayDimFetch implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualArrayItem.php
+++ b/src/Psalm/Node/Expr/VirtualArrayItem.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\ArrayItem;
+use Psalm\Node\VirtualNode;
+
+class VirtualArrayItem extends ArrayItem implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualArrowFunction.php
+++ b/src/Psalm/Node/Expr/VirtualArrowFunction.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\ArrowFunction;
+use Psalm\Node\VirtualNode;
+
+class VirtualArrowFunction extends ArrowFunction implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualAssign.php
+++ b/src/Psalm/Node/Expr/VirtualAssign.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Assign;
+use Psalm\Node\VirtualNode;
+
+class VirtualAssign extends Assign implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualAssignRef.php
+++ b/src/Psalm/Node/Expr/VirtualAssignRef.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\AssignRef;
+use Psalm\Node\VirtualNode;
+
+class VirtualAssignRef extends AssignRef implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualBitwiseNot.php
+++ b/src/Psalm/Node/Expr/VirtualBitwiseNot.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\BitwiseNot;
+use Psalm\Node\VirtualNode;
+
+class VirtualBitwiseNot extends BitwiseNot implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualBooleanNot.php
+++ b/src/Psalm/Node/Expr/VirtualBooleanNot.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\BooleanNot;
+use Psalm\Node\VirtualNode;
+
+class VirtualBooleanNot extends BooleanNot implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualClassConstFetch.php
+++ b/src/Psalm/Node/Expr/VirtualClassConstFetch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\ClassConstFetch;
+use Psalm\Node\VirtualNode;
+
+class VirtualClassConstFetch extends ClassConstFetch implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualClone.php
+++ b/src/Psalm/Node/Expr/VirtualClone.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Clone_;
+use Psalm\Node\VirtualNode;
+
+class VirtualClone extends Clone_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualClosure.php
+++ b/src/Psalm/Node/Expr/VirtualClosure.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Closure;
+use Psalm\Node\VirtualNode;
+
+class VirtualClosure extends Closure implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualClosureUse.php
+++ b/src/Psalm/Node/Expr/VirtualClosureUse.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\ClosureUse;
+use Psalm\Node\VirtualNode;
+
+class VirtualClosureUse extends ClosureUse implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualConstFetch.php
+++ b/src/Psalm/Node/Expr/VirtualConstFetch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\ConstFetch;
+use Psalm\Node\VirtualNode;
+
+class VirtualConstFetch extends ConstFetch implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualEmpty.php
+++ b/src/Psalm/Node/Expr/VirtualEmpty.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Empty_;
+use Psalm\Node\VirtualNode;
+
+class VirtualEmpty extends Empty_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualError.php
+++ b/src/Psalm/Node/Expr/VirtualError.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Error;
+use Psalm\Node\VirtualNode;
+
+/**
+ * Error node used during parsing with error recovery.
+ *
+ * An error node may be placed at a position where an expression is required, but an error occurred.
+ * Error nodes will not be present if the parser is run in throwOnError mode (the default).
+ */
+class VirtualError extends Error implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualErrorSuppress.php
+++ b/src/Psalm/Node/Expr/VirtualErrorSuppress.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\ErrorSuppress;
+use Psalm\Node\VirtualNode;
+
+class VirtualErrorSuppress extends ErrorSuppress implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualEval.php
+++ b/src/Psalm/Node/Expr/VirtualEval.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Eval_;
+use Psalm\Node\VirtualNode;
+
+class VirtualEval extends Eval_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualExit.php
+++ b/src/Psalm/Node/Expr/VirtualExit.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Exit_;
+use Psalm\Node\VirtualNode;
+
+class VirtualExit extends Exit_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualFuncCall.php
+++ b/src/Psalm/Node/Expr/VirtualFuncCall.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\FuncCall;
+use Psalm\Node\VirtualNode;
+
+class VirtualFuncCall extends FuncCall implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualInclude.php
+++ b/src/Psalm/Node/Expr/VirtualInclude.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Include_;
+use Psalm\Node\VirtualNode;
+
+class VirtualInclude extends Include_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualInstanceof.php
+++ b/src/Psalm/Node/Expr/VirtualInstanceof.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Instanceof_;
+use Psalm\Node\VirtualNode;
+
+class VirtualInstanceof extends Instanceof_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualIsset.php
+++ b/src/Psalm/Node/Expr/VirtualIsset.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Isset_;
+use Psalm\Node\VirtualNode;
+
+class VirtualIsset extends Isset_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualList.php
+++ b/src/Psalm/Node/Expr/VirtualList.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\List_;
+use Psalm\Node\VirtualNode;
+
+class VirtualList extends List_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualMatch.php
+++ b/src/Psalm/Node/Expr/VirtualMatch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Match_;
+use Psalm\Node\VirtualNode;
+
+class VirtualMatch extends Match_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualMethodCall.php
+++ b/src/Psalm/Node/Expr/VirtualMethodCall.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\MethodCall;
+use Psalm\Node\VirtualNode;
+
+class VirtualMethodCall extends MethodCall implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualNew.php
+++ b/src/Psalm/Node/Expr/VirtualNew.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\New_;
+use Psalm\Node\VirtualNode;
+
+class VirtualNew extends New_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualNullsafeMethodCall.php
+++ b/src/Psalm/Node/Expr/VirtualNullsafeMethodCall.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\NullsafeMethodCall;
+use Psalm\Node\VirtualNode;
+
+class VirtualNullsafeMethodCall extends NullsafeMethodCall implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualNullsafePropertyFetch.php
+++ b/src/Psalm/Node/Expr/VirtualNullsafePropertyFetch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\NullsafePropertyFetch;
+use Psalm\Node\VirtualNode;
+
+class VirtualNullsafePropertyFetch extends NullsafePropertyFetch implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualPostDec.php
+++ b/src/Psalm/Node/Expr/VirtualPostDec.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\PostDec;
+use Psalm\Node\VirtualNode;
+
+class VirtualPostDec extends PostDec implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualPostInc.php
+++ b/src/Psalm/Node/Expr/VirtualPostInc.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\PostInc;
+use Psalm\Node\VirtualNode;
+
+class VirtualPostInc extends PostInc implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualPreDec.php
+++ b/src/Psalm/Node/Expr/VirtualPreDec.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\PreDec;
+use Psalm\Node\VirtualNode;
+
+class VirtualPreDec extends PreDec implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualPreInc.php
+++ b/src/Psalm/Node/Expr/VirtualPreInc.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\PreInc;
+use Psalm\Node\VirtualNode;
+
+class VirtualPreInc extends PreInc implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualPrint.php
+++ b/src/Psalm/Node/Expr/VirtualPrint.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Print_;
+use Psalm\Node\VirtualNode;
+
+class VirtualPrint extends Print_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualPropertyFetch.php
+++ b/src/Psalm/Node/Expr/VirtualPropertyFetch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\PropertyFetch;
+use Psalm\Node\VirtualNode;
+
+class VirtualPropertyFetch extends PropertyFetch implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualShellExec.php
+++ b/src/Psalm/Node/Expr/VirtualShellExec.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\ShellExec;
+use Psalm\Node\VirtualNode;
+
+class VirtualShellExec extends ShellExec implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualStaticCall.php
+++ b/src/Psalm/Node/Expr/VirtualStaticCall.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\StaticCall;
+use Psalm\Node\VirtualNode;
+
+class VirtualStaticCall extends StaticCall implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualStaticPropertyFetch.php
+++ b/src/Psalm/Node/Expr/VirtualStaticPropertyFetch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\StaticPropertyFetch;
+use Psalm\Node\VirtualNode;
+
+class VirtualStaticPropertyFetch extends StaticPropertyFetch implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualTernary.php
+++ b/src/Psalm/Node/Expr/VirtualTernary.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Ternary;
+use Psalm\Node\VirtualNode;
+
+class VirtualTernary extends Ternary implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualThrow.php
+++ b/src/Psalm/Node/Expr/VirtualThrow.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Throw_;
+use Psalm\Node\VirtualNode;
+
+class VirtualThrow extends Throw_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualUnaryMinus.php
+++ b/src/Psalm/Node/Expr/VirtualUnaryMinus.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\UnaryMinus;
+use Psalm\Node\VirtualNode;
+
+class VirtualUnaryMinus extends UnaryMinus implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualUnaryPlus.php
+++ b/src/Psalm/Node/Expr/VirtualUnaryPlus.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\UnaryPlus;
+use Psalm\Node\VirtualNode;
+
+class VirtualUnaryPlus extends UnaryPlus implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualVariable.php
+++ b/src/Psalm/Node/Expr/VirtualVariable.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Variable;
+use Psalm\Node\VirtualNode;
+
+class VirtualVariable extends Variable implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualYield.php
+++ b/src/Psalm/Node/Expr/VirtualYield.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\Yield_;
+use Psalm\Node\VirtualNode;
+
+class VirtualYield extends Yield_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Expr/VirtualYieldFrom.php
+++ b/src/Psalm/Node/Expr/VirtualYieldFrom.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Expr;
+
+use PhpParser\Node\Expr\YieldFrom;
+use Psalm\Node\VirtualNode;
+
+class VirtualYieldFrom extends YieldFrom implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Name/VirtualFullyQualified.php
+++ b/src/Psalm/Node/Name/VirtualFullyQualified.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Name;
+
+use PhpParser\Node\Name\FullyQualified;
+use Psalm\Node\VirtualNode;
+
+class VirtualFullyQualified extends FullyQualified implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Name/VirtualRelative.php
+++ b/src/Psalm/Node/Name/VirtualRelative.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Name;
+
+use PhpParser\Node\Name\Relative;
+use Psalm\Node\VirtualNode;
+
+class VirtualRelative extends Relative implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/MagicConst/VirtualClass.php
+++ b/src/Psalm/Node/Scalar/MagicConst/VirtualClass.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar\MagicConst;
+
+use PhpParser\Node\Scalar\MagicConst\Class_;
+use Psalm\Node\VirtualNode;
+
+class VirtualClass extends Class_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/MagicConst/VirtualDir.php
+++ b/src/Psalm/Node/Scalar/MagicConst/VirtualDir.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar\MagicConst;
+
+use PhpParser\Node\Scalar\MagicConst\Dir;
+use Psalm\Node\VirtualNode;
+
+class VirtualDir extends Dir implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/MagicConst/VirtualFile.php
+++ b/src/Psalm/Node/Scalar/MagicConst/VirtualFile.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar\MagicConst;
+
+use PhpParser\Node\Scalar\MagicConst\File;
+use Psalm\Node\VirtualNode;
+
+class VirtualFile extends File implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/MagicConst/VirtualFunction.php
+++ b/src/Psalm/Node/Scalar/MagicConst/VirtualFunction.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar\MagicConst;
+
+use PhpParser\Node\Scalar\MagicConst\Function_;
+use Psalm\Node\VirtualNode;
+
+class VirtualFunction extends Function_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/MagicConst/VirtualLine.php
+++ b/src/Psalm/Node/Scalar/MagicConst/VirtualLine.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar\MagicConst;
+
+use PhpParser\Node\Scalar\MagicConst\Line;
+use Psalm\Node\VirtualNode;
+
+class VirtualLine extends Line implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/MagicConst/VirtualMethod.php
+++ b/src/Psalm/Node/Scalar/MagicConst/VirtualMethod.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar\MagicConst;
+
+use PhpParser\Node\Scalar\MagicConst\Method;
+use Psalm\Node\VirtualNode;
+
+class VirtualMethod extends Method implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/MagicConst/VirtualNamespace.php
+++ b/src/Psalm/Node/Scalar/MagicConst/VirtualNamespace.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar\MagicConst;
+
+use PhpParser\Node\Scalar\MagicConst\Namespace_;
+use Psalm\Node\VirtualNode;
+
+class VirtualNamespace extends Namespace_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/MagicConst/VirtualTrait.php
+++ b/src/Psalm/Node/Scalar/MagicConst/VirtualTrait.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar\MagicConst;
+
+use PhpParser\Node\Scalar\MagicConst\Trait_;
+use Psalm\Node\VirtualNode;
+
+class VirtualTrait extends Trait_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/VirtualDNumber.php
+++ b/src/Psalm/Node/Scalar/VirtualDNumber.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar;
+
+use PhpParser\Node\Scalar\DNumber;
+use Psalm\Node\VirtualNode;
+
+class VirtualDNumber extends DNumber implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/VirtualEncapsed.php
+++ b/src/Psalm/Node/Scalar/VirtualEncapsed.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar;
+
+use PhpParser\Node\Scalar\Encapsed;
+use Psalm\Node\VirtualNode;
+
+class VirtualEncapsed extends Encapsed implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/VirtualEncapsedStringPart.php
+++ b/src/Psalm/Node/Scalar/VirtualEncapsedStringPart.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar;
+
+use PhpParser\Node\Scalar\EncapsedStringPart;
+use Psalm\Node\VirtualNode;
+
+class VirtualEncapsedStringPart extends EncapsedStringPart implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/VirtualLNumber.php
+++ b/src/Psalm/Node/Scalar/VirtualLNumber.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar;
+
+use PhpParser\Node\Scalar\LNumber;
+use Psalm\Node\VirtualNode;
+
+class VirtualLNumber extends LNumber implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Scalar/VirtualString.php
+++ b/src/Psalm/Node/Scalar/VirtualString.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Scalar;
+
+use PhpParser\Node\Scalar\String_;
+use Psalm\Node\VirtualNode;
+
+class VirtualString extends String_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/TraitUseAdaptation/VirtualAlias.php
+++ b/src/Psalm/Node/Stmt/TraitUseAdaptation/VirtualAlias.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt\TraitUseAdaptation;
+
+use PhpParser\Node\Stmt\TraitUseAdaptation\Alias;
+use Psalm\Node\VirtualNode;
+
+class VirtualAlias extends Alias implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/TraitUseAdaptation/VirtualPrecedence.php
+++ b/src/Psalm/Node/Stmt/TraitUseAdaptation/VirtualPrecedence.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt\TraitUseAdaptation;
+
+use PhpParser\Node\Stmt\TraitUseAdaptation\Precedence;
+use Psalm\Node\VirtualNode;
+
+class VirtualPrecedence extends Precedence implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualBreak.php
+++ b/src/Psalm/Node/Stmt/VirtualBreak.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Break_;
+use Psalm\Node\VirtualNode;
+
+class VirtualBreak extends Break_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualCase.php
+++ b/src/Psalm/Node/Stmt/VirtualCase.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Case_;
+use Psalm\Node\VirtualNode;
+
+class VirtualCase extends Case_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualCatch.php
+++ b/src/Psalm/Node/Stmt/VirtualCatch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Catch_;
+use Psalm\Node\VirtualNode;
+
+class VirtualCatch extends Catch_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualClass.php
+++ b/src/Psalm/Node/Stmt/VirtualClass.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Class_;
+use Psalm\Node\VirtualNode;
+
+class VirtualClass extends Class_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualClassConst.php
+++ b/src/Psalm/Node/Stmt/VirtualClassConst.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\ClassConst;
+use Psalm\Node\VirtualNode;
+
+class VirtualClassConst extends ClassConst implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualClassMethod.php
+++ b/src/Psalm/Node/Stmt/VirtualClassMethod.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\ClassMethod;
+use Psalm\Node\VirtualNode;
+
+class VirtualClassMethod extends ClassMethod implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualConst.php
+++ b/src/Psalm/Node/Stmt/VirtualConst.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Const_;
+use Psalm\Node\VirtualNode;
+
+class VirtualConst extends Const_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualContinue.php
+++ b/src/Psalm/Node/Stmt/VirtualContinue.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Continue_;
+use Psalm\Node\VirtualNode;
+
+class VirtualContinue extends Continue_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualDeclare.php
+++ b/src/Psalm/Node/Stmt/VirtualDeclare.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Declare_;
+use Psalm\Node\VirtualNode;
+
+class VirtualDeclare extends Declare_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualDeclareDeclare.php
+++ b/src/Psalm/Node/Stmt/VirtualDeclareDeclare.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\DeclareDeclare;
+use Psalm\Node\VirtualNode;
+
+class VirtualDeclareDeclare extends DeclareDeclare implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualDo.php
+++ b/src/Psalm/Node/Stmt/VirtualDo.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Do_;
+use Psalm\Node\VirtualNode;
+
+class VirtualDo extends Do_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualEcho.php
+++ b/src/Psalm/Node/Stmt/VirtualEcho.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Echo_;
+use Psalm\Node\VirtualNode;
+
+class VirtualEcho extends Echo_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualElse.php
+++ b/src/Psalm/Node/Stmt/VirtualElse.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Else_;
+use Psalm\Node\VirtualNode;
+
+class VirtualElse extends Else_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualElseIf.php
+++ b/src/Psalm/Node/Stmt/VirtualElseIf.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\ElseIf_;
+use Psalm\Node\VirtualNode;
+
+class VirtualElseIf extends ElseIf_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualExpression.php
+++ b/src/Psalm/Node/Stmt/VirtualExpression.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Expression;
+use Psalm\Node\VirtualNode;
+
+/**
+ * Represents statements of type "expr;"
+ */
+class VirtualExpression extends Expression implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualFinally.php
+++ b/src/Psalm/Node/Stmt/VirtualFinally.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Finally_;
+use Psalm\Node\VirtualNode;
+
+class VirtualFinally extends Finally_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualFor.php
+++ b/src/Psalm/Node/Stmt/VirtualFor.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\For_;
+use Psalm\Node\VirtualNode;
+
+class VirtualFor extends For_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualForeach.php
+++ b/src/Psalm/Node/Stmt/VirtualForeach.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Foreach_;
+use Psalm\Node\VirtualNode;
+
+class VirtualForeach extends Foreach_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualFunction.php
+++ b/src/Psalm/Node/Stmt/VirtualFunction.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node;
+use PhpParser\Node\Stmt\Function_;
+use Psalm\Node\VirtualNode;
+
+/**
+ * @property Node\Name $namespacedName Namespaced name (if using NameResolver)
+ */
+class VirtualFunction extends Function_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualGlobal.php
+++ b/src/Psalm/Node/Stmt/VirtualGlobal.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Global_;
+use Psalm\Node\VirtualNode;
+
+class VirtualGlobal extends Global_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualGoto.php
+++ b/src/Psalm/Node/Stmt/VirtualGoto.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Goto_;
+use Psalm\Node\VirtualNode;
+
+class VirtualGoto extends Goto_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualGroupUse.php
+++ b/src/Psalm/Node/Stmt/VirtualGroupUse.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\GroupUse;
+use Psalm\Node\VirtualNode;
+
+class VirtualGroupUse extends GroupUse implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualHaltCompiler.php
+++ b/src/Psalm/Node/Stmt/VirtualHaltCompiler.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\HaltCompiler;
+use Psalm\Node\VirtualNode;
+
+class VirtualHaltCompiler extends HaltCompiler implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualIf.php
+++ b/src/Psalm/Node/Stmt/VirtualIf.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\If_;
+use Psalm\Node\VirtualNode;
+
+class VirtualIf extends If_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualInlineHTML.php
+++ b/src/Psalm/Node/Stmt/VirtualInlineHTML.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\InlineHTML;
+use Psalm\Node\VirtualNode;
+
+class VirtualInlineHTML extends InlineHTML implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualInterface.php
+++ b/src/Psalm/Node/Stmt/VirtualInterface.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Interface_;
+use Psalm\Node\VirtualNode;
+
+class VirtualInterface extends Interface_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualLabel.php
+++ b/src/Psalm/Node/Stmt/VirtualLabel.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Label;
+use Psalm\Node\VirtualNode;
+
+class VirtualLabel extends Label implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualNamespace.php
+++ b/src/Psalm/Node/Stmt/VirtualNamespace.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Namespace_;
+use Psalm\Node\VirtualNode;
+
+class VirtualNamespace extends Namespace_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualNop.php
+++ b/src/Psalm/Node/Stmt/VirtualNop.php
@@ -1,0 +1,12 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Nop;
+use Psalm\Node\VirtualNode;
+
+/** Nop/empty statement (;). */
+class VirtualNop extends Nop implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualProperty.php
+++ b/src/Psalm/Node/Stmt/VirtualProperty.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Property;
+use Psalm\Node\VirtualNode;
+
+class VirtualProperty extends Property implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualPropertyProperty.php
+++ b/src/Psalm/Node/Stmt/VirtualPropertyProperty.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\PropertyProperty;
+use Psalm\Node\VirtualNode;
+
+class VirtualPropertyProperty extends PropertyProperty implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualReturn.php
+++ b/src/Psalm/Node/Stmt/VirtualReturn.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Return_;
+use Psalm\Node\VirtualNode;
+
+class VirtualReturn extends Return_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualStatic.php
+++ b/src/Psalm/Node/Stmt/VirtualStatic.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Static_;
+use Psalm\Node\VirtualNode;
+
+class VirtualStatic extends Static_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualStaticVar.php
+++ b/src/Psalm/Node/Stmt/VirtualStaticVar.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\StaticVar;
+use Psalm\Node\VirtualNode;
+
+class VirtualStaticVar extends StaticVar implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualSwitch.php
+++ b/src/Psalm/Node/Stmt/VirtualSwitch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Switch_;
+use Psalm\Node\VirtualNode;
+
+class VirtualSwitch extends Switch_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualThrow.php
+++ b/src/Psalm/Node/Stmt/VirtualThrow.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Throw_;
+use Psalm\Node\VirtualNode;
+
+class VirtualThrow extends Throw_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualTrait.php
+++ b/src/Psalm/Node/Stmt/VirtualTrait.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Trait_;
+use Psalm\Node\VirtualNode;
+
+class VirtualTrait extends Trait_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualTraitUse.php
+++ b/src/Psalm/Node/Stmt/VirtualTraitUse.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\TraitUse;
+use Psalm\Node\VirtualNode;
+
+class VirtualTraitUse extends TraitUse implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualTryCatch.php
+++ b/src/Psalm/Node/Stmt/VirtualTryCatch.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\TryCatch;
+use Psalm\Node\VirtualNode;
+
+class VirtualTryCatch extends TryCatch implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualUnset.php
+++ b/src/Psalm/Node/Stmt/VirtualUnset.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Unset_;
+use Psalm\Node\VirtualNode;
+
+class VirtualUnset extends Unset_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualUse.php
+++ b/src/Psalm/Node/Stmt/VirtualUse.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\Use_;
+use Psalm\Node\VirtualNode;
+
+class VirtualUse extends Use_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualUseUse.php
+++ b/src/Psalm/Node/Stmt/VirtualUseUse.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\UseUse;
+use Psalm\Node\VirtualNode;
+
+class VirtualUseUse extends UseUse implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/Stmt/VirtualWhile.php
+++ b/src/Psalm/Node/Stmt/VirtualWhile.php
@@ -1,0 +1,11 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node\Stmt;
+
+use PhpParser\Node\Stmt\While_;
+use Psalm\Node\VirtualNode;
+
+class VirtualWhile extends While_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualArg.php
+++ b/src/Psalm/Node/VirtualArg.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\Arg;
+
+class VirtualArg extends Arg implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualAttribute.php
+++ b/src/Psalm/Node/VirtualAttribute.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\Attribute;
+
+class VirtualAttribute extends Attribute implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualAttributeGroup.php
+++ b/src/Psalm/Node/VirtualAttributeGroup.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\AttributeGroup;
+
+class VirtualAttributeGroup extends AttributeGroup implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualConst.php
+++ b/src/Psalm/Node/VirtualConst.php
@@ -1,0 +1,14 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\Const_;
+use PhpParser\Node\Name;
+
+/**
+ * @property Name $namespacedName Namespaced name (for global constants, if using NameResolver)
+ */
+class VirtualConst extends Const_ implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualIdentifier.php
+++ b/src/Psalm/Node/VirtualIdentifier.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\Identifier;
+
+/**
+ * Represents a non-namespaced name. Namespaced names are represented using Name nodes.
+ */
+class VirtualIdentifier extends Identifier implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualMatchArm.php
+++ b/src/Psalm/Node/VirtualMatchArm.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\MatchArm;
+
+class VirtualMatchArm extends MatchArm implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualName.php
+++ b/src/Psalm/Node/VirtualName.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\Name;
+
+class VirtualName extends Name implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualNode.php
+++ b/src/Psalm/Node/VirtualNode.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Psalm\Node;
+
+/**
+ * Describe a Node that is not part of the original AST and was created by Psalm for analysis
+ */
+interface VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualNullableType.php
+++ b/src/Psalm/Node/VirtualNullableType.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\NullableType;
+
+class VirtualNullableType extends NullableType implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualParam.php
+++ b/src/Psalm/Node/VirtualParam.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\Param;
+
+class VirtualParam extends Param implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualUnionType.php
+++ b/src/Psalm/Node/VirtualUnionType.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\UnionType;
+
+class VirtualUnionType extends UnionType implements VirtualNode
+{
+
+}

--- a/src/Psalm/Node/VirtualVarLikeIdentifier.php
+++ b/src/Psalm/Node/VirtualVarLikeIdentifier.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace Psalm\Node;
+
+use PhpParser\Node\VarLikeIdentifier;
+
+/**
+ * Represents a name that is written in source code with a leading dollar,
+ * but is not a proper variable. The leading dollar is not stored as part of the name.
+ *
+ * Examples: Names in property declarations are formatted as variables. Names in static property
+ * lookups are also formatted as variables.
+ */
+class VirtualVarLikeIdentifier extends VarLikeIdentifier implements VirtualNode
+{
+
+}


### PR DESCRIPTION
This should solve https://github.com/vimeo/psalm/issues/5215

A few notes:
1) I had errors in PhpParser pop up now that Psalm's code inherits PhpParser code and Psalm's PropertyMap being more precise than PhpParser's code
2) I had errors in Psalm for Unused classes because I migrated every Node from PhpParser, not only used Nodes. Not sure if I should keep it or delete those.
