### PR TITLE
Basic enum checks

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -226,6 +226,8 @@
             <xs:element name="DocblockTypeContradiction" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="DuplicateArrayKey" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="DuplicateClass" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="DuplicateEnumCase" type="ClassIssueHandlerType" minOccurs="0" />
+            <xs:element name="DuplicateEnumCaseValue" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="DuplicateFunction" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="DuplicateMethod" type="MethodIssueHandlerType" minOccurs="0" />
             <xs:element name="DuplicateParam" type="IssueHandlerType" minOccurs="0" />
@@ -266,6 +268,7 @@
             <xs:element name="InvalidDocblock" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidDocblockParamName" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidEnumBackingType" type="ClassIssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidEnumCaseValue" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidExtendClass" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidFalsableReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidFunctionCall" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/issues/DuplicateEnumCase.md
+++ b/docs/running_psalm/issues/DuplicateEnumCase.md
@@ -1,0 +1,27 @@
+# DuplicateEnumCase
+
+Emitted when enum has duplicate cases.
+
+```php
+<?php
+
+enum Status 
+{
+    case Open;
+    case Open;
+}
+```
+
+## How to fix
+
+Remove or rename the offending duplicates.
+
+```php
+<?php
+
+enum Status 
+{
+    case Open;
+    case Closed;
+}
+```

--- a/docs/running_psalm/issues/DuplicateEnumCaseValue.md
+++ b/docs/running_psalm/issues/DuplicateEnumCaseValue.md
@@ -1,0 +1,27 @@
+# DuplicateEnumCaseValue
+
+Emitted when a backed enum has duplicate case values.
+
+```php
+<?php
+
+enum Status: string 
+{
+    case Open = "open";
+    case Closed = "open";
+}
+```
+
+## How to fix
+
+Change case values so that there are no duplicates.
+
+```php
+<?php
+
+enum Status: string 
+{
+    case Open = "open";
+    case Closed = "closed";
+}
+```

--- a/docs/running_psalm/issues/InvalidEnumBackingType.md
+++ b/docs/running_psalm/issues/InvalidEnumBackingType.md
@@ -6,7 +6,8 @@ by something else.
 ```php
 <?php
 
-enum Status: array {
+enum Status: array 
+{
    case None = [];
 }
 ```

--- a/docs/running_psalm/issues/InvalidEnumCaseValue.md
+++ b/docs/running_psalm/issues/InvalidEnumCaseValue.md
@@ -1,0 +1,77 @@
+# InvalidEnumCaseValue
+
+Emitted when case value is invalid (see below).
+
+## Case with a value on a pure enum
+
+```php
+<?php
+
+enum Status 
+{
+    case Open = "open";
+}
+```
+
+### How to fix
+
+Either remove the value or alter the enum to be backed.
+
+```php
+<?php
+
+enum Status: string 
+{
+    case Open = "open";
+}
+```
+
+## Case without a value on a backed enum
+
+```php
+<?php
+
+enum Status: string 
+{
+    case Open;    
+}
+```
+
+### How to fix
+
+Either alter the enum to be pure, or add a value.
+
+```php
+<?php
+
+enum Status 
+{
+    case Open;
+}
+```
+
+## Case type mismatch
+
+Case type should match the backing type of the enum.
+
+```php
+<?php
+
+enum Status: string
+{
+    case Open = 1;
+}
+```
+
+### How to fix
+
+Change the types so that they match
+
+```php
+<?php
+
+enum Status: string 
+{
+    case Open = "open";
+}
+```

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -202,6 +202,7 @@ class AtomicPropertyFetchAnalyzer
                     }
                 }
 
