### PR TITLE
fix wrong version used in psalter

### DIFF
--- a/src/psalter.php
+++ b/src/psalter.php
@@ -313,6 +313,10 @@ HELP;
             $keyed_issues = [];
         }
 
+        if (!isset($options['php-version'])) {
+            $options['php-version'] = $config->getPhpVersion();
+        }
+
         if (isset($options['php-version'])) {
             if (!is_string($options['php-version'])) {
                 die('Expecting a version number in the format x.y' . PHP_EOL);


### PR DESCRIPTION
Following #5853, @weirdan pointed the real issue, the php-version from composer is not pushed to the Codebase instance in psalter.php like it is on psalm.php. This PR fixes that