### PR TITLE
fix regression for redundant condition when assigning

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
@@ -215,7 +215,7 @@ class IfConditionalAnalyzer
             )
         );
 
-        self::handleParadoxicalCondition($statements_analyzer, $cond);
+        self::handleParadoxicalCondition($statements_analyzer, $cond, true);
 
         // get all the var ids that were referenced in the conditional, but not assigned in it
         $cond_referenced_var_ids = array_diff_key($cond_referenced_var_ids, $assigned_in_conditional_var_ids);
@@ -321,7 +321,8 @@ class IfConditionalAnalyzer
 
     public static function handleParadoxicalCondition(
         StatementsAnalyzer  $statements_analyzer,
-        PhpParser\Node\Expr $stmt
+        PhpParser\Node\Expr $stmt,
+        bool $emit_redundant_with_assignation = false
     ): void {
         $type = $statements_analyzer->node_data->getType($stmt);
 
@@ -350,7 +351,9 @@ class IfConditionalAnalyzer
                         // fall through
                     }
                 }
-            } elseif ($type->isAlwaysTruthy() && !$stmt instanceof PhpParser\Node\Expr\Assign) {
+            } elseif ($type->isAlwaysTruthy() &&
+                (!$stmt instanceof PhpParser\Node\Expr\Assign || $emit_redundant_with_assignation)
+            ) {
                 if ($type->from_docblock) {
                     if (IssueBuffer::accepts(
                         new RedundantConditionGivenDocblockType(

--- a/tests/TypeReconciliation/RedundantConditionTest.php
+++ b/tests/TypeReconciliation/RedundantConditionTest.php
@@ -841,6 +841,32 @@ class RedundantConditionTest extends \Psalm\Tests\TestCase
                             assert(!is_int($a));
                         }
                     }'
+            ],
+            'alwaysTrueAssignAllowedInsideAND' => [
+                '<?php
+                    class A{
+                        public function get(): stdClass{ return new stdClass;}
+                    }
+                    $a = new A();
+
+                    if (($c = $a->get()) && rand(0,1)){
+
+
+                    }
+                    '
+            ],
+            'alwaysTrueAssignAllowedInsideOr' => [
+                '<?php
+                    class A{
+                        public function get(): ?stdClass{ return new stdClass;}
+                    }
+                    $a = new A();
+
+                    if ($a->get() || ($c = rand(0,1))){
+
+
+                    }
+                    '
             ]
         ];
     }
@@ -1435,7 +1461,21 @@ class RedundantConditionTest extends \Psalm\Tests\TestCase
                 '<?php
                     if(rand(0,1) && false){}',
                 'error_message' => 'TypeDoesNotContainType',
-            ]
+            ],
+            'alwaysTrueAssign' => [
+                '<?php
+                    class A{
+                        public function get(): stdClass{ return new stdClass;}
+                    }
+                    $a = new A();
+
+                    if ($c = $a->get()){
+
+
+                    }
+                    ',
+                'error_message' => 'RedundantCondition',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Commit https://github.com/vimeo/psalm/commit/b9e65f066a4b7aab0703c236e46bf938a9303e16 introduced a regression where Psalm couldn't detect redundant conditions when there is an assignation inside the condition.

This is due to the fact that I excluded assignation to be able to support this: 
`if(($var = $var2->getAlwaysTrueResult()) && $var === 12)`

I put back this check for `Or` operations or when there is a single condition inside the if().

EDIT: I removed the check for `Or` to support `if($a || ($c = 12))`