### PR TITLE
Update return type for xdebug_get_profiler_filename()

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -15455,7 +15455,7 @@ return [
 'xdebug_get_function_stack' => ['array', 'message='=>'string', 'options='=>'int'],
 'xdebug_get_headers' => ['array'],
 'xdebug_get_monitored_functions' => ['array'],
-'xdebug_get_profiler_filename' => ['string'],
+'xdebug_get_profiler_filename' => ['string|false'],
 'xdebug_get_stack_depth' => ['int'],
 'xdebug_get_tracefile_name' => ['string'],
 'xdebug_is_debugger_active' => ['bool'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -16294,7 +16294,7 @@ return [
     'xdebug_get_function_stack' => ['array', 'message='=>'string', 'options='=>'int'],
     'xdebug_get_headers' => ['array'],
     'xdebug_get_monitored_functions' => ['array'],
-    'xdebug_get_profiler_filename' => ['string'],
+    'xdebug_get_profiler_filename' => ['string|false'],
     'xdebug_get_stack_depth' => ['int'],
     'xdebug_get_tracefile_name' => ['string'],
     'xdebug_is_debugger_active' => ['bool'],


### PR DESCRIPTION
Best I can tell this function was introduced in xdebug 2.0 and has had a return type of string|false from the beginning.

Fixes #6484