### PR TITLE
Update mysql_connect_error() return type definition

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -8427,7 +8427,7 @@ return [
 'mysqli_commit' => ['bool', 'mysql'=>'mysqli', 'flags='=>'int', 'name='=>'string'],
 'mysqli_connect' => ['mysqli|false', 'hostname='=>'string', 'username='=>'string', 'password='=>'string', 'database='=>'string', 'port='=>'int', 'socket='=>'string'],
 'mysqli_connect_errno' => ['int'],
-'mysqli_connect_error' => ['string'],
+'mysqli_connect_error' => ['?string'],
 'mysqli_data_seek' => ['bool', 'result'=>'mysqli_result', 'offset'=>'int'],
 'mysqli_debug' => ['bool', 'options'=>'string'],
 'mysqli_disable_reads_from_master' => ['bool', 'link'=>'mysqli'],


### PR DESCRIPTION
Tiny update to the call map.

While refactoring a very old code base, Psalm is proving to be an extremely helpful tool once again. I did however run into a little issue where the return type of `mysqli_connect_error()` is incorrectly defined. Reading the documentation on PHP.net, that's no wonder, because it *does* claim the return type is string.

However, in the `Return values` section it explains `null` is returned when no error occurred:

https://www.php.net/manual/en/mysqli.connect-error.php#refsect1-mysqli.connect-error-returnvalues