### PR TITLE
Add support for advanced IssueHandler in plugins

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -125,7 +125,6 @@
                 <referencedMethod name="Psalm\Codebase::createClassLikeStorage"/>
                 <referencedMethod name="Psalm\Codebase::isVariadic"/>
                 <referencedMethod name="Psalm\Codebase::getMethodReturnsByRef"/>
-                <referencedMethod name="Psalm\Config::setAdvancedErrorLevel"/>
             </errorLevel>
         </PossiblyUnusedMethod>
 

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -125,6 +125,7 @@
                 <referencedMethod name="Psalm\Codebase::createClassLikeStorage"/>
                 <referencedMethod name="Psalm\Codebase::isVariadic"/>
                 <referencedMethod name="Psalm\Codebase::getMethodReturnsByRef"/>
+                <referencedMethod name="Psalm\Config::setAdvancedErrorLevel"/>
             </errorLevel>
         </PossiblyUnusedMethod>
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1169,6 +1169,12 @@ class Config
         $this->composer_class_loader = $loader;
     }
 
+    public function setAdvancedErrorLevel(string $issue_key, array $config): void
+    {
+        $this->issue_handlers[$issue_key] = new IssueHandler();
+        $this->issue_handlers[$issue_key]->setCustomLevels($config, $this->base_dir);
+    }
+
     public function setCustomErrorLevel(string $issue_key, string $error_level): void
     {
         $this->issue_handlers[$issue_key] = new IssueHandler();

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1169,9 +1169,12 @@ class Config
         $this->composer_class_loader = $loader;
     }
 
-    public function setAdvancedErrorLevel(string $issue_key, array $config): void
+    public function setAdvancedErrorLevel(string $issue_key, array $config, ?string $default_error_level = null): void
     {
         $this->issue_handlers[$issue_key] = new IssueHandler();
+        if ($default_error_level !== null) {
+            $this->issue_handlers[$issue_key]->setErrorLevel($default_error_level);
+        }
         $this->issue_handlers[$issue_key]->setCustomLevels($config, $this->base_dir);
     }
 

--- a/src/Psalm/Config/ErrorLevelFileFilter.php
+++ b/src/Psalm/Config/ErrorLevelFileFilter.php
@@ -15,6 +15,29 @@ class ErrorLevelFileFilter extends FileFilter
     /**
      * @return static
      */
+    public static function loadFromArray(
+        array $config,
+        string $base_dir,
+        bool $inclusive
+    ): ErrorLevelFileFilter {
+        $filter = parent::loadFromArray($config, $base_dir, $inclusive);
+
+        if (isset($config['type'])) {
+            $filter->error_level = (string) $config['type'];
+
+            if (!in_array($filter->error_level, \Psalm\Config::$ERROR_LEVELS, true)) {
+                throw new \Psalm\Exception\ConfigException('Unexpected error level ' . $filter->error_level);
+            }
+        } else {
+            throw new \Psalm\Exception\ConfigException('<type> element expects a level');
+        }
+
+        return $filter;
+    }
+
+    /**
+     * @return static
+     */
     public static function loadFromXMLElement(
         SimpleXMLElement $e,
         string $base_dir,

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -398,7 +398,7 @@ class FileFilter
                 $config['referencedVariable'][]['name'] = strtolower((string)$referenced_variable['name']);
             }
         }
-        var_dump($config);
+
         return static::loadFromArray($config, $base_dir, $inclusive);
     }
 

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -103,9 +103,10 @@ class FileFilter
 
         $filter = new static($inclusive);
 
