### PR TITLE
remove second autoloader call

### DIFF
--- a/src/Psalm/Internal/Cli/Psalter.php
+++ b/src/Psalm/Internal/Cli/Psalter.php
@@ -265,8 +265,6 @@ HELP;
             $config->debug_emitted_issues = true;
         }
 
-        $config->visitComposerAutoloadFiles($project_analyzer);
-
         if (array_key_exists('issues', $options)) {
             if (!is_string($options['issues']) || !$options['issues']) {
                 die('Expecting a comma-separated list of issues' . PHP_EOL);

--- a/src/Psalm/Internal/Cli/Refactor.php
+++ b/src/Psalm/Internal/Cli/Refactor.php
@@ -308,8 +308,6 @@ HELP;
             $project_analyzer->debug_lines = true;
         }
 
-        $config->visitComposerAutoloadFiles($project_analyzer);
-
         $project_analyzer->refactorCodeAfterCompletion($to_refactor);
 
         $start_time = microtime(true);


### PR DESCRIPTION
This was a test to see if we could remove two lines that made a second autoloader call in https://github.com/vimeo/psalm/issues/6772

The CI is green. Not sure how representative the CI is on that though...