### PR TITLE
Combine types with null argument

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1539,13 +1539,11 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         $suggested_type = $property_storage->suggested_type;
 
         if (isset($this->inferred_property_types[$property_name])) {
-            $suggested_type = $suggested_type
-                ? Type::combineUnionTypes(
-                    $suggested_type,
-                    $this->inferred_property_types[$property_name],
-                    $codebase
-                )
-                : $this->inferred_property_types[$property_name];
+            $suggested_type = Type::combineUnionTypes(
+                $suggested_type,
+                $this->inferred_property_types[$property_name] ?? null,
+                $codebase
+            );
         }
 
         if ($suggested_type && !$property_storage->has_default && $property_storage->is_static) {

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -243,17 +243,8 @@ class ReturnTypeCollector
             if ($type instanceof Type\Atomic\TArray) {
                 [$key_type_param, $value_type_param] = $type->type_params;
 
-                if (!$key_type) {
-                    $key_type = clone $key_type_param;
-                } else {
-                    $key_type = Type::combineUnionTypes($key_type_param, $key_type);
-                }
-
-                if (!$value_type) {
-                    $value_type = clone $value_type_param;
-                } else {
-                    $value_type = Type::combineUnionTypes($value_type_param, $value_type);
-                }
+                $key_type = Type::combineUnionTypes(clone $key_type_param, $key_type);
+                $value_type = Type::combineUnionTypes(clone $value_type_param, $value_type);
             } elseif ($type instanceof Type\Atomic\TIterable
                 || $type instanceof Type\Atomic\TNamedObject
             ) {

--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -456,19 +456,11 @@ class ForeachAnalyzer
                     $always_non_empty_array = false;
                 }
 
-                if (!$value_type) {
-                    $value_type = clone $iterator_atomic_type->type_params[1];
-                } else {
-                    $value_type = Type::combineUnionTypes($value_type, $iterator_atomic_type->type_params[1]);
-                }
+                $value_type = Type::combineUnionTypes($value_type, clone $iterator_atomic_type->type_params[1]);
 
                 $key_type_part = $iterator_atomic_type->type_params[0];
 
-                if (!$key_type) {
-                    $key_type = $key_type_part;
-                } else {
-                    $key_type = Type::combineUnionTypes($key_type, $key_type_part);
-                }
+                $key_type = Type::combineUnionTypes($key_type, $key_type_part);
 
                 ArrayFetchAnalyzer::taintArrayFetch(
                     $statements_analyzer,
@@ -573,17 +565,8 @@ class ForeachAnalyzer
                     throw new \UnexpectedValueException('Should not happen');
                 }
 
-                if (!$value_type) {
-                    $value_type = $intersection_value_type;
-                } else {
-                    $value_type = Type::combineUnionTypes($value_type, $intersection_value_type);
-                }
-
-                if (!$key_type) {
-                    $key_type = $intersection_key_type;
-                } else {
-                    $key_type = Type::combineUnionTypes($key_type, $intersection_key_type);
-                }
+                $value_type = Type::combineUnionTypes($value_type, $intersection_value_type);
+                $key_type = Type::combineUnionTypes($key_type, $intersection_key_type);
 
                 ArrayFetchAnalyzer::taintArrayFetch(
                     $statements_analyzer,
@@ -755,23 +738,15 @@ class ForeachAnalyzer
             if ($iterator_atomic_type instanceof Type\Atomic\TNamedObject
                 && strtolower($iterator_atomic_type->value) === 'simplexmlelement'
             ) {
-                if ($value_type) {
-                    $value_type = Type::combineUnionTypes(
-                        $value_type,
-                        new Type\Union([clone $iterator_atomic_type])
-                    );
-                } else {
-                    $value_type = new Type\Union([clone $iterator_atomic_type]);
-                }
+                $value_type = Type::combineUnionTypes(
+                    $value_type,
+                    new Type\Union([clone $iterator_atomic_type])
+                );
 
-                if ($key_type) {
-                    $key_type = Type::combineUnionTypes(
-                        $key_type,
-                        Type::getString()
-                    );
-                } else {
-                    $key_type = Type::getString();
-                }
+                $key_type = Type::combineUnionTypes(
+                    $key_type,
+                    Type::getString()
+                );
             }
 
             if ($iterator_atomic_type instanceof Type\Atomic\TIterable
@@ -914,17 +889,8 @@ class ForeachAnalyzer
                                 break;
                             }
 
-                            if (!$key_type) {
-                                $key_type = $key_type_part;
-                            } else {
-                                $key_type = Type::combineUnionTypes($key_type, $key_type_part);
-                            }
-
-                            if (!$value_type) {
-                                $value_type = $value_type_part;
-                            } else {
-                                $value_type = Type::combineUnionTypes($value_type, $value_type_part);
-                            }
+                            $key_type = Type::combineUnionTypes($key_type, $key_type_part);
+                            $value_type = Type::combineUnionTypes($value_type, $value_type_part);
                         }
                     }
                 } elseif ($codebase->classImplements(
@@ -954,19 +920,11 @@ class ForeachAnalyzer
                     );
 
                     if ($iterator_value_type && !$iterator_value_type->isMixed()) {
-                        if (!$value_type) {
-                            $value_type = $iterator_value_type;
-                        } else {
-                            $value_type = Type::combineUnionTypes($value_type, $iterator_value_type);
-                        }
+                        $value_type = Type::combineUnionTypes($value_type, $iterator_value_type);
                     }
 
                     if ($iterator_key_type && !$iterator_key_type->isMixed()) {
-                        if (!$key_type) {
-                            $key_type = $iterator_key_type;
-                        } else {
-                            $key_type = Type::combineUnionTypes($key_type, $iterator_key_type);
-                        }
+                        $key_type = Type::combineUnionTypes($key_type, $iterator_key_type);
                     }
                 }
 
@@ -998,21 +956,9 @@ class ForeachAnalyzer
             || ($iterator_atomic_type instanceof Type\Atomic\TGenericObject
                 && strtolower($iterator_atomic_type->value) === 'traversable')
         ) {
-            $value_type_part = $iterator_atomic_type->type_params[1];
+            $value_type = Type::combineUnionTypes($value_type, $iterator_atomic_type->type_params[1]);
+            $key_type = Type::combineUnionTypes($key_type, $iterator_atomic_type->type_params[0]);
 
-            if (!$value_type) {
-                $value_type = $value_type_part;
-            } else {
-                $value_type = Type::combineUnionTypes($value_type, $value_type_part);
-            }
-
-            $key_type_part = $iterator_atomic_type->type_params[0];
-
-            if (!$key_type) {
-                $key_type = $key_type_part;
-            } else {
-                $key_type = Type::combineUnionTypes($key_type, $key_type_part);
-            }
             return;
         }
 
@@ -1162,14 +1108,10 @@ class ForeachAnalyzer
 
             foreach ($extended_type->getAtomicTypes() as $extended_atomic_type) {
                 if (!$extended_atomic_type instanceof Type\Atomic\TTemplateParam) {
-                    if (!$return_type) {
-                        $return_type = $extended_type;
-                    } else {
-                        $return_type = Type::combineUnionTypes(
-                            $return_type,
-                            $extended_type
-                        );
-                    }
+                    $return_type = Type::combineUnionTypes(
+                        $return_type,
+                        $extended_type
+                    );
 
                     continue;
                 }
@@ -1184,14 +1126,10 @@ class ForeachAnalyzer
                 );
 
                 if ($candidate_type) {
-                    if (!$return_type) {
-                        $return_type = $candidate_type;
-                    } else {
-                        $return_type = Type::combineUnionTypes(
-                            $return_type,
-                            $candidate_type
-                        );
-                    }
+                    $return_type = Type::combineUnionTypes(
+                        $return_type,
+                        $candidate_type
+                    );
                 }
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
@@ -517,15 +517,11 @@ class IfAnalyzer
             }
 
             foreach ($possibly_redefined_vars as $var => $type) {
-                if (isset($if_scope->possibly_redefined_vars[$var])) {
-                    $if_scope->possibly_redefined_vars[$var] = Type::combineUnionTypes(
-                        $type,
-                        $if_scope->possibly_redefined_vars[$var],
-                        $codebase
-                    );
-                } else {
-                    $if_scope->possibly_redefined_vars[$var] = $type;
-                }
+                $if_scope->possibly_redefined_vars[$var] = Type::combineUnionTypes(
+                    $type,
+                    $if_scope->possibly_redefined_vars[$var] ?? null,
+                    $codebase
+                );
             }
         }
     }

