### PR TITLE
Add documentation to LSP

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "composer/xdebug-handler": "^1.1",
         "dnoegel/php-xdg-base-dir": "^0.1.1",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
-        "felixfbecker/language-server-protocol": "^1.4",
+        "felixfbecker/language-server-protocol": "^1.5",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
         "nikic/php-parser": "^4.10.1",
         "openlss/lib-array2xml": "^1.0",

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1330,7 +1330,7 @@ class Codebase
                     strlen($signature_label),
                     strlen($signature_label) + strlen($parameter_label),
                 ],
-                $param->description ?? null,
+                $param->description ?? null
             );
 
             $signature_label .= $parameter_label;

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -941,10 +941,15 @@ class Codebase
         return $function;
     }
 
-    public function getSymbolInformation(string $file_path, string $symbol): ?string
+    /**
+     * @param string $file_path
+     * @param string $symbol
+     * @return array{ type: string, description?: string|null}|null
+     */
+    public function getSymbolInformation(string $file_path, string $symbol): ?array
     {
         if (\is_numeric($symbol[0])) {
-            return \preg_replace('/^[^:]*:/', '', $symbol);
+            return ['type' => \preg_replace('/^[^:]*:/', '', $symbol)];
         }
 
         try {
@@ -963,7 +968,10 @@ class Codebase
 
                     $storage = $this->methods->getStorage($declaring_method_id);
 
-                    return '<?php ' . $storage->getSignature(true);
+                    return [
+                        'type' => '<?php ' . $storage->getSignature(true),
+                        'description' => $storage->description,
+                    ];
                 }
 
                 [, $symbol_name] = explode('::', $symbol);
@@ -971,7 +979,10 @@ class Codebase
                 if (strpos($symbol, '$') !== false) {
                     $storage = $this->properties->getStorage($symbol);
 
-                    return '<?php ' . $storage->getInfo() . ' ' . $symbol_name;
+                    return [
+                        'type' => '<?php ' . $storage->getInfo() . ' ' . $symbol_name,
+                        'description' => $storage->description,
+                    ];
                 }
 
                 [$fq_classlike_name, $const_name] = explode('::', $symbol);
@@ -985,7 +996,10 @@ class Codebase
                     return null;
                 }
 
-                return '<?php ' . $const_name;
+                return [
+                    'type' => '<?php ' . $const_name,
+                    'description' => $class_constants[$const_name]->description,
+                ];
             }
 
             if (strpos($symbol, '()')) {
@@ -995,7 +1009,10 @@ class Codebase
                 if (isset($file_storage->functions[$function_id])) {
                     $function_storage = $file_storage->functions[$function_id];
 
-                    return '<?php ' . $function_storage->getSignature(true);
+                    return [
+                        'type' => '<?php ' . $function_storage->getSignature(true),
+                        'description' => $function_storage->description,
+                    ];
                 }
 
                 if (!$function_id) {
@@ -1003,19 +1020,25 @@ class Codebase
                 }
 
                 $function = $this->functions->getStorage(null, $function_id);
-                return '<?php ' . $function->getSignature(true);
+                return [
+                    'type' => '<?php ' . $function->getSignature(true),
+                    'description' => $function->description,
+                ];
             }
 
             if (strpos($symbol, '$') === 0) {
                 $type = VariableFetchAnalyzer::getGlobalType($symbol);
                 if (!$type->isMixed()) {
-                    return '<?php ' . $type;
+                    return ['type' => '<?php ' . $type];
                 }
             }
 
             try {
                 $storage = $this->classlike_storage_provider->get($symbol);
-                return '<?php ' . ($storage->abstract ? 'abstract ' : '') . 'class ' . $storage->name;
+                return [
+                    'type' => '<?php ' . ($storage->abstract ? 'abstract ' : '') . 'class ' . $storage->name,
+                    'description' => $storage->description,
+                ];
             } catch (\InvalidArgumentException $e) {
             }
 
@@ -1030,17 +1053,17 @@ class Codebase
                 );
                 if (isset($namespace_constants[$const_name])) {
                     $type = $namespace_constants[$const_name];
-                    return '<?php const ' . $symbol . ' ' . $type;
+                    return ['type' => '<?php const ' . $symbol . ' ' . $type];
                 }
             } else {
                 $file_storage = $this->file_storage_provider->get($file_path);
                 if (isset($file_storage->constants[$symbol])) {
-                    return '<?php const ' . $symbol . ' ' . $file_storage->constants[$symbol];
+                    return ['type' => '<?php const ' . $symbol . ' ' . $file_storage->constants[$symbol]];
                 }
                 $constant = ConstFetchAnalyzer::getGlobalConstType($this, $symbol, $symbol);
 
                 if ($constant) {
-                    return '<?php const ' . $symbol . ' ' . $constant;
+                    return ['type' => '<?php const ' . $symbol . ' ' . $constant];
                 }
             }
             return null;
