### PR TITLE
Unused global variable after modification

### DIFF
--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -370,7 +370,7 @@ class Context
     /**
      * @var array<string, bool>
      */
-    public $vars_from_global;
+    public $vars_from_global = [];
 
     public function __construct(?string $self = null)
     {

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -367,6 +367,11 @@ class Context
      */
     public $has_returned = false;
 
+    /**
+     * @var array<string, bool>
+     */
+    public $vars_from_global;
+
     public function __construct(?string $self = null)
     {
         $this->self = $self;

--- a/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
@@ -65,6 +65,7 @@ class GlobalAnalyzer
                     $context->vars_in_scope[$var_id]->parent_nodes = [
                         $assignment_node->id => $assignment_node,
                     ];
+                    $context->vars_from_global[$var_id] = true;
                     $statements_analyzer->registerVariable(
                         $var_id,
                         new CodeLocation($statements_analyzer, $var),

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -194,7 +194,7 @@ class StatementsAnalyzer extends SourceAnalyzer
             && $context->check_variables
         ) {
             //var_dump($this->data_flow_graph);
-            $this->checkUnreferencedVars($stmts);
+            $this->checkUnreferencedVars($stmts, $context);
         }
 
         if ($codebase->alter_code && $root_scope && $this->vars_to_initialize) {
@@ -701,7 +701,7 @@ class StatementsAnalyzer extends SourceAnalyzer
     /**
      * @param  array<PhpParser\Node\Stmt>   $stmts
      */
-    public function checkUnreferencedVars(array $stmts): void
+    public function checkUnreferencedVars(array $stmts, Context $context): void
     {
         $source = $this->getSource();
         $codebase = $source->getCodebase();
@@ -776,6 +776,7 @@ class StatementsAnalyzer extends SourceAnalyzer
             $assignment_node = DataFlowNode::getForAssignment($var_id, $original_location);
 
             if (!isset($this->byref_uses[$var_id])
+                && !isset($context->vars_from_global[$var_id])
                 && !VariableFetchAnalyzer::isSuperGlobal($var_id)
                 && $this->data_flow_graph instanceof VariableUseGraph
                 && !$this->data_flow_graph->isVariableUsed($assignment_node)

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -2424,6 +2424,14 @@ class UnusedVariableTest extends TestCase
                         return $randomBytes;
                     }'
             ],
+            'globalChangeValue' => [
+                '<?php
+                    function setProxySettingsFromEnv(): void {
+                        global $a;
+
+                        $a = false;
+                    }'
+            ],
         ];
     }
 

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -3269,15 +3269,6 @@ class UnusedVariableTest extends TestCase
                     };',
                 'error_message' => 'UnusedVariable',
             ],
-            'globalVariableUsage' => [
-                '<?php
-                    $a = "hello";
-                    function example() : void {
-                        global $a;
-                    }
-                    example();',
-                'error_message' => 'UnusedVariable',
-            ],
             'warnAboutOriginalBadArray' => [
                 '<?php
                     function takesArray(array $arr) : void {


### PR DESCRIPTION
This would fix https://github.com/vimeo/psalm/issues/6111#issuecomment-881064978

This basically registers every global variable and prevent emitting UnusedVariable on those.

This means true positives (where UnusedVariable was emitted and the variable was not used) won't work anymore: https://psalm.dev/r/edb1c159ea. Hence the failing test here

However, this bring the behaviour closer to what already exists for references: https://psalm.dev/r/67292ae85a

Going beyond that would mean Psalm would have to record not only variable read access detecting usage but also write access. This seems a big piece of work for detecting a few globals and references unused.

If this is good enough to be merged, I'll remove the failing test and this will become the new behaviour for those cases.