### PR TITLE
Make Psalm understand infinite while loop in control actions

### DIFF
--- a/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
@@ -345,6 +345,22 @@ class ScopeAnalyzer
                         return $action !== self::ACTION_NONE;
                     }
                 );
+
+                if ($stmt instanceof PhpParser\Node\Stmt\While_
+                    && $nodes
+                    && ($stmt_expr_type = $nodes->getType($stmt->cond))
+                    && $stmt_expr_type->isTrue()
+                ) {
+                    //infinite while loop that only return don't have an exit path
+                    $have_exit_path = (bool)array_diff(
+                        $control_actions,
+                        [self::ACTION_END, self::ACTION_RETURN]
+                    );
+
+                    if (!$have_exit_path) {
+                        return array_values(array_unique($control_actions));
+                    }
+                }
             }
 
             if ($stmt instanceof PhpParser\Node\Stmt\TryCatch) {

--- a/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
@@ -349,7 +349,7 @@ class ScopeAnalyzer
                 if ($stmt instanceof PhpParser\Node\Stmt\While_
                     && $nodes
                     && ($stmt_expr_type = $nodes->getType($stmt->cond))
-                    && $stmt_expr_type->isTruthy()
+                    && $stmt_expr_type->isAlwaysTruthy()
                 ) {
                     //infinite while loop that only return don't have an exit path
                     $have_exit_path = (bool)array_diff(

--- a/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
@@ -349,7 +349,7 @@ class ScopeAnalyzer
                 if ($stmt instanceof PhpParser\Node\Stmt\While_
                     && $nodes
                     && ($stmt_expr_type = $nodes->getType($stmt->cond))
-                    && $stmt_expr_type->isTrue()
+                    && $stmt_expr_type->isTruthy()
                 ) {
                     //infinite while loop that only return don't have an exit path
                     $have_exit_path = (bool)array_diff(

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
@@ -218,7 +218,7 @@ class IfConditionalAnalyzer
         $cond_type = $statements_analyzer->node_data->getType($cond);
 
         if ($cond_type !== null) {
-            if ($cond_type->isFalse()) {
+            if ($cond_type->isAlwaysFalsy()) {
                 if ($cond_type->from_docblock) {
                     if (IssueBuffer::accepts(
                         new DocblockTypeContradiction(

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -958,9 +958,134 @@ class Union implements TypeNode
         return count($this->types) === 1 && isset($this->types['false']);
     }
 
+    public function isAlwaysFalsy(): bool
+    {
+        foreach ($this->getAtomicTypes() as $atomic_type) {
+            if ($atomic_type instanceof Type\Atomic\TFalse) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TLiteralInt && $atomic_type->value === 0) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TLiteralFloat && $atomic_type->value === 0.0) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TLiteralString &&
+                ($atomic_type->value === '' || $atomic_type->value === '0')
+            ) {
+                    continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TNull) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TKeyedArray &&
+                $atomic_type->sealed === true &&
+                count($atomic_type->properties) === 0) {
+                continue;
+            }
+
+            if ($atomic_type instanceof TTemplateParam && $atomic_type->as->isAlwaysFalsy()) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TIntRange &&
+                $atomic_type->min_bound === 0 &&
+                $atomic_type->max_bound === 0
+            ) {
+                continue;
+            }
+
+            //we can't be sure the type is always falsy
+            return false;
+        }
+
+        return true;
+    }
+
     public function isTrue(): bool
     {
         return count($this->types) === 1 && isset($this->types['true']);
+    }
+
+    public function isTruthy(): bool
+    {
+        foreach ($this->getAtomicTypes() as $atomic_type) {
+            if ($atomic_type instanceof Type\Atomic\TTrue) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TLiteralInt && $atomic_type->value !== 0) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TLiteralFloat && $atomic_type->value !== 0.0) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TLiteralString &&
+                ($atomic_type->value !== '' && $atomic_type->value !== '0')
+            ) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TNonFalsyString) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TNonEmptyArray) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TNonEmptyList) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TObject) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TNamedObject) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TIntRange && !$atomic_type->contains(0)) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TPositiveInt) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TLiteralClassString) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TClassString) {
+                continue;
+            }
+
+            if ($atomic_type instanceof Type\Atomic\TKeyedArray) {
+                foreach ($atomic_type->properties as $property) {
+                    if ($property->possibly_undefined === false) {
+                        continue;
+                    }
+                }
+            }
+
+            if ($atomic_type instanceof TTemplateParam && $atomic_type->as->isAlwaysTruthy()) {
+                continue;
+            }
+
+            //we can't be sure the type is always truthy
+            return false;
+        }
+
+        return true;
     }
 
     public function isVoid(): bool

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -983,12 +983,6 @@ class Union implements TypeNode
                 continue;
             }
 
