### PR TITLE
Enable `ClassLikes` to properly detect implementing class aliases

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -680,11 +680,9 @@ class ClassLikes
         }
 
         foreach ($class_storage->class_implements as $implementing_interface_lc => $_) {
-            if (!isset($this->classlike_aliases[$implementing_interface_lc])) {
-                continue;
-            }
-
-            $aliased_interface_lc = strtolower($this->classlike_aliases[$implementing_interface_lc]);
+            $aliased_interface_lc = strtolower(
+                $this->getUnAliasedName($implementing_interface_lc)
+            );
 
             if ($aliased_interface_lc === $interface_id) {
                 return true;

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -26,6 +26,7 @@ use Psalm\Storage\ClassLikeStorage;
 use Psalm\Type;
 use ReflectionProperty;
 
+use function array_keys;
 use function array_merge;
 use function array_pop;
 use function count;
@@ -675,7 +676,23 @@ class ClassLikes
         }
         $class_storage = $this->classlike_storage_provider->get($fq_class_name);
 
-        return isset($class_storage->class_implements[$interface_id]);
+        if (isset($class_storage->class_implements[$interface_id])) {
+            return true;
+        }
+
+        foreach (array_keys($class_storage->class_implements) as $implementing_interface_lc) {
+            if (!isset($this->classlike_aliases[$implementing_interface_lc])) {
+                continue;
+            }
+
+            $aliased_interface_lc = strtolower($this->classlike_aliases[$implementing_interface_lc]);
+
+            if ($aliased_interface_lc === $interface_id) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function interfaceExists(

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -26,7 +26,6 @@ use Psalm\Storage\ClassLikeStorage;
 use Psalm\Type;
 use ReflectionProperty;
 
-use function array_keys;
 use function array_merge;
 use function array_pop;
 use function count;
@@ -680,7 +679,7 @@ class ClassLikes
             return true;
         }
 
-        foreach (array_keys($class_storage->class_implements) as $implementing_interface_lc) {
+        foreach ($class_storage->class_implements as $implementing_interface_lc => $_) {
             if (!isset($this->classlike_aliases[$implementing_interface_lc])) {
                 continue;
             }

--- a/tests/Internal/Codebase/ClassLikesTest.php
+++ b/tests/Internal/Codebase/ClassLikesTest.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types=1);
+
+namespace Psalm\Tests\Internal\Codebase;
+
+use Psalm\Codebase;
+use Psalm\Internal\Codebase\ClassLikes;
+use Psalm\Internal\Codebase\Reflection;
+use Psalm\Internal\Codebase\Scanner;
+use Psalm\Internal\Provider\ClassLikeStorageProvider;
+use Psalm\Internal\Provider\FileReferenceProvider;
+use Psalm\Internal\Provider\FileStorageProvider;
+use Psalm\Internal\Provider\Providers;
+use Psalm\Internal\Provider\StatementsProvider;
+use Psalm\Progress\VoidProgress;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Tests\TestCase;
+
+final class ClassLikesTest extends TestCase
+{
+    /**
+     * @var ClassLikes
+     */
+    private $classLikes;
+
+    /**
+     * @var ClassLikeStorageProvider
+     */
+    private $storageProvider;
+
+    /**
+     * @var FileReferenceProvider
+     */
+    private $fileReferenceProvider;
+
+    /**
+     * @var StatementsProvider
+     */
+    private $statementsProvider;
+
+    /**
+     * @var Scanner
+     */
+    private $codebaseScanner;
+
+    /**
+     * @var Codebase
+     */
+    private $codebase;
+
+    /**
+     * @var Providers
+     */
+    private $providers;
+
+    /**
+     * @var VoidProgress
+     */
+    private $progress;
+
+    /**
+     * @var FileStorageProvider
+     */
+    private $fileStorageProvider;
+
+    /**
+     * @var Reflection
+     */
+    private $reflection;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->storageProvider = new ClassLikeStorageProvider();
+        $this->fileReferenceProvider = new FileReferenceProvider();
+        $this->statementsProvider = new StatementsProvider($this->file_provider);
+        $this->providers = new Providers($this->file_provider);
+        $this->progress = new VoidProgress();
+        $this->codebase = new Codebase(
+            $this->testConfig,
+            $this->providers,
+            $this->progress
+        );
+        $this->fileStorageProvider = new FileStorageProvider();
+        $this->reflection = new Reflection(
+            $this->storageProvider,
+            $this->codebase
+        );
+        $this->codebaseScanner = new Scanner(
+            $this->codebase,
+            $this->testConfig,
+            $this->fileStorageProvider,
+            $this->file_provider,
+            $this->reflection,
+            $this->fileReferenceProvider,
+            $this->progress
+        );
+        $this->classLikes = new ClassLikes(
+            $this->testConfig,
+            $this->storageProvider,
+            $this->fileReferenceProvider,
+            $this->statementsProvider,
+            $this->codebaseScanner
+        );
+    }
+
+    public function testWillDetectClassImplementingAliasedInterface(): void
+    {
+        $this->classLikes->addClassAlias('Foo', 'bar');
+
+        $classStorage = new ClassLikeStorage('Baz');
+        $classStorage->class_implements['bar'] = 'Bar';
+
+        $this->storageProvider->addMore(['baz' => $classStorage]);
+
+        self::assertTrue($this->classLikes->classImplements('Baz', 'Foo'));
+    }
+}

--- a/tests/Internal/Codebase/ClassLikesTest.php
+++ b/tests/Internal/Codebase/ClassLikesTest.php
@@ -3,16 +3,8 @@ declare(strict_types=1);
 
 namespace Psalm\Tests\Internal\Codebase;
 
-use Psalm\Codebase;
 use Psalm\Internal\Codebase\ClassLikes;
-use Psalm\Internal\Codebase\Reflection;
-use Psalm\Internal\Codebase\Scanner;
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
-use Psalm\Internal\Provider\FileReferenceProvider;
-use Psalm\Internal\Provider\FileStorageProvider;
-use Psalm\Internal\Provider\Providers;
-use Psalm\Internal\Provider\StatementsProvider;
-use Psalm\Progress\VoidProgress;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Tests\TestCase;
 
@@ -21,98 +13,29 @@ final class ClassLikesTest extends TestCase
     /**
      * @var ClassLikes
      */
-    private $classLikes;
+    private $classlikes;
 
     /**
      * @var ClassLikeStorageProvider
      */
-    private $storageProvider;
-
-    /**
-     * @var FileReferenceProvider
-     */
-    private $fileReferenceProvider;
-
-    /**
-     * @var StatementsProvider
-     */
-    private $statementsProvider;
-
-    /**
-     * @var Scanner
-     */
-    private $codebaseScanner;
-
-    /**
-     * @var Codebase
-     */
-    private $codebase;
-
-    /**
-     * @var Providers
-     */
-    private $providers;
-
-    /**
-     * @var VoidProgress
-     */
-    private $progress;
-
-    /**
-     * @var FileStorageProvider
-     */
-    private $fileStorageProvider;
-
-    /**
-     * @var Reflection
-     */
-    private $reflection;
+    private $storage_provider;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->storageProvider = new ClassLikeStorageProvider();
-        $this->fileReferenceProvider = new FileReferenceProvider();
-        $this->statementsProvider = new StatementsProvider($this->file_provider);
-        $this->providers = new Providers($this->file_provider);
-        $this->progress = new VoidProgress();
-        $this->codebase = new Codebase(
-            $this->testConfig,
-            $this->providers,
-            $this->progress
-        );
-        $this->fileStorageProvider = new FileStorageProvider();
-        $this->reflection = new Reflection(
-            $this->storageProvider,
-            $this->codebase
-        );
-        $this->codebaseScanner = new Scanner(
-            $this->codebase,
-            $this->testConfig,
-            $this->fileStorageProvider,
-            $this->file_provider,
-            $this->reflection,
-            $this->fileReferenceProvider,
-            $this->progress
-        );
-        $this->classLikes = new ClassLikes(
-            $this->testConfig,
-            $this->storageProvider,
-            $this->fileReferenceProvider,
-            $this->statementsProvider,
-            $this->codebaseScanner
-        );
+        $this->classlikes = $this->project_analyzer->getCodebase()->classlikes;
+        $this->storage_provider = $this->project_analyzer->getCodebase()->classlike_storage_provider;
     }
 
     public function testWillDetectClassImplementingAliasedInterface(): void
     {
-        $this->classLikes->addClassAlias('Foo', 'bar');
+        $this->classlikes->addClassAlias('Foo', 'bar');
 
         $classStorage = new ClassLikeStorage('Baz');
         $classStorage->class_implements['bar'] = 'Bar';
 
-        $this->storageProvider->addMore(['baz' => $classStorage]);
+        $this->storage_provider->addMore(['baz' => $classStorage]);
 
-        self::assertTrue($this->classLikes->classImplements('Baz', 'Foo'));
+        self::assertTrue($this->classlikes->classImplements('Baz', 'Foo'));
     }
 }


### PR DESCRIPTION
Fixes #6325

