### PR TITLE
fix usage of callable with array_map

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
@@ -98,7 +98,8 @@ class ArrayMapReturnTypeProvider implements \Psalm\Plugin\EventHandler\FunctionR
                 $generic_key_type = Type::getInt();
             }
 
-            if ($closure_types = $function_call_type->getClosureTypes()) {
+            if ($function_call_type->hasCallableType()) {
+                $closure_types = $function_call_type->getClosureTypes() ?: $function_call_type->getCallableTypes();
                 $closure_atomic_type = \reset($closure_types);
 
                 $closure_return_type = $closure_atomic_type->return_type ?: Type::getMixed();

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -633,7 +633,7 @@ class Union implements TypeNode
     /**
      * @return array<string, Atomic\TCallable>
      */
-    private function getCallableTypes(): array
+    public function getCallableTypes(): array
     {
         return array_filter(
             $this->types,

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -534,6 +534,25 @@ class ClosureTest extends TestCase
                         }
                     }'
             ],
+            'CallableWithArrayMap' => [
+                '<?php
+                    /**
+                     * @psalm-template T
+                     * @param class-string<T> $className
+                     * @return callable(...mixed):T
+                     */
+                    function maker(string $className) {
+                       return function(...$args) use ($className) {
+                          /** @psalm-suppress MixedMethodCall */
+                          return new $className(...$args);
+                       };
+                    }
+                    $maker = maker(stdClass::class);
+                    $result = array_map($maker, ["abc"]);',
+                'assertions' => [
+                    '$result' => 'array{stdClass}'
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This should fix #5314 
Only closures were used to infer return type. I added callables.