### PR TITLE
Permit null timestamp to date() in PHP 8

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1706,7 +1706,7 @@ return [
 'cyrus_connect' => ['resource', 'host='=>'string', 'port='=>'string', 'flags='=>'int'],
 'cyrus_query' => ['array', 'connection'=>'resource', 'query'=>'string'],
 'cyrus_unbind' => ['bool', 'connection'=>'resource', 'trigger_name'=>'string'],
-'date' => ['string|false', 'format'=>'string', 'timestamp='=>'int'],
+'date' => ['string', 'format'=>'string', 'timestamp='=>'?int'],
 'date_add' => ['DateTime|false', 'object'=>'DateTime', 'interval'=>'DateInterval'],
 'date_create' => ['DateTime|false', 'datetime='=>'string', 'timezone='=>'?DateTimeZone'],
 'date_create_from_format' => ['DateTime|false', 'format'=>'string', 'datetime'=>'string', 'timezone='=>'?\DateTimeZone'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -348,6 +348,7 @@ return [
 'curl_share_init' => ['resource'],
 'curl_share_setopt' => ['bool', 'sh'=>'resource', 'option'=>'int', 'value'=>'mixed'],
 'curl_unescape' => ['string|false', 'ch'=>'resource', 'string'=>'string'],
+'date' => ['string', 'format'=>'string', 'timestamp='=>'int'],
 'date_add' => ['DateTime|false', 'object'=>'DateTime', 'interval'=>'DateInterval'],
 'date_date_set' => ['DateTime|false', 'object'=>'DateTime', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
 'date_diff' => ['DateInterval|false', 'obj1'=>'DateTimeInterface', 'obj2'=>'DateTimeInterface', 'absolute='=>'bool'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -55,6 +55,7 @@ return [
 'DateTimeImmutable::format' => ['string', 'format'=>'string'],
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
 'DateTimeZone::listIdentifiers' => ['list<string>', 'timezoneGroup='=>'int', 'countryCode='=>'string|null'],
+'date' => ['string', 'format'=>'string', 'timestamp='=>'?int'],
 'date_add' => ['DateTime', 'object'=>'DateTime', 'interval'=>'DateInterval'],
 'date_date_set' => ['DateTime', 'object'=>'DateTime', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
 'date_diff' => ['DateInterval', 'obj1'=>'DateTimeInterface', 'obj2'=>'DateTimeInterface', 'absolute='=>'bool'],


### PR DESCRIPTION
## What's new
PHP 8 allows the timestamp to be null, but version 7.4 doesn't.
Creates a mapping for date() to allow $timestamp to be null in PHP 8.

Closes #6243