### PR TITLE
Literal float methods to `Union` type

### DIFF
--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1489,4 +1489,31 @@ class Union implements TypeNode
     {
         return $this->types;
     }
+
+    /**
+     * @return bool true if this is a float literal with only one possible value
+     */
+    public function isSingleFloatLiteral(): bool
+    {
+        return count($this->types) === 1 && count($this->literal_float_types) === 1;
+    }
+
+    /**
+     * @throws \InvalidArgumentException if isSingleFloatLiteral is false
+     *
+     * @return TLiteralFloat the only float literal represented by this union type
+     */
+    public function getSingleFloatLiteral(): TLiteralFloat
+    {
+        if (count($this->types) !== 1 || count($this->literal_float_types) !== 1) {
+            throw new \InvalidArgumentException('Not a float literal');
+        }
+
+        return reset($this->literal_float_types);
+    }
+
+    public function hasLiteralFloat(): bool
+    {
+        return count($this->literal_float_types) > 0;
+    }
 }

--- a/tests/Type/UnionTest.php
+++ b/tests/Type/UnionTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace Psalm\Tests\Type;
+
+use InvalidArgumentException;
+use Psalm\Tests\TestCase;
+use Psalm\Type\Atomic\TFloat;
+use Psalm\Type\Atomic\TLiteralFloat;
+use Psalm\Type\Union;
+
+final class UnionTest extends TestCase
+{
+
+    public function testWillDetectSingleLiteralFloat(): void
+    {
+        $literalFloat = new TLiteralFloat(1.0);
+        $union = new Union([$literalFloat]);
+
+        self::assertTrue($union->isSingleFloatLiteral());
+        self::assertTrue($union->hasLiteralFloat());
+        self::assertSame($literalFloat, $union->getSingleFloatLiteral());
+    }
+
+    public function testWillThrowInvalidArgumentExceptionWhenSingleFloatLiteralIsRequestedButNoneExists(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $union = new Union([new TFloat()]);
+        $union->getSingleFloatLiteral();
+    }
+}


### PR DESCRIPTION
Hey there, 

I recently started to write a plugin to handle #5040
I tried to receive the value of a `float` type but then realized that the union type lacks methods for literal float.
In that plugin, i definitely could use `Union#isSingleFloatLiteral` along with `Union#getSingleFloatLiteral` and `Union#hasLiteralFloat`.


This, I'd like to add these methods with this PR. If anything is missing, feel free to hit me up.