### PR TITLE
Update return types for get_headers and get_meta_tags

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1266,16 +1266,20 @@ function base64_encode(string $data) : string {}
  *
  * @param resource|null $context
  *
+ * @return ($format is 0 ? list<string> : array<string, string|list<string>>)|false
+ *
  * @psalm-taint-sink ssrf $url
  */
-function get_headers(string $url, int $format = 0, $context = null) : array {}
+function get_headers(string $url, int $format = 0, $context = null) : array|false {}
 
 /**
  * @psalm-pure
  *
+ * @return array<lowercase-string, string>|false
+ *
  * @psalm-taint-sink ssrf $filename
  */
-function get_meta_tags(string $filename, bool $use_include_path = false) : array {}
+function get_meta_tags(string $filename, bool $use_include_path = false) : array|false {}
 
 /**
  * @return ($categorize is false ? array<string,int|string|float|bool|null|array|resource> : array<string, array<string,int|string|float|bool|null|array|resource>>)


### PR DESCRIPTION
Fixes #6199, and I also fixed the incorrect return type for the `get_meta_tags` function.

https://www.php.net/manual/en/function.get-headers
https://www.php.net/manual/en/function.get-meta-tags
