### PR TITLE
fix Uncaught ValueError: strrpos()

### DIFF
--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -297,8 +297,12 @@ class CodeLocation
         $this->text = mb_strcut($file_contents, $this->selection_start, $this->selection_end - $this->selection_start);
 
         // reset preview start to beginning of line
-        $this->column_from = $this->selection_start -
-            (int)strrpos($file_contents, "\n", $this->selection_start - strlen($file_contents));
+        if ($file_contents !== '') {
+            $this->column_from = $this->selection_start -
+                (int)strrpos($file_contents, "\n", $this->selection_start - strlen($file_contents));
+        } else {
+            $this->column_from = $this->selection_start;
+        }
 
         $newlines = substr_count($this->text, "\n");
 


### PR DESCRIPTION
This fixes the following error:

Uncaught ValueError: strrpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack) in /var/www/html/vendor/vimeo/psalm/src/Psalm/CodeLocation.php:301

It happens when Psalm tries to add an issue on a file that doesn't have content

(Yes, I do that with a plugin)