### PR TITLE
Handle malformed parentheses during type parsing phase

### DIFF
--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -179,6 +179,14 @@ class TypeParser
         }
 
         if ($parse_tree instanceof ParseTree\EncapsulationTree) {
+            if (!$parse_tree->terminated) {
+                throw new TypeParseTreeException('Unterminated parentheses');
+            }
+
+            if (!isset($parse_tree->children[0])) {
+                throw new TypeParseTreeException('Empty parentheses');
+            }
+
             return self::getTypeFromTree(
                 $parse_tree->children[0],
                 $codebase,

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -69,7 +69,7 @@ function array_intersect_assoc(array $arr, array $arr2, array ...$arr3)
  * @return (
  *     PHP_MAJOR_VERSION is 8 ?
  *         ($arr is non-empty-array ? non-empty-array<TKey, TValue> : array<TKey, TValue>) :
- *         ($arr is non-empty-array ? non-empty-array<TKey, TValue>|false : array<TKey, TValue>|false
+ *         ($arr is non-empty-array ? non-empty-array<TKey, TValue>|false : array<TKey, TValue>|false)
  * )
  * @psalm-ignore-falsable-return
  * @psalm-pure

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1789,6 +1789,29 @@ class AnnotationTest extends TestCase
                 ',
                 'error_message' => 'PossiblyInvalidDocblockTag',
             ],
+            'unterminatedParentheses' => [
+                '<?php
+                    /** @return ( */
+                    function f() {}
+                ',
+                'error_message' => 'InvalidDocblock',
+            ],
+            'emptyParentheses' => [
+                '<?php
+                    /** @return () */
+                    function f() {}
+                ',
+                'error_message' => 'InvalidDocblock',
+            ],
+            'unbalancedParentheses' => [
+                "<?php
+                    /** @return ((string) */
+                    function f(): string {
+                        return '';
+                    }
+                ",
+                'error_message' => 'InvalidDocblock',
+            ],
         ];
     }
 }


### PR DESCRIPTION
This PR updates the `TypeParser` to throw a `TypeParseTreeException` when unterminated, empty, or unbalanced parentheses are encountered. Previously, empty parentheses would cause Psalm to crash, and the balance was not being verified so `(((((((((((string` would be incorrectly evaluated as `string`.

Closes #6159