### PR TITLE
Callmap leak

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -969,8 +969,12 @@ class ArgumentsAnalyzer
                     $function_param = $last_param;
                 }
 
-                $by_ref_type = clone $function_param->type;
-                $by_ref_out_type = clone $function_param->out_type;
+                if ($function_param->type) {
+                    $by_ref_type = clone $function_param->type;
+                }
+                if ($function_param->out_type) {
+                    $by_ref_out_type = clone $function_param->out_type;
+                }
 
                 if ($by_ref_type && $by_ref_type->isNullable()) {
                     $check_null_ref = false;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -969,8 +969,8 @@ class ArgumentsAnalyzer
                     $function_param = $last_param;
                 }
 
-                $by_ref_type = $function_param->type;
-                $by_ref_out_type = $function_param->out_type;
+                $by_ref_type = clone $function_param->type;
+                $by_ref_out_type = clone $function_param->out_type;
 
                 if ($by_ref_type && $by_ref_type->isNullable()) {
                     $check_null_ref = false;

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1602,6 +1602,22 @@ class FunctionCallTest extends TestCase
                         foo($s);
                     }',
             ],
+            'preventObjectLeakingFromCallmapReference' => [
+                '<?php
+                    function one(): void
+                    {
+                        try {
+                            exec("", $output);
+                        } catch (Exception $e){
+                        }
+                    }
+
+                    function two(): mixed
+                    {
+                        exec("", $lines);
+                        return $lines;
+                    }',
+            ],
         ];
     }
 

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1612,7 +1612,7 @@ class FunctionCallTest extends TestCase
                         }
                     }
 
-                    function two(): mixed
+                    function two(): array
                     {
                         exec("", $lines);
                         return $lines;


### PR DESCRIPTION
This fixes a leak where types from the callmap would be provided to further analysis, if the analysis needed to change the type or flags (in this case, "possibly_undefined_from_try", the callmap itself would change and start providing this new type on each new use.

This fixes #6543
This will most probably fix #4748