### PR TITLE
Mark ceil() return type as float

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1013,7 +1013,7 @@ return [
 'CallbackFilterIterator::next' => ['void'],
 'CallbackFilterIterator::rewind' => ['void'],
 'CallbackFilterIterator::valid' => ['bool'],
-'ceil' => ['float|int', 'num'=>'float'],
+'ceil' => ['float', 'num'=>'float'],
 'chdb::__construct' => ['void', 'pathname'=>'string'],
 'chdb::get' => ['string', 'key'=>'string'],
 'chdb_create' => ['bool', 'pathname'=>'string', 'data'=>'array'],


### PR DESCRIPTION
https://www.php.net/manual/en/function.ceil.php

The return value of ceil() is still of type float as the value range of float is usually bigger than that of int.

Resolves #5354