### PR TITLE
Fix false positive ParadoxicalCondition in negation of in_array

### DIFF
--- a/src/Psalm/Internal/Analyzer/AlgebraAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/AlgebraAnalyzer.php
@@ -12,6 +12,7 @@ use Psalm\IssueBuffer;
 use function array_intersect_key;
 use function array_unique;
 use function count;
+use function preg_match;
 
 /**
  * @internal
@@ -135,6 +136,12 @@ class AlgebraAnalyzer
                     if ($negated_clause_2->possibilities[$key] != $keyed_possibilities) {
                         $negated_clause_2_contains_1_possibilities = false;
                         break;
+                    }
+                    foreach ($keyed_possibilities as $possibility) {
+                        if (preg_match('@^!?in-array-@', $possibility)) {
+                            $negated_clause_2_contains_1_possibilities = false;
+                            break;
+                        }
                     }
                 }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -3456,13 +3456,22 @@ class AssertionFinder
                         }
                     } else {
                         foreach ($value_type->getAtomicTypes() as $atomic_value_type) {
-                            if ($atomic_value_type instanceof Type\Atomic\TFalse
+                            if ($atomic_value_type instanceof Type\Atomic\TLiteralInt
+                                || $atomic_value_type instanceof Type\Atomic\TLiteralString
+                                || $atomic_value_type instanceof Type\Atomic\TLiteralFloat
+                                || $atomic_value_type instanceof Type\Atomic\TEnumCase
+                            ) {
+                                $assertions[] = '=' . $atomic_value_type->getAssertionString();
+                            } elseif ($atomic_value_type instanceof Type\Atomic\TFalse
                                 || $atomic_value_type instanceof Type\Atomic\TTrue
                                 || $atomic_value_type instanceof Type\Atomic\TNull
                             ) {
                                 $assertions[] = $atomic_value_type->getAssertionString();
-                            } else {
-                                $assertions[] = '=' . $atomic_value_type->getAssertionString();
+                            } elseif (!$atomic_value_type instanceof Type\Atomic\TMixed) {
+                                // mixed doesn't tell us anything and can be omitted.
+                                //
+                                // For the meaning of in-array, see the above comment.
+                                $assertions[] = 'in-array-' . $value_type->getId();
                             }
                         }
                     }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -465,7 +465,7 @@ class AssertionFinder
 
                     if ($var_name_left &&
                         (!$var_type->isSingle() || $var_type->getAssertionString() !== $assertion)) {
-                        $if_types[$var_name_left] = [['~'.$assertion]];
+                        $if_types[$var_name_left] = [['='.$assertion]];
                     }
 
                     $var_name_right = ExpressionIdentifier::getArrayVarId(
@@ -476,7 +476,7 @@ class AssertionFinder
 
                     if ($var_name_right &&
                         (!$other_type->isSingle() || $other_type->getAssertionString() !== $assertion)) {
-                        $if_types[$var_name_right] = [['~'.$assertion]];
+                        $if_types[$var_name_right] = [['='.$assertion]];
                     }
 
                     return $if_types ? [$if_types] : [];
@@ -3456,14 +3456,13 @@ class AssertionFinder
                         }
                     } else {
                         foreach ($value_type->getAtomicTypes() as $atomic_value_type) {
-                            if ($atomic_value_type instanceof Type\Atomic\TLiteralInt
-                                || $atomic_value_type instanceof Type\Atomic\TLiteralString
-                                || $atomic_value_type instanceof Type\Atomic\TLiteralFloat
-                                || $atomic_value_type instanceof Type\Atomic\TEnumCase
+                            if ($atomic_value_type instanceof Type\Atomic\TFalse
+                                || $atomic_value_type instanceof Type\Atomic\TTrue
+                                || $atomic_value_type instanceof Type\Atomic\TNull
                             ) {
-                                $assertions[] = '=' . $atomic_value_type->getAssertionString();
-                            } else {
                                 $assertions[] = $atomic_value_type->getAssertionString();
+                            } else {
+                                $assertions[] = '=' . $atomic_value_type->getAssertionString();
                             }
                         }
                     }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -3442,6 +3442,15 @@ class AssertionFinder
                     $assertions = [];
 
                     if (!$is_sealed) {
+                        // `in-array-*` has special handling in the detection of paradoxical
+                        // conditions and the fact the negation doesn't imply anything.
+                        //
+                        // In the vast majority of cases, the negation of `in-array-*`
+                        // (`Algebra::negateType`) doesn't imply anything because:
+                        // - The array can be empty, or
+                        // - The array may have one of the types but not the others.
+                        //
+                        // NOTE: the negation of the negation is the original assertion.
                         if ($value_type->getId() !== '' && !$value_type->isMixed()) {
                             $assertions[] = 'in-array-' . $value_type->getId();
                         }

--- a/tests/TypeReconciliation/InArrayTest.php
+++ b/tests/TypeReconciliation/InArrayTest.php
@@ -211,6 +211,18 @@ class InArrayTest extends \Psalm\Tests\TestCase
                 [],
                 '8.0'
             ],
+            'in_array-keyed-array-string-twice' => [
+                '<?php
+                    function contains(string $a, string $b, mixed $element): void
+                    {
+                        if (in_array($element, [$a], true)) {
+                        } elseif (in_array($element, [$b], true)) {
+                        }
+                    }',
+                [],
+                [],
+                '8.0'
+            ],
         ];
     }
 
@@ -379,6 +391,28 @@ class InArrayTest extends \Psalm\Tests\TestCase
                     }',
                 'error_message' => 'MixedReturnStatement - src' . DIRECTORY_SEPARATOR . 'somefile.php:12:32 - Could not infer a return type',
                 'error_level' => ['RedundantConditionGivenDocblockType'],
+            ],
+            'inArrayDetectType' => [
+                '<?php
+                    function x($foo, string $bar): void {
+                        if (!in_array($foo, [$bar], true)) {
+                            throw new Exception();
+                        }
+
+                        if (is_string($foo)) {}
+                    }',
+                // foo is always string
+                'error_message' => 'RedundantCondition',
+            ],
+            'inArrayRemoveInvalid' => [
+                '<?php
+                    function x(?string $foo, int $bar): void {
+                        if (!in_array($foo, [$bar], true)) {
+                            throw new Exception();
+                        }
+                    }',
+                // Type null|string is never int
+                'error_message' => 'RedundantCondition',
             ],
         ];
     }

--- a/tests/TypeReconciliation/InArrayTest.php
+++ b/tests/TypeReconciliation/InArrayTest.php
@@ -195,6 +195,22 @@ class InArrayTest extends \Psalm\Tests\TestCase
                 [],
                 '8.0'
             ],
+            'in_array-string-twice' => [
+                '<?php
+                    /**
+                     * @param string[] $list1
+                     * @param string[] $list2
+                     */
+                    function contains(array $list1, array $list2, string $element): void
+                    {
+                        if (in_array($element, $list1, true)) {
+                        } elseif (in_array($element, $list2, true)) {
+                        }
+                    }',
+                [],
+                [],
+                '8.0'
+            ],
         ];
     }
 

