### PR TITLE
bugfix: add missing `TNonEmptyMixed` to `Atomic#create`

### DIFF
--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -34,6 +34,7 @@ use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNever;
 use Psalm\Type\Atomic\TNonEmptyArray;
 use Psalm\Type\Atomic\TNonEmptyList;
+use Psalm\Type\Atomic\TNonEmptyMixed;
 use Psalm\Type\Atomic\TNonEmptyScalar;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TNumeric;
@@ -283,6 +284,9 @@ abstract class Atomic implements TypeNode
 
             case 'empty-scalar':
                 return new TEmptyScalar;
+
+            case 'non-empty-mixed':
+                return new TNonEmptyMixed();
         }
 
         if (strpos($value, '-') && substr($value, 0, 4) !== 'OCI-') {


### PR DESCRIPTION
```
Uncaught Exception: Unrecognized type non-empty-mixed░░░░░░░  1621 / 6083 (26%)
Stack trace in the forked worker:
#0 /vendor/vimeo/psalm/src/Psalm/Internal/Type/TypeParser.php(87): Psalm\Type\Atomic::create('non-empty-mixed', NULL, Array, Array)
#1 /vendor/vimeo/psalm/src/Psalm/Type.php(75): Psalm\Internal\Type\TypeParser::parseTokens(Array, NULL, Array)
#2 /vendor/vimeo/psalm/src/Psalm/Internal/Type/NegatedAssertionReconciler.php(158): Psalm\Type::parseString('non-empty-mixed')
#3 /vendor/vimeo/psalm/src/Psalm/Internal/Type/AssertionReconciler.php(115): Psalm\Internal\Type\NegatedAssertionReconciler::reconcile(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), 'non-empty-mixed', false, false, Object(Psalm\Type\Union), Array, 'mixed', '$value', false, NULL, Array, 0)
#4 /vendor/vimeo/psalm/src/Psalm/Type/Reconciler.php(197): Psalm\Internal\Type\AssertionReconciler::reconcile('in-array-non-em...', Object(Psalm\Type\Union), '$value', Object(Psalm\Internal\Analyzer\StatementsAnalyzer), false, Array, NULL, Array, 0, false)
#5 /vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php(343): Psalm\Type\Reconciler::reconcileKeyedTypes(Array, Array, Array, Array, Array, Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Array, false, Object(Psalm\CodeLocation))
#6 /vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php(491): Psalm\Internal\Analyzer\Statements\Block\IfElseAnalyzer::analyze(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Stmt\If_), Object(Psalm\Context))
#7 /vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php(185): Psalm\Internal\Analyzer\StatementsAnalyzer::analyzeStatement(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Stmt\If_), Object(Psalm\Context), Object(Psalm\Context))
#8 /vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php(433): Psalm\Internal\Analyzer\StatementsAnalyzer->analyze(Array, Object(Psalm\Context), Object(Psalm\Context), true)
#9 /vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ClassAnalyzer.php(1782): Psalm\Internal\Analyzer\FunctionLikeAnalyzer->analyze(Object(Psalm\Context), Object(Psalm\Internal\Provider\NodeDataProvider), Object(Psalm\Context))
#10 /vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ClassAnalyzer.php(404): Psalm\Internal\Analyzer\ClassAnalyzer->analyzeClassMethod(Object(PhpParser\Node\Stmt\ClassMethod), Object(Psalm\Storage\ClassLikeStorage), Object(Psalm\Internal\Analyzer\ClassAnalyzer), Object(Psalm\Context), Object(Psalm\Context))
#11 /vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/FileAnalyzer.php(214): Psalm\Internal\Analyzer\ClassAnalyzer->analyze(Object(Psalm\Context), Object(Psalm\Context))
#12 /vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Analyzer.php(348): Psalm\Internal\Analyzer\FileAnalyzer->analyze(NULL)
#13 /vendor/vimeo/psalm/src/Psalm/Internal/Fork/Pool.php(194): Psalm\Internal\Codebase\Analyzer->Psalm\Internal\Codebase\{closure}(273, '/Users/max/git/...')
#14 /vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Analyzer.php(414): Psalm\Internal\Fork\Pool->__construct(Array, Object(Closure), Object(Closure), Object(Closure), Object(Closure))
#15 /vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Analyzer.php(277): Psalm\Internal\Codebase\Analyzer->doAnalysis(Object(Psalm\Internal\Analyzer\ProjectAnalyzer), 7)
#16 /vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php(640): Psalm\Internal\Codebase\Analyzer->analyzeFiles(Object(Psalm\Internal\Analyzer\ProjectAnalyzer), 7, false, true)
#17 /vendor/vimeo/psalm/src/Psalm/Internal/Cli/Psalm.php(359): Psalm\Internal\Analyzer\ProjectAnalyzer->check('/Users/max/git/...', true)
#18 /vendor/vimeo/psalm/psalm(4): Psalm\Internal\Cli\Psalm::run(Array)
#19 {main} in /vendor/vimeo/psalm/src/Psalm/Internal/Fork/Pool.php:366
```

I am not able to create a reproducible error on psalm.dev, but I have something like this which triggers this exception:
https://psalm.dev/r/b77686dd7e