### PR TITLE
Add a note about baseline suppression files in the ignoreFiles section

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -409,6 +409,8 @@ Contains a list of all the directories that Psalm should inspect. You can also s
 </projectFiles>
 ```
 
+> If you're looking to ignore individual files, consider starting with a [baseline suppression file](https://psalm.dev/docs/running_psalm/dealing_with_code_issues/#using-a-baseline-file) (which can be automatically generated for your existing errors).
+
 #### &lt;extraFiles&gt;
 Optional. Same format as `<projectFiles>`. Directories Psalm should load but not inspect.
 


### PR DESCRIPTION
Hi there, thanks for doing god's work.

Coming from phpstan, I ran into some confusion with ignoring individual files. I figured I'd just take my list of files in `excludes_analyse` from my `phpstan.neon` and pop it into the XML config, but that doesn't appear to be doable. After exploring the docs a bit further, `--set-baseline` is a super smart and easy way kick off psalm usage. It may be helpful to note that in the configuration section itself.