### PR TITLE
Prevent infinite loop in case a TClassConstant is expanded to itself

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -2076,11 +2076,13 @@ class ArrayFetchAnalyzer
                 );
 
                 if ($expanded instanceof Atomic) {
-                    $has_valid_absolute_offset = self::checkArrayOffsetType(
-                        $offset_type,
-                        [$expanded],
-                        $codebase
-                    );
+                    if (!$expanded instanceof Atomic\TClassConstant) {
+                        $has_valid_absolute_offset = self::checkArrayOffsetType(
+                            $offset_type,
+                            [$expanded],
+                            $codebase
+                        );
+                    }
                 } else {
                     $has_valid_absolute_offset = self::checkArrayOffsetType(
                         $offset_type,

--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -81,12 +81,14 @@ class UnionTypeComparator
                 );
 
                 if ($expanded instanceof Atomic) {
-                    $input_atomic_types[] = $expanded;
+                    if (!$expanded instanceof Atomic\TClassConstant) {
+                        $input_atomic_types[] = $expanded;
+                        continue;
+                    }
                 } else {
                     $input_atomic_types = array_merge($expanded, $input_atomic_types);
+                    continue;
                 }
-
-                continue;
             }
 
             $type_match_found = false;


### PR DESCRIPTION
This should fix #5949

I'm not sure what went wrong yet. `expandAtomic` returned the TClassConstant so there was an infinite loop trying to get the type behind it.

With this fix, the code
```php
/**
 * @property self::TYPE_A|self::TYPE_B $type
 */
class A {
    public const TYPE_A='a';
    public const TYPE_B='b';
    
    public function __get($key)  {return '';}
}

$obj = new A;

echo $obj->type;
```

emits a `ERROR: InvalidArgument - sandbox.php:16:6 - Argument 1 of echo expects string, self::TYPE_A|self::TYPE_B provided`. I'm not sure if it reverts back to the error that was there before #5943 or if it's a new error caused by it. (EDIT: the error was already there)