### PR TITLE
Fix BC break introduced in 4.6.3

### DIFF
--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -1,11 +1,33 @@
 <?php
 namespace Psalm;
 
+use Psalm\Internal\Analyzer\IssueData;
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\Internal\ExecutionEnvironment\BuildInfoCollector;
+use Psalm\Issue\CodeIssue;
+use Psalm\Issue\UnusedPsalmSuppress;
 use Psalm\Plugin\EventHandler\Event\AfterAnalysisEvent;
+use Psalm\Report\CheckstyleReport;
+use Psalm\Report\CodeClimateReport;
+use Psalm\Report\CompactReport;
+use Psalm\Report\ConsoleReport;
+use Psalm\Report\EmacsReport;
+use Psalm\Report\GithubActionsReport;
+use Psalm\Report\JsonReport;
+use Psalm\Report\JsonSummaryReport;
+use Psalm\Report\JunitReport;
 use Psalm\Report\PhpStormReport;
+use Psalm\Report\PylintReport;
+use Psalm\Report\SarifReport;
+use Psalm\Report\SonarqubeReport;
+use Psalm\Report\TextReport;
+use Psalm\Report\XmlReport;
+
+use function array_merge;
 use function array_pop;
 use function array_search;
 use function array_splice;
+use function array_values;
 use function count;
 use function debug_print_backtrace;
 use function dirname;
@@ -13,40 +35,20 @@ use function explode;
 use function file_put_contents;
 use function fwrite;
 use function get_class;
+use function in_array;
 use function is_dir;
 use function memory_get_peak_usage;
-use function mkdir;
 use function microtime;
+use function mkdir;
 use function number_format;
 use function ob_get_clean;
 use function ob_start;
-use function sprintf;
-use Psalm\Internal\Analyzer\IssueData;
-use Psalm\Internal\Analyzer\ProjectAnalyzer;
-use Psalm\Internal\ExecutionEnvironment\BuildInfoCollector;
-use Psalm\Issue\CodeIssue;
-use Psalm\Issue\UnusedPsalmSuppress;
-use Psalm\Report\CheckstyleReport;
-use Psalm\Report\CodeClimateReport;
-use Psalm\Report\CompactReport;
-use Psalm\Report\ConsoleReport;
-use Psalm\Report\EmacsReport;
-use Psalm\Report\GithubActionsReport;
-use Psalm\Report\SarifReport;
-use Psalm\Report\JsonReport;
-use Psalm\Report\JsonSummaryReport;
-use Psalm\Report\JunitReport;
-use Psalm\Report\PylintReport;
-use Psalm\Report\SonarqubeReport;
-use Psalm\Report\TextReport;
-use Psalm\Report\XmlReport;
 use function sha1;
+use function sprintf;
 use function str_repeat;
 use function str_replace;
 use function usort;
-use function array_merge;
-use function array_values;
-use function in_array;
+
 use const DEBUG_BACKTRACE_IGNORE_ARGS;
 use const STDERR;
 
@@ -92,6 +94,9 @@ class IssueBuffer
      * @var array<string, array<int, bool>>
      */
     protected static $used_suppressions = [];
+
+    /** @var array<array-key,mixed> */
+    private static $server = [];
 
     /**
      * @param   string[]  $suppressed_issues
@@ -441,7 +446,6 @@ class IssueBuffer
      */
     public static function finish(
         ProjectAnalyzer $project_analyzer,
-        BuildInfoCollector $build_info_collector,
         bool $is_full,
         float $start_time,
         bool $add_stats = false,
@@ -543,12 +547,13 @@ class IssueBuffer
             }
         }
 
-        $source_control_info = null;
-        $build_info = $build_info_collector->collect();
 
         if ($codebase->config->eventDispatcher->after_analysis
             || $codebase->config->eventDispatcher->legacy_after_analysis
         ) {
+            $source_control_info = null;
+            $build_info = (new BuildInfoCollector(self::$server))->collect();
+
             try {
                 $source_control_info = (new \Psalm\Internal\ExecutionEnvironment\GitInfoCollector())->collect();
             } catch (\RuntimeException $e) {
@@ -860,5 +865,14 @@ class IssueBuffer
         }
 
         self::$recorded_issues[self::$recording_level][] = $e;
+    }
+
+    /**
+     * @internal
+     * @param array<array-key,mixed> $server
+     */
+    final public static function captureServer(array $server): void
+    {
+        self::$server = $server;
     }
 }

--- a/src/psalm-refactor.php
+++ b/src/psalm-refactor.php
@@ -42,7 +42,7 @@ require_once __DIR__ . '/Psalm/Internal/ErrorHandler.php';
 require_once __DIR__ . '/command_functions.php';
 require_once __DIR__ . '/Psalm/Internal/Composer.php';
 require_once __DIR__ . '/Psalm/Internal/IncludeCollector.php';
-require_once __DIR__ . '/' . 'Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php';
+require_once __DIR__ . '/' . 'Psalm/IssueBuffer.php';
 
 (
     /** @param array<int,string> $argv */
@@ -162,7 +162,7 @@ HELP;
         $vendor_dir = \Psalm\getVendorDir($current_dir);
 
         // capture environment before registering autoloader (it may destroy it)
-        $build_info_collector = new BuildInfoCollector($_SERVER);
+        IssueBuffer::captureServer($_SERVER);
 
         $include_collector = new IncludeCollector();
         $first_autoloader = $include_collector->runAndCollect(
@@ -309,6 +309,6 @@ HELP;
 
         $project_analyzer->check($current_dir);
 
-        IssueBuffer::finish($project_analyzer, $build_info_collector, false, $start_time);
+        IssueBuffer::finish($project_analyzer, false, $start_time);
     }
 )($argv);

