### PR TITLE
Pass statement to MethodReturnTypeProviderEvent

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -54,7 +54,7 @@ class FunctionCallReturnTypeFetcher
             $stmt_type = $codebase->functions->return_type_provider->getReturnType(
                 $statements_analyzer,
                 $function_id,
-                $stmt->args,
+                $stmt,
                 $context,
                 new CodeLocation($statements_analyzer->getSource(), $function_name)
             );

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -56,6 +56,7 @@ class MethodCallReturnTypeFetcher
                 $stmt->args,
                 $context,
                 new CodeLocation($statements_analyzer->getSource(), $stmt->name),
+                $stmt,
                 $lhs_type_part instanceof TGenericObject ? $lhs_type_part->type_params : null
             );
 
@@ -76,6 +77,7 @@ class MethodCallReturnTypeFetcher
                     $stmt->args,
                     $context,
                     new CodeLocation($statements_analyzer->getSource(), $stmt->name),
+                    $stmt,
                     $lhs_type_part instanceof TGenericObject ? $lhs_type_part->type_params : null,
                     $fq_class_name,
                     $method_name

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -53,10 +53,9 @@ class MethodCallReturnTypeFetcher
                 $statements_analyzer,
                 $premixin_method_id->fq_class_name,
                 $premixin_method_id->method_name,
-                $stmt->args,
+                $stmt,
                 $context,
                 new CodeLocation($statements_analyzer->getSource(), $stmt->name),
-                $stmt,
                 $lhs_type_part instanceof TGenericObject ? $lhs_type_part->type_params : null
             );
 
@@ -74,10 +73,9 @@ class MethodCallReturnTypeFetcher
                     $statements_analyzer,
                     $declaring_fq_class_name,
                     $declaring_method_name,
-                    $stmt->args,
+                    $stmt,
                     $context,
                     new CodeLocation($statements_analyzer->getSource(), $stmt->name),
-                    $stmt,
                     $lhs_type_part instanceof TGenericObject ? $lhs_type_part->type_params : null,
                     $fq_class_name,
                     $method_name

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -39,10 +39,9 @@ class MissingMethodCallHandler
                 $statements_analyzer,
                 $method_id->fq_class_name,
                 $method_id->method_name,
-                $stmt->args,
+                $stmt,
                 $context,
-                new CodeLocation($statements_analyzer->getSource(), $stmt->name),
-                $stmt
+                new CodeLocation($statements_analyzer->getSource(), $stmt->name)
             );
 
             if ($return_type_candidate) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -41,7 +41,8 @@ class MissingMethodCallHandler
                 $method_id->method_name,
                 $stmt->args,
                 $context,
-                new CodeLocation($statements_analyzer->getSource(), $stmt->name)
+                new CodeLocation($statements_analyzer->getSource(), $stmt->name),
+                $stmt
             );
 
             if ($return_type_candidate) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -470,10 +470,9 @@ class AtomicStaticCallAnalyzer
                         $statements_analyzer,
                         $method_id->fq_class_name,
                         $method_id->method_name,
-                        $stmt->args,
+                        $stmt,
                         $context,
                         new CodeLocation($statements_analyzer->getSource(), $stmt_name),
-                        $stmt,
                         null,
                         null,
                         strtolower($stmt_name->name)

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -473,6 +473,7 @@ class AtomicStaticCallAnalyzer
                         $stmt->args,
                         $context,
                         new CodeLocation($statements_analyzer->getSource(), $stmt_name),
+                        $stmt,
                         null,
                         null,
                         strtolower($stmt_name->name)

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -193,7 +193,8 @@ class ExistingAtomicStaticCallAnalyzer
                 $stmt_name->name,
                 $stmt->args,
                 $context,
-                new CodeLocation($statements_analyzer->getSource(), $stmt_name)
+                new CodeLocation($statements_analyzer->getSource(), $stmt_name),
+                $stmt
             );
         }
 
@@ -214,6 +215,7 @@ class ExistingAtomicStaticCallAnalyzer
                     $stmt->args,
                     $context,
                     new CodeLocation($statements_analyzer->getSource(), $stmt_name),
+                    $stmt,
                     null,
                     $fq_class_name,
                     $stmt_name->name

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -191,10 +191,9 @@ class ExistingAtomicStaticCallAnalyzer
                 $statements_analyzer,
                 $fq_class_name,
                 $stmt_name->name,
-                $stmt->args,
+                $stmt,
                 $context,
-                new CodeLocation($statements_analyzer->getSource(), $stmt_name),
-                $stmt
+                new CodeLocation($statements_analyzer->getSource(), $stmt_name)
             );
         }
 
@@ -212,10 +211,9 @@ class ExistingAtomicStaticCallAnalyzer
                     $statements_analyzer,
                     $declaring_fq_class_name,
                     $declaring_method_name,
-                    $stmt->args,
+                    $stmt,
                     $context,
                     new CodeLocation($statements_analyzer->getSource(), $stmt_name),
