### PR TITLE
Arithmetic operation between numeric and int or float gives int|float

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -667,11 +667,15 @@ class NonDivArithmeticOpAnalyzer
                 }
 
                 if ($parent instanceof PhpParser\Node\Expr\BinaryOp\Mod) {
-                    $result_type = Type::getInt();
-                } elseif (!$result_type) {
-                    $result_type = Type::getNumeric();
+                    $new_result_type = Type::getInt();
                 } else {
-                    $result_type = Type::combineUnionTypes(Type::getNumeric(), $result_type);
+                    $new_result_type = new Type\Union([new TFloat(), new TInt()]);
+                }
+
+                if (!$result_type) {
+                    $result_type = $new_result_type;
+                } else {
+                    $result_type = Type::combineUnionTypes($new_result_type, $result_type);
                 }
 
                 $has_valid_right_operand = true;

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -640,6 +640,26 @@ class BinaryOperationTest extends TestCase
                         return "foo" . $s1;
                     }',
             ],
+            'numericWithInt' => [
+                '<?php
+                    /** @return numeric */
+                    function getNumeric(){
+                        return 1;
+                    }
+                    $a = getNumeric();
+                    $a++;
+                    $b = getNumeric() * 2;
+                    $c = 1 - getNumeric();
+                    $d = 2;
+                    $d -= getNumeric();
+                    ',
+                'assertions' => [
+                    '$a' => 'float|int',
+                    '$b' => 'float|int',
+                    '$c' => 'float|int',
+                    '$d' => 'float|int',
+                ],
+            ],
             'encapsedStringWithIntIncludingLiterals' => [
                 '<?php
                     /**


### PR DESCRIPTION
This PR refine the result of any non-div arithmetic operation between numeric and int or float. The result is now `int|float` while it was `numeric` before