### PR TITLE
Makes $_SESSION possibly undefined at the source

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -284,7 +284,6 @@ class AssertionFinder
                         && !$var_type->isMixed()
                         && !$var_type->possibly_undefined
                         && !$var_type->possibly_undefined_from_try
-                        && $var_name !== '$_SESSION'
                     ) {
                         $if_types[$var_name] = [['!null']];
                     } else {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -557,7 +557,11 @@ class VariableFetchAnalyzer
         }
 
         if (self::isSuperGlobal($var_id)) {
-            return Type::getArray();
+            $type = Type::getArray();
+            if ($var_id === '$_SESSION') {
+                $type->possibly_undefined = true;
+            }
+            return $type;
         }
 
         return Type::getMixed();

--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -86,7 +86,6 @@ class NegatedAssertionReconciler extends Reconciler
                 if (!$existing_var_type->isNullable()
                     && $key
                     && strpos($key, '[') === false
-                    && $key !== '$_SESSION'
                 ) {
                     foreach ($existing_var_type->getAtomicTypes() as $atomic) {
                         if (!$existing_var_type->hasMixed()

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -460,7 +460,6 @@ class SimpleAssertionReconciler extends \Psalm\Type\Reconciler
         $did_remove_type = ($key && strpos($key, '['))
             || !$existing_var_type->initialized
             || $existing_var_type->possibly_undefined
-            || $key === '$_SESSION'
             || $existing_var_type->ignore_isset;
 
         if ($existing_var_type->isNullable()) {


### PR DESCRIPTION
This is more correct (I need this for another PR) and it allows removing some specific bypass that have been added here and there in the code.