### PR TITLE
improve array_splice inference

### DIFF
--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -52,6 +52,7 @@ class FunctionReturnTypeProvider
         $this->registerClass(ReturnTypeProvider\ArrayRandReturnTypeProvider::class);
         $this->registerClass(ReturnTypeProvider\ArrayReduceReturnTypeProvider::class);
         $this->registerClass(ReturnTypeProvider\ArraySliceReturnTypeProvider::class);
+        $this->registerClass(ReturnTypeProvider\ArraySpliceReturnTypeProvider::class);
         $this->registerClass(ReturnTypeProvider\ArrayReverseReturnTypeProvider::class);
         $this->registerClass(ReturnTypeProvider\ArrayUniqueReturnTypeProvider::class);
         $this->registerClass(ReturnTypeProvider\ArrayValuesReturnTypeProvider::class);

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySpliceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySpliceReturnTypeProvider.php
@@ -1,0 +1,71 @@
+<?php
+namespace Psalm\Internal\Provider\ReturnTypeProvider;
+
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+
+class ArraySpliceReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return array<lowercase-string>
+     */
+    public static function getFunctionIds() : array
+    {
+        return ['array_splice'];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event) : Type\Union
+    {
+        $statements_source = $event->getStatementsSource();
+        $call_args = $event->getCallArgs();
+        if (!$statements_source instanceof StatementsAnalyzer) {
+            return Type::getMixed();
+        }
+
+        $first_arg = $call_args[0]->value ?? null;
+
+        $first_arg_array = $first_arg
+            && ($first_arg_type = $statements_source->node_data->getType($first_arg))
+            && $first_arg_type->hasType('array')
+            && ($array_atomic_type = $first_arg_type->getAtomicTypes()['array'])
+            && ($array_atomic_type instanceof Type\Atomic\TArray
+                || $array_atomic_type instanceof Type\Atomic\TKeyedArray
+                || $array_atomic_type instanceof Type\Atomic\TList)
+        ? $array_atomic_type
+        : null;
+
+        if (!$first_arg_array) {
+            return Type::getArray();
+        }
+
+        $already_cloned = false;
+
+        if ($first_arg_array instanceof Type\Atomic\TKeyedArray) {
+            $already_cloned = true;
+            $first_arg_array = $first_arg_array->getGenericArrayType();
+        }
+
+        if ($first_arg_array instanceof Type\Atomic\TArray) {
+            if (!$already_cloned) {
+                $first_arg_array = clone $first_arg_array;
+            }
+            $array_type = new Type\Atomic\TArray($first_arg_array->type_params);
+        } else {
+            $array_type = new Type\Atomic\TArray([Type::getInt(), clone $first_arg_array->type_param]);
+        }
+
+        if (!$array_type->type_params[0]->hasString()) {
+            if ($array_type->type_params[1]->isString()) {
+                $array_type = new Type\Atomic\TList(Type::getString());
+            } elseif ($array_type->type_params[1]->isInt()) {
+                $array_type = new Type\Atomic\TList(Type::getInt());
+            } else {
+                $array_type = new Type\Atomic\TList(Type::getMixed());
+            }
+        }
+
+        return new Type\Union([$array_type]);
+    }
+}

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1350,7 +1350,7 @@ class ArrayFunctionCallTest extends TestCase
                     $d = [1, 2, 3];
                     $e = array_splice($d, -1, 1);',
                 'assertions' => [
-                    '$e' => 'array<array-key, mixed>'
+                    '$e' => 'list<int>'
                 ],
             ],
             'arraySpliceOtherType' => [


### PR DESCRIPTION
This should fix #5678

I mainly used array_slice return type provider to adapt it, this will be better than before but there is definitely some improvements to be made:
1) I'm not sure what this does: https://github.com/vimeo/psalm/compare/master...orklah:array_splice?expand=1#diff-5953e521e3d01187b486b9c7a2e7e57ca6c4aa65886e4825c1bc765de64029cbR50
2) The fourth param should be used to infer the return type. Right now I'm only using the first one.
3) There is a reference for the first param that should be treated the same way
4) I only return `list<int>`, `list<string>` or `list<mixed>` to avoid making a really long list. I searched for a method that would widen a type to standard scalars (for example `'foo'|'bar'` would become string) but I couldn't find it
