### PR TITLE
create a tmp fake var for ternaries inside coalesce

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
@@ -38,6 +38,7 @@ class CoalesceAnalyzer
             || $root_expr instanceof PhpParser\Node\Expr\Cast
             || $root_expr instanceof PhpParser\Node\Expr\NullsafePropertyFetch
             || $root_expr instanceof PhpParser\Node\Expr\NullsafeMethodCall
+            || $root_expr instanceof PhpParser\Node\Expr\Ternary
         ) {
             $left_var_id = '$<tmp coalesce var>' . (int) $left_expr->getAttribute('startFilePos');
 

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -700,6 +700,19 @@ class BinaryOperationTest extends TestCase
                     '$b' => 'float|int',
                 ],
             ],
+            'coalesceFilterOutNullEvenWithTernary' => [
+                '<?php
+
+                    interface FooInterface
+                    {
+                        public function toString(): ?string;
+                    }
+
+                    function example(object $foo): string
+                    {
+                        return ($foo instanceof FooInterface ? $foo->toString() : null) ?? "Not a stringable foo";
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/5063, I'll add test later and cleanup later

I spent some time on this because it has the potential to fix those too: #5600 #5285. Unfortunately, adding Variable to the list of nodes that create a temporary var create a few false positives too that are hard to analyse. that's why I'm only PRing the Ternary one

