### PR TITLE
make array_replace and array_replace_recursive not nullable

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -397,7 +397,7 @@ return [
 'array_rand' => ['int|string|array<int,int>|array<int,string>', 'array'=>'non-empty-array', 'num'=>'int'],
 'array_rand\'1' => ['int|string', 'array'=>'array'],
 'array_reduce' => ['mixed', 'array'=>'array', 'callback'=>'callable(mixed,mixed):mixed', 'initial='=>'mixed'],
-'array_replace' => ['?array', 'array'=>'array', 'replacements'=>'array', '...args='=>'array'],
+'array_replace' => ['array', 'array'=>'array', 'replacements'=>'array', '...args='=>'array'],
 'array_replace_recursive' => ['array', 'array'=>'array', 'replacements'=>'array', '...args='=>'array'],
 'array_reverse' => ['array', 'array'=>'array', 'preserve_keys='=>'bool'],
 'array_search' => ['int|string|false', 'needle'=>'mixed', 'haystack'=>'array', 'strict='=>'bool'],

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -468,15 +468,6 @@ class FunctionCallReturnTypeFetcher
                 }
         }
 
-        switch ($call_map_key) {
-            case 'array_replace':
-            case 'array_replace_recursive':
-                if ($codebase->config->ignore_internal_nullable_issues) {
-                    $stmt_type->ignore_nullable_issues = true;
-                }
-                break;
-        }
-
         return $stmt_type;
     }
 


### PR DESCRIPTION
This will fix #6186. The only way those function return null is when a wrong parameter is given in input. These kind of errors will be flagged by Psalm and have become a runtime error since PHP8.