### PR TITLE
Don't mark promoted properties as unused params

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -792,6 +792,10 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 continue;
             }
 
+            if ($storage->params[$position]->promoted_property) {
+                continue;
+            }
+
             $did_match_param = false;
 
             foreach ($this->function->params as $param) {

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -2328,7 +2328,20 @@ class UnusedVariableTest extends TestCase
                         return $b;
                     }
                 '
-            ]
+            ],
+            'promotedPropertiesAreNeverMarkedAsUnusedParams' => [
+                '<?php
+                    class Container {
+                        private function __construct(
+                            public float $value
+                        ) {}
+
+                        public static function fromValue(float $value): self {
+                            return new self($value);
+                        }
+                    }
+                '
+            ],
         ];
     }
 


### PR DESCRIPTION
If anything, they should be marked as unused properties.

Fixes vimeo/psalm#4964