### PR TITLE
Don't crash on falsy with int ranges

### DIFF
--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -713,7 +713,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                         if ($literal_type->min_bound === null || $literal_type->min_bound <= -1) {
                             $existing_var_type->addType(new Type\Atomic\TIntRange($literal_type->min_bound, -1));
                         }
-                        if ($literal_type->min_bound === null || $literal_type->max_bound >= 1) {
+                        if ($literal_type->max_bound === null || $literal_type->max_bound >= 1) {
                             $existing_var_type->addType(new Type\Atomic\TIntRange(1, $literal_type->max_bound));
                         }
                     }

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -608,6 +608,39 @@ class IntRangeTest extends TestCase
                     '$k===' => 'int<40, max>',
                 ],
             ],
+            'dontCrashOnFalsy' => [
+                '<?php
+
+                    function doAnalysis(): void
+                    {
+                        /** @var int<3, max> $shuffle_count */
+                        $shuffle_count = 1;
+
+                        /** @var list<string> $file_paths */
+                        $file_paths = [];
+
+                        /** @var int<0, max> $count */
+                        $count = 1;
+                        /** @var int $middle */
+                        $middle = 1;
+                        /** @var int<0, max> $remainder */
+                        $remainder = 1;
+
+
+                        for ($i = 0; $i < $shuffle_count; $i++) {
+                            for ($j = 0; $j < $middle; $j++) {
+                                if ($j * $shuffle_count + $i < $count) {
+                                    echo $file_paths[$j * $shuffle_count + $i];
+                                }
+                            }
+
+                            if ($remainder) {
+                                echo $file_paths[$middle * $shuffle_count + $remainder - 1];
+                                $remainder--;
+                            }
+                        }
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This intend to fix #6725

The assert at the end is never supposed to be false because we add a type in the union each time we remove one. However, there was a bug in the int range addition so it didn't add the correct type