### PR TITLE
Fixes #6013, implement workspace/didChangeWatchedFiles

### DIFF
--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -19,6 +19,7 @@ use LanguageServerProtocol\TextDocumentSyncOptions;
 use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\LanguageServer\Server\TextDocument;
+use Psalm\Internal\LanguageServer\Server\Workspace;
 use Throwable;
 
 use function Amp\asyncCoroutine;
@@ -50,6 +51,13 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
      * @var ?Server\TextDocument
      */
     public $textDocument;
+
+    /**
+     * Handles workspace/* method calls
+     *
+     * @var ?Server\Workspace
+     */
+    public $workspace;
 
     /**
      * @var ProtocolReader
@@ -215,6 +223,14 @@ class LanguageServer extends AdvancedJsonRpc\Dispatcher
 
                 if ($this->textDocument === null) {
                     $this->textDocument = new TextDocument(
+                        $this,
+                        $codebase,
+                        $this->project_analyzer->onchange_line_limit
+                    );
+                }
+
+                if ($this->workspace === null) {
+                    $this->workspace = new Workspace(
                         $this,
                         $codebase,
                         $this->project_analyzer->onchange_line_limit

--- a/src/Psalm/Internal/LanguageServer/Server/Workspace.php
+++ b/src/Psalm/Internal/LanguageServer/Server/Workspace.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types = 1);
+namespace Psalm\Internal\LanguageServer\Server;
+
+use LanguageServerProtocol\FileChangeType;
+use LanguageServerProtocol\FileEvent;
+use Psalm\Codebase;
+use Psalm\Internal\LanguageServer\LanguageServer;
+
+/**
+ * Provides method handlers for all textDocument/* methods
+ */
+class Workspace
+{
+    /**
+     * @var LanguageServer
+     */
+    protected $server;
+
+    /**
+     * @var Codebase
+     */
+    protected $codebase;
+
+    /** @var ?int */
+    protected $onchange_line_limit;
+
+    public function __construct(
+        LanguageServer $server,
+        Codebase $codebase,
+        ?int $onchange_line_limit
+    ) {
+        $this->server = $server;
+        $this->codebase = $codebase;
+        $this->onchange_line_limit = $onchange_line_limit;
+    }
+
+    /**
+     * The watched files notification is sent from the client to the server when the client
+     * detects changes to files and folders watched by the language client (note although
+     * the name suggest that only file events are sent it is about file system events
+     * which include folders as well). It is recommended that servers register for these
+     * file system events using the registration mechanism. In former implementations clients
+     * pushed file events without the server actively asking for it.
+     *
+     * @param FileEvent[] $changes
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function didChangeWatchedFiles(array $changes): void
+    {
+        foreach ($changes as $change) {
+            $file_path = LanguageServer::uriToPath($change->uri);
+
+            if ($change->type === FileChangeType::DELETED) {
+                $this->codebase->invalidateInformationForFile($file_path);
+                return;
+            }
+
+            if (!$this->codebase->config->isInProjectDirs($file_path)) {
+                return;
+            }
+
+            if ($this->onchange_line_limit === 0) {
+                return;
+            }
+
+            //If the file is currently open then dont analyse it because its tracked by the client
+            if (!$this->codebase->file_provider->isOpen($file_path)) {
+                $this->server->queueFileAnalysis($file_path, $change->uri);
+            }
+        }
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/Server/Workspace.php
+++ b/src/Psalm/Internal/LanguageServer/Server/Workspace.php
@@ -8,7 +8,7 @@ use Psalm\Codebase;
 use Psalm\Internal\LanguageServer\LanguageServer;
 
 /**
- * Provides method handlers for all textDocument/* methods
+ * Provides method handlers for all workspace/* methods
  */
 class Workspace
 {


### PR DESCRIPTION
This implements `workspace/didChangeWatchedFiles`

We also check to make sure the watch file that was changed is not currently open so this technically depends on #6010 being merged otherwise the files aren't tracked and there will be conflicts