### PR TITLE
don't use is_a with user classes

### DIFF
--- a/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
@@ -2,7 +2,6 @@
 
 namespace Psalm\Internal\Type;
 
-use Iterator;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Type\Comparator\CallableTypeComparator;
@@ -14,7 +13,6 @@ use function array_merge;
 use function array_values;
 use function count;
 use function in_array;
-use function is_a;
 use function reset;
 use function strpos;
 use function substr;


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/6723

With https://github.com/vimeo/psalm/pull/6390, Psalm started requiring to have access to user class through autoloading for inference purposes. However, when classes were known through extraFiles, knowing they exists didn't mean they could be autoloaded.

This PR tries to keep the feature working while not requiring is_a.

I'm not actually certain of my fix here...