### PR TITLE
Suppress test issues with Symfony functions used with `::class` constant

### DIFF
--- a/tests/fixtures/SuicidalAutoloader/autoloader.php
+++ b/tests/fixtures/SuicidalAutoloader/autoloader.php
@@ -16,6 +16,13 @@ spl_autoload_register(function (string $className) {
         'PHPUnit\Framework\DOMDocument',
         'PHPUnit\Framework\DOMElement',
         'Stringable',
+
+        // https://github.com/symfony/symfony/pull/40203
+        // these are actually functions, referenced as `if (!function_exists(u::class))`
+        'Symfony\Component\String\u',
+        'Symfony\Component\String\b',
+        'Symfony\Component\String\s',
+        'Symfony\Component\Translation\t',
     ];
 
     if (in_array($className, $knownBadClasses)) {


### PR DESCRIPTION
These appeared in symfony/symfony#40203