--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
@@ -519,14 +519,10 @@ class SwitchCaseAnalyzer
             } else {
                 foreach ($case_scope->break_vars as $var_id => $type) {
                     if (isset($context->vars_in_scope[$var_id])) {
-                        if (!isset($switch_scope->possibly_redefined_vars[$var_id])) {
-                            $switch_scope->possibly_redefined_vars[$var_id] = clone $type;
-                        } else {
-                            $switch_scope->possibly_redefined_vars[$var_id] = Type::combineUnionTypes(
-                                clone $type,
-                                $switch_scope->possibly_redefined_vars[$var_id]
-                            );
-                        }
+                        $switch_scope->possibly_redefined_vars[$var_id] = Type::combineUnionTypes(
+                            clone $type,
+                            $switch_scope->possibly_redefined_vars[$var_id] ?? null
+                        );
                     }
                 }
             }
@@ -618,14 +614,10 @@ class SwitchCaseAnalyzer
                 $switch_scope->possibly_redefined_vars = $case_redefined_vars;
             } else {
                 foreach ($case_redefined_vars as $var_id => $type) {
-                    if (!isset($switch_scope->possibly_redefined_vars[$var_id])) {
-                        $switch_scope->possibly_redefined_vars[$var_id] = clone $type;
-                    } else {
-                        $switch_scope->possibly_redefined_vars[$var_id] = Type::combineUnionTypes(
-                            clone $type,
-                            $switch_scope->possibly_redefined_vars[$var_id]
-                        );
-                    }
+                    $switch_scope->possibly_redefined_vars[$var_id] = Type::combineUnionTypes(
+                        clone $type,
+                        $switch_scope->possibly_redefined_vars[$var_id] ?? null
+                    );
                 }
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/TryAnalyzer.php
@@ -89,17 +89,11 @@ class TryAnalyzer
 
         if ($try_context->finally_scope) {
             foreach ($context->vars_in_scope as $var_id => $type) {
-                if (isset($try_context->finally_scope->vars_in_scope[$var_id])) {
-                    if ($try_context->finally_scope->vars_in_scope[$var_id] !== $type) {
-                        $try_context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
-                            $try_context->finally_scope->vars_in_scope[$var_id],
-                            $type,
-                            $statements_analyzer->getCodebase()
-                        );
-                    }
-                } else {
-                    $try_context->finally_scope->vars_in_scope[$var_id] = $type;
-                }
+                $try_context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
+                    $try_context->finally_scope->vars_in_scope[$var_id] ?? null,
+                    $type,
+                    $statements_analyzer->getCodebase()
+                );
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/BreakAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/BreakAnalyzer.php
@@ -39,28 +39,20 @@ class BreakAnalyzer
                 $loop_scope->possibly_redefined_loop_parent_vars = $redefined_vars;
             } else {
                 foreach ($redefined_vars as $var => $type) {
-                    if (isset($loop_scope->possibly_redefined_loop_parent_vars[$var])) {
-                        $loop_scope->possibly_redefined_loop_parent_vars[$var] = Type::combineUnionTypes(
-                            $type,
-                            $loop_scope->possibly_redefined_loop_parent_vars[$var]
-                        );
-                    } else {
-                        $loop_scope->possibly_redefined_loop_parent_vars[$var] = $type;
-                    }
+                    $loop_scope->possibly_redefined_loop_parent_vars[$var] = Type::combineUnionTypes(
+                        $type,
+                        $loop_scope->possibly_redefined_loop_parent_vars[$var] ?? null
+                    );
                 }
             }
 
             if ($loop_scope->iteration_count === 0) {
                 foreach ($context->vars_in_scope as $var_id => $type) {
                     if (!isset($loop_scope->loop_parent_context->vars_in_scope[$var_id])) {
-                        if (isset($loop_scope->possibly_defined_loop_parent_vars[$var_id])) {
-                            $loop_scope->possibly_defined_loop_parent_vars[$var_id] = Type::combineUnionTypes(
-                                $type,
-                                $loop_scope->possibly_defined_loop_parent_vars[$var_id]
-                            );
-                        } else {
-                            $loop_scope->possibly_defined_loop_parent_vars[$var_id] = $type;
-                        }
+                        $loop_scope->possibly_defined_loop_parent_vars[$var_id] = Type::combineUnionTypes(
+                            $type,
+                            $loop_scope->possibly_defined_loop_parent_vars[$var_id] ?? null
+                        );
                     }
                 }
             }
@@ -68,13 +60,11 @@ class BreakAnalyzer
             if ($context->finally_scope) {
                 foreach ($context->vars_in_scope as $var_id => $type) {
                     if (isset($context->finally_scope->vars_in_scope[$var_id])) {
-                        if ($context->finally_scope->vars_in_scope[$var_id] !== $type) {
-                            $context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
-                                $context->finally_scope->vars_in_scope[$var_id],
-                                $type,
-                                $statements_analyzer->getCodebase()
-                            );
-                        }
+                        $context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
+                            $context->finally_scope->vars_in_scope[$var_id],
+                            $type,
+                            $statements_analyzer->getCodebase()
+                        );
                     } else {
                         $context->finally_scope->vars_in_scope[$var_id] = $type;
                         $type->possibly_undefined = true;
@@ -92,14 +82,10 @@ class BreakAnalyzer
                         $case_scope->break_vars = [];
                     }
 
-                    if (isset($case_scope->break_vars[$var_id])) {
-                        $case_scope->break_vars[$var_id] = Type::combineUnionTypes(
-                            $type,
-                            $case_scope->break_vars[$var_id]
-                        );
-                    } else {
-                        $case_scope->break_vars[$var_id] = $type;
-                    }
+                    $case_scope->break_vars[$var_id] = Type::combineUnionTypes(
+                        $type,
+                        $case_scope->break_vars[$var_id] ?? null
+                    );
                 }
             }
         }

