### PR TITLE
json_encode does not return false if JSON_THROW_ON_ERROR is in flags

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1123,7 +1123,7 @@ function json_decode(string $json, ?bool $associative = null, int $depth = 512, 
 /**
  * @psalm-pure
  *
- * @return string|false
+ * @return ($flags is 4194304 ? string : string|false)
  *
  * @psalm-flow ($value) -> return
  * @psalm-ignore-falsable-return


### PR DESCRIPTION
This fixes https://github.com/vimeo/psalm/issues/2996

A few caveats:
- JSON_THROW_ON_ERROR  appeared on PHP 7.3. If anyone push the literal 4194304 in PHP 7.2, the return type will be funky
- I didn't use int-mask because there are 29 JSON_* constants and I thought Psalm would not like that. The consequence is that if someone combine flags, The return type will go back to |false