### PR TITLE
Detect unused return values

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -381,6 +381,7 @@
             <xs:element name="PossiblyUnusedMethod" type="MethodIssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyUnusedParam" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyUnusedProperty" type="PropertyIssueHandlerType" minOccurs="0" />
+            <xs:element name="PossiblyUnusedReturnValue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PropertyNotSetInConstructor" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="PropertyTypeCoercion" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="RawObjectIteration" type="IssueHandlerType" minOccurs="0" />
@@ -456,6 +457,7 @@
             <xs:element name="UnusedParam" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnusedProperty" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="UnusedPsalmSuppress" type="FunctionIssueHandlerType" minOccurs="0" />
+            <xs:element name="UnusedReturnValue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnusedVariable" type="IssueHandlerType" minOccurs="0" />
         </xs:choice>
     </xs:complexType>

--- a/docs/running_psalm/issues/PossiblyUnusedMethod.md
+++ b/docs/running_psalm/issues/PossiblyUnusedMethod.md
@@ -1,6 +1,6 @@
 # PossiblyUnusedMethod
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any calls to a given class method
+Emitted when `--find-dead-code` is turned on and Psalm cannot find any calls to a public or protected method.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/PossiblyUnusedReturnValue.md
+++ b/docs/running_psalm/issues/PossiblyUnusedReturnValue.md
@@ -1,0 +1,14 @@
+# PossiblyUnusedReturnValue
+
+Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a public/protected method’s return type.
+
+```php
+<?php
+
+class A {
+    public function foo() : string {
+        return "hello";
+    }
+}
+(new A)->foo();
+```

--- a/docs/running_psalm/issues/UnusedReturnValue.md
+++ b/docs/running_psalm/issues/UnusedReturnValue.md
@@ -1,0 +1,18 @@
+# UnusedReturnValue
+
+Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a private method’s return value.
+
+```php
+<?php
+
+class A {
+    public function __construct() {
+        $this->foo();
+    }
+    private function foo() : string {
+        return "hello";
+    }
+}
+
+new A();
+```

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -128,6 +128,13 @@
             </errorLevel>
         </PossiblyUnusedMethod>
 
+        <PossiblyUnusedReturnValue>
+            <errorLevel type="suppress">
+                <directory name="tests" />
+                <file name="src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php" />
+            </errorLevel>
+        </PossiblyUnusedReturnValue>
+
         <InternalMethod>
             <errorLevel type="suppress">
                 <directory name="tests"/>

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -80,6 +80,13 @@ class Context
     public $inside_use = false;
 
     /**
+     * Whether or not we're inside a return expression
+     *
+     * @var bool
+     */
+    public $inside_return = false;
+
+    /**
      * Whether or not we're inside a throw
      *
      * @var bool

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -544,7 +544,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 $this->source->getFQCLN(),
                 $storage->return_type_location,
                 $context->has_returned,
-                $global_context && $global_context->inside_call
+                $global_context && ($global_context->inside_call || $global_context->inside_return)
             );
 
             $closure_yield_types = [];

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -66,7 +66,8 @@ class MethodComparator
 
         $codebase->methods->file_reference_provider->addMethodReferenceToClassMember(
             strtolower((string)($implementer_declaring_method_id ?: $implementer_method_id)),
-            strtolower($guide_classlike_storage->name . '::' . $guide_method_storage->cased_name)
+            strtolower($guide_classlike_storage->name . '::' . $guide_method_storage->cased_name),
+            true
         );
 
         self::checkForObviousMethodMismatches(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -931,7 +931,13 @@ class ArgumentAnalyzer
                     $context->calling_method_id,
                     null,
                     $statements_analyzer,
-                    $statements_analyzer->getFilePath()
+                    $statements_analyzer->getFilePath(),
+                    true,
+                    $context->inside_return
+                        || $context->inside_call
+                        || $context->inside_use
+                        || $context->inside_assignment
+                        || $context->inside_conditional
                 );
             }
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -994,6 +994,7 @@ class FunctionCallAnalyzer extends CallAnalyzer
                  */
                 if (!$context->inside_assignment
                     && !$context->inside_call
+                    && !$context->inside_return
                     && !$context->inside_use
                     && !$context->inside_throw
                     && !self::callUsesByReferenceArguments($function_call_info, $stmt)

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -201,7 +201,12 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                 ? $statements_analyzer
                 : null,
             $statements_analyzer->getFilePath(),
-            false
+            false,
+            $context->inside_return
+                || $context->inside_call
+                || $context->inside_use
+                || $context->inside_assignment
+                || $context->inside_conditional
         );
 
         $fake_method_exists = false;
