### PR TITLE
Update DateTimeInterface type reconciliation

### DIFF
--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -208,6 +208,21 @@ class NegatedAssertionReconciler extends Reconciler
             return $existing_var_type;
         }
 
+        if (!$is_equality
+            && ($assertion === 'DateTime' || $assertion === 'DateTimeImmutable')
+            && isset($existing_var_atomic_types['DateTimeInterface'])
+        ) {
+            $existing_var_type->removeType('DateTimeInterface');
+
+            if ($assertion === 'DateTime') {
+                $existing_var_type->addType(new TNamedObject('DateTimeImmutable'));
+            } else {
+                $existing_var_type->addType(new TNamedObject('DateTime'));
+            }
+
+            return $existing_var_type;
+        }
+
         if (strtolower($assertion) === 'traversable'
             && isset($existing_var_atomic_types['iterable'])
         ) {

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -110,6 +110,8 @@ class ReconcilerTest extends \Psalm\Tests\TestCase
             'notSomeClassWithSomeClassPipeBool' => ['bool', '!SomeClass', 'SomeClass|bool'],
             'notSomeClassWithSomeClassPipeNull' => ['null', '!SomeClass', 'SomeClass|null'],
             'notSomeClassWithAPipeB' => ['B', '!A', 'A|B'],
+            'notDateTimeWithDateTimeInterface' => ['DateTimeImmutable', '!DateTime', 'DateTimeInterface'],
+            'notDateTimeImmutableWithDateTimeInterface' => ['DateTime', '!DateTimeImmutable', 'DateTimeInterface'],
 
             'myObjectWithSomeClassPipeBool' => ['SomeClass', 'SomeClass', 'SomeClass|bool'],
             'myObjectWithAPipeB' => ['A', 'A', 'A|B'],

--- a/tests/TypeReconciliation/TypeTest.php
+++ b/tests/TypeReconciliation/TypeTest.php
@@ -1073,6 +1073,36 @@ class TypeTest extends \Psalm\Tests\TestCase
                      */
                     function consume($input): void{}'
             ],
+            'notDateTimeWithDateTimeInterface' => [
+                '<?php
+                    function foo(\DateTimeInterface $dateTime): DateTimeInterface {
+                        $dateInterval = new DateInterval("P1D");
+
+                        if ($dateTime instanceof \DateTime) {
+                            $dateTime->add($dateInterval);
+
+                            return $dateTime;
+                        } else {
+                            return $dateTime->add($dateInterval);
+                        }
+                    }
+                ',
+            ],
+            'notDateTimeImmutableWithDateTimeInterface' => [
+                '<?php
+                    function foo(\DateTimeInterface $dateTime): DateTimeInterface {
+                        $dateInterval = new DateInterval("P1D");
+
+                        if ($dateTime instanceof \DateTimeImmutable) {
+                            return $dateTime->add($dateInterval);
+                        } else {
+                            $dateTime->add($dateInterval);
+
+                            return $dateTime;
+                        }
+                    }
+                ',
+            ],
         ];
     }
 

--- a/tests/TypeReconciliation/TypeTest.php
+++ b/tests/TypeReconciliation/TypeTest.php
@@ -1075,10 +1075,10 @@ class TypeTest extends \Psalm\Tests\TestCase
             ],
             'notDateTimeWithDateTimeInterface' => [
                 '<?php
-                    function foo(\DateTimeInterface $dateTime): DateTimeInterface {
+                    function foo(DateTimeInterface $dateTime): DateTimeInterface {
                         $dateInterval = new DateInterval("P1D");
 
-                        if ($dateTime instanceof \DateTime) {
+                        if ($dateTime instanceof DateTime) {
                             $dateTime->add($dateInterval);
 
                             return $dateTime;
@@ -1090,10 +1090,10 @@ class TypeTest extends \Psalm\Tests\TestCase
             ],
             'notDateTimeImmutableWithDateTimeInterface' => [
                 '<?php
-                    function foo(\DateTimeInterface $dateTime): DateTimeInterface {
+                    function foo(DateTimeInterface $dateTime): DateTimeInterface {
                         $dateInterval = new DateInterval("P1D");
 
-                        if ($dateTime instanceof \DateTimeImmutable) {
+                        if ($dateTime instanceof DateTimeImmutable) {
                             return $dateTime->add($dateInterval);
                         } else {
                             $dateTime->add($dateInterval);


### PR DESCRIPTION
As discussed in #6152

`DateTimeInterface&!DateTime` evaluates to `DateTimeImmutable`
`DateTimeInterface&!DateTimeImmutable` evaluates to `DateTime`