### PR TITLE
Allow Xdebug handler 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "amphp/byte-stream": "^1.5",
         "composer/package-versions-deprecated": "^1.8.0",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
-        "composer/xdebug-handler": "^1.1",
+        "composer/xdebug-handler": "^1.1 || ^2.0",
         "dnoegel/php-xdg-base-dir": "^0.1.1",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
         "felixfbecker/language-server-protocol": "^1.5",


### PR DESCRIPTION
I bumped the constraint since its limitation would prevent me to test PHP-CS-Fixer 3.0: https://github.com/FriendsOfPHP/PHP-CS-Fixer/blob/3.0/composer.json#L21

I went through the [UPGRADE document](https://github.com/composer/xdebug-handler/blob/main/UPGRADE.md) but nothing seems to impede a cross-version support.