### PR TITLE
offset the starting position of the function in case of attributes

### DIFF
--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -123,6 +123,14 @@ class FunctionDocblockManipulator
         $this->docblock_end = $function_start = (int)$stmt->getAttribute('startFilePos');
         $function_end = (int)$stmt->getAttribute('endFilePos');
 
+        $attributes = $stmt->getAttrGroups();
+        foreach ($attributes as $attribute) {
+            // if we have attribute groups, we need to consider that the function starts after them
+            if ((int) $attribute->getAttribute('endFilePos') > $function_start) {
+                $function_start = (int) $attribute->getAttribute('endFilePos');
+            }
+        }
+
         foreach ($stmt->params as $param) {
             if ($param->var instanceof PhpParser\Node\Expr\Variable
                 && \is_string($param->var->name)

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -1088,6 +1088,32 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                 false,
                 true,
             ],
+            'WithAttributes' => [
+                '<?php
+
+                    class A
+                    {
+                        #[Foo()]
+                        public function bar()
+                        {
+                        }
+                    }
+                    ',
+                '<?php
+
+                    class A
+                    {
+                        #[Foo()]
+                        public function bar(): void
+                        {
+                        }
+                    }
+                    ',
+                '7.1',
+                ['MissingReturnType'],
+                true,
+                true,
+            ],
         ];
     }
 }


### PR DESCRIPTION
This fixes #6542

Somehow, PHP-Parser considers that `$stmt->getAttribute('startFilePos')` when a function has an attribute is at the beggining of the attribute.

The method Psalm uses for locating the place where it can add a type in signature is by looking after the parameters when there are some and then check for the first closing parenthesis. If there's no parameter, it looks at the first closing parenthesis from the start of the function.

And this is how it breaks. When there is no parameter and an attribute, the first parenthesis can be inside the attribute. This makes Psalm confused as to where it can add the return types and it derps.

My fix for that was to check for attributes and then consider that the function starts at the end of the last attribute.

There may be more elegant ways to do that but I'm not familiar enough with PHP-Parser API