--- a/src/Psalm/Internal/Analyzer/Statements/ContinueAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ContinueAnalyzer.php
@@ -72,26 +72,20 @@ class ContinueAnalyzer
             }
 
             foreach ($redefined_vars as $var => $type) {
-                if (isset($loop_scope->possibly_redefined_loop_vars[$var])) {
-                    $loop_scope->possibly_redefined_loop_vars[$var] = Type::combineUnionTypes(
-                        $type,
-                        $loop_scope->possibly_redefined_loop_vars[$var]
-                    );
-                } else {
-                    $loop_scope->possibly_redefined_loop_vars[$var] = $type;
-                }
+                $loop_scope->possibly_redefined_loop_vars[$var] = Type::combineUnionTypes(
+                    $type,
+                    $loop_scope->possibly_redefined_loop_vars[$var] ?? null
+                );
             }
 
             if ($context->finally_scope) {
                 foreach ($context->vars_in_scope as $var_id => $type) {
                     if (isset($context->finally_scope->vars_in_scope[$var_id])) {
-                        if ($context->finally_scope->vars_in_scope[$var_id] !== $type) {
-                            $context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
-                                $context->finally_scope->vars_in_scope[$var_id],
-                                $type,
-                                $statements_analyzer->getCodebase()
-                            );
-                        }
+                        $context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
+                            $context->finally_scope->vars_in_scope[$var_id],
+                            $type,
+                            $statements_analyzer->getCodebase()
+                        );
                     } else {
                         $context->finally_scope->vars_in_scope[$var_id] = $type;
                         $type->possibly_undefined = true;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -1330,14 +1330,10 @@ class InstancePropertyAssignmentAnalyzer
             if ($lhs_var_id === '$this'
                 && $source_analyzer instanceof ClassAnalyzer
             ) {
-                if (isset($source_analyzer->inferred_property_types[$prop_name])) {
-                    $source_analyzer->inferred_property_types[$prop_name] = Type::combineUnionTypes(
-                        $assignment_value_type,
-                        $source_analyzer->inferred_property_types[$prop_name]
-                    );
-                } else {
-                    $source_analyzer->inferred_property_types[$prop_name] = $assignment_value_type;
-                }
+                $source_analyzer->inferred_property_types[$prop_name] = Type::combineUnionTypes(
+                    $assignment_value_type,
+                    $source_analyzer->inferred_property_types[$prop_name] ?? null
+                );
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
@@ -206,14 +206,10 @@ class StaticPropertyAssignmentAnalyzer
                 if ($source_analyzer instanceof ClassAnalyzer
                     && $fq_class_name === $source_analyzer->getFQCLN()
                 ) {
-                    if (isset($source_analyzer->inferred_property_types[$prop_name_name])) {
-                        $source_analyzer->inferred_property_types[$prop_name_name] = Type::combineUnionTypes(
-                            $assignment_value_type,
-                            $source_analyzer->inferred_property_types[$prop_name_name]
-                        );
-                    } else {
-                        $source_analyzer->inferred_property_types[$prop_name_name] = $assignment_value_type;
-                    }
+                    $source_analyzer->inferred_property_types[$prop_name_name] = Type::combineUnionTypes(
+                        $assignment_value_type,
+                        $source_analyzer->inferred_property_types[$prop_name_name] ?? null
+                    );
                 }
             } else {
                 $class_property_type = clone $class_property_type;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php
@@ -329,14 +329,10 @@ class ArithmeticOpAnalyzer
             );
 
             if ($calculated_type) {
-                if ($result_type) {
-                    $result_type = Type::combineUnionTypes(
-                        $calculated_type,
-                        $result_type
-                    );
-                } else {
-                    $result_type = $calculated_type;
-                }
+                $result_type = Type::combineUnionTypes(
+                    $calculated_type,
+                    $result_type
+                );
 
                 $has_valid_left_operand = true;
                 $has_valid_right_operand = true;
@@ -372,11 +368,7 @@ class ArithmeticOpAnalyzer
                 $has_string_increment = true;
             }
 
-            if ($result_type) {
-                $result_type = Type::combineUnionTypes($new_result_type, $result_type);
-            } else {
-                $result_type = $new_result_type;
-            }
+            $result_type = Type::combineUnionTypes($new_result_type, $result_type);
 
             $has_valid_left_operand = true;
             $has_valid_right_operand = true;
@@ -444,13 +436,7 @@ class ArithmeticOpAnalyzer
                 && $parent instanceof PhpParser\Node\Expr\AssignOp\Plus
                 && !$right_type_part instanceof TMixed
             ) {
-                $result_type_member = new Type\Union([$right_type_part]);
-
-                if (!$result_type) {
-                    $result_type = $result_type_member;
-                } else {
-                    $result_type = Type::combineUnionTypes($result_type_member, $result_type);
-                }
+                $result_type = Type::combineUnionTypes(new Type\Union([$right_type_part]), $result_type);
 
                 return null;
             }
@@ -559,11 +545,7 @@ class ArithmeticOpAnalyzer
                 );
             }
 
