### PR TITLE
Make ClassLikeNodeScanner resilient against missing class storage

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -195,7 +195,11 @@ class ClassLikeNodeScanner
                     $storage->aliases = $this->aliases;
 
                     foreach ($storage->dependent_classlikes as $dependent_name_lc => $_) {
-                        $dependent_storage = $this->codebase->classlike_storage_provider->get($dependent_name_lc);
+                        try {
+                            $dependent_storage = $this->codebase->classlike_storage_provider->get($dependent_name_lc);
+                        } catch (\InvalidArgumentException $exception) {
+                            continue;
+                        }
                         $dependent_storage->populated = false;
                         $this->codebase->classlike_storage_provider->makeNew($dependent_name_lc);
                     }


### PR DESCRIPTION
Fixes https://github.com/psalm/psalm-plugin-laravel/issues/134, and probably fixes #5971 as well.