### PR TITLE
Implement literal analysis for all pure built-in string and array functions

### DIFF
--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -14,7 +14,6 @@ use function min;
 use const PHP_EOL;
 use Psalm\Codebase;
 use Psalm\Config;
-use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Internal\ErrorHandler;
 use Psalm\Internal\Provider\FileProvider;
 use Psalm\Internal\Provider\FileReferenceProvider;

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -596,7 +596,7 @@ class FunctionReturnTypeProvider
                 $has_leftover,
                 $current,
                 $index+1,
-                $params[$paramsIndex]->is_variadic ? $paramsIndex : $paramsIndex+1,
+                $params[$paramsIndex]->is_variadic ? $paramsIndex : $paramsIndex+1
             );
         }
         if ($cur_leftover) {

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -21,6 +21,7 @@ use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TNonEmptyList;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TTrue;
 use Psalm\Type\Union;
@@ -698,6 +699,7 @@ class FunctionReturnTypeProvider
                 foreach ($atomic_key_type->properties as $key => $sub) {
                     if ($sub->possibly_undefined) {
                         $possibly_undefined = true;
+                        $has_leftover = true;
                         continue;
                     }
                     $res = self::extractLiterals($sub, $skip);
@@ -718,6 +720,10 @@ class FunctionReturnTypeProvider
                         $values[] = [$subsub];
                     }
                 }
