### PR TITLE
❗Allow plugins to modify Config::$fileExtensions early

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -198,3 +198,14 @@
  - [BC] Method `Psalm\DocComment::parse()` was removed
  - [BC] Class `Psalm\Type\Atomic\THtmlEscapedString` has been removed
  - [BC] Property `Psalm\Context::$vars_from_global` has been renamed to `$referenced_globals`
+ - [BC] Self-registration of file type scanners and file type analyzers has been changed
+   - `Psalm\Plugin\RegistrationInterface::addFileTypeScanner` was removed
+   - `Psalm\Plugin\RegistrationInterface::addFileTypeAnalyzer` was removed
+   - :information_source: migration possible using `Psalm\Plugin\FileExtensionsInterface`
+   - `Psalm\PluginRegistrationSocket::addFileTypeScanner` was removed
+   - `Psalm\PluginRegistrationSocket::getAdditionalFileTypeScanners` was removed
+   - `Psalm\PluginRegistrationSocket::addFileTypeAnalyzer` was removed
+   - `Psalm\PluginRegistrationSocket::getAdditionalFileTypeAnalyzers` was removed
+   - `Psalm\PluginRegistrationSocket::getAdditionalFileExtensions` was removed
+   - `Psalm\PluginRegistrationSocket::addFileExtension` was removed
+   - :information_source: migration possible using `Psalm\PluginFileExtensionsSocket`

--- a/docs/running_psalm/checking_non_php_files.md
+++ b/docs/running_psalm/checking_non_php_files.md
@@ -23,14 +23,21 @@ Plugins can register their own custom scanner  and analyzer implementations for 
 namespace Psalm\Example;
 
 use Psalm\Plugin\PluginEntryPointInterface;
+use Psalm\Plugin\PluginFileExtensionsInterface;
+use Psalm\Plugin\FileExtensionsInterface;
 use Psalm\Plugin\RegistrationInterface;
 
-class CustomPlugin implements PluginEntryPointInterface
+class CustomPlugin implements PluginEntryPointInterface, PluginFileExtensionsInterface
 {
     public function __invoke(RegistrationInterface $registration, ?\SimpleXMLElement $config = null): void
     {
-        $registration->addFileTypeScanner('phpt', TemplateScanner::class);
-        $registration->addFileTypeAnalyzer('phpt', TemplateAnalyzer::class);
+        // ... regular plugin processes, stub registration, hook registration
     }
+
+    public function processFileExtensions(FileExtensionsInterface $fileExtensions, ?SimpleXMLElement $config = null): void
+    {
+        $fileExtensions->addFileTypeScanner('phpt', TemplateScanner::class);
+        $fileExtensions->addFileTypeAnalyzer('phpt', TemplateAnalyzer::class);
+    }    
 }
 ```

--- a/docs/running_psalm/plugins/authoring_plugins.md
+++ b/docs/running_psalm/plugins/authoring_plugins.md
@@ -39,8 +39,8 @@ To register a stub file manually use `Psalm\Plugin\RegistrationInterface::addStu
 In addition to XML configuration node `<fileExtensions>` plugins can register their own custom scanner
 and analyzer implementations for particular file extensions, e.g.
 
-* `Psalm\Plugin\RegistrationInterface::addFileTypeScanner('html', CustomFileScanner::class)`
-* `Psalm\Plugin\RegistrationInterface::addFileTypeAnalyzer('html', CustomFileAnalyzer::class)`
+* `Psalm\Plugin\FileExtensionsInterface::addFileTypeScanner('html', CustomFileScanner::class)`
+* `Psalm\Plugin\FileExtensionsInterface::addFileTypeAnalyzer('html', CustomFileAnalyzer::class)`
 
 ## Publishing your plugin on Packagist
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1395,7 +1395,7 @@ class Config
             } catch (Throwable $t) {
                 throw new ConfigException(
                     'Failed to process plugin file extensions ' . $pluginClassName,
-                    1635800581,
+                    1_635_800_581,
                     $t
                 );
             }
@@ -1438,7 +1438,7 @@ class Config
             } catch (Throwable $t) {
                 throw new ConfigException(
                     'Failed to invoke plugin ' . $plugin_class_name,
-                    1635800582,
+                    1_635_800_582,
                     $t
                 );
             }
