### PR TITLE
Use psalm/endtoend-test-phpunit

### DIFF
--- a/bin/test-with-real-projects.sh
+++ b/bin/test-with-real-projects.sh
@@ -24,7 +24,7 @@ collections)
 	;;
 
 psl)
-	git clone --depth=1 git@github.com:muglug/psl.git
+	git clone git@github.com:muglug/psl.git
 	cd psl
 	git checkout 1.6.x
 	composer install --ignore-platform-reqs

--- a/bin/test-with-real-projects.sh
+++ b/bin/test-with-real-projects.sh
@@ -9,22 +9,22 @@ cd testing-with-real-projects
 
 case $1 in
 phpunit)
-	git clone git@github.com:muglug/phpunit.git
-	cd phpunit
+	git clone --depth=1 git@github.com:psalm/endtoend-test-phpunit
+	cd endtoend-test-phpunit
 	composer install
 	~/project/build/psalm.phar --config=.psalm/config.xml --monochrome --show-info=false
 	~/project/build/psalm.phar --config=.psalm/static-analysis.xml --monochrome
 	;;
 
 collections)
-	git clone git@github.com:muglug/collections.git
+	git clone --depth=1 git@github.com:muglug/collections.git
 	cd collections
 	composer install
 	~/project/psalm --monochrome --show-info=false
 	;;
 
 psl)
-	git clone git@github.com:muglug/psl.git
+	git clone --depth=1 git@github.com:muglug/psl.git
 	cd psl
 	git checkout 1.6.x
 	composer install --ignore-platform-reqs
@@ -32,7 +32,7 @@ psl)
 	;;
 
 laravel)
-	git clone git@github.com:muglug/framework.git
+	git clone --depth=1 git@github.com:muglug/framework.git
 	cd framework
 	composer install
 	~/project/psalm --monochrome


### PR DESCRIPTION
Fixes vimeo/psalm#6044

Should be faster too, with limited clone depth. I've reset `psalm/endtoend-test-phpunit/master` to `upstream/master` as it worked fine locally without any baseline changes.