### PR TITLE
iterator_to_array must always return array-key

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
@@ -2,8 +2,9 @@
 namespace Psalm\Internal\Provider\ReturnTypeProvider;
 
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Type\Atomic\TTemplateParam;
+use function array_shift;
 use function assert;
-use PhpParser;
 use Psalm\Internal\Analyzer\Statements\Block\ForeachAnalyzer;
 use Psalm\Internal\Type\Comparator\AtomicTypeComparator;
 use Psalm\Internal\Codebase\InternalCallMapHandler;
@@ -84,6 +85,15 @@ class IteratorToArrayReturnTypeProvider implements \Psalm\Plugin\EventHandler\Fu
 
                 if ($key_type->hasMixed()) {
                     $key_type = Type::getArrayKey();
+                }
+
+                if ($key_type->isSingle() && $key_type->hasTemplate()) {
+                    $template_types = $key_type->getTemplateTypes();
+                    $template_type = array_shift($template_types);
+                    if ($template_type->as->hasMixed()) {
+                        $template_type->as = Type::getArrayKey();
+                        $key_type = new Type\Union([$template_type]);
+                    }
                 }
 
                 return new Type\Union([

--- a/tests/Php71Test.php
+++ b/tests/Php71Test.php
@@ -235,6 +235,19 @@ class Php71Test extends TestCase
                       return $i;
                     }',
             ],
+            'iterator_to_arrayMixedKey' => [
+                '<?php
+                    /**
+                     * @template TKey
+                     * @template TValue
+                     * @param Traversable<TKey, TValue> $traversable
+                     * @return array<TValue>
+                     */
+                    function toArray(Traversable $traversable): array
+                    {
+                        return iterator_to_array($traversable);
+                    }',
+            ],
             'noReservedWordInDocblock' => [
                 '<?php
                     /**


### PR DESCRIPTION
This PR should fix #5396. When the return of iterator contains a mixed templated key, we can narrow it to array-key because PHP will throw a TypeError if it's not the case.