### PR TITLE
Do not let string subtypes subsume class-strings

### DIFF
--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -47,6 +47,7 @@ use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\Atomic\TTraitString;
 use Psalm\Type\Atomic\TTrue;
 use Psalm\Type\Union;
+
 use function array_filter;
 use function array_intersect_key;
 use function array_keys;
@@ -280,7 +281,10 @@ class TypeCombiner
                 }
             }
 
-            if (!isset($combination->value_types['string'])) {
+            $has_non_specific_string = isset($combination->value_types['string'])
+                && get_class($combination->value_types['string']) === Type\Atomic\TString::class;
+
+            if (!$has_non_specific_string) {
                 $object_type = self::combine(
                     array_values($combination->class_string_types),
                     $codebase

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -479,6 +479,34 @@ class TypeCombinationTest extends TestCase
                     'Exception::class',
                 ],
             ],
+            'combineClassStringWithNumericString' => [
+                'class-string|numeric-string',
+                [
+                    'class-string',
+                    'numeric-string',
+                ],
+            ],
+            'combineRefinedClassStringWithNumericString' => [
+                'class-string<Exception>|numeric-string',
+                [
+                    'class-string<Exception>',
+                    'numeric-string',
+                ],
+            ],
+            'combineClassStringWithTraitString' => [
+                'class-string|trait-string',
+                [
+                    'class-string',
+                    'trait-string',
+                ],
+            ],
+            'combineRefinedClassStringWithTraitString' => [
+                'class-string<Exception>|trait-string',
+                [
+                    'class-string<Exception>',
+                    'trait-string',
+                ],
+            ],
             'combineCallableAndCallableString' => [
                 'callable',
                 [


### PR DESCRIPTION
Previously, Psalm would treat unions like `class-string|numeric-string` as `numeric-string`, while the only case when string should subsume`class-string` is when we're combining `class-string` with non-specific `string`.

Fixes vimeo/psalm#5491