### PR TITLE
Ternary templates

### DIFF
--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -143,8 +143,7 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
                 $code_location,
                 $suppressed_issues,
                 $failed_reconciliation,
-                false,
-                $inside_loop
+                false
             );
         }
 
@@ -2219,8 +2218,7 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
         ?CodeLocation $code_location,
         array $suppressed_issues,
         int &$failed_reconciliation,
-        bool $recursive_check,
-        bool $inside_loop
+        bool $recursive_check
     ) : Union {
         $old_var_type_string = $existing_var_type->getId();
         $existing_var_atomic_types = $existing_var_type->getAtomicTypes();
@@ -2360,27 +2358,26 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
             $existing_var_type->addType(new TEmptyNumeric());
         }
 
-        foreach ($existing_var_atomic_types as $existing_var_atomic_type) {
+        foreach ($existing_var_atomic_types as $type_key => $existing_var_atomic_type) {
             if ($existing_var_atomic_type instanceof TTemplateParam) {
                 if (!$existing_var_atomic_type->as->isMixed()) {
                     $template_did_fail = 0;
 
-                    $tmp_existing_var_atomic_type = clone $existing_var_atomic_type;
+                    $existing_var_atomic_type = clone $existing_var_atomic_type;
 
-                    $reconciled_type = self::reconcileFalsyOrEmpty(
+                    $existing_var_atomic_type->as = self::reconcileFalsyOrEmpty(
                         $assertion,
-                        $tmp_existing_var_atomic_type->as,
+                        $existing_var_atomic_type->as,
                         $key,
                         $negated,
                         $code_location,
                         $suppressed_issues,
                         $template_did_fail,
-                        $recursive_check,
-                        $inside_loop
+                        $recursive_check
                     );
 
-                    if (!$template_did_fail && !$inside_loop) {
-                        $existing_var_atomic_type->as = $reconciled_type;
+                    if (!$template_did_fail) {
+                        $existing_var_type->removeType($type_key);
                         $existing_var_type->addType($existing_var_atomic_type);
                     }
                 }

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -180,8 +180,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                 $failed_reconciliation,
                 $is_equality,
                 $is_strict_equality,
-                false,
-                $inside_loop
+                false
             );
         }
 
@@ -571,8 +570,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
         int &$failed_reconciliation,
         bool $is_equality,
         bool $is_strict_equality,
-        bool $recursive_check,
-        bool $inside_loop
+        bool $recursive_check
     ) : Type\Union {
         $old_var_type_string = $existing_var_type->getId();
         $existing_var_atomic_types = $existing_var_type->getAtomicTypes();
@@ -725,16 +723,16 @@ class SimpleNegatedAssertionReconciler extends Reconciler
             }
         }
 
-        foreach ($existing_var_atomic_types as $existing_var_atomic_type) {
+        foreach ($existing_var_atomic_types as $type_key => $existing_var_atomic_type) {
             if ($existing_var_atomic_type instanceof TTemplateParam) {
                 if (!$is_equality && !$existing_var_atomic_type->as->isMixed()) {
                     $template_did_fail = 0;
 
-                    $tmp_existing_var_atomic_type = clone $existing_var_atomic_type;
+                    $existing_var_atomic_type = clone $existing_var_atomic_type;
 
-                    $reconciled_type = self::reconcileFalsyOrEmpty(
+                    $existing_var_atomic_type->as = self::reconcileFalsyOrEmpty(
                         $assertion,
-                        $tmp_existing_var_atomic_type->as,
+                        $existing_var_atomic_type->as,
                         $key,
                         $negated,
                         $code_location,
@@ -742,12 +740,11 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                         $template_did_fail,
                         $is_equality,
                         $is_strict_equality,
-                        true,
-                        $inside_loop
+                        true
                     );
 
-                    if (!$template_did_fail && !$inside_loop) {
-                        $existing_var_atomic_type->as = $reconciled_type;
+                    if (!$template_did_fail) {
+                        $existing_var_type->removeType($type_key);
                         $existing_var_type->addType($existing_var_atomic_type);
                     }
                 }

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -826,6 +826,21 @@ class ConditionalReturnTypeTest extends TestCase
                     }
                     '
             ],
+            'dontChokeOnFalsyAssertionsWithTemplatesOutsideLoop' => [
+                '<?php
+                    class A {}
+                    class B {}
+
+                    /**
+                     * @psalm-return ($a is true ? list<A> : list<B>)
+                     */
+                    function get_liste_designation_client(bool $a = false) {
+                        (!$a ? "a" : "b");
+                        (!$a ? "a" : "b");
+                        return [];
+                    }
+                    '
+            ],
         ];
     }
 }


### PR DESCRIPTION
https://github.com/vimeo/psalm/pull/6720 was not a good fix. I found other cases not in loop with the same issue. I dug up more, turns out the issue was with ternaries. The type of a sub-context would leak to the general context and became wrong.

The explanation will be simple with the code at hand, I'll add comments in review for explanation