+                if (!$atomic_key_type instanceof TNonEmptyList) {
+                    $values []= [];
+                }
+                $has_leftover = true;
             } elseif ($atomic_key_type instanceof TArray && $atomic_key_type->type_params[1]->isEmpty()) {
                 $values []= [];
             } else {

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -574,7 +574,7 @@ class FunctionReturnTypeProvider
         bool &$has_leftover,
         array $current = [],
         int $index = 0,
-        int $paramsIndex = 0,
+        int $paramsIndex = 0
     ): \Generator {
         if ($index === count($args)) {
             yield $current;

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -506,6 +506,12 @@ class FunctionReturnTypeProvider
                     $has_leftover
                 ) as $args) {
                     try {
+                        /**
+                         * @psalm-suppress PossiblyInvalidArgument
+                         * @psalm-suppress PossiblyUndefinedIntArrayOffset
+                         * @psalm-suppress PossiblyInvalidOperand
+                         * @psalm-suppress PossiblyInvalidCast
+                         */
                         if (($function_id === 'array_combine' && count($args[0]) !== count($args[1])) ||
                             ($function_id === 'str_repeat' && (strlen($args[0]) * $args[1]) >= $maxStrLen) ||
                             ($function_id === 'str_pad' && $args[1] >= $maxStrLen) ||
@@ -515,7 +521,8 @@ class FunctionReturnTypeProvider
                             $has_leftover = true;
                             continue;
                         }
-                        $newTypes = Type::fromLiteral($res = $function_id(...$args));
+                        /** @psalm-suppress MixedArgument */
+                        $newTypes = Type::fromLiteral($function_id(...$args));
                         $types = $types ? Type::combineUnionTypes($types, $newTypes) : $newTypes;
                     } catch (\Throwable $e) {
                     }
@@ -653,6 +660,10 @@ class FunctionReturnTypeProvider
      *
      * @param Union $type
      * @param boolean $has_leftover
+     * 
+     * @psalm-suppress InvalidReturnType
+     * @psalm-suppress InvalidReturnStatement
+     *
      * @return list<array|float|int|string>
      */
     public static function extractLiterals(

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -482,6 +482,10 @@ class FunctionReturnTypeProvider
                                 continue;
                             }
                             $had_array = true;
+                            /**
+                             * @psalm-suppress MixedAssignment
+                             * @psalm-suppress MixedArgument
+                             */
                             foreach ($elem as $sub) {
                                 $type_args []= Type::fromLiteral($sub);
                             }
@@ -660,7 +664,7 @@ class FunctionReturnTypeProvider
      *
      * @param Union $type
      * @param boolean $has_leftover
-     * 
+     *
      * @psalm-suppress InvalidReturnType
      * @psalm-suppress InvalidReturnStatement
      *
@@ -709,20 +713,10 @@ class FunctionReturnTypeProvider
                     $values []= $array;
                 }
             } elseif ($atomic_key_type instanceof TList) {
-                $skip = false;
-                $array = [];
                 foreach ($atomic_key_type->type_param->getAtomicTypes() as $sub) {
-                    $res = self::extractLiterals(new Union([$sub]), $skip);
-                    if (count($res) !== 1) {
-                        $skip = true;
-                        break;
+                    foreach (self::extractLiterals(new Union([$sub]), $has_leftover) as $subsub) {
+                        $values[] = [$subsub];
                     }
-                    $array[] = $res[0];
-                }
-                if ($skip) {
-                    $has_leftover = true;
-                } else {
-                    $values []= $array;
                 }
             } elseif ($atomic_key_type instanceof TArray && $atomic_key_type->type_params[1]->isEmpty()) {
                 $values []= [];

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -2,18 +2,313 @@
 namespace Psalm\Internal\Provider;
 
 use PhpParser;
+use PhpParser\Node\Arg;
+use Psalm\Codebase;
 use Psalm\CodeLocation;
 use Psalm\Context;
+use Psalm\Internal\Codebase\InternalCallMapHandler;
+use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\Hook\FunctionReturnTypeProviderInterface as LegacyFunctionReturnTypeProviderInterface;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\StatementsSource;
+use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TEmpty;
+use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TList;
+use Psalm\Type\Atomic\TLiteralClassString;
+use Psalm\Type\Atomic\TLiteralFloat;
+use Psalm\Type\Atomic\TLiteralInt;
+use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Atomic\TTrue;
+use Psalm\Type\Union;
+
+use function count;
 use function strtolower;
 use function is_subclass_of;
+use function function_exists;
+use function is_array;
 
 class FunctionReturnTypeProvider
 {
+    /**
+     * Whitelisted methods for execution
+     *
+     * @var array<lowercase-string, true>
+     */
+    private const WHITELIST = [
+        // Core
+        'strlen' => true,
+        'strcmp' => true,
+        'strncmp' => true,
+        'strcasecmp' => true,
+        'strncasecmp' => true,
+
+        // ctype
+        'ctype_alnum' => true,
+        'ctype_alpha' => true,
+        'ctype_cntrl' => true,
+        'ctype_digit' => true,
+        'ctype_lower' => true,
+        'ctype_graph' => true,
+        'ctype_print' => true,
+        'ctype_punct' => true,
+        'ctype_space' => true,
+        'ctype_upper' => true,
+        'ctype_xdigit' => true,
+
+        // standard (escaping)
+        'addcslashes' => true,
+        'addslashes' => true,
+        'escapeshellarg' => true,
+        'escapeshellcmd' => true,
+        'html_entity_decode' => true,
+        'htmlentities' => true,
+        'htmlspecialchars' => true,
+        'htmlspecialchars_decode' => true,
+        'http_build_query' => true,
+
+        // standard (arrays except sorting functions)
+        'array_change_key_case' => true,
+        'array_chunk' => true,
+        'array_column' => true,
+        'array_combine' => true,
+        'array_count_values' => true,
+        'array_diff' => true,
+        'array_diff_assoc' => true,
+        'array_diff_key' => true,
+        'array_diff_uassoc' => true,
+        'array_diff_ukey' => true,
+        'array_fill' => true,
+        'array_fill_keys' => true,
+        'array_filter' => true,
+        'array_flip' => true,
+        'array_intersect' => true,
+        'array_intersect_assoc' => true,
+        'array_intersect_key' => true,
+        'array_intersect_uassoc' => true,
+        'array_intersect_ukey' => true,
+        'array_key_exists' => true,
+        'array_key_first' => true,
+        'array_key_last' => true,
+        'array_keys' => true,
+        'array_map' => true,
+        'array_merge' => true,
+        'array_merge_recursive' => true,
+        'array_multisort' => true,
+        'array_pad' => true,
+        'array_pop' => true,
+        'array_product' => true,
+        'array_push' => true,
+        'array_reduce' => true,
+        'array_replace' => true,
+        'array_replace_recursive' => true,
+        'array_reverse' => true,
+        'array_search' => true,
+        'array_shift' => true,
+        'array_slice' => true,
+        'array_splice' => true,
+        'array_sum' => true,
+        'array_udiff' => true,
+        'array_udiff_assoc' => true,
+        'array_udiff_uassoc' => true,
+        'array_uintersect' => true,
+        'array_uintersect_assoc' => true,
+        'array_uintersect_uassoc' => true,
+        'array_unique' => true,
+        'array_unshift' => true,
+        'array_values' => true,
+        'compact' => true,
+        'count' => true,
+        'sizeof' => true,
+        'end' => true,
+        'explode' => true,
+        'implode' => true,
+        'in_array' => true,
+        'join' => true,
+        'range' => true,
+
+        // standard (strings)
+        'chop' => true,
+        'chunk_split' => true,
+        'count_chars' => true,
+        'lcfirst' => true,
+        'ltrim' => true,
+        'rtrim' => true,
+        'str_contains' => true,
+        'str_ends_with' => true,
+        'str_getcsv' => true,
+        'str_ireplace' => true,
+        'str_pad' => true,
+        'str_repeat' => true,
+        'str_replace' => true,
+        'str_rot13' => true,
+        'str_split' => true,
+        'str_starts_with' => true,
+        'str_word_count' => true,
+        'strchr' => true,
+        'strcoll' => true,
+        'strcspn' => true,
+        'strip_tags' => true,
+        'stripcslashes' => true,
+        'stripos' => true,
+        'stripslashes' => true,
+        'stristr' => true,
+        'strnatcasecmp' => true,
+        'strnatcmp' => true,
+        'strpbrk' => true,
+        'strpos' => true,
+        'strptime' => true,
+        'strrchr' => true,
+        'strrev' => true,
+        'strripos' => true,
+        'strrpos' => true,
+        'strspn' => true,
+        'strstr' => true,
+        'strtok' => true,
+        'strtolower' => true,
+        'strtoupper' => true,
+        'strtr' => true,
+        'strval' => true,
+        'substr' => true,
+        'substr_compare' => true,
+        'substr_count' => true,
+        'substr_replace' => true,
+        'trim' => true,
+        'ucfirst' => true,
+        'ucwords' => true,
+        'wordwrap' => true,
+
+        // standard (string formatting)
+        'number_format' => true,
+        'sprintf' => true,
+        'vsprintf' => true,
+
+        // standard (encoding)
+        'chr' => true,
+        'base64_decode' => true,
+        'base64_encode' => true,
+        'base_convert' => true,
+        'bin2hex' => true,
+        'bindec' => true,
+        'convert_uudecode' => true,
+        'convert_uuencode' => true,
+        'decbin' => true,
+        'dechex' => true,
+        'decoct' => true,
+        'hex2bin' => true,
+        'hexdec' => true,
+        'octdec' => true,
+        'ord' => true,
+
+        'pack' => true,
+        'unpack' => true,
+
+        'nl2br' => true,
+        'parse_url' => true,
+        'php_strip_whitespace' => true,
+        'quoted_printable_decode' => true,
+        'quoted_printable_encode' => true,
+        'quotemeta' => true,
+        'rawurldecode' => true,
+        'rawurlencode' => true,
+        'urldecode' => true,
+        'urlencode' => true,
+        'utf8_decode' => true,
+        'utf8_encode' => true,
+
+        'hebrev' => true,
+
+        'ip2long' => true,
+        'long2ip' => true,
+
+        'highlight_string' => true,
+
+        // standard (filesystem, pure)
+        'basename' => true,
+        'dirname' => true,
+        'fnmatch' => true,
+
+        // standard (math)
+        'abs' => true,
+        'acos' => true,
+        'acosh' => true,
+        'asin' => true,
+        'asinh' => true,
+        'atan' => true,
+        'atan2' => true,
+        'atanh' => true,
+        'ceil' => true,
+        'cos' => true,
+        'cosh' => true,
+        'deg2rad' => true,
+        'exp' => true,
+        'expm1' => true,
+        'fdiv' => true,
+        'floor' => true,
+        'fmod' => true,
+        'hypot' => true,
+        'intdiv' => true,
+        'intval' => true,
+        'is_finite' => true,
+        'is_infinite' => true,
+        'is_nan' => true,
+        'log' => true,
+        'log10' => true,
+        'log1p' => true,
+        'max' => true,
+        'min' => true,
+        'pi' => true,
+        'pow' => true,
+        'rad2deg' => true,
+        'round' => true,
+        'sin' => true,
+        'sinh' => true,
+        'sqrt' => true,
+        'tan' => true,
+        'tanh' => true,
+
+        // standard (hashes)
+        'crc32' => true,
+        'sha1' => true,
+        'md5' => true,
+
+        // standard (type juggling)
+        'boolval' => true,
+        'doubleval' => true,
+        'floatval' => true,
+        'get_debug_type' => true,
+        'gettype' => true,
+        'is_array' => true,
+        'is_bool' => true,
+        'is_callable' => true,
+        'is_countable' => true,
+        'is_double' => true,
+        'is_float' => true,
+        'is_int' => true,
+        'is_integer' => true,
+        'is_iterable' => true,
+        'is_long' => true,
+        'is_null' => true,
+        'is_numeric' => true,
+        'is_object' => true,
+        'is_resource' => true,
+        'is_scalar' => true,
+        'is_string' => true,
+
+        // standard (phonetic string manipulation)
+        'levenshtein' => true,
+        'metaphone' => true,
+        'soundex' => true,
+
+        // standard (misc)
+        'version_compare' => true,
+    ];
+
     /**
      * @var array<
      *   lowercase-string,
@@ -118,7 +413,8 @@ class FunctionReturnTypeProvider
     public function has(string $function_id) : bool
     {
         return isset(self::$handlers[strtolower($function_id)]) ||
-            isset(self::$legacy_handlers[strtolower($function_id)]);
+            isset(self::$legacy_handlers[strtolower($function_id)]) ||
+            isset(self::WHITELIST[strtolower($function_id)]);
     }
 
     /**
@@ -132,6 +428,100 @@ class FunctionReturnTypeProvider
         Context $context,
         CodeLocation $code_location
     ): ?Type\Union {
+        $codebase = $statements_source->getCodebase();
+        $types = null;
+        if ($statements_source instanceof \Psalm\Internal\Analyzer\StatementsAnalyzer &&
+            isset(self::WHITELIST[$function_id]) &&
+            function_exists($function_id) &&
+            InternalCallMapHandler::getCallablesFromCallMap($function_id) &&
+            $codebase->functions->isCallMapFunctionPure(
+                $codebase,
+                $statements_source->getNodeTypeProvider(),
+                $function_id,
+                $call_args
+            )
+        ) {
+            $node_data = $statements_source->node_data;
+            $callable = InternalCallMapHandler::getCallableFromCallMapById(
+                $codebase,
+                $function_id,
+                $call_args,
+                $node_data
+            );
+            $required = 0;
+            $byRef = false;
+            $variadic = false;
+            foreach ($callable->params ?? [] as $param) {
+                if (!$param->is_optional) {
+                    $required++;
+                }
+                if ($param->by_ref) {
+                    $byRef = true;
+                }
+                if ($param->is_variadic) {
+                    $variadic = true;
+                }
+            }
+            if ($byRef && $function_id === 'end') {
+                $byRef = false;
+            }
+            $has_leftover = false;
+            $type_args = [];
+            foreach ($call_args as $arg) {
+                $type = $node_data->getType($arg->value);
+                if ($arg->unpack) {
+                    if (!$type) {
+                        $type_args []= null;
+                        $has_leftover = true;
+                        continue;
+                    }
+                    $had_array = false;
+                    foreach (self::extractLiterals($type, $has_leftover) as $elem) {
+                        if (is_array($elem)) {
+                            if ($had_array) {
+                                $has_leftover = true;
+                                continue;
+                            }
+                            $had_array = true;
+                            foreach ($elem as $sub) {
+                                $type_args []= Type::fromLiteral($sub);
+                            }
+                        } else {
+                            $has_leftover = true;
+                        }
+                    }
+                } else {
+                    $type_args []= $type;
+                }
+            }
+            if (!$byRef &&
+                $callable->params &&
+                $required <= count($type_args) &&
+                (count($type_args) <= count($callable->params) || $variadic)
+            ) {
+                foreach ($this->permutateArguments(
+                    $callable->params,
+                    $type_args,
+                    $codebase,
+                    $has_leftover
+                ) as $args) {
+                    try {
+                        if ($function_id === 'array_combine' && count($args[0]) !== count($args[1])) {
+                            $has_leftover = true;
+                            continue;
+                        }
+                        $newTypes = Type::fromLiteral($res = $function_id(...$args));
+                        $types = $types ? Type::combineUnionTypes($types, $newTypes) : $newTypes;
+                    } catch (\Throwable $e) {
+                    }
+                }
+
+                if (!$has_leftover && $types) {
+                    return $types;
+                }
+            }
+        }
+
         foreach (self::$legacy_handlers[strtolower($function_id)] ?? [] as $function_handler) {
             $return_type = $function_handler(
                 $statements_source,
@@ -142,7 +532,7 @@ class FunctionReturnTypeProvider
             );
 
             if ($return_type) {
-                return $return_type;
+                return $types ? Type::combineUnionTypes($types, $return_type) : $return_type;
             }
         }
 
@@ -157,10 +547,165 @@ class FunctionReturnTypeProvider
             $return_type = $function_handler($event);
 
             if ($return_type) {
-                return $return_type;
+                return $types ? Type::combineUnionTypes($types, $return_type) : $return_type;
             }
         }
 
         return null;
+    }
+
+
+    /**
+     * Permutate arguments
+     *
+     * @param list<FunctionLikeParameter> $params
+     * @param list<?Union> $args
+     * @param NodeDataProvider $node_data
+     * @param Codebase $codebase
+     * @param bool $has_leftover
+     * @param array<int, array|float|int|string> $current
+     * @param integer $index
+     * @return \Generator<int, array<int, array|float|int|string>, null, void>
+     */
+    public static function permutateArguments(
+        array $params,
+        array $args,
+        Codebase $codebase,
+        bool &$has_leftover,
+        array $current = [],
+        int $index = 0,
+        int $paramsIndex = 0,
+    ): \Generator {
+        if ($index === count($args)) {
+            yield $current;
+            return;
+        }
+
+        $cur_leftover = false;
+        foreach (self::getAllowedLiteralParamValues(
+            $args[$index],
+            $params[$paramsIndex]->type,
+            $codebase,
+            $cur_leftover
+        ) as $value) {
+            $current[$index] = $value;
+            yield from self::permutateArguments(
+                $params,
+                $args,
+                $codebase,
+                $has_leftover,
+                $current,
+                $index+1,
+                $params[$paramsIndex]->is_variadic ? $paramsIndex : $paramsIndex+1,
+            );
+        }
+        if ($cur_leftover) {
+            $has_leftover = true;
+        }
+    }
+
+    /**
+     * Get all allowed literal values for the specified parameter
+     *
+     * @param ?Union $type
+     * @param ?Union $required_type
+     * @param boolean $has_leftover
+     * @return list<array|float|int|string>
+     */
+    public static function getAllowedLiteralParamValues(
+        ?Union $type,
+        ?Union $required_type,
+        Codebase $codebase,
+        bool &$has_leftover
+    ): array {
+        if (!$type) {
+            return [];
+        }
+        if (!$required_type || $required_type->hasMixed()) {
+            $has_leftover = false;
+            $accepted = $type;
+        } else {
+            $acceptedKeys = [];
+            if (!UnionTypeComparator::canBeContainedBy($codebase, $type, $required_type, false, false, $acceptedKeys)) {
+                return [];
+            }
+            $accepted = clone $type;
+            $allKeys = \array_keys($type->getAtomicTypes());
+            foreach ($allKeys as $atomic_key) {
+                if (!isset($acceptedKeys[$atomic_key])) {
+                    $has_leftover = true;
+                    $accepted->removeType($atomic_key);
+                }
+            }
+        }
+        $res = self::extractLiterals($accepted, $has_leftover);
+        return $res;
+    }
+
+
+    /**
+     * Extract literal types
+     *
+     * @param Union $type
+     * @param boolean $has_leftover
+     * @return list<array|float|int|string>
+     */
+    public static function extractLiterals(
+        Union $type,
+        bool &$has_leftover
+    ): array {
+        $values = [];
+        foreach ($type->getAtomicTypes() as $atomic_key_type) {
+            if ($atomic_key_type instanceof TLiteralString) {
+                $values []= $atomic_key_type->value;
+            } elseif ($atomic_key_type instanceof TLiteralClassString) {
+                $values []= $atomic_key_type->value;
+            } elseif ($atomic_key_type instanceof TLiteralInt) {
+                $values []= $atomic_key_type->value;
+            } elseif ($atomic_key_type instanceof TLiteralFloat) {
+                $values []= $atomic_key_type->value;
+            } elseif ($atomic_key_type instanceof TTrue || $atomic_key_type instanceof TFalse) {
+                $values []= $atomic_key_type instanceof TTrue;
+            } elseif ($atomic_key_type instanceof TNull) {
+                $values []= null;
+            } elseif ($atomic_key_type instanceof TKeyedArray) {
+                $skip = false;
+                $array = [];
+                foreach ($atomic_key_type->properties as $key => $sub) {
+                    $res = self::extractLiterals($sub, $skip);
+                    if (count($res) !== 1) {
+                        $skip = true;
+                        break;
+                    }
+                    $array[$key] = $res[0];
+                }
+                if ($skip) {
+                    $has_leftover = true;
+                } else {
+                    $values []= $array;
+                }
+            } elseif ($atomic_key_type instanceof TList) {
+                $skip = false;
+                $array = [];
+                foreach ($atomic_key_type->type_param->getAtomicTypes() as $sub) {
+                    $res = self::extractLiterals(new Union([$sub]), $skip);
+                    if (count($res) !== 1) {
+                        $skip = true;
+                        break;
+                    }
+                    $array[] = $res[0];
+                }
+                if ($skip) {
+                    $has_leftover = true;
+                } else {
+                    $values []= $array;
+                }
+            } elseif ($atomic_key_type instanceof TArray && $atomic_key_type->type_params[1]->isEmpty()) {
+                $values []= [];
+            } else {
+                $has_leftover = true;
+            }
+        }
+        return $values;
     }
 }

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -55,7 +55,6 @@ use function strtolower;
 use function substr;
 use function gettype;
 use function is_array;
-use function array_map;
 
 abstract class Type
 {

--- a/src/Psalm/Type/Atomic/TCallableString.php
+++ b/src/Psalm/Type/Atomic/TCallableString.php
@@ -4,7 +4,7 @@ namespace Psalm\Type\Atomic;
 /**
  * Denotes the `callable-string` type, used to represent an unknown string that is also `callable`.
  */
-class TCallableString extends TString
+class TCallableString extends TNonEmptyString
 {
 
     public function getKey(bool $include_extra = true): string

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -833,9 +833,9 @@ class ArrayAssignmentTest extends TestCase
                     $a_values = array_values($a);
                     $a_keys = array_keys($a);',
                 'assertions' => [
-                    '$a' => 'array{"hello", 5}',
-                    '$a_values' => 'array{0: "hello", 1: 5}',
-                    '$a_keys' => 'array{0: 0, 1: 1}',
+                    '$a===' => 'array{"hello", 5}',
+                    '$a_values===' => 'array{0: "hello", 1: 5}',
+                    '$a_keys===' => 'array{0: 0, 1: 1}',
                 ],
             ],
             'changeIntOffsetKeyValuesWithDirectAssignment' => [
@@ -858,11 +858,25 @@ class ArrayAssignmentTest extends TestCase
             ],
             'mergeIntOffsetValues' => [
                 '<?php
-                    $d = array_merge(["hello", 5], []);
-                    $e = array_merge(["hello", 5], ["hello again"]);',
+                    /**
+                     * @var array{string, int} $a
+                     * @var array<empty, empty> $b
+                     * @var array{string} $c
+                     */
+                    $d = array_merge($a, $b);
+                    $e = array_merge($a, $c);',
                 'assertions' => [
                     '$d' => 'array{0: string, 1: int}',
                     '$e' => 'array{0: string, 1: int, 2: string}',
+                ],
+            ],
+            'mergeIntOffsetValuesLiteral' => [
+                '<?php
+                    $d = array_merge(["hello", 5], []);
+                    $e = array_merge(["hello", 5], ["hello again"]);',
+                'assertions' => [
+                    '$d===' => 'array{0: "hello", 1: 5}',
+                    '$e===' => 'array{0: "hello", 1: 5, 2: "hello again"}',
                 ],
             ],
             'addIntOffsetToEmptyArray' => [

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -833,9 +833,9 @@ class ArrayAssignmentTest extends TestCase
                     $a_values = array_values($a);
                     $a_keys = array_keys($a);',
                 'assertions' => [
-                    '$a' => 'array{string, int}',
-                    '$a_values' => 'non-empty-list<int|string>',
-                    '$a_keys' => 'non-empty-list<int>',
+                    '$a' => 'array{"hello", 5}',
+                    '$a_values' => 'array{0: "hello", 1: 5}',
+                    '$a_keys' => 'array{0: 0, 1: 1}',
                 ],
             ],
             'changeIntOffsetKeyValuesWithDirectAssignment' => [

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -2261,6 +2261,15 @@ class ArrayFunctionCallTest extends TestCase
                         }
                     }'
             ],
+            'countOnList' => [
+                '<?php
+                    /** @var list<"a"|"b"|"c"> $a */
+                    $b = count($a);
+                ',
+                'assertions' => [
+                    '$b' => 'int'
+                ]
+            ],
             'arrayColumnwithKeyedArrayWithoutRedundantUnion' => [
                 '<?php
                     /**

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -51,7 +51,7 @@ class ArrayFunctionCallTest extends TestCase
                     $d = array_filter(["a" => 0, "b" => 1, "c" => null], "a");
                 ',
                 'assertions' => [
-                    '$d' => 'array{a?: int, b?: int, c?: int}',
+                    '$d' => 'array<string, int|null>',
                 ],
             ],
             'arrayFilterAdvanced' => [
@@ -1151,10 +1151,9 @@ class ArrayFunctionCallTest extends TestCase
             'implodeNonEmptyArrayAndString' => [
                 '<?php
                     /** @var non-empty-list<non-empty-string> $l */
-                    $l = ["a", "b"];
                     $a = implode(":", $l);',
                 [
-                    '$a' => 'non-empty-string',
+                    '$a===' => 'non-empty-string',
                 ]
             ],
             'implodeNonEmptyArrayAndStringLiteral' => [
@@ -1706,8 +1705,7 @@ class ArrayFunctionCallTest extends TestCase
             ],
             'arraySliceDontPreserveIntKeys' => [
                 '<?php
-                    /** @var array<string, int> $a */
-                    $a = [1 => "a", 4 => "b", 3 => "c"];
+                    /** @var array<int, string> $a */
                     $b = array_slice($a, 1, 2, true);
                     $c = array_slice($a, 1, 2, false);
                     $d = array_slice($a, 1, 2);',

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -143,7 +143,7 @@ class BinaryOperationTest extends TestCase
             ],
             'numericAddition' => [
                 '<?php
-                    $a = "5";
+                    /** @var string $a */
 
                     if (is_numeric($a)) {
                         $b = $a + 4;

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -551,14 +551,35 @@ class FunctionCallTest extends TestCase
                         return rand(0, 1) ? "==" : "=";
                     }
 
-                    $a = version_compare("5.0.0", "7.0.0");
-                    $b = version_compare("5.0.0", "7.0.0", "==");
-                    $c = version_compare("5.0.0", "7.0.0", getString());
+                    /** 
+                     * @var string $f
+                     * @var string $s
+                     */
+                    $a = version_compare($f, $s);
+                    $b = version_compare($f, $s, "==");
+                    $c = version_compare($f, $s, getString());
                 ',
                 'assertions' => [
                     '$a' => 'int',
                     '$b' => 'bool',
                     '$c' => 'bool',
+                ],
+            ],
+            'versionCompareLiteral' => [
+                '<?php
+                    /** @return "="|"==" */
+                    function getString() : string {
+                        return rand(0, 1) ? "==" : "=";
+                    }
+
+                    $a = version_compare("5.0.0", "7.0.0");
+                    $b = version_compare("5.0.0", "7.0.0", "==");
+                    $c = version_compare("5.0.0", "7.0.0", getString());
+                ',
+                'assertions' => [
+                    '$a===' => '-1',
+                    '$b===' => 'false',
+                    '$c===' => 'false',
                 ],
             ],
             'getTimeOfDay' => [
@@ -618,8 +639,8 @@ class FunctionCallTest extends TestCase
                     $porta = parse_url("", PHP_URL_PORT);
                     $porte = parse_url("localhost:443", PHP_URL_PORT);',
                 'assertions' => [
-                    '$porta' => 'false|int|null',
-                    '$porte' => 'false|int|null',
+                    '$porta' => 'null',
+                    '$porte===' => '443',
                 ],
                 'error_levels' => ['MixedReturnStatement', 'MixedInferredReturnType'],
             ],
@@ -645,7 +666,7 @@ class FunctionCallTest extends TestCase
             ],
             'parseUrlTypes' => [
                 '<?php
-                    $url = "foo";
+                    /** @var string $url */;
                     $components = parse_url($url);
                     $scheme = parse_url($url, PHP_URL_SCHEME);
                     $host = parse_url($url, PHP_URL_HOST);
@@ -665,6 +686,30 @@ class FunctionCallTest extends TestCase
                     '$path' => 'false|null|string',
                     '$query' => 'false|null|string',
                     '$fragment' => 'false|null|string',
+                ],
+            ],
+            'parseUrlTypesLiteral' => [
+                '<?php
+                    $url = "http://owo:pwd@google.com:123/a/b/c?v=1#h=2";
+                    $components = parse_url($url);
+                    $scheme = parse_url($url, PHP_URL_SCHEME);
+                    $host = parse_url($url, PHP_URL_HOST);
+                    $port = parse_url($url, PHP_URL_PORT);
+                    $user = parse_url($url, PHP_URL_USER);
+                    $pass = parse_url($url, PHP_URL_PASS);
+                    $path = parse_url($url, PHP_URL_PATH);
+                    $query = parse_url($url, PHP_URL_QUERY);
+                    $fragment = parse_url($url, PHP_URL_FRAGMENT);',
+                'assertions' => [
+                    '$components===' => 'array{fragment: "h=2", host: "google.com", pass: "pwd", path: "/a/b/c", port: 123, query: "v=1", scheme: "http", user: "owo"}',
+                    '$scheme===' => '"http"',
+                    '$host===' => '"google.com"',
+                    '$port===' => '123',
+                    '$user===' => '"owo"',
+                    '$pass===' => '"pwd"',
+                    '$path===' => '"/a/b/c"',
+                    '$query===' => '"v=1"',
+                    '$fragment===' => '"h=2"',
                 ],
             ],
             'triggerUserError' => [

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2639,7 +2639,7 @@ class ConditionalTest extends \Psalm\Tests\TestCase
             ],
             'typeTransformation' => [
                 '<?php
-                    $a = "5";
+                    /** @var string $a */;
 
                     if (is_numeric($a)) {
                         if (is_int($a)) {

--- a/tests/TypeReconciliation/TypeAlgebraTest.php
+++ b/tests/TypeReconciliation/TypeAlgebraTest.php
@@ -353,7 +353,11 @@ class TypeAlgebraTest extends \Psalm\Tests\TestCase
                 '<?php
                     function foo(string $a): void {
                         if (!$a) {
-                            list($a) = explode(":", "a:b");
+                            /**
+                             * @var string $b
+                             * @var string $c
+                             */
+                            list($a) = explode($b, $c);
 
                             if ($a) { }
                         }


### PR DESCRIPTION
This PR allows inferring the exact return type of a whitelisted subset of pure built-in functions, by actually executing them during static analysis.
This all started when I implemented proper return types for literal values in the ExplodeReturnTypeProvider: after implementing it manually, I realized that a similar but more generic approach could be used for all pure functions, with due precautions: this is the implementation so far.

Basically, when a call to a whitelisted built-in pure function occurs, all and only the literal types of the parameters provided to the function are extracted, and permutated to generate all combinations of possible exact return types.
If any of the parameter unions contains 0 literals, execution does not occur.
Execution is also skipped if we're running on a version of PHP that does not provide the required function (to make this reproducible across all versions, I suggest adding the symfony polyfills as runtime dependency).

The real underlying reason for this MR is an upcoming implementation of recursive static analysis in psalm, which should allow even more insight into complex systems, by similarly recursively replacing parameter types of functions with the exact literal value passed in a specific call, generating full call stacks and analyzing possible paradoxes/other issues of each single call stack.
Of course, this would also require inferring the exact literal return type of built-in functions, which is what this MR provides.

Generics and conditional types provide a similar, yet much less powerful solution: with recursive static analysis, finding bugs will be even easier, and will not require annotating every single function with generics and rewriting the behavior as a generic conditional.