### PR TITLE
Changed some confusing comments and docblocks

### DIFF
--- a/examples/plugins/FunctionCasingChecker.php
+++ b/examples/plugins/FunctionCasingChecker.php
@@ -17,14 +17,10 @@ use function strtolower;
 use function end;
 
 /**
- * Prevents any assignment to a float value
+ * Checks that functions and methods are correctly-cased
  */
 class FunctionCasingChecker implements AfterFunctionCallAnalysisInterface, AfterMethodCallAnalysisInterface
 {
-    /**
-     * @param  MethodCall|StaticCall $expr
-     * @param  FileManipulation[] $file_replacements
-     */
     public static function afterMethodCallAnalysis(AfterMethodCallAnalysisEvent $event): void
     {
         $expr = $event->getExpr();

--- a/examples/plugins/PreventFloatAssignmentChecker.php
+++ b/examples/plugins/PreventFloatAssignmentChecker.php
@@ -16,8 +16,6 @@ class PreventFloatAssignmentChecker implements AfterExpressionAnalysisInterface
     /**
      * Called after an expression has been checked
      *
-     * @param  FileManipulation[]   $file_replacements
-     *
      * @return null|false
      */
     public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool {

--- a/examples/plugins/StringChecker.php
+++ b/examples/plugins/StringChecker.php
@@ -14,8 +14,6 @@ class StringChecker implements AfterExpressionAnalysisInterface
     /**
      * Called after an expression has been checked
      *
-     * @param  FileManipulation[]   $file_replacements
-     *
      * @return null|false
      */
     public static function afterExpressionAnalysis(AfterExpressionAnalysisEvent $event): ?bool {


### PR DESCRIPTION
Hi, I noticed some inconsistency in the comments in plugin examples. It might be a bit confusing for newcomers. 

1. FunctionCaseChecker description refers to float assignment.
2. PHPDocs define types for arguments that had already been removed here: https://github.com/vimeo/psalm/pull/4881/files