### PR TITLE
Make taint source keys unique to the added taints.

### DIFF
--- a/src/Psalm/Internal/Codebase/TaintFlowGraph.php
+++ b/src/Psalm/Internal/Codebase/TaintFlowGraph.php
@@ -441,7 +441,9 @@ class TaintFlowGraph extends DataFlowGraph
             $new_destination->specialized_calls = $generated_source->specialized_calls;
             $new_destination->path_types = array_merge($generated_source->path_types, [$path_type]);
 
-            $key = $to_id . ' ' . \json_encode($new_destination->specialized_calls);
+            $key = $to_id .
+                ' ' . \json_encode($new_destination->specialized_calls) .
+                ' ' . \json_encode($new_destination->taints);
             $new_sources[$key] = $new_destination;
         }
 

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -1116,5 +1116,30 @@ class PluginTest extends \Psalm\Tests\TestCase
         $this->project_analyzer->trackTaintedInputs();
 
         $this->analyzeFile($file_path, new Context());
+
+        $this->addFile(
+            $file_path,
+            '<?php // --taint-analysis
+
+            /**
+             * @psalm-taint-sink html $build
+             */
+            function output(array $build) {}
+
+            $build = [
+                "nested" => [
+                    "safe_key" => $_GET["input"],
+                    "a" => $_GET["input"],
+                ],
+            ];
+            output($build);'
+        );
+
+        $this->project_analyzer->trackTaintedInputs();
+
+        $this->expectException(\Psalm\Exception\CodeException::class);
+        $this->expectExceptionMessageRegExp('/TaintedHtml/');
+
+        $this->analyzeFile($file_path, new Context());
     }
 }


### PR DESCRIPTION
This issue addresses #5439 by making sources keyed on the added taints. If you remove this change, the added test should fail to demonstrate the problem.