### PR TITLE
[BUGFIX] Avoid crash during interface checks on non-existing classes

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -670,6 +670,9 @@ class ClassLikes
             $fq_class_name = $this->classlike_aliases[$fq_class_name];
         }
 
+        if (!$this->classlike_storage_provider->has($fq_class_name)) {
+            return false;
+        }
         $class_storage = $this->classlike_storage_provider->get($fq_class_name);
 
         return isset($class_storage->class_implements[$interface_id]);


### PR DESCRIPTION
`ClassLikes::classImplements(NonExisting::class, WellKnown::class)`
now returns `false` instead of throwing an exception for non-existing
classes.

Fixes: #5983