### PR TITLE
Don't refine empty/falsy assertions on templates inside loops

### DIFF
--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -143,7 +143,8 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
                 $code_location,
                 $suppressed_issues,
                 $failed_reconciliation,
-                false
+                false,
+                $inside_loop
             );
         }
 
@@ -2218,7 +2219,8 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
         ?CodeLocation $code_location,
         array $suppressed_issues,
         int &$failed_reconciliation,
-        bool $recursive_check
+        bool $recursive_check,
+        bool $inside_loop
     ) : Union {
         $old_var_type_string = $existing_var_type->getId();
         $existing_var_atomic_types = $existing_var_type->getAtomicTypes();
@@ -2363,20 +2365,22 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
                 if (!$existing_var_atomic_type->as->isMixed()) {
                     $template_did_fail = 0;
 
-                    $existing_var_atomic_type = clone $existing_var_atomic_type;
+                    $tmp_existing_var_atomic_type = clone $existing_var_atomic_type;
 
-                    $existing_var_atomic_type->as = self::reconcileFalsyOrEmpty(
+                    $reconciled_type = self::reconcileFalsyOrEmpty(
                         $assertion,
-                        $existing_var_atomic_type->as,
+                        $tmp_existing_var_atomic_type->as,
                         $key,
                         $negated,
                         $code_location,
                         $suppressed_issues,
                         $template_did_fail,
-                        $recursive_check
+                        $recursive_check,
+                        $inside_loop
                     );
 
-                    if (!$template_did_fail) {
+                    if (!$template_did_fail && !$inside_loop) {
+                        $existing_var_atomic_type->as = $reconciled_type;
                         $existing_var_type->addType($existing_var_atomic_type);
                     }
                 }

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -180,7 +180,8 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                 $failed_reconciliation,
                 $is_equality,
                 $is_strict_equality,
-                false
+                false,
+                $inside_loop
             );
         }
 
@@ -570,7 +571,8 @@ class SimpleNegatedAssertionReconciler extends Reconciler
         int &$failed_reconciliation,
         bool $is_equality,
         bool $is_strict_equality,
-        bool $recursive_check
+        bool $recursive_check,
+        bool $inside_loop
     ) : Type\Union {
         $old_var_type_string = $existing_var_type->getId();
         $existing_var_atomic_types = $existing_var_type->getAtomicTypes();
@@ -728,11 +730,11 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                 if (!$is_equality && !$existing_var_atomic_type->as->isMixed()) {
                     $template_did_fail = 0;
 
-                    $existing_var_atomic_type = clone $existing_var_atomic_type;
+                    $tmp_existing_var_atomic_type = clone $existing_var_atomic_type;
 
-                    $existing_var_atomic_type->as = self::reconcileFalsyOrEmpty(
+                    $reconciled_type = self::reconcileFalsyOrEmpty(
                         $assertion,
-                        $existing_var_atomic_type->as,
+                        $tmp_existing_var_atomic_type->as,
                         $key,
                         $negated,
                         $code_location,
@@ -740,10 +742,12 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                         $template_did_fail,
                         $is_equality,
                         $is_strict_equality,
-                        true
+                        true,
+                        $inside_loop
                     );
 
-                    if (!$template_did_fail) {
+                    if (!$template_did_fail && !$inside_loop) {
+                        $existing_var_atomic_type->as = $reconciled_type;
                         $existing_var_type->addType($existing_var_atomic_type);
                     }
                 }

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -811,6 +811,21 @@ class ConditionalReturnTypeTest extends TestCase
                         return iterator_to_array($iterable, false);
                     }'
             ],
+            'dontChokeOnFalsyAssertionsWithTemplatesInLoop' => [
+                '<?php
+                    /**
+                     * @psalm-return ($list_output is true ? list : array)
+                     */
+                    function scope(bool $list_output = true): array
+                    {
+                        for ($i = 0; $i < 5; $i++) {
+                            $list_output ? [] : [];
+                        }
+
+                        return [];
+                    }
+                    '
+            ],
         ];
     }
 }


### PR DESCRIPTION
This should fix a bug that was already there, but I extended it when I implemented template checks for SimpleAssertionReconciler (duplicated it from SimpleNegatedAssertionReconciler)

Turns out when Psalm was encountering a template (in my example, it was for conditional return but I see no reason it wouldn't apply to other templates) that was in a ternary (again, no reason it wouldn't happens for other structures) in a loop, it refined the template based on the assertion.

So say you have a `T as bool`, it would be refined to a `T as false`, and then fail when confronted to the same condition again saying the assertion was redundant and impossible depending on the operand.

I just made it so the templates are not refined when we're inside a loop and it worked.

It may not be the better way to fix this, but it's the only one that came to mind.