### PR TITLE
Use variable in backtick

### DIFF
--- a/dictionaries/PropertyMap.php
+++ b/dictionaries/PropertyMap.php
@@ -517,6 +517,9 @@ return [
     'phpparser\\node\\matcharm' => [
         'conds' => 'null|non-empty-list<PhpParser\Node\Expr>',
     ],
+    'phpparser\\node\\expr\\shellexec' => [
+        'parts' => 'list<PhpParser\Node>',
+    ],
     'rdkafka\\message' => [
         'err' => 'int',
         'topic_name' => 'string',

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -350,6 +350,9 @@ class ExpressionAnalyzer
                         }
 
                         $expr_type = $statements_analyzer->node_data->getType($part);
+                        if ($expr_type === null) {
+                            break;
+                        }
 
                         foreach ($expr_type->parent_nodes as $parent_node) {
                             $statements_analyzer->data_flow_graph->addPath(

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1049,6 +1049,13 @@ class UnusedCodeTest extends TestCase
                     }
                 ',
             ],
+            'variableUsedInBacktick' => [
+                '<?php
+                    $used = "echo";
+                    /** @psalm-suppress ForbiddenCode */
+                    `$used`;
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR allows Psalm to see variables that are used inside a backtick expression

This PR fixes #6367