### PR TITLE
add "error" from php-parser to baseline

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -492,4 +492,9 @@
       <code>$type[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
+  <file src="vendor/nikic/php-parser/lib/PhpParser/Node/Expr/ArrowFunction.php">
+    <PossiblyUndefinedStringArrayOffset occurrences="1">
+      <code>$subNodes['expr']</code>
+    </PossiblyUndefinedStringArrayOffset>
+  </file>
 </files>


### PR DESCRIPTION
This adds an error detected by Psalm in PHP-Parser to the baseline.

It's not so much an error than an undocumented array because PHP-Parser doesn't use specific phpdoc. This is the first one of this type because every other property use null coalescing for initialisation but this one doesn't, apparently on purpose: https://github.com/nikic/PHP-Parser/pull/808

This was the error that was messing with the CI on #6153