### PR TITLE
fix #5501

### DIFF
--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -180,7 +180,10 @@ class DocComment
      */
     public static function parsePreservingLength(\PhpParser\Comment\Doc $docblock) : ParsedDocblock
     {
-        $parsed_docblock = \Psalm\Internal\Scanner\DocblockParser::parse($docblock->getText());
+        $parsed_docblock = \Psalm\Internal\Scanner\DocblockParser::parse(
+            $docblock->getText(),
+            $docblock->getStartFilePos()
+        );
 
         foreach ($parsed_docblock->tags as $special_key => $_) {
             if (substr($special_key, 0, 6) === 'psalm-') {

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -102,11 +102,11 @@ class CommentAnalyzer
 
                 $line_parts = self::splitDocLine($var_line);
 
-                $line_number = $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset);
+                $line_number = $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos());
                 $description = $parsed_docblock->description;
 
                 if ($line_parts && $line_parts[0]) {
-                    $type_start = $offset + $comment->getStartFilePos();
+                    $type_start = $offset;
                     $type_end = $type_start + strlen($line_parts[0]);
 
                     $line_parts[0] = self::sanitizeDocblockType($line_parts[0]);

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -102,7 +102,12 @@ class CommentAnalyzer
 
                 $line_parts = self::splitDocLine($var_line);
 
-                $line_number = $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos());
+                $line_number = $comment->getStartLine() + substr_count(
+                    $comment_text,
+                    "\n",
+                    0,
+                    $offset - $comment->getStartFilePos()
+                );
                 $description = $parsed_docblock->description;
 
                 if ($line_parts && $line_parts[0]) {

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -402,7 +402,7 @@ class StatementsAnalyzer extends SourceAnalyzer
 
                     foreach ($suppressed as $offset => $suppress_entry) {
                         foreach (DocComment::parseSuppressList($suppress_entry) as $issue_offset => $issue_type) {
-                            $new_issues[$issue_offset + $offset + $docblock->getStartFilePos()] = $issue_type;
+                            $new_issues[$issue_offset + $offset] = $issue_type;
 
                             if ($issue_type === 'InaccessibleMethod') {
                                 continue;
@@ -411,7 +411,7 @@ class StatementsAnalyzer extends SourceAnalyzer
                             if ($codebase->track_unused_suppressions) {
                                 IssueBuffer::addUnusedSuppression(
                                     $statements_analyzer->getFilePath(),
-                                    $issue_offset + $offset + $docblock->getStartFilePos(),
+                                    $issue_offset + $offset,
                                     $issue_type
                                 );
                             }

--- a/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ParamReplacementVisitor.php
@@ -63,7 +63,10 @@ class ParamReplacementVisitor extends PhpParser\NodeVisitorAbstract
         } elseif ($node instanceof PhpParser\Node\Stmt\ClassMethod
             && ($docblock = $node->getDocComment())
         ) {
-            $parsed_docblock = \Psalm\Internal\Scanner\DocblockParser::parse($docblock->getText());
+            $parsed_docblock = \Psalm\Internal\Scanner\DocblockParser::parse(
+                $docblock->getText(),
+                $docblock->getStartFilePos()
+            );
 
             $replaced = false;
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -506,8 +506,7 @@ class ClassLikeDocblockParser
 
                     $line_parts[1] = preg_replace('/,$/', '', $line_parts[1]);
 
-                    $start = $offset;
-                    $end = $start + strlen($line_parts[0]);
+                    $end = $offset + strlen($line_parts[0]);
 
                     $line_parts[0] = str_replace("\n", '', preg_replace('@^[ \t]*\*@m', '', $line_parts[0]));
 
@@ -534,7 +533,7 @@ class ClassLikeDocblockParser
                             $offset - $comment->getStartFilePos()
                         ),
                         'tag' => $property_tag,
-                        'start' => $start,
+                        'start' => $offset,
                         'end' => $end,
                     ];
                 }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -16,7 +16,6 @@ use Psalm\Internal\Type\TypeParser;
 use Psalm\Internal\Type\TypeTokenizer;
 
 use function array_key_first;
-use function array_merge;
 use function array_shift;
 use function count;
 use function implode;
@@ -82,10 +81,16 @@ class ClassLikeDocblockParser
                         $template_modifier,
                         implode(' ', $template_type),
                         false,
-                        $offset
+                        $offset - $comment->getStartFilePos()
                     ];
                 } else {
-                    $templates[$template_name][$source_prefix] = [$template_name, null, null, false, $offset];
+                    $templates[$template_name][$source_prefix] = [
+                        $template_name,
+                        null,
+                        null,
+                        false,
+                        $offset - $comment->getStartFilePos()
+                    ];
                 }
             }
         }
