### PR TITLE
Remove brackets around issue ref in console output

### DIFF
--- a/src/Psalm/Report/ConsoleReport.php
+++ b/src/Psalm/Report/ConsoleReport.php
@@ -31,7 +31,7 @@ class ConsoleReport extends Report
             $issue_string .= 'INFO';
         }
 
-        $issue_reference = $issue_data->link ? ' (see ' . $issue_data->link . ')' : '';
+        $issue_reference = $issue_data->link ? ' - see: ' . $issue_data->link : '';
 
         $issue_string .= ': ' . $issue_data->type
             . ' - ' . $issue_data->file_name . ':' . $issue_data->line_from . ':' . $issue_data->column_from

--- a/src/Psalm/Report/GithubActionsReport.php
+++ b/src/Psalm/Report/GithubActionsReport.php
@@ -12,7 +12,7 @@ class GithubActionsReport extends Report
     {
         $output = '';
         foreach ($this->issues_data as $issue_data) {
-            $issue_reference = $issue_data->link ? ' (see ' . $issue_data->link . ')' : '';
+            $issue_reference = $issue_data->link ? ' - see: ' . $issue_data->link : '';
             $output .= sprintf(
                 '::%s file=%s,line=%s,col=%s::%s',
                 ($issue_data->severity === Config::REPORT_ERROR ? 'error' : 'warning'),

--- a/src/Psalm/Report/PhpStormReport.php
+++ b/src/Psalm/Report/PhpStormReport.php
@@ -31,7 +31,7 @@ class PhpStormReport extends Report
             $issue_string .= 'INFO';
         }
 
-        $issue_reference = $issue_data->link ? ' (see ' . $issue_data->link . ')' : '';
+        $issue_reference = $issue_data->link ? ' - see: ' . $issue_data->link : '';
 
         $issue_string .= ': ' . $issue_data->type
             . "\nat " . $issue_data->file_path . ':' . $issue_data->line_from . ':' . $issue_data->column_from

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -992,19 +992,19 @@ somefile.php:17: [W0001] PossiblyUndefinedGlobalVariable: Possibly undefined glo
         $console_report_options->use_color = false;
 
         $this->assertSame(
-            'ERROR: UndefinedVariable - somefile.php:3:10 - Cannot find referenced variable $as_you_____type (see https://psalm.dev/024)
+            'ERROR: UndefinedVariable - somefile.php:3:10 - Cannot find referenced variable $as_you_____type - see: https://psalm.dev/024
   return $as_you_____type;
 
-ERROR: MixedReturnStatement - somefile.php:3:10 - Could not infer a return type (see https://psalm.dev/138)
+ERROR: MixedReturnStatement - somefile.php:3:10 - Could not infer a return type - see: https://psalm.dev/138
   return $as_you_____type;
 
-ERROR: MixedInferredReturnType - somefile.php:2:42 - Could not verify return type \'null|string\' for psalmCanVerify (see https://psalm.dev/047)
+ERROR: MixedInferredReturnType - somefile.php:2:42 - Could not verify return type \'null|string\' for psalmCanVerify - see: https://psalm.dev/047
 function psalmCanVerify(int $your_code): ?string {
 
-ERROR: UndefinedConstant - somefile.php:8:6 - Const CHANGE_ME is not defined (see https://psalm.dev/020)
+ERROR: UndefinedConstant - somefile.php:8:6 - Const CHANGE_ME is not defined - see: https://psalm.dev/020
 echo CHANGE_ME;
 
-INFO: PossiblyUndefinedGlobalVariable - somefile.php:17:6 - Possibly undefined global variable $a, first seen on line 11 (see https://psalm.dev/126)
+INFO: PossiblyUndefinedGlobalVariable - somefile.php:17:6 - Possibly undefined global variable $a, first seen on line 11 - see: https://psalm.dev/126
 echo $a
 
 ',
@@ -1021,16 +1021,16 @@ echo $a
         $console_report_options->show_info = false;
 
         $this->assertSame(
-            'ERROR: UndefinedVariable - somefile.php:3:10 - Cannot find referenced variable $as_you_____type (see https://psalm.dev/024)
+            'ERROR: UndefinedVariable - somefile.php:3:10 - Cannot find referenced variable $as_you_____type - see: https://psalm.dev/024
   return $as_you_____type;
 
-ERROR: MixedReturnStatement - somefile.php:3:10 - Could not infer a return type (see https://psalm.dev/138)
+ERROR: MixedReturnStatement - somefile.php:3:10 - Could not infer a return type - see: https://psalm.dev/138
   return $as_you_____type;
 
-ERROR: MixedInferredReturnType - somefile.php:2:42 - Could not verify return type \'null|string\' for psalmCanVerify (see https://psalm.dev/047)
+ERROR: MixedInferredReturnType - somefile.php:2:42 - Could not verify return type \'null|string\' for psalmCanVerify - see: https://psalm.dev/047
 function psalmCanVerify(int $your_code): ?string {
 
-ERROR: UndefinedConstant - somefile.php:8:6 - Const CHANGE_ME is not defined (see https://psalm.dev/020)
+ERROR: UndefinedConstant - somefile.php:8:6 - Const CHANGE_ME is not defined - see: https://psalm.dev/020
 echo CHANGE_ME;
 
 ',
@@ -1047,19 +1047,19 @@ echo CHANGE_ME;
         $console_report_options->use_color = false;
 
         $this->assertSame(
-            'ERROR: UndefinedVariable - somefile.php:3:10 - Cannot find referenced variable $as_you_____type (see https://psalm.dev/024)
+            'ERROR: UndefinedVariable - somefile.php:3:10 - Cannot find referenced variable $as_you_____type - see: https://psalm.dev/024
 
 
-ERROR: MixedReturnStatement - somefile.php:3:10 - Could not infer a return type (see https://psalm.dev/138)
+ERROR: MixedReturnStatement - somefile.php:3:10 - Could not infer a return type - see: https://psalm.dev/138
 
 
-ERROR: MixedInferredReturnType - somefile.php:2:42 - Could not verify return type \'null|string\' for psalmCanVerify (see https://psalm.dev/047)
+ERROR: MixedInferredReturnType - somefile.php:2:42 - Could not verify return type \'null|string\' for psalmCanVerify - see: https://psalm.dev/047
 
 
-ERROR: UndefinedConstant - somefile.php:8:6 - Const CHANGE_ME is not defined (see https://psalm.dev/020)
+ERROR: UndefinedConstant - somefile.php:8:6 - Const CHANGE_ME is not defined - see: https://psalm.dev/020
 
 
-INFO: PossiblyUndefinedGlobalVariable - somefile.php:17:6 - Possibly undefined global variable $a, first seen on line 11 (see https://psalm.dev/126)
+INFO: PossiblyUndefinedGlobalVariable - somefile.php:17:6 - Possibly undefined global variable $a, first seen on line 11 - see: https://psalm.dev/126
 
 
 ',


### PR DESCRIPTION
Both GitHub and GitLab treat the closing bracket as part of the URL, so
opening it directly from the log view doesn't currently work.

* GitHub:
  ![grafik](https://user-images.githubusercontent.com/495429/125141743-2cad0a00-e116-11eb-9f38-b26c062e3113.png)
* GitLab:
  ![grafik](https://user-images.githubusercontent.com/495429/125141393-4732b380-e115-11eb-828c-198ca7bba1dc.png)

PS: For GitLab, I [opened a PR](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/65888) to fix this upstream.
