### PR TITLE
Allow undefined variable detection in arrow functions

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -188,8 +188,6 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
                             );
                         }
                     }
-                } else {
-                    $use_context->vars_in_scope[$use_var_id] = Type::getMixed();
                 }
 
                 $use_context->vars_possibly_in_scope[$use_var_id] = true;

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -889,6 +889,24 @@ class ClosureTest extends TestCase
                     );',
                 'error_message' => 'InvalidArgument'
             ],
+            'undefinedVariableInEncapsedString' => [
+                '<?php
+                    fn(): string => "$a";
+                ',
+                'error_message' => 'UndefinedVariable',
+                [],
+                false,
+                '7.4'
+            ],
+            'undefinedVariableInStringCast' => [
+                '<?php
+                    fn(): string => (string) $a;
+                ',
+                'error_message' => 'UndefinedVariable',
+                [],
+                false,
+                '7.4'
+            ],
         ];
     }
 }


### PR DESCRIPTION
Previously Psalm would assume that any variable it sees in the arrow function body is defined (and mixed, if it's not available in the outer scope). This prevented undefined variable detection. Dropping that assumption allows it to work.

Fixes vimeo/psalm#5331