### PR TITLE
fix isAlwaysTruthy: TNonEmptyString can be falsy (with '0')

### DIFF
--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1045,11 +1045,11 @@ class Union implements TypeNode
                 continue;
             }
 
-            if ($atomic_type instanceof Type\Atomic\TNonEmptyString) {
+            if ($atomic_type instanceof Type\Atomic\TNonFalsyString) {
                 continue;
             }
 
-            if ($atomic_type instanceof Type\Atomic\TNonEmptyNonspecificLiteralString) {
+            if ($atomic_type instanceof Type\Atomic\TCallableString) {
                 continue;
             }
 


### PR DESCRIPTION
This fixes a mistake. There is a value in TNonEmptyString that is falsy so we can't use it in isAlwaysTruthy. 

I added TNonFalsyString (and TCallableString until #6521 can be merged)