-                    $stmt,
                     null,
                     $fq_class_name,
                     $stmt_name->name

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -125,12 +125,11 @@ class FunctionReturnTypeProvider
 
     /**
      * @param  non-empty-string $function_id
-     * @param  list<PhpParser\Node\Arg>  $call_args
      */
     public function getReturnType(
         StatementsSource $statements_source,
         string $function_id,
-        array $call_args,
+        PhpParser\Node\Expr\FuncCall $stmt,
         Context $context,
         CodeLocation $code_location
     ): ?Type\Union {
@@ -138,7 +137,7 @@ class FunctionReturnTypeProvider
             $return_type = $function_handler(
                 $statements_source,
                 $function_id,
-                $call_args,
+                $stmt->args,
                 $context,
                 $code_location
             );
@@ -152,7 +151,7 @@ class FunctionReturnTypeProvider
             $event = new FunctionReturnTypeProviderEvent(
                 $statements_source,
                 $function_id,
-                $call_args,
+                $stmt,
                 $context,
                 $code_location
             );

--- a/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
@@ -108,7 +108,7 @@ class MethodReturnTypeProvider
     /**
      * @param list<PhpParser\Node\Arg>  $call_args
      * @param  ?array<Type\Union> $template_type_parameters
-     *
+     * @param PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall $stmt
      */
     public function getReturnType(
         StatementsSource $statements_source,
@@ -117,6 +117,7 @@ class MethodReturnTypeProvider
         array $call_args,
         Context $context,
         CodeLocation $code_location,
+        $stmt,
         ?array $template_type_parameters = null,
         ?string $called_fq_classlike_name = null,
         ?string $called_method_name = null
@@ -147,6 +148,7 @@ class MethodReturnTypeProvider
                 $call_args,
                 $context,
                 $code_location,
+                $stmt,
                 $template_type_parameters,
                 $called_fq_classlike_name,
                 $called_method_name ? strtolower($called_method_name) : null

--- a/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
@@ -106,18 +106,16 @@ class MethodReturnTypeProvider
     }
 
     /**
-     * @param list<PhpParser\Node\Arg>  $call_args
-     * @param  ?array<Type\Union> $template_type_parameters
      * @param PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall $stmt
+     * @param  ?array<Type\Union> $template_type_parameters
      */
     public function getReturnType(
         StatementsSource $statements_source,
         string $fq_classlike_name,
         string $method_name,
-        array $call_args,
+        $stmt,
         Context $context,
         CodeLocation $code_location,
-        $stmt,
         ?array $template_type_parameters = null,
         ?string $called_fq_classlike_name = null,
         ?string $called_method_name = null
@@ -127,7 +125,7 @@ class MethodReturnTypeProvider
                 $statements_source,
                 $fq_classlike_name,
                 strtolower($method_name),
-                $call_args,
+                $stmt->args,
                 $context,
                 $code_location,
                 $template_type_parameters,
@@ -145,10 +143,9 @@ class MethodReturnTypeProvider
                 $statements_source,
                 $fq_classlike_name,
                 strtolower($method_name),
-                $call_args,
+                $stmt,
                 $context,
                 $code_location,
-                $stmt,
                 $template_type_parameters,
                 $called_fq_classlike_name,
                 $called_method_name ? strtolower($called_method_name) : null

--- a/src/Psalm/Plugin/EventHandler/Event/FunctionReturnTypeProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/FunctionReturnTypeProviderEvent.php
@@ -19,9 +19,9 @@ class FunctionReturnTypeProviderEvent
      */
     private $function_id;
     /**
-     * @var list<PhpParser\Node\Arg>
+     * @var PhpParser\Node\Expr\FuncCall
      */
-    private $call_args;
+    private $stmt;
     /**
      * @var Context
      */
@@ -36,19 +36,18 @@ class FunctionReturnTypeProviderEvent
      * return but another plugin may be able to determine the type, return null. Otherwise return a mixed union type
      * if something should be returned, but can't be more specific.
      *
-     * @param list<PhpParser\Node\Arg>    $call_args
      * @param non-empty-string $function_id
      */
     public function __construct(
         StatementsSource $statements_source,
         string $function_id,
-        array $call_args,
+        PhpParser\Node\Expr\FuncCall $stmt,
         Context $context,
         CodeLocation $code_location
     ) {
         $this->statements_source = $statements_source;
         $this->function_id = $function_id;
-        $this->call_args = $call_args;
+        $this->stmt = $stmt;
         $this->context = $context;
         $this->code_location = $code_location;
     }
@@ -71,7 +70,7 @@ class FunctionReturnTypeProviderEvent
      */
     public function getCallArgs(): array
     {
-        return $this->call_args;
+        return $this->stmt->args;
     }
 
     public function getContext(): Context
@@ -82,5 +81,10 @@ class FunctionReturnTypeProviderEvent
     public function getCodeLocation(): CodeLocation
     {
         return $this->code_location;
+    }
+
+    public function getStmt(): PhpParser\Node\Expr\FuncCall
+    {
+        return $this->stmt;
     }
 }

--- a/src/Psalm/Plugin/EventHandler/Event/MethodReturnTypeProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/MethodReturnTypeProviderEvent.php
@@ -36,6 +36,10 @@ class MethodReturnTypeProviderEvent
      */
     private $code_location;
     /**
+     * @var PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall
+     */
+    private $stmt;
+    /**
      * @var Type\Union[]|null
      */
     private $template_type_parameters;
@@ -54,6 +58,7 @@ class MethodReturnTypeProviderEvent
      * something should be returned, but can't be more specific.
      *
      * @param  list<PhpParser\Node\Arg>    $call_args
+     * @param PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall $stmt
      * @param  ?array<Type\Union> $template_type_parameters
      * @param lowercase-string $method_name_lowercase
      * @param lowercase-string $called_method_name_lowercase
@@ -65,6 +70,7 @@ class MethodReturnTypeProviderEvent
         array $call_args,
         Context $context,
         CodeLocation $code_location,
+        $stmt,
         ?array $template_type_parameters = null,
         ?string $called_fq_classlike_name = null,
         ?string $called_method_name_lowercase = null
@@ -75,6 +81,7 @@ class MethodReturnTypeProviderEvent
         $this->call_args = $call_args;
         $this->context = $context;
         $this->code_location = $code_location;
+        $this->stmt = $stmt;
         $this->template_type_parameters = $template_type_parameters;
         $this->called_fq_classlike_name = $called_fq_classlike_name;
         $this->called_method_name_lowercase = $called_method_name_lowercase;
@@ -135,5 +142,13 @@ class MethodReturnTypeProviderEvent
     public function getCalledMethodNameLowercase(): ?string
     {
         return $this->called_method_name_lowercase;
+    }
+
+    /**
+     * @return PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall
+     */
+    public function getStmt()
+    {
+        return $this->stmt;
     }
 }

