### PR TITLE
Allow xml:base attribute in configuration elements

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -5,6 +5,7 @@
     targetNamespace="https://getpsalm.org/schema/config"
     elementFormDefault="qualified"
 >
+    <xs:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/03/xml.xsd" />
     <xs:element name="psalm" type="PsalmType" />
 
     <xs:complexType name="PsalmType">
@@ -96,15 +97,18 @@
             <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
             <xs:element name="ignoreFiles" minOccurs="0" maxOccurs="1" type="IgnoreFilesType" />
         </xs:choice>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="TaintAnalysisType">
         <xs:choice maxOccurs="unbounded">
             <xs:element name="ignoreFiles" minOccurs="0" maxOccurs="1" type="IgnoreFilesType" />
         </xs:choice>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="NameAttributeType">
+        <xs:attribute ref="xml:base" />
         <xs:attribute name="name" type="xs:string" use="required" />
     </xs:complexType>
 
@@ -120,12 +124,14 @@
         </xs:choice>
 
         <xs:attribute name="allowMissingFiles" type="xs:string" />
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="ProjectDirectoryAttributeType">
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="ignoreTypeStats" type="xs:string" />
         <xs:attribute name="useStrictTypes" type="xs:string" />
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="FileExtensionsType">
@@ -138,18 +144,21 @@
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="MockClassesType">
         <xs:sequence>
             <xs:element name="class" maxOccurs="unbounded" type="NameAttributeType" />
         </xs:sequence>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="UniversalObjectCratesType">
         <xs:sequence>
             <xs:element name="class" maxOccurs="unbounded" type="NameAttributeType" />
         </xs:sequence>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="ExceptionsType">
@@ -157,18 +166,21 @@
             <xs:element name="class" minOccurs="0" maxOccurs="unbounded" type="ExceptionType" />
             <xs:element name="classAndDescendants" minOccurs="0" maxOccurs="unbounded" type="ExceptionType" />
         </xs:sequence>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="StubsType">
         <xs:sequence>
             <xs:element name="file" maxOccurs="unbounded" type="StubsAttributeType" />
         </xs:sequence>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="ExitFunctionsType">
         <xs:sequence>
             <xs:element name="function" maxOccurs="unbounded" type="NameAttributeType" />
         </xs:sequence>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="PluginsType">
@@ -187,6 +199,7 @@
                 </xs:complexType>
             </xs:element>
         </xs:choice>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="IssueHandlersType">
@@ -463,6 +476,7 @@
             <xs:element name="UnusedReturnValue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnusedVariable" type="IssueHandlerType" minOccurs="0" />
         </xs:choice>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="IssueHandlerType">
@@ -612,6 +626,7 @@
         <xs:sequence>
             <xs:element name="var" maxOccurs="unbounded" type="IdentifierType" />
         </xs:sequence>
+        <xs:attribute ref="xml:base" />
     </xs:complexType>
 
     <xs:complexType name="IdentifierType">


### PR DESCRIPTION
Modifies the schema to allow xml:base attribute element in configuration elements. This is done to allow including split configuration located in subdirectory.

Solution from https://stackoverflow.com/questions/22774425/attempting-to-connect-xml-files-with-xinclude-attribute-xmlbase-error/22791471#22791471

Fixes #6058