### PR TITLE
don't taint the result of most binary operations

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -378,6 +378,7 @@ class BinaryOpAnalyzer
             && $stmt instanceof PhpParser\Node\Expr\BinaryOp
             && !$stmt instanceof PhpParser\Node\Expr\BinaryOp\Concat
             && !$stmt instanceof PhpParser\Node\Expr\BinaryOp\Coalesce
+            && (!$stmt instanceof PhpParser\Node\Expr\BinaryOp\Plus || !$result_type->hasArray())
         ) {
             //among BinaryOp, only Concat and Coalesce can pass tainted value to the result
             return;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -380,7 +380,7 @@ class BinaryOpAnalyzer
             && !$stmt instanceof PhpParser\Node\Expr\BinaryOp\Coalesce
             && (!$stmt instanceof PhpParser\Node\Expr\BinaryOp\Plus || !$result_type->hasArray())
         ) {
-            //among BinaryOp, only Concat and Coalesce can pass tainted value to the result
+            //among BinaryOp, only Concat and Coalesce can pass tainted value to the result. Also Plus on arrays only
             return;
         }
 

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -644,6 +644,12 @@ class TaintTest extends TestCase
 
                     takesArray(["good" => $_GET["bad"]]);'
             ],
+            'resultOfComparisonIsNotTainted' => [
+                '<?php
+                    $input = $_GET["foo"];
+                    $var = $input === "x";
+                    var_dump($var);'
+            ],
         ];
     }
 

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -650,6 +650,12 @@ class TaintTest extends TestCase
                     $var = $input === "x";
                     var_dump($var);'
             ],
+            'resultOfPlusIsNotTainted' => [
+                '<?php
+                    $input = $_GET["foo"];
+                    $var = $input + 1;
+                    var_dump($var);'
+            ],
         ];
     }
 
@@ -2157,6 +2163,16 @@ class TaintTest extends TestCase
                     }
 
                     takesArray([$_GET["bad"] => "good"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'resultOfPlusIsTaintedOnArrays' => [
+                '<?php
+                    scope($_GET["foo"]);
+                    function scope(array $foo)
+                    {
+                        $var = $foo + [];
+                        var_dump($var);
+                    }',
                 'error_message' => 'TaintedHtml',
             ],
             'taintArrayKeyWithExplicitSink' => [


### PR DESCRIPTION
As far as I can tell, only Concat and Coalesce binary ops can pass taint to the result.

To whoever it may concern: this method is called for other Expr, there are other Expr that does not imply tainted results (I'm thinking PostInc for example: https://psalm.dev/r/4e6d6d9566). If someone want to give a hand and list all Expr that could and couldn't pass taint, it would be most helpful and I'd gladly amend this to add them all.

This will fix #6804