### PR TITLE
Add json_last_error to impure function

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -489,7 +489,7 @@ class Functions
             'bcscale',
             
             // json
-            'json_last_error',
+            'json_encode', 'json_decode', 'json_last_error',
         ];
 
         if (\in_array(strtolower($function_id), $impure_functions, true)) {

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -489,7 +489,7 @@ class Functions
             'bcscale',
             
             // json
-            'json_encode', 'json_decode', 'json_last_error',
+            'json_last_error',
         ];
 
         if (\in_array(strtolower($function_id), $impure_functions, true)) {

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -487,6 +487,9 @@ class Functions
 
             // bcmath
             'bcscale',
+            
+            // json
+            'json_last_error',
         ];
 
         if (\in_array(strtolower($function_id), $impure_functions, true)) {


### PR DESCRIPTION
The usage can be: 

```bash
<?php

$string = '{\'Organization\': \'Test\'}';
json_decode($string);

var_dump(json_last_error());
```

which `json_last_error()` depends on last `json_decode()` ref https://3v4l.org/E3HKI