### PR TITLE
Update Sublime LSP to match latest version

### DIFF
--- a/docs/running_psalm/language_server.md
+++ b/docs/running_psalm/language_server.md
@@ -53,9 +53,8 @@ I use the excellent Sublime [LSP plugin](https://github.com/tomv564/LSP) with th
         "psalm":
         {
             "command": ["php", "vendor/bin/psalm-language-server"],
-            "scopes": ["source.php", "embedding.php"],
-            "syntaxes": ["Packages/PHP/PHP.sublime-syntax"],
-            "languageId": "php"
+            "selector": "source.php | embedding.php",
+            "enabled": true
         }
 ```
 


### PR DESCRIPTION
I noticed the current config didn't work on the Sublime Text LSP plugin, I've updated it to the latest version of the config for the plugin which works with Sublime Text 4