@@ -319,7 +324,13 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                         && !$context->collect_mutations
                         ? $statements_analyzer
                         : null,
-                    $statements_analyzer->getFilePath()
+                    $statements_analyzer->getFilePath(),
+                    true,
+                    $context->inside_return
+                        || $context->inside_call
+                        || $context->inside_use
+                        || $context->inside_assignment
+                        || $context->inside_conditional
                 )
             ) {
                 $new_call_context = MissingMethodCallHandler::handleMagicMethod(
@@ -719,7 +730,13 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                                 && !$context->collect_mutations
                                     ? $statements_analyzer
                                     : null,
-                                $statements_analyzer->getFilePath()
+                                $statements_analyzer->getFilePath(),
+                                true,
+                                $context->inside_return
+                                    || $context->inside_call
+                                    || $context->inside_use
+                                    || $context->inside_assignment
+                                    || $context->inside_conditional
                             )) {
                                 $lhs_type_part = clone $lhs_type_part_new;
                                 $class_storage = $mixin_class_storage;
@@ -785,7 +802,13 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                 && !$context->collect_mutations
                     ? $statements_analyzer
                     : null,
-                $statements_analyzer->getFilePath()
+                $statements_analyzer->getFilePath(),
+                true,
+                $context->inside_return
+                    || $context->inside_call
+                    || $context->inside_use
+                    || $context->inside_assignment
+                    || $context->inside_conditional
             )) {
                 $mixin_declaring_class_storage = $codebase->classlike_storage_provider->get(
                     $class_storage->mixin_declaring_fqcln

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -71,7 +71,8 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             [$calling_method_class] = explode('::', $context->calling_method_id);
             $codebase->file_reference_provider->addMethodReferenceToClassMember(
                 $calling_method_class . '::__construct',
-                strtolower((string) $method_id)
+                strtolower((string) $method_id),
+                false
             );
         }
 
@@ -124,7 +125,8 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             [$calling_method_class] = explode('::', $context->calling_method_id);
             $codebase->file_reference_provider->addMethodReferenceToClassMember(
                 $calling_method_class . '::__construct',
-                strtolower((string) $method_id)
+                strtolower((string) $method_id),
+                false
             );
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -106,7 +106,7 @@ class MethodCallPurityAnalyzer
                 && !$context->inside_use
                 && !$context->inside_throw
             ) {
-                if (!$context->inside_assignment && !$context->inside_call) {
+                if (!$context->inside_assignment && !$context->inside_call && !$context->inside_return) {
                     if (IssueBuffer::accepts(
                         new \Psalm\Issue\UnusedMethodCall(
                             'The call to ' . $cased_method_id . ' is not used',

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -63,7 +63,8 @@ class NewAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAna
                 ) {
                     $codebase->file_reference_provider->addMethodReferenceToClassMember(
                         $context->calling_method_id,
-                        'use:' . $stmt->class->parts[0] . ':' . \md5($statements_analyzer->getFilePath())
+                        'use:' . $stmt->class->parts[0] . ':' . \md5($statements_analyzer->getFilePath()),
+                        false
                     );
                 }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
@@ -110,7 +110,8 @@ class StaticCallAnalyzer extends CallAnalyzer
                 ) {
                     $codebase->file_reference_provider->addMethodReferenceToClassMember(
                         $context->calling_method_id,
-                        'use:' . $stmt->class->parts[0] . ':' . \md5($statements_analyzer->getFilePath())
+                        'use:' . $stmt->class->parts[0] . ':' . \md5($statements_analyzer->getFilePath()),
+                        false
                     );
                 }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -300,7 +300,12 @@ class AtomicStaticCallAnalyzer
                 : null,
             $statements_analyzer,
             $statements_analyzer->getFilePath(),
-            false
+            false,
+            $context->inside_return
+                || $context->inside_call
+                || $context->inside_use
+                || $context->inside_assignment
+                || $context->inside_conditional
         );
 
         $fake_method_exists = false;
@@ -340,7 +345,13 @@ class AtomicStaticCallAnalyzer
                     && !$context->collect_mutations
                         ? $statements_analyzer
                         : null,
-                    $statements_analyzer->getFilePath()
+                    $statements_analyzer->getFilePath(),
+                    true,
+                    $context->inside_return
+                        || $context->inside_call
+                        || $context->inside_use
+                        || $context->inside_assignment
+                        || $context->inside_conditional
                 )) {
                     $mixin_candidates = [];
                     foreach ($class_storage->templatedMixins as $mixin_candidate) {
@@ -458,7 +469,13 @@ class AtomicStaticCallAnalyzer
                     && !$context->collect_mutations
                     ? $statements_analyzer
                     : null,
-                $statements_analyzer->getFilePath()
+                $statements_analyzer->getFilePath(),
+                true,
+                $context->inside_return
+                    || $context->inside_call
+                    || $context->inside_use
+                    || $context->inside_assignment
+                    || $context->inside_conditional
             )) {
                 if ($codebase->methods->return_type_provider->has($fq_class_name)) {
                     $return_type_candidate = $codebase->methods->return_type_provider->getReturnType(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -290,7 +290,8 @@ class ClassConstFetchAnalyzer
             if ($context->calling_method_id) {
                 $codebase->file_reference_provider->addMethodReferenceToClassMember(
                     $context->calling_method_id,
-                    strtolower($fq_class_name) . '::' . $stmt->name->name
+                    strtolower($fq_class_name) . '::' . $stmt->name->name,
+                    false
                 );
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
@@ -75,7 +75,8 @@ class StaticPropertyFetchAnalyzer
             ) {
                 $codebase->file_reference_provider->addMethodReferenceToClassMember(
                     $context->calling_method_id,
-                    'use:' . $stmt->class->parts[0] . ':' . \md5($statements_analyzer->getFilePath())
+                    'use:' . $stmt->class->parts[0] . ':' . \md5($statements_analyzer->getFilePath()),
+                    false
                 );
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -424,6 +424,7 @@ class VariableFetchAnalyzer
         if ($statements_analyzer->data_flow_graph
             && $codebase->find_unused_variables
             && ($context->inside_call
+                || $context->inside_return
                 || $context->inside_conditional
                 || $context->inside_use
                 || $context->inside_isset
@@ -441,7 +442,7 @@ class VariableFetchAnalyzer
             }
 
             foreach ($stmt_type->parent_nodes as $parent_node) {
-                if ($context->inside_call) {
+                if ($context->inside_call || $context->inside_return) {
                     $statements_analyzer->data_flow_graph->addPath(
                         $parent_node,
                         new DataFlowNode(

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -129,7 +129,7 @@ class ReturnAnalyzer
         }
 
         if ($stmt->expr) {
-            $context->inside_call = true;
+            $context->inside_return = true;
 
             if ($stmt->expr instanceof PhpParser\Node\Expr\Closure
                 || $stmt->expr instanceof PhpParser\Node\Expr\ArrowFunction
@@ -142,6 +142,7 @@ class ReturnAnalyzer
             }
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->expr, $context) === false) {
+                $context->inside_return = false;
                 return;
             }
 
@@ -178,6 +179,8 @@ class ReturnAnalyzer
             } else {
                 $stmt_type = Type::getMixed();
             }
+
+            $context->inside_return = false;
         } else {
             $stmt_type = Type::getVoid();
         }

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -1879,6 +1879,41 @@ class ClassLikes
                     }
                 }
             } else {
+                if ($method_storage->return_type
+                    && $method_storage->return_type_location
+                    && !$method_storage->return_type->isVoid()
+                    && !$method_storage->return_type->isNever()
+                    && $method_id->method_name !== '__tostring'
+                ) {
+                    $method_return_referenced = $this->file_reference_provider->isMethodReturnReferenced(
+                        strtolower((string) $method_id)
+                    );
+
+                    if (!$method_return_referenced) {
+                        if ($method_storage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
+                            if (IssueBuffer::accepts(
+                                new \Psalm\Issue\UnusedReturnValue(
+                                    'The return value for this private method is never used',
+                                    $method_storage->return_type_location
+                                ),
+                                $method_storage->suppressed_issues
+                            )) {
+                                // fall through
+                            }
+                        } else {
+                            if (IssueBuffer::accepts(
+                                new \Psalm\Issue\PossiblyUnusedReturnValue(
+                                    'The return value for this method is never used',
+                                    $method_storage->return_type_location
+                                ),
+                                $method_storage->suppressed_issues
+                            )) {
+                                // fall through
+                            }
+                        }
+                    }
+                }
+
                 if ($method_storage->visibility !== ClassLikeAnalyzer::VISIBILITY_PRIVATE
                     && !$classlike_storage->is_interface
                 ) {

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -89,7 +89,8 @@ class Methods
         ?CodeLocation $code_location = null,
         ?StatementsSource $source = null,
         ?string $source_file_path = null,
-        bool $use_method_existence_provider = true
+        bool $use_method_existence_provider = true,
+        bool $is_used = false
     ) : bool {
         $fq_class_name = $method_id->fq_class_name;
         $method_name = $method_id->method_name;
@@ -160,12 +161,14 @@ class Methods
                     if ($calling_method_id) {
                         $this->file_reference_provider->addMethodReferenceToClassMember(
                             $calling_method_id,
-                            $potential_id
+                            $potential_id,
+                            $is_used
                         );
                     } elseif ($source_file_path) {
                         $this->file_reference_provider->addFileReferenceToClassMember(
                             $source_file_path,
-                            $potential_id
+                            $potential_id,
+                            $is_used
                         );
                     }
                 }
@@ -173,12 +176,14 @@ class Methods
                 if ($calling_method_id) {
                     $this->file_reference_provider->addMethodReferenceToClassMember(
                         $calling_method_id,
-                        strtolower((string) $declaring_method_id)
+                        strtolower((string) $declaring_method_id),
+                        $is_used
                     );
                 } elseif ($source_file_path) {
                     $this->file_reference_provider->addFileReferenceToClassMember(
                         $source_file_path,
-                        strtolower((string) $declaring_method_id)
+                        strtolower((string) $declaring_method_id),
+                        $is_used
                     );
                 }
             }
@@ -203,12 +208,14 @@ class Methods
                 if ($calling_method_id) {
                     $this->file_reference_provider->addMethodReferenceToClassMember(
                         $calling_method_id,
-                        $interface_method_id_lc
+                        $interface_method_id_lc,
+                        $is_used
                     );
                 } elseif ($source_file_path) {
                     $this->file_reference_provider->addFileReferenceToClassMember(
                         $source_file_path,
-                        $interface_method_id_lc
+                        $interface_method_id_lc,
+                        $is_used
                     );
                 }
             }
@@ -233,12 +240,14 @@ class Methods
                         // also store failures in case the method is added later
                         $this->file_reference_provider->addMethodReferenceToClassMember(
                             $calling_method_id,
-                            strtolower((string) $overridden_method_id)
+                            strtolower((string) $overridden_method_id),
+                            $is_used
                         );
                     } elseif ($source_file_path) {
                         $this->file_reference_provider->addFileReferenceToClassMember(
                             $source_file_path,
-                            strtolower((string) $overridden_method_id)
+                            strtolower((string) $overridden_method_id),
+                            $is_used
                         );
                     }
                 }

--- a/src/Psalm/Internal/Codebase/Properties.php
+++ b/src/Psalm/Internal/Codebase/Properties.php
@@ -132,7 +132,8 @@ class Properties
             if ($context && $context->calling_method_id) {
                 $this->file_reference_provider->addMethodReferenceToClassMember(
                     $context->calling_method_id,
-                    strtolower($declaring_property_class) . '::$' . $property_name
+                    strtolower($declaring_property_class) . '::$' . $property_name,
+                    false
                 );
 
                 if ($read_mode) {
@@ -144,7 +145,8 @@ class Properties
             } elseif ($source) {
                 $this->file_reference_provider->addFileReferenceToClassMember(
                     $source->getFilePath(),
-                    strtolower($declaring_property_class) . '::$' . $property_name
+                    strtolower($declaring_property_class) . '::$' . $property_name,
+                    false
                 );
 
                 if ($read_mode) {

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -28,6 +28,8 @@ class FileReferenceCacheProvider
     private const ANALYZED_METHODS_CACHE_NAME = 'analyzed_methods';
     private const CLASS_METHOD_CACHE_NAME = 'class_method_references';
     private const CLASS_PROPERTY_CACHE_NAME = 'class_property_references';
+    private const CLASS_METHOD_RETURN_CACHE_NAME = 'class_method_return_references';
+    private const FILE_METHOD_RETURN_CACHE_NAME = 'file_method_return_references';
     private const FILE_CLASS_MEMBER_CACHE_NAME = 'file_class_member_references';
     private const FILE_CLASS_PROPERTY_CACHE_NAME = 'file_class_property_references';
     private const ISSUES_CACHE_NAME = 'issues';
@@ -215,6 +217,32 @@ class FileReferenceCacheProvider
     /**
      * @psalm-suppress MixedAssignment
      */
+    public function getCachedMethodMethodReturnReferences(): ?array
+    {
+        $cache_directory = $this->config->getCacheDirectory();
+
+        if (!$cache_directory) {
+            return null;
+        }
+
+        $class_member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CLASS_METHOD_RETURN_CACHE_NAME;
+
+        if (!is_readable($class_member_cache_location)) {
+            return null;
+        }
+
+        $class_member_reference_cache = unserialize((string) file_get_contents($class_member_cache_location));
+
+        if (!is_array($class_member_reference_cache)) {
+            throw new \UnexpectedValueException('The reference cache must be an array');
+        }
+
+        return $class_member_reference_cache;
+    }
+
+    /**
+     * @psalm-suppress MixedAssignment
+     */
     public function getCachedMethodMissingMemberReferences(): ?array
     {
         $cache_directory = $this->config->getCacheDirectory();
@@ -278,6 +306,34 @@ class FileReferenceCacheProvider
         $file_class_member_cache_location = $cache_directory
             . DIRECTORY_SEPARATOR
             . self::FILE_CLASS_PROPERTY_CACHE_NAME;
+
+        if (!is_readable($file_class_member_cache_location)) {
+            return null;
+        }
+
+        $file_class_member_reference_cache = unserialize((string) file_get_contents($file_class_member_cache_location));
+
+        if (!is_array($file_class_member_reference_cache)) {
+            throw new \UnexpectedValueException('The reference cache must be an array');
+        }
+
+        return $file_class_member_reference_cache;
+    }
+
+    /**
+     * @psalm-suppress MixedAssignment
+     */
+    public function getCachedFileMethodReturnReferences(): ?array
+    {
+        $cache_directory = $this->config->getCacheDirectory();
+
+        if (!$cache_directory) {
+            return null;
+        }
+
+        $file_class_member_cache_location = $cache_directory
+            . DIRECTORY_SEPARATOR
+            . self::FILE_METHOD_RETURN_CACHE_NAME;
 
         if (!is_readable($file_class_member_cache_location)) {
             return null;
@@ -475,6 +531,19 @@ class FileReferenceCacheProvider
         file_put_contents($member_cache_location, serialize($property_references));
     }
 
+    public function setCachedMethodMethodReturnReferences(array $method_return_references): void
+    {
+        $cache_directory = $this->config->getCacheDirectory();
+
+        if (!$cache_directory) {
+            return;
+        }
+
+        $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CLASS_METHOD_RETURN_CACHE_NAME;
+
+        file_put_contents($member_cache_location, serialize($method_return_references));
+    }
+
     public function setCachedMethodMissingMemberReferences(array $member_references): void
     {
         $cache_directory = $this->config->getCacheDirectory();
@@ -512,6 +581,19 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::FILE_CLASS_PROPERTY_CACHE_NAME;
 
         file_put_contents($member_cache_location, serialize($property_references));
+    }
+
+    public function setCachedFileMethodReturnReferences(array $method_return_references): void
+    {
+        $cache_directory = $this->config->getCacheDirectory();
+
+        if (!$cache_directory) {
+            return;
+        }
+
+        $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::FILE_METHOD_RETURN_CACHE_NAME;
+
+        file_put_contents($member_cache_location, serialize($method_return_references));
     }
 
     public function setCachedFileMissingMemberReferences(array $member_references): void

--- a/src/Psalm/Internal/TypeVisitor/TypeChecker.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeChecker.php
@@ -157,7 +157,8 @@ class TypeChecker extends NodeVisitor
         ) {
             $codebase->file_reference_provider->addMethodReferenceToClassMember(
                 $this->calling_method_id,
-                'use:' . $atomic->text . ':' . \md5($this->source->getFilePath())
+                'use:' . $atomic->text . ':' . \md5($this->source->getFilePath()),
+                false
             );
         }
 

--- a/src/Psalm/Issue/PossiblyUnusedReturnValue.php
+++ b/src/Psalm/Issue/PossiblyUnusedReturnValue.php
@@ -1,0 +1,8 @@
+<?php
+namespace Psalm\Issue;
+
+class PossiblyUnusedReturnValue extends CodeIssue
+{
+    public const ERROR_LEVEL = -2;
+    public const SHORTCODE = 273;
+}

--- a/src/Psalm/Issue/UnusedReturnValue.php
+++ b/src/Psalm/Issue/UnusedReturnValue.php
@@ -1,0 +1,8 @@
+<?php
+namespace Psalm\Issue;
+
+class UnusedReturnValue extends CodeIssue
+{
+    public const ERROR_LEVEL = -2;
+    public const SHORTCODE = 272;
+}

--- a/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
+++ b/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
@@ -26,10 +26,16 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     private $cached_method_property_references;
 
     /** @var ?array */
+    private $cached_method_method_return_references;
+
+    /** @var ?array */
     private $cached_file_member_references;
 
     /** @var ?array */
     private $cached_file_property_references;
+
+    /** @var ?array */
+    private $cached_file_method_return_references;
 
     /** @var ?array */
     private $cached_method_missing_member_references;
@@ -96,6 +102,11 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
         return $this->cached_file_property_references;
     }
 
+    public function getCachedFileMethodReturnReferences(): ?array
+    {
+        return $this->cached_file_method_return_references;
+    }
+
     public function getCachedMethodMemberReferences(): ?array
     {
         return $this->cached_method_member_references;
@@ -104,6 +115,11 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     public function getCachedMethodPropertyReferences(): ?array
     {
         return $this->cached_method_property_references;
+    }
+
+    public function getCachedMethodMethodReturnReferences(): ?array
+    {
+        return $this->cached_method_method_return_references;
     }
 
     public function getCachedFileMissingMemberReferences(): ?array
@@ -161,6 +177,11 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
         $this->cached_method_property_references = $property_references;
     }
 
+    public function setCachedMethodMethodReturnReferences(array $method_return_references): void
+    {
+        $this->cached_method_method_return_references = $method_return_references;
+    }
+
     public function setCachedMethodMissingMemberReferences(array $member_references): void
     {
         $this->cached_method_missing_member_references = $member_references;
@@ -174,6 +195,11 @@ class FakeFileReferenceCacheProvider extends \Psalm\Internal\Provider\FileRefere
     public function setCachedFilePropertyReferences(array $property_references): void
     {
         $this->cached_file_property_references = $property_references;
+    }
+
+    public function setCachedFileMethodReturnReferences(array $method_return_references): void
+    {
+        $this->cached_file_method_return_references = $method_return_references;
     }
 
     public function setCachedFileMissingMemberReferences(array $member_references): void


### PR DESCRIPTION
I think this could be useful?

Here's the associated diff after I ran against Psalm’s codebase: https://github.com/vimeo/psalm/commit/8509999f3fc2afe550c3f9a7a9612007968c5aa6

Triggers when a method has a non-void return type if the method return value is never used.