### PR TITLE
Proposal: Type Constraints

### DIFF
--- a/src/Psalm/Exception/InvalidConstraintException.php
+++ b/src/Psalm/Exception/InvalidConstraintException.php
@@ -1,0 +1,6 @@
+<?php
+namespace Psalm\Exception;
+
+class InvalidConstraintException extends \Exception
+{
+}

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -53,6 +53,20 @@ class ScalarTypeComparator
         bool $allow_float_int_equality = true,
         ?TypeComparisonResult $atomic_comparison_result = null
     ) : bool {
+        // I'm thinking about replacing TypeComparators with Atomic::isSupertypeOf and
+        // Atomic::isSubtypeOf, but that can be done separately from type constraints.
+        if ($container_type_part instanceof TInt
+            && $input_type_part instanceof TInt
+        ) {
+            return $container_type_part->isSupertypeOf(
+                $input_type_part,
+                $codebase,
+                $allow_interface_equality,
+                $allow_float_int_equality,
+                $atomic_comparison_result
+            );
+        }
+
         if ($container_type_part instanceof TNonEmptyString
             && get_class($input_type_part) === TString::class
         ) {

--- a/src/Psalm/Internal/Type/ParseTree/ConstrainedTypeTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/ConstrainedTypeTree.php
@@ -1,0 +1,21 @@
+<?php
+namespace Psalm\Internal\Type\ParseTree;
+
+/**
+ * @internal
+ */
+class ConstrainedTypeTree extends \Psalm\Internal\Type\ParseTree
+{
+    /**
+     * @var string
+     */
+    public $type;
+
+    public function __construct(
+        string $type,
+        ?\Psalm\Internal\Type\ParseTree $parent = null
+    ) {
+        $this->type = $type;
+        $this->parent = $parent;
+    }
+}

--- a/src/Psalm/Internal/Type/ParseTree/TypeConstraintTree.php
+++ b/src/Psalm/Internal/Type/ParseTree/TypeConstraintTree.php
@@ -1,0 +1,18 @@
+<?php
+namespace Psalm\Internal\Type\ParseTree;
+
+/**
+ * @internal
+ */
+class TypeConstraintTree extends \Psalm\Internal\Type\ParseTree
+{
+    /**
+     * @var string|null
+     */
+    public $name;
+
+    /**
+     * @var \Psalm\Internal\Type\ParseTree|null
+     */
+    public $value_tree;
+}

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -98,6 +98,8 @@ class TypeTokenizer
      */
     public static function tokenize(string $string_type, bool $ignore_space = true): array
     {
+        // TODO handle int(min max=5) correctly
+        // (should be [..., 'min', ' ', 'max', ...] or [..., 'min', 'max', ...], not [..., 'minmax', ...])
         $type_tokens = [['', 0]];
         $was_char = false;
         $quote_char = null;

--- a/src/Psalm/Type/Atomic/IConstrainableType.php
+++ b/src/Psalm/Type/Atomic/IConstrainableType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Psalm\Type\Atomic;
+
+use Psalm\Exception\InvalidConstraintException;
+
+interface IConstrainableType
+{
+    /**
+     * @param mixed $value
+     * @throws InvalidConstraintException
+     */
+    public function setConstraint(?string $name, $value): void;
+}

--- a/src/Psalm/Type/Atomic/TInt.php
+++ b/src/Psalm/Type/Atomic/TInt.php
@@ -1,11 +1,32 @@
 <?php
 namespace Psalm\Type\Atomic;
 
+use Psalm\Codebase;
+use Psalm\Exception\InvalidConstraintException;
+use Psalm\Internal\Type\Comparator\TypeComparisonResult;
+use Psalm\Type\Atomic;
+use function implode;
+use function is_int;
+
 /**
  * Denotes the `int` type, where the exact value is unknown.
  */
-class TInt extends Scalar
+class TInt extends Scalar implements IConstrainableType
 {
+    /**
+     * Minimum allowed value
+     *
+     * @var int|null
+     */
+    public $min;
+
+    /**
+     * Maximum allowed value
+     *
+     * @var int|null
+     */
+    public $max;
+
     public function __toString(): string
     {
         return 'int';
@@ -14,6 +35,27 @@ class TInt extends Scalar
     public function getKey(bool $include_extra = true): string
     {
         return 'int';
+    }
+
+    public function getId(bool $nested = false): string
+    {
+        if ($this->min === null && $this->max === null) {
+            return 'int';
+        }
+
+        if ($this->min === $this->max) {
+            // Literal int
+            return (string) $this->min;
+        }
+
+        $constraints = [];
+        if ($this->min !== null) {
+            $constraints[] = 'min=' . $this->min;
+        }
+        if ($this->max !== null) {
+            $constraints[] = 'max=' . $this->max;
+        }
+        return 'int(' . implode(', ', $constraints) . ')';
     }
 
     /**
@@ -27,5 +69,64 @@ class TInt extends Scalar
         int $php_minor_version
     ): ?string {
         return $php_major_version >= 7 ? 'int' : null;
+    }
+
+    /**
+     * @param mixed $value
+     */
+    public function setConstraint(?string $name, $value): void
+    {
+        if (!is_int($value)) {
+            throw new InvalidConstraintException("int $name constraint must be an integer");
+        }
+        if ($name === null) {
+            $this->min = $this->max = $value;
+        } elseif ($name === 'min') {
+            $this->min = $value;
+        } elseif ($name === 'max') {
+            $this->max = $value;
+        } else {
+            throw new InvalidConstraintException("int doesn't have constraint $name");
+        }
+    }
+
+    public function isSupertypeOf(
+        Atomic $other,
+        Codebase $_codebase,
+        bool $_allow_interface_equality = false,
+        bool $_allow_float_int_equality = true,
+        ?TypeComparisonResult $type_comparison_result = null
+    ): bool {
+        if (!$other instanceof TInt) {
+            return false;
+        }
+        if ($other instanceof TLiteralInt) {
+            $other->min = $other->max = $other->value;
+        }
+        if ($this instanceof TLiteralInt) {
+            $this->min = $this->max = $this->value;
+        }
+        if ($other instanceof TPositiveInt) {
+            $other->min = 1;
+        }
+        if ($this instanceof TPositiveInt) {
+            $this->min = 1;
+        }
+
+        if (($this->min === null || $other->min !== null && $this->min <= $other->min)
+            && ($this->max === null || $other->max !== null && $this->max >= $other->max)
+        ) {
+            return true;
+        }
+
+        if ($type_comparison_result
+            // A literal can't be coerced to another literal
+            && !($this instanceof TLiteralInt && $other instanceof TLiteralInt)
+        ) {
+            $type_comparison_result->type_coerced = true;
+            $type_comparison_result->type_coerced_from_scalar = true;
+        }
+
+        return false;
     }
 }

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -270,6 +270,7 @@ class Union implements TypeNode
             }
         } elseif ($type instanceof TInt && $this->literal_int_types) {
             foreach ($this->literal_int_types as $key => $_) {
+                // TODO respect min/max
                 unset($this->literal_int_types[$key], $this->types[$key]);
             }
         } elseif ($type instanceof TFloat && $this->literal_float_types) {

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -668,6 +668,21 @@ class ArgTest extends TestCase
                 ',
                 'error_message' => 'ArgumentTypeCoercion',
             ],
+            'intConstraintCoercion' => [
+                '<?php
+                    /** @param int(min=2, max=4) $bar */
+                    function foo(int $bar): int
+                    {
+                        return [
+                            2 => 4,
+                            3 => 9,
+                            4 => 16,
+                        ][$bar];
+                    }
+                    foo(6);
+                ',
+                'error_message' => 'ArgumentTypeCoercion',
+            ],
         ];
     }
 }