@@ -116,10 +121,16 @@ class ClassLikeDocblockParser
                         $template_modifier,
                         implode(' ', $template_type),
                         true,
-                        $offset
+                        $offset - $comment->getStartFilePos()
                     ];
                 } else {
-                    $templates[$template_name][$source_prefix] = [$template_name, null, null, true, $offset];
+                    $templates[$template_name][$source_prefix] = [
+                        $template_name,
+                        null,
+                        null,
+                        true,
+                        $offset - $comment->getStartFilePos()
+                    ];
                 }
             }
         }
@@ -255,21 +266,24 @@ class ClassLikeDocblockParser
         if (isset($parsed_docblock->tags['psalm-suppress'])) {
             foreach ($parsed_docblock->tags['psalm-suppress'] as $offset => $suppress_entry) {
                 foreach (DocComment::parseSuppressList($suppress_entry) as $issue_offset => $suppressed_issue) {
-                    $info->suppressed_issues[$issue_offset + $offset + $comment->getStartFilePos()] = $suppressed_issue;
+                    $info->suppressed_issues[$issue_offset + $offset] = $suppressed_issue;
                 }
             }
         }
 
-        $imported_types = array_merge(
-            $parsed_docblock->tags['phpstan-import-type'] ?? [],
-            $parsed_docblock->tags['psalm-import-type'] ?? []
-        );
+        $imported_types = ($parsed_docblock->tags['phpstan-import-type'] ?? []) +
+            ($parsed_docblock->tags['psalm-import-type'] ?? []);
 
         foreach ($imported_types as $offset => $imported_type_entry) {
             $info->imported_types[] = [
-                'line_number' => $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset),
-                'start_offset' => $comment->getStartFilePos() + $offset,
-                'end_offset' => $comment->getStartFilePos() + $offset + strlen($imported_type_entry),
+                'line_number' => $comment->getStartLine() + substr_count(
+                    $comment->getText(),
+                    "\n",
+                    0,
+                    $offset - $comment->getStartFilePos()
+                ),
+                'start_offset' => $offset,
+                'end_offset' => $offset + strlen($imported_type_entry),
                 'parts' => CommentAnalyzer::splitDocLine($imported_type_entry) ?: []
             ];
         }
@@ -428,7 +442,12 @@ class ClassLikeDocblockParser
                     $statements[0]->stmts[0]->setDocComment(
                         new \PhpParser\Comment\Doc(
                             $doc_comment->getText(),
-                            $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset),
+                            $comment->getStartLine() + substr_count(
+                                $comment->getText(),
+                                "\n",
+                                0,
+                                $offset - $comment->getStartFilePos()
+                            ),
                             $node_doc_comment->getStartFilePos()
                         )
                     );
@@ -487,7 +506,7 @@ class ClassLikeDocblockParser
 
                     $line_parts[1] = preg_replace('/,$/', '', $line_parts[1]);
 
-                    $start = $offset + $comment->getStartFilePos();
+                    $start = $offset;
                     $end = $start + strlen($line_parts[0]);
 
                     $line_parts[0] = str_replace("\n", '', preg_replace('@^[ \t]*\*@m', '', $line_parts[0]));
@@ -508,7 +527,12 @@ class ClassLikeDocblockParser
                     $info->properties[] = [
                         'name' => $name,
                         'type' => $line_parts[0],
-                        'line_number' => $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset),
+                        'line_number' => $comment->getStartLine() + substr_count(
+                            $comment->getText(),
+                            "\n",
+                            0,
+                            $offset - $comment->getStartFilePos()
+                        ),
                         'tag' => $property_tag,
                         'start' => $start,
                         'end' => $end,

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -67,7 +67,7 @@ class FunctionLikeDocblockParser
 
                         $line_parts[1] = preg_replace('/,$/', '', $line_parts[1]);
 
-                        $start = $offset + $comment->getStartFilePos();
+                        $start = $offset;
                         $end = $start + strlen($line_parts[0]);
 
                         $line_parts[0] = CommentAnalyzer::sanitizeDocblockType($line_parts[0]);
@@ -82,7 +82,7 @@ class FunctionLikeDocblockParser
                         $info_param = [
                             'name' => trim($line_parts[1]),
                             'type' => $line_parts[0],
-                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset),
+                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos()),
                             'start' => $start,
                             'end' => $end,
                         ];
@@ -137,7 +137,7 @@ class FunctionLikeDocblockParser
                         $info->params_out[] = [
                             'name' => trim($line_parts[1]),
                             'type' => str_replace("\n", '', $line_parts[0]),
-                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset),
+                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos()),
                         ];
                     }
                 } else {
@@ -155,7 +155,7 @@ class FunctionLikeDocblockParser
 
                     $info->self_out = [
                         'type' => str_replace("\n", '', $line_parts[0]),
-                        'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset),
+                        'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos()),
                     ];
                 }
             }
