### PR TITLE
Psalter psalm-param

### DIFF
--- a/tests/FileManipulation/ParamTypeManipulationTest.php
+++ b/tests/FileManipulation/ParamTypeManipulationTest.php
@@ -72,6 +72,7 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                     class C {
                         /**
                          * @param string $a
+                         * @psalm-param \'hello\' $a
                          */
                         public function fooFoo(string $a): void {}
                     }
@@ -96,6 +97,8 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                     class C {
                         /**
                          * @param string $a
+                         *
+                         * @psalm-param \'hello\' $a
                          */
                         public function fooFoo($a): void {}
                     }
@@ -150,6 +153,8 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                     class C {
                         /**
                          * @param string $a
+                         *
+                         * @psalm-param \'hello\' $a
                          */
                         public function fooFoo($a): void {}
                     }
@@ -189,6 +194,7 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                     class C {
                         /**
                          * @param string $a
+                         * @psalm-param \'hello\' $a
                          */
                         public function fooFoo(string $a): void {}
                     }
@@ -231,6 +237,7 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                     class C {
                         /**
                          * @param string $bar
+                         * @psalm-param \'hello\' $bar
                          */
                         public function foo(string &$bar) : void {
                             $bar .= " me";
@@ -238,6 +245,32 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                     }
 
                     $a = "hello";
+                    (new C)->foo($a);',
+                '7.1',
+                ['MissingParamType'],
+                true,
+            ],
+            'NamespacedParamNeeded' => [
+                '<?php
+                    class C {
+                        public function foo($bar) : void {
+                            echo $bar;
+                        }
+                    }
+
+                    $a = stdClass::class;
+                    (new C)->foo($a);',
+                '<?php
+                    class C {
+                        /**
+                         * @psalm-param stdClass::class $bar
+                         */
+                        public function foo(string $bar) : void {
+                            echo $bar;
+                        }
+                    }
+
+                    $a = stdClass::class;;
                     (new C)->foo($a);',
                 '7.1',
                 ['MissingParamType'],

--- a/tests/FileManipulation/ParamTypeManipulationTest.php
+++ b/tests/FileManipulation/ParamTypeManipulationTest.php
@@ -71,7 +71,6 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                 '<?php
                     class C {
                         /**
-                         * @param string $a
                          * @psalm-param \'hello\' $a
                          */
                         public function fooFoo(string $a): void {}
@@ -193,7 +192,6 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                 '<?php
                     class C {
                         /**
-                         * @param string $a
                          * @psalm-param \'hello\' $a
                          */
                         public function fooFoo(string $a): void {}
@@ -236,7 +234,6 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                 '<?php
                     class C {
                         /**
-                         * @param string $bar
                          * @psalm-param \'hello\' $bar
                          */
                         public function foo(string &$bar) : void {
@@ -270,7 +267,7 @@ class ParamTypeManipulationTest extends FileManipulationTestCase
                         }
                     }
 
-                    $a = stdClass::class;;
+                    $a = stdClass::class;
                     (new C)->foo($a);',
                 '7.1',
                 ['MissingParamType'],


### PR DESCRIPTION
This makes use of a param that was not used previously, most probably by mistake.

It allows Psalm to add @psalm-param annotations when fixing "MissingParamType" with Psalter for better precision

It also fix an issue where a @param annotation was added even when it didn't add value over type signature just because the @psalm-param type would have been better (but was ignored in the end)