### PR TITLE
allow psalter to add literal string/int in psalm phpdoc

### DIFF
--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -66,6 +66,6 @@ class TLiteralString extends TString
         ?string $this_class,
         bool $use_phpdoc_format
     ): string {
-        return 'string';
+        return $use_phpdoc_format ? 'string' : "'" . $this->value . "'";
     }
 }

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -2,6 +2,7 @@
 namespace Psalm\Type;
 
 use function array_filter;
+use function array_merge;
 use function array_values;
 use function count;
 use function get_class;
@@ -426,29 +427,44 @@ class Union implements TypeNode
         ?string $this_class,
         bool $use_phpdoc_format
     ): string {
-        $types = [];
+        $other_types = [];
 
-        $multi_ints = count($this->literal_int_types) > 1
-            || $this->hasPositiveInt();
-        $multi_strings = count($this->literal_string_types) > 1;
-        $multi_floats = count($this->literal_float_types) > 1;
+        $literal_ints = [];
+        $literal_strings = [];
+
+        $has_non_literal_int = false;
+        $has_non_literal_string = false;
 
         foreach ($this->types as $type) {
-            if ($type instanceof TLiteralInt && !$multi_ints) {
-                $type_string = 'int';
-            } elseif ($type instanceof TLiteralFloat && !$multi_floats) {
-                $type_string = 'float';
-            } elseif ($type instanceof TLiteralString && !$multi_strings) {
-                $type_string = 'string';
+            $type_string = $type->toNamespacedString($namespace, $aliased_classes, $this_class, $use_phpdoc_format);
+            if ($type instanceof TLiteralInt) {
+                $literal_ints[] = $type_string;
+            } elseif ($type instanceof TLiteralString) {
+                $literal_strings[] = $type_string;
             } else {
-                $type_string = $type->toNamespacedString($namespace, $aliased_classes, $this_class, $use_phpdoc_format);
+                if(get_class($type) === TString::class){
+                    $has_non_literal_string = true;
+                } elseif(get_class($type) === TInt::class){
+                    $has_non_literal_int = true;
+                }
+                $other_types[] = $type_string;
             }
-
-            $types[] = $type_string;
         }
 
-        sort($types);
-        return implode('|', \array_unique($types));
+        if (count($literal_ints) <= 3 && !$has_non_literal_int) {
+            $other_types = array_merge($other_types, $literal_ints);
+        } else {
+            $other_types[] = 'int';
+        }
+
+        if (count($literal_strings) <= 3 && !$has_non_literal_string) {
+            $other_types = array_merge($other_types, $literal_strings);
+        } else {
+            $other_types[] = 'string';
+        }
+
+        sort($other_types);
+        return implode('|', \array_unique($other_types));
     }
 
     /**

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -442,9 +442,9 @@ class Union implements TypeNode
             } elseif ($type instanceof TLiteralString) {
                 $literal_strings[] = $type_string;
             } else {
-                if(get_class($type) === TString::class){
+                if (get_class($type) === TString::class) {
                     $has_non_literal_string = true;
-                } elseif(get_class($type) === TInt::class){
+                } elseif (get_class($type) === TInt::class) {
                     $has_non_literal_int = true;
                 }
                 $other_types[] = $type_string;

--- a/tests/FileManipulation/MissingPropertyTypeTest.php
+++ b/tests/FileManipulation/MissingPropertyTypeTest.php
@@ -26,6 +26,8 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                     class A {
                         /**
                          * @var int|string
+                         *
+                         * @psalm-var \'hello\'|4
                          */
                         public $v;
 
@@ -56,6 +58,8 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                     class A {
                         /**
                          * @var int|null
+                         *
+                         * @psalm-var 4|null
                          */
                         public $v;
 
@@ -84,6 +88,8 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                     class A {
                         /**
                          * @var int|null
+                         *
+                         * @psalm-var 4|null
                          */
                         public $v;
 
@@ -139,6 +145,8 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                     class A {
                         /**
                          * @var int|string
+                         *
+                         * @psalm-var \'hello\'|4
                          */
                         public $v;
 

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -50,6 +50,8 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @return string
+                     *
+                     * @psalm-return \'hello\'
                      */
                     function foo() {
                         return "hello";
@@ -79,6 +81,8 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @return null|string
+                     *
+                     * @psalm-return \'hello\'|null
                      */
                     function foo() {
                         return rand(0, 1) ? "hello" : null;
@@ -95,6 +99,8 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @return null|string
+                     *
+                     * @psalm-return \'hello\'|null
                      */
                     function foo() {
                         return rand(0, 1) ? "hello" : null;
@@ -153,7 +159,7 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     /**
                      * @return string[]
                      *
-                     * @psalm-return array{0: string}
+                     * @psalm-return array{0: \'hello\'}
                      */
                     function foo() {
                         return ["hello"];
@@ -171,7 +177,7 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     /**
                      * @return string[]
                      *
-                     * @psalm-return array{0: string}
+                     * @psalm-return array{0: \'hello\'}
                      */
                     function foo(): array {
                         return ["hello"];
@@ -189,7 +195,7 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     /**
                      * @return string[]
                      *
-                     * @psalm-return array{a: string, b?: string}
+                     * @psalm-return array{a: \'goodbye\'|\'hello\', b?: \'hello again\'}
                      */
                     function foo(): array {
                         return rand(0, 1) ? ["a" => "hello"] : ["a" => "goodbye", "b" => "hello again"];
@@ -214,7 +220,7 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     /**
                      * @return int[]
                      *
-                     * @psalm-return array{a?: int, b?: int}
+                     * @psalm-return array{a?: 1, b?: 2}
                      */
                     function foo(): array {
                         if (rand(0, 1)) {
@@ -251,7 +257,7 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     /**
                      * @return ((int|int[])[]|int)[]
                      *
-                     * @psalm-return array{a: int, b: int, c: array{a: int, b: int, c: array{a: int, b: int, c: int}}}
+                     * @psalm-return array{a: 1, b: 2, c: array{a: 1, b: 2, c: array{a: 1, b: 2, c: 3}}}
                      */
                     function foo(): array {
                         return [
@@ -289,7 +295,7 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     /**
                      * @return string[]
                      *
-                     * @psalm-return array{a: string, b?: string}
+                     * @psalm-return array{a: \'goodbye\'|\'hello\', b?: \'hello again\'}
                      */
                     function foo(): array {
                         if (rand(0, 1)) {
@@ -532,6 +538,8 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @return null|string
+                     *
+                     * @psalm-return \'hello\'|null
                      */
                     function foo() {
                       if (rand(0, 1)) {
@@ -543,6 +551,8 @@ class MissingReturnTypeTest extends FileManipulationTestCase
 
                     /**
                      * @return null|string
+                     *
+                     * @psalm-return \'hello\'|null
                      */
                     function bar() {
                       if (rand(0, 1)) {

--- a/tests/FileManipulation/ParamTypeManipulationTest.php
+++ b/tests/FileManipulation/ParamTypeManipulationTest.php
@@ -70,6 +70,9 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                     (new C)->fooFoo("hello");',
                 '<?php
                     class C {
+                        /**
+                         * @param string $a
+                         */
                         public function fooFoo(string $a): void {}
                     }
 
@@ -184,6 +187,9 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                     (new D)->fooFoo("hello");',
                 '<?php
                     class C {
+                        /**
+                         * @param string $a
+                         */
                         public function fooFoo(string $a): void {}
                     }
 
@@ -223,6 +229,9 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                     (new C)->foo($a);',
                 '<?php
                     class C {
+                        /**
+                         * @param string $bar
+                         */
                         public function foo(string &$bar) : void {
                             $bar .= " me";
                         }

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -17,6 +17,8 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                 '<?php
                     $a = /**
                      * @return string
+                     *
+                     * @psalm-return \'hello\'
                      */
                     function() {
                         return "hello";
@@ -47,6 +49,8 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @return string
+                     *
+                     * @psalm-return \'hello\'
                      */
                     function foo() {
                         return "hello";
@@ -66,6 +70,8 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @return string
+                     *
+                     * @psalm-return \'hello\'
                      */
                     function foo(): string {
                         return "hello";
@@ -95,6 +101,8 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @return false|string
+                     *
+                     * @psalm-return \'hello\'|false
                      */
                     function foo() {
                         return rand(0, 1) ? "hello" : false;
@@ -111,6 +119,8 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @return null|string
+                     *
+                     * @psalm-return \'hello\'|null
                      */
                     function foo() {
                         return rand(0, 1) ? "hello" : null;
@@ -194,6 +204,8 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                      *          - `google`
                      *
                      * @return string
+                     *
+                     * @psalm-return \'hello\'
                      */
                     function foo(): string {
                       return "hello";
@@ -338,6 +350,8 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                     class A {
                         /**
                          * @return string some notes
+                         *
+                         * @psalm-return \'hello\'
                          */
                         function foo() : string {
                             return "hello";
@@ -502,7 +516,7 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                         /**
                          * @return string[]
                          *
-                         * @psalm-return array{0: string}
+                         * @psalm-return array{0: \'hello\'}
                          */
                         public function foo(): ?array {
                             return ["hello"];
@@ -528,7 +542,7 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                         /**
                          * @return string[]
                          *
-                         * @psalm-return array{0: string}
+                         * @psalm-return array{0: \'hello\'}
                          */
                         public function foo(): array {
                             return ["hello"];


### PR DESCRIPTION
This PR will allow Psalter to be more precise when encountering a small list of literals. I arbitrary chose 3 as the limit to avoid making a mess but this could be changed in the future.