### PR TITLE
array_is_list on empty array returns true

### DIFF
--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1897,6 +1897,13 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
                     }
                 }
 
+                if ($type->type_params[0]->isEmpty()
+                    || $type->type_params[1]->isEmpty()
+                ) {
+                    //we allow an empty array to pass as a list. We keep the type as empty array though (more precise)
+                    $array_types[] = $type;
+                }
+
                 $did_remove_type = true;
             } elseif ($type instanceof TCallable) {
                 $array_types[] = new TCallableKeyedArray([

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1632,6 +1632,18 @@ class FunctionCallTest extends TestCase
                 [],
                 '8.1',
             ],
+            'array_is_list_on_empty_array' => [
+                '<?php
+                    $a = [];
+                    if(array_is_list($a)) {
+                        //$a is still empty array
+                    }
+                    ',
+                [],
+                [],
+                '8.1',
+            ],
+
         ];
     }
 


### PR DESCRIPTION
This solve a specific case with array_is_list where it was considered impossible on an empty array