### PR TITLE
Int range

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Psalm\Internal\Type\Comparator;
+
+use Psalm\Codebase;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Type;
+use Psalm\Type\Atomic\Scalar;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TArrayKey;
+use Psalm\Type\Atomic\TBool;
+use Psalm\Type\Atomic\TCallableString;
+use Psalm\Type\Atomic\TClassString;
+use Psalm\Type\Atomic\TDependentGetClass;
+use Psalm\Type\Atomic\TDependentGetDebugType;
+use Psalm\Type\Atomic\TDependentGetType;
+use Psalm\Type\Atomic\TDependentListKey;
+use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TFloat;
+use Psalm\Type\Atomic\THtmlEscapedString;
+use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TIntRange;
+use Psalm\Type\Atomic\TLiteralClassString;
+use Psalm\Type\Atomic\TLiteralFloat;
+use Psalm\Type\Atomic\TLiteralInt;
+use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TLowercaseString;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNonEmptyNonspecificLiteralString;
+use Psalm\Type\Atomic\TNonEmptyString;
+use Psalm\Type\Atomic\TNonFalsyString;
+use Psalm\Type\Atomic\TNonspecificLiteralInt;
+use Psalm\Type\Atomic\TNonspecificLiteralString;
+use Psalm\Type\Atomic\TNumeric;
+use Psalm\Type\Atomic\TNumericString;
+use Psalm\Type\Atomic\TPositiveInt;
+use Psalm\Type\Atomic\TScalar;
+use Psalm\Type\Atomic\TSingleLetter;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Atomic\TTemplateParam;
+use Psalm\Type\Atomic\TTemplateParamClass;
+use Psalm\Type\Atomic\TTraitString;
+use Psalm\Type\Atomic\TTrue;
+
+use function array_values;
+use function get_class;
+use function strtolower;
+
+/**
+ * @internal
+ */
+class IntegerRangeComparator
+{
+    public static function isContainedBy(
+        TIntRange $input_type_part,
+        TIntRange $container_type_part,
+    ) : bool {
+        $is_input_min = $input_type_part->min_bound === TIntRange::BOUND_MIN;
+        $is_input_max = $input_type_part->max_bound === TIntRange::BOUND_MAX;
+        $is_container_min = $container_type_part->min_bound === TIntRange::BOUND_MIN;
+        $is_container_max = $container_type_part->max_bound === TIntRange::BOUND_MAX;
+
+        $is_input_min_in_container = (
+                $is_container_min ||
+                (!$is_input_min && $container_type_part->min_bound <= $input_type_part->min_bound)
+            );
+        $is_input_max_in_container = (
+                $is_container_max ||
+                (!$is_input_max && $container_type_part->max_bound >= $input_type_part->max_bound)
+            );
+        return $is_input_min_in_container && $is_input_max_in_container;
+    }
+}

--- a/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
@@ -2,49 +2,7 @@
 
 namespace Psalm\Internal\Type\Comparator;
 
