### PR TITLE
don't register taints for numeric variables

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/EchoAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/EchoAnalyzer.php
@@ -38,7 +38,7 @@ class EchoAnalyzer
             $expr_type = $statements_analyzer->node_data->getType($expr);
 
             if ($statements_analyzer->data_flow_graph instanceof TaintFlowGraph) {
-                if ($expr_type) {
+                if ($expr_type && $expr_type->hasObjectType()) {
                     $expr_type = CastAnalyzer::castStringAttempt(
                         $statements_analyzer,
                         $context,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -1505,6 +1505,14 @@ class ArgumentAnalyzer
             return $input_type;
         }
 
+        // numeric types can't be tainted
+        if ($statements_analyzer->data_flow_graph instanceof TaintFlowGraph
+            && $input_type->isSingle()
+            && ($input_type->isInt() || $input_type->isFloat())
+        ) {
+            return $input_type;
+        }
+
         $event = new AddRemoveTaintsEvent($expr, $context, $statements_analyzer, $codebase);
 
         $added_taints = $codebase->config->eventDispatcher->dispatchAddTaints($event);

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -616,6 +616,21 @@ class TaintTest extends TestCase
                     echo foo($_GET["foo"], true);
                     echo foo($_GET["foo"]);'
             ],
+            'NoTaintForInt' => [
+                '<?php // --taint-analysis
+
+                    function foo(int $value): void {
+                        echo $value;
+                    }
+
+                    foo($_GET["foo"]);
+
+                    function bar(): int {
+                        return $_GET["foo"];
+                    }
+
+                    echo bar();'
+            ],
             'conditionallyEscapedTaintPassedTrueStaticCall' => [
                 '<?php
                     class U {


### PR DESCRIPTION
this fixes #4872

I was pretty confused for a moment, I expected two fixes: get rid of the taint when passing through params, and when passing through a return type

However, as soon as I fixed the params one, both disappeared. I then realised that echo was treated as a function and it stopped registering taint given they were ints. I searched for sinks that are not functions (or treated as such by psalm) and couldn't find some. Maybe I'm mistaken on this.

Note also that this PR represent a subtle change in behaviour: declaring that a function takes an int as a param or gives int as a return type *in phpdoc* will now remove possible taints. It may be possible to do so only if the type does not come from docblock but it seemed more aligned with Psalm's policy to trust types even in docblock