### PR TITLE
Fix usage of gettype in a switch with closed resource

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -2381,7 +2381,15 @@ class AssertionFinder
             }
         } else {
             if ($var_name && $var_type) {
-                $if_types[$var_name] = [['!' . $var_type]];
+                if ($var_type === 'class@anonymous') {
+                    $if_types[$var_name] = [['!=object']];
+                } elseif ($var_type === 'resource (closed)') {
+                    $if_types[$var_name] = [['!closed-resource']];
+                } elseif (substr($var_type, 0, 10) === 'resource (') {
+                    $if_types[$var_name] = [['!=resource']];
+                } else {
+                    $if_types[$var_name] = [['!' . $var_type]];
+                }
             }
         }
 
@@ -3054,7 +3062,15 @@ class AssertionFinder
             }
         } else {
             if ($var_name && $var_type) {
-                $if_types[$var_name] = [[$var_type]];
+                if ($var_type === 'class@anonymous') {
+                    $if_types[$var_name] = [['=object']];
+                } elseif ($var_type === 'resource (closed)') {
+                    $if_types[$var_name] = [['closed-resource']];
+                } elseif (substr($var_type, 0, 10) === 'resource (') {
+                    $if_types[$var_name] = [['=resource']];
+                } else {
+                    $if_types[$var_name] = [[$var_type]];
+                }
             }
         }
 

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -792,6 +792,15 @@ class FunctionCallTest extends TestCase
                         if ($t === "object") {}
                     }',
             ],
+            'getTypeSwitchClosedResource' => [
+                '<?php
+                    $data = "foo";
+                    switch (gettype($data)) {
+                        case "resource (closed)":
+                        case "unknown type":
+                            return "foo";
+                    }',
+            ],
             'functionResolutionInNamespace' => [
                 '<?php
                     namespace Foo;


### PR DESCRIPTION
This fixes #6088

It was caused by the absence of a specific code handling this situation that I retrieved from getDebugType(In)?equalityAssertions