### PR TITLE
fix: declare that php 7.3 is minimum level required

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "^7.1|^8",
+        "php": "^7.3|^8",
         "ext-SimpleXML": "*",
         "ext-dom": "*",
         "ext-json": "*",


### PR DESCRIPTION
I upgraded to psalm 4 and realized that php 7.3 is now required (per the release notes https://github.com/vimeo/psalm/releases/tag/4.0.0)

> It bumps the minimum requirement to PHP 7.3.