@@ -1246,8 +1269,10 @@ class Codebase
     /**
      * @param  non-empty-string $function_symbol
      */
-    public function getSignatureInformation(string $function_symbol) : ?\LanguageServerProtocol\SignatureInformation
+    public function getSignatureInformation(string $function_symbol, string $file_path = null) : ?\LanguageServerProtocol\SignatureInformation
     {
+        $signature_label = '';
+        $signature_documentation = null;
         if (strpos($function_symbol, '::') !== false) {
             /** @psalm-suppress ArgumentTypeCoercion */
             $method_id = new \Psalm\Internal\MethodIdentifier(...explode('::', $function_symbol));
@@ -1260,11 +1285,18 @@ class Codebase
 
             $method_storage = $this->methods->getStorage($declaring_method_id);
             $params = $method_storage->params;
+            $signature_label = $method_storage->cased_name;
+            $signature_documentation = $method_storage->description;
         } else {
             try {
-                $function_storage = $this->functions->getStorage(null, strtolower($function_symbol));
-
+                if ($file_path) {
+                    $function_storage = $this->functions->getStorage(null, strtolower($function_symbol), dirname($file_path), $file_path);
+                } else {
+                    $function_storage = $this->functions->getStorage(null, strtolower($function_symbol));
+                }
                 $params = $function_storage->params;
+                $signature_label = $function_storage->cased_name;
+                $signature_documentation = $function_storage->description;
             } catch (\Exception $exception) {
                 if (InternalCallMapHandler::inCallMap($function_symbol)) {
                     $callables = InternalCallMapHandler::getCallablesFromCallMap($function_symbol);
@@ -1280,15 +1312,18 @@ class Codebase
             }
         }
 
-        $signature_label = '(';
+        $signature_label .= '(';
         $parameters = [];
 
         foreach ($params as $i => $param) {
             $parameter_label = ($param->type ?: 'mixed') . ' $' . $param->name;
-            $parameters[] = new \LanguageServerProtocol\ParameterInformation([
-                strlen($signature_label),
-                strlen($signature_label) + strlen($parameter_label),
-            ]);
+            $parameters[] = new \LanguageServerProtocol\ParameterInformation(
+                [
+                    strlen($signature_label),
+                    strlen($signature_label) + strlen($parameter_label),
+                ],
+                $param->description ?? null,
+            );
 
             $signature_label .= $parameter_label;
 
@@ -1301,7 +1336,8 @@ class Codebase
 
         return new \LanguageServerProtocol\SignatureInformation(
             $signature_label,
-            $parameters
+            $parameters,
+            $signature_documentation
         );
     }
 
@@ -1440,7 +1476,7 @@ class Codebase
                             $method_storage->cased_name,
                             \LanguageServerProtocol\CompletionItemKind::METHOD,
                             (string)$method_storage,
-                            null,
+                            $method_storage->description,
                             (string)$method_storage->visibility,
                             $method_storage->cased_name,
                             $method_storage->cased_name . (count($method_storage->params) !== 0 ? '($0)' : '()'),
@@ -1466,7 +1502,7 @@ class Codebase
                             '$' . $property_name,
                             \LanguageServerProtocol\CompletionItemKind::PROPERTY,
                             $property_storage->getInfo(),
-                            null,
+                            $property_storage->description,
                             (string)$property_storage->visibility,
                             $property_name,
                             ($gap === '::' ? '$' : '') . $property_name
@@ -1479,12 +1515,12 @@ class Codebase
                         }
                     }
 
