### PR TITLE
Add `@ignore-var` and `@psalm-ignore-var`

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -74,7 +74,7 @@ When specifying types in a format not supported by phpDocumentor ([but supported
 
 ### `@psalm-ignore-var`
 
-This annotation is used to ignore the `@var` annotation written in the same docblock. Some IDEs don't fully understand complex types like generics. To take advantage of such IDE's auto-completion, you may sometimes want to use explicit `@var` annotations even when psalm can infer the type well enough. This weakens the effectiveness of type checking in many cases since the explicit `@var` annotation overrides the types inferred by psalm. As psalm ignores the `@var` annotation which is co-located with `@psalm-ignore-var`, IDEs can use the type specified by the `@var` for auto-completion, while psalm can still use its own inferred type for type checking.
+This annotation is used to ignore the `@var` annotation written in the same docblock. Some IDEs don't fully understand complex types like generics. To take advantage of such IDE's auto-completion, you may sometimes want to use explicit `@var` annotations even when psalm can infer the type just fine. This weakens the effectiveness of type checking in many cases since the explicit `@var` annotation overrides the types inferred by psalm. As psalm ignores the `@var` annotation which is co-located with `@psalm-ignore-var`, IDEs can use the type specified by the `@var` for auto-completion, while psalm can still use its own inferred type for type checking.
 
 ```php
 <?php

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -72,6 +72,30 @@ function addFoo(?string &$s) : void {
 
 When specifying types in a format not supported by phpDocumentor ([but supported by Psalm](#type-syntax)) you may wish to prepend `@psalm-` to the PHPDoc tag, so as to avoid confusing your IDE. If a `@psalm`-prefixed tag is given, Psalm will use it in place of its non-prefixed counterpart.
 
+### `@psalm-ignore-var`
+
+This annotation is used to ignore the `@var` annotation written in the same docblock. Some IDEs don't fully understand complex types like generics. To take advantage of such IDE's auto-completion, you may sometimes want to use explicit `@var` annotations even when psalm can infer the type well enough. This weakens the effectiveness of type checking in many cases since the explicit `@var` annotation overrides the types inferred by psalm. As psalm ignores the `@var` annotation which is co-located with `@psalm-ignore-var`, IDEs can use the type specified by the `@var` for auto-completion, while psalm can still use its own inferred type for type checking.
+
+```php
+<?php
+/** @return iterable<array-key,\DateTime> $f */
+function getTimes(int $n): iterable {
+    while ($n--) {
+        yield new \DateTime();
+    }
+};
+/**
+ * @var \Datetime[] $times
+ * @psalm-ignore-var
+ */
+$times = getTimes(3);
+// this trace shows "iterable<array-key, DateTime>" instead of "array<array-key, Datetime>"
+/** @psalm-trace $times */
+foreach ($times as $time) {
+    echo $time->format('Y-m-d H:i:s.u') . PHP_EOL;
+}
+```
+
 ### `@psalm-suppress SomeIssueName`
 
 This annotation is used to suppress issues. It can be used in function docblocks, class docblocks and also inline, applying to the following statement.

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -35,7 +35,7 @@ class DocComment
         'allow-private-mutation', 'readonly-allow-private-mutation',
         'yield', 'trace', 'import-type', 'flow', 'taint-specialize', 'taint-escape',
         'taint-unescape', 'self-out', 'consistent-constructor', 'stub-override',
-        'require-extends', 'require-implements', 'param-out'
+        'require-extends', 'require-implements', 'param-out', 'ignore-var'
     ];
 
     /**

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -228,10 +228,14 @@ class DocblockParser
             || isset($docblock->tags['psalm-var'])
             || isset($docblock->tags['phpstan-var'])
         ) {
-            $docblock->combined_tags['var']
-                = ($docblock->tags['var'] ?? [])
-                + ($docblock->tags['phpstan-var'] ?? [])
-                + ($docblock->tags['psalm-var'] ?? []);
+            if (!isset($docblock->tags['ignore-var'])
+                && !isset($docblock->tags['psalm-ignore-var'])
+            ) {
+                $docblock->combined_tags['var']
+                    = ($docblock->tags['var'] ?? [])
+                    + ($docblock->tags['phpstan-var'] ?? [])
+                    + ($docblock->tags['psalm-var'] ?? []);
+            }
         }
 
         if (isset($docblock->tags['param-out'])

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -350,6 +350,30 @@ class AnnotationTest extends TestCase
 
                     $a[0]->getMessage();',
             ],
+            'ignoreVarDocblock' => [
+                '<?php
+                    /**
+                     * @var array<Exception>
+                     * @ignore-var
+                     */
+                    $a = [];
+
+                    $a[0]->getMessage();',
+                'assertions' => [],
+                'error_level' => ['EmptyArrayAccess', 'MixedMethodCall'],
+            ],
+            'psalmIgnoreVarDocblock' => [
+                '<?php
+                    /**
+                     * @var array<Exception>
+                     * @psalm-ignore-var
+                     */
+                    $a = [];
+
+                    $a[0]->getMessage();',
+                'assertions' => [],
+                'error_level' => ['EmptyArrayAccess', 'MixedMethodCall'],
+            ],
             'mixedDocblockParamTypeDefinedInParent' => [
                 '<?php
                     class A {


### PR DESCRIPTION
This annotation is used to ignore the `@var` annotation written in the same docblock.

## Background
To take advantage of the IDE's auto-completion, you may sometimes want to use explicit `@var` annotations even when psalm can infer the type well enough. This weakens the effectiveness of type checking in many cases since the explicit `@var` annotation overrides the types inferred by psalm.

See this example for more detail.
https://psalm.dev/r/c19d749dbe

## What is changed if this PR is merged
Psalm ignores the `@var` annotation which is co-located with `@psalm-ignore-var`. Then IDEs that don't fully understand complex types like generics can use the manually specified types with `@var` for auto-completion, while psalm can still use its own inferred types for type checking.

## Disclaimer
I'm not confident about my English skills. The sentences may seem odd to you. I know you aren't my English teacher, but if any wordings of the added doc or this PR sounds unnatural, please feel free to correct them. Then I can train myself better.
