### PR TITLE
Add support for native PHP readonly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "felixfbecker/advanced-json-rpc": "^3.0.3",
         "felixfbecker/language-server-protocol": "^1.5",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-        "nikic/php-parser": "^4.10.5",
+        "nikic/php-parser": "^4.12",
         "openlss/lib-array2xml": "^1.0",
         "sebastian/diff": "^3.0 || ^4.0",
         "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -405,6 +405,16 @@ class InstancePropertyAssignmentAnalyzer
     ): void {
         foreach ($stmt->props as $prop) {
             if ($prop->default) {
+                if ($stmt->isReadonly()) {
+                    IssueBuffer::add(
+                        new InvalidPropertyAssignment(
+                            'Readonly property ' . $context->self . '::$' . $prop->name->name
+                                . ' cannot have a default',
+                            new CodeLocation($statements_analyzer->getSource(), $prop->default)
+                        )
+                    );
+                }
+
                 ExpressionAnalyzer::analyze($statements_analyzer, $prop->default, $context);
 
                 if ($prop_default_type = $statements_analyzer->node_data->getType($prop->default)) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -1355,7 +1355,7 @@ class ClassLikeNodeScanner
             if (! $property_storage->internal && $var_comment && $var_comment->internal) {
                 $property_storage->internal = NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name);
             }
-            $property_storage->readonly = $var_comment ? $var_comment->readonly : false;
+            $property_storage->readonly = $stmt->isReadonly() || ($var_comment && $var_comment->readonly);
             $property_storage->allow_private_mutation = $var_comment ? $var_comment->allow_private_mutation : false;
             $property_storage->description = $var_comment ? $var_comment->description : null;
 

--- a/tests/ReadonlyPropertyTest.php
+++ b/tests/ReadonlyPropertyTest.php
@@ -14,7 +14,7 @@ class ReadonlyPropertyTest extends TestCase
     public function providerValidCodeParse(): iterable
     {
         return [
-            'readonlyPropertySetInConstructor' => [
+            'docblockReadonlyPropertySetInConstructor' => [
                 '<?php
                     class A {
                         /**
@@ -29,7 +29,22 @@ class ReadonlyPropertyTest extends TestCase
 
                     echo (new A)->bar;'
             ],
-            'readonlyWithPrivateMutationsAllowedPropertySetInAnotherMEthod' => [
+            'readonlyPropertySetInConstructor' => [
+                '<?php
+                    class A {
+                        public readonly string $bar;
+
+                        public function __construct() {
+                            $this->bar = "hello";
+                        }
+                    }
+
+                    echo (new A)->bar;',
+                [],
+                [],
+                '8.1'
+            ],
+            'docblockReadonlyWithPrivateMutationsAllowedPropertySetInAnotherMethod' => [
                 '<?php
                     class A {
                         /**
@@ -124,7 +139,7 @@ class ReadonlyPropertyTest extends TestCase
                     }',
                 'error_message' => 'InaccessibleProperty',
             ],
-            'readonlyPropertySetInConstructorAndAlsoOutsideClass' => [
+            'docblockReadonlyPropertySetInConstructorAndAlsoOutsideClass' => [
                 '<?php
                     class A {
                         /**
@@ -139,7 +154,24 @@ class ReadonlyPropertyTest extends TestCase
 
                     $a = new A();
                     $a->bar = "goodbye";',
-                'error_message' => 'InaccessibleProperty',
+                'error_message' => 'InaccessibleProperty - src' . DIRECTORY_SEPARATOR . 'somefile.php:14:21',
+            ],
+            'readonlyPropertySetInConstructorAndAlsoOutsideClass' => [
+                '<?php
+                    class A {
+                        public readonly string $bar;
+
+                        public function __construct() {
+                            $this->bar = "hello";
+                        }
+                    }
+
+                    $a = new A();
+                    $a->bar = "goodbye";',
+                'error_message' => 'InaccessibleProperty - src' . DIRECTORY_SEPARATOR . 'somefile.php:11:21',
+                [],
+                false,
+                '8.1',
             ],
             'readonlyPropertySetInConstructorAndAlsoOutsideClassWithAllowPrivate' => [
                 '<?php
@@ -200,6 +232,16 @@ class ReadonlyPropertyTest extends TestCase
 
                     $test->prop += 1;',
                 'error_message' => 'InaccessibleProperty'
+            ],
+            'readonlyPropertyWithDefault' => [
+                '<?php
+                    class A {
+                        public readonly string $s = "a";
+                    }',
+                'error_message' => 'InvalidPropertyAssignment',
+                [],
+                false,
+                '8.1',
             ],
         ];
     }


### PR DESCRIPTION
Updates nikic/php-parser to [4.12.0](https://github.com/nikic/PHP-Parser/releases/tag/v4.12.0), which provides an extra method supporting `readonly`.