### PR TITLE
Fix #6066 - introduce more robust system for capturing template constraints

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -754,7 +754,10 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                                 $pt_name = array_keys($parent_storage->template_types)[$pt_offset];
                                 if (isset($template_standins->lower_bounds[$pt_name][$parent_class])) {
                                     $lower_bounds[$pt_name][$parent_class] =
-                                        $template_standins->lower_bounds[$pt_name][$parent_class]->type;
+                                        TemplateStandinTypeReplacer::getMostSpecificTypeFromBounds(
+                                            $template_standins->lower_bounds[$pt_name][$parent_class],
+                                            $codebase
+                                        );
                                 }
                             }
                         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -367,17 +367,19 @@ class ArgumentAnalyzer
                             [$template_type->param_name]
                             [$template_type->defining_class]
                     )) {
-                        $template_result->lower_bounds[$template_type->param_name][$template_type->defining_class]
-                            = new TemplateBound(
+                        $template_result->lower_bounds[$template_type->param_name][$template_type->defining_class] = [
+                            new TemplateBound(
                                 clone $template_result->upper_bounds
                                     [$template_type->param_name]
                                     [$template_type->defining_class]->type
-                            );
+                            )
+                        ];
                     } else {
-                        $template_result->lower_bounds[$template_type->param_name][$template_type->defining_class]
-                            = new TemplateBound(
+                        $template_result->lower_bounds[$template_type->param_name][$template_type->defining_class] = [
+                            new TemplateBound(
                                 clone $template_type->as
-                            );
+                            )
+                        ];
                     }
                 }
             }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -283,8 +283,8 @@ class FunctionCallAnalyzer extends CallAnalyzer
                 $statements_analyzer->node_data->setIfTrueAssertions(
                     $stmt,
                     array_map(
-                        function (Assertion $assertion) use ($inferred_lower_bounds) : Assertion {
-                            return $assertion->getUntemplatedCopy($inferred_lower_bounds ?: [], null);
+                        function (Assertion $assertion) use ($inferred_lower_bounds, $codebase) : Assertion {
+                            return $assertion->getUntemplatedCopy($inferred_lower_bounds ?: [], null, $codebase);
                         },
                         $function_call_info->function_storage->if_true_assertions
                     )
@@ -295,8 +295,8 @@ class FunctionCallAnalyzer extends CallAnalyzer
                 $statements_analyzer->node_data->setIfFalseAssertions(
                     $stmt,
                     array_map(
-                        function (Assertion $assertion) use ($inferred_lower_bounds) : Assertion {
-                            return $assertion->getUntemplatedCopy($inferred_lower_bounds ?: [], null);
+                        function (Assertion $assertion) use ($inferred_lower_bounds, $codebase) : Assertion {
+                            return $assertion->getUntemplatedCopy($inferred_lower_bounds ?: [], null, $codebase);
                         },
                         $function_call_info->function_storage->if_false_assertions
                     )

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -67,21 +67,27 @@ class FunctionCallReturnTypeFetcher
                         if (!isset($template_result->lower_bounds[$template_name])) {
                             if ($template_name === 'TFunctionArgCount') {
                                 $template_result->lower_bounds[$template_name] = [
-                                    'fn-' . $function_id => new TemplateBound(
-                                        Type::getInt(false, count($stmt->args))
-                                    )
+                                    'fn-' . $function_id => [
+                                        new TemplateBound(
+                                            Type::getInt(false, count($stmt->args))
+                                        )
+                                    ]
                                 ];
                             } elseif ($template_name === 'TPhpMajorVersion') {
                                 $template_result->lower_bounds[$template_name] = [
-                                    'fn-' . $function_id => new TemplateBound(
-                                        Type::getInt(false, $codebase->php_major_version)
-                                    )
+                                    'fn-' . $function_id => [
+                                            new TemplateBound(
+                                                Type::getInt(false, $codebase->php_major_version)
+                                            )
+                                    ]
                                 ];
                             } else {
                                 $template_result->lower_bounds[$template_name] = [
-                                    'fn-' . $function_id => new TemplateBound(
-                                        Type::getEmpty()
-                                    )
+                                    'fn-' . $function_id => [
+                                        new TemplateBound(
+                                            Type::getEmpty()
+                                        )
+                                    ]
                                 ];
                             }
                         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -322,11 +322,13 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
                     array_map(
                         function (Assertion $assertion) use (
                             $class_template_params,
-                            $lhs_var_id
+                            $lhs_var_id,
+                            $codebase
                         ) : Assertion {
                             return $assertion->getUntemplatedCopy(
                                 $class_template_params ?: [],
-                                $lhs_var_id
+                                $lhs_var_id,
+                                $codebase
                             );
                         },
                         $method_storage->if_true_assertions
@@ -340,11 +342,13 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
                     array_map(
                         function (Assertion $assertion) use (
                             $class_template_params,
-                            $lhs_var_id
+                            $lhs_var_id,
+                            $codebase
                         ) : Assertion {
                             return $assertion->getUntemplatedCopy(
                                 $class_template_params ?: [],
-                                $lhs_var_id
+                                $lhs_var_id,
+                                $codebase
                             );
                         },
                         $method_storage->if_false_assertions

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -534,19 +534,25 @@ class MethodCallReturnTypeFetcher
                 ) {
                     if ($template_type->param_name === 'TFunctionArgCount') {
                         $template_result->lower_bounds[$template_type->param_name] = [
-                            'fn-' . strtolower((string) $method_id) => new TemplateBound(
-                                Type::getInt(false, $arg_count)
-                            )
+                            'fn-' . strtolower((string) $method_id) => [
+                                new TemplateBound(
+                                    Type::getInt(false, $arg_count)
+                                )
+                            ]
                         ];
                     } elseif ($template_type->param_name === 'TPhpMajorVersion') {
                         $template_result->lower_bounds[$template_type->param_name] = [
-                            'fn-' . strtolower((string) $method_id) => new TemplateBound(
-                                Type::getInt(false, $codebase->php_major_version)
-                            )
+                            'fn-' . strtolower((string) $method_id) => [
+                                new TemplateBound(
+                                    Type::getInt(false, $codebase->php_major_version)
+                                )
+                            ]
                         ];
                     } else {
                         $template_result->lower_bounds[$template_type->param_name] = [
-                            ($template_type->defining_class) => new TemplateBound(Type::getEmpty())
+                            ($template_type->defining_class) => [
+                                new TemplateBound(Type::getEmpty())
+                            ]
                         ];
                     }
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -318,8 +318,8 @@ class ExistingAtomicStaticCallAnalyzer
                 $statements_analyzer->node_data->setIfTrueAssertions(
                     $stmt,
                     array_map(
-                        function (Assertion $assertion) use ($generic_params) : Assertion {
-                            return $assertion->getUntemplatedCopy($generic_params, null);
+                        function (Assertion $assertion) use ($generic_params, $codebase) : Assertion {
+                            return $assertion->getUntemplatedCopy($generic_params, null, $codebase);
                         },
                         $method_storage->if_true_assertions
                     )
@@ -330,8 +330,8 @@ class ExistingAtomicStaticCallAnalyzer
                 $statements_analyzer->node_data->setIfFalseAssertions(
                     $stmt,
                     array_map(
-                        function (Assertion $assertion) use ($generic_params) : Assertion {
-                            return $assertion->getUntemplatedCopy($generic_params, null);
+                        function (Assertion $assertion) use ($generic_params, $codebase) : Assertion {
+                            return $assertion->getUntemplatedCopy($generic_params, null, $codebase);
                         },
                         $method_storage->if_false_assertions
                     )
@@ -488,19 +488,25 @@ class ExistingAtomicStaticCallAnalyzer
                     )) {
                         if ($template_type->param_name === 'TFunctionArgCount') {
                             $template_result->lower_bounds[$template_type->param_name] = [
-                                'fn-' . strtolower((string)$method_id) => new TemplateBound(
-                                    Type::getInt(false, count($stmt->args))
-                                )
+                                'fn-' . strtolower((string)$method_id) => [
+                                    new TemplateBound(
+                                        Type::getInt(false, count($stmt->args))
+                                    )
+                                ]
                             ];
                         } elseif ($template_type->param_name === 'TPhpMajorVersion') {
                             $template_result->lower_bounds[$template_type->param_name] = [
-                                'fn-' . strtolower((string)$method_id) => new TemplateBound(
-                                    Type::getInt(false, $codebase->php_major_version)
-                                )
+                                'fn-' . strtolower((string)$method_id) => [
+                                    new TemplateBound(
+                                        Type::getInt(false, $codebase->php_major_version)
+                                    )
+                                ]
                             ];
                         } else {
                             $template_result->lower_bounds[$template_type->param_name] = [
-                                ($template_type->defining_class) => new TemplateBound(Type::getEmpty())
+                                ($template_type->defining_class) => [
+                                    new TemplateBound(Type::getEmpty())
+                                ]
                             ];
                         }
                     }

--- a/src/Psalm/Internal/Type/TemplateBound.php
+++ b/src/Psalm/Internal/Type/TemplateBound.php
@@ -32,9 +32,7 @@ class TemplateBound
     public $arg_offset;
 
     /**
-     * TemplateResult implicitly supports bounds like
-     * `T >: some_type` and `T <: some_type` but not `T =: some_type`
-     * This adds support for that when
+     * When non-null, indicates an equality template bound (vs a lower or upper bound)
      *
      * @var ?string
      */

--- a/src/Psalm/Internal/Type/TemplateBound.php
+++ b/src/Psalm/Internal/Type/TemplateBound.php
@@ -18,7 +18,7 @@ class TemplateBound
      *
      * The shallowest-appearance of the template takes prominence when inferring the type of T.
      *
-     * @var ?int
+     * @var int
      */
     public $appearance_depth;
 
@@ -31,10 +31,24 @@ class TemplateBound
      */
     public $arg_offset;
 
-    public function __construct(Union $type, ?int $appearance_depth = null, ?int $arg_offset = null)
-    {
+    /**
+     * TemplateResult implicitly supports bounds like
+     * `T >: some_type` and `T <: some_type` but not `T =: some_type`
+     * This adds support for that when
+     *
+     * @var ?string
+     */
+    public $equality_bound_classlike;
+
+    public function __construct(
+        Union $type,
+        int $appearance_depth = 0,
+        ?int $arg_offset = null,
+        ?string $equality_bound_classlike = null
+    ) {
         $this->type = $type;
         $this->appearance_depth = $appearance_depth;
         $this->arg_offset = $arg_offset;
+        $this->equality_bound_classlike = $equality_bound_classlike;
     }
 }

--- a/src/Psalm/Internal/Type/TemplateResult.php
+++ b/src/Psalm/Internal/Type/TemplateResult.php
@@ -6,6 +6,21 @@ use Psalm\Type\Union;
 
 use function array_map;
 
+/**
+ * This class captures the result of running Psalm's argument analysis with
+ * regard to generic parameters.
+ *
+ * It captures upper and lower bounds for parameters. Mostly we just care about
+ * lower bounds — those are captured when calling a function that expects a
+ * non-callable templated argument.
+ *
+ * Upper bounds are found in callable parameter types. Given a parameter type
+ * `callable(T1): void` and an argument typed as `callable(int): void`, `int` will
+ * be added as an _upper_ bound for the template param `T1`. This only applies to
+ * parameters — given a parameter type `callable(): T2` and an argument typed as
+ * `callable(): string`, `string` will be added as a _lower_ bound for the template
+ * param `T2`.
+ */
 class TemplateResult
 {
     /**
@@ -14,7 +29,7 @@ class TemplateResult
     public $template_types;
 
     /**
-     * @var array<string, array<string, TemplateBound>>
+     * @var array<string, array<string, non-empty-list<TemplateBound>>>
      */
     public $lower_bounds;
 
@@ -47,7 +62,7 @@ class TemplateResult
             function ($type_map) {
                 return array_map(
                     function ($type) {
-                        return new TemplateBound($type);
+                        return [new TemplateBound($type)];
                     },
                     $type_map
                 );

--- a/src/Psalm/Type/Atomic/CallableTrait.php
+++ b/src/Psalm/Type/Atomic/CallableTrait.php
@@ -218,6 +218,7 @@ trait CallableTrait
                     $calling_function,
                     $replace,
                     !$add_lower_bound,
+                    null,
                     $depth
                 );
             }

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -191,6 +191,8 @@ trait GenericTrait
 
         $input_object_type_params = [];
 
+        $container_type_params_covariant = [];
+
         if ($input_type instanceof Atomic\TGenericObject
             && ($this instanceof Atomic\TGenericObject || $this instanceof Atomic\TIterable)
             && $codebase
@@ -198,7 +200,8 @@ trait GenericTrait
             $input_object_type_params = TemplateStandinTypeReplacer::getMappedGenericTypeParams(
                 $codebase,
                 $input_type,
-                $this
+                $this,
+                $container_type_params_covariant
             );
         }
 
@@ -239,6 +242,10 @@ trait GenericTrait
                 $calling_function,
                 $replace,
                 $add_lower_bound,
+                !($container_type_params_covariant[$offset] ?? true)
+                    && $this instanceof Atomic\TGenericObject
+                    ? $this->value
+                    : null,
                 $depth + 1
             );
         }

--- a/src/Psalm/Type/Atomic/HasIntersectionTrait.php
+++ b/src/Psalm/Type/Atomic/HasIntersectionTrait.php
@@ -3,6 +3,7 @@ namespace Psalm\Type\Atomic;
 
 use Psalm\Codebase;
 use Psalm\Internal\Type\TemplateResult;
+use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Type;
 use Psalm\Type\Atomic;
 
@@ -85,14 +86,16 @@ trait HasIntersectionTrait
             if ($extra_type instanceof TTemplateParam
                 && isset($template_result->lower_bounds[$extra_type->param_name][$extra_type->defining_class])
             ) {
-                $template_type = clone $template_result->lower_bounds
-                    [$extra_type->param_name][$extra_type->defining_class]->type;
+                $template_type = TemplateStandinTypeReplacer::getMostSpecificTypeFromBounds(
+                    $template_result->lower_bounds[$extra_type->param_name][$extra_type->defining_class],
+                    $codebase
+                );
 
                 foreach ($template_type->getAtomicTypes() as $template_type_part) {
                     if ($template_type_part instanceof TNamedObject) {
-                        $new_types[$template_type_part->getKey()] = $template_type_part;
+                        $new_types[$template_type_part->getKey()] = clone $template_type_part;
                     } elseif ($template_type_part instanceof TTemplateParam) {
-                        $new_types[$template_type_part->getKey()] = $template_type_part;
+                        $new_types[$template_type_part->getKey()] = clone $template_type_part;
                     }
                 }
             } else {

--- a/src/Psalm/Type/Atomic/TClassString.php
+++ b/src/Psalm/Type/Atomic/TClassString.php
@@ -147,6 +147,7 @@ class TClassString extends TString
             $calling_function,
             $replace,
             $add_lower_bound,
+            null,
             $depth
         );
 

--- a/src/Psalm/Type/Atomic/TClassStringMap.php
+++ b/src/Psalm/Type/Atomic/TClassStringMap.php
@@ -183,6 +183,7 @@ class TClassStringMap extends \Psalm\Type\Atomic
                 $calling_function,
                 $replace,
                 $add_lower_bound,
+                null,
                 $depth + 1
             );
 

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -353,6 +353,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
                 $calling_function,
                 $replace,
                 $add_lower_bound,
+                null,
                 $depth
             );
         }

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -156,6 +156,7 @@ class TList extends \Psalm\Type\Atomic
                 $calling_function,
                 $replace,
                 $add_lower_bound,
+                null,
                 $depth + 1
             );
 

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -251,6 +251,7 @@ class TObjectWithProperties extends TObject
                 $calling_function,
                 $replace,
                 $add_lower_bound,
+                null,
                 $depth
             );
         }


### PR DESCRIPTION
## Background

Psalm currently can reason about upper and lower bounds for generic parameters.

Assuming `array_map` has the signature

```
array_map<T1, T2>(callable<T1>: T2, array<T1>): array<T2>;
```

When analysing the call to `array_map` here:

```php
class A {}
class AChild extends A {}

function foo(AChild ...$arr): void {
    array_map(
        function(A $a): A {
            return $a;
        },
        $arr
  );
}
```

Psalm would generate an upper and lower bounds for `T1`:

Upper bound: `T1 <: A` — that is, `T1` is `A` or a subtype of `A`
Lower bound: `T1 >: AChild` — that is, `T1` is `AChild` or a supertype of `AChild`

It then checks to see whether those bounds are possible, or whether they clash:

```php
class A {}
class B {}

function foo(B ...$arr): void {
    array_map(
        function(A $a): A {
            return $a;
        },
        $arr
  );
}
```

In this case Psalm generates constraints `T1 <: A` and `T1 >: B`, and sees that they are incompatible.

## What's changed

This PR introduces a new type of constraint, the equality constraint (`T = A`).

Psalm now attempts to reconcile equality constraints (modelled as lower bounds with a nullable `string` set) with other lower bounds, producing an error if the bounds are incompatible.
  