+                // todo: this is suboptimal when we reference enum directly, e.g. Status::Open->value
                 $statements_analyzer->node_data->setType(
                     $stmt,
                     new Type\Union($case_values)

--- a/src/Psalm/Issue/DuplicateEnumCase.php
+++ b/src/Psalm/Issue/DuplicateEnumCase.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+class DuplicateEnumCase extends ClassIssue
+{
+    public const ERROR_LEVEL = -1;
+    public const SHORTCODE = 277;
+}

--- a/src/Psalm/Issue/DuplicateEnumCaseValue.php
+++ b/src/Psalm/Issue/DuplicateEnumCaseValue.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+class DuplicateEnumCaseValue extends ClassIssue
+{
+    public const ERROR_LEVEL = -1;
+    public const SHORTCODE = 279;
+}

--- a/src/Psalm/Issue/InvalidEnumCaseValue.php
+++ b/src/Psalm/Issue/InvalidEnumCaseValue.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+class InvalidEnumCaseValue extends ClassIssue
+{
+    public const ERROR_LEVEL = -1;
+    public const SHORTCODE = 278;
+}

--- a/src/Psalm/Storage/EnumCaseStorage.php
+++ b/src/Psalm/Storage/EnumCaseStorage.php
@@ -1,6 +1,8 @@
 <?php
 namespace Psalm\Storage;
 
+use Psalm\CodeLocation;
+
 class EnumCaseStorage
 {
     /**
@@ -8,12 +10,17 @@ class EnumCaseStorage
      */
     public $value;
 
+    /** @var CodeLocation */
+    public $stmt_location;
+
     /**
      * @param int|string|null  $value
      */
     public function __construct(
-        $value
+        $value,
+        CodeLocation $location
     ) {
         $this->value = $value;
+        $this->stmt_location = $location;
     }
 }

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -305,6 +305,9 @@ class DocumentationTest extends TestCase
                     break;
 
                 case 'InvalidEnumBackingType':
+                case 'InvalidEnumCaseValue':
+                case 'DuplicateEnumCase':
+                case 'DuplicateEnumCaseValue':
                     $php_version = '8.1';
                     break;
             }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -84,6 +84,21 @@ class EnumTest extends TestCase
                 [],
                 '8.1'
             ],
+            'literalExpressionAsCaseValue' => [
+                '<?php
+                    enum Mask: int {
+                        case One = 1 << 0;
+                        case Two = 1 << 1;
+                    }
+                    $z = Mask::Two->value;
+                ',
+                'assertions' => [
+                    // xxx: we should be able to do better when we reference a case explicitly, like above
+                    '$z===' => '1|2',
+                ],
+                [],
+                '8.1'
+            ],
         ];
     }
 
@@ -206,6 +221,69 @@ class EnumTest extends TestCase
                     enum Status: array {}
                 ',
                 'error_message' => 'InvalidEnumBackingType',
+                [],
+                false,
+                '8.1',
+            ],
+            'duplicateValues' => [
+                '<?php
+                    enum Status: string
+                    {
+                        case Foo = "foo";
+                        case Bar = "bar";
+                        case Baz = "bar";
+                    }
+                ',
+                'error_message' => 'DuplicateEnumCaseValue',
+                [],
+                false,
+                '8.1',
+            ],
+            'duplicateCases' => [
+                '<?php
+                    enum Status
+                    {
+                        case Foo;
+                        case Foo;
+                    }
+                ',
+                'error_message' => 'DuplicateEnumCase',
+                [],
+                false,
+                '8.1',
+            ],
+            'caseWithAValueOfANonBackedEnum' => [
+                '<?php
+                    enum Status
+                    {
+                        case Foo = 1;
+                    }
+                ',
+                'error_message' => 'InvalidEnumCaseValue',
+                [],
+                false,
+                '8.1',
+            ],
+            'caseWithoutAValueOfABackedEnum' => [
+                '<?php
+                    enum Status: int
+                    {
+                        case Foo;
+                    }
+                ',
+                'error_message' => 'InvalidEnumCaseValue',
+                [],
+                false,
+                '8.1',
+            ],
+            'caseTypeMismatch' => [
+                '<?php
+                    enum Status: int
+                    {
+                        case Foo = "one";
+                    }
+                ',
+                'error_message' => 'InvalidEnumCaseValue',
                 [],
                 false,
                 '8.1',


### PR DESCRIPTION
* Duplicate cases
* Duplicate case values
* Invalid case values: value on a pure enum case, missing value on a backed enum case, backing type / case type mismatch
* Adds literal expression evaluation, e.g. `enum Mask: int { case Two = 1 << 1; }`

Fixes vimeo/psalm#6426
Fixes vimeo/psalm#6427