@@ -1505,11 +1505,11 @@ class Config
                 self::requirePath($pluginclas_class_path);
             } else {
                 if (!class_exists($pluginClassName)) {
-                    throw new \UnexpectedValueException($pluginClassName . ' is not a known class');
+                    throw new UnexpectedValueException($pluginClassName . ' is not a known class');
                 }
             }
             if (!is_a($pluginClassName, PluginInterface::class, true)) {
-                throw new \UnexpectedValueException($pluginClassName . ' is not a PluginInterface implementation');
+                throw new UnexpectedValueException($pluginClassName . ' is not a PluginInterface implementation');
             }
             $this->plugins[$pluginClassName] = new $pluginClassName;
             $projectAnalyzer->progress->debug('Loaded plugin ' . $pluginClassName . PHP_EOL);

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -306,6 +306,7 @@ class ProjectAnalyzer
         $this->stdout_report_options = $stdout_report_options;
         $this->generated_report_options = $generated_report_options;
 
+        $this->config->processPluginFileExtensions($this);
         $file_extensions = $this->config->getFileExtensions();
 
         foreach ($this->config->getProjectDirectories() as $dir_name) {

--- a/src/Psalm/Plugin/FileExtensionsInterface.php
+++ b/src/Psalm/Plugin/FileExtensionsInterface.php
@@ -1,0 +1,20 @@
+<?php
+namespace Psalm\Plugin;
+
+use Psalm\Internal\Analyzer\FileAnalyzer;
+use Psalm\Internal\Scanner\FileScanner;
+
+interface FileExtensionsInterface
+{
+    /**
+     * @param string $fileExtension e.g. `'html'`
+     * @param class-string<FileScanner> $className
+     */
+    public function addFileTypeScanner(string $fileExtension, string $className): void;
+
+    /**
+     * @param string $fileExtension e.g. `'html'`
+     * @param class-string<FileAnalyzer> $className
+     */
+    public function addFileTypeAnalyzer(string $fileExtension, string $className): void;
+}

--- a/src/Psalm/Plugin/FileExtensionsInterface.php
+++ b/src/Psalm/Plugin/FileExtensionsInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Plugin;
 
 use Psalm\Internal\Analyzer\FileAnalyzer;

--- a/src/Psalm/Plugin/PluginEntryPointInterface.php
+++ b/src/Psalm/Plugin/PluginEntryPointInterface.php
@@ -4,7 +4,7 @@ namespace Psalm\Plugin;
 
 use SimpleXMLElement;
 
-interface PluginEntryPointInterface
+interface PluginEntryPointInterface extends PluginInterface
 {
     public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null): void;
 }

--- a/src/Psalm/Plugin/PluginFileExtensionsInterface.php
+++ b/src/Psalm/Plugin/PluginFileExtensionsInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Plugin;
 
 use SimpleXMLElement;

--- a/src/Psalm/Plugin/PluginFileExtensionsInterface.php
+++ b/src/Psalm/Plugin/PluginFileExtensionsInterface.php
@@ -1,0 +1,12 @@
+<?php
+namespace Psalm\Plugin;
+
+use SimpleXMLElement;
+
+interface PluginFileExtensionsInterface extends PluginInterface
+{
+    public function processFileExtensions(
+        FileExtensionsInterface $fileExtensions,
+        ?SimpleXMLElement $config = null
+    ): void;
+}

--- a/src/Psalm/Plugin/PluginInterface.php
+++ b/src/Psalm/Plugin/PluginInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Plugin;
 
 interface PluginInterface

--- a/src/Psalm/Plugin/PluginInterface.php
+++ b/src/Psalm/Plugin/PluginInterface.php
@@ -1,0 +1,6 @@
+<?php
+namespace Psalm\Plugin;
+
+interface PluginInterface
+{
+}

--- a/src/Psalm/Plugin/RegistrationInterface.php
+++ b/src/Psalm/Plugin/RegistrationInterface.php
@@ -2,9 +2,6 @@
 
 namespace Psalm\Plugin;
 
