### PR TITLE
Catch ComplicatedExpressionException in ArrayFilterReturnTypeProvider

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -245,14 +245,18 @@ class ArrayFilterReturnTypeProvider implements \Psalm\Plugin\EventHandler\Functi
 
                         $cond_object_id = \spl_object_id($stmt->expr);
 
-                        $filter_clauses = \Psalm\Internal\Algebra\FormulaGenerator::getFormula(
-                            $cond_object_id,
-                            $cond_object_id,
-                            $stmt->expr,
-                            $context->self,
-                            $statements_source,
-                            $codebase
-                        );
+                        try {
+                            $filter_clauses = \Psalm\Internal\Algebra\FormulaGenerator::getFormula(
+                                $cond_object_id,
+                                $cond_object_id,
+                                $stmt->expr,
+                                $context->self,
+                                $statements_source,
+                                $codebase
+                            );
+                        } catch (\Psalm\Exception\ComplicatedExpressionException $e) {
+                            $filter_clauses = [];
+                        }
 
                         $assertions = \Psalm\Internal\Algebra::getTruthsFromFormula(
                             $filter_clauses,


### PR DESCRIPTION
Many errors like this happened:

```
Uncaught Exception: Psalm\Exception\ComplicatedExpressionException
Stack trace in the forked worker:
 #0 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Algebra.php(606): Psalm\Internal\Algebra::groupImpossibilities(Array)
 #1 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Algebra/FormulaGenerator.php(255): Psalm\Internal\Algebra::negateFormula(NULL)
 #2 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php(249): Psalm\Internal\Algebra\FormulaGenerator::getFormula(2818034, 2818034, Object(PhpParser\Node\Expr\BinaryOp\Identical), 'Guzzle\\Plugin\\C...', Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(Psalm\Codebase))
 #3 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php(159): Psalm\Internal\Provider\ReturnTypeProvider\ArrayFilterReturnTypeProvider::getFunctionReturnType(Object(Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent))
 #4 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php(59): Psalm\Internal\Provider\FunctionReturnTypeProvider->getReturnType(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), 'array_filter', Object(PhpParser\Node\Expr\FuncCall), Object(Psalm\Context), Object(Psalm\CodeLocation))
 #5 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php(197): Psalm\Internal\Analyzer\Statements\Expression\Call\FunctionCallReturnTypeFetcher::fetch(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(Psalm\Codebase), Object(PhpParser\Node\Expr\FuncCall), Object(PhpParser\Node\Name), 'array_filter', true, false, NULL, Object(Psalm\Type\Atomic\TCallable), Object(Psalm\Internal\Type\TemplateResult), Object(Psalm\Context))
 #6 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php(263): Psalm\Internal\Analyzer\Statements\Expression\Call\FunctionCallAnalyzer::analyze(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Expr\FuncCall), Object(Psalm\Context))
 #7 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php(43): Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer::handleExpression(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Expr\FuncCall), Object(Psalm\Context), false, NULL, false)
 #8 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php(200): Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer::analyze(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Expr\FuncCall), Object(Psalm\Context))
 #9 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php(149): Psalm\Internal\Analyzer\Statements\Expression\Call\ArgumentsAnalyzer::analyze(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Array, Array, 'array_values', true, Object(Psalm\Context))
 #10 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php(263): Psalm\Internal\Analyzer\Statements\Expression\Call\FunctionCallAnalyzer::analyze(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Expr\FuncCall), Object(Psalm\Context))
 #11 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php(43): Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer::handleExpression(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Expr\FuncCall), Object(Psalm\Context), false, NULL, false)
 #12 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php(144): Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer::analyze(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Expr\FuncCall), Object(Psalm\Context))
 #13 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php(517): Psalm\Internal\Analyzer\Statements\ReturnAnalyzer::analyze(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Stmt\Return_), Object(Psalm\Context))
 #14 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php(185): Psalm\Internal\Analyzer\StatementsAnalyzer::analyzeStatement(Object(Psalm\Internal\Analyzer\StatementsAnalyzer), Object(PhpParser\Node\Stmt\Return_), Object(Psalm\Context), Object(Psalm\Context))
 #15 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php(433): Psalm\Internal\Analyzer\StatementsAnalyzer->analyze(Array, Object(Psalm\Context), Object(Psalm\Context), true)
 #16 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ClassAnalyzer.php(1782): Psalm\Internal\Analyzer\FunctionLikeAnalyzer->analyze(Object(Psalm\Context), Object(Psalm\Internal\Provider\NodeDataProvider), Object(Psalm\Context))
 #17 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ClassAnalyzer.php(404): Psalm\Internal\Analyzer\ClassAnalyzer->analyzeClassMethod(Object(PhpParser\Node\Stmt\ClassMethod), Object(Psalm\Storage\ClassLikeStorage), Object(Psalm\Internal\Analyzer\ClassAnalyzer), Object(Psalm\Context), Object(Psalm\Context))
 #18 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/FileAnalyzer.php(214): Psalm\Internal\Analyzer\ClassAnalyzer->analyze(Object(Psalm\Context), Object(Psalm\Context))
 #19 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Analyzer.php(348): Psalm\Internal\Analyzer\FileAnalyzer->analyze(NULL)
 #20 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Fork/Pool.php(194): Psalm\Internal\Codebase\Analyzer->Psalm\Internal\Codebase\{closure}(369, '/Users/morris/P...')
 #21 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Analyzer.php(414): Psalm\Internal\Fork\Pool->__construct(Array, Object(Closure), Object(Closure), Object(Closure), Object(Closure))
 #22 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Analyzer.php(277): Psalm\Internal\Codebase\Analyzer->doAnalysis(Object(Psalm\Internal\Analyzer\ProjectAnalyzer), 7)
 #23 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php(640): Psalm\Internal\Codebase\Analyzer->analyzeFiles(Object(Psalm\Internal\Analyzer\ProjectAnalyzer), 7, false, true)
 #24 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Cli/Psalm.php(359): Psalm\Internal\Analyzer\ProjectAnalyzer->check('/Users/morris/P...', true)
 #25 /Users/morris/Projects/abc/vendor/vimeo/psalm/psalm(4): Psalm\Internal\Cli\Psalm::run(Array)
 #26 {main} in /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Fork/Pool.php:366
Stack trace:
 #0 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Fork/Pool.php(400): Psalm\Internal\Fork\Pool->readResultsFromChildren()
 #1 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Analyzer.php(488): Psalm\Internal\Fork\Pool->wait()
 #2 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Analyzer.php(277): Psalm\Internal\Codebase\Analyzer->doAnalysis(Object(Psalm\Internal\Analyzer\ProjectAnalyzer), 7)
 #3 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php(640): Psalm\Internal\Codebase\Analyzer->analyzeFiles(Object(Psalm\Internal\Analyzer\ProjectAnalyzer), 7, false, true)
 #4 /Users/morris/Projects/abc/vendor/vimeo/psalm/src/Psalm/Internal/Cli/Psalm.php(359): Psalm\Internal\Analyzer\ProjectAnalyzer->check('/Users/morris/P...', true)
 #5 /Users/morris/Projects/abc/vendor/vimeo/psalm/psalm(4): Psalm\Internal\Cli\Psalm::run(Array)
 #6 {main}
(Psalm 4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa crashed due to an uncaught Throwable)
```

This change catches the exception and just omits the results here.

Disclaimer: I just added the code like @orklah said in https://github.com/vimeo/psalm/pull/6489#issuecomment-921057199  without fully understanding the impact of that. Is it okay to just omit the results? Or should there be a warning/error added to that code part?

Ref #6489