### PR TITLE
Lint all *.php files, not only src

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           COMPOSER_ROOT_VERSION: dev-master
 
       - run: |
-          vendor/bin/parallel-lint src
+          git ls-files | grep \\\.php$ | ./vendor/bin/parallel-lint --stdin
   chunk-matrix:
     name: Generate Chunk Matrix
 


### PR DESCRIPTION
This PR suggests lint all files, not only under `src` files. 
bin, examples, tests, etc.