### PR TITLE
Fix #5761 by marking all `opcache_` functions as impure, as they are affected by runtime/engine

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -485,9 +485,13 @@ class Functions
 
             // bcmath
             'bcscale',
-            
+
             // json
             'json_last_error',
+
+            // opcache
+            'opcache_compile_file', 'opcache_get_configuration', 'opcache_get_status',
+            'opcache_invalidate', 'opcache_is_script_cached', 'opcache_reset',
         ];
 
         if (\in_array(strtolower($function_id), $impure_functions, true)) {


### PR DESCRIPTION
Quoting original issue (fixes #5761):

> Given this snippet ( https://psalm.dev/r/4d51eeab35 ):
>
> ```php
> <?php
>
> function invalidate_cache_for(string $path): void {
>     opcache_invalidate($path);
> }
>
> invalidate_cache_for('foo');
> ```
>
> Psalm reports the `opcache_invalidate()` call as `UnusedFunctionCall`. I'm wondering if `opcache_invalidate()` is perhaps inferred as a pure function? The only reference to it that I could find is in https://github.com/vimeo/psalm/blob/1a59e8180878cd7a1758e30c1558cd27e42f7478/dictionaries/CallMap.php, but no purity markers are there.
>
> I'd gladly fix these, if I could get a pointer to where purity is determined.