### PR TITLE
Fix error message for call to internal method from root namespace

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
@@ -56,7 +56,7 @@ class MethodCallProhibitionAnalyzer
                     new InternalMethod(
                         'The method ' . $codebase_methods->getCasedMethodId($method_id)
                             . ' is internal to ' . $storage->internal
-                            . ' but called from ' . $context->self,
+                            . ' but called from ' . ($context->self ?: 'root namespace'),
                         $code_location,
                         (string) $method_id
                     ),

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -548,7 +548,24 @@ class InternalAnnotationTest extends TestCase
                             }
                         }
                     }',
-                'error_message' => 'InternalMethod',
+                'error_message' => 'The method A\Foo::barBar is internal to A but called from B\Bat',
+            ],
+            'internalMethodWithCallFromRootNamespace' => [
+                '<?php
+                    namespace A {
+                        class Foo {
+                            /**
+                             * @internal
+                             */
+                            public static function barBar(): void {
+                            }
+                        }
+                    }
+
+                    namespace {
+                        \A\Foo::barBar();
+                    }',
+                'error_message' => 'The method A\Foo::barBar is internal to A but called from root namespace',
             ],
             'internalClassWithStaticCall' => [
                 '<?php


### PR DESCRIPTION
I noticed that the error output linked from https://twitter.com/afilina/status/1425841636282671105 is not grammatical.