### PR TITLE
Class string attributes

### DIFF
--- a/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
@@ -6,6 +6,7 @@ use PhpParser;
 use Psalm\Internal\Scanner\ParsedDocblock;
 use Psalm\Node\Expr\VirtualArray;
 use Psalm\Node\Expr\VirtualArrayItem;
+use Psalm\Node\Expr\VirtualClassConstFetch;
 use Psalm\Node\Expr\VirtualConstFetch;
 use Psalm\Node\Expr\VirtualVariable;
 use Psalm\Node\Name\VirtualFullyQualified;
@@ -331,6 +332,10 @@ class StubsGenerator
     public static function getExpressionFromType(Type\Union $type) : PhpParser\Node\Expr
     {
         foreach ($type->getAtomicTypes() as $atomic_type) {
+            if ($atomic_type instanceof Type\Atomic\TLiteralClassString) {
+                return new VirtualClassConstFetch(new VirtualName($atomic_type->value), new VirtualIdentifier('class'));
+            }
+
             if ($atomic_type instanceof Type\Atomic\TLiteralString) {
                 return new VirtualString($atomic_type->value);
             }

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -126,6 +126,26 @@ class AttributeTest extends TestCase
                 [],
                 '8.0'
             ],
+            'allowsClassString' => [
+                '<?php
+
+                    #[Attribute(Attribute::TARGET_CLASS)]
+                    class Foo
+                    {
+                        /**
+                         * @param class-string<Baz> $_className
+                         */
+                        public function __construct(string $_className)
+                        {
+                        }
+                    }
+
+                    #[Foo(_className: Baz::class)]
+                    class Baz {}',
+                [],
+                [],
+                '8.0'
+            ],
         ];
     }
 


### PR DESCRIPTION
This fixes #6197 and fixes #4871

However, the original snippets produce a new error `UnusedProperty - sandbox.php:6:20 - Cannot find any references to private property Foo::$className`. I'm not sure if it's a false positive because the property is indeed unused but I couldn't reproduce without attributes involved.