### PR TITLE
Prevent unnecessary filter_var() warnings on primitive types

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -666,6 +666,13 @@ function array_sum(array $input) {}
 function array_product(array $input) {}
 
 /**
+ * 257 is FILTER_VALIDATE_INT
+ * @psalm-taint-escape ($filter is 257 ? 'html' : null)
+ * @psalm-flow ($value, $filter, $options) -> return
+ */
+function filter_var(mixed $value, int $filter = FILTER_DEFAULT, array|int $options = 0): mixed {}
+
+/**
  * @psalm-pure
  *
  * @psalm-taint-escape html

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -668,6 +668,13 @@ function array_product(array $input) {}
 /**
  * 257 is FILTER_VALIDATE_INT
  * @psalm-taint-escape ($filter is 257 ? 'html' : null)
+ *
+ * 258 is FILTER_VALIDATE_BOOLEAN
+ * @psalm-taint-escape ($filter is 258 ? 'html' : null)
+ *
+ * 259 is FILTER_VALIDATE_FLOAT
+ * @psalm-taint-escape ($filter is 259 ? 'html' : null)
+ *
  * @psalm-flow ($value, $filter, $options) -> return
  */
 function filter_var(mixed $value, int $filter = FILTER_DEFAULT, array|int $options = 0): mixed {}

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -233,6 +233,10 @@ class TaintTest extends TestCase
                         echo $a;
                     }'
             ],
+            'taintFilterVarInt' => [
+                '<?php
+                    echo filter_var($_GET["id"], FILTER_VALIDATE_INT);'
+            ],
             'taintLdapEscape' => [
                 '<?php
                     $ds = ldap_connect(\'example.com\');
@@ -1619,7 +1623,7 @@ class TaintTest extends TestCase
                     echo $get["test"];',
                 'error_message' => 'TaintedHtml',
             ],
-            'taintFilterVar' => [
+            'taintFilterVarCallback' => [
                 '<?php
                     $get = filter_var($_GET, FILTER_CALLBACK, ["options" => "trim"]);
 

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -235,7 +235,15 @@ class TaintTest extends TestCase
             ],
             'taintFilterVarInt' => [
                 '<?php
-                    echo filter_var($_GET["id"], FILTER_VALIDATE_INT);'
+                    echo filter_var($_GET["bad"], FILTER_VALIDATE_INT);'
+            ],
+            'taintFilterVarBoolean' => [
+                '<?php
+                    echo filter_var($_GET["bad"], FILTER_VALIDATE_BOOLEAN);'
+            ],
+            'taintFilterVarFloat' => [
+                '<?php
+                    echo filter_var($_GET["bad"], FILTER_VALIDATE_FLOAT);'
             ],
             'taintLdapEscape' => [
                 '<?php


### PR DESCRIPTION
I believe this partially solves #3689.  Let me know if you would like me to make any changes.