--- a/src/psalm.php
+++ b/src/psalm.php
@@ -6,7 +6,6 @@ use Psalm\Exception\ConfigException;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Composer;
 use Psalm\Internal\ErrorHandler;
-use Psalm\Internal\ExecutionEnvironment\BuildInfoCollector;
 use Psalm\Internal\IncludeCollector;
 use Psalm\Internal\Provider;
 use Psalm\Progress\DebugProgress;
@@ -61,7 +60,7 @@ require_once __DIR__ . '/Psalm/Internal/ErrorHandler.php';
 require_once __DIR__ . '/command_functions.php' ;
 require_once __DIR__ . '/Psalm/Internal/Composer.php';
 require_once __DIR__ . '/' . 'Psalm/Internal/IncludeCollector.php';
-require_once __DIR__ . '/' . 'Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php';
+require_once __DIR__ . '/' . 'Psalm/IssueBuffer.php';
 
 (
     /**
@@ -284,7 +283,7 @@ require_once __DIR__ . '/' . 'Psalm/Internal/ExecutionEnvironment/BuildInfoColle
         $vendor_dir = \Psalm\getVendorDir($current_dir);
 
         // capture environment before registering autoloader (it may destroy it)
-        $build_info_collector = new BuildInfoCollector($_SERVER);
+        IssueBuffer::captureServer($_SERVER);
 
         $include_collector = new IncludeCollector();
         $first_autoloader = $include_collector->runAndCollect(
@@ -842,7 +841,6 @@ require_once __DIR__ . '/' . 'Psalm/Internal/ExecutionEnvironment/BuildInfoColle
         if (!isset($options['i'])) {
             IssueBuffer::finish(
                 $project_analyzer,
-                $build_info_collector,
                 !$paths_to_check,
                 $start_time,
                 isset($options['stats']),

--- a/src/psalter.php
+++ b/src/psalter.php
@@ -53,7 +53,7 @@ require_once __DIR__ . '/Psalm/Internal/ErrorHandler.php';
 require_once __DIR__ . '/command_functions.php';
 require_once __DIR__ . '/Psalm/Internal/Composer.php';
 require_once __DIR__ . '/Psalm/Internal/IncludeCollector.php';
-require_once __DIR__ . '/' . 'Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php';
+require_once __DIR__ . '/' . 'Psalm/IssueBuffer.php';
 
 (
     /** @param array<int,string> $argv */
@@ -224,7 +224,7 @@ HELP;
         $vendor_dir = \Psalm\getVendorDir($current_dir);
 
         // capture environment before registering autoloader (it may destroy it)
-        $build_info_collector = new BuildInfoCollector($_SERVER);
+        IssueBuffer::captureServer($_SERVER);
 
         $include_collector = new IncludeCollector();
         $first_autoloader = $include_collector->runAndCollect(
@@ -515,6 +515,6 @@ HELP;
             }
         }
 
-        IssueBuffer::finish($project_analyzer, $build_info_collector, false, $start_time);
+        IssueBuffer::finish($project_analyzer, false, $start_time);
     }
 )($argv);

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -956,7 +956,7 @@ class PluginTest extends \Psalm\Tests\TestCase
 
         $this->project_analyzer->check('tests/fixtures/DummyProject', true);
         ob_start();
-        \Psalm\IssueBuffer::finish($this->project_analyzer, new BuildInfoCollector([]), true, microtime(true));
+        \Psalm\IssueBuffer::finish($this->project_analyzer, true, microtime(true));
         ob_end_clean();
     }
 

--- a/tests/IssueBufferTest.php
+++ b/tests/IssueBufferTest.php
@@ -81,7 +81,7 @@ class IssueBufferTest extends TestCase
         $projectAnalzyer->generated_report_options = [];
 
         \ob_start();
-        IssueBuffer::finish($projectAnalzyer, new BuildInfoCollector([]), false, \microtime(true), false, $baseline);
+        IssueBuffer::finish($projectAnalzyer, false, \microtime(true), false, $baseline);
         $output = \ob_get_clean();
         $this->assertStringNotContainsString("ERROR", $output, "all issues baselined");
         IssueBuffer::clear();

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -157,7 +157,7 @@ class ProjectCheckerTest extends TestCase
 
         $this->project_analyzer->check('tests/fixtures/DummyProject', true);
         ob_start();
-        \Psalm\IssueBuffer::finish($this->project_analyzer, new BuildInfoCollector([]), true, microtime(true));
+        \Psalm\IssueBuffer::finish($this->project_analyzer, true, microtime(true));
         ob_end_clean();
 
         $this->assertSame(
@@ -201,7 +201,7 @@ class ProjectCheckerTest extends TestCase
 
         $this->project_analyzer->check('tests/fixtures/DummyProject', true);
         ob_start();
-        \Psalm\IssueBuffer::finish($this->project_analyzer, new BuildInfoCollector([]), true, microtime(true));
+        \Psalm\IssueBuffer::finish($this->project_analyzer, true, microtime(true));
         ob_end_clean();
 
         $this->assertSame(

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -1053,7 +1053,7 @@ column_to: 8
         );
 
         ob_start();
-        IssueBuffer::finish($this->project_analyzer, new BuildInfoCollector([]), true, 0);
+        IssueBuffer::finish($this->project_analyzer, true, 0);
         ob_end_clean();
         $this->assertFileExists(__DIR__ . '/test-report.json');
         $this->assertSame('[]


### PR DESCRIPTION
Fixes vimeo/psalm#5405

Requires new patch release.

This PR reverts changes to the signature of `IssueBuffer::finish()` and introduces separate method to be used to capture `$_SERVER`