--- a/src/Psalm/Plugin/EventHandler/Event/MethodReturnTypeProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/MethodReturnTypeProviderEvent.php
@@ -24,10 +24,6 @@ class MethodReturnTypeProviderEvent
      */
     private $method_name_lowercase;
     /**
-     * @var list<PhpParser\Node\Arg>
-     */
-    private $call_args;
-    /**
      * @var Context
      */
     private $context;
@@ -57,7 +53,6 @@ class MethodReturnTypeProviderEvent
      * but another plugin may be able to determine the type, return null. Otherwise return a mixed union type if
      * something should be returned, but can't be more specific.
      *
-     * @param  list<PhpParser\Node\Arg>    $call_args
      * @param PhpParser\Node\Expr\MethodCall|PhpParser\Node\Expr\StaticCall $stmt
      * @param  ?array<Type\Union> $template_type_parameters
      * @param lowercase-string $method_name_lowercase
@@ -67,10 +62,9 @@ class MethodReturnTypeProviderEvent
         StatementsSource $source,
         string $fq_classlike_name,
         string $method_name_lowercase,
-        array $call_args,
+        $stmt,
         Context $context,
         CodeLocation $code_location,
-        $stmt,
         ?array $template_type_parameters = null,
         ?string $called_fq_classlike_name = null,
         ?string $called_method_name_lowercase = null
@@ -78,7 +72,6 @@ class MethodReturnTypeProviderEvent
         $this->source = $source;
         $this->fq_classlike_name = $fq_classlike_name;
         $this->method_name_lowercase = $method_name_lowercase;
-        $this->call_args = $call_args;
         $this->context = $context;
         $this->code_location = $code_location;
         $this->stmt = $stmt;
@@ -110,7 +103,7 @@ class MethodReturnTypeProviderEvent
      */
     public function getCallArgs(): array
     {
-        return $this->call_args;
+        return $this->stmt->args;
     }
 
     public function getContext(): Context


### PR DESCRIPTION
I'm trying to solve the following issue on psalm-doctrine: https://github.com/psalm/psalm-plugin-doctrine/issues/77

According to @orklah, this is possible if I can access to the statement from the MethodReturnTypeProviderEvent.

This require to update some signatures.
I added the `$stmt` param at the same position it was done in https://github.com/vimeo/psalm/pull/5333
But maybe it can be improved. For instance, I see that both `$stmt->args` and `$stmt` are now pass to the `getReturnType`.

So maybe @muglug @weirdan, you'll prefer I change `$stmt->args` to `$stmt` in the original signature.
Or I can just pass `$stmt->var`.

Also, only the signature `MethodReturnTypeProvider::getReturnType` is changed ; maybe you'd like I update `FunctionReturnTypeProvider::getReturnType` too (and FunctionReturnTypeProviderEvent ?) in order to have a similar signature.

Of course, I'm opened to better solution in order to solve https://github.com/psalm/psalm-plugin-doctrine/issues/77 (with psalm assert maybe ?)