### PR TITLE
Union types php7

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -913,7 +913,6 @@ class ReturnTypeAnalyzer
 
         $allow_native_type = !$docblock_only
             && (int)$php_major_version >= 7
-            && ((int)$php_minor_version >= 8 || $inferred_return_type->isSingle())
             && (
                 $codebase->allow_backwards_incompatible_changes
                 || $is_final
@@ -926,8 +925,8 @@ class ReturnTypeAnalyzer
                     $source->getNamespace(),
                     $source->getAliasedClassesFlipped(),
                     $source->getFQCLN(),
-                    $codebase->php_major_version,
-                    $codebase->php_minor_version
+                    (int)$php_major_version,
+                    (int)$php_minor_version
                 ) : null,
             $inferred_return_type->toNamespacedString(
                 $source->getNamespace(),
@@ -941,7 +940,7 @@ class ReturnTypeAnalyzer
                 $source->getFQCLN(),
                 true
             ),
-            $inferred_return_type->canBeFullyExpressedInPhp($codebase->php_major_version, $codebase->php_minor_version),
+            $inferred_return_type->canBeFullyExpressedInPhp((int)$php_major_version, (int)$php_minor_version),
             $function_like_storage ? $function_like_storage->return_type_description : null
         );
     }

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -43,6 +43,7 @@ use function substr;
 use function count;
 use function in_array;
 use function array_diff;
+use function explode;
 
 /**
  * @internal
@@ -906,8 +907,13 @@ class ReturnTypeAnalyzer
             $is_final = $function->isFinal() || $class_storage->final;
         }
 
+        $php_versions = explode('.', (string)$project_analyzer->getConfig()->getPhpVersion());
+        $php_major_version = $php_versions[0] ?? '0';
+        $php_minor_version = $php_versions[1] ?? '0';
+
         $allow_native_type = !$docblock_only
-            && $codebase->php_major_version >= 7
+            && (int)$php_major_version >= 7
+            && ((int)$php_minor_version >= 8 || $inferred_return_type->isSingle())
             && (
                 $codebase->allow_backwards_incompatible_changes
                 || $is_final


### PR DESCRIPTION
This is a draft for a fix of https://psalm.dev/r/334d9720aa?php=7.1

When clicking fix code on this link, Psalter will add union types even though the php version is set to 7.1.

It happens too when running psalter on psalm itself when the php version running psalm is >8.

It's due to an ambiguity in php versions in Psalm.

There are two php versions:
- One in codebase. It's the PHP version that is fetched directly from PHP_MINOR_VERSION and PHP_MAJOR_VERSION, which means it's the version used to run Psalm
- One in config, through the `getPhpVersion` method. It's the one fetched from the config file, the command line or from composer directly. It's the version we want to check the project with and we don't want psalter to use another version when fixing code.

Unfortunately, it's almost always the first one that's used in the code. This means the behaviour when the code doesn't use the same php version than the server used to run psalm is pretty random.

It have effects in CI, in psalm.dev and even in psalm's own test where the php version we can set is actually the first one, which makes test in this PR fail.

How should we proceed forward on this? Should we try to make a big change and replace almost every usage of the Codebase versions by the one in config?