### PR TITLE
Double directory separator on "Cannot resolve stubfile path"

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -961,7 +961,7 @@ class Config
 
                 if (!$file_path) {
                     throw new Exception\ConfigException(
-                        'Cannot resolve stubfile path ' . $config->base_dir . DIRECTORY_SEPARATOR . $stub_file['name']
+                        'Cannot resolve stubfile path ' . $config->base_dir . $stub_file['name']
                     );
                 }
 


### PR DESCRIPTION
Error message says
```
Problem parsing /Users/m/projects/project/psalm.xml:
  Cannot resolve stubfile path /Users/m/projects/project//stubs/ActiveDataProvider.phpstub
```
Notice the double slash at the second line. The message is correct, the file does not exist but in this case it is caused by different file extension not by psalm using incorrect path.