### PR TITLE
refinement of Possibly undefined int array offset

### DIFF
--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1912,7 +1912,7 @@ class ArrayFunctionCallTest extends TestCase
                      * @param list<string> $a
                      * @param int $b
                      */
-                    function a($a, $b)
+                    function a($a, $b): void
                     {
                         if ($b >= 0) {
                             echo $a[$b];

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1906,6 +1906,19 @@ class ArrayFunctionCallTest extends TestCase
                         );
                     }'
             ],
+            'allowAccessToListFrom0OrPositiveIntOffset' => [
+                '<?php
+                    /**
+                     * @param list<string> $a
+                     * @param int $b
+                     */
+                    function a($a, $b)
+                    {
+                        if ($b >= 0) {
+                            echo $a[$b];
+                        }
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR is related to https://github.com/vimeo/psalm/pull/5815

The test I added here does not fail without this PR but it fail with https://github.com/vimeo/psalm/pull/5815. This is the fix that allows accessing a `list` with a `0|positive-int` offset without triggering `PossiblyUndefinedIntArrayOffset` (The same way it's not triggered when accessing an `array` with a non-literal `int`)

Unfortunately the tests fail. The `testEnsureListOffsetExistsAfterArrayPop` does not emit `PossiblyUndefinedIntArrayOffset` anymore but I'm not sure what this test is checking and if I can just remove `$this->expectExceptionMessage('PossiblyUndefinedIntArrayOffset');` from it without altering the test purpose