-use Psalm\Internal\Analyzer\FileAnalyzer;
-use Psalm\Internal\Scanner\FileScanner;
-
 interface RegistrationInterface
 {
     public function addStubFile(string $file_name): void;
@@ -13,18 +10,4 @@ interface RegistrationInterface
      * @param class-string $handler
      */
     public function registerHooksFromClass(string $handler): void;
-
-    /**
-     * @param string $fileExtension e.g. `'html'`
-     * @param class-string<FileScanner> $className
-     * @deprecated will be removed in v5.0, use \Psalm\Plugin\FileExtensionsInterface instead (#6788)
-     */
-    public function addFileTypeScanner(string $fileExtension, string $className): void;
-
-    /**
-     * @param string $fileExtension e.g. `'html'`
-     * @param class-string<FileAnalyzer> $className
-     * @deprecated will be removed in v5.0, use \Psalm\Plugin\FileExtensionsInterface instead (#6788)
-     */
-    public function addFileTypeAnalyzer(string $fileExtension, string $className): void;
 }

--- a/src/Psalm/PluginFileExtensionsSocket.php
+++ b/src/Psalm/PluginFileExtensionsSocket.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm;
 
 use LogicException;
@@ -54,7 +55,7 @@ class PluginFileExtensionsSocket implements FileExtensionsInterface
                     $className,
                     FileScanner::class
                 ),
-                1622727271
+                1_622_727_271
             );
         }
         if (!empty($this->config->getFiletypeScanners()[$fileExtension])
@@ -62,7 +63,7 @@ class PluginFileExtensionsSocket implements FileExtensionsInterface
         ) {
             throw new LogicException(
                 sprintf('Cannot redeclare scanner for file-type %s', $fileExtension),
-                1622727272
+                1_622_727_272
             );
         }
         $this->additionalFileTypeScanners[$fileExtension] = $className;
@@ -90,7 +91,7 @@ class PluginFileExtensionsSocket implements FileExtensionsInterface
                     $className,
                     FileAnalyzer::class
                 ),
-                1622727281
+                1_622_727_281
             );
         }
         if (!empty($this->config->getFiletypeAnalyzers()[$fileExtension])
@@ -98,7 +99,7 @@ class PluginFileExtensionsSocket implements FileExtensionsInterface
         ) {
             throw new LogicException(
                 sprintf('Cannot redeclare analyzer for file-type %s', $fileExtension),
-                1622727282
+                1_622_727_282
             );
         }
         $this->additionalFileTypeAnalyzers[$fileExtension] = $className;

