### PR TITLE
Flag unexpected tags on function docblocks

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -343,6 +343,7 @@
             <xs:element name="PossiblyInvalidArrayOffset" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidCast" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidClone" type="IssueHandlerType" minOccurs="0" />
+	    <xs:element name="PossiblyInvalidDocblockTag" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidFunctionCall" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidIterator" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidMethodCall" type="IssueHandlerType" minOccurs="0" />

--- a/config.xsd
+++ b/config.xsd
@@ -343,7 +343,7 @@
             <xs:element name="PossiblyInvalidArrayOffset" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidCast" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidClone" type="IssueHandlerType" minOccurs="0" />
-	    <xs:element name="PossiblyInvalidDocblockTag" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="PossiblyInvalidDocblockTag" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidFunctionCall" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidIterator" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyInvalidMethodCall" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/issues/PossiblyInvalidDocblockTag.md
+++ b/docs/running_psalm/issues/PossiblyInvalidDocblockTag.md
@@ -1,0 +1,11 @@
+# PossiblyInvalidDocblockTag
+
+Emitted when Psalm detects a likely mix-up of docblock tags, e.g. `@var`
+used on a method (where `@param` is likely expected).
+
+```php
+<?php
+
+/** @var int $param */
+function foo($param): void {}
+```

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -216,4 +216,7 @@ class FunctionDocblockComment
      * @var ?string
      */
     public $description;
+
+    /** @var array<string, array{lines:list<int>, suggested_replacement?:string}> */
+    public $unexpected_tags = [];
 }

--- a/src/Psalm/Issue/PossiblyInvalidDocblockTag.php
+++ b/src/Psalm/Issue/PossiblyInvalidDocblockTag.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+class PossiblyInvalidDocblockTag extends CodeIssue
+{
+    public const ERROR_LEVEL = 4;
+    public const SHORTCODE = 270;
+}

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1752,6 +1752,20 @@ class AnnotationTest extends TestCase
                     }',
                 'error_message' => 'ImplementedReturnTypeMismatch'
             ],
+            'unexpectedImportType' => [
+                '<?php
+                    /** @psalm-import-type asd */
+                    function f(): void {}
+                ',
+                'error_message' => 'PossiblyInvalidDocblockTag',
+            ],
+            'unexpectedVarOnFunction' => [
+                '<?php
+                    /** @var int $p */
+                    function f($p): void {}
+                ',
+                'error_message' => 'PossiblyInvalidDocblockTag',
+            ],
         ];
     }
 }

--- a/tests/FunctionLikeDocblockParserTest.php
+++ b/tests/FunctionLikeDocblockParserTest.php
@@ -79,4 +79,22 @@ class FunctionLikeDocblockParserTest extends BaseTestCase
         $function_docblock = FunctionLikeDocblockParser::parse($php_parser_doc);
         $this->assertSame([['T', 'of', 'string', false]], $function_docblock->templates);
     }
+
+    public function testReturnsUnexpectedTags(): void
+    {
+        $doc = '/**
+ * @psalm-import-type abcd
+ * @var int $p
+ */
+';
+        $php_parser_doc = new \PhpParser\Comment\Doc($doc, 0);
+        $function_docblock = FunctionLikeDocblockParser::parse($php_parser_doc);
+        $this->assertEquals(
+            [
+                'psalm-import-type' => ['lines' => [1]],
+                'var' => ['lines' => [2], 'suggested_replacement' => 'param'],
+            ],
+            $function_docblock->unexpected_tags
+        );
+    }
 }


### PR DESCRIPTION
This makes Psalm flag `@var` and `@psalm-import-type` tags used on methods (the list should also be fairly easy to extend). 

Fixes vimeo/psalm#5782