### PR TITLE
Add missing opening PHP tag in the docs

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -510,6 +510,7 @@ class User {
 The @psalm-require-extends-annotation allows you to define a requirements that a trait imposes on the using class.
 
 ```php
+<?php
 abstract class DatabaseModel {
   // methods, properties, etc.
 }

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -507,7 +507,7 @@ class User {
 
 ### `@psalm-require-extends`
 
-The @psalm-require-extends-annotation allows you to define a requirements that a trait imposes on the using class.
+The `@psalm-require-extends` annotation allows you to define a requirements that a trait imposes on the using class.
 
 ```php
 <?php


### PR DESCRIPTION
I assume the `<?php` is needed for the syntax highlighting to work as this is the only example where it's missing and the only one without syntax highlighting on this page.