--- a/tests/TypeReconciliation/ValueTest.php
+++ b/tests/TypeReconciliation/ValueTest.php
@@ -972,28 +972,6 @@ class ValueTest extends \Psalm\Tests\TestCase
                     }',
                 'error_message' => 'RedundantCondition',
             ],
-            'inArrayDetectType' => [
-                '<?php
-                    function x($foo, string $bar): void {
-                        if (!in_array($foo, [$bar], true)) {
-                            throw new Exception();
-                        }
-
-                        if (is_string($foo)) {}
-                    }',
-                // foo is always string
-                'error_message' => 'RedundantCondition',
-            ],
-            'inArrayRemoveInvalid' => [
-                '<?php
-                    function x(?string $foo, int $bar): void {
-                        if (!in_array($foo, [$bar], true)) {
-                            throw new Exception();
-                        }
-                    }',
-                // Type null|string is never int
-                'error_message' => 'RedundantCondition',
-            ],
             'neverNotIdenticalFloatType' => [
                 '<?php
                     $a = 4.1;


### PR DESCRIPTION
For #6439

This turned out to be a better approach than making the negation of `in_array` equal to `mixed`.
`mixed` is changing the type of the value to mixed. Also, double negation wouldn't work in the previously considered approach.

`in-array-x` and `!in-array-x` do not contradict each other (a string might be in an array of strings, but not in another array (such as the empty array)), so prevent the warning from being emitted.