### PR TITLE
Support `array_slice` template parameter return type inference

### DIFF
--- a/tests/ReturnTypeProvider/ArraySliceTest.php
+++ b/tests/ReturnTypeProvider/ArraySliceTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Psalm\Tests\ReturnTypeProvider;
+
+use Psalm\Tests\TestCase;
+use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+class ArraySliceTest extends TestCase
+{
+    use ValidCodeAnalysisTestTrait;
+
+    public function providerValidCodeParse(): iterable
+    {
+        yield 'arraySliceWithTemplatedArrayParameter' => [
+            '<?php
+                /**
+                 * @template T as string[]
+                 * @param T $a
+                 * @return string[]
+                 */
+                function f(array $a): array
+                {
+                    return array_slice($a, 1);
+                }
+            ',
+        ];
+    }
+}


### PR DESCRIPTION
This PR updates the `ArraySliceReturnTypeProvider` to recognise template parameters, and correctly infer the return type of the function when a template parameter is provided.

Closes #6160