### PR TITLE
Fix PDOStatement::fetchAll() return type

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -9883,7 +9883,7 @@ return [
 'PDOStatement::errorInfo' => ['array'],
 'PDOStatement::execute' => ['bool', 'params='=>'?array'],
 'PDOStatement::fetch' => ['mixed', 'mode='=>'int', 'cursorOrientation='=>'int', 'cursorOffset='=>'int'],
-'PDOStatement::fetchAll' => ['array', 'mode='=>'int', '...args='=>'mixed'],
+'PDOStatement::fetchAll' => ['array|false', 'mode='=>'int', '...args='=>'mixed'],
 'PDOStatement::fetchColumn' => ['mixed', 'column='=>'int'],
 'PDOStatement::fetchObject' => ['object|false', 'class='=>'?string', 'ctorArgs='=>'?array'],
 'PDOStatement::getAttribute' => ['mixed', 'attribute'=>'int'],


### PR DESCRIPTION
From the PHP [documentation](https://www.php.net/manual/en/pdostatement.fetchall.php):
> ```php
> public PDOStatement::fetchAll (int $fetch_style = ?, mixed $fetch_argument = ?, array $ctor_args = array()): array|false
> ```
> […]
>
> An empty array is returned if there are zero results to fetch, or `false` on failure.