### PR TITLE
Missing property type on public property is dangerous

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1562,6 +1562,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
             && isset($project_analyzer->getIssuesToFix()['MissingPropertyType'])
             && !\in_array('MissingPropertyType', $this->getSuppressedIssues())
             && $suggested_type
+            && $property_storage->visibility !== ClassLikeAnalyzer::VISIBILITY_PUBLIC
         ) {
             if ($suggested_type->hasMixed() || $suggested_type->isNull()) {
                 return;

--- a/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php
@@ -183,6 +183,7 @@ class PropertyDocblockManipulator
 
         if ($this->new_phpdoc_type
             && $this->new_phpdoc_type !== $old_phpdoc_type
+            && $this->new_phpdoc_type !== $this->new_php_type
         ) {
             $modified_docblock = true;
             $parsed_docblock->tags['var'] = [
@@ -199,6 +200,7 @@ class PropertyDocblockManipulator
         if ($this->new_psalm_type
             && $this->new_phpdoc_type !== $this->new_psalm_type
             && $this->new_psalm_type !== $old_psalm_type
+            && $this->new_psalm_type !== $this->new_php_type
         ) {
             $modified_docblock = true;
             $parsed_docblock->tags['psalm-var'] = [$this->new_psalm_type];

--- a/tests/FileManipulation/MissingPropertyTypeTest.php
+++ b/tests/FileManipulation/MissingPropertyTypeTest.php
@@ -259,7 +259,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                     }',
                 '<?php
                     class A {
-                        public bool $u = false;
+                        protected bool $u = false;
 
                         public function bar() {
                             $this->u = true;

--- a/tests/FileManipulation/MissingPropertyTypeTest.php
+++ b/tests/FileManipulation/MissingPropertyTypeTest.php
@@ -116,7 +116,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                     }',
                 '<?php
                     class A {
-                        public ?int $v = null;
+                        protected ?int $v = null;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -177,7 +177,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                     }',
                 '<?php
                     class A {
-                        public int $v;
+                        protected int $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -236,8 +236,8 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                     }',
                 '<?php
                     class A {
-                        public int $u;
-                        public int $v;
+                        protected int $u;
+                        protected int $v;
 
                         public function __construct(int $i, int $j) {
                             $this->u = $i;

--- a/tests/FileManipulation/MissingPropertyTypeTest.php
+++ b/tests/FileManipulation/MissingPropertyTypeTest.php
@@ -12,7 +12,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'addMissingUnionType56' => [
                 '<?php
                     class A {
-                        public $v;
+                        protected $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -29,7 +29,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                          *
                          * @psalm-var \'hello\'|4
                          */
-                        public $v;
+                        protected $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -46,7 +46,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'addMissingNullableType56' => [
                 '<?php
                     class A {
-                        public $v;
+                        protected $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -61,7 +61,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                          *
                          * @psalm-var 4|null
                          */
-                        public $v;
+                        protected $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -76,7 +76,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'addMissingNullableTypeNoDefault74' => [
                 '<?php
                     class A {
-                        public $v;
+                        protected $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -91,7 +91,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                          *
                          * @psalm-var 4|null
                          */
-                        public $v;
+                        protected $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -106,7 +106,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'addMissingNullableTypeWithDefault74' => [
                 '<?php
                     class A {
-                        public $v = null;
+                        protected $v = null;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -131,7 +131,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'addMissingUnionTypeSetInBranches74' => [
                 '<?php
                     class A {
-                        public $v;
+                        protected $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -148,7 +148,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                          *
                          * @psalm-var \'hello\'|4
                          */
-                        public $v;
+                        protected $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -165,7 +165,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'addMissingIntTypeSetInBranches74' => [
                 '<?php
                     class A {
-                        public $v;
+                        protected $v;
 
                         public function __construct() {
                             if (rand(0, 1)) {
@@ -194,8 +194,8 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'addMissingDocblockTypesSpacedProperly' => [
                 '<?php
                     class A {
-                        public $u;
-                        public $v;
+                        protected $u;
+                        protected $v;
 
                         public function __construct(int $i, int $j) {
                             $this->u = $i;
@@ -207,12 +207,12 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                         /**
                          * @var int
                          */
-                        public $u;
+                        protected $u;
 
                         /**
                          * @var int
                          */
-                        public $v;
+                        protected $v;
 
                         public function __construct(int $i, int $j) {
                             $this->u = $i;
@@ -226,8 +226,8 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'addMissingTypehintsSpacedProperly' => [
                 '<?php
                     class A {
-                        public $u;
-                        public $v;
+                        protected $u;
+                        protected $v;
 
                         public function __construct(int $i, int $j) {
                             $this->u = $i;
@@ -251,7 +251,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'addMissingTypehintWithDefault' => [
                 '<?php
                     class A {
-                        public $u = false;
+                        protected $u = false;
 
                         public function bar() {
                             $this->u = true;
@@ -272,7 +272,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
             'dontAddMissingPropertyTypeInTrait' => [
                 '<?php
                     trait T {
-                        public $u;
+                        protected $u;
                     }
                     class A {
                         use T;
@@ -283,7 +283,7 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                     }',
                 '<?php
                     trait T {
-                        public $u;
+                        protected $u;
                     }
                     class A {
                         use T;


### PR DESCRIPTION
This fixes #6583 . That's a shame because it's pretty useful but the example in the issue is concerning. Psalm doesn't check at all for external access and it's very easy to break something here. It also avoid adding type in phpdoc if it's the same than signature