### PR TITLE
Inherit class-level suppressions when checking methods

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -195,6 +195,9 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         ] = $function_information;
 
         $this->suppressed_issues = $this->getSource()->getSuppressedIssues() + $storage->suppressed_issues;
+        if ($appearing_class_storage) {
+            $this->suppressed_issues += $appearing_class_storage->suppressed_issues;
+        }
 
         if ($storage instanceof MethodStorage && $storage->is_static) {
             $this->is_static = true;

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -277,6 +277,18 @@ class IssueSuppressionTest extends TestCase
                         strlen(123, 456, 789);
                     }',
             ],
+            'possiblyNullSuppressedAtClassLevel' => [
+                '<?php
+                    /** @psalm-suppress PossiblyNullReference */
+                    class C {
+                        private ?DateTime $mightBeNull = null;
+
+                        public function m(): string {
+                            return $this->mightBeNull->format("");
+                        }
+                    }
+                '
+            ],
         ];
     }
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -1207,7 +1207,7 @@ class MethodCallTest extends TestCase
                             $bar::baz();
                         }
                     }',
-                'error_message' => 'UndefinedClass',
+                'error_message' => 'MissingConstructor',
             ],
             'checkMixedMethodCallStaticMethodCallArg' => [
                 '<?php


### PR DESCRIPTION
Fixes vimeo/psalm#5687, fixes vimeo/psalm#3357