### PR TITLE
Improve type resolution of class constants.

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -1495,14 +1495,12 @@ class ClassLikes
         }
 
         if ($constant_storage->unresolved_node) {
-            return new Type\Union([
-                ConstantTypeResolver::resolve(
-                    $this,
-                    $constant_storage->unresolved_node,
-                    $statements_analyzer,
-                    $visited_constant_ids
-                )
-            ]);
+            $constant_storage->type = new Type\Union([ConstantTypeResolver::resolve(
+                $this,
+                $constant_storage->unresolved_node,
+                $statements_analyzer,
+                $visited_constant_ids
+            )]);
         }
 
         return $constant_storage->type;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
@@ -15,6 +15,7 @@ use Psalm\Codebase;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Scanner\UnresolvedConstant;
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;
+use function assert;
 use function strtolower;
 
 class ExpressionResolver
@@ -22,19 +23,22 @@ class ExpressionResolver
     public static function getUnresolvedClassConstExpr(
         PhpParser\Node\Expr $stmt,
         Aliases $aliases,
-        ?string $fq_classlike_name
+        ?string $fq_classlike_name,
+        ?string $parent_fq_class_name = null
     ) : ?UnresolvedConstantComponent {
         if ($stmt instanceof PhpParser\Node\Expr\BinaryOp) {
             $left = self::getUnresolvedClassConstExpr(
                 $stmt->left,
                 $aliases,
-                $fq_classlike_name
+                $fq_classlike_name,
+                $parent_fq_class_name
             );
 
             $right = self::getUnresolvedClassConstExpr(
                 $stmt->right,
                 $aliases,
-                $fq_classlike_name
+                $fq_classlike_name,
+                $parent_fq_class_name
             );
 
             if (!$left || !$right) {
@@ -78,7 +82,8 @@ class ExpressionResolver
             $cond = self::getUnresolvedClassConstExpr(
                 $stmt->cond,
                 $aliases,
-                $fq_classlike_name
+                $fq_classlike_name,
+                $parent_fq_class_name
             );
 
             $if = null;
@@ -87,7 +92,8 @@ class ExpressionResolver
                 $if = self::getUnresolvedClassConstExpr(
                     $stmt->if,
                     $aliases,
-                    $fq_classlike_name
+                    $fq_classlike_name,
+                    $parent_fq_class_name
                 );
 
                 if ($if === null) {
@@ -98,7 +104,8 @@ class ExpressionResolver
             $else = self::getUnresolvedClassConstExpr(
                 $stmt->else,
                 $aliases,
-                $fq_classlike_name
+                $fq_classlike_name,
+                $parent_fq_class_name
             );
 
             if ($cond && $else && $if !== false) {
@@ -131,13 +138,15 @@ class ExpressionResolver
             $left = self::getUnresolvedClassConstExpr(
                 $stmt->var,
                 $aliases,
-                $fq_classlike_name
+                $fq_classlike_name,
+                $parent_fq_class_name
             );
 
             $right = self::getUnresolvedClassConstExpr(
                 $stmt->dim,
                 $aliases,
-                $fq_classlike_name
+                $fq_classlike_name,
+                $parent_fq_class_name
             );
 
             if ($left && $right) {
@@ -150,15 +159,20 @@ class ExpressionResolver
                 && $stmt->name instanceof PhpParser\Node\Identifier
                 && $fq_classlike_name
                 && $stmt->class->parts !== ['static']
-                && $stmt->class->parts !== ['parent']
+                && ($stmt->class->parts !== ['parent'] || $parent_fq_class_name !== null)
             ) {
                 if ($stmt->class->parts === ['self']) {
                     $const_fq_class_name = $fq_classlike_name;
                 } else {
-                    $const_fq_class_name = ClassLikeAnalyzer::getFQCLNFromNameObject(
-                        $stmt->class,
-                        $aliases
-                    );
+                    if ($stmt->class->parts === ['parent']) {
+                        assert($parent_fq_class_name !== null);
+                        $const_fq_class_name = $parent_fq_class_name;
+                    } else {
+                        $const_fq_class_name = ClassLikeAnalyzer::getFQCLNFromNameObject(
+                            $stmt->class,
+                            $aliases
+                        );
+                    }
                 }
 
                 return new UnresolvedConstant\ClassConstant($const_fq_class_name, $stmt->name->name);
@@ -186,7 +200,8 @@ class ExpressionResolver
                     $item_key_type = self::getUnresolvedClassConstExpr(
                         $item->key,
                         $aliases,
-                        $fq_classlike_name
+                        $fq_classlike_name,
+                        $parent_fq_class_name
                     );
 
                     if (!$item_key_type) {
@@ -199,14 +214,19 @@ class ExpressionResolver
                 $item_value_type = self::getUnresolvedClassConstExpr(
                     $item->value,
                     $aliases,
-                    $fq_classlike_name
+                    $fq_classlike_name,
+                    $parent_fq_class_name
                 );
 
                 if (!$item_value_type) {
                     return null;
                 }
 
-                $items[] = new UnresolvedConstant\KeyValuePair($item_key_type, $item_value_type);
+                if ($item->unpack) {
+                    $items[] = new UnresolvedConstant\ArraySpread($item_value_type);
+                } else {
+                    $items[] = new UnresolvedConstant\KeyValuePair($item_key_type, $item_value_type);
+                }
             }
 
             return new UnresolvedConstant\ArrayValue($items);

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ArraySpread.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ArraySpread.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Psalm\Internal\Scanner\UnresolvedConstant;
+
+use Psalm\Internal\Scanner\UnresolvedConstantComponent;
+
+/**
+ * @psalm-immutable
+ */
+class ArraySpread extends UnresolvedConstantComponent
+{
+    /** @var UnresolvedConstantComponent */
+    public $array;
+
+    public function __construct(UnresolvedConstantComponent $array)
+    {
+        $this->array = $array;
+    }
+}

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayValue.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayValue.php
@@ -9,10 +9,10 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
  */
 class ArrayValue extends UnresolvedConstantComponent
 {
-    /** @var array<int, KeyValuePair> */
+    /** @var array<int, KeyValuePair|ArraySpread> */
     public $entries;
 
-    /** @param list<KeyValuePair> $entries */
+    /** @param list<KeyValuePair|ArraySpread> $entries */
     public function __construct(array $entries)
     {
         $this->entries = $entries;

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -228,6 +228,92 @@ class ConstantTest extends TestCase
                     '$b' => 'string',
                 ],
             ],
+            'lateConstantResolutionParentArrayPlus' => [
+                '<?php
+                    class A {
+                        public const ARR = ["a" => true];
+                    }
+
+                    class B extends A {
+                        public const ARR = parent::ARR + ["b" => true];
+                    }
+
+                    class C extends B {
+                        public const ARR = parent::ARR + ["c" => true];
+                    }
+
+                    /** @param array{a: true, b: true, c: true} $arg */
+                    function foo(array $arg): void {}
+                    foo(C::ARR);
+                ',
+            ],
+            'lateConstantResolutionParentArraySpread' => [
+                '<?php
+                    class A {
+                        public const ARR = ["a"];
+                    }
+
+                    class B extends A {
+                        public const ARR = [...parent::ARR, "b"];
+                    }
+
+                    class C extends B {
+                        public const ARR = [...parent::ARR, "c"];
+                    }
+
+                    /** @param array{"a", "b", "c"} $arg */
+                    function foo(array $arg): void {}
+                    foo(C::ARR);
+                ',
+            ],
+            'lateConstantResolutionParentStringConcat' => [
+                '<?php
+                    class A {
+                        public const STR = "a";
+                    }
+
+                    class B extends A {
+                        public const STR = parent::STR . "b";
+                    }
+
+                    class C extends B {
+                        public const STR = parent::STR . "c";
+                    }
+
+                    /** @param "abc" $foo */
+                    function foo(string $foo): void {}
+                    foo(C::STR);
+                ',
+            ],
+            'lateConstantResolutionSpreadEmptyArray' => [
+                '<?php
+                    class A {
+                        public const ARR = [];
+                    }
+
+                    class B extends A {
+                        public const ARR = [...parent::ARR];
+                    }
+
+                    class C extends B {
+                        public const ARR = [...parent::ARR];
+                    }
+
+                    /** @param array<empty, empty> $arg */
+                    function foo(array $arg): void {}
+                    foo(C::ARR);
+                ',
+            ],
+            'classConstConcatEol' => [
+                '<?php
+                    class Foo {
+                        public const BAR = "bar" . PHP_EOL;
+                    }
+
+                    $foo = Foo::BAR;
+                ',
+                'assertions' => ['$foo' => 'string'],
+            ],
             'allowConstCheckForDifferentPlatforms' => [
                 '<?php
                     if ("phpdbg" === \PHP_SAPI) {}',


### PR DESCRIPTION
Handle array plus operator (fixes #5588).
Handle array spread operator.
Improve string concatenation to resolve to literal instead of unknown string.

I feel like it should be possible to let ConstantTypeResolver take advantage of the better type analysis in ArrayAnalyzer, ConcatAnalyzer, etc, but it would require a restructuring that's beyond me for the time being.