### PR TITLE
adding documentation about @no-named-arguments and allowNamedArgumentCalls

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -538,6 +538,19 @@ class NormalClass {
 
 Behaves the same way as `@psalm-require-extends`, but for interfaces.
 
+### `@no-named-arguments`
+
+This will prevent access to the function or method tagged with named parameters (by emitting a `NamedArgumentNotAllowed` issue).
+
+Incidentally, it will change the inferred type for the following code:
+```php
+<?php
+    function a(int ...$a){
+        var_dump($a);
+    }
+```
+The type of `$a` is `array<array-key, int>` without `@no-named-arguments` but becomes `list<int>` with it, because it exclude the case where the offset would be a string with the name of the parameter
+
 ## Type Syntax
 
 Psalm supports PHPDoc’s [type syntax](https://docs.phpdoc.org/latest/guide/guides/types.html), and also the [proposed PHPDoc PSR type syntax](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types).

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -314,6 +314,16 @@ When `true`, Psalm will run [Taint Analysis](../security_analysis/index.md) on y
 
 When `false`, Psalm will not consider issue at lower level than `errorLevel` as `info` (they will be suppressed instead). This can be a big improvement in analysis time for big projects. However, this config will prevent Psalm to count or suggest fixes for suppressed issue
 
+#### allowNamedArgumentCalls
+
+```xml
+<psalm 
+  allowNamedArgumentCalls="[bool]"
+>
+```
+
+When `false`, Psalm will not report `ParamNameMismatch` issues in your code anymore. This does not replace the use of individual `@no-named-arguments` to prevent external access to a library's method or to reduce the type to a `list` when using variadics
+
 ### Running Psalm
 
 #### autoloader


### PR DESCRIPTION
I saw a change on a project today where allowNamedArgumentCalls was set to false. I expected this to have the same effect as a `@no-named-argument` project-wide but it didn't seem to work.

After thinking about that, my assumption didn't make sense because without `@no-named-argument` directly in code, Psalm can't enforce the absence of named parameters on external calls.

Those were largely undocumented so I added some details