### PR TITLE
Also support non-literal types in strict in_array() check

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -3442,7 +3442,7 @@ class AssertionFinder
                     $assertions = [];
 
                     if (!$is_sealed) {
-                        if ($value_type->getId() !== '') {
+                        if ($value_type->getId() !== '' && !$value_type->isMixed()) {
                             $assertions[] = 'in-array-' . $value_type->getId();
                         }
                     } else {
@@ -3453,10 +3453,7 @@ class AssertionFinder
                                 || $atomic_value_type instanceof Type\Atomic\TEnumCase
                             ) {
                                 $assertions[] = '=' . $atomic_value_type->getAssertionString();
-                            } elseif ($atomic_value_type instanceof Type\Atomic\TFalse
-                                || $atomic_value_type instanceof Type\Atomic\TTrue
-                                || $atomic_value_type instanceof Type\Atomic\TNull
-                            ) {
+                            } else {
                                 $assertions[] = $atomic_value_type->getAssertionString();
                             }
                         }

--- a/tests/TypeReconciliation/InArrayTest.php
+++ b/tests/TypeReconciliation/InArrayTest.php
@@ -169,6 +169,32 @@ class InArrayTest extends \Psalm\Tests\TestCase
                 [],
                 '8.0'
             ],
+            'in_arrayNullOrString' => [
+                '<?php
+                    function test(?string $x, string $y): void {
+                        if (in_array($x, [null, $y], true)) {
+                            if ($x === null) {
+                                echo "Saw null\n";
+                            }
+                            echo "Saw $x\n";
+                        }
+                    }',
+                [],
+                [],
+                '8.0'
+            ],
+            'in_array-mixed-twice' => [
+                '<?php
+                    function contains(array $list1, array $list2, mixed $element): void
+                    {
+                        if (in_array($element, $list1, true)) {
+                        } elseif (in_array($element, $list2, true)) {
+                        }
+                    }',
+                [],
+                [],
+                '8.0'
+            ],
         ];
     }
 

--- a/tests/TypeReconciliation/ValueTest.php
+++ b/tests/TypeReconciliation/ValueTest.php
@@ -961,6 +961,39 @@ class ValueTest extends \Psalm\Tests\TestCase
                     }',
                 'error_message' => 'RedundantCondition',
             ],
+            'inArrayRemoveNull' => [
+                '<?php
+                    function x(?string $foo, string $bar): void {
+                        if (!in_array($foo, [$bar], true)) {
+                            throw new Exception();
+                        }
+
+                        if (is_string($foo)) {}
+                    }',
+                'error_message' => 'RedundantCondition',
+            ],
+            'inArrayDetectType' => [
+                '<?php
+                    function x($foo, string $bar): void {
+                        if (!in_array($foo, [$bar], true)) {
+                            throw new Exception();
+                        }
+
+                        if (is_string($foo)) {}
+                    }',
+                // foo is always string
+                'error_message' => 'RedundantCondition',
+            ],
+            'inArrayRemoveInvalid' => [
+                '<?php
+                    function x(?string $foo, int $bar): void {
+                        if (!in_array($foo, [$bar], true)) {
+                            throw new Exception();
+                        }
+                    }',
+                // Type null|string is never int
+                'error_message' => 'RedundantCondition',
+            ],
             'neverNotIdenticalFloatType' => [
                 '<?php
                     $a = 4.1;


### PR DESCRIPTION
Modified approach to #6396 by orklah

Fixes #6333
Fixes #6317 


Not very familiar with the approach taken here (in general for type assertions), but `=null` for an assertion seems to not work (strict equality), while `null` does.