### PR TITLE
config.xsd: fix default errorLevel

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -63,7 +63,7 @@
         <xs:attribute name="strictBinaryOperands" type="xs:boolean" default="false" />
         <xs:attribute name="throwExceptionOnError" type="xs:boolean" default="false" />
         <xs:attribute name="totallyTyped" type="xs:boolean" default="false" />
-        <xs:attribute name="errorLevel" type="xs:integer" default="1" />
+        <xs:attribute name="errorLevel" type="xs:integer" default="2" />
         <xs:attribute name="reportMixedIssues" type="xs:boolean" default="true" />
         <xs:attribute name="useDocblockTypes" type="xs:boolean" default="true" />
         <xs:attribute name="useDocblockPropertyTypes" type="xs:boolean" default="false" />


### PR DESCRIPTION
Default errorLevel seems to be `2` instead of `1`: https://github.com/vimeo/psalm/blob/c05a3ea0739c11770eecec1c8cd8126ca9e3ec7c/src/Psalm/Config.php#L848