### PR TITLE
Remove redundant namespaced phpdoc

### DIFF
--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -100,6 +100,17 @@ trait GenericTrait
             return $value_type_string . '[]';
         }
 
+        $type_params = $this->type_params;
+
+        //no need for special format if the key is not determined and the content can be displayed with phpdoc format
+        if ($this instanceof TArray &&
+            isset($type_params[0]) &&
+            $type_params[0]->isArrayKey()
+        ) {
+            //we remove the key for display
+            unset($type_params[0]);
+        }
+
         $extra_types = '';
 
         if ($this instanceof TNamedObject && $this->extra_types) {
@@ -128,7 +139,7 @@ trait GenericTrait
                         function (Union $type_param) use ($namespace, $aliased_classes, $this_class): string {
                             return $type_param->toNamespacedString($namespace, $aliased_classes, $this_class, false);
                         },
-                        $this->type_params
+                        $type_params
                     )
                 ) .
                 '>' . $extra_types;

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -11,9 +11,9 @@ use Psalm\Type\Atomic;
 use Psalm\Type\Union;
 
 use function array_map;
+use function array_values;
 use function count;
 use function implode;
-use function sort;
 use function substr;
 
 trait GenericTrait
@@ -104,7 +104,7 @@ trait GenericTrait
 
         $type_params = $this->type_params;
 
-        //no need for special format if the key is not determined and the content can be displayed with phpdoc format
+        //no need for special format if the key is not determined
         if ($this instanceof TArray &&
             count($type_params) === 2 &&
             isset($type_params[0]) &&
@@ -121,7 +121,7 @@ trait GenericTrait
             $type_params[0]->isMixed()
         ) {
             //when the value of an array is mixed, no need for namespaced phpdoc
-            return '';
+            return 'array';
         }
 
         $extra_types = '';

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -11,6 +11,7 @@ use Psalm\Type\Atomic;
 use Psalm\Type\Union;
 
 use function array_map;
+use function count;
 use function implode;
 use function substr;
 
@@ -104,11 +105,21 @@ trait GenericTrait
 
         //no need for special format if the key is not determined and the content can be displayed with phpdoc format
         if ($this instanceof TArray &&
+            count($type_params) === 2 &&
             isset($type_params[0]) &&
             $type_params[0]->isArrayKey()
         ) {
             //we remove the key for display
             unset($type_params[0]);
+        }
+
+        if ($this instanceof TArray &&
+            count($type_params) === 1 &&
+            isset($type_params[0]) &&
+            $type_params[0]->isMixed()
+        ) {
+            //when the value of an array is mixed, no need for namespaced phpdoc
+            return '';
         }
 
         $extra_types = '';

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -13,6 +13,7 @@ use Psalm\Type\Union;
 use function array_map;
 use function count;
 use function implode;
+use function sort;
 use function substr;
 
 trait GenericTrait
@@ -111,6 +112,7 @@ trait GenericTrait
         ) {
             //we remove the key for display
             unset($type_params[0]);
+            $type_params = array_values($type_params);
         }
 
         if ($this instanceof TArray &&

--- a/tests/FileManipulation/ClassMoveTest.php
+++ b/tests/FileManipulation/ClassMoveTest.php
@@ -326,7 +326,7 @@ class ClassMoveTest extends \Psalm\Tests\TestCase
                         public static $one = "one";
 
                         /**
-                         * @var array<array-key, mixed>
+                         * @var array
                          */
                         public static $vars = ["one"];
                     }

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -331,7 +331,7 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     /**
                      * @return string[]
                      *
-                     * @psalm-return array<array-key, string>
+                     * @psalm-return array<string>
                      */
                     function bar(): array {
                         return foo();
@@ -359,7 +359,7 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     /**
                      * @return string[]
                      *
-                     * @psalm-return array<array-key, string>
+                     * @psalm-return array<string>
                      */
                     function bar() {
                         return foo();


### PR DESCRIPTION
this PR reduce the verbosity of psalm when it doesn't add value
it reduces and `@psalm-return array<array-key, mixed>` to just `@psalm-return array`.

I wanted to push further and remove the whole @psalm-return but the refactor tool depend on it. I also wanted to go further by removing `array<string>` because phpdoc is enough with `string[]` but I couldn't find a good way to do that, It would have needed a `canBeFullyExpressedInPhpdoc` method that doesn't exist and I'm not sure it's worth adding it for now