### PR TITLE
Declare `html-escaped-string` is deprecated on doc

### DIFF
--- a/docs/annotating_code/type_syntax/scalar_types.md
+++ b/docs/annotating_code/type_syntax/scalar_types.md
@@ -78,4 +78,4 @@ An empty string, lowercased or both at once.
 
 A string which can safely be used in a html context.
 
-_This type will remove in 5.x._
+_This type will be removed in Psalm 5.x._

--- a/docs/annotating_code/type_syntax/scalar_types.md
+++ b/docs/annotating_code/type_syntax/scalar_types.md
@@ -74,6 +74,8 @@ An empty string, lowercased or both at once.
 
 `empty` here is defined as all strings except the empty string `''`. Another type `non-falsy-string` is effectively a subtype of `non-empty-string`, and also precludes the string value `'0'`.
 
-### html-escaped-string
+### html-escaped-string (deprecated)
 
-A string which can safely be used in a html context
+A string which can safely be used in a html context.
+
+_This type will remove in 5.x._


### PR DESCRIPTION
ref. #5564 , and current HEAD's 
https://github.com/vimeo/psalm/blob/c7fd665fba1d62bc3d797ea4ad0478c0c0a2be41/src/Psalm/Internal/Type/TypeTokenizer.php#L51-L52

current document https://psalm.dev/docs/annotating_code/type_syntax/scalar_types/
does not mention that `html-escaped-string` will be remove.