### PR TITLE
seal the result of two sealed KeyedArrays

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -544,13 +544,16 @@ class NonDivArithmeticOpAnalyzer
                     }
                 }
 
-                $result_type_member = new Type\Union([new TKeyedArray($properties)]);
+                $new_keyed_array = new TKeyedArray($properties);
+                $new_keyed_array->sealed = $left_type_part->sealed && $right_type_part->sealed;
+                $result_type_member = new Type\Union([$new_keyed_array]);
             } else {
                 $result_type_member = TypeCombiner::combine(
                     [$left_type_part, $right_type_part],
                     $codebase,
                     true
                 );
+
             }
 
             if (!$result_type) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/NonDivArithmeticOpAnalyzer.php
@@ -553,7 +553,6 @@ class NonDivArithmeticOpAnalyzer
                     $codebase,
                     true
                 );
-
             }
 
             if (!$result_type) {

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1629,7 +1629,7 @@ class ArrayAssignmentTest extends TestCase
                     }
                     $_a = Token::ONE + Token::TWO + Token::THREE;
                     ',
-                'assertions' => ['$_a' => 'array{16: 16, 17: 17, 18: 18}']
+                'assertions' => ['$_a===' => 'array{16: 16, 17: 17, 18: 18}']
             ],
         ];
     }

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1545,7 +1545,8 @@ class ArrayAssignmentTest extends TestCase
                     }'
             ],
             'ArrayCreateTemplateArrayKey' => [
-                '/**
+                '<?php
+                /**
                   * @template K of array-key
                   * @param K $key
                   */
@@ -1609,6 +1610,26 @@ class ArrayAssignmentTest extends TestCase
                             return $names[$aprop];
                         }
                     }',
+            ],
+            'AddTwoSealedArrays'  => [
+                '<?php
+                    final class Token
+                    {
+                        public const ONE = [
+                            16 => 16,
+                        ];
+
+                        public const TWO = [
+                            17 => 17,
+                        ];
+
+                        public const THREE = [
+                            18 => 18,
+                        ];
+                    }
+                    $_a = Token::ONE + Token::TWO + Token::THREE;
+                    ',
+                'assertions' => ['$_a' => 'array{16: 16, 17: 17, 18: 18}']
             ],
         ];
     }


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/6261

The result of '+' for 2 sealed TKeyedArrays wasn't sealed itself so any additional '+' treated missing keys as "possibly mixed"

I also fixed a missing `<?php` in a test. Hope it won't fail now!