### PR TITLE
Add false as return type of shell_exec

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -12117,7 +12117,7 @@ return [
 'shapeObj::toWkt' => ['string'],
 'shapeObj::union' => ['shapeObj', 'shape'=>'shapeObj'],
 'shapeObj::within' => ['int', 'shape2'=>'shapeObj'],
-'shell_exec' => ['?string', 'command'=>'string'],
+'shell_exec' => ['string|false|null', 'command'=>'string'],
 'shm_attach' => ['resource', 'key'=>'int', 'size='=>'int', 'permissions='=>'int'],
 'shm_detach' => ['bool', 'shm'=>'resource'],
 'shm_get_var' => ['mixed', 'shm'=>'resource', 'key'=>'int'],


### PR DESCRIPTION
The doc is only talking about string|null, but
false is possible when the pipe can't be etablished
@see https://github.com/php/php-src/pull/7306#issuecomment-886489235

Closes #6177