### PR TITLE
Forbid template annotation on closures

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -455,6 +455,18 @@ class FunctionLikeNodeScanner
                     }
                 }
 
+                if ($stmt instanceof PhpParser\Node\Expr\Closure
+                    || $stmt instanceof PhpParser\Node\Expr\ArrowFunction
+                ) {
+                    if ($docblock_info->templates !== []) {
+                        $docblock_info->templates = [];
+                        $storage->docblock_issues[] = new InvalidDocblock(
+                            'Templated closures are not supported',
+                            new CodeLocation($this->file_scanner, $stmt, null, true)
+                        );
+                    }
+                }
+
                 FunctionLikeDocblockScanner::addDocblockInfo(
                     $this->codebase,
                     $this->file_scanner,

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -926,6 +926,23 @@ class ClosureTest extends TestCase
                 false,
                 '7.4'
             ],
+            'forbidTemplateAnnotationOnClosure' => [
+                '<?php
+                    /** @template T */
+                    function (): void {};
+                ',
+                'error_message' => 'InvalidDocblock',
+            ],
+            'forbidTemplateAnnotationOnShortClosure' => [
+                '<?php
+                    /** @template T */
+                    fn(): bool => false;
+                ',
+                'error_message' => 'InvalidDocblock',
+                [],
+                false,
+                '7.4'
+            ],
         ];
     }
 }


### PR DESCRIPTION
They don't work properly anyway.

Fixes vimeo/psalm#5472