### PR TITLE
Add support for object-like non-empty array.

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/KeyedArrayComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/KeyedArrayComparator.php
@@ -27,6 +27,17 @@ class KeyedArrayComparator
     ) : bool {
         $all_types_contain = true;
 
+        if ($input_type_part instanceof TKeyedArray
+            && $container_type_part instanceof TKeyedArray
+            && $container_type_part->isNonEmpty()
+            && !$input_type_part->isNonEmpty()
+        ) {
+            if ($atomic_comparison_result) {
+                $atomic_comparison_result->type_coerced = true;
+            }
+            return false;
+        }
+
         foreach ($container_type_part->properties as $key => $container_property_type) {
             if (!isset($input_type_part->properties[$key])) {
                 if (!$container_property_type->possibly_undefined) {

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -1200,7 +1200,7 @@ class TypeParser
             $properties[$property_key] = $property_type;
         }
 
-        if ($type !== 'array' && $type !== 'object' && $type !== 'callable-array') {
+        if ($type !== 'array' && $type !== 'object' && $type !== 'callable-array' && $type !== 'non-empty-array') {
             throw new TypeParseTreeException('Unexpected brace character');
         }
 
@@ -1221,6 +1221,10 @@ class TypeParser
         if ($is_tuple) {
             $object_like->sealed = true;
             $object_like->is_list = true;
+        }
+
+        if ($type === 'non-empty-array') {
+            $object_like->non_empty = true;
         }
 
         return $object_like;

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1209,6 +1209,17 @@ class ArrayAssignmentTest extends TestCase
                         return $arr;
                     }',
             ],
+            'nonEmptyObjectLikeArray' => [
+                '<?php
+                    /**
+                     * @param non-empty-array{a?: string, b?: string} $arr
+                     * @return non-empty-list<string>
+                     */
+                    function foo(array $arr): array {
+                        return array_values($arr);
+                    }
+                ',
+            ],
             'unpackedArgIsList' => [
                 '<?php
                     final class Values
@@ -1744,6 +1755,23 @@ class ArrayAssignmentTest extends TestCase
                         return $arr;
                     }',
                 'error_message' => 'InvalidReturnStatement',
+            ],
+            'nonEmptyObjectLikeArrayCantBeEmpty' => [
+                '<?php
+                    /**
+                     * @param non-empty-array{a?: string, b?: string} $arr
+                     * @psalm-return list<string>
+                     */
+                    function foo($arr): array
+                    {
+                        return array_values($arr);
+                    }
+
+                    /** @var array{a?: string} */
+                    $a = [];
+                    foo($a);
+                ',
+                'error_message' => 'ArgumentTypeCoercion',
             ],
             'preventArrayAssignmentOnReturnValue' => [
                 '<?php


### PR DESCRIPTION
Object-like arrays are already considered non-empty if they have a required key, but this is useful if all of the keys are optional but at least one of them must be set.