-use Psalm\Codebase;
-use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
-use Psalm\Type;
-use Psalm\Type\Atomic\Scalar;
-use Psalm\Type\Atomic\TArray;
-use Psalm\Type\Atomic\TArrayKey;
-use Psalm\Type\Atomic\TBool;
-use Psalm\Type\Atomic\TCallableString;
-use Psalm\Type\Atomic\TClassString;
-use Psalm\Type\Atomic\TDependentGetClass;
-use Psalm\Type\Atomic\TDependentGetDebugType;
-use Psalm\Type\Atomic\TDependentGetType;
-use Psalm\Type\Atomic\TDependentListKey;
-use Psalm\Type\Atomic\TFalse;
-use Psalm\Type\Atomic\TFloat;
-use Psalm\Type\Atomic\THtmlEscapedString;
-use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TIntRange;
-use Psalm\Type\Atomic\TLiteralClassString;
-use Psalm\Type\Atomic\TLiteralFloat;
-use Psalm\Type\Atomic\TLiteralInt;
-use Psalm\Type\Atomic\TLiteralString;
-use Psalm\Type\Atomic\TLowercaseString;
-use Psalm\Type\Atomic\TNamedObject;
-use Psalm\Type\Atomic\TNonEmptyNonspecificLiteralString;
-use Psalm\Type\Atomic\TNonEmptyString;
-use Psalm\Type\Atomic\TNonFalsyString;
-use Psalm\Type\Atomic\TNonspecificLiteralInt;
-use Psalm\Type\Atomic\TNonspecificLiteralString;
-use Psalm\Type\Atomic\TNumeric;
-use Psalm\Type\Atomic\TNumericString;
-use Psalm\Type\Atomic\TPositiveInt;
-use Psalm\Type\Atomic\TScalar;
-use Psalm\Type\Atomic\TSingleLetter;
-use Psalm\Type\Atomic\TString;
-use Psalm\Type\Atomic\TTemplateParam;
-use Psalm\Type\Atomic\TTemplateParamClass;
-use Psalm\Type\Atomic\TTraitString;
-use Psalm\Type\Atomic\TTrue;
-
-use function array_values;
-use function get_class;
-use function strtolower;
 
 /**
  * @internal

--- a/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
@@ -53,7 +53,7 @@ class IntegerRangeComparator
 {
     public static function isContainedBy(
         TIntRange $input_type_part,
-        TIntRange $container_type_part,
+        TIntRange $container_type_part
     ) : bool {
         $is_input_min = $input_type_part->min_bound === TIntRange::BOUND_MIN;
         $is_input_max = $input_type_part->max_bound === TIntRange::BOUND_MAX;

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -19,6 +19,7 @@ use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\THtmlEscapedString;
 use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TIntRange;
 use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
@@ -383,13 +384,22 @@ class ScalarTypeComparator
             return false;
         }
 
+        if ($input_type_part instanceof TIntRange && $container_type_part instanceof TIntRange) {
+            return IntegerRangeComparator::isContainedBy(
+                $input_type_part,
+                $container_type_part
+            );
+        }
+
         if ($input_type_part instanceof TInt && $container_type_part instanceof TPositiveInt) {
             if ($input_type_part instanceof TPositiveInt) {
                 return true;
             }
-
             if ($input_type_part instanceof TLiteralInt) {
                 return $input_type_part->value > 0;
+            }
+            if ($input_type_part instanceof TIntRange) {
+                return $input_type_part->isPositive();
             }
 
             if ($atomic_comparison_result) {

--- a/src/Psalm/Type/Atomic/TIntRange.php
+++ b/src/Psalm/Type/Atomic/TIntRange.php
@@ -1,0 +1,77 @@
+<?php
+namespace Psalm\Type\Atomic;
+
+/**
+ * Denotes an interval of integers between two bounds
+ */
+class TIntRange extends TInt
+{
+    const BOUND_MIN = 'min';
+    const BOUND_MAX = 'max';
+
+    /**
+     * @var int|string
+     * @psalm-var int|'min'
+     */
+    public $min_bound;
+    /**
+     * @var int|string
+     * @var int|'max'
+     */
+    public $max_bound;
+
+    /**
+     * @param int|self::BOUND_MIN $min_bound
+     * @param int|self::BOUND_MAX $max_bound
+     */
+    public function __construct($min_bound, $max_bound)
+    {
+        $this->min_bound = $min_bound;
+        $this->max_bound = $max_bound;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getKey();
+    }
+
+    public function getKey(bool $include_extra = true): string
+    {
+        return 'int<' . $this->min_bound . ', ' . $this->max_bound . '>';
+    }
+
+    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    {
+        return false;
+    }
+
+    /**
+     * @param array<lowercase-string, string> $aliased_classes
+     */
+    public function toPhpString(
+        ?string $namespace,
+        array $aliased_classes,
+        ?string $this_class,
+        int $php_major_version,
+        int $php_minor_version
+    ): ?string {
+        return $php_major_version >= 7 ? 'int' : null;
+    }
+
+    /**
+     * @param array<lowercase-string, string> $aliased_classes
+     */
+    public function toNamespacedString(
+        ?string $namespace,
+        array $aliased_classes,
+        ?string $this_class,
+        bool $use_phpdoc_format
+    ): string {
+        return $use_phpdoc_format ? 'int' : 'int<' . $this->min_bound . ', ' . $this->max_bound . '>';
+    }
+
+    public function isPositive(): bool
+    {
+        return $this->min_bound !== self::BOUND_MIN && $this->min_bound > 0;
+    }
+}

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace Psalm\Tests;
+
+use function class_exists;
+
+use const DIRECTORY_SEPARATOR;
+
+class IntRangeTest extends TestCase
+{
+    use Traits\InvalidCodeAnalysisTestTrait;
+    use Traits\ValidCodeAnalysisTestTrait;
+
+    /**
+     * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
+     */
+    public function providerValidCodeParse(): iterable
+    {
+        return [
+            'intRangeContained' => [
+                '<?php
+                    /**
+                     * @param int<1,12> $a
+                     * @return int<-1, max>
+                     */
+                    function scope(int $a){
+                        return $a;
+                    }',
+            ],
+            'positiveIntRange' => [
+                '<?php
+                    /**
+                     * @param int<1,12> $a
+                     * @return positive-int
+                     */
+                    function scope(int $a){
+                        return $a;
+                    }',
+            ],
+            'intRangeToInt' => [
+                '<?php
+                    /**
+                     * @param int<1,12> $a
+                     * @return int
+                     */
+                    function scope(int $a){
+                        return $a;
+                    }',
+            ],
+        ];
+    }
+
+    /**
+     * @return iterable<string,array{string,error_message:string,1?:string[],2?:bool,3?:string}>
+     */
+    public function providerInvalidCodeParse(): iterable
+    {
+        return [
+            'intRangeNotContained' => [
+                '<?php
+                    /**
+                     * @param int<1,12> $a
+                     * @return int<-1, 11>
+                     * @psalm-suppress InvalidReturnStatement
+                     */
+                    function scope(int $a){
+                        return $a;
+                    }',
+                'error_message' => 'InvalidReturnType',
+            ],
+        ];
+    }
+}

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -1,10 +1,6 @@
 <?php
 namespace Psalm\Tests;
 
-use function class_exists;
-
-use const DIRECTORY_SEPARATOR;
-
 class IntRangeTest extends TestCase
 {
     use Traits\InvalidCodeAnalysisTestTrait;


### PR DESCRIPTION
This PR adds basic functionality for integer range, as they were added in PHPStan in their latest release.

This will allow Psalm to read them, transforming them back to known types when large enough(positive-int, int) and to perform very basic operations.

This is the first step of many. To have full support, we will have to work on:
- docblock assertions
- combine/intersect
- internal assertions
- for loops with boundaries

at least