### PR TITLE
bugfix: do not throw `ConfigException` when missing files are allowed

### DIFF
--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -239,6 +239,10 @@ class FileFilter
                     );
 
                     if (empty($globs)) {
+                        if ($allow_missing_files) {
+                            continue;
+                        }
+
                         throw new ConfigException(
                             'Could not resolve config path to ' . $base_dir . DIRECTORY_SEPARATOR .
                                 (string)$file['name']
@@ -246,7 +250,7 @@ class FileFilter
                     }
 
                     foreach ($globs as $glob_index => $file_path) {
-                        if (!$file_path) {
+                        if (!$file_path && !$allow_missing_files) {
                             throw new ConfigException(
                                 'Could not resolve config path to ' . $base_dir . DIRECTORY_SEPARATOR .
                                     (string)$file['name'] . ':' . $glob_index


### PR DESCRIPTION
Hey there,

I've came along an issue with my configuration and searched for similar issues/fixes here.
Ive stumbled upon #4259 and #4238 where #4259 fixed some exception already in another case.

Since there are two more cases where an exception is thrown due to missing files, I'd like to contribute.

Thanks.