### PR TITLE
Nullsafe calls should not trigger NPE on consecutive calls 

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/NullsafeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/NullsafeAnalyzer.php
@@ -90,6 +90,11 @@ class NullsafeAnalyzer
 
         $statements_analyzer->node_data = $old_node_data;
 
+        if ($ternary_type) {
+            //after a nullsafe, the null propagate to consecutive calls but it should not trigger issues
+            $ternary_type->ignore_nullable_issues = true;
+        }
+
         $statements_analyzer->node_data->setType($stmt, $ternary_type ?: Type::getMixed());
 
         return true;

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -983,7 +983,27 @@ class MethodCallTest extends TestCase
                 [],
                 ['MixedReturnStatement', 'MixedInferredReturnType'],
                 '8.0'
-            ]
+            ],
+            'NullsafeShortCircuit' => [
+                '<?php
+                    interface Bar {
+                        public function doBaz(): void;
+                    }
+
+                    interface Foo {
+                        public function getBar(): Bar;
+                    }
+
+                    function fooOrNull(): ?Foo {
+                        return null;
+                    }
+
+                    fooOrNull()?->getBar()->doBaz();
+                    ',
+                [],
+                [],
+                '8.0'
+            ],
         ];
     }
 


### PR DESCRIPTION
This should solve #4523

I'm sure this is not the best way to do that but it seems to do well enough.

One side effect I could foresee is if `baz()` can return null in `$a?->baz()`, then a potential NPE won't be reported on `$a?->baz()->bar()` anymore