### PR TITLE
Always return type inference summary, even if no files were analyzed due to caching

### DIFF
--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -29,6 +29,7 @@ use function substr;
 use function usort;
 use function array_values;
 use const PATHINFO_EXTENSION;
+use function implode;
 
 /**
  * @psalm-type  TaggedCodeType = array<int, array{0: int, 1: non-empty-string}>

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -1253,18 +1253,21 @@ class Analyzer
 
         $total_files = count($all_deep_scanned_files);
 
+        $lines = [];
+        
         if (!$total_files) {
-            return 'No files analyzed';
+            $lines[] = 'No files analyzed';
         }
 
         if (!$total) {
-            return 'Psalm was unable to infer types in the codebase';
+            $lines[] = 'Psalm was unable to infer types in the codebase';
+        } else {
+            $percentage = $nonmixed_count === $total ? '100' : number_format(100 * $nonmixed_count / $total, 4);
+            $lines[] = 'Psalm was able to infer types for ' . $percentage . '%'
+                . ' of the codebase';
         }
-
-        $percentage = $nonmixed_count === $total ? '100' : number_format(100 * $nonmixed_count / $total, 4);
-
-        return 'Psalm was able to infer types for ' . $percentage . '%'
-            . ' of the codebase';
+        
+        return implode("\n", $lines);
     }
 
     public function getNonMixedStats(): string


### PR DESCRIPTION
Fixes #5319.

Thanks to @orklah for pointing the corresponding code location out.