### PR TITLE
Add proper handling of unpacked arguments with string keys

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -655,7 +655,7 @@ class ArgumentsAnalyzer
 
                         foreach ($array_key_types as $array_key) {
                             if ($array_key instanceof Type\Atomic\TLiteralInt) {
-                                if ($function_param_count > $argument_offset) {
+                                if ($function_param_count > $i) {
                                     $arg_function_params[$argument_offset][] = $function_params[$i];
                                     $i++;
                                 }

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -268,6 +268,15 @@ class ArgTest extends TestCase
                 [],
                 '8.0'
             ],
+            'useUnpackedNamedVariadicArguments' => [
+                '<?php
+                    function takesArguments(int ...$args) : void {}
+
+                    takesArguments(...["age" => 5]);',
+                [],
+                [],
+                '8.0'
+            ],
             'variadicArgsOptional' => [
                 '<?php
                     bar(...["aaaaa"]);
@@ -377,6 +386,27 @@ class ArgTest extends TestCase
                         );
                     }',
                 'error_message' => 'InvalidNamedArgument'
+            ],
+            'useUnpackedInvalidNamedArgument' => [
+                '<?php
+                    class CustomerData {
+                        public function __construct(
+                            public string $name,
+                            public string $email,
+                            public int $age,
+                        ) {}
+                    }
+
+                    /**
+                     * @param array{aage: int, name: string, email: string} $input
+                     */
+                    function foo(array $input) : CustomerData {
+                        return new CustomerData(...$input);
+                    }',
+                'error_message' => 'InvalidNamedArgument',
+                [],
+                false,
+                '8.0'
             ],
             'noNamedArgsMethod' => [
                 '<?php
@@ -499,6 +529,18 @@ class ArgTest extends TestCase
                     }
 
                     test(1, param: 2);',
+                'error_message' => 'InvalidNamedArgument',
+                [],
+                false,
+                '8.0'
+            ],
+            'overwriteOrderedWithUnpackedNamedParam' => [
+                '<?php
+                    function test(int $param, int $param2): void {
+                        echo $param + $param2;
+                    }
+
+                    test(1, ...["param" => 2]);',
                 'error_message' => 'InvalidNamedArgument',
                 [],
                 false,


### PR DESCRIPTION
Hello!

These changes solve the problems with the unpacking of arrays with string keys described in #5445.
I'm not sure if any tests are needed here. If they are required, please point me to where they need to be placed, and I will add them.

Fixes: #5445.