-            if (!$result_type) {
-                $result_type = $result_type_member;
-            } else {
-                $result_type = Type::combineUnionTypes($result_type_member, $result_type, $codebase, true);
-            }
+            $result_type = Type::combineUnionTypes($result_type_member, $result_type, $codebase, true);
 
             if ($left instanceof PhpParser\Node\Expr\ArrayDimFetch
                 && $context
@@ -595,14 +577,10 @@ class ArithmeticOpAnalyzer
                             && strtolower($left_type_part->value) === 'gmp')
                         || ($left_type_part->isNumericType() || $left_type_part instanceof TMixed)))
             ) {
-                if (!$result_type) {
-                    $result_type = new Type\Union([new TNamedObject('GMP')]);
-                } else {
-                    $result_type = Type::combineUnionTypes(
-                        new Type\Union([new TNamedObject('GMP')]),
-                        $result_type
-                    );
-                }
+                $result_type = Type::combineUnionTypes(
+                    new Type\Union([new TNamedObject('GMP')]),
+                    $result_type
+                );
             } else {
                 if ($statements_source && IssueBuffer::accepts(
                     new InvalidOperand(
@@ -657,11 +635,7 @@ class ArithmeticOpAnalyzer
                     $new_result_type = new Type\Union([new TFloat(), new TInt()]);
                 }
 
-                if (!$result_type) {
-                    $result_type = $new_result_type;
-                } else {
-                    $result_type = Type::combineUnionTypes($new_result_type, $result_type);
-                }
+                $result_type = Type::combineUnionTypes($new_result_type, $result_type);
 
                 $has_valid_right_operand = true;
                 $has_valid_left_operand = true;
@@ -742,8 +716,6 @@ class ArithmeticOpAnalyzer
                                 $result_type = Type::getInt();
                             }
                         }
-                    } elseif (!$result_type) {
-                        $result_type = $always_positive ? Type::getPositiveInt(true) : Type::getInt(true);
                     } else {
                         $result_type = Type::combineUnionTypes(
                             $always_positive ? Type::getPositiveInt(true) : Type::getInt(true),
@@ -761,8 +733,6 @@ class ArithmeticOpAnalyzer
             if ($left_type_part instanceof TFloat && $right_type_part instanceof TFloat) {
                 if ($parent instanceof PhpParser\Node\Expr\BinaryOp\Mod) {
                     $result_type = Type::getInt();
-                } elseif (!$result_type) {
-                    $result_type = Type::getFloat();
                 } else {
                     $result_type = Type::combineUnionTypes(Type::getFloat(), $result_type);
                 }
@@ -791,8 +761,6 @@ class ArithmeticOpAnalyzer
 
                 if ($parent instanceof PhpParser\Node\Expr\BinaryOp\Mod) {
                     $result_type = Type::getInt();
-                } elseif (!$result_type) {
-                    $result_type = Type::getFloat();
                 } else {
                     $result_type = Type::combineUnionTypes(Type::getFloat(), $result_type);
                 }
@@ -908,14 +876,10 @@ class ArithmeticOpAnalyzer
     ): void {
         if ($parent instanceof PhpParser\Node\Expr\BinaryOp\Div) {
             //can't assume an int range will stay int after division
-            if (!$result_type) {
-                $result_type = new Type\Union([new Type\Atomic\TInt(), new Type\Atomic\TFloat()]);
-            } else {
-                $result_type = Type::combineUnionTypes(
-                    new Type\Union([new Type\Atomic\TInt(), new Type\Atomic\TFloat()]),
-                    $result_type
-                );
-            }
+            $result_type = Type::combineUnionTypes(
+                new Type\Union([new Type\Atomic\TInt(), new Type\Atomic\TFloat()]),
+                $result_type
+            );
             return;
         }
 
@@ -929,14 +893,10 @@ class ArithmeticOpAnalyzer
             $parent instanceof PhpParser\Node\Expr\BinaryOp\BitwiseXor
         ) {
             //really complex to calculate
-            if (!$result_type) {
-                $result_type = Type::getInt();
-            } else {
-                $result_type = Type::combineUnionTypes(
-                    Type::getInt(),
-                    $result_type
-                );
-            }
+            $result_type = Type::combineUnionTypes(
+                Type::getInt(),
+                $result_type
+            );
             return;
         }
 
@@ -944,14 +904,10 @@ class ArithmeticOpAnalyzer
             $parent instanceof PhpParser\Node\Expr\BinaryOp\ShiftRight
         ) {
             //really complex to calculate
-            if (!$result_type) {
-                $result_type = new Type\Union([new Type\Atomic\TInt()]);
-            } else {
-                $result_type = Type::combineUnionTypes(
-                    new Type\Union([new Type\Atomic\TInt()]),
-                    $result_type
-                );
-            }
+            $result_type = Type::combineUnionTypes(
+                new Type\Union([new Type\Atomic\TInt()]),
+                $result_type
+            );
             return;
         }
 
@@ -1007,11 +963,7 @@ class ArithmeticOpAnalyzer
 
         $new_result_type = new Type\Union([new Type\Atomic\TIntRange($min_value, $max_value)]);
 
-        if (!$result_type) {
-            $result_type = $new_result_type;
-        } else {
-            $result_type = Type::combineUnionTypes($new_result_type, $result_type);
-        }
+        $result_type = Type::combineUnionTypes($new_result_type, $result_type);
     }
 
     /**
@@ -1208,11 +1160,7 @@ class ArithmeticOpAnalyzer
             $new_result_type = Type::getInt(true);
         }
 
-        if (!$result_type) {
-            $result_type = $new_result_type;
-        } else {
-            $result_type = Type::combineUnionTypes($new_result_type, $result_type);
-        }
+        $result_type = Type::combineUnionTypes($new_result_type, $result_type);
     }
 
     private static function analyzePowBetweenIntRange(
@@ -1281,11 +1229,7 @@ class ArithmeticOpAnalyzer
             }
         }
 
-        if (!$result_type) {
-            $result_type = $new_result_type;
-        } else {
-            $result_type = Type::combineUnionTypes($new_result_type, $result_type);
-        }
+        $result_type = Type::combineUnionTypes($new_result_type, $result_type);
     }
 
     private static function analyzeModBetweenIntRange(
@@ -1351,13 +1295,9 @@ class ArithmeticOpAnalyzer
             $new_result_type = Type::getInt(true);
         }
 
-        if (!$result_type) {
-            $result_type = $new_result_type;
-        } else {
-            $result_type = Type::combineUnionTypes(
-                $new_result_type,
-                $result_type
-            );
-        }
+        $result_type = Type::combineUnionTypes(
+            $new_result_type,
+            $result_type
+        );
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -689,17 +689,12 @@ class ArgumentAnalyzer
 
                 if ($declaring_method_id) {
                     $id_lc = strtolower((string) $declaring_method_id);
-                    if (!isset($codebase->analyzer->possible_method_param_types[$id_lc][$argument_offset])) {
-                        $codebase->analyzer->possible_method_param_types[$id_lc][$argument_offset]
-                            = clone $input_type;
-                    } else {
-                        $codebase->analyzer->possible_method_param_types[$id_lc][$argument_offset]
-                            = Type::combineUnionTypes(
-                                $codebase->analyzer->possible_method_param_types[$id_lc][$argument_offset],
-                                clone $input_type,
-                                $codebase
-                            );
-                    }
+                    $codebase->analyzer->possible_method_param_types[$id_lc][$argument_offset]
+                        = Type::combineUnionTypes(
+                            $codebase->analyzer->possible_method_param_types[$id_lc][$argument_offset] ?? null,
+                            clone $input_type,
+                            $codebase
+                        );
                 }
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -408,15 +408,11 @@ class ArgumentsAnalyzer
                                 }
                             }
 
-                            if (!$newly_inferred_type) {
-                                $newly_inferred_type = $replaced_type_part->params[$closure_param_offset]->type;
-                            } else {
-                                $newly_inferred_type = Type::combineUnionTypes(
-                                    $newly_inferred_type,
-                                    $replaced_type_part->params[$closure_param_offset]->type,
-                                    $codebase
-                                );
-                            }
+                            $newly_inferred_type = Type::combineUnionTypes(
+                                $newly_inferred_type,
+                                $replaced_type_part->params[$closure_param_offset]->type,
+                                $codebase
+                            );
                         }
                     }
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
@@ -127,16 +127,10 @@ class ClassTemplateParamCollector
                                 if ($mapped_offset !== false
                                     && isset($lhs_type_part->type_params[$mapped_offset])
                                 ) {
-                                    $candidate_type = $lhs_type_part->type_params[$mapped_offset];
-
-                                    if (!$output_type_extends) {
-                                        $output_type_extends = $candidate_type;
-                                    } else {
-                                        $output_type_extends = Type::combineUnionTypes(
-                                            $candidate_type,
-                                            $output_type_extends
-                                        );
-                                    }
+                                    $output_type_extends = Type::combineUnionTypes(
+                                        $lhs_type_part->type_params[$mapped_offset],
+                                        $output_type_extends
+                                    );
                                 }
                             } elseif (isset(
                                 $static_class_storage
@@ -156,27 +150,17 @@ class ClassTemplateParamCollector
                                 if ($mapped_offset !== false
                                     && isset($lhs_type_part->type_params[$mapped_offset])
                                 ) {
-                                    $candidate_type = $lhs_type_part->type_params[$mapped_offset];
-
-                                    if (!$output_type_extends) {
-                                        $output_type_extends = $candidate_type;
-                                    } else {
-                                        $output_type_extends = Type::combineUnionTypes(
-                                            $candidate_type,
-                                            $output_type_extends
-                                        );
-                                    }
+                                    $output_type_extends = Type::combineUnionTypes(
+                                        $lhs_type_part->type_params[$mapped_offset],
+                                        $output_type_extends
+                                    );
                                 }
                             }
                         } else {
-                            if (!$output_type_extends) {
-                                $output_type_extends = new Type\Union([$type_extends_atomic]);
-                            } else {
-                                $output_type_extends = Type::combineUnionTypes(
-                                    new Type\Union([$type_extends_atomic]),
-                                    $output_type_extends
-                                );
-                            }
+                            $output_type_extends = Type::combineUnionTypes(
+                                new Type\Union([$type_extends_atomic]),
+                                $output_type_extends
+                            );
                         }
                     }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -599,7 +599,7 @@ class FunctionCallAnalyzer extends CallAnalyzer
                     } else {
                         $statements_analyzer->node_data->setType(
                             $real_stmt,
-                            $var_type_part->return_type ?: Type::getMixed()
+                            $var_type_part->return_type ?? Type::getMixed()
                         );
                     }
 
@@ -819,14 +819,14 @@ class FunctionCallAnalyzer extends CallAnalyzer
             $statements_analyzer->node_data->setType(
                 $real_stmt,
                 Type::combineUnionTypes(
-                    $fake_method_call_type ?: Type::getMixed(),
+                    $fake_method_call_type ?? Type::getMixed(),
                     $stmt_type
                 )
             );
         } else {
             $statements_analyzer->node_data->setType(
                 $real_stmt,
-                $fake_method_call_type ?: Type::getMixed()
+                $fake_method_call_type ?? Type::getMixed()
             );
         }
     }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -532,17 +532,9 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                 ) ?: Type::getMixed();
             }
 
-            if (!$result->return_type) {
-                $result->return_type = $return_type_candidate;
-            } else {
-                $result->return_type = Type::combineUnionTypes($return_type_candidate, $result->return_type);
-            }
+            $result->return_type = Type::combineUnionTypes($return_type_candidate, $result->return_type);
         } elseif ($all_intersection_return_type) {
-            if (!$result->return_type) {
-                $result->return_type = $all_intersection_return_type;
-            } else {
-                $result->return_type = Type::combineUnionTypes($all_intersection_return_type, $result->return_type);
-            }
+            $result->return_type = Type::combineUnionTypes($all_intersection_return_type, $result->return_type);
         } elseif ($method_name === '__tostring') {
             $result->return_type = Type::getString();
         } else {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -53,15 +53,11 @@ class MissingMethodCallHandler
                     ) ?: Type::getMixed();
                 }
 
-                if (!$result->return_type) {
-                    $result->return_type = $return_type_candidate;
-                } else {
-                    $result->return_type = Type::combineUnionTypes(
-                        $return_type_candidate,
-                        $result->return_type,
-                        $codebase
-                    );
-                }
+                $result->return_type = Type::combineUnionTypes(
+                    $return_type_candidate,
+                    $result->return_type,
+                    $codebase
+                );
 
                 CallAnalyzer::checkMethodArgs(
                     $method_id,
@@ -122,15 +118,11 @@ class MissingMethodCallHandler
                     ) ?: Type::getMixed();
                 }
 
-                if (!$result->return_type) {
-                    $result->return_type = $return_type_candidate;
-                } else {
-                    $result->return_type = Type::combineUnionTypes(
-                        $return_type_candidate,
-                        $result->return_type,
-                        $codebase
-                    );
-                }
+                $result->return_type = Type::combineUnionTypes(
+                    $return_type_candidate,
+                    $result->return_type,
+                    $codebase
+                );
 
                 return null;
             }
@@ -270,11 +262,7 @@ class MissingMethodCallHandler
                     $class_storage->final
                 );
 
-                if (!$result->return_type) {
-                    $result->return_type = $return_type_candidate;
-                } else {
-                    $result->return_type = Type::combineUnionTypes($return_type_candidate, $result->return_type);
-                }
+                $result->return_type = Type::combineUnionTypes($return_type_candidate, $result->return_type);
 
                 return;
             }
@@ -301,11 +289,7 @@ class MissingMethodCallHandler
                 $all_intersection_existent_method_ids
             );
 
-            if (!$result->return_type) {
-                $result->return_type = $all_intersection_return_type;
-            } else {
-                $result->return_type = Type::combineUnionTypes($all_intersection_return_type, $result->return_type);
-            }
+            $result->return_type = Type::combineUnionTypes($all_intersection_return_type, $result->return_type);
 
             return;
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -221,9 +221,6 @@ class MethodCallAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\
             $class_type = array_reduce(
                 $possible_new_class_types,
                 function (?Type\Union $type_1, Type\Union $type_2) use ($codebase): Type\Union {
-                    if ($type_1 === null) {
-                        return $type_2;
-                    }
                     return Type::combineUnionTypes($type_1, $type_2, $codebase);
                 }
             );

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -678,14 +678,7 @@ class NewAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAna
                         }
                     }
 
-                    if ($new_type) {
-                        $new_type = Type::combineUnionTypes(
-                            $new_type,
-                            new Type\Union([$new_type_part])
-                        );
-                    } else {
-                        $new_type = new Type\Union([$new_type_part]);
-                    }
+                    $new_type = Type::combineUnionTypes($new_type, new Type\Union([$new_type_part]));
 
                     if ($lhs_type_part->as_type
                         && $codebase->classlikes->classExists($lhs_type_part->as_type->value)
@@ -794,14 +787,7 @@ class NewAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAna
                         }
                     }
 
-                    if ($new_type) {
-                        $new_type = Type::combineUnionTypes(
-                            $new_type,
-                            new Type\Union([$generated_type])
-                        );
-                    } else {
-                        $new_type = new Type\Union([$generated_type]);
-                    }
+                    $new_type = Type::combineUnionTypes($new_type, new Type\Union([$generated_type]));
                 }
 
                 continue;
@@ -850,14 +836,7 @@ class NewAnalyzer extends \Psalm\Internal\Analyzer\Statements\Expression\CallAna
                 // fall through
             }
 
-            if ($new_type) {
-                $new_type = Type::combineUnionTypes(
-                    $new_type,
-                    Type::getObject()
-                );
-            } else {
-                $new_type = Type::getObject();
-            }
+            $new_type = Type::combineUnionTypes($new_type, Type::getObject());
         }
 
         if (!$has_single_class) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -844,17 +844,13 @@ class AtomicStaticCallAnalyzer
 
             $stmt_type = $statements_analyzer->node_data->getType($stmt);
 
-            if (!$stmt_type) {
-                $statements_analyzer->node_data->setType($stmt, $return_type_candidate);
-            } else {
-                $statements_analyzer->node_data->setType(
-                    $stmt,
-                    Type::combineUnionTypes(
-                        $return_type_candidate,
-                        $stmt_type
-                    )
-                );
-            }
+            $statements_analyzer->node_data->setType(
+                $stmt,
+                Type::combineUnionTypes(
+                    $return_type_candidate,
+                    $stmt_type
+                )
+            );
         }
 
         return null;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -420,14 +420,11 @@ class ExistingAtomicStaticCallAnalyzer
             $context
         );
 
-        if ($stmt_type = $statements_analyzer->node_data->getType($stmt)) {
-            $statements_analyzer->node_data->setType(
-                $stmt,
-                Type::combineUnionTypes($stmt_type, $return_type_candidate)
-            );
-        } else {
-            $statements_analyzer->node_data->setType($stmt, $return_type_candidate);
-        }
+        $stmt_type = $statements_analyzer->node_data->getType($stmt);
+        $statements_analyzer->node_data->setType(
+            $stmt,
+            Type::combineUnionTypes($stmt_type, $return_type_candidate)
+        );
 
         if ($codebase->store_node_types
             && !$context->collect_initializations

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -393,14 +393,10 @@ class CallAnalyzer
                                     $output_type_candidate = new Type\Union([$atomic_type]);
                                 }
 
-                                if (!$output_type) {
-                                    $output_type = $output_type_candidate;
-                                } else {
-                                    $output_type = Type::combineUnionTypes(
-                                        $output_type_candidate,
-                                        $output_type
-                                    );
-                                }
+                                $output_type = Type::combineUnionTypes(
+                                    $output_type_candidate,
+                                    $output_type
+                                );
                             }
 
                             $template_types[$template_name][$declaring_class_storage->name] = $output_type;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -179,14 +179,11 @@ class ArrayFetchAnalyzer
                     }
                 }
 
-                if ($stmt_type = $statements_analyzer->node_data->getType($stmt)) {
-                    $statements_analyzer->node_data->setType(
-                        $stmt,
-                        Type::combineUnionTypes($stmt_type, Type::getNull())
-                    );
-                } else {
-                    $statements_analyzer->node_data->setType($stmt, Type::getNull());
-                }
+                $stmt_type = $statements_analyzer->node_data->getType($stmt);
+                $statements_analyzer->node_data->setType(
+                    $stmt,
+                    Type::combineUnionTypes($stmt_type, Type::getNull())
+                );
 
                 return true;
             }
@@ -566,11 +563,7 @@ class ArrayFetchAnalyzer
 
                 if ($in_assignment) {
                     if ($replacement_type) {
-                        if ($array_access_type) {
-                            $array_access_type = Type::combineUnionTypes($array_access_type, $replacement_type);
-                        } else {
-                            $array_access_type = clone $replacement_type;
-                        }
+                        $array_access_type = Type::combineUnionTypes($array_access_type, clone $replacement_type);
                     } else {
                         if (IssueBuffer::accepts(
                             new PossiblyNullArrayAssignment(
@@ -599,11 +592,7 @@ class ArrayFetchAnalyzer
                         }
                     }
 
-                    if ($array_access_type) {
-                        $array_access_type = Type::combineUnionTypes($array_access_type, Type::getNull());
-                    } else {
-                        $array_access_type = Type::getNull();
-                    }
+                    $array_access_type = Type::combineUnionTypes($array_access_type, Type::getNull());
                 }
 
                 continue;
@@ -1086,14 +1075,10 @@ class ArrayFetchAnalyzer
             }
         }
 
-        if ($array_access_type) {
-            return Type::combineUnionTypes(
-                $array_access_type,
-                Type::getMixed($type instanceof TEmpty)
-            );
-        }
-
-        return Type::getMixed($type instanceof TEmpty);
+        return Type::combineUnionTypes(
+            $array_access_type,
+            Type::getMixed($type instanceof TEmpty)
+        );
     }
 
     /**
@@ -1378,14 +1363,10 @@ class ArrayFetchAnalyzer
             );
         }
 
-        if (!$array_access_type) {
-            $array_access_type = $type->type_params[1];
-        } else {
-            $array_access_type = Type::combineUnionTypes(
-                $array_access_type,
-                $type->type_params[1]
-            );
-        }
+        $array_access_type = Type::combineUnionTypes(
+            $array_access_type,
+            $type->type_params[1]
+        );
 
         if ($array_access_type->isEmpty()
             && !$array_type->hasMixed()
@@ -1495,15 +1476,11 @@ class ArrayFetchAnalyzer
                     );
                 }
 
-                if (!$array_access_type) {
-                    $array_access_type = $expected_value_param_get;
-                } else {
-                    $array_access_type = Type::combineUnionTypes(
-                        $array_access_type,
-                        $expected_value_param_get,
-                        $codebase
-                    );
-                }
+                $array_access_type = Type::combineUnionTypes(
+                    $array_access_type,
+                    $expected_value_param_get,
+                    $codebase
+                );
             }
         }
     }
@@ -1541,35 +1518,23 @@ class ArrayFetchAnalyzer
                     $has_valid_offset = true;
 
                     if ($replacement_type) {
-                        if (isset($type->properties[$key_value])) {
-                            $type->properties[$key_value] = Type::combineUnionTypes(
-                                $type->properties[$key_value],
-                                $replacement_type
-                            );
-                        } else {
-                            $type->properties[$key_value] = $replacement_type;
-                        }
-                    }
-
-                    if (!$array_access_type) {
-                        $array_access_type = clone $type->properties[$key_value];
-                    } else {
-                        $array_access_type = Type::combineUnionTypes(
-                            $array_access_type,
-                            $type->properties[$key_value]
+                        $type->properties[$key_value] = Type::combineUnionTypes(
+                            $type->properties[$key_value] ?? null,
+                            $replacement_type
                         );
                     }
+
+                    $array_access_type = Type::combineUnionTypes(
+                        $array_access_type,
+                        clone $type->properties[$key_value]
+                    );
                 } elseif ($in_assignment) {
                     $type->properties[$key_value] = new Type\Union([new TEmpty]);
 
-                    if (!$array_access_type) {
-                        $array_access_type = clone $type->properties[$key_value];
-                    } else {
-                        $array_access_type = Type::combineUnionTypes(
-                            $array_access_type,
-                            $type->properties[$key_value]
-                        );
-                    }
+                    $array_access_type = Type::combineUnionTypes(
+                        $array_access_type,
+                        clone $type->properties[$key_value]
+                    );
                 } elseif ($type->previous_value_type) {
                     if ($codebase->config->ensure_array_string_offsets_exist) {
                         self::checkLiteralStringArrayOffset(
@@ -1699,23 +1664,15 @@ class ArrayFetchAnalyzer
                         $array_type->addType($type);
                     }
 
-                    if (!$array_access_type) {
-                        $array_access_type = clone $generic_params;
-                    } else {
-                        $array_access_type = Type::combineUnionTypes(
-                            $array_access_type,
-                            $generic_params
-                        );
-                    }
+                    $array_access_type = Type::combineUnionTypes(
+                        $array_access_type,
+                        clone $generic_params
+                    );
                 } else {
-                    if (!$array_access_type) {
-                        $array_access_type = $type->getGenericValueType();
-                    } else {
-                        $array_access_type = Type::combineUnionTypes(
-                            $array_access_type,
-                            $type->getGenericValueType()
-                        );
-                    }
+                    $array_access_type = Type::combineUnionTypes(
+                        $array_access_type,
+                        $type->getGenericValueType()
+                    );
                 }
 
                 $has_valid_offset = true;
@@ -1794,14 +1751,10 @@ class ArrayFetchAnalyzer
             );
         }
 
-        if (!$array_access_type) {
-            $array_access_type = $type->type_param;
-        } else {
-            $array_access_type = Type::combineUnionTypes(
-                $array_access_type,
-                $type->type_param
-            );
-        }
+        $array_access_type = Type::combineUnionTypes(
+            $array_access_type,
+            $type->type_param
+        );
     }
 
     private static function handleArrayAccessOnNamedObject(
@@ -1945,14 +1898,10 @@ class ArrayFetchAnalyzer
             }
         }
 
-        if (!$array_access_type) {
-            $array_access_type = $call_array_access_type;
-        } else {
-            $array_access_type = Type::combineUnionTypes(
-                $array_access_type,
-                $call_array_access_type
-            );
-        }
+        $array_access_type = Type::combineUnionTypes(
+            $array_access_type,
+            $call_array_access_type
+        );
     }
 
     /**
@@ -2041,14 +1990,10 @@ class ArrayFetchAnalyzer
         } else {
             $has_valid_offset = true;
 
-            if (!$array_access_type) {
-                $array_access_type = Type::getSingleLetter();
-            } else {
-                $array_access_type = Type::combineUnionTypes(
-                    $array_access_type,
-                    Type::getSingleLetter()
-                );
-            }
+            $array_access_type = Type::combineUnionTypes(
+                $array_access_type,
+                Type::getSingleLetter()
+            );
         }
     }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -94,17 +94,15 @@ class AtomicPropertyFetchAnalyzer
         if ($lhs_type_part instanceof TObjectWithProperties
             && isset($lhs_type_part->properties[$prop_name])
         ) {
-            if ($stmt_type = $statements_analyzer->node_data->getType($stmt)) {
-                $statements_analyzer->node_data->setType(
-                    $stmt,
-                    Type::combineUnionTypes(
-                        $lhs_type_part->properties[$prop_name],
-                        $stmt_type
-                    )
-                );
-            } else {
-                $statements_analyzer->node_data->setType($stmt, $lhs_type_part->properties[$prop_name]);
-            }
+            $stmt_type = $statements_analyzer->node_data->getType($stmt);
+
+            $statements_analyzer->node_data->setType(
+                $stmt,
+                Type::combineUnionTypes(
+                    $lhs_type_part->properties[$prop_name],
+                    $stmt_type
+                )
+            );
 
             return;
         }
@@ -472,14 +470,11 @@ class AtomicPropertyFetchAnalyzer
             $class_property_type->has_mutations = false;
         }
 
-        if ($stmt_type = $statements_analyzer->node_data->getType($stmt)) {
-            $statements_analyzer->node_data->setType(
-                $stmt,
-                Type::combineUnionTypes($class_property_type, $stmt_type)
-            );
-        } else {
-            $statements_analyzer->node_data->setType($stmt, $class_property_type);
-        }
+        $stmt_type = $statements_analyzer->node_data->getType($stmt);
+        $statements_analyzer->node_data->setType(
+            $stmt,
+            Type::combineUnionTypes($class_property_type, $stmt_type)
+        );
     }
 
     public static function checkPropertyDeprecation(
@@ -646,14 +641,11 @@ class AtomicPropertyFetchAnalyzer
             $statements_analyzer->node_data = $old_data_provider;
 
             if ($fake_method_call_type) {
-                if ($stmt_type = $statements_analyzer->node_data->getType($stmt)) {
-                    $statements_analyzer->node_data->setType(
-                        $stmt,
-                        Type::combineUnionTypes($fake_method_call_type, $stmt_type)
-                    );
-                } else {
-                    $statements_analyzer->node_data->setType($stmt, $fake_method_call_type);
-                }
+                $stmt_type = $statements_analyzer->node_data->getType($stmt);
+                $statements_analyzer->node_data->setType(
+                    $stmt,
+                    Type::combineUnionTypes($fake_method_call_type, $stmt_type)
+                );
             } else {
                 $statements_analyzer->node_data->setType($stmt, Type::getMixed());
             }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php
@@ -158,15 +158,11 @@ class YieldAnalyzer
                             $classlike_storage
                         );
 
-                        if ($yield_type) {
-                            $yield_type = Type::combineUnionTypes(
-                                $yield_type,
-                                $yield_candidate_type,
-                                $codebase
-                            );
-                        } else {
-                            $yield_type = $yield_candidate_type;
-                        }
+                        $yield_type = Type::combineUnionTypes(
+                            $yield_type,
+                            $yield_candidate_type,
+                            $codebase
+                        );
                     } else {
                         $yield_type = Type::getMixed();
                     }

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -190,13 +190,11 @@ class ReturnAnalyzer
         if ($context->finally_scope) {
             foreach ($context->vars_in_scope as $var_id => $type) {
                 if (isset($context->finally_scope->vars_in_scope[$var_id])) {
-                    if ($context->finally_scope->vars_in_scope[$var_id] !== $type) {
-                        $context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
-                            $context->finally_scope->vars_in_scope[$var_id],
-                            $type,
-                            $statements_analyzer->getCodebase()
-                        );
-                    }
+                    $context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
+                        $context->finally_scope->vars_in_scope[$var_id],
+                        $type,
+                        $statements_analyzer->getCodebase()
+                    );
                 } else {
                     $context->finally_scope->vars_in_scope[$var_id] = $type;
                     $type->possibly_undefined = true;

--- a/src/Psalm/Internal/Analyzer/Statements/ThrowAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ThrowAnalyzer.php
@@ -34,13 +34,11 @@ class ThrowAnalyzer
         if ($context->finally_scope) {
             foreach ($context->vars_in_scope as $var_id => $type) {
                 if (isset($context->finally_scope->vars_in_scope[$var_id])) {
-                    if ($context->finally_scope->vars_in_scope[$var_id] !== $type) {
-                        $context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
-                            $context->finally_scope->vars_in_scope[$var_id],
-                            $type,
-                            $statements_analyzer->getCodebase()
-                        );
-                    }
+                    $context->finally_scope->vars_in_scope[$var_id] = Type::combineUnionTypes(
+                        $context->finally_scope->vars_in_scope[$var_id],
+                        $type,
+                        $statements_analyzer->getCodebase()
+                    );
                 } else {
                     $context->finally_scope->vars_in_scope[$var_id] = $type;
                     $type->possibly_undefined = true;

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -572,17 +572,12 @@ class Analyzer
                         $this->possible_method_param_types[$declaring_method_id] = $possible_param_types;
                     } else {
                         foreach ($possible_param_types as $offset => $possible_param_type) {
-                            if (!isset($this->possible_method_param_types[$declaring_method_id][$offset])) {
-                                $this->possible_method_param_types[$declaring_method_id][$offset]
-                                    = $possible_param_type;
-                            } else {
-                                $this->possible_method_param_types[$declaring_method_id][$offset]
-                                    = \Psalm\Type::combineUnionTypes(
-                                        $this->possible_method_param_types[$declaring_method_id][$offset],
-                                        $possible_param_type,
-                                        $codebase
-                                    );
-                            }
+                            $this->possible_method_param_types[$declaring_method_id][$offset]
+                                = \Psalm\Type::combineUnionTypes(
+                                    $this->possible_method_param_types[$declaring_method_id][$offset] ?? null,
+                                    $possible_param_type,
+                                    $codebase
+                                );
                         }
                     }
                 }
@@ -1368,7 +1363,7 @@ class Analyzer
         $total_files = count($all_deep_scanned_files);
 
         $lines = [];
-        
+
         if (!$total_files) {
             $lines[] = 'No files analyzed';
         }
@@ -1380,7 +1375,7 @@ class Analyzer
             $lines[] = 'Psalm was able to infer types for ' . $percentage . '%'
                 . ' of the codebase';
         }
-        
+
         return implode("\n", $lines);
     }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -44,11 +44,7 @@ class TypeHintResolver
                     $php_minor_version
                 );
 
-                if (!$type) {
-                    $type = $resolved_type;
-                } else {
-                    $type = Type::combineUnionTypes($resolved_type, $type);
-                }
+                $type = Type::combineUnionTypes($resolved_type, $type);
             }
 
             return $type;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
@@ -463,15 +463,11 @@ class ArrayMapReturnTypeProvider implements \Psalm\Plugin\EventHandler\FunctionR
                 }
             }
 
-            if (!$mapping_return_type) {
-                $mapping_return_type = $function_id_return_type;
-            } else {
-                $mapping_return_type = Type::combineUnionTypes(
-                    $function_id_return_type,
-                    $mapping_return_type,
-                    $codebase
-                );
-            }
+            $mapping_return_type = Type::combineUnionTypes(
+                $function_id_return_type,
+                $mapping_return_type,
+                $codebase
+            );
         }
 
         return $mapping_return_type;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/MinMaxReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/MinMaxReturnTypeProvider.php
@@ -42,14 +42,10 @@ class MinMaxReturnTypeProvider implements FunctionReturnTypeProviderInterface
 
         foreach ($call_args as $arg) {
             if ($array_arg_type = $nodeTypeProvider->getType($arg->value)) {
-                if (!$return_type) {
-                    $return_type = $array_arg_type;
-                } else {
-                    $return_type = \Psalm\Type::combineUnionTypes(
-                        $return_type,
-                        $array_arg_type
-                    );
-                }
+                $return_type = \Psalm\Type::combineUnionTypes(
+                    $return_type,
+                    $array_arg_type
+                );
             } else {
                 return Type::getMixed();
             }

--- a/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
@@ -353,10 +353,6 @@ class TemplateInferredTypeReplacer
                         $atomic_type->else_type,
                         $codebase
                     );
-                } elseif ($if_template_type && !$else_template_type) {
-                    $class_template_type = $if_template_type;
-                } elseif (!$if_template_type) {
-                    $class_template_type = $else_template_type;
                 } else {
                     $class_template_type = Type::combineUnionTypes(
                         $if_template_type,

--- a/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
@@ -1085,15 +1085,11 @@ class TemplateStandinTypeReplacer
 
             $had_invariant = $had_invariant ?: $template_bound->equality_bound_classlike !== null;
 
-            if ($current_type === null) {
-                $current_type = $template_bound->type;
-            } else {
-                $current_type = \Psalm\Type::combineUnionTypes(
-                    $current_type,
-                    $template_bound->type,
-                    $codebase
-                );
-            }
+            $current_type = \Psalm\Type::combineUnionTypes(
+                $current_type,
+                $template_bound->type,
+                $codebase
+            );
 
             $last_arg_offset = $template_bound->arg_offset;
         }
@@ -1189,14 +1185,10 @@ class TemplateStandinTypeReplacer
 
                         $candidate_param_type->from_template_default = true;
 
-                        if (!$new_input_param) {
-                            $new_input_param = $candidate_param_type;
-                        } else {
-                            $new_input_param = \Psalm\Type::combineUnionTypes(
-                                $new_input_param,
-                                $candidate_param_type
-                            );
-                        }
+                        $new_input_param = \Psalm\Type::combineUnionTypes(
+                            $new_input_param,
+                            $candidate_param_type
+                        );
                     }
 
                     $new_input_param = clone $new_input_param;

--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -527,18 +527,13 @@ class TypeCombiner
             }
 
             foreach ($type->type_params as $i => $type_param) {
-                if (isset($combination->array_type_params[$i])) {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->array_type_params[$i] = Type::combineUnionTypes(
-                        $combination->array_type_params[$i],
-                        $type_param,
-                        $codebase,
-                        $overwrite_empty_array
-                    );
-                } else {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->array_type_params[$i] = $type_param;
-                }
+                /** @psalm-suppress PropertyTypeCoercion */
+                $combination->array_type_params[$i] = Type::combineUnionTypes(
+                    $combination->array_type_params[$i] ?? null,
+                    $type_param,
+                    $codebase,
+                    $overwrite_empty_array
+                );
             }
 
             if ($type instanceof TNonEmptyArray) {
@@ -573,18 +568,13 @@ class TypeCombiner
 
         if ($type instanceof TList) {
             foreach ([Type::getInt(), $type->type_param] as $i => $type_param) {
-                if (isset($combination->array_type_params[$i])) {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->array_type_params[$i] = Type::combineUnionTypes(
-                        $combination->array_type_params[$i],
-                        $type_param,
-                        $codebase,
-                        $overwrite_empty_array
-                    );
-                } else {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->array_type_params[$i] = $type_param;
-                }
+                /** @psalm-suppress PropertyTypeCoercion */
+                $combination->array_type_params[$i] = Type::combineUnionTypes(
+                    $combination->array_type_params[$i] ?? null,
+                    $type_param,
+                    $codebase,
+                    $overwrite_empty_array
+                );
             }
 
             if ($type instanceof TNonEmptyList) {
@@ -613,18 +603,13 @@ class TypeCombiner
 
         if ($type instanceof Atomic\TClassStringMap) {
             foreach ([$type->getStandinKeyParam(), $type->value_param] as $i => $type_param) {
-                if (isset($combination->array_type_params[$i])) {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->array_type_params[$i] = Type::combineUnionTypes(
-                        $combination->array_type_params[$i],
-                        $type_param,
-                        $codebase,
-                        $overwrite_empty_array
-                    );
-                } else {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->array_type_params[$i] = $type_param;
-                }
+                /** @psalm-suppress PropertyTypeCoercion */
+                $combination->array_type_params[$i] = Type::combineUnionTypes(
+                    $combination->array_type_params[$i] ?? null,
+                    $type_param,
+                    $codebase,
+                    $overwrite_empty_array
+                );
             }
 
             $combination->array_always_filled = false;
@@ -643,18 +628,13 @@ class TypeCombiner
             || ($type instanceof TArray && $type_key === 'iterable')
         ) {
             foreach ($type->type_params as $i => $type_param) {
-                if (isset($combination->builtin_type_params[$type_key][$i])) {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->builtin_type_params[$type_key][$i] = Type::combineUnionTypes(
-                        $combination->builtin_type_params[$type_key][$i],
-                        $type_param,
-                        $codebase,
-                        $overwrite_empty_array
-                    );
-                } else {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->builtin_type_params[$type_key][$i] = $type_param;
-                }
+                /** @psalm-suppress PropertyTypeCoercion */
+                $combination->builtin_type_params[$type_key][$i] = Type::combineUnionTypes(
+                    $combination->builtin_type_params[$type_key][$i] ?? null,
+                    $type_param,
+                    $codebase,
+                    $overwrite_empty_array
+                );
             }
 
             return null;
@@ -662,18 +642,13 @@ class TypeCombiner
 
         if ($type instanceof TGenericObject) {
             foreach ($type->type_params as $i => $type_param) {
-                if (isset($combination->object_type_params[$type_key][$i])) {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->object_type_params[$type_key][$i] = Type::combineUnionTypes(
-                        $combination->object_type_params[$type_key][$i],
-                        $type_param,
-                        $codebase,
-                        $overwrite_empty_array
-                    );
-                } else {
-                    /** @psalm-suppress PropertyTypeCoercion */
-                    $combination->object_type_params[$type_key][$i] = $type_param;
-                }
+                /** @psalm-suppress PropertyTypeCoercion */
+                $combination->object_type_params[$type_key][$i] = Type::combineUnionTypes(
+                    $combination->object_type_params[$type_key][$i] ?? null,
+                    $type_param,
+                    $codebase,
+                    $overwrite_empty_array
+                );
             }
 
             return null;
@@ -689,29 +664,21 @@ class TypeCombiner
             $combination->objectlike_sealed = $combination->objectlike_sealed && $type->sealed;
 
             if ($type->previous_value_type) {
-                if (!$combination->objectlike_value_type) {
-                    $combination->objectlike_value_type = $type->previous_value_type;
-                } else {
-                    $combination->objectlike_value_type = Type::combineUnionTypes(
-                        $type->previous_value_type,
-                        $combination->objectlike_value_type,
-                        $codebase,
-                        $overwrite_empty_array
-                    );
-                }
+                $combination->objectlike_value_type = Type::combineUnionTypes(
+                    $type->previous_value_type,
+                    $combination->objectlike_value_type,
+                    $codebase,
+                    $overwrite_empty_array
+                );
             }
 
             if ($type->previous_key_type) {
-                if (!$combination->objectlike_key_type) {
-                    $combination->objectlike_key_type = $type->previous_key_type;
-                } else {
-                    $combination->objectlike_key_type = Type::combineUnionTypes(
-                        $type->previous_key_type,
-                        $combination->objectlike_key_type,
-                        $codebase,
-                        $overwrite_empty_array
-                    );
-                }
+                $combination->objectlike_key_type = Type::combineUnionTypes(
+                    $type->previous_key_type,
+                    $combination->objectlike_key_type,
+                    $codebase,
+                    $overwrite_empty_array
+                );
             }
 
             $has_defined_keys = false;
@@ -1479,16 +1446,12 @@ class TypeCombiner
             $objectlike_keys = [];
 
             foreach ($combination->objectlike_entries as $property_name => $property_type) {
-                if ($objectlike_generic_type) {
-                    $objectlike_generic_type = Type::combineUnionTypes(
-                        $property_type,
-                        $objectlike_generic_type,
-                        $codebase,
-                        $overwrite_empty_array
-                    );
-                } else {
-                    $objectlike_generic_type = clone $property_type;
-                }
+                $objectlike_generic_type = Type::combineUnionTypes(
+                    clone $property_type,
+                    $objectlike_generic_type,
+                    $codebase,
+                    $overwrite_empty_array
+                );
 
                 if (is_int($property_name)) {
                     $objectlike_keys[$property_name] = new TLiteralInt($property_name);
@@ -1512,14 +1475,12 @@ class TypeCombiner
 
             $objectlike_key_type = new Type\Union(array_values($objectlike_keys));
 
-            if ($combination->objectlike_key_type) {
-                $objectlike_key_type = Type::combineUnionTypes(
-                    $combination->objectlike_key_type,
-                    $objectlike_key_type,
-                    $codebase,
-                    $overwrite_empty_array
-                );
-            }
+            $objectlike_key_type = Type::combineUnionTypes(
+                $combination->objectlike_key_type,
+                $objectlike_key_type,
+                $codebase,
+                $overwrite_empty_array
+            );
 
             $generic_type_params[0] = Type::combineUnionTypes(
                 $generic_type_params[0],

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -440,13 +440,25 @@ abstract class Type
      *
      */
     public static function combineUnionTypes(
-        Union $type_1,
-        Union $type_2,
+        ?Union $type_1,
+        ?Union $type_2,
         ?Codebase $codebase = null,
         bool $overwrite_empty_array = false,
         bool $allow_mixed_union = true,
         int $literal_limit = 500
     ): Union {
+        if ($type_2 === null && $type_1 === null) {
+            throw new \UnexpectedValueException('At least one type must be provided to combine');
+        }
+
+        if ($type_1 === null) {
+            return $type_2;
+        }
+
+        if ($type_2 === null) {
+            return $type_1;
+        }
+
         if ($type_1 === $type_2) {
             return $type_1;
         }

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -219,11 +219,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
 
         $key_type->possibly_undefined = false;
 
-        if ($this->previous_key_type) {
-            $key_type = Type::combineUnionTypes($this->previous_key_type, $key_type);
-        }
-
-        return $key_type;
+        return Type::combineUnionTypes($this->previous_key_type, $key_type);
     }
 
     public function getGenericValueType(): Union
@@ -231,16 +227,10 @@ class TKeyedArray extends \Psalm\Type\Atomic
         $value_type = null;
 
         foreach ($this->properties as $property) {
-            if ($value_type === null) {
-                $value_type = clone $property;
-            } else {
-                $value_type = Type::combineUnionTypes($property, $value_type);
-            }
+            $value_type = Type::combineUnionTypes(clone $property, $value_type);
         }
 
-        if ($this->previous_value_type) {
-            $value_type = Type::combineUnionTypes($this->previous_value_type, $value_type);
-        }
+        $value_type = Type::combineUnionTypes($this->previous_value_type, $value_type);
 
         $value_type->possibly_undefined = false;
 
@@ -263,11 +253,7 @@ class TKeyedArray extends \Psalm\Type\Atomic
                 $key_types[] = new Type\Atomic\TLiteralString($key);
             }
 
-            if ($value_type === null) {
-                $value_type = clone $property;
-            } else {
-                $value_type = Type::combineUnionTypes($property, $value_type);
-            }
+            $value_type = Type::combineUnionTypes(clone $property, $value_type);
 
             if (!$property->possibly_undefined) {
                 $has_defined_keys = true;
@@ -276,13 +262,8 @@ class TKeyedArray extends \Psalm\Type\Atomic
 
         $key_type = TypeCombiner::combine($key_types);
 
-        if ($this->previous_value_type) {
-            $value_type = Type::combineUnionTypes($this->previous_value_type, $value_type);
-        }
-
-        if ($this->previous_key_type) {
-            $key_type = Type::combineUnionTypes($this->previous_key_type, $key_type);
-        }
+        $value_type = Type::combineUnionTypes($this->previous_value_type, $value_type);
+        $key_type = Type::combineUnionTypes($this->previous_key_type, $key_type);
 
         $value_type->possibly_undefined = false;
 

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -214,13 +214,11 @@ class Reconciler
                         $result_type_candidate->addType(new TEmpty);
                     }
 
-                    $orred_type = $orred_type
-                        ? Type::combineUnionTypes(
-                            $result_type_candidate,
-                            $orred_type,
-                            $codebase
-                        )
-                        : $result_type_candidate;
+                    $orred_type = Type::combineUnionTypes(
+                        $result_type_candidate,
+                        $orred_type,
+                        $codebase
+                    );
                 }
 
                 $result_type = $orred_type;
@@ -681,15 +679,11 @@ class Reconciler
                             }
                         }
 
-                        if (!$new_base_type) {
-                            $new_base_type = $new_base_type_candidate;
-                        } else {
-                            $new_base_type = Type::combineUnionTypes(
-                                $new_base_type,
-                                $new_base_type_candidate,
-                                $codebase
-                            );
-                        }
+                        $new_base_type = Type::combineUnionTypes(
+                            $new_base_type,
+                            $new_base_type_candidate,
+                            $codebase
+                        );
 
                         $existing_keys[$new_base_key] = $new_base_type;
                     }
@@ -780,15 +774,11 @@ class Reconciler
                             $class_property_type = Type::getMixed();
                         }
 
-                        if ($new_base_type instanceof Type\Union) {
-                            $new_base_type = Type::combineUnionTypes(
-                                $new_base_type,
-                                $class_property_type,
-                                $codebase
-                            );
-                        } else {
-                            $new_base_type = $class_property_type;
-                        }
+                        $new_base_type = Type::combineUnionTypes(
+                            $new_base_type,
+                            $class_property_type,
+                            $codebase
+                        );
 
                         $existing_keys[$new_base_key] = $new_base_type;
                     }


### PR DESCRIPTION
This allow pushing null to one argument of Type::combineUnionTypes to make it easier to use everywhere