### PR TITLE
Separate memory limit formatting from retrieval

### DIFF
--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -589,7 +589,12 @@ HELP;
      */
     public static function getMemoryLimitInBytes(): int
     {
-        $limit = ini_get('memory_limit');
+        return self::convertMemoryLimitToBytes(ini_get('memory_limit'));
+    }
+
+    /** @psalm-pure */
+    public static function convertMemoryLimitToBytes(string $limit): int
+    {
         // for unlimited = -1
         if ($limit < 0) {
             return -1;

--- a/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
+++ b/tests/CommandFunctions/GetMemoryLimitInBytesTest.php
@@ -1,27 +1,11 @@
 <?php
+
 namespace Psalm\Tests\CommandFunctions;
 
 use Psalm\Internal\CliUtils;
 
-use function ini_get;
-use function ini_set;
-
-/**
- * testcase for src/command_functions.php
- */
 class GetMemoryLimitInBytesTest extends \Psalm\Tests\TestCase
 {
-    /**
-     * @var string
-     */
-    private $previousLimit;
-
-    public function setUp(): void
-    {
-        $this->previousLimit = (string)ini_get('memory_limit');
-        parent::setUp();
-    }
-
     /**
      * @return array<int,array<string|int>>
      */
@@ -56,19 +40,15 @@ class GetMemoryLimitInBytesTest extends \Psalm\Tests\TestCase
      *
      * @param int|string $setting
      * @param int|string $expectedBytes
-     *
      */
     public function testGetMemoryLimitInBytes(
         $setting,
         $expectedBytes
     ): void {
-        ini_set('memory_limit', (string)$setting);
-        $this->assertSame($expectedBytes, CliUtils::getMemoryLimitInBytes(), 'Memory limit in bytes does not fit setting');
-    }
-
-    public function tearDown(): void
-    {
-        ini_set('memory_limit', $this->previousLimit);
-        parent::tearDown();
+        $this->assertSame(
+            $expectedBytes,
+            CliUtils::convertMemoryLimitToBytes((string)$setting),
+            'Memory limit in bytes does not fit setting'
+        );
     }
 }


### PR DESCRIPTION
This addresses https://github.com/vimeo/psalm/pull/6030#issuecomment-872611832

Previously PHP would allow to set memory limit to be below current memory usage, and the test changed in this PR abused that. As we actually don't need to test `ini_get()`, value decoding was split into its own method, and we're testing that decoding instead.