-            if ($atomic_type instanceof Type\Atomic\TKeyedArray &&
-                $atomic_type->sealed === true &&
-                count($atomic_type->properties) === 0) {
-                continue;
-            }
-
             if ($atomic_type instanceof TTemplateParam && $atomic_type->as->isAlwaysFalsy()) {
                 continue;
             }
@@ -1012,7 +1006,7 @@ class Union implements TypeNode
         return count($this->types) === 1 && isset($this->types['true']);
     }
 
-    public function isTruthy(): bool
+    public function isAlwaysTruthy(): bool
     {
         foreach ($this->getAtomicTypes() as $atomic_type) {
             if ($atomic_type instanceof Type\Atomic\TTrue) {
@@ -1053,9 +1047,9 @@ class Union implements TypeNode
                 continue;
             }
 
-            if ($atomic_type instanceof Type\Atomic\TIntRange && !$atomic_type->contains(0)) {
+            /*if ($atomic_type instanceof Type\Atomic\TIntRange && !$atomic_type->contains(0)) {
                 continue;
-            }
+            }*/
 
             if ($atomic_type instanceof Type\Atomic\TPositiveInt) {
                 continue;

--- a/tests/Loop/WhileTest.php
+++ b/tests/Loop/WhileTest.php
@@ -712,7 +712,7 @@ class WhileTest extends \Psalm\Tests\TestCase
                 '<?php
                     function getResultWithRetry(): string
                     {
-                        while (true) {
+                        while (new stdClass) {
                             return "";
                         }
                     }'

--- a/tests/Loop/WhileTest.php
+++ b/tests/Loop/WhileTest.php
@@ -708,6 +708,46 @@ class WhileTest extends \Psalm\Tests\TestCase
                         if ($a->foo !== null) {}
                     }'
             ],
+            'whileTrueDontHaveExitPathForReturn' => [
+                '<?php
+                    function getResultWithRetry(): string
+                    {
+                        while (true) {
+                            return "";
+                        }
+                    }'
+            ],
+            'ComplexWhileTrueDontHaveExitPathForReturn' => [
+                '<?php
+                    class Test {
+                        private int $retryAttempts = 10;
+
+                        private function getResult(): string
+                        {
+                            // return tring or throw exception whatever
+                            throw new Exception();
+                        }
+
+                        private function getResultWithRetry(): string
+                        {
+                            $attempt = 1;
+
+                            while (true) {
+                                try {
+                                    return $this->getResult();
+                                } catch (Throwable $exception) {
+                                    if ($attempt >= $this->retryAttempts) {
+                                        throw $exception;
+                                    }
+
+                                    $attempt++;
+
+                                    continue;
+                                }
+                            }
+                        }
+                    }'
+            ],
         ];
     }
 

--- a/tests/TypeReconciliation/AssignmentInConditionalTest.php
+++ b/tests/TypeReconciliation/AssignmentInConditionalTest.php
@@ -383,7 +383,7 @@ class AssignmentInConditionalTest extends \Psalm\Tests\TestCase
             'repeatedSet' => [
                 '<?php
                     function foo(): void {
-                        if ($a = rand(0, 1) ? "" : null) {
+                        if ($a = rand(0, 1) ? "1" : null) {
                             return;
                         }
 
@@ -399,7 +399,7 @@ class AssignmentInConditionalTest extends \Psalm\Tests\TestCase
             'repeatedSetInsideWhile' => [
                 '<?php
                     function foo(): void {
-                        if ($a = rand(0, 1) ? "" : null) {
+                        if ($a = rand(0, 1) ? "1" : null) {
                             return;
                         } else {
                             while (rand(0, 1)) {

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -3046,6 +3046,13 @@ class ConditionalTest extends \Psalm\Tests\TestCase
                     }',
                 'error_message' => 'TypeDoesNotContainType',
             ],
+            'falsyValuesInIf' => [
+                '<?php
+                    if (0) {
+                        echo 123;
+                    }',
+                'error_message' => 'TypeDoesNotContainType',
+            ],
         ];
     }
 }


### PR DESCRIPTION
This PR fixes #6386

What it does is making Psalm understand that if a while loop has a `true` in its condition, then it won't have an exit path.