### PR TITLE
Marked iterator_to_array as an impure function

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -472,7 +472,7 @@ class Functions
             'ldap_set_option',
 
             // iterators
-            'rewind', 'iterator_apply',
+            'rewind', 'iterator_apply', 'iterator_to_array',
 
             // mysqli
             'mysqli_select_db', 'mysqli_dump_debug_info', 'mysqli_kill', 'mysqli_multi_query',

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -793,7 +793,6 @@ class ConditionalReturnTypeTest extends TestCase
             'conditionalArrayValues' => [
                 '<?php
                     /**
-                     * @psalm-pure
                      * @template TValue
                      * @template TIterable of ?iterable<TValue>
                      * @param TIterable $iterable


### PR DESCRIPTION
`iterator_to_array` can be used to traverse a generator with side effects, for instance.