### PR TITLE
Assertions for Integer Range

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -56,6 +56,7 @@
             <errorLevel type="suppress">
                 <referencedClass name="PackageVersions\Versions"/>
                 <referencedClass name="Psalm\Plugin\Hook\*" />
+                <referencedClass name="Psalm\Type\Atomic\TPositiveInt" />
             </errorLevel>
         </DeprecatedClass>
 

--- a/src/Psalm/Internal/Algebra.php
+++ b/src/Psalm/Internal/Algebra.php
@@ -456,6 +456,10 @@ class Algebra
         array $right_clauses,
         int $conditional_object_id
     ): array {
+        if (count($left_clauses) > 60000 || count($right_clauses) > 60000) {
+            return [];
+        }
+
         $clauses = [];
 
         $all_wedges = true;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -93,7 +93,7 @@ class AssertionFinder
 
             if ($var_name) {
                 if ($candidate_if_types) {
-                    $if_types[$var_name] = [['&' . \json_encode($candidate_if_types[0])]];
+                    $if_types[$var_name] = [['@' . \json_encode($candidate_if_types[0])]];
                 } else {
                     $if_types[$var_name] = [['!falsy']];
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -3730,7 +3730,7 @@ class AssertionFinder
             }
 
             if ($var_name) {
-                $if_types[$var_name] = [['+' . $superior_value_comparison]];
+                $if_types[$var_name] = [['=isset'], ['+' . $superior_value_comparison]];
             }
 
             return $if_types ? [$if_types] : [];
@@ -3937,7 +3937,7 @@ class AssertionFinder
             }
 
             if ($var_name) {
-                $if_types[$var_name] = [['-' . $inferior_value_comparison]];
+                $if_types[$var_name] = [['=isset'], ['-' . $inferior_value_comparison]];
             }
 
             return $if_types ? [$if_types] : [];

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -3730,7 +3730,7 @@ class AssertionFinder
             }
 
             if ($var_name) {
-                $if_types[$var_name] = [['=isset'], ['+' . $superior_value_comparison]];
+                $if_types[$var_name] = [['=isset'], ['>' . $superior_value_comparison]];
             }
 
             return $if_types ? [$if_types] : [];
