### PR TITLE
Analyze array keys first when checking an array

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -232,51 +232,6 @@ class ArrayAnalyzer
         PhpParser\Node\Expr\ArrayItem $item,
         Codebase $codebase
     ) : void {
-        if (ExpressionAnalyzer::analyze($statements_analyzer, $item->value, $context) === false) {
-            return;
-        }
-
-        if ($item->unpack) {
-            $unpacked_array_type = $statements_analyzer->node_data->getType($item->value);
-
-            if (!$unpacked_array_type) {
-                return;
-            }
-
-            self::handleUnpackedArray(
-                $statements_analyzer,
-                $array_creation_info,
-                $item,
-                $unpacked_array_type
-            );
-
-            if (($data_flow_graph = $statements_analyzer->data_flow_graph)
-                && $data_flow_graph instanceof \Psalm\Internal\Codebase\VariableUseGraph
-                && $unpacked_array_type->parent_nodes
-            ) {
-                $var_location = new CodeLocation($statements_analyzer->getSource(), $item->value);
-
-                $new_parent_node = \Psalm\Internal\DataFlow\DataFlowNode::getForAssignment(
-                    'array',
-                    $var_location
-                );
-
-                $data_flow_graph->addNode($new_parent_node);
-
-                foreach ($unpacked_array_type->parent_nodes as $parent_node) {
-                    $data_flow_graph->addPath(
-                        $parent_node,
-                        $new_parent_node,
-                        'arrayvalue-assignment'
-                    );
-                }
-
-                $array_creation_info->parent_taint_nodes += [$new_parent_node->id => $new_parent_node];
-            }
-
-            return;
-        }
-
         $item_key_value = null;
         $item_key_type = null;
         $item_is_list_item = false;
@@ -353,6 +308,50 @@ class ArrayAnalyzer
             $array_creation_info->array_keys[$item_key_value] = true;
         }
 
+        if (ExpressionAnalyzer::analyze($statements_analyzer, $item->value, $context) === false) {
+            return;
+        }
+
+        if ($item->unpack) {
+            $unpacked_array_type = $statements_analyzer->node_data->getType($item->value);
+
+            if (!$unpacked_array_type) {
+                return;
+            }
+
+            self::handleUnpackedArray(
+                $statements_analyzer,
+                $array_creation_info,
+                $item,
+                $unpacked_array_type
+            );
+
+            if (($data_flow_graph = $statements_analyzer->data_flow_graph)
+                && $data_flow_graph instanceof \Psalm\Internal\Codebase\VariableUseGraph
+                && $unpacked_array_type->parent_nodes
+            ) {
+                $var_location = new CodeLocation($statements_analyzer->getSource(), $item->value);
+
+                $new_parent_node = \Psalm\Internal\DataFlow\DataFlowNode::getForAssignment(
+                    'array',
+                    $var_location
+                );
+
+                $data_flow_graph->addNode($new_parent_node);
+
+                foreach ($unpacked_array_type->parent_nodes as $parent_node) {
+                    $data_flow_graph->addPath(
+                        $parent_node,
+                        $new_parent_node,
+                        'arrayvalue-assignment'
+                    );
+                }
+
+                $array_creation_info->parent_taint_nodes += [$new_parent_node->id => $new_parent_node];
+            }
+
+            return;
+        }
 
         if (($data_flow_graph = $statements_analyzer->data_flow_graph)
             && ($data_flow_graph instanceof \Psalm\Internal\Codebase\VariableUseGraph

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1610,6 +1610,19 @@ class ArrayAssignmentTest extends TestCase
                         }
                     }',
             ],
+            'InitVariableInOffset'  => [
+                '<?php
+                    $_a = [
+                        $_init_var = "a" => [
+                            "value" => $_init_var,
+                        ],
+                    ];
+
+                    /** @param array{a: array{value: "a"}} $a */
+                    function expectArray(array $a): array{
+                        return $a;
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This will partly solve #6061. It ensure keys are analyzed before the value of the array, so any assignment here can be used later.

I had to make `$array_creation_info` to be able to replace the whole object with a clone because there is a special handling for unpacking and it has to be after analyzing the value (so after analyzing the keys with this PR) but it also needs the ArrayCreationInfo untouched.

This PR doesn't solve the whole #6061 issue because it doesn't handle the UnusedVariable that's emitted (I don't get how this works yet)