### PR TITLE
Add a means to switch return types based on PHP_VERSION_ID

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -76,9 +76,21 @@ class FunctionCallReturnTypeFetcher
                             } elseif ($template_name === 'TPhpMajorVersion') {
                                 $template_result->lower_bounds[$template_name] = [
                                     'fn-' . $function_id => [
-                                            new TemplateBound(
-                                                Type::getInt(false, $codebase->php_major_version)
+                                        new TemplateBound(
+                                            Type::getInt(false, $codebase->php_major_version)
+                                        )
+                                    ]
+                                ];
+                            } elseif ($template_name === 'TPhpVersionId') {
+                                $template_result->lower_bounds[$template_name] = [
+                                    'fn-' . $function_id => [
+                                        new TemplateBound(
+                                            Type::getInt(
+                                                false,
+                                                10000 * $codebase->php_major_version
+                                                + 100 * $codebase->php_minor_version
                                             )
+                                        )
                                     ]
                                 ];
                             } else {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -548,6 +548,18 @@ class MethodCallReturnTypeFetcher
                                 )
                             ]
                         ];
+                    } elseif ($template_type->param_name === 'TPhpVersionId') {
+                        $template_result->lower_bounds[$template_type->param_name] = [
+                            'fn-' . strtolower((string) $method_id) => [
+                                new TemplateBound(
+                                    Type::getInt(
+                                        false,
+                                        10000 * $codebase->php_major_version
+                                        + 100 * $codebase->php_minor_version
+                                    )
+                                )
+                            ]
+                        ];
                     } else {
                         $template_result->lower_bounds[$template_type->param_name] = [
                             ($template_type->defining_class) => [

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -499,6 +499,18 @@ class ExistingAtomicStaticCallAnalyzer
                                     )
                                 ]
                             ];
+                        } elseif ($template_type->param_name === 'TPhpVersionId') {
+                            $template_result->lower_bounds[$template_type->param_name] = [
+                                'fn-' . strtolower((string) $method_id) => [
+                                    new TemplateBound(
+                                        Type::getInt(
+                                            false,
+                                            10000 * $codebase->php_major_version
+                                            + 100 * $codebase->php_minor_version
+                                        )
+                                    )
+                                ]
+                            ];
                         } else {
                             $template_result->lower_bounds[$template_type->param_name] = [
                                 ($template_type->defining_class) => [

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -484,6 +484,19 @@ class FunctionLikeDocblockScanner
 
                 $fixed_type_tokens[$i][0] = $template_name;
             }
+
+            if ($token_body === 'PHP_VERSION_ID') {
+                $template_name = 'TPhpVersionId';
+
+                $storage->template_types[$template_name] = [
+                    $template_function_id => Type::getInt()
+                ];
+
+                $function_template_types[$template_name]
+                    = $storage->template_types[$template_name];
+
+                $fixed_type_tokens[$i][0] = $template_name;
+            }
         }
 
         return [$fixed_type_tokens, $function_template_types];

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -465,7 +465,10 @@ class TypeTokenizer
                 continue;
             }
 
-            if ($string_type_token[0] === 'func_num_args()' || $string_type_token[0] === 'PHP_MAJOR_VERSION') {
+            if ($string_type_token[0] === 'func_num_args()'
+                || $string_type_token[0] === 'PHP_MAJOR_VERSION'
+                || $string_type_token[0] === 'PHP_VERSION_ID'
+            ) {
                 continue;
             }
 

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -864,14 +864,26 @@ class ConditionalReturnTypeTest extends TestCase
                     /**
                      * @psalm-return (PHP_VERSION_ID is int<70300, max> ? string : int)
                      */
-                     function getSomething()
-                     {
+                    function getSomething()
+                    {
                         return mt_rand(1, 10) > 5 ? "a value" : 42;
-                     }
+                    }
 
-                     $something = getSomething();
+                    /**
+                     * @psalm-return (PHP_VERSION_ID is int<70100, max> ? string : int)
+                     */
+                    function getSomethingElse()
+                    {
+                        return mt_rand(1, 10) > 5 ? "a value" : 42;
+                    }
+
+                    $something = getSomething();
+                    $somethingElse = getSomethingElse();
                 ',
-                ['$something' => 'int'],
+                [
+                    '$something' => 'int',
+                    '$somethingElse' => 'string'
+                ],
                 [],
                 '7.2'
             ]

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -859,6 +859,22 @@ class ConditionalReturnTypeTest extends TestCase
                     }
                     '
             ],
+            'returnTypeBasedOnPhpVersionId' => [
+                '<?php
+                    /**
+                     * @psalm-return (PHP_VERSION_ID is int<70300, max> ? string : int)
+                     */
+                     function getSomething()
+                     {
+                        return mt_rand(1, 10) > 5 ? "a value" : 42;
+                     }
+
+                     $something = getSomething();
+                ',
+                ['$something' => 'int'],
+                [],
+                '7.2'
+            ]
         ];
     }
 }


### PR DESCRIPTION
As suggested by @weirdan in vimeo/psalm#6755 considering return type changes in PHP 8.1

I wouldn't claim that I completely understand all the changes I made, but I used https://github.com/vimeo/psalm/commit/42802e11d1327b99ff9bdd3bafbcd3291c406e91 as a reference.
