### PR TITLE
ConcatAnalyzer improvements and non-falsy-string fixes.

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -51,10 +51,12 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
      */
     public function getClosureId(): string
     {
-        return strtolower($this->getFilePath())
-            . ':' . $this->function->getLine()
-            . ':' . (int)$this->function->getAttribute('startFilePos')
-            . ':-:closure';
+        return strtolower(
+            $this->getFilePath()
+                . ':' . $this->function->getLine()
+                . ':' . (int)$this->function->getAttribute('startFilePos')
+                . ':-:closure'
+        );
     }
 
     /**

--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -51,12 +51,10 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
      */
     public function getClosureId(): string
     {
-        return strtolower(
-            $this->getFilePath()
-                . ':' . $this->function->getLine()
-                . ':' . (int)$this->function->getAttribute('startFilePos')
-                . ':-:closure'
-        );
+        return strtolower($this->getFilePath())
+            . ':' . $this->function->getLine()
+            . ':' . (int)$this->function->getAttribute('startFilePos')
+            . ':-:closure';
     }
 
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
@@ -157,7 +157,7 @@ class StaticPropertyAssignmentAnalyzer
 
                             $file_manipulations = [];
 
-                            if (strtolower($new_fq_class_name) !== strtolower($old_declaring_fq_class_name)) {
+                            if (strtolower($new_fq_class_name) !== $old_declaring_fq_class_name) {
                                 $file_manipulations[] = new \Psalm\FileManipulation(
                                     (int) $stmt->class->getAttribute('startFilePos'),
                                     (int) $stmt->class->getAttribute('endFilePos') + 1,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -144,10 +144,10 @@ class ConcatAnalyzer
             // If one of the types is a single int or string literal, and the other
             // type is all string or int literals, combine them into new literal(s).
             $literal_concat = false;
-            if (($left_type->isSingleStringLiteral() || $left_type->isSingleIntLiteral())
-                && ($right_type->allStringLiterals() || $right_type->allIntLiterals())
-                || ($right_type->isSingleStringLiteral() || $right_type->isSingleIntLiteral())
-                && ($left_type->allStringLiterals() || $left_type->allIntLiterals())
+            if ((($left_type->isSingleStringLiteral() || $left_type->isSingleIntLiteral())
+                    && ($right_type->allStringLiterals() || $right_type->allIntLiterals()))
+                || (($right_type->isSingleStringLiteral() || $right_type->isSingleIntLiteral())
+                    && ($left_type->allStringLiterals() || $left_type->allIntLiterals()))
             ) {
                 $literal_concat = true;
                 $result_type_parts = [];

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -171,13 +171,13 @@ class ConcatAnalyzer
             }
 
             if (!$literal_concat) {
-                $left_numeric_type = Type::getNumericString();
-                $left_numeric_type->addType(new Type\Atomic\TInt());
-                $left_numeric_type->addType(new Type\Atomic\TFloat());
+                $numeric_type = Type::getNumericString();
+                $numeric_type->addType(new Type\Atomic\TInt());
+                $numeric_type->addType(new Type\Atomic\TFloat());
                 $left_is_numeric = UnionTypeComparator::isContainedBy(
                     $codebase,
                     $left_type,
-                    $left_numeric_type
+                    $numeric_type
                 );
                 $right_numeric_type = Type::getPositiveInt();
                 $right_numeric_type->addType(new Type\Atomic\TLiteralInt(0));
@@ -187,15 +187,17 @@ class ConcatAnalyzer
                     $right_numeric_type
                 );
 
+                $lowercase_type = clone $numeric_type;
+                $lowercase_type->addType(new Type\Atomic\TLowercaseString());
                 $left_is_lowercase = UnionTypeComparator::isContainedBy(
                     $codebase,
                     $left_type,
-                    Type::getLowercaseString()
+                    $lowercase_type
                 );
                 $right_is_lowercase = UnionTypeComparator::isContainedBy(
                     $codebase,
                     $right_type,
-                    Type::getLowercaseString()
+                    $lowercase_type
                 );
 
                 $left_is_non_empty = UnionTypeComparator::isContainedBy(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
@@ -292,7 +292,7 @@ class StaticPropertyFetchAnalyzer
 
                         $file_manipulations = [];
 
-                        if (strtolower($new_fq_class_name) !== strtolower($old_declaring_fq_class_name)) {
+                        if (strtolower($new_fq_class_name) !== $old_declaring_fq_class_name) {
                             $file_manipulations[] = new \Psalm\FileManipulation(
                                 (int) $stmt->class->getAttribute('startFilePos'),
                                 (int) $stmt->class->getAttribute('endFilePos') + 1,

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -259,14 +259,14 @@ class ScalarTypeComparator
             return true;
         }
 
-        if ($container_type_part instanceof TNonEmptyString
+        if (get_class($container_type_part) === TNonEmptyString::class
             && $input_type_part instanceof TNonFalsyString
         ) {
             return true;
         }
 
         if ($container_type_part instanceof TNonFalsyString
-            && get_class($input_type_part) === TNonEmptyString::class
+            && $input_type_part instanceof TNonEmptyString
         ) {
             if ($atomic_comparison_result) {
                 $atomic_comparison_result->type_coerced = true;

--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -1068,12 +1068,12 @@ class TypeCombiner
                                 || get_class($type) === TNonFalsyString::class)
                             && get_class($combination->value_types['string']) === TNonEmptyLowercaseString::class
                         ) {
-                            $combination->value_types['string'] = $type;
+                            $combination->value_types['string'] = new TNonEmptyString();
                         } elseif ((get_class($combination->value_types['string']) === TNonEmptyString::class
                                 || get_class($combination->value_types['string']) === TNonFalsyString::class)
                             && get_class($type) === TNonEmptyLowercaseString::class
                         ) {
-                            //no-change
+                            $combination->value_types['string'] = new TNonEmptyString();
                         } elseif (get_class($type) === TLowercaseString::class
                             && get_class($combination->value_types['string']) === TNonEmptyLowercaseString::class
                         ) {

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -28,8 +28,11 @@ use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNonEmptyLowercaseString;
+use Psalm\Type\Atomic\TNonEmptyString;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TNumeric;
 use Psalm\Type\Atomic\TNumericString;
@@ -174,12 +177,33 @@ abstract class Type
         return $union;
     }
 
+    public static function getLowercaseString(): Union
+    {
+        $type = new TLowercaseString();
+
+        return new Union([$type]);
+    }
+
     public static function getPositiveInt(bool $from_calculation = false): Union
     {
         $union = new Union([new Type\Atomic\TPositiveInt()]);
         $union->from_calculation = $from_calculation;
 
         return $union;
+    }
+
+    public static function getNonEmptyLowercaseString(): Union
+    {
+        $type = new TNonEmptyLowercaseString();
+
+        return new Union([$type]);
+    }
+
+    public static function getNonEmptyString(): Union
+    {
+        $type = new TNonEmptyString();
+
+        return new Union([$type]);
     }
 
     public static function getNumeric(): Union

--- a/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
@@ -4,7 +4,7 @@ namespace Psalm\Type\Atomic;
 /**
  * Denotes a non-empty-string where every character is lowercased. (which can also result from a `strtolower` call).
  */
-class TNonEmptyLowercaseString extends TNonFalsyString
+class TNonEmptyLowercaseString extends TNonEmptyString
 {
     public function getKey(bool $include_extra = true): string
     {

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -650,6 +650,24 @@ class ArgTest extends TestCase
                 ',
                 'error_message' => 'InvalidArgument',
             ],
+            'numericStringIsNotNonFalsy' => [
+                '<?php
+                    /** @param non-falsy-string $arg */
+                    function foo(string $arg): string
+                    {
+                        return $arg;
+                    }
+
+                    /** @return numeric-string */
+                    function bar(): string
+                    {
+                        return "0";
+                    }
+
+                    foo(bar());
+                ',
+                'error_message' => 'ArgumentTypeCoercion',
+            ],
         ];
     }
 }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -257,6 +257,24 @@ class BinaryOperationTest extends TestCase
                     foo(-123.456 . 789);
                 ',
             ],
+            'concatenateIntIsLowercase' => [
+                '<?php
+                    /**
+                     * @param non-empty-lowercase-string $bar
+                     * @return non-empty-lowercase-string
+                     */
+                    function foobar(string $bar): string
+                    {
+                        return $bar;
+                    }
+
+                    /** @var lowercase-string */
+                    $foo = "abc";
+                    /** @var int */
+                    $bar = 123;
+                    foobar($foo . $bar);
+                ',
+            ],
             'possiblyInvalidAdditionOnBothSides' => [
                 '<?php
                     function foo(string $s) : int {

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1553,6 +1553,15 @@ class FunctionCallTest extends TestCase
                     '$a' => 'DateTimeImmutable|float',
                 ],
             ],
+            'strtolowerEmptiness' => [
+                '<?php
+                    /** @param non-empty-string $s */
+                    function foo(string $s) : void {
+                        $s = strtolower($s);
+
+                        foo($s);
+                    }',
+            ],
         ];
     }
 
@@ -2036,16 +2045,6 @@ class FunctionCallTest extends TestCase
                         return "";
                     }',
                 'error_message' => 'PossiblyUndefinedArrayOffset',
-            ],
-            'strtolowerEmptiness' => [
-                '<?php
-                    /** @param non-empty-string $s */
-                    function foo(string $s) : void {
-                        $s = strtolower($s);
-
-                        if ($s) {}
-                    }',
-                'error_message' => 'RedundantConditionGivenDocblockType',
             ],
             'strposNoSetFirstParam' => [
                 '<?php

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -714,6 +714,13 @@ class TypeCombinationTest extends TestCase
                     'non-empty-string'
                 ]
             ],
+            'combineNonEmptyLowercaseAndNonFalsyString' => [
+                'non-empty-string',
+                [
+                    'non-falsy-string',
+                    'non-empty-lowercase-string',
+                ]
+            ],
         ];
     }
 


### PR DESCRIPTION
Deduplicate code.
Improve type inference.
Allow literal type inference when only one side has multiple types (fixes #5483).
Fix invalid type inference with negative int as right operand.