### PR TITLE
[Doc] Show how to install the phar by direct download

### DIFF
--- a/docs/running_psalm/installation.md
+++ b/docs/running_psalm/installation.md
@@ -35,8 +35,19 @@ Read more about plugins in [Using Plugins chapter](plugins/using_plugins.md).
 
 ## Using the Phar
 
-Sometimes your project can conflict with one or more of Psalm’s dependencies.
+Sometimes your project can conflict with one or more of Psalm’s dependencies. In
+that case you may find the Phar (a self-contained PHP executable) useful.
 
-In that case you may find the Phar (a self-contained PHP executable) useful.
+The Phar can be downloaded from Github:
 
-Run `composer require --dev psalm/phar` to install it.
+```bash
+wget https://github.com/vimeo/psalm/releases/latest/download/psalm.phar
+chmod +x psalm.phar
+./psalm.phar --version
+```
+
+Alternatively, you can use Composer to install the Phar:
+
+```bash
+composer require --dev psalm/phar
+```


### PR DESCRIPTION
In my highly opinionated mind, the correct way to install a tool like Psalm is to download a binary. This would be obvious for any PHP developer if the tool (psalm) was written in GoLang or Ruby. Nobody would ever see a Ruby tool and think "I wish I can download this with composer". 

Don't get me wrong, the `psalm/phar` package has its use cases, but it should not be the "standard way". 

Using `wget` to download a phar is the [recommended way of PHPUnit](https://phpunit.readthedocs.io/en/9.5/installation.html). 

Since each release of psalm has the `psalm.phar` attached to it, we can use this special link. See [Github docs](https://docs.github.com/en/github/administering-a-repository/linking-to-releases).