### PR TITLE
Always truthy conditions

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
@@ -242,7 +242,7 @@ class IfConditionalAnalyzer
                         // fall through
                     }
                 }
-            } elseif ($cond_type->isTrue()) {
+            } elseif ($cond_type->isAlwaysTruthy()) {
                 if ($cond_type->from_docblock) {
                     if (IssueBuffer::accepts(
                         new RedundantConditionGivenDocblockType(

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -284,7 +284,7 @@ class ClassLikeDocblockParser
                 ),
                 'start_offset' => $offset,
                 'end_offset' => $offset + strlen($imported_type_entry),
-                'parts' => CommentAnalyzer::splitDocLine($imported_type_entry) ?: []
+                'parts' => CommentAnalyzer::splitDocLine($imported_type_entry)
             ];
         }
 

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -2364,6 +2364,7 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
             }
         }
 
+        /** @psalm-suppress RedundantCondition can be empty after removing above */
         if ($existing_var_type->getAtomicTypes()) {
             return $existing_var_type;
         }

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -450,6 +450,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
             }
         }
 
+        /** @psalm-suppress RedundantCondition can be empty after removing above */
         if ($existing_var_type->getAtomicTypes()) {
             return $existing_var_type;
         }
@@ -516,6 +517,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
             }
         }
 
+        /** @psalm-suppress RedundantCondition can be empty after removing above */
         if ($existing_var_type->getAtomicTypes()) {
             return $existing_var_type;
         }
@@ -601,6 +603,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
             $existing_var_type->possibly_undefined = false;
             $existing_var_type->possibly_undefined_from_try = false;
 
+            /** @psalm-suppress RedundantCondition can be empty after removing above */
             if ($existing_var_type->getAtomicTypes()) {
                 return $existing_var_type;
             }
@@ -826,6 +829,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
             }
         }
 
+        /** @psalm-suppress RedundantCondition can be empty after removing above */
         if ($existing_var_type->getAtomicTypes()) {
             return $existing_var_type;
         }
@@ -1569,6 +1573,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
             }
         }
 
+        /** @psalm-suppress RedundantCondition can be empty after removing above */
         if ($existing_var_type->getAtomicTypes()) {
             return $existing_var_type;
         }

--- a/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
@@ -58,6 +58,7 @@ class TemplateStandinTypeReplacer
                 }
             }
 
+            /** @psalm-suppress RedundantCondition can be empty after removing above */
             if ($new_input_type->getAtomicTypes()) {
                 $input_type = $new_input_type;
             }


### PR DESCRIPTION
A few weeks ago we introduced alwaysTruthy and alwaysFalsy to Unions. Psalm flags correctly falsy conditions, but not truthy ones. This PR fixes that.

It did find a lot of cases in Psalm but except one, this was wrong phpdoc (I think on purpose). getAtomicTypes is declared as non-empty, but when you removeTypes from an Union, it can become empty.