-        if (is_iterable($config['directory'] ?? false)) {
+        if (isset($config['directory']) && is_iterable($config['directory'])) {
+            /** @var array $directory */
             foreach ($config['directory'] as $directory) {
-                $directory_path = (string) $directory['name'] ?? '';
+                $directory_path = (string) ($directory['name'] ?? '');
                 $ignore_type_stats = strtolower(
                         isset($directory['ignoreTypeStats']) ? (string) $directory['ignoreTypeStats'] : ''
                     ) === 'true';
@@ -170,13 +171,13 @@ class FileFilter
 
                     throw new ConfigException(
                         'Could not resolve config path to ' . $base_dir
-                        . DIRECTORY_SEPARATOR . (string)$directory['name']
+                        . DIRECTORY_SEPARATOR . $directory_path
                     );
                 }
 
                 if (!is_dir($directory_path)) {
                     throw new ConfigException(
-                        $base_dir . DIRECTORY_SEPARATOR . (string)$directory['name']
+                        $base_dir . DIRECTORY_SEPARATOR . $directory_path
                         . ' is not a directory'
                     );
                 }
@@ -219,9 +220,10 @@ class FileFilter
             }
         }
 
-        if (is_iterable($config['file'] ?? false)) {
+        if (isset($config['file']) && is_iterable($config['file'])) {
+            /** @var array $file */
             foreach ($config['file'] as $file) {
-                $file_path = (string) $file['name'] ?? '';
+                $file_path = (string) ($file['name'] ?? '');
 
                 if ($file_path[0] === '/' && DIRECTORY_SEPARATOR === '/') {
                     $prospective_file_path = $file_path;
@@ -274,9 +276,10 @@ class FileFilter
             }
         }
 
-        if (is_iterable($config['referencedClass'] ?? false)) {
+        if (isset($config['referencedClass']) && is_iterable($config['referencedClass'])) {
+            /** @var array $referenced_class */
             foreach ($config['referencedClass'] as $referenced_class) {
-                $class_name = strtolower((string)$referenced_class['name'] ?? '');
+                $class_name = strtolower((string) ($referenced_class['name'] ?? ''));
 
                 if (strpos($class_name, '*') !== false) {
                     $regex = '/' . \str_replace('*', '.*', str_replace('\\', '\\\\', $class_name)) . '/i';
@@ -287,9 +290,10 @@ class FileFilter
             }
         }
 
-        if (is_iterable($config['referencedMethod'] ?? false)) {
+        if (isset($config['referencedMethod']) && is_iterable($config['referencedMethod'])) {
+            /** @var array $referenced_method */
             foreach ($config['referencedMethod'] as $referenced_method) {
-                $method_id = (string)$referenced_method['name'] ?? '';
+                $method_id = (string) ($referenced_method['name'] ?? '');
 
                 if (!preg_match('/^[^:]+::[^:]+$/', $method_id) && !static::isRegularExpression($method_id)) {
                     throw new ConfigException(
@@ -301,21 +305,24 @@ class FileFilter
             }
         }
 
-        if (is_iterable($config['referencedFunction'] ?? false)) {
+        if (isset($config['referencedFunction']) && is_iterable($config['referencedFunction'])) {
+            /** @var array $referenced_function */
             foreach ($config['referencedFunction'] as $referenced_function) {
-                $filter->method_ids[] = strtolower((string)$referenced_function['name'] ?? '');
+                $filter->method_ids[] = strtolower((string) ($referenced_function['name'] ?? ''));
             }
         }
 
-        if (is_iterable($config['referencedProperty'] ?? false)) {
+        if (isset($config['referencedProperty']) && is_iterable($config['referencedProperty'])) {
+            /** @var array $referenced_property */
             foreach ($config['referencedProperty'] as $referenced_property) {
-                $filter->property_ids[] = strtolower((string)$referenced_property['name'] ?? '');
+                $filter->property_ids[] = strtolower((string) ($referenced_property['name'] ?? ''));
             }
         }
 
-        if (is_iterable($config['referencedVariable'] ?? false)) {
+        if (isset($config['referencedVariable']) && is_iterable($config['referencedVariable'])) {
+            /** @var array $referenced_variable */
             foreach ($config['referencedVariable'] as $referenced_variable) {
-                $filter->var_names[] = strtolower((string)$referenced_variable['name'] ?? '');
+                $filter->var_names[] = strtolower((string) ($referenced_variable['name'] ?? ''));
             }
         }
 

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -399,7 +399,7 @@ class FileFilter
             }
         }
 
-        return static::loadFromArray($config, $base_dir, $inclusive);
+        return self::loadFromArray($config, $base_dir, $inclusive);
     }
 
     private static function isRegularExpression(string $string) : bool

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -10,6 +10,7 @@ use function explode;
 use function glob;
 use function in_array;
 use function is_dir;
+use function is_iterable;
 use function preg_match;
 use function preg_replace;
 use function readlink;
@@ -108,11 +109,11 @@ class FileFilter
             foreach ($config['directory'] as $directory) {
                 $directory_path = (string) ($directory['name'] ?? '');
                 $ignore_type_stats = strtolower(
-                        isset($directory['ignoreTypeStats']) ? (string) $directory['ignoreTypeStats'] : ''
-                    ) === 'true';
+                    isset($directory['ignoreTypeStats']) ? (string) $directory['ignoreTypeStats'] : ''
+                ) === 'true';
                 $declare_strict_types = strtolower(
-                        isset($directory['useStrictTypes']) ? (string) $directory['useStrictTypes'] : ''
-                    ) === 'true';
+                    isset($directory['useStrictTypes']) ? (string) $directory['useStrictTypes'] : ''
+                ) === 'true';
 
                 if ($directory_path[0] === '/' && DIRECTORY_SEPARATOR === '/') {
                     $prospective_directory_path = $directory_path;
@@ -347,8 +348,8 @@ class FileFilter
                 $config['directory'][] = [
                     'name' => (string) $directory['name'],
                     'ignoreTypeStats' => strtolower(
-                            isset($directory['ignoreTypeStats']) ? (string) $directory['ignoreTypeStats'] : ''
-                        ) === 'true',
+                        isset($directory['ignoreTypeStats']) ? (string) $directory['ignoreTypeStats'] : ''
+                    ) === 'true',
 
                     'useStrictTypes' => strtolower(
                         isset($directory['useStrictTypes']) ? (string) $directory['useStrictTypes'] : ''

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -45,6 +45,13 @@ class IssueHandler
         return $handler;
     }
 
+    public function setCustomLevels(array $customLevels, string $base_dir): void
+    {
+        foreach ($customLevels as $customLevel) {
+            $this->custom_levels[] = ErrorLevelFileFilter::loadFromArray($customLevel, $base_dir, true);
+        }
+    }
+
     public function setErrorLevel(string $error_level): void
     {
         if (!in_array($error_level, \Psalm\Config::$ERROR_LEVELS, true)) {

--- a/src/Psalm/Config/IssueHandler.php
+++ b/src/Psalm/Config/IssueHandler.php
@@ -47,6 +47,7 @@ class IssueHandler
 
     public function setCustomLevels(array $customLevels, string $base_dir): void
     {
+        /** @var array $customLevel */
         foreach ($customLevels as $customLevel) {
             $this->custom_levels[] = ErrorLevelFileFilter::loadFromArray($customLevel, $base_dir, true);
         }


### PR DESCRIPTION
Currently a plugin can only define a basic IssueHandler with the Config::setCustomErrorLevel() method.
This pull request add the new Config::setAdvancedErrorLevel() method to be able to define any kind of IssueHandler.

To be able to implement this feature, this pull request also add methods to create FileFilters from an array instead of an XMLElement. The current configuration is highly coupled with XML.  In the future is may be a good idea to reduce this coupling.

Usage example:

```php
Config::getInstance()->setAdvancedErrorLevel('PossiblyUndefinedMethod', [[
            'type' => 'suppress',
            'directory' => [['name' => 'tests']]
        ]]);
```

Tested manually in a project.
I wanted to add some unit tests, but it looks like no test really exist for the `setCustomErrorLevel` method and all `FileFilter` classes. As I'm not familiar with type of test used in Psalm, so I didn't add anything. Don't hesitate if you have suggestions about this.