### PR TITLE
Better understanding of Templates in lhs of callable TKeyedArray 

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
@@ -9,6 +9,7 @@ use Psalm\Type;
 use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TCallable;
+use Psalm\Type\Atomic\TClassString;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TList;
@@ -430,6 +431,24 @@ class CallableTypeComparator
                             strtolower($lhs_atomic_type->value) . '::',
                             $calling_method_id ?: $file_name
                         );
+                    } elseif ($lhs_atomic_type instanceof Atomic\TTemplateParam) {
+                        $lhs_template_type = $lhs_atomic_type->as;
+                        if ($lhs_template_type->isSingle()) {
+                            $lhs_template_atomic_type = $lhs_template_type->getSingleAtomic();
+                            $member_id = null;
+                            if ($lhs_template_atomic_type instanceof TNamedObject) {
+                                $member_id = $lhs_template_atomic_type->value;
+                            } elseif ($lhs_template_atomic_type instanceof TClassString) {
+                                $member_id = $lhs_template_atomic_type->as;
+                            }
+
+                            if ($member_id) {
+                                $codebase->analyzer->addMixedMemberName(
+                                    strtolower($member_id) . '::',
+                                    $calling_method_id ?: $file_name
+                                );
+                            }
+                        }
                     }
                 }
             }
@@ -456,7 +475,7 @@ class CallableTypeComparator
                         $lhs_template_atomic_type = $lhs_template_type->getSingleAtomic();
                         if ($lhs_template_atomic_type instanceof TNamedObject) {
                             $class_name = $lhs_template_atomic_type->value;
-                        } elseif ($lhs_template_atomic_type instanceof Type\Atomic\TClassString) {
+                        } elseif ($lhs_template_atomic_type instanceof TClassString) {
                             $class_name = $lhs_template_atomic_type->as;
                         }
                     }

--- a/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
@@ -450,6 +450,16 @@ class CallableTypeComparator
             foreach ($lhs->getAtomicTypes() as $lhs_atomic_type) {
                 if ($lhs_atomic_type instanceof TNamedObject) {
                     $class_name = $lhs_atomic_type->value;
+                } elseif ($lhs_atomic_type instanceof Atomic\TTemplateParam) {
+                    $lhs_template_type = $lhs_atomic_type->as;
+                    if ($lhs_template_type->isSingle()) {
+                        $lhs_template_atomic_type = $lhs_template_type->getSingleAtomic();
+                        if ($lhs_template_atomic_type instanceof TNamedObject) {
+                            $class_name = $lhs_template_atomic_type->value;
+                        } elseif ($lhs_template_atomic_type instanceof Type\Atomic\TClassString) {
+                            $class_name = $lhs_template_atomic_type->as;
+                        }
+                    }
                 } elseif ($lhs_atomic_type instanceof Type\Atomic\TClassString
                     && $lhs_atomic_type->as
                 ) {

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1680,4 +1680,9 @@ class Union implements TypeNode
     {
         return count($this->literal_float_types) > 0;
     }
+
+    public function getSingleAtomic(): Atomic
+    {
+        return reset($this->types);
+    }
 }


### PR DESCRIPTION
This allow Psalm to understand what's going on better when encountering a template in a callable TKeyedArray.

This is a fix I made while working on #6230 because Psalm started flagging those as unrecognized templates. This will prevent flagging methods as unused when we know the class name and this will help psalm further analyze a method call given it now knows the class on which the method is called