### PR TITLE
create callmap for 8.1 and introduce array_is_list

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -2,7 +2,7 @@
 namespace Phan\Language\Internal;
 
 /**
- * CURRENT PHP TARGET VERSION: 8.0
+ * CURRENT PHP TARGET VERSION: 8.1
  * The version above has to match Psalm\Internal\Codebase\InternalCallMapHandler::PHP_(MAJOR|MINOR)_VERSION
  *
  * Format
@@ -382,6 +382,7 @@ return [
 'array_intersect_uassoc\'1' => ['associative-array', 'array'=>'array', 'rest'=>'array', 'arr3'=>'array', 'arg4'=>'array|callable(mixed,mixed):int', '...rest'=>'array|callable(mixed,mixed):int'],
 'array_intersect_ukey' => ['associative-array', 'array'=>'array', 'rest'=>'array', 'key_compare_func'=>'callable(mixed,mixed):int'],
 'array_intersect_ukey\'1' => ['associative-array', 'array'=>'array', 'rest'=>'array', 'arr3'=>'array', 'arg4'=>'array|callable(mixed,mixed):int', '...rest'=>'array|callable(mixed,mixed):int'],
+'array_is_list' => ['bool', 'array'=>'array'],
 'array_key_exists' => ['bool', 'key'=>'string|int', 'array'=>'array|ArrayObject'],
 'array_key_first' => ['int|string|null', 'array'=>'array'],
 'array_key_last' => ['int|string|null', 'array'=>'array'],

--- a/dictionaries/CallMap_81_delta.php
+++ b/dictionaries/CallMap_81_delta.php
@@ -1,0 +1,27 @@
+<?php // phpcs:ignoreFile
+
+/**
+ * This contains the information needed to convert the function signatures for php 8.1 to php 8.0 (and vice versa)
+ *
+ * This file has three sections.
+ * The 'added' section contains function/method names from FunctionSignatureMap (And alternates, if applicable) that do not exist in php 8.0
+ * The 'removed' section contains the signatures that were removed in php 8.1
+ * The 'changed' section contains functions for which the signature has changed for php 8.1.
+ *     Each function in the 'changed' section has an 'old' and a 'new' section,
+ *     representing the function as it was in PHP 8.0 and in PHP 8.1, respectively
+ *
+ * @see CallMap.php
+ *
+ * @phan-file-suppress PhanPluginMixedKeyNoKey (read by Phan when analyzing this file)
+ */
+return [
+  'added' => [
+    'array_is_list' => ['bool', 'array'=>'array'],
+  ],
+  'changed' => [
+
+  ],
+  'removed' => [
+
+  ],
+];

--- a/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
+++ b/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
@@ -26,7 +26,7 @@ use function version_compare;
 class InternalCallMapHandler
 {
     private const PHP_MAJOR_VERSION = 8;
-    private const PHP_MINOR_VERSION = 0;
+    private const PHP_MINOR_VERSION = 1;
     private const LOWEST_AVAILABLE_DELTA = 71;
 
     /**
@@ -404,7 +404,7 @@ class InternalCallMapHandler
                     $cased_key = strtolower($key);
                     self::$call_map[$cased_key] = $value;
                 }
-                
+
                 foreach ($diff_call_map['changed'] as $key => ['old' => $value]) {
                     $cased_key = strtolower($key);
                     self::$call_map[$cased_key] = $value;


### PR DESCRIPTION
This PR create the callmap file for PHP 8.1 and open the way for the rest of the functions.

It also introduce array_is_list and fix an element in #6395