### PR TITLE
adapt bcdiv for PHP8 in stubs

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -948,7 +948,7 @@ function realpath(string $path) {}
  *
  * @param numeric-string $left_operand
  * @param numeric-string $right_operand
- * @return ($right_operand is "0" ? null : numeric-string)
+ * @return (PHP_MAJOR_VERSION is 8 ? numeric-string : ($right_operand is "0" ? null : numeric-string))
  */
 function bcdiv(string $left_operand, string $right_operand, int $scale = 0): ?string {}
 


### PR DESCRIPTION
Now that I learned we can use PHP_MAJOR_VERSION in stubs, I checked changed functions in callmap_80 that appear in stubs and this was the only one