### PR TITLE
Checks the intersection type if the magic method does not exist

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -133,7 +133,7 @@ class MissingMethodCallHandler
 
                 return null;
             }
-        } else {
+        } elseif ($all_intersection_return_type == null) {
             ArgumentsAnalyzer::analyze(
                 $statements_analyzer,
                 $stmt->args,

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -1011,4 +1011,53 @@ class MagicMethodAnnotationTest extends TestCase
 
         $this->analyzeFile('somefile.php', new Context());
     }
+
+    public function testIntersectionTypeWhenMagicMethodDoesNotExistButIsProvidedBySecondType(): void
+    {
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /** @method foo(): int */
+              class A {
+                public function __call(string $method, array $args) {}
+              }
+
+              class B {
+                public function otherMethod(): void {}
+              }
+
+              /** @var A & B $b */
+              $b = new B();
+              $b->otherMethod();
+              '
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testIntersectionTypeWhenMethodDoesNotExistOnEither(): void
+    {
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /** @method foo(): int */
+              class A {
+                public function __call(string $method, array $args) {}
+              }
+
+              class B {
+                public function otherMethod(): void {}
+              }
+
+              /** @var A & B $b */
+              $b = new B();
+              $b->nonExistantMethod();
+              '
+        );
+
+        $error_message = 'UndefinedMagicMethod';
+        $this->expectException(\Psalm\Exception\CodeException::class);
+        $this->expectExceptionMessage($error_message);
+        $this->analyzeFile('somefile.php', new Context());
+    }
 }


### PR DESCRIPTION
The original issue we had was with the type `S3Client & MockObject`. Since S3Client has magic methods, calling MockObject methods on it (->expects, ->method, etc) was failing. Using `MockObject & S3Client` would work, because the method is detected on MockObject before checking S3Client. However, an intersection type should still check both, and the order should not matter (I think). 

I think the issue is that when a magic method was detected as missing, it would stop analysis and not validate union or intersection types. The tests I added replicate the problem well, however my confidence in how I fixed it is about 10%. I would need help to validate the solution, I did this in about 15 minutes and didn't understand all the implications. At least it's a starting point! 

Thanks!