### PR TITLE
fix: Handle DataFlowNodeData in XmlReport

### DIFF
--- a/src/Psalm/Report/XmlReport.php
+++ b/src/Psalm/Report/XmlReport.php
@@ -2,6 +2,7 @@
 namespace Psalm\Report;
 
 use LSS\Array2XML;
+use Psalm\Internal\Analyzer\DataFlowNodeData;
 use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
 
@@ -30,8 +31,8 @@ class XmlReport extends Report
 
                         if (null !== $issue_data['other_references']) {
                             $issue_data['other_references'] = array_map(
-                                function ($trace): array {
-                                    return (array) $trace;
+                                function (DataFlowNodeData $reference): array {
+                                    return (array) $reference;
                                 },
                                 $issue_data['other_references']
                             );

--- a/src/Psalm/Report/XmlReport.php
+++ b/src/Psalm/Report/XmlReport.php
@@ -18,6 +18,25 @@ class XmlReport extends Report
                     function (IssueData $issue_data): array {
                         $issue_data = (array) $issue_data;
                         unset($issue_data['dupe_key']);
+
+                        if (null !== $issue_data['taint_trace']) {
+                            $issue_data['taint_trace'] = array_map(
+                                function ($trace): array {
+                                    return (array) $trace;
+                                },
+                                $issue_data['taint_trace']
+                            );
+                        }
+
+                        if (null !== $issue_data['other_references']) {
+                            $issue_data['other_references'] = array_map(
+                                function ($trace): array {
+                                    return (array) $trace;
+                                },
+                                $issue_data['other_references']
+                            );
+                        }
+
                         return $issue_data;
                     },
                     $this->issues_data

--- a/src/Psalm/Report/XmlReport.php
+++ b/src/Psalm/Report/XmlReport.php
@@ -7,6 +7,7 @@ use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
 
 use function array_map;
+use function get_object_vars;
 
 class XmlReport extends Report
 {
@@ -17,7 +18,7 @@ class XmlReport extends Report
             [
                 'item' => array_map(
                     function (IssueData $issue_data): array {
-                        $issue_data = (array) $issue_data;
+                        $issue_data = get_object_vars($issue_data);
                         unset($issue_data['dupe_key']);
 
                         if (null !== $issue_data['taint_trace']) {


### PR DESCRIPTION
Adding `other_references` and `taint_trade` to [IssueData](https://github.com/vimeo/psalm/blame/d8cddd64c0743b633af67824f4fc6708cb805cc7/src/Psalm/Internal/Analyzer/IssueData.php) has caused a regression in XML report generation. LSS\Array2XML expects a nested array of scalars, but it now sometimes contains DataFlowNodeData objects.

I'm not sure of the best way to do this so I just extended the existing way. Feel free to either edit or leave some suggestions.