### PR TITLE
Fix: Require ext-ctype

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     "require": {
         "php": "^7.1|^8",
         "ext-SimpleXML": "*",
+        "ext-ctype": "*",
         "ext-dom": "*",
         "ext-json": "*",
         "ext-libxml": "*",


### PR DESCRIPTION
This pull request

* [x] explicitly requires the implicitly required `ext-ctype`

Spotted in https://github.com/sebastianbergmann/phpunit/pull/4759.

💁‍♂️ Running

```
$ git grep ctype_
```

yields (among others)

```
src/Psalm/Internal/Codebase/ConstantTypeResolver.php:9:use function ctype_digit;
src/Psalm/Internal/Codebase/ConstantTypeResolver.php:202:                    } elseif (ctype_digit($key_type->value)) {
```

❗ You might be interested in taking a look at https://github.com/shivammathur/setup-php/issues/487, where @shivammathur has already put capabilities in place that allow disabling all PHP extensions, and enabling those that are required. This allows detecting hidden dependencies on PHP extensions.