### PR TITLE
Fix CS - Fix ArrayFillReturnTypeProvider - consider second param

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFillReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFillReturnTypeProvider.php
@@ -68,7 +68,8 @@ class ArrayFillReturnTypeProvider implements \Psalm\Plugin\EventHandler\Function
         ]);
     }
 
-    private static function isPositiveNumericType (Type\Union $arg): bool {
+    private static function isPositiveNumericType(Type\Union $arg): bool
+    {
         if ($arg->isSingle() && $arg->hasPositiveInt()) {
             return true;
         }


### PR DESCRIPTION
Follow up on: #5770 

@muglug My MR unfortunately made it to the master branch with bad code formatting (I suppose that it's required to pass the whole pipeline casually but it was somehow skipped in this case due to manual intervention?)

Let's make the pipeline green again :)