### PR TITLE
Don't assert mixed type

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -3378,7 +3378,7 @@ class AssertionFinder
             }
 
 
-            if ($other_var_name && $other_type) {
+            if ($other_var_name && $other_type && !$other_type->isMixed()) {
                 if ($identical) {
                     try {
                         $assertion = $other_type->getAssertionString(true);


### PR DESCRIPTION
This was registering a lot of noise with `~mixed` assertions that were clogging the Clause module. With this, #6741 goes from 300 seconds to 4 seconds