### PR TITLE
Allow type inference on dynamic ClassConstFetch

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -199,8 +199,9 @@ class NewAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAna
                 $extends = $stmt->class->extends ? (string) $stmt->class->extends : null;
                 $result_atomic_type = new Type\Atomic\TAnonymousClassInstance($fq_class_name, false, $extends);
             } else {
-                $result_atomic_type = new TNamedObject($fq_class_name);
-                $result_atomic_type->was_static = $from_static;
+                //if the class is a Name, it can't represent a child
+                $definite_class = $stmt->class instanceof PhpParser\Node\Name;
+                $result_atomic_type = new TNamedObject($fq_class_name, $from_static, $definite_class);
             }
 
             $statements_analyzer->node_data->setType(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -670,12 +670,10 @@ class ClassConstFetchAnalyzer
                 }
             }
 
-            if ($const_class_storage->final) {
-                $stmt_type = clone $class_constant_type;
+            $stmt_type = clone $class_constant_type;
 
-                $statements_analyzer->node_data->setType($stmt, $stmt_type);
-                $context->vars_in_scope[$const_id] = $stmt_type;
-            }
+            $statements_analyzer->node_data->setType($stmt, $stmt_type);
+            $context->vars_in_scope[$const_id] = $stmt_type;
 
             return true;
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -256,7 +256,7 @@ class SimpleTypeInferer
                 }
 
                 if (strtolower($stmt->name->name) === 'class') {
-                    return Type::getLiteralClassString($const_fq_class_name);
+                    return Type::getLiteralClassString($const_fq_class_name, true);
                 }
 
                 if ($existing_class_constants === null

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -271,9 +271,9 @@ abstract class Type
         ]);
     }
 
-    public static function getLiteralClassString(string $class_type): Union
+    public static function getLiteralClassString(string $class_type, bool $definite_class = false): Union
     {
-        $type = new TLiteralClassString($class_type);
+        $type = new TLiteralClassString($class_type, $definite_class);
 
         return new Union([$type]);
     }

--- a/src/Psalm/Type/Atomic/TLiteralClassString.php
+++ b/src/Psalm/Type/Atomic/TLiteralClassString.php
@@ -13,11 +13,15 @@ use function strtolower;
 class TLiteralClassString extends TLiteralString
 {
     /**
-     * @param string $value string
+     * Whether or not this type can represent a child of the class named in $value
+     * @var bool
      */
-    public function __construct(string $value)
+    public $definite_class = false;
+
+    public function __construct(string $value, bool $definite_class = false)
     {
-        $this->value = $value;
+        parent::__construct($value);
+        $this->definite_class = $definite_class;
     }
 
     public function __toString(): string

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -28,9 +28,15 @@ class TNamedObject extends Atomic
     public $was_static = false;
 
     /**
+     * Whether or not this type can represent a child of the class named in $value
+     * @var bool
+     */
+    public $definite_class = false;
+
+    /**
      * @param string $value the name of the object
      */
-    public function __construct(string $value, bool $was_static = false)
+    public function __construct(string $value, bool $was_static = false, bool $definite_class = false)
     {
         if ($value[0] === '\\') {
             $value = substr($value, 1);
@@ -38,6 +44,7 @@ class TNamedObject extends Atomic
 
         $this->value = $value;
         $this->was_static = $was_static;
+        $this->definite_class = $definite_class;
     }
 
     public function __toString(): string

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -316,7 +316,7 @@ class ConstantTest extends TestCase
             ],
             'dynamicClassConstFetch' => [
                 '<?php
-                    final class Foo
+                    class Foo
                     {
                         public const BAR = "bar";
                     }
@@ -325,9 +325,33 @@ class ConstantTest extends TestCase
                     $_trace = $foo::BAR;',
                 'assertions' => ['$_trace===' => '"bar"'],
             ],
+            'unsafeInferenceClassConstFetch' => [
+                '<?php
+                    class Foo
+                    {
+                        public const BAR = "bar";
+                    }
+
+                    /** @var Foo $foo */
+                    $foo = new stdClass();
+                    $_trace = $foo::BAR;',
+                'assertions' => ['$_trace' => 'mixed'],
+            ],
+            'FinalInferenceClassConstFetch' => [
+                '<?php
+                    final class Foo
+                    {
+                        public const BAR = "bar";
+                    }
+
+                    /** @var Foo $foo */
+                    $foo = new stdClass();
+                    $_trace = $foo::BAR;',
+                'assertions' => ['$_trace===' => '"bar"'],
+            ],
             'dynamicClassConstFetchClassString' => [
                 '<?php
-                    final class C {
+                    class C {
                         public const CC = 1;
                     }
 

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -325,6 +325,16 @@ class ConstantTest extends TestCase
                     $_trace = $foo::BAR;',
                 'assertions' => ['$_trace===' => '"bar"'],
             ],
+            'dynamicClassConstFetchClassString' => [
+                '<?php
+                    final class C {
+                        public const CC = 1;
+                    }
+
+                    $c = C::class;
+                    $d = $c::CC;',
+                'assertions' => ['$d===' => '1'],
+            ],
             'allowConstCheckForDifferentPlatforms' => [
                 '<?php
                     if ("phpdbg" === \PHP_SAPI) {}',

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -314,6 +314,17 @@ class ConstantTest extends TestCase
                 ',
                 'assertions' => ['$foo' => 'string'],
             ],
+            'dynamicClassConstFetch' => [
+                '<?php
+                    final class Foo
+                    {
+                        public const BAR = "bar";
+                    }
+
+                    $foo = new Foo();
+                    $_trace = $foo::BAR;',
+                'assertions' => ['$_trace===' => '"bar"'],
+            ],
             'allowConstCheckForDifferentPlatforms' => [
                 '<?php
                     if ("phpdbg" === \PHP_SAPI) {}',


### PR DESCRIPTION
fix #5096 (almost)

I had to make the class in the example final to keep consistency with the code above. The whole block of code is copy/pasted from above with a few changes that makes it hard to refactor, even more given the code must be placed after analyzing the expression.