### PR TITLE
Add source attribute to checkstyle report

### DIFF
--- a/src/Psalm/Report/CheckstyleReport.php
+++ b/src/Psalm/Report/CheckstyleReport.php
@@ -1,8 +1,10 @@
 <?php
 namespace Psalm\Report;
 
-use function htmlspecialchars;
+use Psalm\Config;
 use Psalm\Report;
+use ReflectionClass;
+use function htmlspecialchars;
 use function sprintf;
 
 class CheckstyleReport extends Report
@@ -20,12 +22,21 @@ class CheckstyleReport extends Report
                 $issue_data->message
             );
 
+            /** @var class-string $parent_issue */
+            $parent_issue = '\Psalm\\Issue\\' . $issue_data->type;
+            $parent_issue_classname = (new ReflectionClass($parent_issue))
+                ->getParentClass()
+                ->getShortName();
+            $parent_issue_type = Config::getParentIssueType($issue_data->type) ? : $parent_issue_classname;
+            $issue_source = 'Psalm.' . $parent_issue_type . '.' . $issue_data->type;
+
             $output .= '<file name="' . htmlspecialchars($issue_data->file_name) . '">' . "\n";
             $output .= ' ';
             $output .= '<error';
             $output .= ' line="' . $issue_data->line_from . '"';
             $output .= ' column="' . $issue_data->column_from . '"';
             $output .= ' severity="' . $issue_data->severity . '"';
+            $output .= ' source="' . $issue_source . '"';
             $output .= ' message="' . htmlspecialchars($message) . '"';
             $output .= '/>' . "\n";
             $output .= '</file>' . "\n";

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -68,13 +68,13 @@ class ReportOutputTest extends TestCase
     public function analyzeTaintFlowFilesForReport() : void
     {
         $vulnerable_file_contents = '<?php
- 
+
 function addPrefixToInput($prefix, $input): string {
     return $prefix . $input;
 }
 
 $prefixedData = addPrefixToInput(\'myprefix\', $_POST[\'cmd\']);
-        
+
 shell_exec($prefixedData);
 
 echo "Successfully executed the command: " . $prefixedData;';
@@ -907,19 +907,19 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:17:6 - Possibly undefined g
             '<?xml version="1.0" encoding="UTF-8"?>
 <checkstyle>
 <file name="somefile.php">
- <error line="3" column="10" severity="error" message="UndefinedVariable: Cannot find referenced variable $as_you_____type"/>
+ <error line="3" column="10" severity="error" source="Psalm.CodeIssue.UndefinedVariable" message="UndefinedVariable: Cannot find referenced variable $as_you_____type"/>
 </file>
 <file name="somefile.php">
- <error line="3" column="10" severity="error" message="MixedReturnStatement: Could not infer a return type"/>
+ <error line="3" column="10" severity="error" source="Psalm.CodeIssue.MixedReturnStatement" message="MixedReturnStatement: Could not infer a return type"/>
 </file>
 <file name="somefile.php">
- <error line="2" column="42" severity="error" message="MixedInferredReturnType: Could not verify return type \'null|string\' for psalmCanVerify"/>
+ <error line="2" column="42" severity="error" source="Psalm.CodeIssue.MixedInferredReturnType" message="MixedInferredReturnType: Could not verify return type \'null|string\' for psalmCanVerify"/>
 </file>
 <file name="somefile.php">
- <error line="8" column="6" severity="error" message="UndefinedConstant: Const CHANGE_ME is not defined"/>
+ <error line="8" column="6" severity="error" source="Psalm.CodeIssue.UndefinedConstant" message="UndefinedConstant: Const CHANGE_ME is not defined"/>
 </file>
 <file name="somefile.php">
- <error line="17" column="6" severity="info" message="PossiblyUndefinedGlobalVariable: Possibly undefined global variable $a, first seen on line 11"/>
+ <error line="17" column="6" severity="info" source="Psalm.UndefinedGlobalVariable.PossiblyUndefinedGlobalVariable" message="PossiblyUndefinedGlobalVariable: Possibly undefined global variable $a, first seen on line 11"/>
 </file>
 </checkstyle>
 ',


### PR DESCRIPTION
CheckStyle report supports "source" attribute (example [here](https://github.com/checkstyle/checkstyle/blob/e09397dab3c24c294e7559aeb28fcd461b9cd9e1/src/test/resources/com/puppycrawl/tools/checkstyle/ant/checkstyleanttask/ExpectedCheckstyleAntTaskXmlOutput.xml#L4)).
CheckStyle parsing tools are getting category and type from the "source" attribute (Jenkins reporting [plugin](https://github.com/jenkinsci/analysis-model/blob/18a6d7cdb4fa1cb485d36a2f328667f171354102/src/main/java/edu/hm/hafner/analysis/parser/checkstyle/CheckStyleParser.java#L88-L99)).
This change will allow the reporting tools to define the meta data correctly. See the screenshot from Jenkins with applied change.
![image](https://user-images.githubusercontent.com/25210529/111365260-a81b1500-8668-11eb-8d5e-dd27a756d5a3.png)

The source is based on getParentIssueType() and falls back to Issue's parent class if parent issue type is null.