### PR TITLE
Fix `sscanf()` signature

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -13663,7 +13663,7 @@ return [
 'sqlsrv_server_info' => ['array', 'conn'=>'resource'],
 'sqrt' => ['float', 'num'=>'float'],
 'srand' => ['void', 'seed='=>'int', 'mode='=>'int'],
-'sscanf' => ['list<mixed>|int', 'string'=>'string', 'format'=>'string', '&...w_vars='=>'string|int|float'],
+'sscanf' => ['list<float|int|string|null>|int|null', 'string'=>'string', 'format'=>'string', '&...w_vars='=>'string|int|float|null'],
 'ssdeep_fuzzy_compare' => ['int', 'signature1'=>'string', 'signature2'=>'string'],
 'ssdeep_fuzzy_hash' => ['string', 'to_hash'=>'string'],
 'ssdeep_fuzzy_hash_filename' => ['string', 'file_name'=>'string'],

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -477,9 +477,9 @@ function date(string $format, int $timestamp = 0) {}
  * @psalm-pure
  *
  * @param mixed $vars
- * @param-out string|int|float $vars
+ * @param-out string|int|float|null $vars
  * @psalm-flow ($str, $format) -> return
- * @return (func_num_args() is 2 ? list<float|int|string> : int)
+ * @return (func_num_args() is 2 ? (null|list<float|int|string|null>) : int)
  */
 function sscanf(string $str, string $format, &...$vars) {}
 
@@ -718,7 +718,7 @@ function htmlspecialchars_decode(string $string, ?int $quote_style = null) : str
 
 /**
  * @psalm-pure
- * 
+ *
  * @psalm-return (
  *     $string is non-empty-string
  *     ? positive-int

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1057,9 +1057,9 @@ class FunctionCallTest extends TestCase
                 '<?php
                     sscanf("10:05:03", "%d:%d:%d", $hours, $minutes, $seconds);',
                 'assertions' => [
-                    '$hours' => 'float|int|string',
-                    '$minutes' => 'float|int|string',
-                    '$seconds' => 'float|int|string',
+                    '$hours' => 'float|int|null|string',
+                    '$minutes' => 'float|int|null|string',
+                    '$seconds' => 'float|int|null|string',
                 ],
             ],
             'noImplicitAssignmentToStringFromMixedWithDocblockTypes' => [
@@ -1417,7 +1417,7 @@ class FunctionCallTest extends TestCase
                 '<?php
                     $data = sscanf("42 psalm road", "%s %s");',
                 [
-                    '$data' => 'list<float|int|string>',
+                    '$data' => 'list<float|int|null|string>|null',
                 ]
             ],
             'sscanfReturnTypeWithMoreThanTwoParameters' => [
@@ -1425,7 +1425,9 @@ class FunctionCallTest extends TestCase
                     $n = sscanf("42 psalm road", "%s %s", $p1, $p2);',
                 [
                     '$n' => 'int',
-                ]
+                    '$p1' => 'float|int|null|string',
+                    '$p2' => 'float|int|null|string',
+                ],
             ],
             'writeArgsAllowed' => [
                 '<?php


### PR DESCRIPTION
Fixes vimeo/psalm#5870

`sscanf()` returns:
* `null` when input string is empty and no out variables provided: https://3v4l.org/2OfgdC
* `list` with nulls for unmatched specifiers: https://3v4l.org/Njvgf
* `null` for out variables corresponding to unmatched specifiers and the number of matched specifiers as a return value: https://3v4l.org/8OZMk
* `-1` when input string is empty and out variables are provided: https://3v4l.org/qq1Al