### PR TITLE
don't consider calls to methods with assertions as Unused

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -106,7 +106,13 @@ class MethodCallPurityAnalyzer
                 && !$context->inside_general_use
                 && !$context->inside_throw
             ) {
-                if (!$context->inside_assignment && !$context->inside_call && !$context->inside_return) {
+                if (!$context->inside_assignment
+                    && !$context->inside_call
+                    && !$context->inside_return
+                    && !$method_storage->assertions
+                    && !$method_storage->if_true_assertions
+                    && !$method_storage->if_false_assertions
+                ) {
                     if (IssueBuffer::accepts(
                         new \Psalm\Issue\UnusedMethodCall(
                             'The call to ' . $cased_method_id . ' is not used',

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1091,7 +1091,7 @@ class UnusedCodeTest extends TestCase
                     }
 
                     $a = new A();
-                    $a->getVal(null);',
+                    echo $a->getVal(null);',
             ],
         ];
     }

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1069,6 +1069,30 @@ class UnusedCodeTest extends TestCase
                         echo "hello";
                     }',
             ],
+            'NotUnusedWhenAssert' => [
+                '<?php
+
+                    class A {
+                        public function getVal(?string $val): string {
+                            $this->assert($val);
+
+                            return $val;
+                        }
+
+                        /**
+                         * @psalm-assert string $val
+                         * @psalm-mutation-free
+                         */
+                        private function assert(?string $val): void {
+                            if (null === $val) {
+                                throw new Exception();
+                            }
+                        }
+                    }
+
+                    $a = new A();
+                    $a->getVal(null);',
+            ],
         ];
     }
 


### PR DESCRIPTION
This will fix #5735 and will fix https://github.com/vimeo/psalm/issues/5528. If anyone understands mixins, I guess the fix for https://github.com/vimeo/psalm/issues/3701 should be around those parts too.

I don't fully understands every check that's made here so I just excluded the error but I have the feeling like there would be improvements to be made here. For starter, I don't understand why https://github.com/vimeo/psalm/pull/6834/files#diff-af464bb3ab4e6193d8b7eec8d9c52b8be4e801fda844f86d0db7c9c0b2e63637R92 there is assertions, if_true assertions but not if_false_assertions here.