### PR TITLE
Handle the case where a switch return on each case

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
@@ -98,11 +98,16 @@ class SwitchAnalyzer
 
         $statements_analyzer->node_data->cache_assertions = false;
 
+        $all_options_returned = true;
+
         for ($i = 0, $l = count($stmt->cases); $i < $l; $i++) {
             $case = $stmt->cases[$i];
 
             /** @var string */
             $case_exit_type = $case_exit_types[$i];
+            if ($case_exit_type !== 'return_throw') {
+                $all_options_returned = false;
+            }
 
             $case_actions = $case_action_map[$i];
 
@@ -214,6 +219,9 @@ class SwitchAnalyzer
             $context->vars_possibly_in_scope,
             $switch_scope->new_vars_possibly_in_scope
         );
+
+        //a switch can't return in all options without a default
+        $context->has_returned = $all_options_returned && $has_default;
 
         return null;
     }

--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
@@ -87,6 +87,8 @@ class SwitchAnalyzer
                 } elseif (in_array(ScopeAnalyzer::ACTION_LEAVE_SWITCH, $case_actions, true)) {
                     $last_case_exit_type = 'break';
                 }
+            } elseif (count($case_actions) !== 1) {
+                $last_case_exit_type = 'hybrid';
             }
 
             $case_exit_types[$i] = $last_case_exit_type;

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -639,6 +639,36 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                 false,
                 true,
             ],
+            'switchReturn' => [
+                '<?php
+                    /**
+                     * @param string $a
+                     */
+                    function get_form_fields(string $a) {
+                        switch($a){
+                            default:
+                                return [];
+                        }
+                    }',
+                '<?php
+                    /**
+                     * @param string $a
+                     *
+                     * @return array
+                     *
+                     * @psalm-return array<empty, empty>
+                     */
+                    function get_form_fields(string $a): array {
+                        switch($a){
+                            default:
+                                return [];
+                        }
+                    }',
+                '7.3',
+                ['MissingReturnType'],
+                false,
+                true,
+            ],
         ];
     }
 }


### PR DESCRIPTION
This PR fix https://github.com/vimeo/psalm/issues/4499.

It handles the case where a switch always return. This allows for example Psalter to add the return type automatically