### PR TITLE
Add issue link to GitHub Actions report

### DIFF
--- a/src/Psalm/Report/GithubActionsReport.php
+++ b/src/Psalm/Report/GithubActionsReport.php
@@ -11,13 +11,14 @@ class GithubActionsReport extends Report
     {
         $output = '';
         foreach ($this->issues_data as $issue_data) {
+            $issue_reference = $issue_data->link ? ' (see ' . $issue_data->link . ')' : '';
             $output .= sprintf(
                 '::%s file=%s,line=%s,col=%s::%s',
                 ($issue_data->severity === Config::REPORT_ERROR ? 'error' : 'warning'),
                 $issue_data->file_name,
                 $issue_data->line_from,
                 $issue_data->column_from,
-                $issue_data->message
+                $issue_data->message . $issue_reference
             ) . "\n";
         }
 


### PR DESCRIPTION
If an issue link is available, include it in the annotations on GitHub.

Nothing fancy and copied from `ConsoleReport`, but it'd be helpful to have the link when available.