### PR TITLE
Added TValue template to PDOStatement stub

### DIFF
--- a/stubs/pdo.phpstub
+++ b/stubs/pdo.phpstub
@@ -1,6 +1,12 @@
 <?php
 
-class PdoStatement implements Traversable {
+/**
+ * @template TValue
+ *
+ * @template-implements Traversable<int, TValue>
+ */
+class PDOStatement implements Traversable
+{
     /**
      * @psalm-taint-sink callable $class
      *


### PR DESCRIPTION
Makes sense in this case, for example:

```php
/** @var PDOStatement<array{question_id: string, title: string}> */
$questions = $pdo->query(
    <<<'SQL'
        select question_id, title
        from question_view
        SQL,
    PDO::FETCH_ASSOC,
);
```