### PR TITLE
allow dismissing return value of pure functions with by-reference arguments

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallInfo.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallInfo.php
@@ -63,4 +63,22 @@ class FunctionCallInfo
      * @var array
      */
     public $byref_uses = [];
+
+    /**
+     * @mutation-free
+     */
+    public function hasByReferenceParameters(): bool
+    {
+        if (null === $this->function_params) {
+            return false;
+        }
+
+        foreach ($this->function_params as $value) {
+            if ($value->by_ref) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -779,6 +779,120 @@ class UnusedCodeTest extends TestCase
                         return strrev($string);
                     }'
             ],
+            'unusedByReferenceFunctionCall' => [
+                '<?php
+                    /**
+                     * @pure
+                     */
+                    function bar(string &$str): string
+                    {
+                        $str .= "foo";
+
+                        return $str;
+                    }
+
+                    /**
+                     * @pure
+                     */
+                    function baz(): string
+                    {
+                        $f = "foo";
+                        bar($f);
+
+                        return $f;
+                    }'
+            ],
+            'unusedVoidByReferenceFunctionCall' => [
+                '<?php
+                    /**
+                     * @pure
+                     */
+                    function bar(string &$str): void
+                    {
+                        $str .= "foo";
+                    }
+
+                    /**
+                     * @pure
+                     */
+                    function baz(): string
+                    {
+                        $f = "foo";
+                        bar($f);
+
+                        return $f;
+                    }'
+            ],
+            'unusedNamedByReferenceFunctionCall' => [
+                '<?php
+                    /**
+                     * @pure
+                     */
+                    function bar(string $c = "", string &$str = ""): string
+                    {
+                        $c .= $str;
+                        $str .= $c;
+
+                        return $c;
+                    }
+
+                    /**
+                     * @pure
+                     */
+                    function baz(): string
+                    {
+                        $f = "foo";
+                        bar(str: $f);
+
+                        return $f;
+                    }'
+            ],
+            'unusedNamedByReferenceFunctionCallV2' => [
+                '<?php
+                    /**
+                     * @pure
+                     */
+                    function bar(string &$st, string &$str = ""): string
+                    {
+                        $st .= $str;
+
+                        return $st;
+                    }
+
+                    /**
+                     * @pure
+                     */
+                    function baz(): string
+                    {
+                        $f = "foo";
+                        bar(st: $f);
+
+                        return $f;
+                    }',
+            ],
+            'unusedNamedByReferenceFunctionCallV3' => [
+                '<?php
+                    /**
+                     * @pure
+                     */
+                    function bar(string &$st, ?string &$str = ""): string
+                    {
+                        $st .= (string) $str;
+
+                        return $st;
+                    }
+
+                    /**
+                     * @pure
+                     */
+                    function baz(): string
+                    {
+                        $f = "foo";
+                        bar(st: $f, str: $c);
+
+                        return $f;
+                    }',
+            ]
         ];
     }
 
@@ -1092,6 +1206,54 @@ class UnusedCodeTest extends TestCase
                         return false;
                     }',
                 'error_message' => 'UnevaluatedCode',
+            ],
+            'UnusedFunctionCallWithOptionalByReferenceParameter' => [
+                '<?php
+                    /**
+                     * @pure
+                     */
+                    function bar(string $c, string &$str = ""): string
+                    {
+                        $c .= $str;
+
+                        return $c;
+                    }
+
+                    /**
+                     * @pure
+                     */
+                    function baz(): string
+                    {
+                        $f = "foo";
+                        bar($f);
+
+                        return $f;
+                    }',
+                'error_message' => 'UnusedFunctionCall',
+            ],
+            'UnusedFunctionCallWithOptionalByReferenceParameterV2' => [
+                '<?php
+                    /**
+                     * @pure
+                     */
+                    function bar(string $st, string &$str = ""): string
+                    {
+                        $st .= $str;
+
+                        return $st;
+                    }
+
+                    /**
+                     * @pure
+                     */
+                    function baz(): string
+                    {
+                        $f = "foo";
+                        bar(st: $f);
+
+                        return $f;
+                    }',
+                'error_message' => 'UnusedFunctionCall',
             ],
         ];
     }


### PR DESCRIPTION
this is another case where to makes sense to call a pure function without using it's return value
