### PR TITLE
Inaccurate error with different types in PHPDoc and typehint

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -44,7 +44,7 @@ class ReturnTypeCollector
                 } elseif ($stmt->expr instanceof PhpParser\Node\Scalar\String_) {
                     $return_types[] = Type::getString();
                 } elseif ($stmt->expr instanceof PhpParser\Node\Scalar\LNumber) {
-                    $return_types[] = Type::getString();
+                    $return_types[] = Type::getInt();
                 } elseif ($stmt->expr instanceof PhpParser\Node\Expr\ConstFetch) {
                     if ((string)$stmt->expr->name === 'true') {
                         $return_types[] = Type::getTrue();

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -11,6 +11,7 @@ use Psalm\Exception\InvalidMethodOverrideException;
 use Psalm\Exception\TypeParseTreeException;
 use Psalm\Internal\Scanner\FileScanner;
 use Psalm\Internal\Scanner\FunctionDocblockComment;
+use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Type\TypeAlias;
 use Psalm\Internal\Type\TypeParser;
 use Psalm\Internal\Type\TypeTokenizer;
@@ -908,6 +909,12 @@ class FunctionLikeDocblockScanner
                     && !$storage->return_type->isNullable()
                     && !$storage->return_type->hasTemplate()
                     && !$storage->return_type->hasConditional()
+                    //don't add null to docblock type if it's not contained in signature type
+                    && UnionTypeComparator::isContainedBy(
+                        $codebase,
+                        $storage->return_type,
+                        $storage->signature_return_type
+                    )
                 ) {
                     $storage->return_type->addType(new Type\Atomic\TNull());
                 }


### PR DESCRIPTION
This fixes #6128

After running the snippet in the original issue, we now get this result:

> ERROR: MismatchingDocblockReturnType - sandbox.php:4:12 - Docblock has incorrect return type 'string', should be 'int|null' (see https://psalm.dev/142)
> * @return string
>
>
>ERROR: InvalidReturnType - sandbox.php:4:12 - The declared return type 'string' for getInt is incorrect, got 'int|null' (see https://psalm.dev/011)
> * @return string


The MismatchingDocblockReturnType is indeed fixed. Note that a new error is emitted that basically sees the error from another point of view. Not sure if that's expected. EDIT: I believe it's expected. I tried and when there are three different types (signature + docblock + code), the two errors are consistent so it's not just a duplicate

I also fixed a bug I made in ReturnTypeCollector a few months ago that was messing with the second error 

I didn't add test because it's changing wording and I don't think we already have tests that do so.