### PR TITLE
Encode XML output consistently

### DIFF
--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -4,6 +4,10 @@ namespace Psalm;
 use Psalm\Internal\Analyzer\IssueData;
 
 use function array_filter;
+use function htmlspecialchars;
+
+use const ENT_QUOTES;
+use const ENT_XML1;
 
 abstract class Report
 {
@@ -97,6 +101,11 @@ abstract class Report
 
         $this->mixed_expression_count = $mixed_expression_count;
         $this->total_expression_count = $total_expression_count;
+    }
+
+    protected function xmlEncode(string $data): string
+    {
+        return htmlspecialchars($data, ENT_XML1 | ENT_QUOTES, 'UTF-8');
     }
 
     abstract public function create(): string;

--- a/src/Psalm/Report/CheckstyleReport.php
+++ b/src/Psalm/Report/CheckstyleReport.php
@@ -3,7 +3,6 @@ namespace Psalm\Report;
 
 use Psalm\Report;
 
-use function htmlspecialchars;
 use function sprintf;
 
 class CheckstyleReport extends Report
@@ -21,13 +20,13 @@ class CheckstyleReport extends Report
                 $issue_data->message
             );
 
-            $output .= '<file name="' . htmlspecialchars($issue_data->file_name) . '">' . "\n";
+            $output .= '<file name="' . $this->xmlEncode($issue_data->file_name) . '">' . "\n";
             $output .= ' ';
             $output .= '<error';
             $output .= ' line="' . $issue_data->line_from . '"';
             $output .= ' column="' . $issue_data->column_from . '"';
             $output .= ' severity="' . $issue_data->severity . '"';
-            $output .= ' message="' . htmlspecialchars($message) . '"';
+            $output .= ' message="' . $this->xmlEncode($message) . '"';
             $output .= '/>' . "\n";
             $output .= '</file>' . "\n";
         }

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -8,11 +8,7 @@ use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
 
 use function count;
-use function htmlspecialchars;
 use function trim;
-
-use const ENT_QUOTES;
-use const ENT_XML1;
 
 /**
  * based on https://github.com/m50/psalm-json-to-junit
@@ -165,10 +161,10 @@ class JunitReport extends Report
 
     private function dataToOutput(IssueData $data): string
     {
-        $ret = 'message: ' . htmlspecialchars(trim($data->message), ENT_XML1 | ENT_QUOTES) . "\n";
+        $ret = 'message: ' . $this->xmlEncode(trim($data->message)) . "\n";
         $ret .= 'type: ' . trim($data->type) . "\n";
-        $ret .= 'snippet: ' . htmlspecialchars(trim($data->snippet), ENT_XML1 | ENT_QUOTES) . "\n";
-        $ret .= 'selected_text: ' . htmlspecialchars(trim($data->selected_text)) . "\n";
+        $ret .= 'snippet: ' . $this->xmlEncode(trim($data->snippet)) . "\n";
+        $ret .= 'selected_text: ' . $this->xmlEncode(trim($data->selected_text)) . "\n";
         $ret .= 'line: ' . $data->line_from . "\n";
         $ret .= 'column_from: ' . $data->column_from . "\n";
         $ret .= 'column_to: ' . $data->column_to . "\n";

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -1107,7 +1107,7 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:17:6 - Possibly undefined g
  <error line="3" column="10" severity="error" message="MixedReturnStatement: Could not infer a return type"/>
 </file>
 <file name="somefile.php">
- <error line="2" column="42" severity="error" message="MixedInferredReturnType: Could not verify return type \'null|string\' for psalmCanVerify"/>
+ <error line="2" column="42" severity="error" message="MixedInferredReturnType: Could not verify return type &apos;null|string&apos; for psalmCanVerify"/>
 </file>
 <file name="somefile.php">
  <error line="8" column="6" severity="error" message="UndefinedConstant: Const CHANGE_ME is not defined"/>


### PR DESCRIPTION
This fixes test failures when running on PHP 8.1, due to changed `htmlspecialchars()` defaults