### PR TITLE
only return true in Union::is*Type* if there is a single type

### DIFF
--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -943,7 +943,8 @@ class Union implements TypeNode
     public function isEmptyMixed(): bool
     {
         return isset($this->types['mixed'])
-            && $this->types['mixed'] instanceof Type\Atomic\TEmptyMixed;
+            && $this->types['mixed'] instanceof Type\Atomic\TEmptyMixed
+            && count($this->types) === 1;
     }
 
     public function isVanillaMixed(): bool
@@ -1140,12 +1141,12 @@ class Union implements TypeNode
 
     public function isVoid(): bool
     {
-        return isset($this->types['void']);
+        return isset($this->types['void']) && count($this->types) === 1;
     }
 
     public function isNever(): bool
     {
-        return isset($this->types['never']);
+        return isset($this->types['never']) && count($this->types) === 1;
     }
 
     public function isGenerator(): bool
@@ -1157,7 +1158,7 @@ class Union implements TypeNode
 
     public function isEmpty(): bool
     {
-        return isset($this->types['empty']);
+        return isset($this->types['empty']) && count($this->types) === 1;
     }
 
     public function substitute(Union $old_type, ?Union $new_type = null): void


### PR DESCRIPTION
This fixes a inconsistency I noticed. Union has two sets of useful functions: `has*Type*` and `is*Type*`. `has` ones checks that the type is in there while `is` ones checks that the only type(s) in the union are of the given type.

Before the fix, it allowed for `isEmptyMixed` or `isEmpty` to return true for `empty-mixed|2` and `empty|2` for example. It's quite unlikely this lead to actual bugs because those types are pretty rare, especially in Union with other types, but I didn't want to leave this like that :)