### PR TITLE
[TASK] Enrich taint details for outputting core stubs

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -350,8 +350,21 @@ function sodium_memzero(string &$reference): void
  *
  * @psalm-taint-specialize
  * @psalm-flow ($var) -> return
+ * @psalm-taint-sink html $var
  */
 function var_export($var, bool $return = false) {}
+
+/**
+ * @param mixed $value
+ * @param list<mixed> $values
+ * @return string
+ *
+ * @psalm-taint-specialize
+ * @psalm-flow ($value, $values) -> return
+ * @psalm-taint-sink html $value
+ * @psalm-taint-sink html $values
+ */
+function var_dump($value, ...$values) {}
 
 /**
  * @param mixed $var
@@ -360,6 +373,7 @@ function var_export($var, bool $return = false) {}
  *
  * @psalm-taint-specialize
  * @psalm-flow ($var) -> return
+ * @psalm-taint-sink html $var
  */
 function print_r($var, bool $return = false) {}
 
@@ -949,7 +963,10 @@ function wordwrap(string $str, int $width = 75, string $break = "\n", bool $cut 
  *
  * @param string|int|float $values
  *
+ * @psalm-taint-specialize
  * @psalm-flow ($format, $values) -> return
+ * @psalm-taint-sink html $format
+ * @psalm-taint-sink html $values
  */
 function printf(string $format, ...$values) : string {}
 

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -196,7 +196,7 @@ class TaintTest extends TestCase
             ],
             'specializedCoreFunctionCall' => [
                 '<?php
-                    $a = (string) $_GET["user_id"];
+                    $a = (string) ($data["user_id"] ?? "");
 
                     echo print_r([], true);
 
@@ -1504,6 +1504,26 @@ class TaintTest extends TestCase
                 '<?php
                     print($_GET["name"]);',
                 'error_message' => 'TaintedHtml - src' . DIRECTORY_SEPARATOR . 'somefile.php:2:27 - Detected tainted HTML in path: $_GET -> $_GET[\'name\'] (src/somefile.php:2:27) -> call to print (src/somefile.php:2:27) -> print#1',
+            ],
+            'printf' => [
+                '<?php
+                    printf($_GET["name"]);',
+                'error_message' => 'TaintedHtml - src' . DIRECTORY_SEPARATOR . 'somefile.php:2:28 - Detected tainted HTML in path: $_GET -> $_GET[\'name\'] (src/somefile.php:2:28) -> call to printf (src/somefile.php:2:28) -> printf#1',
+            ],
+            'print_r' => [
+                '<?php
+                    print_r($_GET["name"]);',
+                'error_message' => 'TaintedHtml - src' . DIRECTORY_SEPARATOR . 'somefile.php:2:29 - Detected tainted HTML in path: $_GET -> $_GET[\'name\'] (src/somefile.php:2:29) -> call to print_r (src/somefile.php:2:29) -> print_r#1',
+            ],
+            'var_dump' => [
+                '<?php
+                    var_dump($_GET["name"]);',
+                'error_message' => 'TaintedHtml - src' . DIRECTORY_SEPARATOR . 'somefile.php:2:30 - Detected tainted HTML in path: $_GET -> $_GET[\'name\'] (src/somefile.php:2:30) -> call to var_dump (src/somefile.php:2:30) -> var_dump#1',
+            ],
+            'var_export' => [
+                '<?php
+                    var_export($_GET["name"]);',
+                'error_message' => 'TaintedHtml - src' . DIRECTORY_SEPARATOR . 'somefile.php:2:32 - Detected tainted HTML in path: $_GET -> $_GET[\'name\'] (src/somefile.php:2:32) -> call to var_export (src/somefile.php:2:32) -> var_export#1',
             ],
             'unpackArgs' => [
                 '<?php


### PR DESCRIPTION
Affects taint behavior or PHP core functions `printf`, `print_r`, `var_dump`, `var_export`.
This change does not change nor introduce conditional taint sinks as discussed in issue #4669.