### PR TITLE
Fix #6061 — delay analysis of array value except when unpacking

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -232,11 +232,11 @@ class ArrayAnalyzer
         PhpParser\Node\Expr\ArrayItem $item,
         Codebase $codebase
     ) : void {
-        if (ExpressionAnalyzer::analyze($statements_analyzer, $item->value, $context) === false) {
-            return;
-        }
-
         if ($item->unpack) {
+            if (ExpressionAnalyzer::analyze($statements_analyzer, $item->value, $context) === false) {
+                return;
+            }
+
             $unpacked_array_type = $statements_analyzer->node_data->getType($item->value);
 
             if (!$unpacked_array_type) {
@@ -333,6 +333,10 @@ class ArrayAnalyzer
             $item_is_list_item = true;
             $item_key_value = $array_creation_info->int_offset++;
             $array_creation_info->item_key_atomic_types[] = new Type\Atomic\TLiteralInt($item_key_value);
+        }
+
+        if (ExpressionAnalyzer::analyze($statements_analyzer, $item->value, $context) === false) {
+            return;
         }
 
         $array_creation_info->all_list = $array_creation_info->all_list && $item_is_list_item;

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -2392,6 +2392,16 @@ class UnusedVariableTest extends TestCase
                         return implode("/", $arr);
                     }'
             ],
+            'initVariableInOffset'  => [
+                '<?php
+                    $a = [
+                        $b = "b" => $b,
+                    ];
+
+                    foreach ($a as $key => $value) {
+                        echo $key . " " . $value;
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This undoes a mistake made in https://github.com/vimeo/psalm/commit/3f2d57c7a3a69ae1d3b6544db0ae0796c73ae2c9.

cc @orklah — I think this fix is preferable to yours (unless there's something I've missed)