### PR TITLE
foreach on list gives a positive|0 offset

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -347,7 +347,7 @@ class ForeachAnalyzer
      * @param PhpParser\Node\Stmt\Foreach_|PhpParser\Node\Expr\YieldFrom $stmt
      * @return false|null
      */
-    public static function  checkIteratorType(
+    public static function checkIteratorType(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\NodeAbstract $stmt,
         PhpParser\Node\Expr $expr,


### PR DESCRIPTION
This fixes a case where foreach on a list was giving a integer offset instead of a 0|positive-int one.

This fixes a false positive I found on a big repo