### PR TITLE
Ternary override type when reassigning

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/TernaryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/TernaryAnalyzer.php
@@ -15,6 +15,7 @@ use Psalm\Type;
 use Psalm\Type\Reconciler;
 
 use function array_filter;
+use function array_intersect;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -230,6 +231,17 @@ class TernaryAnalyzer
                     $type
                 );
             }
+        }
+
+        $redef_var_ifs = array_keys($if_context->getRedefinedVars($context->vars_in_scope));
+        $redef_var_else = array_keys($t_else_context->getRedefinedVars($context->vars_in_scope));
+        $redef_all = array_intersect($redef_var_ifs, $redef_var_else);
+
+        foreach ($redef_all as $redef_var_id) {
+            $context->vars_in_scope[$redef_var_id] = Type::combineUnionTypes(
+                $if_context->vars_in_scope[$redef_var_id],
+                $t_else_context->vars_in_scope[$redef_var_id]
+            );
         }
 
         $context->vars_possibly_in_scope = array_merge(

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2672,7 +2672,7 @@ class ConditionalTest extends \Psalm\Tests\TestCase
                     $b = rand(0,1) ? "" : "a";
                     $b === "a" ? $_a = "Y" : $_a = "N";',
                 'assertions' => [
-                    '$_a===' => "'N'|'Y'",
+                    '$_a===' => '"N"|"Y"',
                 ]
             ],
         ];

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2665,7 +2665,16 @@ class ConditionalTest extends \Psalm\Tests\TestCase
                          $takesValid($val3);
                      }
                  }'
-            ]
+            ],
+            'ternaryRedefineAllVars' => [
+                '<?php
+                    $_a = null;
+                    $b = rand(0,1) ? "" : "a";
+                    $b === "a" ? $_a = "Y" : $_a = "N";',
+                'assertions' => [
+                    '$_a===' => "'N'|'Y'",
+                ]
+            ],
         ];
     }
 


### PR DESCRIPTION
This fixes #6384.

I feel like TernaryAnalyzer should actually be much more similar to IfElseAnalyzer. I'd bet there is a lot of bugs there that is resolved in the other.

I tried going all the way and creating a set of Virtual statements to push to IfElseAnalyzer but I forgot that there is a slight difference because one is an expression and the other a statement, so you can't just translate one into the other