### PR TITLE
Allow 0 for all bitmask types

### DIFF
--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -442,6 +442,7 @@ class TypeParser
             $potential_values = array_merge($new_values, $potential_values);
         }
 
+        array_unshift($potential_values, 0);
         $potential_values = array_unique($potential_values);
 
         return array_map(

--- a/src/Psalm/Type/Atomic/TIntMask.php
+++ b/src/Psalm/Type/Atomic/TIntMask.php
@@ -5,7 +5,7 @@ use function substr;
 
 /**
  * Represents the type that is the result of a bitmask combination of its parameters.
- * `int-mask<1, 2, 4>` corresponds to `1|2|3|4|5|6|7`
+ * `int-mask<1, 2, 4>` corresponds to `0|1|2|3|4|5|6|7`
  */
 class TIntMask extends TInt
 {

--- a/src/Psalm/Type/Atomic/TIntMaskOf.php
+++ b/src/Psalm/Type/Atomic/TIntMaskOf.php
@@ -4,7 +4,7 @@ namespace Psalm\Type\Atomic;
 /**
  * Represents the type that is the result of a bitmask combination of its parameters.
  * This is the same concept as TIntMask but TIntMaskOf is used with with a reference to constants in code
- * `int-mask<MyClass::CLASS_CONSTANT_*>` will corresponds to `1|2|3|4|5|6|7` if there are three constant 1, 2 and 4
+ * `int-mask<MyClass::CLASS_CONSTANT_*>` will corresponds to `0|1|2|3|4|5|6|7` if there are three constant 1, 2 and 4
  */
 class TIntMaskOf extends TInt
 {

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1185,6 +1185,14 @@ class AnnotationTest extends TestCase
 
                     takesFlags(FileFlag::MODIFIED | FileFlag::NEW);'
             ],
+            'intMaskWithZero' => [
+                '<?php
+                    /** @param int-mask<1,2> $_flags */
+                    function takesFlags(int $_flags): void {}
+
+                    takesFlags(0);
+                '
+            ],
             'intMaskOfWithClassWildcard' => [
                 '<?php
                     class FileFlag {
@@ -1201,6 +1209,20 @@ class AnnotationTest extends TestCase
                     }
 
                     takesFlags(FileFlag::MODIFIED | FileFlag::NEW);'
+            ],
+            'intMaskOfWithZero' => [
+                '<?php
+                    class FileFlag {
+                        public const OPEN = 1;
+                        public const MODIFIED = 2;
+                        public const NEW = 4;
+                    }
+
+                    /** @param int-mask-of<FileFlag::*> $_flags */
+                    function takesFlags(int $_flags): void {}
+
+                    takesFlags(0);
+                '
             ],
             'emptyStringFirst' => [
                 '<?php

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -917,15 +917,15 @@ class TypeParseTest extends TestCase
 
         $docblock_type = Type::parseString('int-mask<1, 2, 4>');
 
-        $this->assertSame('1|2|3|4|5|6|7', $docblock_type->getId());
+        $this->assertSame('0|1|2|3|4|5|6|7', $docblock_type->getId());
 
         $docblock_type = Type::parseString('int-mask<1, 4>');
 
-        $this->assertSame('1|4|5', $docblock_type->getId());
+        $this->assertSame('0|1|4|5', $docblock_type->getId());
 
         $docblock_type = Type::parseString('int-mask<PREG_PATTERN_ORDER, PREG_OFFSET_CAPTURE, PREG_UNMATCHED_AS_NULL>');
 
-        $this->assertSame('1|256|257|512|513|768|769', $docblock_type->getId());
+        $this->assertSame('0|1|256|257|512|513|768|769', $docblock_type->getId());
     }
 
     public function testIntMaskWithClassConstant(): void


### PR DESCRIPTION
When function takes a bitmask of flags I expect to be able to turn them on and off individually. The way Psalm treated `int-mask<self::FLAG_1, self::FLAG_2>` effectively required to turn on at least one of the flags. 

Fixes vimeo/psalm#6119