### PR TITLE
String increment on numeric string

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -387,12 +387,18 @@ class NonDivArithmeticOpAnalyzer
             && $right_type_part instanceof TInt
             && $parent instanceof PhpParser\Node\Expr\PostInc
         ) {
-            $has_string_increment = true;
-
-            if (!$result_type) {
-                $result_type = Type::getNonEmptyString();
+            if ($left_type_part instanceof Type\Atomic\TNumericString) {
+                $new_result_type = new Type\Union([new TFloat(), new TInt()]);
+                $new_result_type->from_calculation = true;
             } else {
-                $result_type = Type::combineUnionTypes(Type::getNonEmptyString(), $result_type);
+                $new_result_type = Type::getNonEmptyString();
+                $has_string_increment = true;
+            }
+
+            if ($result_type) {
+                $result_type = Type::combineUnionTypes($new_result_type, $result_type);
+            } else {
+                $result_type = $new_result_type;
             }
 
             $has_valid_left_operand = true;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -390,7 +390,12 @@ class NonDivArithmeticOpAnalyzer
                 $parent instanceof PhpParser\Node\Expr\PreInc
             )
         ) {
-            if ($left_type_part instanceof Type\Atomic\TNumericString) {
+            if ($left_type_part instanceof Type\Atomic\TNumericString || (
+                    $left_type_part instanceof Type\Atomic\TLiteralString &&
+                    //Matches '1', '1.', '-1', '-1.'. Does not match '.1'
+                    preg_match('/^\-?\d+\.?\d*$/', $left_type_part->value)
+                )
+            ) {
                 $new_result_type = new Type\Union([new TFloat(), new TInt()]);
                 $new_result_type->from_calculation = true;
             } else {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -387,9 +387,7 @@ class NonDivArithmeticOpAnalyzer
             && $right_type_part instanceof TInt
             && (
                 $parent instanceof PhpParser\Node\Expr\PostInc ||
-                $parent instanceof PhpParser\Node\Expr\PreInc ||
-                $parent instanceof PhpParser\Node\Expr\PostDec ||
-                $parent instanceof PhpParser\Node\Expr\PreDec
+                $parent instanceof PhpParser\Node\Expr\PreInc
             )
         ) {
             if ($left_type_part instanceof Type\Atomic\TNumericString) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -36,6 +36,7 @@ use Psalm\Type\Atomic\TTemplateParam;
 use function array_diff_key;
 use function array_values;
 use function is_int;
+use function is_numeric;
 use function preg_match;
 use function strtolower;
 
@@ -390,11 +391,8 @@ class NonDivArithmeticOpAnalyzer
                 $parent instanceof PhpParser\Node\Expr\PreInc
             )
         ) {
-            if ($left_type_part instanceof Type\Atomic\TNumericString || (
-                    $left_type_part instanceof Type\Atomic\TLiteralString &&
-                    //Matches '1', '1.', '-1', '-1.'. Does not match '.1'
-                    preg_match('/^\-?\d+\.?\d*$/', $left_type_part->value)
-                )
+            if ($left_type_part instanceof Type\Atomic\TNumericString ||
+                ($left_type_part instanceof Type\Atomic\TLiteralString && is_numeric($left_type_part->value))
             ) {
                 $new_result_type = new Type\Union([new TFloat(), new TInt()]);
                 $new_result_type->from_calculation = true;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -385,7 +385,12 @@ class NonDivArithmeticOpAnalyzer
 
         if ($left_type_part instanceof Type\Atomic\TString
             && $right_type_part instanceof TInt
-            && $parent instanceof PhpParser\Node\Expr\PostInc
+            && (
+                $parent instanceof PhpParser\Node\Expr\PostInc ||
+                $parent instanceof PhpParser\Node\Expr\PreInc ||
+                $parent instanceof PhpParser\Node\Expr\PostDec ||
+                $parent instanceof PhpParser\Node\Expr\PreDec
+            )
         ) {
             if ($left_type_part instanceof Type\Atomic\TNumericString) {
                 $new_result_type = new Type\Union([new TFloat(), new TInt()]);

--- a/src/Psalm/Type/Atomic/TNonEmptyString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyString.php
@@ -2,7 +2,7 @@
 namespace Psalm\Type\Atomic;
 
 /**
- * Denotes a string, that is also non-empty
+ * Denotes a string, that is also non-empty (every string except '')
  */
 class TNonEmptyString extends TString
 {

--- a/src/Psalm/Type/Atomic/TNonFalsyString.php
+++ b/src/Psalm/Type/Atomic/TNonFalsyString.php
@@ -2,7 +2,7 @@
 namespace Psalm\Type\Atomic;
 
 /**
- * Denotes a string, that is also non-empty
+ * Denotes a string, that is also non-falsy (every string except '' and '0')
  */
 class TNonFalsyString extends TNonEmptyString
 {

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -674,6 +674,18 @@ class BinaryOperationTest extends TestCase
                         }
                     }',
             ],
+            'NumericStringIncrementLiteral' => [
+                '<?php
+                    $a = "123";
+                    $b = "123";
+                    $a++;
+                    ++$b;
+                    ',
+                'assertions' => [
+                    '$a' => 'float|int',
+                    '$b' => 'float|int',
+                ],
+            ],
         ];
     }
 

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -662,6 +662,18 @@ class BinaryOperationTest extends TestCase
                         return "Hello $s1 $s2";
                     }',
             ],
+            'NumericStringIncrement' => [
+                '<?php
+                    function scope(array $a): int|float {
+                        $offset = array_search("foo", $a);
+                        if(is_numeric($offset)){
+                            return $offset++;
+                        }
+                        else{
+                            return 0;
+                        }
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR allows incrementing on a numeric-string without triggering StringIncrement as this is most probably on purpose. Also, it fixes the resulting type from `non-empty-string` to `float|int`. This is particularly useful when working with numeric array-keys due to PHP shenanigans that cast string to int