### PR TITLE
fixed typo in contributing/index.md

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -30,7 +30,7 @@ Before you send a pull request, make sure you follow these guidelines:
 
 Run integration checks locally:
 
-- `composer phpcs` - checks the code is properly linted
+- `composer cs` - checks the code is properly linted
 - `vendor/bin/paratest` - runs PHPUnit tests in parallel
 - `./psalm` - runs Psalm on itself
 


### PR DESCRIPTION
Hello 

There is no `phpcs` composer script and this part of the doc seems to be a typo (at least it fails on my machine)

There is a `cs` command however that runs `phpcs -p` internally.  