@@ -3937,7 +3937,7 @@ class AssertionFinder
             }
 
             if ($var_name) {
-                $if_types[$var_name] = [['=isset'], ['-' . $inferior_value_comparison]];
+                $if_types[$var_name] = [['=isset'], ['<' . $inferior_value_comparison]];
             }
 
             return $if_types ? [$if_types] : [];

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -93,7 +93,7 @@ class AssertionFinder
 
             if ($var_name) {
                 if ($candidate_if_types) {
-                    $if_types[$var_name] = [['>' . \json_encode($candidate_if_types[0])]];
+                    $if_types[$var_name] = [['&' . \json_encode($candidate_if_types[0])]];
                 } else {
                     $if_types[$var_name] = [['!falsy']];
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -1583,6 +1583,42 @@ class AssertionFinder
      * @param PhpParser\Node\Expr\BinaryOp\Greater|PhpParser\Node\Expr\BinaryOp\GreaterOrEqual $conditional
      * @return false|int
      */
+    protected static function hasSuperiorNumberCheck(
+        PhpParser\Node\Expr\BinaryOp $conditional,
+        ?int &$literal_value_comparison
+    ) {
+        if ($conditional->right instanceof PhpParser\Node\Scalar\LNumber) {
+            $literal_value_comparison = $conditional->right->value +
+                ($conditional instanceof PhpParser\Node\Expr\BinaryOp\Greater ? 1 : 0);
+
+            return self::ASSIGNMENT_TO_RIGHT;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param PhpParser\Node\Expr\BinaryOp\Smaller|PhpParser\Node\Expr\BinaryOp\SmallerOrEqual $conditional
+     * @return false|int
+     */
+    protected static function hasInferiorNumberCheck(
+        PhpParser\Node\Expr\BinaryOp $conditional,
+        ?int &$literal_value_comparison
+    ) {
+        if ($conditional->right instanceof PhpParser\Node\Scalar\LNumber) {
+            $literal_value_comparison = $conditional->right->value +
+                ($conditional instanceof PhpParser\Node\Expr\BinaryOp\Smaller ? -1 : 0);
+
+            return self::ASSIGNMENT_TO_RIGHT;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param PhpParser\Node\Expr\BinaryOp\Greater|PhpParser\Node\Expr\BinaryOp\GreaterOrEqual $conditional
+     * @return false|int
+     */
     protected static function hasZeroCheck(
         PhpParser\Node\Expr\BinaryOp $conditional,
         ?int &$zero_count
@@ -3617,6 +3653,8 @@ class AssertionFinder
         $count_equality_position = self::hasNonEmptyCountEqualityCheck($conditional, $min_count);
         $min_comparison = null;
         $positive_number_position = self::hasPositiveNumberCheck($conditional, $min_comparison);
+        $superior_value_comparison = null;
+        $superior_value_position = self::hasSuperiorNumberCheck($conditional, $superior_value_comparison);
         $zero_comparison = null;
         $zero_position = self::hasZeroCheck($conditional, $zero_comparison);
         $max_count = null;
@@ -3671,6 +3709,28 @@ class AssertionFinder
                 } else {
                     $if_types[$var_name] = [['!non-empty-countable']];
                 }
+            }
+
+            return $if_types ? [$if_types] : [];
+        }
+
+        if ($superior_value_position) {
+            if ($superior_value_position === self::ASSIGNMENT_TO_RIGHT) {
+                $var_name = ExpressionIdentifier::getArrayVarId(
+                    $conditional->left,
+                    $this_class_name,
+                    $source
+                );
+            } else {
+                $var_name = ExpressionIdentifier::getArrayVarId(
+                    $conditional->right,
+                    $this_class_name,
+                    $source
+                );
+            }
+
+            if ($var_name) {
+                $if_types[$var_name] = [['+' . $superior_value_comparison]];
             }
 
             return $if_types ? [$if_types] : [];
@@ -3805,6 +3865,8 @@ class AssertionFinder
         $min_count = null;
         $count_equality_position = self::hasNonEmptyCountEqualityCheck($conditional, $min_count);
         $typed_value_position = self::hasTypedValueComparison($conditional, $source);
+        $inferior_value_comparison = null;
+        $inferior_value_position = self::hasInferiorNumberCheck($conditional, $inferior_value_comparison);
 
         $max_count = null;
         $count_inequality_position = self::hasLessThanCountEqualityCheck($conditional, $max_count);
@@ -3854,6 +3916,28 @@ class AssertionFinder
                 } else {
                     $if_types[$var_name] = [['!non-empty-countable']];
                 }
+            }
+
+            return $if_types ? [$if_types] : [];
+        }
+
+        if ($inferior_value_position) {
+            if ($inferior_value_position === self::ASSIGNMENT_TO_RIGHT) {
+                $var_name = ExpressionIdentifier::getArrayVarId(
+                    $conditional->left,
+                    $this_class_name,
+                    $source
+                );
+            } else {
+                $var_name = ExpressionIdentifier::getArrayVarId(
+                    $conditional->right,
+                    $this_class_name,
+                    $source
+                );
+            }
+
+            if ($var_name) {
+                $if_types[$var_name] = [['-' . $inferior_value_comparison]];
             }
 
             return $if_types ? [$if_types] : [];

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -86,7 +86,7 @@ class AssertionReconciler extends \Psalm\Type\Reconciler
 
         $original_assertion = $assertion;
 
-        if ($assertion[0] === '>') {
+        if ($assertion[0] === '@') {
             $assertion = 'falsy';
             $is_negation = true;
         }

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -412,7 +412,7 @@ class ScalarTypeComparator
 
         if ($input_type_part instanceof TInt && $container_type_part instanceof TIntRange) {
             if ($input_type_part instanceof TPositiveInt) {
-                if ($container_type_part->min_bound > 0) {
+                if ($container_type_part->min_bound > 1) {
                     //any positive int can't be pushed inside a range with a min > 0
                     if ($atomic_comparison_result) {
                         $atomic_comparison_result->type_coerced = true;
@@ -443,10 +443,12 @@ class ScalarTypeComparator
                     ($max_bound === null || $max_bound >= $input_type_part->value);
             }
 
-            //any int can't be pushed inside a range without coercion
-            if ($atomic_comparison_result) {
-                $atomic_comparison_result->type_coerced = true;
-                $atomic_comparison_result->type_coerced_from_scalar = true;
+            //any int can't be pushed inside a range without coercion (unless the range is from min to max)
+            if ($container_type_part->min_bound !== null && $container_type_part->max_bound !== null) {
+                if ($atomic_comparison_result) {
+                    $atomic_comparison_result->type_coerced = true;
+                    $atomic_comparison_result->type_coerced_from_scalar = true;
+                }
             }
 
             return false;

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -444,7 +444,7 @@ class ScalarTypeComparator
             }
 
             //any int can't be pushed inside a range without coercion (unless the range is from min to max)
-            if ($container_type_part->min_bound !== null && $container_type_part->max_bound !== null) {
+            if ($container_type_part->min_bound !== null || $container_type_part->max_bound !== null) {
                 if ($atomic_comparison_result) {
                     $atomic_comparison_result->type_coerced = true;
                     $atomic_comparison_result->type_coerced_from_scalar = true;

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -413,7 +413,7 @@ class ScalarTypeComparator
         if ($input_type_part instanceof TInt && $container_type_part instanceof TIntRange) {
             if ($input_type_part instanceof TPositiveInt) {
                 if ($container_type_part->min_bound > 1) {
-                    //any positive int can't be pushed inside a range with a min > 0
+                    //any positive int can't be pushed inside a range with a min > 1
                     if ($atomic_comparison_result) {
                         $atomic_comparison_result->type_coerced = true;
                         $atomic_comparison_result->type_coerced_from_scalar = true;

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -412,12 +412,18 @@ class ScalarTypeComparator
 
         if ($input_type_part instanceof TInt && $container_type_part instanceof TIntRange) {
             if ($input_type_part instanceof TPositiveInt) {
-                if ($container_type_part->min_bound <= 0) {
+                if ($container_type_part->min_bound > 0) {
+                    //any positive int can't be pushed inside a range with a min > 0
+                    if ($atomic_comparison_result) {
+                        $atomic_comparison_result->type_coerced = true;
+                        $atomic_comparison_result->type_coerced_from_scalar = true;
+                    }
+
                     return false;
                 }
 
-                if ($container_type_part->max_bound === null) {
-                    //any positive int can't be pushed inside a range with no max without coercion
+                if ($container_type_part->max_bound !== null) {
+                    //any positive int can't be pushed inside a range where the max bound isn't max without coercion
                     if ($atomic_comparison_result) {
                         $atomic_comparison_result->type_coerced = true;
                         $atomic_comparison_result->type_coerced_from_scalar = true;

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -410,6 +410,42 @@ class ScalarTypeComparator
             return false;
         }
 
+        if ($input_type_part instanceof TInt && $container_type_part instanceof TIntRange) {
+            if ($input_type_part instanceof TPositiveInt) {
+                if ($container_type_part->min_bound <= 0) {
+                    return false;
+                }
+
+                if ($container_type_part->max_bound === null) {
+                    //any positive int can't be pushed inside a range with no max without coercion
+                    if ($atomic_comparison_result) {
+                        $atomic_comparison_result->type_coerced = true;
+                        $atomic_comparison_result->type_coerced_from_scalar = true;
+                    }
+
+                    return false;
+                }
+
+                return true;
+            }
+            if ($input_type_part instanceof TLiteralInt) {
+                $min_bound = $container_type_part->min_bound;
+                $max_bound = $container_type_part->max_bound;
+
+                return
+                    ($min_bound === null || $min_bound <= $input_type_part->value) &&
+                    ($max_bound === null || $max_bound >= $input_type_part->value);
+            }
+
+            //any int can't be pushed inside a range without coercion
+            if ($atomic_comparison_result) {
+                $atomic_comparison_result->type_coerced = true;
+                $atomic_comparison_result->type_coerced_from_scalar = true;
+            }
+
+            return false;
+        }
+
         if (get_class($input_type_part) === TFloat::class && $container_type_part instanceof TLiteralFloat) {
             if ($atomic_comparison_result) {
                 $atomic_comparison_result->type_coerced = true;

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1569,7 +1569,11 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
         foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
             if ($atomic_type instanceof Atomic\TIntRange) {
                 $existing_var_type->removeType($atomic_type->getKey());
-                $atomic_type->min_bound = max($atomic_type->min_bound, (int)$assertion);
+                if ($atomic_type->min_bound === null) {
+                    $atomic_type->min_bound = (int)$assertion;
+                } else {
+                    $atomic_type->min_bound = max($atomic_type->min_bound, (int)$assertion);
+                }
                 $existing_var_type->addType($atomic_type);
             } elseif ($atomic_type instanceof TInt) {
                 $existing_var_type->removeType('int');
@@ -1587,6 +1591,11 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
         foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
             if ($atomic_type instanceof Atomic\TIntRange) {
                 $existing_var_type->removeType($atomic_type->getKey());
+                if ($atomic_type->max_bound === null) {
+                    $atomic_type->max_bound = (int)$assertion;
+                } else {
+                    $atomic_type->max_bound = min($atomic_type->max_bound, (int)$assertion);
+                }
                 $atomic_type->max_bound = min($atomic_type->max_bound, (int)$assertion);
                 $existing_var_type->addType($atomic_type);
             } elseif ($atomic_type instanceof TInt) {
@@ -1594,7 +1603,6 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
                 $existing_var_type->addType(new Atomic\TIntRange(null, (int)$assertion));
             }
         }
-
         return $existing_var_type;
     }
 

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -102,14 +102,14 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
             );
         }
 
-        if ($assertion[0] === '+') {
+        if ($assertion[0] === '>') {
             return self::reconcileSuperiorTo(
                 $existing_var_type,
                 substr($assertion, 1)
             );
         }
 
-        if ($assertion[0] === '-') {
+        if ($assertion[0] === '<') {
             return self::reconcileInferiorTo(
                 $existing_var_type,
                 substr($assertion, 1)

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1596,7 +1596,6 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
                 } else {
                     $atomic_type->max_bound = min($atomic_type->max_bound, (int)$assertion);
                 }
-                $atomic_type->max_bound = min($atomic_type->max_bound, (int)$assertion);
                 $existing_var_type->addType($atomic_type);
             } elseif ($atomic_type instanceof TInt) {
                 $existing_var_type->removeType('int');

--- a/src/Psalm/Type/Atomic/TPositiveInt.php
+++ b/src/Psalm/Type/Atomic/TPositiveInt.php
@@ -3,6 +3,7 @@ namespace Psalm\Type\Atomic;
 
 /**
  * Denotes an int that is also positive (strictly > 0)
+ * @deprecated will be removed in Psalm 5, this is replaced by TIntRange when min_bound is at least 1
  */
 class TPositiveInt extends TInt
 {

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -162,9 +162,9 @@ class Reconciler
                 $orred_type = null;
 
                 foreach ($new_type_part_parts as $new_type_part_part) {
-                    if ($new_type_part_part[0] === '>'
+                    if ($new_type_part_part[0] === '@'
                         || ($new_type_part_part[0] === '!'
-                            && $new_type_part_part[1] === '>')
+                            && $new_type_part_part[1] === '@')
                     ) {
                         if ($new_type_part_part[0] === '!') {
                             $nested_negated = !$negated;

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -47,7 +47,7 @@ class IntRangeTest extends TestCase
                     function getInt(): int{return 0;}
                     $a = getInt();
                     assert($a >= 500);
-                    assert($a < 5000)',
+                    assert($a < 5000);',
                 'assertions' => [
                     '$a===' => 'int<500, 4999>'
                 ]

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -42,6 +42,16 @@ class IntRangeTest extends TestCase
                         return $a;
                     }',
             ],
+            'intReduced' => [
+                '<?php
+                    function getInt(): int{return 0;}
+                    $a = getInt();
+                    assert($a >= 500);
+                    assert($a < 5000)',
+                'assertions' => [
+                    '$a===' => 'int<500, 4999>'
+                ]
+            ],
         ];
     }
 


### PR DESCRIPTION
This is another batch of changes for Integer Ranges

- It deprecates TPositiveInt (and fixes #6209)
- it introduces assertions for Smaller and Greater operations to reduce Integer Ranges
- It allows checks for whether an IntRange is contained into other ints and the other way around 

Unfortunately, right now, it makes tests crash because of this horror: https://github.com/vimeo/psalm/blob/master/tests/TypeReconciliation/TypeAlgebraTest.php#L785

I suppose it's missing some kind of threshold trigger but I'm not sure where I should put it to have minimal impact.
EDIT: I made a blackfire profile of the job (slightly cut so it still runs): https://blackfire.io/profiles/1134ee3f-8529-4296-a980-fa7fb64dd49f/graph?settings%5Bdimension%5D=wt&settings%5Bdisplay%5D=landscape&settings%5BtabPane%5D=nodes&selected=&callname=main()
EDIT: I added a threshold on Algebra::combineOredClauses