### PR TITLE
Forbid declaring enums as attributes

### DIFF
--- a/src/Psalm/Internal/Analyzer/AttributeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/AttributeAnalyzer.php
@@ -95,6 +95,16 @@ class AttributeAnalyzer
                 )) {
                     // fall through
                 }
+            } elseif ($classlike_storage->is_enum) {
+                if (\Psalm\IssueBuffer::accepts(
+                    new InvalidAttribute(
+                        'Enums cannot act a attribute classes',
+                        $attribute->name_location
+                    ),
+                    $source->getSuppressedIssues()
+                )) {
+                    // fall through
+                }
             }
         }
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -364,6 +364,16 @@ class EnumTest extends TestCase
                 false,
                 '8.1',
             ],
+            'enumsAsAttributes' => [
+                '<?php
+                    #[Attribute(Attribute::TARGET_CLASS)]
+                    enum Status { }
+                    ',
+                'error_message' => 'InvalidAttribute',
+                [],
+                false,
+                '8.1',
+            ],
         ];
     }
 }


### PR DESCRIPTION
This is in line with current Psalm behavior. We forbid non-instantiable classlikes as attributes, including abstract classes and classes with non-public constructors.

Refs vimeo/psalm#6841