### PR TITLE
fix is_a when used with Stringable classes

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1298,6 +1298,6 @@ function get_defined_constants(bool $categorize = false): array {}
 /**
  * @param mixed $object_or_class
  * @param class-string $class
- * @return ($allow_string is false ? ($object_or_class is string ? false : bool) : bool)
+ * @return ($allow_string is false ? ($object_or_class is object ? bool : false) : bool)
  */
 function is_a($object_or_class, string $class, $allow_string = false): bool{}

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1662,6 +1662,14 @@ class FunctionCallTest extends TestCase
                     foo(...$arguments);
                     ',
             ],
+            'is_aWithStringableClass' => [
+                '<?php
+                    /**
+                     * @psalm-var class-string<Throwable> $exceptionType
+                     */
+                    if (\is_a(new Exception(), $exceptionType)) {}
+                    ',
+            ],
         ];
     }
 


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/6765

Psalm was being too smart while checking the stub. I asked for is_a with string first param to return false and it returned false even if the first param was a Stringable object.

This PR inverse the logic and return false if the first param is not an object