### PR TITLE
assert both sides of an equality

### DIFF
--- a/src/Psalm/Internal/Algebra.php
+++ b/src/Psalm/Internal/Algebra.php
@@ -90,6 +90,12 @@ class Algebra
     {
         $clause_count = count($clauses);
 
+        //65536 seems to be a significant threshold, when put at 65537, the code https://psalm.dev/r/216f362ea6 goes
+        //from seconds in analysis to many minutes
+        if ($clause_count > 65536) {
+            return [];
+        }
+
         if ($clause_count > 50) {
             $all_has_unknown = true;
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -3354,11 +3354,23 @@ class AssertionFinder
                 $source
             );
 
+            $other_var_name = ExpressionIdentifier::getArrayVarId(
+                $conditional->right,
+                $this_class_name,
+                $source
+            );
+
             $other_type = $source->node_data->getType($conditional->left);
             $var_type = $source->node_data->getType($conditional->right);
         } elseif ($typed_value_position === self::ASSIGNMENT_TO_LEFT) {
             $var_name = ExpressionIdentifier::getArrayVarId(
                 $conditional->right,
+                $this_class_name,
+                $source
+            );
+
+            $other_var_name = ExpressionIdentifier::getArrayVarId(
+                $conditional->left,
                 $this_class_name,
                 $source
             );
@@ -3382,6 +3394,14 @@ class AssertionFinder
                 $if_types[$var_name] = [['=' . $var_type->getAssertionString(true)]];
             } else {
                 $if_types[$var_name] = [['~' . $var_type->getAssertionString()]];
+            }
+
+            if ($other_var_name && $other_type && count($other_type->getAtomicTypes()) === 1) {
+                if ($identical) {
+                    $if_types[$other_var_name] = [['=' . $other_type->getAssertionString(true)]];
+                } else {
+                    $if_types[$other_var_name] = [['~' . $other_type->getAssertionString()]];
+                }
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -3396,6 +3396,8 @@ class AssertionFinder
                 $if_types[$var_name] = [['~' . $var_type->getAssertionString()]];
             }
 
+            // we count the Atomics instead of using isSingle because Psalm considers multiple literals as Single
+            // however, getAssertionString return the assertion for the first Atomic only
             if ($other_var_name && $other_type && count($other_type->getAtomicTypes()) === 1) {
                 if ($identical) {
                     $if_types[$other_var_name] = [['=' . $other_type->getAssertionString(true)]];

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2675,6 +2675,22 @@ class ConditionalTest extends \Psalm\Tests\TestCase
                     '$_a===' => '"N"|"Y"',
                 ]
             ],
+            'assertionsWorksBothWays' => [
+                '<?php
+                    $a = 2;
+                    $b = getPositiveInt();
+
+                    assert($a === $b);
+
+                    /** @return positive-int */
+                    function getPositiveInt(): int{
+                        return 2;
+                    }',
+                'assertions' => [
+                    '$a===' => '2',
+                    '$b===' => '2',
+                ]
+            ],
             'nullErasureWithSmallerAndGreater' => [
                 '<?php
                     function getIntOrNull(): ?int{return null;}


### PR DESCRIPTION
before this PR, 
`if($a === $b)` 
was making sure $a would be restricted with the type of $b but not the opposite.

This is not a big issue with simple types but with positive-int, int-ranges or more complex unions, it can become an issue. This PR makes sure the opposite assertion is made

I hit a bunch of walls and some weird pieces of code while doing this so the result is not optimal.
For example Union::getAssertionString() when applied to Unions with more than one Atomic just returns Atomic::getAssertionString() on the first Atomic from the Union. This has really weird effects because `stdClass|null` returns a `null` assertion that breaks things. Returning an empty string also breaks code so I had to resort to limiting this behaviour to Union with only one atomic