### PR TITLE
fix wrong operator priority

### DIFF
--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -231,8 +231,8 @@ class Reconciler
             }
 
             if (($statements_analyzer->data_flow_graph instanceof \Psalm\Internal\Codebase\TaintFlowGraph
-                    && (!$result_type->hasScalarType())
-                        || ($result_type->hasString() && !$result_type->hasLiteralString()))
+                    && (!$result_type->hasScalarType()
+                        || ($result_type->hasString() && !$result_type->hasLiteralString())))
                 || $statements_analyzer->data_flow_graph instanceof \Psalm\Internal\Codebase\VariableUseGraph
             ) {
                 if ($before_adjustment && $before_adjustment->parent_nodes) {


### PR DESCRIPTION
This fixes a seemingly wrong priority between || and &&.

It seem to be a conditional made to skip everything that is either not a scalar or a string literal from TaintFlow analysis.

However, the conditional as it was was doing `(is taint flow AND not scalar) OR (has string AND not literal)` I fixed the brackets to say `(is taint flow) AND ((not scalar) OR (has string AND not literal))`