@@ -289,7 +289,7 @@ class FunctionLikeDocblockParser
                         $info->globals[] = [
                             'name' => $line_parts[1],
                             'type' => $line_parts[0],
-                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset),
+                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos()),
                         ];
                     }
                 } else {
@@ -330,7 +330,7 @@ class FunctionLikeDocblockParser
         if (isset($parsed_docblock->tags['psalm-suppress'])) {
             foreach ($parsed_docblock->tags['psalm-suppress'] as $offset => $suppress_entry) {
                 foreach (DocComment::parseSuppressList($suppress_entry) as $issue_offset => $suppressed_issue) {
-                    $info->suppressed_issues[$issue_offset + $offset + $comment->getStartFilePos()] = $suppressed_issue;
+                    $info->suppressed_issues[$issue_offset + $offset] = $suppressed_issue;
                 }
             }
         }
@@ -345,8 +345,8 @@ class FunctionLikeDocblockParser
 
                 $info->throws[] = [
                     $throws_class,
-                    $offset + $comment->getStartFilePos(),
-                    $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset)
+                    $offset,
+                    $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset - $comment->getStartFilePos())
                 ];
             }
         }
@@ -517,7 +517,8 @@ class FunctionLikeDocblockParser
                     throw new IncorrectDocblockException('Misplaced variable');
                 }
 
-                $start = $offset + $comment->getStartFilePos();
+                $start = $offset;
+
                 $end = $start + strlen($line_parts[0]);
 
                 $line_parts[0] = CommentAnalyzer::sanitizeDocblockType($line_parts[0]);
@@ -526,7 +527,7 @@ class FunctionLikeDocblockParser
                 $info->return_type_description = $line_parts ? implode(' ', $line_parts) : null;
 
                 $info->return_type_line_number
-                    = $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset);
+                    = $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset - $comment->getStartFilePos());
                 $info->return_type_start = $start;
                 $info->return_type_end = $end;
             } else {
@@ -612,6 +613,6 @@ class FunctionLikeDocblockParser
 
     private static function docblockLineNumber(PhpParser\Comment\Doc $comment, int $offset): int
     {
-        return $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset);
+        return $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset - $comment->getStartFilePos());
     }
 }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -67,8 +67,7 @@ class FunctionLikeDocblockParser
 
                         $line_parts[1] = preg_replace('/,$/', '', $line_parts[1]);
 
-                        $start = $offset;
-                        $end = $start + strlen($line_parts[0]);
+                        $end = $offset + strlen($line_parts[0]);
 
                         $line_parts[0] = CommentAnalyzer::sanitizeDocblockType($line_parts[0]);
 
@@ -82,8 +81,13 @@ class FunctionLikeDocblockParser
                         $info_param = [
                             'name' => trim($line_parts[1]),
                             'type' => $line_parts[0],
-                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos()),
-                            'start' => $start,
+                            'line_number' => $comment->getStartLine() + substr_count(
+                                $comment_text,
+                                "\n",
+                                0,
+                                $offset - $comment->getStartFilePos()
+                            ),
+                            'start' => $offset,
                             'end' => $end,
                         ];
 
@@ -137,7 +141,12 @@ class FunctionLikeDocblockParser
                         $info->params_out[] = [
                             'name' => trim($line_parts[1]),
                             'type' => str_replace("\n", '', $line_parts[0]),
-                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos()),
+                            'line_number' => $comment->getStartLine() + substr_count(
+                                $comment_text,
+                                "\n",
+                                0,
+                                $offset - $comment->getStartFilePos()
+                            ),
                         ];
                     }
                 } else {
@@ -155,7 +164,12 @@ class FunctionLikeDocblockParser
 
                     $info->self_out = [
                         'type' => str_replace("\n", '', $line_parts[0]),
-                        'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos()),
+                        'line_number' => $comment->getStartLine() + substr_count(
+                            $comment_text,
+                            "\n",
+                            0,
+                            $offset - $comment->getStartFilePos()
+                        ),
                     ];
                 }
             }
@@ -289,7 +303,12 @@ class FunctionLikeDocblockParser
                         $info->globals[] = [
                             'name' => $line_parts[1],
                             'type' => $line_parts[0],
-                            'line_number' => $comment->getStartLine() + substr_count($comment_text, "\n", 0, $offset - $comment->getStartFilePos()),
+                            'line_number' => $comment->getStartLine() + substr_count(
+                                $comment_text,
+                                "\n",
+                                0,
+                                $offset - $comment->getStartFilePos()
+                            ),
                         ];
                     }
                 } else {
@@ -346,7 +365,12 @@ class FunctionLikeDocblockParser
                 $info->throws[] = [
                     $throws_class,
                     $offset,
-                    $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset - $comment->getStartFilePos())
+                    $comment->getStartLine() + substr_count(
+                        $comment->getText(),
+                        "\n",
+                        0,
+                        $offset - $comment->getStartFilePos()
+                    )
                 ];
             }
         }
