### PR TITLE
Restrict errorLevel and type attributes to valid values

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -457,12 +457,12 @@
                         <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                     </xs:choice>
 
-                    <xs:attribute name="type" type="xs:string" use="required" />
+                    <xs:attribute name="type" type="ErrorLevelType" use="required" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
-        <xs:attribute name="errorLevel" type="xs:string" />
+        <xs:attribute name="errorLevel" type="ErrorLevelType" />
     </xs:complexType>
 
     <xs:complexType name="PluginIssueHandlerType">
@@ -474,12 +474,12 @@
                         <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                     </xs:choice>
 
-                    <xs:attribute name="type" type="xs:string" use="required" />
+                    <xs:attribute name="type" type="ErrorLevelType" use="required" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
-        <xs:attribute name="errorLevel" type="xs:string" />
+        <xs:attribute name="errorLevel" type="ErrorLevelType" />
         <xs:attribute name="name" type="xs:string" use="required" />
     </xs:complexType>
 
@@ -493,12 +493,12 @@
                         <xs:element name="referencedMethod" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                     </xs:choice>
 
-                    <xs:attribute name="type" type="xs:string" use="required" />
+                    <xs:attribute name="type" type="ErrorLevelType" use="required" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
-        <xs:attribute name="errorLevel" type="xs:string" />
+        <xs:attribute name="errorLevel" type="ErrorLevelType" />
     </xs:complexType>
 
     <xs:complexType name="FunctionIssueHandlerType">
@@ -511,12 +511,12 @@
                         <xs:element name="referencedFunction" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                     </xs:choice>
 
-                    <xs:attribute name="type" type="xs:string" use="required" />
+                    <xs:attribute name="type" type="ErrorLevelType" use="required" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
-        <xs:attribute name="errorLevel" type="xs:string" />
+        <xs:attribute name="errorLevel" type="ErrorLevelType" />
     </xs:complexType>
 
     <xs:complexType name="ArgumentIssueHandlerType">
@@ -529,12 +529,12 @@
                         <xs:element name="referencedFunction" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                     </xs:choice>
 
-                    <xs:attribute name="type" type="xs:string" use="required" />
+                    <xs:attribute name="type" type="ErrorLevelType" use="required" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
-        <xs:attribute name="errorLevel" type="xs:string" />
+        <xs:attribute name="errorLevel" type="ErrorLevelType" />
     </xs:complexType>
 
     <xs:complexType name="ClassIssueHandlerType">
@@ -547,12 +547,12 @@
                         <xs:element name="referencedClass" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                     </xs:choice>
 
-                    <xs:attribute name="type" type="xs:string" use="required" />
+                    <xs:attribute name="type" type="ErrorLevelType" use="required" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
-        <xs:attribute name="errorLevel" type="xs:string" />
+        <xs:attribute name="errorLevel" type="ErrorLevelType" />
     </xs:complexType>
 
     <xs:complexType name="PropertyIssueHandlerType">
@@ -565,12 +565,12 @@
                         <xs:element name="referencedProperty" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                     </xs:choice>
 
-                    <xs:attribute name="type" type="xs:string" use="required" />
+                    <xs:attribute name="type" type="ErrorLevelType" use="required" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
-        <xs:attribute name="errorLevel" type="xs:string" />
+        <xs:attribute name="errorLevel" type="ErrorLevelType" />
     </xs:complexType>
 
     <xs:complexType name="VariableIssueHandlerType">
@@ -583,12 +583,12 @@
                         <xs:element name="referencedVariable" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
                     </xs:choice>
 
-                    <xs:attribute name="type" type="xs:string" use="required" />
+                    <xs:attribute name="type" type="ErrorLevelType" use="required" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
-        <xs:attribute name="errorLevel" type="xs:string" />
+        <xs:attribute name="errorLevel" type="ErrorLevelType" />
     </xs:complexType>
 
     <xs:complexType name="GlobalsType">
@@ -606,4 +606,12 @@
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="onlyGlobalScope" type="xs:string" />
     </xs:complexType>
+
+    <xs:simpleType name="ErrorLevelType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="error"/>
+            <xs:enumeration value="info"/>
+            <xs:enumeration value="suppress"/>
+        </xs:restriction>
+    </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
This provides better validation and autocompletion for `psalm.xml`.