### PR TITLE
Mixed contains everything

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -266,6 +266,10 @@ class UnionTypeComparator
         ?Type\Union $input_type,
         Type\Union $container_type
     ): bool {
+        if ($container_type->isMixed()) {
+            return true;
+        }
+
         if (!$input_type) {
             return false;
         }

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -937,6 +937,22 @@ class MethodSignatureTest extends TestCase
                         use MyTrait;
                     }'
             ],
+            'MixedParamInImplementation' => [
+                '<?php
+                    interface I
+                    {
+                        /**
+                         * @param mixed $a
+                         */
+                        public function a($a): void;
+                    }
+
+
+                    final class B implements I
+                    {
+                        public function a(mixed $a): void {}
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
This should fix #5088.

However, I'm not entirely sure this is the right fix.

The ternary here seems to handle two cases: 
- we're in PHP <= 7.3 or we don't have a signature type, then we go in UnionTypeComparator::isContainedByInPhp
- we're in PHP >= 7.4 and we have a signature type, then we go in UnionTypeComparator::isContainedBy

The case in the test is pretty in between because we have a signature type only in the implementation. I don't really know why there are two methods for handling signature and phpdoc, by I kinda have the feeling we enter the wrong one.