### PR TITLE
Fix get_object_vars() return signature

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -3739,7 +3739,7 @@ return [
 'get_magic_quotes_gpc' => ['int|false'],
 'get_magic_quotes_runtime' => ['int|false'],
 'get_meta_tags' => ['array', 'filename'=>'string', 'use_include_path='=>'bool'],
-'get_object_vars' => ['array<string,mixed>', 'object'=>'object'],
+'get_object_vars' => ['array<int|string,mixed>', 'object'=>'object'],
 'get_parent_class' => ['class-string|false', 'object_or_class='=>'mixed'],
 'get_required_files' => ['list<string>'],
 'get_resource_id' => ['int', 'resource'=>'resource'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -11077,7 +11077,7 @@ return [
     'get_magic_quotes_gpc' => ['int|false'],
     'get_magic_quotes_runtime' => ['int|false'],
     'get_meta_tags' => ['array', 'filename'=>'string', 'use_include_path='=>'bool'],
-    'get_object_vars' => ['array<string,mixed>', 'object'=>'object'],
+    'get_object_vars' => ['array<int|string,mixed>', 'object'=>'object'],
     'get_parent_class' => ['class-string|false', 'object_or_class='=>'mixed'],
     'get_required_files' => ['list<string>'],
     'get_resource_type' => ['string', 'resource'=>'resource'],


### PR DESCRIPTION
https://psalm.dev/r/ca1f1ecbe0

Current signature is incorrect. An array in the example will contain keys (int)1, (string)'baz', but `array<string, mixed>` is reported. 