### PR TITLE
introducing fsync & fdatasync functions in callmap

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -3179,6 +3179,8 @@ return [
 'fdiv' => ['float', 'num1'=>'float', 'num2'=>'float'],
 'feof' => ['bool', 'stream'=>'resource'],
 'fflush' => ['bool', 'stream'=>'resource'],
+'fsync' => ['bool', 'stream'=>'resource'],
+'fdatasync' => ['bool', 'stream'=>'resource'],
 'ffmpeg_animated_gif::__construct' => ['void', 'output_file_path'=>'string', 'width'=>'int', 'height'=>'int', 'frame_rate'=>'int', 'loop_count='=>'int'],
 'ffmpeg_animated_gif::addFrame' => ['', 'frame_to_add'=>'ffmpeg_frame'],
 'ffmpeg_frame::__construct' => ['void', 'gd_image'=>'resource'],

--- a/dictionaries/CallMap_81_delta.php
+++ b/dictionaries/CallMap_81_delta.php
@@ -17,6 +17,8 @@
 return [
   'added' => [
     'array_is_list' => ['bool', 'array' => 'array'],
+    'fsync' => ['bool', 'stream' => 'resource'],
+    'fdatasync' => ['bool', 'stream' => 'resource'],
   ],
 
   'changed' => [


### PR DESCRIPTION
This PR adds callmap for two new functions that are introduced in PHP 8.1

- fsync
- fdatasync

RFC: https://wiki.php.net/rfc/fsync_function