### PR TITLE
Add the Psalm badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Packagist](https://img.shields.io/packagist/dt/vimeo/psalm.svg)](https://packagist.org/packages/vimeo/psalm)
 [![Coverage Status](https://coveralls.io/repos/github/vimeo/psalm/badge.svg)](https://coveralls.io/github/vimeo/psalm)
 ![Psalm coverage](https://shepherd.dev/github/vimeo/psalm/coverage.svg?)
-
+[![Psalm Enabled](https://img.shields.io/badge/Psalm-enabled-brightgreen.svg?style=flat)](https://psalm.dev/)
 
 Psalm is a static analysis tool for finding errors in PHP applications.
 


### PR DESCRIPTION
HI,

I'd like to put a badge on my project that shows at a glance that Psalm is enabled.

How about adding it to the README as a template for others to copy and paste into their projects, like PHPStan?

[![Psalm Enabled](https://img.shields.io/badge/Psalm-enabled-brightgreen.svg?style=flat)](https://psalm.dev/)

Others can generate whatever they like:
```
https://img.shields.io/badge/Psalm-level%201-brightgreen.svg?style=flat
```
[![Psalm Enabled](https://img.shields.io/badge/Psalm-level%201-brightgreen.svg?style=flat)](https://psalm.dev/)