### PR TITLE
Add imagecreatefromavif() and imageavif() to CallMap

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -5345,7 +5345,7 @@ return [
 'imagealphablending' => ['bool', 'image'=>'GdImage', 'enable'=>'bool'],
 'imageantialias' => ['bool', 'image'=>'GdImage', 'enable'=>'bool'],
 'imagearc' => ['bool', 'image'=>'GdImage', 'center_x'=>'int', 'center_y'=>'int', 'width'=>'int', 'height'=>'int', 'start_angle'=>'int', 'end_angle'=>'int', 'color'=>'int'],
-'imageavif' => ['bool', 'image'=>'GdImage', 'file'=>'resource|string|null', 'quality'=>'int', 'speed'=>'int'],
+'imageavif' => ['bool', 'image'=>'GdImage', 'file='=>'resource|string|null', 'quality='=>'int', 'speed='=>'int'],
 'imagebmp' => ['bool', 'image'=>'GdImage', 'file='=>'resource|string|null', 'compressed='=>'bool'],
 'imagechar' => ['bool', 'image'=>'GdImage', 'font'=>'int', 'x'=>'int', 'y'=>'int', 'char'=>'string', 'color'=>'int'],
 'imagecharup' => ['bool', 'image'=>'GdImage', 'font'=>'int', 'x'=>'int', 'y'=>'int', 'char'=>'string', 'color'=>'int'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -5371,6 +5371,7 @@ return [
 'imagecopyresampled' => ['bool', 'dst_image'=>'GdImage', 'src_image'=>'GdImage', 'dst_x'=>'int', 'dst_y'=>'int', 'src_x'=>'int', 'src_y'=>'int', 'dst_width'=>'int', 'dst_height'=>'int', 'src_width'=>'int', 'src_height'=>'int'],
 'imagecopyresized' => ['bool', 'dst_image'=>'GdImage', 'src_image'=>'GdImage', 'dst_x'=>'int', 'dst_y'=>'int', 'src_x'=>'int', 'src_y'=>'int', 'dst_width'=>'int', 'dst_height'=>'int', 'src_width'=>'int', 'src_height'=>'int'],
 'imagecreate' => ['false|GdImage', 'width'=>'int', 'height'=>'int'],
+'imagecreatefromavif' => ['false|GdImage', 'filename'=>'string'],
 'imagecreatefrombmp' => ['false|GdImage', 'filename'=>'string'],
 'imagecreatefromgd' => ['false|GdImage', 'filename'=>'string'],
 'imagecreatefromgd2' => ['false|GdImage', 'filename'=>'string'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -5345,6 +5345,7 @@ return [
 'imagealphablending' => ['bool', 'image'=>'GdImage', 'enable'=>'bool'],
 'imageantialias' => ['bool', 'image'=>'GdImage', 'enable'=>'bool'],
 'imagearc' => ['bool', 'image'=>'GdImage', 'center_x'=>'int', 'center_y'=>'int', 'width'=>'int', 'height'=>'int', 'start_angle'=>'int', 'end_angle'=>'int', 'color'=>'int'],
+'imageavif' => ['bool', 'image'=>'GdImage', 'file'=>'resource|string|null', 'quality'=>'int', 'speed'=>'int'],
 'imagebmp' => ['bool', 'image'=>'GdImage', 'file='=>'resource|string|null', 'compressed='=>'bool'],
 'imagechar' => ['bool', 'image'=>'GdImage', 'font'=>'int', 'x'=>'int', 'y'=>'int', 'char'=>'string', 'color'=>'int'],
 'imagecharup' => ['bool', 'image'=>'GdImage', 'font'=>'int', 'x'=>'int', 'y'=>'int', 'char'=>'string', 'color'=>'int'],

--- a/dictionaries/CallMap_81_delta.php
+++ b/dictionaries/CallMap_81_delta.php
@@ -19,7 +19,7 @@ return [
     'array_is_list' => ['bool', 'array' => 'array'],
     'fsync' => ['bool', 'stream' => 'resource'],
     'fdatasync' => ['bool', 'stream' => 'resource'],
-    'imageavif' => ['bool', 'image'=>'GdImage', 'file'=>'resource|string|null', 'quality'=>'int', 'speed'=>'int'],
+    'imageavif' => ['bool', 'image'=>'GdImage', 'file='=>'resource|string|null', 'quality='=>'int', 'speed='=>'int'],
     'imagecreatefromavif' => ['false|GdImage', 'filename'=>'string'],
     'mysqli_fetch_column' => ['null|int|float|string|false', 'result'=>'mysqli_result', 'column='=>'int'],
     'mysqli_result::fetch_column' => ['null|int|float|string|false', 'column='=>'int'],

--- a/dictionaries/CallMap_81_delta.php
+++ b/dictionaries/CallMap_81_delta.php
@@ -19,6 +19,7 @@ return [
     'array_is_list' => ['bool', 'array' => 'array'],
     'fsync' => ['bool', 'stream' => 'resource'],
     'fdatasync' => ['bool', 'stream' => 'resource'],
+    'imagecreatefromavif' => ['false|GdImage', 'filename'=>'string'],
     'mysqli_fetch_column' => ['null|int|float|string|false', 'result'=>'mysqli_result', 'column='=>'int'],
     'mysqli_result::fetch_column' => ['null|int|float|string|false', 'column='=>'int'],
   ],

--- a/dictionaries/CallMap_81_delta.php
+++ b/dictionaries/CallMap_81_delta.php
@@ -19,6 +19,7 @@ return [
     'array_is_list' => ['bool', 'array' => 'array'],
     'fsync' => ['bool', 'stream' => 'resource'],
     'fdatasync' => ['bool', 'stream' => 'resource'],
+    'imageavif' => ['bool', 'image'=>'GdImage', 'file'=>'resource|string|null', 'quality'=>'int', 'speed'=>'int'],
     'imagecreatefromavif' => ['false|GdImage', 'filename'=>'string'],
     'mysqli_fetch_column' => ['null|int|float|string|false', 'result'=>'mysqli_result', 'column='=>'int'],
     'mysqli_result::fetch_column' => ['null|int|float|string|false', 'column='=>'int'],


### PR DESCRIPTION
This PR adds the imagecreatefromavif() and imageavif() functions added in PHP 8.1 to the CallMap. This fixes #6415 