### PR TITLE
remove cache after unsetting a key from a TKeyedArray

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
@@ -51,6 +51,7 @@ class UnsetAnalyzer
                             ) {
                                 if (isset($atomic_root_type->properties[$var->dim->value])) {
                                     unset($atomic_root_type->properties[$var->dim->value]);
+                                    $root_type->bustCache(); //remove id cache
                                 }
 
                                 if (!$atomic_root_type->properties) {


### PR DESCRIPTION
This fixes #6343

Interestingly, Union::getId() have a cache that is resetted after adding or removing a type, but when we unset an offset from a TKeyedArray, this cache was kept as is. So everywhere we needed to display the type (including Trace) was displaying the old Id