### PR TITLE
allow dismissing return value of no-return pure functions

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -1003,7 +1003,20 @@ class FunctionCallAnalyzer extends CallAnalyzer
                 && !$context->inside_conditional
                 && !$context->inside_unset
             ) {
-                if (!$context->inside_assignment && !$context->inside_call && !$context->inside_use) {
+                /**
+                 * If a function is pure, and has the return type of 'no-return',
+                 * it's okay to dismiss it's return value.
+                 */
+                if (
+                    !$context->inside_assignment &&
+                    !$context->inside_call &&
+                    !$context->inside_use &&
+                    !(
+                        $function_call_info->function_storage &&
+                        $function_call_info->function_storage->return_type &&
+                        (array_values($function_call_info->function_storage->return_type->getAtomicTypes())[0] ?? null) instanceof Type\Atomic\TNever
+                    )
+                ) {
                     if (IssueBuffer::accepts(
                         new UnusedFunctionCall(
                             'The call to ' . $function_call_info->function_id . ' is not used',

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -753,6 +753,32 @@ class UnusedCodeTest extends TestCase
                     echo $test->id;
                     echo $test->name;'
             ],
+            'unusedNoReturnFunctionCall' => [
+                '<?php
+                    /**
+                     * @return no-return
+                     *
+                     * @pure
+                     *
+                     * @throws RuntimeException
+                     */
+                    function invariant_violation(string $message): void
+                    {
+                        throw new RuntimeException($message);
+                    }
+
+                    /**
+                     * @pure
+                     */
+                    function reverse(string $string): string
+                    {
+                        if ("" === $string) {
+                            invariant_violation("i do not like empty strings.");
+                        }
+
+                        return strrev($string);
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
refs https://github.com/azjezz/psl/pull/163

no-return function either:
1. exit
2. throw exceptions
3. run forever

in all of these cases, it's okay not to use the return value.