### PR DESCRIPTION
This is a **very early** rough draft to get feedback on the idea, half of it isn't even implemented.

I've been thinking about trying to generalize some of psalm's types. Instead of having TPositiveInt we could have an int that has arbitrary min and max, written as `int(min=1)` (equivalent to `positive-int`) or `int(min=10, max=20)`.

This could also be useful to simplify and allow more specific string types. Leaving out class/trait and literal strings, we have:

 - `numeric-string`
 - `callable-string`
 - `non-empty-string`
 - `non-falsy-string`
 - `lowercase-string`
 - `non-empty-lowercase-string`
 - `html-escaped-string`

But what about `non-falsy-lowercase-string`, `lowercase-callable-string`, etc?
This could be implemented as `string(non-falsy, lowercase)` and `string(lowercase, callable)` instead.
Some of these might still be easier to have a separate `T...String` class for, but they could still have the constraints since they'd inherit from `TString`.

We could also have `string(minlen=5, maxlen=10)` instead of `non-empty-string`, and `array(minlen=5, maxlen=10)` instead of `non-empty-array` (and list).

Interactions need to be accounted for of course, `int(min=100, max=200) / int(min=5, max=10)` results in `int(min=10, max=40)`, and `string(callable, lowercase) . string(numeric)` results in `string(lowercase)` (numeric string should probably be a separate class that is always lowercase).

I'm not really set on calling this feature "Type Constraints", since Unions in general can be considered type constraints, but I haven't thought of anything better yet. (Edit: maybe Type Attributes?)