--- a/src/Psalm/PluginFileExtensionsSocket.php
+++ b/src/Psalm/PluginFileExtensionsSocket.php
@@ -1,0 +1,136 @@
+<?php
+namespace Psalm;
+
+use LogicException;
+use Psalm\Internal\Analyzer\FileAnalyzer;
+use Psalm\Internal\Scanner\FileScanner;
+use Psalm\Plugin\FileExtensionsInterface;
+
+use function class_exists;
+use function in_array;
+use function is_a;
+use function sprintf;
+
+class PluginFileExtensionsSocket implements FileExtensionsInterface
+{
+    /**
+     * @var Config
+     */
+    private $config;
+
+    /**
+     * @var array<string, class-string<FileScanner>>
+     */
+    private $additionalFileTypeScanners = [];
+
+    /**
+     * @var array<string, class-string<FileAnalyzer>>
+     */
+    private $additionalFileTypeAnalyzers = [];
+
+    /**
+     * @var list<string>
+     */
+    private $additionalFileExtensions = [];
+
+    /**
+     * @internal
+     */
+    public function __construct(Config $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * @param string $fileExtension e.g. `'html'`
+     * @param class-string<FileScanner> $className
+     */
+    public function addFileTypeScanner(string $fileExtension, string $className): void
+    {
+        if (!class_exists($className) || !is_a($className, FileScanner::class, true)) {
+            throw new LogicException(
+                sprintf(
+                    'Class %s must be of type %s',
+                    $className,
+                    FileScanner::class
+                ),
+                1622727271
+            );
+        }
+        if (!empty($this->config->getFiletypeScanners()[$fileExtension])
+            || !empty($this->additionalFileTypeScanners[$fileExtension])
+        ) {
+            throw new LogicException(
+                sprintf('Cannot redeclare scanner for file-type %s', $fileExtension),
+                1622727272
+            );
+        }
+        $this->additionalFileTypeScanners[$fileExtension] = $className;
+        $this->addFileExtension($fileExtension);
+    }
+
+    /**
+     * @return array<string, class-string<FileScanner>>
+     */
+    public function getAdditionalFileTypeScanners(): array
+    {
+        return $this->additionalFileTypeScanners;
+    }
+
+    /**
+     * @param string $fileExtension e.g. `'html'`
+     * @param class-string<FileAnalyzer> $className
+     */
+    public function addFileTypeAnalyzer(string $fileExtension, string $className): void
+    {
+        if (!class_exists($className) || !is_a($className, FileAnalyzer::class, true)) {
+            throw new LogicException(
+                sprintf(
+                    'Class %s must be of type %s',
+                    $className,
+                    FileAnalyzer::class
+                ),
+                1622727281
+            );
+        }
+        if (!empty($this->config->getFiletypeAnalyzers()[$fileExtension])
+            || !empty($this->additionalFileTypeAnalyzers[$fileExtension])
+        ) {
+            throw new LogicException(
+                sprintf('Cannot redeclare analyzer for file-type %s', $fileExtension),
+                1622727282
+            );
+        }
+        $this->additionalFileTypeAnalyzers[$fileExtension] = $className;
+        $this->addFileExtension($fileExtension);
+    }
+
+    /**
+     * @return array<string, class-string<FileAnalyzer>>
+     */
+    public function getAdditionalFileTypeAnalyzers(): array
+    {
+        return $this->additionalFileTypeAnalyzers;
+    }
+
+    /**
+     * @return list<string> e.g. `['html', 'perl']`
+     */
+    public function getAdditionalFileExtensions(): array
+    {
+        return $this->additionalFileExtensions;
+    }
+
+    /**
+     * @param string $fileExtension e.g. `'html'`
+     */
+    private function addFileExtension(string $fileExtension): void
+    {
+        /** @psalm-suppress RedundantCondition */
+        if (!in_array($fileExtension, $this->additionalFileExtensions, true)
+            && !in_array($fileExtension, $this->config->getFileExtensions(), true)
+        ) {
+            $this->additionalFileExtensions[] = $fileExtension;
+        }
+    }
+}

--- a/src/Psalm/PluginRegistrationSocket.php
+++ b/src/Psalm/PluginRegistrationSocket.php
@@ -3,9 +3,6 @@
 namespace Psalm;
 
 use InvalidArgumentException;
-use LogicException;
-use Psalm\Internal\Analyzer\FileAnalyzer;
-use Psalm\Internal\Scanner\FileScanner;
 use Psalm\Plugin\EventHandler\DynamicFunctionStorageProviderInterface;
 use Psalm\Plugin\EventHandler\FunctionExistenceProviderInterface;
 use Psalm\Plugin\EventHandler\FunctionParamsProviderInterface;
@@ -20,10 +17,7 @@ use Psalm\Plugin\EventHandler\PropertyVisibilityProviderInterface;
 use Psalm\Plugin\RegistrationInterface;
 
 use function class_exists;
-use function in_array;
-use function is_a;
 use function is_subclass_of;
-use function sprintf;
 
 class PluginRegistrationSocket implements RegistrationInterface
 {
@@ -32,21 +26,6 @@ class PluginRegistrationSocket implements RegistrationInterface
 
     /** @var Codebase */
     private $codebase;
-
-    /**
-     * @var array<string, class-string<FileScanner>>
-     */
-    private $additionalFileTypeScanners = [];
-
-    /**
-     * @var array<string, class-string<FileAnalyzer>>
-     */
-    private $additionalFileTypeAnalyzers = [];
-
-    /**
-     * @var list<string>
-     */
-    private $additionalFileExtensions = [];
 
     /**
      * @internal
@@ -112,102 +91,6 @@ class PluginRegistrationSocket implements RegistrationInterface
 
         if (is_subclass_of($handler, DynamicFunctionStorageProviderInterface::class)) {
             $this->codebase->functions->dynamic_storage_provider->registerClass($handler);
-        }
-    }
-
-    /**
-     * @param string $fileExtension e.g. `'html'`
-     * @param class-string<FileScanner> $className
-     * @deprecated will be removed in v5.0, use \Psalm\Plugin\FileExtensionsInterface instead (#6788)
-     */
-    public function addFileTypeScanner(string $fileExtension, string $className): void
-    {
-        if (!class_exists($className) || !is_a($className, FileScanner::class, true)) {
-            throw new LogicException(
-                sprintf(
-                    'Class %s must be of type %s',
-                    $className,
-                    FileScanner::class
-                ),
-                1_622_727_271
-            );
-        }
-        if (!empty($this->config->getFiletypeScanners()[$fileExtension])
-            || !empty($this->additionalFileTypeScanners[$fileExtension])
-        ) {
-            throw new LogicException(
-                sprintf('Cannot redeclare scanner for file-type %s', $fileExtension),
-                1_622_727_272
-            );
-        }
-        $this->additionalFileTypeScanners[$fileExtension] = $className;
-        $this->addFileExtension($fileExtension);
-    }
-
-    /**
-     * @return array<string, class-string<FileScanner>>
-     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
-     */
-    public function getAdditionalFileTypeScanners(): array
-    {
-        return $this->additionalFileTypeScanners;
-    }
-
-    /**
-     * @param string $fileExtension e.g. `'html'`
-     * @param class-string<FileAnalyzer> $className
-     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
-     */
-    public function addFileTypeAnalyzer(string $fileExtension, string $className): void
-    {
-        if (!class_exists($className) || !is_a($className, FileAnalyzer::class, true)) {
-            throw new LogicException(
-                sprintf(
-                    'Class %s must be of type %s',
-                    $className,
-                    FileAnalyzer::class
-                ),
-                1_622_727_281
-            );
-        }
-        if (!empty($this->config->getFiletypeAnalyzers()[$fileExtension])
-            || !empty($this->additionalFileTypeAnalyzers[$fileExtension])
-        ) {
-            throw new LogicException(
-                sprintf('Cannot redeclare analyzer for file-type %s', $fileExtension),
-                1_622_727_282
-            );
-        }
-        $this->additionalFileTypeAnalyzers[$fileExtension] = $className;
-        $this->addFileExtension($fileExtension);
-    }
-
-    /**
-     * @return array<string, class-string<FileAnalyzer>>
-     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
-     */
-    public function getAdditionalFileTypeAnalyzers(): array
-    {
-        return $this->additionalFileTypeAnalyzers;
-    }
-
-    /**
-     * @return list<string> e.g. `['html', 'perl']`
-     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
-     */
-    public function getAdditionalFileExtensions(): array
-    {
-        return $this->additionalFileExtensions;
-    }
-
-    /**
-     * @param string $fileExtension e.g. `'html'`
-     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
-     */
-    private function addFileExtension(string $fileExtension): void
-    {
-        if (!in_array($fileExtension, $this->config->getFileExtensions(), true)) {
-            $this->additionalFileExtensions[] = $fileExtension;
         }
     }
 }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -1416,7 +1416,7 @@ class ConfigTest extends TestCase
         $extension = uniqid('test');
         $names = [
             'scanner' => uniqid('PsalmTestFileTypeScanner'),
-            'analyzer' => uniqid('PsalmTestFileTypeAnaylzer'),
+            'analyzer' => uniqid('PsalmTestFileTypeAnalyzer'),
             'extension' => $extension,
         ];
         $scannerMock = $this->getMockBuilder(FileScanner::class)
@@ -1437,12 +1437,11 @@ class ConfigTest extends TestCase
             <psalm><plugins><pluginClass class="%s"/></plugins></psalm>',
             FileTypeSelfRegisteringPlugin::class
         );
