### PR TITLE
fix build

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2112,7 +2112,6 @@ class Config
             return null;
         }
 
-        /** @var array<string, array<int, string>> */
         $psr4_prefixes = $this->composer_class_loader->getPrefixesPsr4();
 
         // PSR-4 lookup

--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -1,5 +1,5 @@
 <?php
-namespace Psalm\Tests\Internal;
+namespace Psalm\Tests\Internal\Codebase;
 
 use Psalm\Internal\Codebase\InternalCallMapHandler;
 


### PR DESCRIPTION
This fixes a build error about a redundant @var since Composer added some detailed annotation to their internal code. It also fixes an issue in namespaces in tests

ref: https://github.com/composer/composer/blame/master/src/Composer/Autoload/ClassLoader.php#L125