-                    foreach ($class_storage->constants as $const_name => $_) {
+                    foreach ($class_storage->constants as $const_name => $const) {
                         $static_completion_items[] = new \LanguageServerProtocol\CompletionItem(
                             $const_name,
                             \LanguageServerProtocol\CompletionItemKind::VARIABLE,
                             'const ' . $const_name,
-                            null,
+                            $const->description,
                             null,
                             $const_name,
                             $const_name
@@ -1656,7 +1692,7 @@ class Codebase
                 $function_name,
                 \LanguageServerProtocol\CompletionItemKind::FUNCTION,
                 $function->getSignature(false),
-                null,
+                $function->description,
                 null,
                 $function_name,
                 $function_name . (count($function->params) !== 0 ? '($0)' : '()'),

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1642,11 +1642,18 @@ class Codebase
                 $insertion_text = $class_name;
             }
 
+            try {
+                $class_storage = $this->classlike_storage_provider->get($fq_class_name);
+                $description = $class_storage->description;
+            } catch (\Exception $e) {
+                $description = null;
+            }
+
             $completion_items[] = new \LanguageServerProtocol\CompletionItem(
                 $fq_class_name,
                 \LanguageServerProtocol\CompletionItemKind::CLASS_,
                 null,
-                null,
+                $description,
                 null,
                 $fq_class_name,
                 $insertion_text,

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -45,6 +45,7 @@ use function substr_count;
 use function array_pop;
 use function implode;
 use function array_reverse;
+use function dirname;
 
 class Codebase
 {
@@ -1269,8 +1270,10 @@ class Codebase
     /**
      * @param  non-empty-string $function_symbol
      */
-    public function getSignatureInformation(string $function_symbol, string $file_path = null) : ?\LanguageServerProtocol\SignatureInformation
-    {
+    public function getSignatureInformation(
+        string $function_symbol,
+        string $file_path = null
+    ): ?\LanguageServerProtocol\SignatureInformation {
         $signature_label = '';
         $signature_documentation = null;
         if (strpos($function_symbol, '::') !== false) {
@@ -1290,7 +1293,12 @@ class Codebase
         } else {
             try {
                 if ($file_path) {
-                    $function_storage = $this->functions->getStorage(null, strtolower($function_symbol), dirname($file_path), $file_path);
+                    $function_storage = $this->functions->getStorage(
+                        null,
+                        strtolower($function_symbol),
+                        dirname($file_path),
+                        $file_path
+                    );
                 } else {
                     $function_storage = $this->functions->getStorage(null, strtolower($function_symbol));
                 }

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -217,7 +217,9 @@ class CommentAnalyzer
             = isset($parsed_docblock->tags['psalm-allow-private-mutation'])
             || isset($parsed_docblock->tags['psalm-readonly-allow-private-mutation']);
 
-        $var_comment->description = $parsed_docblock->description;
+        if (!$var_comment->description) {
+            $var_comment->description = $parsed_docblock->description;
+        }
 
         if (isset($parsed_docblock->tags['psalm-taint-escape'])) {
             foreach ($parsed_docblock->tags['psalm-taint-escape'] as $param) {

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -102,6 +102,7 @@ class CommentAnalyzer
                 $line_parts = self::splitDocLine($var_line);
 
                 $line_number = $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset);
+                $description = $parsed_docblock->description;
 
                 if ($line_parts && $line_parts[0]) {
                     $type_start = $offset + $comment->getStartFilePos();
@@ -131,8 +132,14 @@ class CommentAnalyzer
 
                     $var_line_number = $line_number;
 
-                    if (count($line_parts) > 1 && $line_parts[1][0] === '$') {
-                        $var_id = $line_parts[1];
+                    if (count($line_parts) > 1) {
+                        if ($line_parts[1][0] === '$') {
+                            $var_id = $line_parts[1];
+                            $description = trim(substr($var_line, strlen($line_parts[0]) + strlen($line_parts[1]) + 2));
+                        } else {
+                            $description = trim(substr($var_line, strlen($line_parts[0]) + 1));
+                        }
+                        $description = preg_replace('/\\n \\*\\s+/um', ' ', $description);
                     }
                 }
 
@@ -168,6 +175,7 @@ class CommentAnalyzer
                 $var_comment->line_number = $var_line_number;
                 $var_comment->type_start = $type_start;
                 $var_comment->type_end = $type_end;
+                $var_comment->description = $description;
 
                 self::decorateVarDocblockComment($var_comment, $parsed_docblock);
 
@@ -182,7 +190,8 @@ class CommentAnalyzer
                 || isset($parsed_docblock->tags['psalm-readonly'])
                 || isset($parsed_docblock->tags['psalm-readonly-allow-private-mutation'])
                 || isset($parsed_docblock->tags['psalm-taint-escape'])
-                || isset($parsed_docblock->tags['psalm-internal']))
+                || isset($parsed_docblock->tags['psalm-internal'])
+                || $parsed_docblock->description)
         ) {
             $var_comment = new VarDocblockComment();
 
@@ -207,6 +216,8 @@ class CommentAnalyzer
         $var_comment->allow_private_mutation
             = isset($parsed_docblock->tags['psalm-allow-private-mutation'])
             || isset($parsed_docblock->tags['psalm-readonly-allow-private-mutation']);
+
+        $var_comment->description = $parsed_docblock->description;
 
         if (isset($parsed_docblock->tags['psalm-taint-escape'])) {
             foreach ($parsed_docblock->tags['psalm-taint-escape'] as $param) {

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -9,7 +9,8 @@ use function error_log;
 use LanguageServerProtocol\CompletionList;
 use LanguageServerProtocol\Hover;
 use LanguageServerProtocol\Location;
-use LanguageServerProtocol\MarkedString;
+use LanguageServerProtocol\MarkupContent;
+use LanguageServerProtocol\MarkupKind;
 use LanguageServerProtocol\Position;
 use LanguageServerProtocol\Range;
 use LanguageServerProtocol\TextDocumentIdentifier;
@@ -211,8 +212,14 @@ class TextDocument
             return new Success(null);
         }
 
-        $contents = [];
-        $contents[] = new MarkedString('php', $symbol_information);
+        $content = "```php\n" . $symbol_information['type'] . "\n```";
+        if (isset($symbol_information['description'])) {
+            $content .= "\n---\n" . $symbol_information['description'];
+        }
+        $contents = new MarkupContent(
+            MarkupKind::MARKDOWN,
+            $content
+        );
 
         return new Success(new Hover($contents, $range));
     }
@@ -295,7 +302,7 @@ class TextDocument
             return new Success(new \LanguageServerProtocol\SignatureHelp());
         }
 
-        $signature_information = $this->codebase->getSignatureInformation($argument_location[0]);
+        $signature_information = $this->codebase->getSignatureInformation($argument_location[0], $file_path);
 
         if (!$signature_information) {
             return new Success(new \LanguageServerProtocol\SignatureHelp());

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -414,6 +414,10 @@ class ClassLikeDocblockParser
             $info->stub_override = true;
         }
 
+        if ($parsed_docblock->description) {
+            $info->description = $parsed_docblock->description;
+        }
+
         self::addMagicPropertyToInfo($comment, $info, $parsed_docblock->tags, 'property');
         self::addMagicPropertyToInfo($comment, $info, $parsed_docblock->tags, 'psalm-property');
         self::addMagicPropertyToInfo($comment, $info, $parsed_docblock->tags, 'property-read');

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -614,6 +614,10 @@ class ClassLikeNodeScanner
             $storage->override_method_visibility = $docblock_info->override_method_visibility;
 
             $storage->suppressed_issues = $docblock_info->suppressed_issues;
+
+            if ($docblock_info->description) {
+                $storage->description = $docblock_info->description;
+            }
         }
 
         foreach ($node->stmts as $node_stmt) {
@@ -1115,6 +1119,7 @@ class ClassLikeNodeScanner
 
         $comment = $stmt->getDocComment();
         $deprecated = false;
+        $description = null;
         $config = $this->config;
 
         if ($comment && $comment->getText() && ($config->use_docblock_types || $config->use_docblock_property_types)) {
@@ -1123,6 +1128,8 @@ class ClassLikeNodeScanner
             if (isset($comments->tags['deprecated'])) {
                 $deprecated = true;
             }
+
+            $description = $comments->description;
         }
 
         foreach ($stmt->consts as $const) {
@@ -1177,6 +1184,8 @@ class ClassLikeNodeScanner
             if ($deprecated) {
                 $constant_storage->deprecated = true;
             }
+
+            $constant_storage->description = $description;
 
             foreach ($stmt->attrGroups as $attr_group) {
                 foreach ($attr_group->attrs as $attr) {
@@ -1286,6 +1295,7 @@ class ClassLikeNodeScanner
             }
             $property_storage->readonly = $var_comment ? $var_comment->readonly : false;
             $property_storage->allow_private_mutation = $var_comment ? $var_comment->allow_private_mutation : false;
+            $property_storage->description = $var_comment ? $var_comment->description : null;
 
             if (!$signature_type && !$doc_var_group_type) {
                 if ($property->default) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -86,9 +86,14 @@ class FunctionLikeDocblockParser
                         ];
 
                         if (isset($line_parts[1]) && isset($line_parts[2])) {
-                            $info_param['description'] = trim(substr($param, strlen($line_parts[0]) + strlen($line_parts[1]) + 2));
+                            $description = substr($param, strlen($line_parts[0]) + strlen($line_parts[1]) + 2);
+                            $info_param['description'] = trim($description);
                             // Handle multiline description.
-                            $info_param['description'] = preg_replace('/\\n \\*\\s+/um', ' ', $info_param['description']);
+                            $info_param['description'] = preg_replace(
+                                '/\\n \\*\\s+/um',
+                                ' ',
+                                $info_param['description']
+                            );
                         }
 
                         $info->params[] = $info_param;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -77,13 +77,21 @@ class FunctionLikeDocblockParser
                             throw new IncorrectDocblockException('Misplaced variable');
                         }
 
-                        $info->params[] = [
+                        $info_param = [
                             'name' => trim($line_parts[1]),
                             'type' => $line_parts[0],
                             'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset),
                             'start' => $start,
                             'end' => $end,
                         ];
+
+                        if (isset($line_parts[1]) && isset($line_parts[2])) {
+                            $info_param['description'] = trim(substr($param, strlen($line_parts[0]) + strlen($line_parts[1]) + 2));
+                            // Handle multiline description.
+                            $info_param['description'] = preg_replace('/\\n \\*\\s+/um', ' ', $info_param['description']);
+                        }
+
+                        $info->params[] = $info_param;
                     }
                 } else {
                     throw new DocblockParseException('Badly-formatted @param');
@@ -435,6 +443,10 @@ class FunctionLikeDocblockParser
         $info->ignore_nullable_return = isset($parsed_docblock->tags['psalm-ignore-nullable-return']);
         $info->ignore_falsable_return = isset($parsed_docblock->tags['psalm-ignore-falsable-return']);
         $info->stub_override = isset($parsed_docblock->tags['psalm-stub-override']);
+
+        if (!empty($parsed_docblock->description)) {
+            $info->description = $parsed_docblock->description;
+        }
 
         return $info;
     }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -352,6 +352,10 @@ class FunctionLikeDocblockScanner
                 $file_storage
             );
         }
+
+        if ($docblock_info->description) {
+            $storage->description = $docblock_info->description;
+        }
     }
 
     /**
@@ -564,7 +568,7 @@ class FunctionLikeDocblockScanner
      * @param array<string, array<string, Type\Union>> $class_template_types
      * @param array<string, non-empty-array<string, Type\Union>> $function_template_types
      * @param array<string, TypeAlias> $type_aliases
-     * @param array<int, array{type:string,name:string,line_number:int,start:int,end:int}>  $docblock_params
+     * @param array<int, array{type:string,name:string,line_number:int,start:int,end:int,description?:string}>  $docblock_params
      */
     private static function improveParamsFromDocblock(
         Codebase $codebase,
@@ -775,6 +779,10 @@ class FunctionLikeDocblockScanner
 
             $storage_param->type = $new_param_type;
             $storage_param->type_location = $docblock_type_location;
+
+            if (isset($docblock_param['description'])) {
+                $storage_param->description = $docblock_param['description'];
+            }
         }
 
         $params_without_docblock_type = array_filter(

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -568,7 +568,7 @@ class FunctionLikeDocblockScanner
      * @param array<string, array<string, Type\Union>> $class_template_types
      * @param array<string, non-empty-array<string, Type\Union>> $function_template_types
      * @param array<string, TypeAlias> $type_aliases
-     * @param array<int, array{type:string,name:string,line_number:int,start:int,end:int,description?:string}>  $docblock_params
+     * @param array<int, array{type:string,name:string,line_number:int,start:int,end:int,description?:string}> $docblock_params
      */
     private static function improveParamsFromDocblock(
         Codebase $codebase,

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -363,7 +363,10 @@ class FunctionLikeDocblockScanner
      * @param  array<string, TypeAlias>|null   $type_aliases
      * @param  array<string, array<string, Type\Union>> $function_template_types
      *
-     * @return array{array<int, array{0: string, 1: int, 2?: string}>, array<string, array<string, Type\Union>>}
+     * @return array{
+     *     array<int, array{0: string, 1: int, 2?: string}>,
+     *     array<string, array<string, Type\Union>>
+     * }
      */
     private static function getConditionalSanitizedTypeTokens(
         string $docblock_return_type,
@@ -568,7 +571,17 @@ class FunctionLikeDocblockScanner
      * @param array<string, array<string, Type\Union>> $class_template_types
      * @param array<string, non-empty-array<string, Type\Union>> $function_template_types
      * @param array<string, TypeAlias> $type_aliases
-     * @param array<int, array{type:string,name:string,line_number:int,start:int,end:int,description?:string}> $docblock_params
+     * @param array<
+     *     int,
+     *     array{
+     *         type:string,
+     *         name:string,
+     *         line_number:int,
+     *         start:int,
+     *         end:int,
+     *         description?:string
+     *     }
+     * > $docblock_params
      */
     private static function improveParamsFromDocblock(
         Codebase $codebase,

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -727,6 +727,10 @@ class FunctionLikeDocblockScanner
 
             $existing_param_type_nullable = $storage_param->is_nullable;
 
+            if (isset($docblock_param['description'])) {
+                $storage_param->description = $docblock_param['description'];
+            }
+
             if (!$storage_param->type || $storage_param->type->hasMixed() || $storage->template_types) {
                 if ($existing_param_type_nullable
                     && !$new_param_type->isNullable()
@@ -779,10 +783,6 @@ class FunctionLikeDocblockScanner
 
             $storage_param->type = $new_param_type;
             $storage_param->type_location = $docblock_type_location;
-
-            if (isset($docblock_param['description'])) {
-                $storage_param->description = $docblock_param['description'];
-            }
         }
 
         $params_without_docblock_type = array_filter(

--- a/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
@@ -137,4 +137,9 @@ class ClassLikeDocblockComment
      * @var array<int, string>
      */
     public $implementation_requirements = [];
+
+    /**
+     * @var ?string
+     */
+    public $description;
 }

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -32,7 +32,17 @@ class FunctionDocblockComment
     public $return_type_line_number;
 
     /**
-     * @var array<int, array{name:string, type:string, line_number: int, start: int, end: int, description?: string}>
+     * @var array<
+     *     int,
+     *     array{
+     *         name:string,
+     *         type:string,
+     *         line_number: int,
+     *         start: int,
+     *         end: int,
+     *         description?: string
+     *     }
+     * >
      */
     public $params = [];
 

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -32,7 +32,7 @@ class FunctionDocblockComment
     public $return_type_line_number;
 
     /**
-     * @var array<int, array{name:string, type:string, line_number: int, start: int, end: int}>
+     * @var array<int, array{name:string, type:string, line_number: int, start: int, end: int, description?: string}>
      */
     public $params = [];
 
@@ -201,4 +201,9 @@ class FunctionDocblockComment
      * @var int
      */
     public $since_php_minor_version = 0;
+
+    /**
+     * @var ?string
+     */
+    public $description;
 }

--- a/src/Psalm/Internal/Scanner/VarDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/VarDocblockComment.php
@@ -82,4 +82,9 @@ class VarDocblockComment
      * @var array<int, string>
      */
     public $suppressed_issues = [];
+
+    /**
+     * @var ?string
+     */
+    public $description;
 }

--- a/src/Psalm/Storage/ClassConstantStorage.php
+++ b/src/Psalm/Storage/ClassConstantStorage.php
@@ -43,6 +43,11 @@ class ClassConstantStorage
     public $attributes = [];
 
     /**
+     * @var ?string
+     */
+    public $description;
+
+    /**
      * @param ClassLikeAnalyzer::VISIBILITY_* $visibility
      */
     public function __construct(?Type\Union $type, int $visibility, ?CodeLocation $location)

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -418,6 +418,11 @@ class ClassLikeStorage
      */
     public $attributes = [];
 
+    /**
+     * @var ?string
+     */
+    public $description;
+
     public function __construct(string $name)
     {
         $this->name = $name;

--- a/src/Psalm/Storage/FunctionLikeParameter.php
+++ b/src/Psalm/Storage/FunctionLikeParameter.php
@@ -103,6 +103,11 @@ class FunctionLikeParameter
      */
     public $attributes = [];
 
+    /**
+     * @var ?string
+     */
+    public $description;
+
     public function __construct(
         string $name,
         bool $by_ref,

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -227,6 +227,11 @@ abstract class FunctionLikeStorage
      */
     public $proxy_calls = [];
 
+    /**
+     * @var ?string
+     */
+    public $description;
+
     public function __toString(): string
     {
         return $this->getSignature(false);

--- a/src/Psalm/Storage/PropertyStorage.php
+++ b/src/Psalm/Storage/PropertyStorage.php
@@ -101,6 +101,11 @@ class PropertyStorage
      */
     public $suppressed_issues = [];
 
+    /**
+     * @var ?string
+     */
+    public $description;
+
     public function getInfo() : string
     {
         switch ($this->visibility) {

--- a/tests/ClassLikeDocblockParserTest.php
+++ b/tests/ClassLikeDocblockParserTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace Psalm\Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use Psalm\Aliases;
+use Psalm\DocComment;
+use Psalm\Internal\RuntimeCaches;
+use Psalm\Internal\Scanner\ParsedDocblock;
+use Psalm\Internal\PhpVisitor\Reflector\ClassLikeDocblockParser;
+use PhpParser\Node\Stmt\Class_;
+
+class ClassLikeDocblockParserTest extends \Psalm\Tests\TestCase
+{
+    public function testDocblockDescription(): void
+    {
+        $doc = '/**
+ * Some Description
+ *
+ */
+';
+        $node = new Class_(null);
+        $php_parser_doc = new \PhpParser\Comment\Doc($doc);
+        $class_docblock = ClassLikeDocblockParser::parse($node, $php_parser_doc, new Aliases());
+
+        $this->assertSame('Some Description', $class_docblock->description);
+    }
+}

--- a/tests/CommentAnalyzerTest.php
+++ b/tests/CommentAnalyzerTest.php
@@ -1,0 +1,78 @@
+<?php
+namespace Psalm\Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use Psalm\DocComment;
+use Psalm\Internal\RuntimeCaches;
+use Psalm\Internal\Scanner\ParsedDocblock;
+use Psalm\Internal\Analyzer\CommentAnalyzer;
+use Psalm\Internal\Scanner\FileScanner;
+use Psalm\Aliases;
+
+class CommentAnalyzerTest extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        RuntimeCaches::clearAll();
+    }
+
+    public function testDocblockVarDescription(): void
+    {
+        $doc = '/**
+ * @var string Some Description
+ */
+';
+        $php_parser_doc = new \PhpParser\Comment\Doc($doc);
+        $comment_docblock = CommentAnalyzer::getTypeFromComment($php_parser_doc, new FileScanner('somefile.php', 'somefile.php', false), new Aliases);
+        $this->assertSame('Some Description', $comment_docblock[0]->description);
+    }
+
+    public function testDocblockVarDescriptionWithVarId(): void
+    {
+        $doc = '/**
+ * @var string $foo Some Description
+ */
+';
+        $php_parser_doc = new \PhpParser\Comment\Doc($doc);
+        $comment_docblock = CommentAnalyzer::getTypeFromComment($php_parser_doc, new FileScanner('somefile.php', 'somefile.php', false), new Aliases);
+        $this->assertSame('Some Description', $comment_docblock[0]->description);
+    }
+
+    public function testDocblockVarDescriptionMultiline(): void
+    {
+        $doc = '/**
+ * @var string $foo Some Description
+ *                  with a long description.
+ */
+';
+        $php_parser_doc = new \PhpParser\Comment\Doc($doc);
+        $comment_docblock = CommentAnalyzer::getTypeFromComment($php_parser_doc, new FileScanner('somefile.php', 'somefile.php', false), new Aliases);
+        $this->assertSame('Some Description with a long description.', $comment_docblock[0]->description);
+    }
+
+    public function testDocblockDescription(): void
+    {
+        $doc = '/**
+ * Some Description
+ *
+ * @var string
+ */
+';
+        $php_parser_doc = new \PhpParser\Comment\Doc($doc);
+        $comment_docblock = CommentAnalyzer::getTypeFromComment($php_parser_doc, new FileScanner('somefile.php', 'somefile.php', false), new Aliases);
+        $this->assertSame('Some Description', $comment_docblock[0]->description);
+    }
+
+    public function testDocblockDescriptionWithVarDescription(): void
+    {
+        $doc = '/**
+ * Some Description
+ *
+ * @var string Use a string
+ */
+';
+        $php_parser_doc = new \PhpParser\Comment\Doc($doc);
+        $comment_docblock = CommentAnalyzer::getTypeFromComment($php_parser_doc, new FileScanner('somefile.php', 'somefile.php', false), new Aliases);
+        $this->assertSame('Use a string', $comment_docblock[0]->description);
+    }
+}

--- a/tests/FunctionLikeDocblockParserTest.php
+++ b/tests/FunctionLikeDocblockParserTest.php
@@ -1,0 +1,59 @@
+<?php
+namespace Psalm\Tests;
+
+use PHPUnit\Framework\TestCase as BaseTestCase;
+use Psalm\DocComment;
+use Psalm\Internal\RuntimeCaches;
+use Psalm\Internal\Scanner\ParsedDocblock;
+use Psalm\Internal\PhpVisitor\Reflector\FunctionLikeDocblockParser;
+
+class FunctionLikeDocblockParserTest extends BaseTestCase
+{
+    public function setUp(): void
+    {
+        RuntimeCaches::clearAll();
+    }
+
+    public function testDocblockDescription(): void
+    {
+        $doc = '/**
+ * Some Description
+ *
+ * @param string $bli
+ * @param int $bla
+ *
+ * @throws \Exception
+ *
+ * @return bool
+ */
+';
+        $php_parser_doc = new \PhpParser\Comment\Doc($doc);
+        $function_docblock = FunctionLikeDocblockParser::parse($php_parser_doc);
+
+        $this->assertSame('Some Description', $function_docblock->description);
+    }
+
+    public function testDocblockParamDescription(): void
+    {
+        $doc = '/**
+ * Some Description
+ *
+ * @param string $bli The BLI tag to iterate over.
+ * @param int $bla    The blah tags
+ *                    that has a very long multiline description.
+ *
+ * @throws \Exception
+ *
+ * @return bool
+ */
+';
+        $php_parser_doc = new \PhpParser\Comment\Doc($doc);
+        $function_docblock = FunctionLikeDocblockParser::parse($php_parser_doc);
+
+        $this->assertTrue(isset($function_docblock->params[0]['description']));
+        $this->assertSame('The BLI tag to iterate over.', $function_docblock->params[0]['description']);
+
+        $this->assertTrue(isset($function_docblock->params[1]['description']));
+        $this->assertSame('The blah tags that has a very long multiline description.', $function_docblock->params[1]['description']);
+    }
+}

--- a/tests/LanguageServer/CompletionTest.php
+++ b/tests/LanguageServer/CompletionTest.php
@@ -923,6 +923,11 @@ class CompletionTest extends \Psalm\Tests\TestCase
             '<?php
                 namespace Bar;
 
+                /**
+                 * My Function in a Bar
+                 *
+                 * @return void
+                 */
                 function my_function_in_bar() : void {
 
                 }
@@ -934,12 +939,13 @@ class CompletionTest extends \Psalm\Tests\TestCase
         $codebase->scanFiles();
         $this->analyzeFile('somefile.php', new Context());
 
-        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', new Position(7, 30));
+        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', new Position(12, 30));
         $this->assertNotNull($completion_data);
         $this->assertSame('*Bar-my_function_in', $completion_data[0]);
 
         $completion_items = $codebase->getCompletionItemsForPartialSymbol($completion_data[0], $completion_data[2], 'somefile.php');
         $this->assertSame(1, count($completion_items));
+        $this->assertEquals('My Function in a Bar', $completion_items[0]->documentation);
     }
 
     public function testCompletionForNamespacedOverriddenFunctionNames(): void

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -580,7 +580,8 @@ class SymbolLookupTest extends \Psalm\Tests\TestCase
         }
     }
 
-    public function testGetSignatureHelpIncludesParamDescription(): void {
+    public function testGetSignatureHelpIncludesParamDescription(): void
+    {
         $codebase = $this->project_analyzer->getCodebase();
         $config = $codebase->config;
         $config->throw_exception = false;


### PR DESCRIPTION
This adds documentation to several features of the LSP. Specifically:

Functions, methods, classes, class constants and class properties will now display their documentation/description in the IDE's Hover information, Autocomplete lists and Signature Information.

Here's some examples:

Autocomplete documentation:

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2021-02-22-11-43-12.71-s06TbqdzGVtyLtmlNF917vsCwfi2dElR2ED2goEx1RTj1BC9BNLvnFjTzBzMzUvThUim63AaPVazo9Rplqdb9yyjiCA2gNT8JL0M.png)

Hover documentation:

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2021-02-22-11-44-13.31-BS9Y2PrPZHshH0XOHMhyuMUYJ8r5D1Sm62S7uPzEnYrBdqJTrr6pe2FlOBLwPPUPgWAsCmreFq3rv4Y2SlY1cHcWHg9vdh19rhsU.png)

Documentation in function param signature 

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2021-02-22-12-03-06.25-1yEqBrn5ZtLBgtFvUfoww5xXTGCnsMXHEeAVSEgU6rNuMc3rOO1StojHlnawihek9HO68CRv5cvV8NqTBgwGxN1knpZoG21wI2cZ.png)

I mostly modeled these off the default TypeScript documentation in VS Code.

--

This is blocked on https://github.com/felixfbecker/php-language-server-protocol/pull/17

Personally I am bullish on including documentation on all the PHP inbuilt functions, this reflects what the Typescript / JS LSP by default also does.

I didn't yet add guards around all documentation collection for the LSP only -- I wasn't quite sure how to do that (I imagine that is stored in the `config` object?), though I wasn't sure how difficult it would be to get the scope/context of that value at each point.

As a comparison, I ran `./vendor/bin/psalm --no-cache --no-reflection-cache --no-file-cache .` on a pretty large WordPress project (which makes a lot of use of phpdocumentation)

`master`
Checks took 5.19 seconds and used 552.723MB of memory

`lsp-documentation`
Checks took 5.19 seconds and used 554.804MB of memory
