### PR TITLE
Kill children on error and check if stream is closed before writing from child.

### DIFF
--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -356,7 +356,11 @@ class Pool
                         } elseif ($message instanceof ForkProcessErrorMessage) {
                             // Kill all children
                             foreach ($this->child_pid_list as $child_pid) {
-                                posix_kill($child_pid, \SIGKILL);
+                                /**
+                                 * @psalm-suppress UndefinedConstant - does not exist on windows
+                                 * @psalm-suppress MixedArgument
+                                 */
+                                posix_kill($child_pid, \SIGTERM);
                             }
                             throw new \Exception($message->message);
                         } else {
@@ -389,38 +393,46 @@ class Pool
      */
     public function wait(): array
     {
-        // Read all the streams from child processes into an array.
-        $content = $this->readResultsFromChildren();
+        $ignore_return_code = false;
+        try {
+            // Read all the streams from child processes into an array.
+            $content = $this->readResultsFromChildren();
+        } catch (\Throwable $e) {
+            // If children were killed because one of them threw an exception we don't care about return codes.
+            $ignore_return_code = true;
+            // PHP guarantees finally is run even after throwing
+            throw $e;
+        } finally {
+            // Wait for all children to return
+            foreach ($this->child_pid_list as $child_pid) {
+                $process_lookup = posix_kill($child_pid, 0);
 
-        // Wait for all children to return
-        foreach ($this->child_pid_list as $child_pid) {
-            $process_lookup = posix_kill($child_pid, 0);
+                $status = 0;
 
-            $status = 0;
+                if ($process_lookup) {
+                    /**
+                     * @psalm-suppress UndefinedConstant - does not exist on windows
+                     * @psalm-suppress MixedArgument
+                     */
+                    posix_kill($child_pid, SIGALRM);
 
-            if ($process_lookup) {
-                /**
-                 * @psalm-suppress UndefinedConstant - does not exist on windows
-                 * @psalm-suppress MixedArgument
-                 */
-                posix_kill($child_pid, SIGALRM);
-
-                if (pcntl_waitpid($child_pid, $status) < 0) {
-                    error_log(posix_strerror(posix_get_last_error()));
+                    if (pcntl_waitpid($child_pid, $status) < 0) {
+                        error_log(posix_strerror(posix_get_last_error()));
+                    }
                 }
-            }
 
-            // Check to see if the child died a graceful death
-            if (pcntl_wifsignaled($status)) {
-                $return_code = pcntl_wexitstatus($status);
-                $term_sig = pcntl_wtermsig($status);
+                // Check to see if the child died a graceful death
+                if (!$ignore_return_code && pcntl_wifsignaled($status)) {
+                    $return_code = pcntl_wexitstatus($status);
+                    $term_sig = pcntl_wtermsig($status);
 
-                /**
-                 * @psalm-suppress UndefinedConstant - does not exist on windows
-                 */
-                if ($term_sig !== SIGALRM) {
-                    $this->did_have_error = true;
-                    error_log("Child terminated with return code $return_code and signal $term_sig");
+                    /**
+                     * @psalm-suppress UndefinedConstant - does not exist on windows
+                     */
+                    if ($term_sig !== SIGALRM) {
+                        $this->did_have_error = true;
+                        error_log("Child terminated with return code $return_code and signal $term_sig");
+                    }
                 }
             }
         }


### PR DESCRIPTION
I've been trying some changes that happen to crash psalm a lot, and it's leaving child processes hanging taking up all my RAM.

My first though was to check the return from `fwrite`, but that [doesn't work](https://www.php.net/manual/en/function.fwrite.php#96951), so I settled on an `feof` call that seems to correctly detect if the read end of the stream has been closed.

I also killed all children when receiving an error from a child to avoid wasting CPU time, but I figure the `feof` check should be left in case the parent process somehow crashes without killing the children.