### PR TITLE
Fix invalid class/method declaration in stub

### DIFF
--- a/stubs/SPL.phpstub
+++ b/stubs/SPL.phpstub
@@ -388,7 +388,7 @@ class SplQueue extends SplDoublyLinkedList {
  * @template TValue
  * @template-implements Iterator<int, TValue>
  */
-class SplHeap implements Iterator, Countable {
+abstract class SplHeap implements Iterator, Countable {
     public function __construct() {}
 
     /**
@@ -401,7 +401,7 @@ class SplHeap implements Iterator, Countable {
      *
      * @since 5.3.0
      */
-    protected abstract function compare($value1, $value2): int {}
+    protected abstract function compare($value1, $value2): int;
 
     /**
      * Counts the number of elements in the heap


### PR DESCRIPTION
```
$ php -l stubs/SPL.phpstub
PHP Fatal error:  Abstract function SplHeap::compare() cannot contain body in stubs/SPL.phpstub on line 404
Errors parsing stubs/SPL.phpstub
```
This PR just fix above error in order to avoid confuse.

refs. PHP manual https://www.php.net/splheap 
```php
abstract class SplHeap
```

(Unexpectedly ? ) PHP-Parser can generate AST from uncompilable php code.

```
$ ./vendor/bin/php-parse -d '<?php abstract class A { protected abstract function compare() {}}'
====> Code <?php abstract class A { protected abstract function compare() {}}
==> Node dump:
array(
    0: Stmt_Class(
        attrGroups: array(
        )
        flags: MODIFIER_ABSTRACT (16)
        name: Identifier(
            name: A
        )
        extends: null
        implements: array(
        )
        stmts: array(
            0: Stmt_ClassMethod(
                attrGroups: array(
                )
                flags: MODIFIER_PROTECTED | MODIFIER_ABSTRACT (18)
                byRef: false
                name: Identifier(
                    name: compare
                )
                params: array(
                )
                returnType: null
                stmts: array(
                )
            )
        )
    )
)
```

