### PR TITLE
limit PHPParser to 4.12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "felixfbecker/advanced-json-rpc": "^3.0.3",
         "felixfbecker/language-server-protocol": "^1.5",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-        "nikic/php-parser": "^4.12",
+        "nikic/php-parser": "4.12.*",
         "openlss/lib-array2xml": "^1.0",
         "sebastian/diff": "^3.0 || ^4.0",
         "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0",


### PR DESCRIPTION
PHPParser just release a 4.13 version, supporting PHP 8.1.

It introduce a new type that must be handled (IntersectionType) and it also change functionLike arguments from `list<Arg>` to  `listArg|VariadicPlaceholder`.

This makes the build fail (and I ignore how Psalm itself will react in presence of those new features).

I tried to make the build pass without trying to support feature but it proved a bigger task than I thought so this PR is just designed to get a working build again