### PR TITLE
Flag staticness mismatch

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -1149,7 +1149,7 @@ class InstancePropertyAssignmentAnalyzer
             $context,
             new CodeLocation($statements_analyzer->getSource(), $stmt)
         )
-        // when methods existance is asserted by a plugin it doesn't necessarily has storage
+        // when property existence is asserted by a plugin it doesn't necessarily has storage
         || ($codebase->properties->hasStorage($property_id)
             && $codebase->properties->getStorage($property_id)->is_static
         )

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -1148,7 +1148,12 @@ class InstancePropertyAssignmentAnalyzer
             $statements_analyzer,
             $context,
             new CodeLocation($statements_analyzer->getSource(), $stmt)
-        )) {
+        )
+        // when methods existance is asserted by a plugin it doesn't necessarily has storage
+        || ($codebase->properties->hasStorage($property_id)
+            && $codebase->properties->getStorage($property_id)->is_static
+        )
+        ) {
             if ($stmt->var instanceof PhpParser\Node\Expr\Variable && $stmt->var->name === 'this') {
                 // if this is a proper error, we'll see it on the first pass
                 if ($context->collect_mutations) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -66,7 +66,8 @@ class AtomicPropertyFetchAnalyzer
         Type\Atomic $lhs_type_part,
         string $prop_name,
         bool &$has_valid_fetch_type,
-        array &$invalid_fetch_types
+        array &$invalid_fetch_types,
+        bool $is_static_access = false
     ) : void {
         if ($lhs_type_part instanceof TNull) {
             return;
@@ -311,7 +312,13 @@ class AtomicPropertyFetchAnalyzer
             )
         ) {
             $property_id = $context->self . '::$' . $prop_name;
-        } elseif (!$naive_property_exists) {
+        } elseif (!$naive_property_exists
+            || (!$is_static_access
+                // when methods existance is asserted by a plugin it doesn't necessarily has storage
+                && $codebase->properties->hasStorage($property_id)
+                && $codebase->properties->getStorage($property_id)->is_static
+            )
+        ) {
             self::handleNonExistentProperty(
                 $statements_analyzer,
                 $codebase,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -314,7 +314,7 @@ class AtomicPropertyFetchAnalyzer
             $property_id = $context->self . '::$' . $prop_name;
         } elseif (!$naive_property_exists
             || (!$is_static_access
-                // when methods existance is asserted by a plugin it doesn't necessarily has storage
+                // when property existence is asserted by a plugin it doesn't necessarily has storage
                 && $codebase->properties->hasStorage($property_id)
                 && $codebase->properties->getStorage($property_id)->is_static
             )

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
@@ -32,7 +32,8 @@ class InstancePropertyFetchAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\PropertyFetch $stmt,
         Context $context,
-        bool $in_assignment = false
+        bool $in_assignment = false,
+        bool $is_static_access = false
     ) : bool {
         $was_inside_general_use = $context->inside_general_use;
         $context->inside_general_use = true;
@@ -247,7 +248,8 @@ class InstancePropertyFetchAnalyzer
                 $lhs_type_part,
                 $prop_name,
                 $has_valid_fetch_type,
-                $invalid_fetch_types
+                $invalid_fetch_types,
+                $is_static_access
             );
         }
 

--- a/src/Psalm/Internal/Codebase/Properties.php
+++ b/src/Psalm/Internal/Codebase/Properties.php
@@ -264,6 +264,24 @@ class Properties
         throw new \UnexpectedValueException('Property ' . $property_id . ' should exist');
     }
 
+    public function hasStorage(string $property_id): bool
+    {
+        // remove trailing backslash if it exists
+        $property_id = preg_replace('/^\\\\/', '', $property_id);
+
+        [$fq_class_name, $property_name] = explode('::$', $property_id);
+
+        $class_storage = $this->classlike_storage_provider->get($fq_class_name);
+
+        if (isset($class_storage->declaring_property_ids[$property_name])) {
+            $declaring_property_class = $class_storage->declaring_property_ids[$property_name];
+            $declaring_class_storage = $this->classlike_storage_provider->get($declaring_property_class);
+
+            return isset($declaring_class_storage->properties[$property_name]);
+        }
+        return false;
+    }
+
     public function getPropertyType(
         string $property_id,
         bool $property_set,

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -1270,11 +1270,9 @@ class PropertyTypeTest extends TestCase
                         public function bar() : void {}
                     }
 
-                    $a = new A();
-
-                    if ($a->instance) {
-                        $a->instance->bar();
-                        echo $a->instance->bat;
+                    if (A::$instance) {
+                        A::$instance->bar();
+                        echo A::$instance->bat;
                     }',
             ],
             'nonStaticPropertyMethodCall' => [
@@ -3534,6 +3532,46 @@ class PropertyTypeTest extends TestCase
                     (new A)->__get();',
                 'error_message' => 'TooFewArguments',
             ],
+            'staticReadOfNonStaticProperty' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $prop = 1;
+                    }
+                    echo A::$prop;
+                ',
+                'error_message' => 'UndefinedPropertyFetch',
+            ],
+            'staticWriteToNonStaticProperty' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public $prop = 1;
+                    }
+                    A::$prop = 42;
+                ',
+                'error_message' => 'UndefinedPropertyAssignment',
+            ],
+            'nonStaticReadOfStaticProperty' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public static $prop = 1;
+                    }
+                    echo (new A)->prop;
+                ',
+                'error_message' => 'UndefinedPropertyFetch',
+            ],
+            'nonStaticWriteToStaticProperty' => [
+                '<?php
+                    class A {
+                        /** @var int */
+                        public static $prop = 1;
+                    }
+                    (new A)->prop = 42;
+                ',
+                'error_message' => 'UndefinedPropertyAssignment',
+            ]
         ];
     }
 }

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -735,7 +735,7 @@ class UnusedCodeTest extends TestCase
                         /**
                          * @var array<string, string>
                          */
-                        public $foo = [];
+                        public static $foo = [];
 
                         /**
                          * @param array<string, string> $map


### PR DESCRIPTION
This handles two new cases:
1. Accessing static property with `->` (produces notices and warnings: https://3v4l.org/TiGan)
2. Accessing non-static property with `::` (causes fatal error: https://3v4l.org/IdYSh)

Fixes vimeo/psalm#6117