### PR TITLE
Allow installation of netresearch/jsonmapper ^4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "dnoegel/php-xdg-base-dir": "^0.1.1",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
         "felixfbecker/language-server-protocol": "^1.4",
-        "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0",
+        "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
         "nikic/php-parser": "^4.10.1",
         "openlss/lib-array2xml": "^1.0",
         "sebastian/diff": "^3.0 || ^4.0",


### PR DESCRIPTION
Greetings 👋🏼!

Similar to https://github.com/vimeo/psalm/pull/3830, this has no immediate effect until https://github.com/felixfbecker/php-advanced-json-rpc/pull/53 is merged and released, but when it is, it promises support for PHP 8 and PHPUnit 9, while keeping support for PHP ^7.1 (https://github.com/cweiske/jsonmapper/blob/v4.0.0/ChangeLog)

<img width="845" src="https://user-images.githubusercontent.com/67554/108142529-3e8a0400-70c6-11eb-9adf-103279586e7f.png">

:octocat: