### PR TITLE
Use appveyor reporter instead of a file upload

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,7 +57,3 @@ test_script:
     - cd c:\projects\php-project-workspace
     - vendor/bin/paratest --log-junit build/phpunit/phpunit.xml
     - php ./psalm --shepherd
-
-on_finish:
-    - ps: $wc = New-Object 'System.Net.WebClient'
-    - ps: $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\build\phpunit\phpunit.xml))

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "slevomat/coding-standard": "^6.3.11",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/process": "^4.3",
-        "weirdan/phpunit-appveyor-reporter": "dev-master",
+        "weirdan/phpunit-appveyor-reporter": "^1.0.0",
         "weirdan/prophecy-shim": "^1.0 || ^2.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "slevomat/coding-standard": "^6.3.11",
         "squizlabs/php_codesniffer": "^3.5",
         "symfony/process": "^4.3",
+        "weirdan/phpunit-appveyor-reporter": "dev-master",
         "weirdan/prophecy-shim": "^1.0 || ^2.0"
     },
     "suggest": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -48,4 +48,7 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <extensions>
+        <extension class="Weirdan\PhpUnitAppVeyorReporter\Listener"></extension>
+    </extensions>
 </phpunit>


### PR DESCRIPTION
Due to the size of the generated PHPUnit report some builds fail on AppVeyor ([example](https://ci.appveyor.com/project/muglug/psalm/builds/38298679)). This PR fixes the issue by using PHPUnit reporter that logs test results to AppVeyor via their API, in real time.