@@ -517,9 +541,7 @@ class FunctionLikeDocblockParser
                     throw new IncorrectDocblockException('Misplaced variable');
                 }
 
-                $start = $offset;
-
-                $end = $start + strlen($line_parts[0]);
+                $end = $offset + strlen($line_parts[0]);
 
                 $line_parts[0] = CommentAnalyzer::sanitizeDocblockType($line_parts[0]);
 
@@ -527,8 +549,13 @@ class FunctionLikeDocblockParser
                 $info->return_type_description = $line_parts ? implode(' ', $line_parts) : null;
 
                 $info->return_type_line_number
-                    = $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset - $comment->getStartFilePos());
-                $info->return_type_start = $start;
+                    = $comment->getStartLine() + substr_count(
+                        $comment->getText(),
+                        "\n",
+                        0,
+                        $offset - $comment->getStartFilePos()
+                    );
+                $info->return_type_start = $offset;
                 $info->return_type_end = $end;
             } else {
                 throw new DocblockParseException('Badly-formatted @return type');
@@ -613,6 +640,11 @@ class FunctionLikeDocblockParser
 
     private static function docblockLineNumber(PhpParser\Comment\Doc $comment, int $offset): int
     {
-        return $comment->getStartLine() + substr_count($comment->getText(), "\n", 0, $offset - $comment->getStartFilePos());
+        return $comment->getStartLine() + substr_count(
+            $comment->getText(),
+            "\n",
+            0,
+            $offset - $comment->getStartFilePos()
+        );
     }
 }

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -17,8 +17,15 @@ use function trim;
 
 use const PREG_OFFSET_CAPTURE;
 
+/**
+ * This class will parse Docblocks in order to extract known tags from them
+ */
 class DocblockParser
 {
+    /**
+     * $offsetStart is the absolute position of the docblock in the file. It'll be used to add to the position of some
+     * special tags (like `psalm-suppress`) for future uses
+     */
     public static function parse(string $docblock, int $offsetStart) : ParsedDocblock
     {
         // Strip off comments.

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -19,7 +19,7 @@ use const PREG_OFFSET_CAPTURE;
 
 class DocblockParser
 {
-    public static function parse(string $docblock) : ParsedDocblock
+    public static function parse(string $docblock, int $offsetStart) : ParsedDocblock
     {
         // Strip off comments.
         $docblock = trim($docblock);
@@ -89,7 +89,7 @@ class DocblockParser
 
                 $data_offset += $line_offset;
 
-                $special[$type][$data_offset + 3] = $data;
+                $special[$type][$data_offset + 3 + $offsetStart] = $data;
 
                 unset($lines[$k]);
             } else {

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1274,7 +1274,7 @@ class AnnotationTest extends TestCase
                         /**
                          * @var array
                          */
-                        public $config = [];
+                        public array $config = [];
                         public function getConfig(): array {return $this->config;}
                     }
 
@@ -1284,7 +1284,7 @@ class AnnotationTest extends TestCase
                          * @var string[]
                          * @psalm-suppress NonInvariantDocblockPropertyType
                          */
-                        public $config = [];
+                        public array $config = [];
                     }
                     $a = new Vendor();
                     $_b = new A();

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1267,6 +1267,29 @@ class AnnotationTest extends TestCase
                         return $instance;
                     }',
             ],
+            'suppressNonInvariantDocblockPropertyType' => [
+                '<?php
+                    class Vendor
+                    {
+                        /**
+                         * @var array
+                         */
+                        public $config = [];
+                        public function getConfig(): array {return $this->config;}
+                    }
+
+                    class A extends Vendor
+                    {
+                        /**
+                         * @var string[]
+                         * @psalm-suppress NonInvariantDocblockPropertyType
+                         */
+                        public $config = [];
+                    }
+                    $a = new Vendor();
+                    $_b = new A();
+                    echo (string)($a->getConfig()[0]??"");'
+            ],
         ];
     }
 


### PR DESCRIPTION
The issue here was that Psalm registered the suppression with an offset (cursor position) relative to the beggining of the docblock whereas the expected offset was absolute (from the beggining of the file).

This lead me to send the starting position of the docblock to the parse function to make the addition, and then I had to go back to every place that used this offset to substract the docblock position.

I hope I didn't miss one, this was not easy to do.

I'm not sure if it will fix other similar issues or not, and frankly, I'm not even sure to understand why some suppression work and not other (I think this has to do with which type of docblock and where it need to be parsed)

this fixes #5501