### PR TITLE
fix #4395

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -20,6 +20,8 @@ class ReturnTypeCollector
      * @param  list<Type\Union>         $yield_types
      *
      * @return list<Type\Union>    a list of return types
+     *
+     * @psalm-suppress ComplexMethod to be refactored
      */
     public static function getReturnTypes(
         Codebase $codebase,
@@ -38,6 +40,18 @@ class ReturnTypeCollector
                     $return_types[] = $stmt_type;
 
                     $yield_types = array_merge($yield_types, self::getYieldTypeFromExpression($stmt->expr, $nodes));
+                } elseif ($stmt->expr instanceof PhpParser\Node\Scalar\String_) {
+                    $return_types[] = Type::getString();
+                } elseif ($stmt->expr instanceof PhpParser\Node\Scalar\LNumber) {
+                    $return_types[] = Type::getString();
+                } elseif ($stmt->expr instanceof PhpParser\Node\Expr\ConstFetch) {
+                    if ((string)$stmt->expr->name === 'true') {
+                        $return_types[] = Type::getTrue();
+                    } elseif ((string)$stmt->expr->name === 'false') {
+                        $return_types[] = Type::getFalse();
+                    } elseif ((string)$stmt->expr->name === 'null') {
+                        $return_types[] = Type::getNull();
+                    }
                 } else {
                     $return_types[] = Type::getMixed();
                 }

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -919,6 +919,20 @@ class ReturnTypeTest extends TestCase
                         throw new RuntimeException;
                     }
                 '
+            ],
+            'scalarLiteralsInferredAfterUndefinedClass' => [
+                '<?php
+                    /** @param object $arg */
+                    function test($arg): ?string
+                    {
+                        /** @psalm-suppress UndefinedClass */
+                        if ($arg instanceof SomeClassThatDoesNotExist) {
+                            return null;
+                        }
+
+                        return "b";
+                    }
+                '
             ]
         ];
     }


### PR DESCRIPTION
This will fix #4395 partially

The issue here is that as soon as Psalm encounters an UndefinedClass, it immediately stops analyzing the rest of the branch. Trying to change this makes psalm reports the same issue (UndefinedClass) on each consecutive usage of the variable.

I tried to tackle this differently by accepting literal scalar values to be "inferred" even when the branch has no inferred types. It will not solve every problem but it will improve the situation for simple cases where a simple scalar (like false, true, null, int or strings) is used for compatibility reasons