### PR TITLE
Fix array<empty, empty> not in array{foo?: mixed}<string, mixed>

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/ArrayTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ArrayTypeComparator.php
@@ -33,6 +33,18 @@ class ArrayTypeComparator
     ) : bool {
         $all_types_contain = true;
 
+        $is_empty_array = $input_type_part->equals(new Type\Atomic\TArray([
+            new Type\Union([new Type\Atomic\TEmpty()]),
+            new Type\Union([new Type\Atomic\TEmpty()])
+        ]));
+        if ($is_empty_array
+            && ($container_type_part instanceof Type\Atomic\TArray
+                || $container_type_part instanceof Type\Atomic\TKeyedArray)
+            && !$container_type_part instanceof Type\Atomic\TNonEmptyArray
+        ) {
+            return true;
+        }
+
         if ($container_type_part instanceof TKeyedArray
             && $input_type_part instanceof TArray
         ) {

--- a/tests/TypeComparatorTest.php
+++ b/tests/TypeComparatorTest.php
@@ -104,7 +104,23 @@ class TypeComparatorTest extends TestCase
         return [
             'iterableAcceptsArray' => [
                 'iterable',
-                'array'
+                'array',
+            ],
+            'listAcceptsEmptyArray' => [
+                'list',
+                'array<empty, empty>',
+            ],
+            'arrayAcceptsEmptyArray' => [
+                'array',
+                'array<empty, empty>',
+            ],
+            'arrayOptionalKeyed1AcceptsEmptyArray' => [
+                'array{foo?: string}',
+                'array<empty, empty>',
+            ],
+            'arrayOptionalKeyed2AcceptsEmptyArray' => [
+                'array{foo?: string}&array<string, mixed>',
+                'array<empty, empty>',
             ],
         ];
     }


### PR DESCRIPTION
Trying to fix https://github.com/vimeo/psalm/issues/4963
I tried to modify my vendor and this seems to fix the issue but there is certainly some improvements.

I'm not familiar at all with the different types.
Should I do something with `List` too ? Is there an easier way to check for empty array ? 