### PR TITLE
Improve internals of TIntRange

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
@@ -13,10 +13,10 @@ class IntegerRangeComparator
         TIntRange $input_type_part,
         TIntRange $container_type_part
     ) : bool {
-        $is_input_min = $input_type_part->min_bound === TIntRange::BOUND_MIN;
-        $is_input_max = $input_type_part->max_bound === TIntRange::BOUND_MAX;
-        $is_container_min = $container_type_part->min_bound === TIntRange::BOUND_MIN;
-        $is_container_max = $container_type_part->max_bound === TIntRange::BOUND_MAX;
+        $is_input_min = $input_type_part->min_bound === null;
+        $is_input_max = $input_type_part->max_bound === null;
+        $is_container_min = $container_type_part->min_bound === null;
+        $is_container_max = $container_type_part->max_bound === null;
 
         $is_input_min_in_container = (
                 $is_container_min ||

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -815,7 +815,7 @@ class TypeParser
                 return new Atomic\TInt();
             }
 
-            if ($min_bound === 0 && $max_bound === null) {
+            if ($min_bound === 1 && $max_bound === null) {
                 return new Atomic\TPositiveInt();
             }
 

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -784,9 +784,6 @@ class TypeParser
                 throw new TypeParseTreeException('int range must have 2 params');
             }
 
-            $min_bound = Atomic\TIntRange::BOUND_MIN;
-            $max_bound = Atomic\TIntRange::BOUND_MAX;
-
             $param0_union_types = array_values($generic_params[0]->getAtomicTypes());
             $param1_union_types = array_values($generic_params[1]->getAtomicTypes());
 
@@ -805,7 +802,8 @@ class TypeParser
                 throw new TypeParseTreeException("max bound for int range param can't be 'min'");
             }
 
-
+            $min_bound = null;
+            $max_bound = null;
             if ($param0_union_types[0] instanceof TLiteralInt) {
                 $min_bound = $param0_union_types[0]->value;
             }
@@ -813,11 +811,11 @@ class TypeParser
                 $max_bound = $param1_union_types[0]->value;
             }
 
-            if ($min_bound === TIntRange::BOUND_MIN && $max_bound === TIntRange::BOUND_MAX) {
+            if ($min_bound === null && $max_bound === null) {
                 return new Atomic\TInt();
             }
 
-            if ($min_bound === 0 && $max_bound === TIntRange::BOUND_MAX) {
+            if ($min_bound === 0 && $max_bound === null) {
                 return new Atomic\TPositiveInt();
             }
 

--- a/src/Psalm/Type/Atomic/TIntRange.php
+++ b/src/Psalm/Type/Atomic/TIntRange.php
@@ -10,21 +10,15 @@ class TIntRange extends TInt
     const BOUND_MAX = 'max';
 
     /**
-     * @var int|string
-     * @psalm-var int|'min'
+     * @var int|null
      */
     public $min_bound;
     /**
-     * @var int|string
-     * @var int|'max'
+     * @var int|null
      */
     public $max_bound;
 
-    /**
-     * @param int|self::BOUND_MIN $min_bound
-     * @param int|self::BOUND_MAX $max_bound
-     */
-    public function __construct($min_bound, $max_bound)
+    public function __construct(?int $min_bound, ?int $max_bound)
     {
         $this->min_bound = $min_bound;
         $this->max_bound = $max_bound;
@@ -37,7 +31,7 @@ class TIntRange extends TInt
 
     public function getKey(bool $include_extra = true): string
     {
-        return 'int<' . $this->min_bound . ', ' . $this->max_bound . '>';
+        return 'int<' . ($this->min_bound ?? 'min') . ', ' . ($this->max_bound ?? 'max') . '>';
     }
 
     public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
@@ -67,11 +61,13 @@ class TIntRange extends TInt
         ?string $this_class,
         bool $use_phpdoc_format
     ): string {
-        return $use_phpdoc_format ? 'int' : 'int<' . $this->min_bound . ', ' . $this->max_bound . '>';
+        return $use_phpdoc_format ?
+            'int' :
+            'int<' . ($this->min_bound ?? 'min') . ', ' . ($this->max_bound ?? 'max') . '>';
     }
 
     public function isPositive(): bool
     {
-        return $this->min_bound !== self::BOUND_MIN && $this->min_bound > 0;
+        return $this->min_bound !== null && $this->min_bound > 0;
     }
 }


### PR DESCRIPTION
The way I designed the internals of TIntRange was dumb. Trying to fit a single string with a meaning along the integer value is not pratical and not elegant. This replace the string value will null.
Can we push that before considering this a BC break of the release from 3 hours ago?