### PR TITLE
Make toPHP second parameter optional

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -7775,7 +7775,7 @@ return [
 'MongoDB\BSON\timestampinterface::getIncrement' => ['int'],
 'MongoDB\BSON\timestampinterface::getTimestamp' => ['int'],
 'MongoDB\BSON\toJSON' => ['string', 'bson'=>'string'],
-'MongoDB\BSON\toPHP' => ['object', 'bson'=>'string', 'typeMap'=>'array'],
+'MongoDB\BSON\toPHP' => ['object', 'bson'=>'string', 'typeMap='=>'array'],
 'MongoDB\BSON\undefined::__construct' => ['void'],
 'MongoDB\BSON\undefined::__toString' => ['string'],
 'MongoDB\BSON\undefined::jsonSerialize' => ['mixed'],


### PR DESCRIPTION
The second parameter of [`MongoDB\BSON\toPHP` function](https://www.php.net/manual/es/function.mongodb.bson-tophp.php) is optional.

https://psalm.dev/r/1113b68dab

