### PR TITLE
NullsafeMethodCall makes the variable not null for the rest of the scope

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -138,6 +138,25 @@ class AssertionFinder
             );
         }
 
+        //A nullsafe method call basically adds an assertion !null for the checked variable
+        if ($conditional instanceof PhpParser\Node\Expr\NullsafeMethodCall) {
+            $if_types = [];
+
+            $var_name = ExpressionIdentifier::getArrayVarId(
+                $conditional->var,
+                $this_class_name,
+                $source
+            );
+
+            if ($var_name) {
+                $if_types[$var_name] = [['!null']];
+            }
+
+            //we may throw a RedundantNullsafeMethodCall here in the future if $var_name is never null
+
+            return $if_types ? [$if_types] : [];
+        }
+
         if ($conditional instanceof PhpParser\Node\Expr\BinaryOp\Greater
             || $conditional instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
         ) {

--- a/tests/TypeReconciliation/TypeAlgebraTest.php
+++ b/tests/TypeReconciliation/TypeAlgebraTest.php
@@ -1077,6 +1077,22 @@ class TypeAlgebraTest extends \Psalm\Tests\TestCase
                         return "";
                     }'
             ],
+            'notNullAfterSuccessfulNullsafeMethodCall' => [
+                '<?php
+                    interface X {
+                        public function a(): bool;
+                        public function b(): string;
+                    }
+
+                    function foo(?X $x): void {
+                        if ($x?->a()) {
+                            echo $x->b();
+                        }
+                    }',
+                [],
+                [],
+                '8.1',
+            ],
         ];
     }
 
@@ -1320,6 +1336,23 @@ class TypeAlgebraTest extends \Psalm\Tests\TestCase
                         }
                     }',
                 'error_message' => 'PossiblyNullReference',
+            ],
+            'stillNullAfterNullsafeMethodCall' => [
+                '<?php
+                    interface X {
+                        public function a(): bool;
+                        public function b(): string;
+                    }
+
+                    function foo(?X $x): void {
+                        if (!($x?->a())) {
+                            echo $x->b();
+                        }
+                    }',
+                'error_message' => 'NullReference',
+                [],
+                false,
+                '8.1',
             ],
         ];
     }


### PR DESCRIPTION
This PR fixes #5734

It adds an assertion !null when using a NullsafeMethodCall on a variable