### PR TITLE
Add ReflectionProperty::getType() and hasType()

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -11564,6 +11564,7 @@ return [
 'ReflectionProperty::getName' => ['string'],
 'ReflectionProperty::getType' => ['?ReflectionType'],
 'ReflectionProperty::getValue' => ['mixed', 'object='=>'object'],
+'ReflectionProperty::hasType' => ['bool'],
 'ReflectionProperty::isDefault' => ['bool'],
 'ReflectionProperty::isPrivate' => ['bool'],
 'ReflectionProperty::isProtected' => ['bool'],

--- a/stubs/Reflection.phpstub
+++ b/stubs/Reflection.phpstub
@@ -76,6 +76,18 @@ class ReflectionProperty implements Reflector
      * @return array<ReflectionAttribute<TClass>>
      */
     public function getAttributes(?string $name = null, int $flags = 0): array {}
+
+    /**
+     * @since 7.4
+     * @psalm-assert-if-true ReflectionType $this->getType()
+     */
+    public function hasType() : bool {}
+
+    /**
+     * @since 7.4
+     * @psalm-mutation-free
+     */
+    public function getType() : ?ReflectionType {}
 }
 
 class ReflectionMethod implements Reflector

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -1509,6 +1509,19 @@ class AssertAnnotationTest extends TestCase
                      */
                     function allIsInstanceOf($value, $class): void {}'
             ],
+            'implicitReflectionPropertyAssertion' => [
+                '<?php
+                    $class = new ReflectionClass(stdClass::class);
+                    $properties = $class->getProperties();
+                    foreach ($properties as $property) {
+                        if ($property->hasType()) {
+                            $property->getType()->allowsNull();
+                        }
+                    }',
+                    [],
+                    [],
+                    '7.4'
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR tries to do as https://github.com/vimeo/psalm/commit/c97ee5ccdb75c85bc9f6285bfe2cb7a2fb1b50dc for [`ReflectionProperty`](https://www.php.net/manual/en/class.reflectionproperty.php) adding [`ReflectionProperty::hasType()`](https://www.php.net/manual/en/reflectionproperty.hastype.php) and [`ReflectionProperty::getType()`](https://www.php.net/manual/en/reflectionproperty.gettype.php).

Right now: https://psalm.dev/r/b00d652573