### PR TITLE
Redundant cast to Int preserve type 

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -44,10 +44,12 @@ class CastAnalyzer
             }
 
             $as_int = true;
+            $valid_int_type = null;
             $maybe_type = $statements_analyzer->node_data->getType($stmt->expr);
 
             if ($maybe_type) {
                 if ($maybe_type->isInt()) {
+                    $valid_int_type = $maybe_type;
                     if (!$maybe_type->from_calculation) {
                         if ($maybe_type->from_docblock) {
                             $issue = new RedundantCastGivenDocblockType(
@@ -87,7 +89,7 @@ class CastAnalyzer
             }
 
             if ($as_int) {
-                $type = Type::getInt();
+                $type = $valid_int_type ?? Type::getInt();
 
                 if ($statements_analyzer->data_flow_graph
                     && $statements_analyzer->data_flow_graph instanceof \Psalm\Internal\Codebase\VariableUseGraph

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -243,6 +243,18 @@ class BinaryOperationTest extends TestCase
                     foo(foo("-123") . 456);
                 ',
             ],
+            'castToIntPreserveNarrowerIntType' => [
+                '<?php
+                    /**
+                     * @param positive-int $i
+                     * @return positive-int
+                     */
+                    function takesAnInt(int $i) {
+                        /** @psalm-suppress RedundantCast */
+                        return (int)$i;
+                    }
+                ',
+            ],
             'concatenateFloatWithInt' => [
                 '<?php
                     /**


### PR DESCRIPTION
This PR conserve the type of an int expression that passes through an int cast. Before this PR, it was widened to `TInt`: https://psalm.dev/r/7f34cf6a8d