### PR TITLE
Formally deprecate `allowCoercionFromStringToClassConst`

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -33,7 +33,16 @@
         <xs:attribute name="serializer" type="xs:string" />
 
         <xs:attribute name="addParamDefaultToDocblockType" type="xs:boolean" default="false" />
-        <xs:attribute name="allowCoercionFromStringToClassConst" type="xs:boolean" default="false" />
+
+        <xs:attribute name="allowCoercionFromStringToClassConst" type="xs:boolean" default="false">
+            <xs:annotation>
+                <!-- note: for PHPStorm to mark the attribute as deprecated the doc entry has to be *single line* and start with the word `deprecated` -->
+                <xs:documentation xml:lang="en">
+                    Deprecated. Has no effect since Psalm 3 and is going to be removed in Psalm 5.
+                </xs:documentation>
+            </xs:annotation>
+        </xs:attribute>
+
         <xs:attribute name="allowFileIncludes" type="xs:boolean" default="true" />
         <xs:attribute name="allowPhpStormGenerics" type="xs:boolean" default="false" />
         <xs:attribute name="allowStringToStandInForClass" type="xs:boolean" default="false" />

--- a/config.xsd
+++ b/config.xsd
@@ -198,6 +198,7 @@
             <xs:element name="CircularReference" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ComplexFunction" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ComplexMethod" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="ConfigIssue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ConflictingReferenceConstraint" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ConstructorSignatureMismatch" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ContinueOutsideLoop" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -24,6 +24,7 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
  - [AbstractMethodCall](issues/AbstractMethodCall.md)
  - [ComplexFunction](issues/ComplexFunction.md)
  - [ComplexMethod](issues/ComplexMethod.md)
+ - [ConfigIssue](issues/ConfigIssue.md)
  - [DuplicateArrayKey](issues/DuplicateArrayKey.md)
  - [DuplicateClass](issues/DuplicateClass.md)
  - [DuplicateFunction](issues/DuplicateFunction.md)

--- a/docs/running_psalm/issues/ConfigIssue.md
+++ b/docs/running_psalm/issues/ConfigIssue.md
@@ -1,0 +1,7 @@
+# ConfigIssue
+
+Emitted for non-fatal configuration issues, e.g. deprecated configuration switches.
+
+## Why this is bad
+
+Your config file may be incompatible with feature Psalm versions.

--- a/src/Psalm/Issue/ConfigIssue.php
+++ b/src/Psalm/Issue/ConfigIssue.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+class ConfigIssue extends CodeIssue
+{
+    public const ERROR_LEVEL = -1;
+    public const SHORTCODE = 271;
+}

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -5,6 +5,7 @@ use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\ExecutionEnvironment\BuildInfoCollector;
 use Psalm\Issue\CodeIssue;
+use Psalm\Issue\ConfigIssue;
 use Psalm\Issue\UnusedPsalmSuppress;
 use Psalm\Plugin\EventHandler\Event\AfterAnalysisEvent;
 use Psalm\Report\CheckstyleReport;
@@ -140,7 +141,7 @@ class IssueBuffer
         $issue_type = array_pop($fqcn_parts);
         $file_path = $e->getFilePath();
 
-        if (!$config->reportIssueInFile($issue_type, $file_path)) {
+        if (!$e instanceof ConfigIssue && !$config->reportIssueInFile($issue_type, $file_path)) {
             return true;
         }
 
@@ -459,8 +460,15 @@ class IssueBuffer
 
         $codebase = $project_analyzer->getCodebase();
 
+        foreach ($codebase->config->config_issues as $issue) {
+            if (self::accepts($issue)) {
+                // fall through
+            }
+        }
+
         $error_count = 0;
         $info_count = 0;
+
 
         $issues_data = [];
 

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -53,7 +53,7 @@ class DocumentationTest extends TestCase
         '@psalm-self-out', // I'm fairly sure it's intentionally undocumented, but can't find the reference
         '@psalm-variadic',
     ];
-    
+
     /**
      * These should be documented
      */
@@ -179,6 +179,7 @@ class DocumentationTest extends TestCase
         $code_blocks['TaintedCustom'] = true;
         $code_blocks['ComplexFunction'] = true;
         $code_blocks['ComplexMethod'] = true;
+        $code_blocks['ConfigIssue'] = true;
 
         $documented_issues = array_keys($code_blocks);
         sort($documented_issues);


### PR DESCRIPTION
`allowCoercionFromStringToClassConst` is a recognized config attribute, but it has no effect. Previous attempt at removing it has caused a lot of breaks (#3982) so it had to be reverted (#4046).

This time, instead of failing validation we emit a deprecation issue and let Psalm run as usual. This should provide smooth upgrade path.