### PR TITLE
htmlspecialchars can return non-empty-string

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -684,6 +684,11 @@ function html_entity_decode(string $string, ?int $quote_style = null, ?string $c
  * @psalm-taint-escape sql
  *
  * @psalm-flow ($string) -> return
+ * @psalm-return (
+ *     $string is non-empty-string
+ *     ? non-empty-string
+ *     : string
+ * )
  */
 function htmlspecialchars(string $string, int $flags = ENT_COMPAT | ENT_HTML401, string $encoding = 'UTF-8', bool $double_encode = true) : string {}
 


### PR DESCRIPTION
https://psalm.dev/r/397951a5d7

The example code shows the issue I am trying to fix. If the code has already done something to guarantee a value is a non-empty-string, there are several built in functions you could pass it to that should then also return a non-empty-string. This will prevent redundant checks and added runtime in projects making use of non-empty-string. This pull request is only changing this one function for now, but if it is accepted I will probably change additional similar functions.

I don't really understand `@psalm-flow`, hopefully this added `@psalm-return` does not interfere? Is there a better approach where `@psalm-flow` could always imply starting from a non-empty-string would return one (again speaking from a place of not understanding `@psalm-flow`).

I looked for a good place to add tests for this change, but I'm lost on that front. Can someone recommend something, or is this a change that would be overkill to explicitly test?