### PR TITLE
Added ext-curl to composer.json suggest property

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,8 @@
         "weirdan/prophecy-shim": "^1.0 || ^2.0"
     },
     "suggest": {
-        "ext-igbinary": "^2.0.5"
+        "ext-igbinary": "^2.0.5 is required, used to serialize caching data",
+        "ext-curl": "In order to send data to shepherd"
     },
     "config": {
         "optimize-autoloader": true,


### PR DESCRIPTION
Today, I noticed this phpunit's commit.
https://github.com/sebastianbergmann/phpunit/commit/809d500c75f15467441f459d45093f5b7f99cfd1#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f

I also updated ext-igbinary value, because
> The format is like package links above, except that the values are free text and not version constraints.
https://getcomposer.org/doc/04-schema.md#suggest

Notes: I just did following command to update composer.json.
```
composer config suggest.ext-curl "In order to send data to shepherd"
composer config suggest.ext-igbinary "^2.0.5 is required, used to serialize caching data"
```