### PR TITLE
Trigger InvalidOperand when processing two numeric types in strict operands mode

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -766,7 +766,8 @@ class NonDivArithmeticOpAnalyzer
                 if ($config->strict_binary_operands) {
                     if ($statements_source && IssueBuffer::accepts(
                         new InvalidOperand(
-                            'Cannot process ints and floats in strict binary operands mode',
+                            'Cannot process ints and floats in strict binary operands mode, '.
+                            'please cast explicitly',
                             new CodeLocation($statements_source, $parent)
                         ),
                         $statements_source->getSuppressedIssues()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -653,6 +653,19 @@ class NonDivArithmeticOpAnalyzer
             if (($left_type_part instanceof TNumeric || $right_type_part instanceof TNumeric)
                 && ($left_type_part->isNumericType() && $right_type_part->isNumericType())
             ) {
+                if ($config->strict_binary_operands) {
+                    if ($statements_source && IssueBuffer::accepts(
+                        new InvalidOperand(
+                            'Cannot process different numeric types together in strict binary operands mode, '.
+                            'please cast explicitly',
+                            new CodeLocation($statements_source, $parent)
+                        ),
+                        $statements_source->getSuppressedIssues()
+                    )) {
+                        // fall through
+                    }
+                }
+
                 if ($parent instanceof PhpParser\Node\Expr\BinaryOp\Mod) {
                     $result_type = Type::getInt();
                 } elseif (!$result_type) {
@@ -753,7 +766,7 @@ class NonDivArithmeticOpAnalyzer
                 if ($config->strict_binary_operands) {
                     if ($statements_source && IssueBuffer::accepts(
                         new InvalidOperand(
-                            'Cannot add ints to floats',
+                            'Cannot process ints and floats in strict binary operands mode',
                             new CodeLocation($statements_source, $parent)
                         ),
                         $statements_source->getSuppressedIssues()
@@ -780,7 +793,8 @@ class NonDivArithmeticOpAnalyzer
                 if ($config->strict_binary_operands) {
                     if ($statements_source && IssueBuffer::accepts(
                         new InvalidOperand(
-                            'Cannot add numeric types together, please cast explicitly',
+                            'Cannot process numeric types together in strict operands mode, '.
+                            'please cast explicitly',
                             new CodeLocation($statements_source, $parent)
                         ),
                         $statements_source->getSuppressedIssues()


### PR DESCRIPTION
this PR fixes #6168 where an operation on a `numeric` type did not trigger InvalidOperand even on strictBinaryOperands mode.

It also improve the wording of the error to mention the flag (I was confused about that when CI on PSL failed) and to remove the term `add` that is improper given that other operations trigger the same issue

This PR should break the build because PSL has at least one place where operations on numeric are performed.