### PR TITLE
Show file and line in case of an exception in a forked worker

### DIFF
--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -220,8 +220,10 @@ class Pool
             // This can happen when developing Psalm from source without running `composer update`,
             // or because of rare bugs in Psalm.
             $process_done_message = new ForkProcessErrorMessage(
-                get_class($t) . " " . $t->getMessage()
-                . "\nStack trace in the forked worker:\n". $t->getTraceAsString()
+                get_class($t) . ' ' . $t->getMessage() . "\n" .
+                "Emitted in " . $t->getFile() . ":" . $t->getLine() . "\n" .
+                "Stack trace in the forked worker:\n" .
+                $t->getTraceAsString()
             );
         }
 


### PR DESCRIPTION
Before:

```
$ vendor/bin/psalm --set-baseline=psalm-baseline.xml --memory-limit=32G
Scanning files...
Analyzing files...

Uncaught Exception: UnexpectedValueException $storage should not be null for DeepCopy\TypeFilter\Spl\SplDoublyLinkedList::apply
Stack trace in the forked worker:
#0 /Users/morris/Projects/ABC/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ClassAnalyzer.php(1856): Psalm\Internal\Codebase\Methods->getStorage(Object(Psalm\Internal\MethodIdentifier))
...
(Psalm 4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa crashed due to an uncaught Throwable)
```

After:

```
$ vendor/bin/psalm --set-baseline=psalm-baseline.xml --memory-limit=32G
Scanning files...
Analyzing files...

Uncaught Exception: UnexpectedValueException $storage should not be null for DeepCopy\TypeFilter\Spl\SplDoublyLinkedList::apply
Emitted in /Users/morris/Projects/ABC/vendor/vimeo/psalm/src/Psalm/Internal/Codebase/Methods.php:1175
Stack trace in the forked worker:
#0 /Users/morris/Projects/ABC/vendor/vimeo/psalm/src/Psalm/Internal/Analyzer/ClassAnalyzer.php(1856): Psalm\Internal\Codebase\Methods->getStorage(Object(Psalm\Internal\MethodIdentifier))
...
(Psalm 4.10.0@916b098b008f6de4543892b1e0651c1c3b92cbfa crashed due to an uncaught Throwable)
```

It helped here to debug issues in my setup.