### PR TITLE
Skip argv when --config file.xml is passed

### DIFF
--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -264,6 +264,9 @@ final class CliUtils
                 }
 
                 if (substr($input_path, 0, 2) === '--' && strlen($input_path) > 2) {
+                    if (substr($input_path, 2) === 'config') {
+                        ++$i;
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
I tried to pass a config file using `--config psalm.xml`. Though in help (`-h`) it's specified as `--config=psalm.xml`.

That resulted in incorrect arg parsing and `psalm.xml` was set as a path to check.

I'm no sure we want to support it though. Seems like code heavily relies on `=` being there.

Related to https://github.com/vimeo/psalm/issues/6056