### PR TITLE
Possible implementation for ArrayReduceReturnTypeProvider support array callables with self and static

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
@@ -217,7 +217,14 @@ class ArrayReduceReturnTypeProvider implements \Psalm\Plugin\EventHandler\Functi
 
                             [$callable_fq_class_name, $method_name] = explode('::', $mapping_function_id_part);
 
-                            if (in_array($callable_fq_class_name, ['self', 'static', 'parent'], true)) {
+                            if (in_array($callable_fq_class_name, ['self', 'static'], true)) {
+                                $callable_fq_class_name = $statements_source->getFQCLN();
+                                if ($callable_fq_class_name === null) {
+                                    continue;
+                                }
+                            }
+
+                            if ($callable_fq_class_name === 'parent') {
                                 continue;
                             }
 

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1325,6 +1325,28 @@ class ArrayFunctionCallTest extends TestCase
                     '$function_call_result' => 'int',
                 ],
             ],
+            'arrayReduceStaticMethods' => [
+                '<?php
+                    $arr = [2, 3, 4, 5];
+
+                    class C {
+                        public static function multiply (int $carry, int $item) : int {
+                            return $carry * $item;
+                        }
+
+                        public static function multiplySelf(array $arr): int {
+                            return array_reduce($arr, [self::class, "multiply"], 1);
+                        }
+
+                        public static function multiplyStatic(array $arr): int {
+                            return array_reduce($arr, [static::class, "multiply"], 1);
+                        }
+                    }
+
+                    $self_call_result = C::multiplySelf($arr);
+                    $static_call_result = C::multiplyStatic($arr);',
+                'assertions' => [],
+            ],
             'arrayReduceMixedReturn' => [
                 '<?php
                     $arr = [2, 3, 4, 5];


### PR DESCRIPTION
Hello! 

This should fix https://github.com/vimeo/psalm/issues/6005

I am not sure why self and static were skipped when handling callables in ArrayReduceReturnTypeProvider, so hopefully this won't break anything - I added a test for it just in case.  
