### PR TITLE
Redundant return type

### DIFF
--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -384,14 +384,18 @@ class FunctionDocblockManipulator
             $parsed_docblock->tags['psalm-pure'] = [''];
         }
 
-        if ($this->new_phpdoc_return_type
-            && $this->new_phpdoc_return_type !== $old_phpdoc_return_type
-        ) {
+
+        if ($this->new_phpdoc_return_type && $this->new_phpdoc_return_type !== $old_phpdoc_return_type) {
             $modified_docblock = true;
-            $parsed_docblock->tags['return'] = [
-                $this->new_phpdoc_return_type
+            if ($this->new_phpdoc_return_type !== $this->new_php_return_type || $this->return_type_description) {
+                //only add the type if it's different than signature or if there's a description
+                $parsed_docblock->tags['return'] = [
+                    $this->new_phpdoc_return_type
                     . ($this->return_type_description ? (' ' . $this->return_type_description) : ''),
-            ];
+                ];
+            } else {
+                unset($parsed_docblock->tags['return']);
+            }
         }
 
         $old_psalm_return_type = null;

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -498,8 +498,6 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     }',
                 '<?php
                     /**
-                     * @return iterable
-                     *
                      * @psalm-return iterable<mixed, int>
                      */
                     function foo(): iterable {
@@ -848,8 +846,6 @@ class MissingReturnTypeTest extends FileManipulationTestCase
                     }',
                 '<?php
                     /**
-                     * @return array
-                     *
                      * @psalm-return array<empty, empty>
                      */
                     function foo(): array {

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -701,8 +701,6 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                     }
                     class a {
                         /**
-                         * @return container
-                         *
                          * @psalm-return container<1>
                          */
                         public function test(): container

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -69,8 +69,6 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                     }',
                 '<?php
                     /**
-                     * @return string
-                     *
                      * @psalm-return \'hello\'
                      */
                     function foo(): string {
@@ -166,9 +164,6 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                         return "hello";
                     }',
                 '<?php
-                    /**
-                     * @return string
-                     */
                     function foo(): string {
                         return "hello";
                     }',
@@ -202,8 +197,6 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                      *    a friend of mine
                      *       + Members
                      *          - `google`
-                     *
-                     * @return string
                      *
                      * @psalm-return \'hello\'
                      */
@@ -269,8 +262,6 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                     }
 
                     /**
-                     * @return Closure
-                     *
                      * @psalm-return Closure(string):string
                      */
                     function bar() : Closure {
@@ -455,9 +446,6 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                     }',
                 '<?php
                     class A {
-                        /**
-                         * @return void
-                         */
                         protected final function foo(): void {}
                     }',
                 '7.3',
@@ -475,9 +463,6 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                     }',
                 '<?php
                     final class A {
-                        /**
-                         * @return void
-                         */
                         protected function foo(): void {}
                     }',
                 '7.3',
@@ -492,9 +477,6 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                      */
                     function foo() {}',
                 '<?php
-                    /**
-                     * @return void
-                     */
                     function foo(): void {}',
                 '7.3',
                 ['InvalidReturnType'],
@@ -667,8 +649,6 @@ class ReturnTypeManipulationTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @param string $a
-                     *
-                     * @return array
                      *
                      * @psalm-return array<empty, empty>
                      */


### PR DESCRIPTION
This adds a bit of code to prevent adding redundant return types in phpdoc when using psalter