-        $projectAnalyzer = $this->getProjectAnalyzerWithConfig(
-            TestConfig::loadFromXML(dirname(__DIR__, 2), $xml)
-        );
-
 
         try {
+            $projectAnalyzer = $this->getProjectAnalyzerWithConfig(
+                TestConfig::loadFromXML(dirname(__DIR__, 2), $xml)
+            );
             $config = $projectAnalyzer->getConfig();
             $config->initializePlugins($projectAnalyzer);
         } catch (ConfigException $exception) {

--- a/tests/Config/Plugin/FileTypeSelfRegisteringPlugin.php
+++ b/tests/Config/Plugin/FileTypeSelfRegisteringPlugin.php
@@ -2,12 +2,12 @@
 
 namespace Psalm\Tests\Config\Plugin;
 
-use Psalm\Plugin\PluginEntryPointInterface;
-use Psalm\Plugin\RegistrationInterface;
+use Psalm\Plugin\FileExtensionsInterface;
+use Psalm\Plugin\PluginFileExtensionsInterface;
 use SimpleXMLElement;
 use stdClass;
 
-class FileTypeSelfRegisteringPlugin implements PluginEntryPointInterface
+class FileTypeSelfRegisteringPlugin implements PluginFileExtensionsInterface
 {
     public const FLAG_SCANNER_TWICE = 1;
     public const FLAG_ANALYZER_TWICE = 2;
@@ -25,32 +25,32 @@ class FileTypeSelfRegisteringPlugin implements PluginEntryPointInterface
      */
     public static $flags = 0;
 
-    public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null): void
+    public function processFileExtensions(FileExtensionsInterface $fileExtensions, ?SimpleXMLElement $config = null): void
     {
         if (self::$flags & self::FLAG_SCANNER_INVALID) {
             /** @psalm-suppress InvalidArgument */
-            $registration->addFileTypeScanner(self::$names['extension'], stdClass::class);
+            $fileExtensions->addFileTypeScanner(self::$names['extension'], stdClass::class);
         } else {
             // that's the regular/valid case
             /** @psalm-suppress ArgumentTypeCoercion */
-            $registration->addFileTypeScanner(self::$names['extension'], self::$names['scanner']);
+            $fileExtensions->addFileTypeScanner(self::$names['extension'], self::$names['scanner']);
         }
         if (self::$flags & self::FLAG_ANALYZER_INVALID) {
             /** @psalm-suppress InvalidArgument */
-            $registration->addFileTypeAnalyzer(self::$names['extension'], stdClass::class);
+            $fileExtensions->addFileTypeAnalyzer(self::$names['extension'], stdClass::class);
         } else {
             // that's the regular/valid case
             /** @psalm-suppress ArgumentTypeCoercion */
-            $registration->addFileTypeAnalyzer(self::$names['extension'], self::$names['analyzer']);
+            $fileExtensions->addFileTypeAnalyzer(self::$names['extension'], self::$names['analyzer']);
         }
 
         if (self::$flags & self::FLAG_SCANNER_TWICE) {
             /** @psalm-suppress ArgumentTypeCoercion */
-            $registration->addFileTypeScanner(self::$names['extension'], self::$names['scanner']);
+            $fileExtensions->addFileTypeScanner(self::$names['extension'], self::$names['scanner']);
         }
         if (self::$flags & self::FLAG_ANALYZER_TWICE) {
             /** @psalm-suppress ArgumentTypeCoercion */
-            $registration->addFileTypeAnalyzer(self::$names['extension'], self::$names['analyzer']);
+            $fileExtensions->addFileTypeAnalyzer(self::$names['extension'], self::$names['analyzer']);
         }
     }
 }


### PR DESCRIPTION
`ProjectAnalyzer` consumed `Config::$fileExtensions` early in its
constructor - without having processed plugins' modifications,
registering their custom scanners or analyzer implementations.

This change
* adds new specific interface `\Psalm\Plugin\FileExtensionsInterface`
  to be used by plugin implementations
* extracts file extension handling from `\Psalm\PluginRegistrationSocket`
  and interface `\Psalm\Plugin\RegistrationInterface` to a new dedicated
  `\Psalm\PluginFileExtensionsSocket` and new interface
  `\Psalm\Plugin\FileExtensionsInterface`
  **!!! this is a breaking change in `PluginRegistrationSocket` !!!**
* adds runtime in-memory cache for `Config::$plugins`
* calls new method `Config::processPluginFileExtensions()`, providing
  modifications to file extension only early in `ProjectAnalyzer`
* adjusts documentation

Adjusted test scenario https://github.com/ohader/psalm-6788/tree/adjusted

Fixes: #6788

---

Deprecation in `4.x` branch, see https://github.com/vimeo/psalm/pull/7455

