### PR TITLE
Added test to keep Union commutative

### DIFF
--- a/tests/UnionTest.php
+++ b/tests/UnionTest.php
@@ -2,6 +2,7 @@
 
 namespace Psalm\Tests;
 
+use Psalm\Internal\Type\TypeCombiner;
 use Psalm\Type\Atomic;
 use Psalm\Type\Union;
 
@@ -63,6 +64,21 @@ class UnionTest extends TestCase
                         Atomic::create($a)
                     ]))->getId(),
                     "$a|$b != $b|$a",
+                );
+            }
+        }
+    }
+
+    public function testUnionsFromTypeCombinerAreCommutative(): void
+    {
+        foreach (self::KNOWN_ATOMICS as $a) {
+            $a = Atomic::create($a);
+            foreach (self::KNOWN_ATOMICS as $b) {
+                $b = Atomic::create($b);
+                $this->assertSame(
+                    TypeCombiner::combine([$a, $b])->getId(),
+                    TypeCombiner::combine([$b, $a])->getId(),
+                    "$a|$b != $b|$a"
                 );
             }
         }

--- a/tests/UnionTest.php
+++ b/tests/UnionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Psalm\Tests;
+
+use Psalm\Type\Atomic;
+use Psalm\Type\Union;
+
+class UnionTest extends TestCase
+{
+    private const KNOWN_ATOMICS = [
+        'int',
+        'float',
+        'string',
+        'bool',
+        'void',
+        'array-key',
+        'iterable',
+        'never-return',
+        'object',
+        'callable',
+        'pure-callable',
+        'array',
+        'non-empty-array',
+        'callable-array',
+        'list',
+        'non-empty-list',
+        'non-empty-string',
+        'non-falsy-string',
+        'lowercase-string',
+        'non-empty-lowercase-string',
+        'resource',
+        'closed-resource',
+        'positive-int',
+        'numeric',
+        'true',
+        'false',
+        'empty',
+        'scalar',
+        'null',
+        'mixed',
+        'callable-object',
+        'class-string',
+        'trait-string',
+        'callable-string',
+        'numeric-string',
+        'html-escaped-string',
+        'false-y',
+        '$this',
+
+    ];
+
+    public function testUnionsAreCommutative(): void
+    {
+        foreach (self::KNOWN_ATOMICS as $a) {
+            foreach (self::KNOWN_ATOMICS as $b) {
+                $this->assertSame(
+                    (new Union([
+                        Atomic::create($a),
+                        Atomic::create($b)
+                    ]))->getId(),
+                    (new Union([
+                        Atomic::create($b),
+                        Atomic::create($a)
+                    ]))->getId(),
+                    "$a|$b != $b|$a",
+                );
+            }
+        }
+    }
+}

--- a/tests/UnionTest.php
+++ b/tests/UnionTest.php
@@ -16,7 +16,7 @@ class UnionTest extends TestCase
         'void',
         'array-key',
         'iterable',
-        'never-return',
+        'never',
         'object',
         'callable',
         'pure-callable',
@@ -35,7 +35,6 @@ class UnionTest extends TestCase
         'numeric',
         'true',
         'false',
-        'empty',
         'scalar',
         'null',
         'mixed',
@@ -44,10 +43,7 @@ class UnionTest extends TestCase
         'trait-string',
         'callable-string',
         'numeric-string',
-        'html-escaped-string',
-        'false-y',
         '$this',
-
     ];
 
     public function testUnionsAreCommutative(): void


### PR DESCRIPTION
Union should be a commutative operation, such that `A|B = B|A`. This seems to be the case with types parsed from strings, but not for unions created directly in the code.

E.g.
```php
new Union([Atomic::create('int'), Atomic::create('positive-int')])
```
currently results in `positive-int`, even though `int` should subsume it.

Refs vimeo/psalm#5342

This PR just provides a failing test, as I'm not sure how best to address the issue.