### PR TITLE
Added phpcs SelfMemberReference rule, and applied

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -41,6 +41,7 @@
             <property name="linesCountBetweenUseTypes" value="1" />
         </properties>
     </rule>
+    <rule ref="Squiz.Classes.SelfMemberReference" />
     <file>bin/</file>
     <file>src/</file>
     <file>tests/</file>

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -596,7 +596,7 @@ class Config
         }
 
         do {
-            $maybe_path = $dir_path . DIRECTORY_SEPARATOR . Config::DEFAULT_FILE_NAME;
+            $maybe_path = $dir_path . DIRECTORY_SEPARATOR . self::DEFAULT_FILE_NAME;
 
             if (file_exists($maybe_path) || file_exists($maybe_path .= '.dist')) {
                 return $maybe_path;
@@ -1526,7 +1526,7 @@ class Config
 
         $parent_issue_type = self::getParentIssueType($issue_type);
 
-        if ($parent_issue_type && $reporting_level === Config::REPORT_ERROR) {
+        if ($parent_issue_type && $reporting_level === self::REPORT_ERROR) {
             $parent_reporting_level = $this->getReportingLevelForFile($parent_issue_type, $e->getFilePath());
 
             if ($parent_reporting_level !== $reporting_level) {

--- a/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
@@ -286,7 +286,7 @@ class ScopeAnalyzer
 
                     $case_does_end = !array_diff(
                         $control_actions,
-                        [ScopeAnalyzer::ACTION_END, ScopeAnalyzer::ACTION_RETURN]
+                        [self::ACTION_END, self::ACTION_RETURN]
                     );
 
                     if ($case_does_end) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
@@ -241,8 +241,8 @@ class ConstFetchAnalyzer
             return $file_storage_provider->get($constant_file_path)->constants[$fq_const_name];
         }
 
-        return ConstFetchAnalyzer::getGlobalConstType($codebase, $fq_const_name, $const_name)
-            ?? ConstFetchAnalyzer::getGlobalConstType($codebase, $const_name, $const_name);
+        return self::getGlobalConstType($codebase, $fq_const_name, $const_name)
+            ?? self::getGlobalConstType($codebase, $const_name, $const_name);
     }
 
     public static function setConstType(

--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -700,7 +700,7 @@ class AtomicTypeComparator
         $first_comparison_result = new TypeComparisonResult();
         $second_comparison_result = new TypeComparisonResult();
 
-        return (AtomicTypeComparator::isContainedBy(
+        return (self::isContainedBy(
             $codebase,
             $type1_part,
             $type2_part,
@@ -709,7 +709,7 @@ class AtomicTypeComparator
             $first_comparison_result
         )
             && !$first_comparison_result->to_string_cast
-        ) || (AtomicTypeComparator::isContainedBy(
+        ) || (self::isContainedBy(
             $codebase,
             $type2_part,
             $type1_part,

--- a/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
@@ -201,7 +201,7 @@ class TemplateStandinTypeReplacer
                     $array_template_type
                         = $template_result->template_types[$atomic_type->array_param_name][$atomic_type->defining_class];
                     $offset_template_type
-                        = TemplateStandinTypeReplacer::getMostSpecificTypeFromBounds(
+                        = self::getMostSpecificTypeFromBounds(
                             array_values($template_result->lower_bounds[$atomic_type->offset_param_name])[0],
                             $codebase
                         );

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -467,7 +467,7 @@ abstract class Type
         }
 
         if ($type_1->isVanillaMixed() && $type_2->isVanillaMixed()) {
-            $combined_type = Type::getMixed();
+            $combined_type = self::getMixed();
         } else {
             $both_failed_reconciliation = false;
 
@@ -565,7 +565,7 @@ abstract class Type
         $type_2_mixed = $type_2->isMixed();
 
         if ($type_1_mixed && $type_2_mixed) {
-            $combined_type = Type::getMixed();
+            $combined_type = self::getMixed();
         } else {
             $both_failed_reconciliation = false;
 

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -320,7 +320,7 @@ class Reconciler
                     || $type[0][0] === 'isset'
                     || $type[0][0] === '!empty'
                 ) {
-                    $key_parts = Reconciler::breakUpPathIntoParts($nk);
+                    $key_parts = self::breakUpPathIntoParts($nk);
 
                     $base_key = array_shift($key_parts);
 
@@ -385,7 +385,7 @@ class Reconciler
                 }
 
                 if ($type[0][0] === 'array-key-exists') {
-                    $key_parts = Reconciler::breakUpPathIntoParts($nk);
+                    $key_parts = self::breakUpPathIntoParts($nk);
 
                     if (count($key_parts) === 4
                         && $key_parts[1] === '['

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -306,18 +306,18 @@ class TypeParseTest extends TestCase
 
     public function testTKeyedArrayWithSimpleArgs(): void
     {
-        $this->assertSame('array{a: int, b: string}', (string) Type:: parseString('array{a: int, b: string}'));
+        $this->assertSame('array{a: int, b: string}', (string) Type::parseString('array{a: int, b: string}'));
     }
 
     public function testTKeyedArrayWithSpace(): void
     {
-        $this->assertSame('array{\'a \': int, \'b  \': string}', (string) Type:: parseString('array{\'a \': int, \'b  \': string}'));
+        $this->assertSame('array{\'a \': int, \'b  \': string}', (string) Type::parseString('array{\'a \': int, \'b  \': string}'));
     }
 
     public function testTKeyedArrayWithQuotedKeys(): void
     {
-        $this->assertSame('array{\'\\"\': int, \'\\\'\': string}', (string) Type:: parseString('array{\'"\': int, \'\\\'\': string}'));
-        $this->assertSame('array{\'\\"\': int, \'\\\'\': string}', (string) Type:: parseString('array{"\\"": int, "\\\'": string}'));
+        $this->assertSame('array{\'\\"\': int, \'\\\'\': string}', (string) Type::parseString('array{\'"\': int, \'\\\'\': string}'));
+        $this->assertSame('array{\'\\"\': int, \'\\\'\': string}', (string) Type::parseString('array{"\\"": int, "\\\'": string}'));
     }
 
     public function testTKeyedArrayWithClassConstantKey(): void
@@ -328,7 +328,7 @@ class TypeParseTest extends TestCase
 
     public function testTKeyedArrayWithQuotedClassConstantKey(): void
     {
-        $this->assertSame('array{\'self::FOO\': string}', (string) Type:: parseString('array{"self::FOO": string}'));
+        $this->assertSame('array{\'self::FOO\': string}', (string) Type::parseString('array{"self::FOO": string}'));
     }
 
     public function testTKeyedArrayWithoutClosingBracket(): void
@@ -867,8 +867,8 @@ class TypeParseTest extends TestCase
         $string = "АаБбВвГгДдЕеЁёЖжЗзИиЙйКкЛлМмНнОоПпРрСсТтУуФфХхЦцЧчШшЩщЪъЫыЬьЭэЮюЯя";
         $string .= $string;
         $expected = mb_substr($string, 0, 80);
-        $this->assertSame("\"$expected...\"", Type:: parseString("'$string'")->getId());
-        $this->assertSame("\"$expected...\"", Type:: parseString("\"$string\"")->getId());
+        $this->assertSame("\"$expected...\"", Type::parseString("'$string'")->getId());
+        $this->assertSame("\"$expected...\"", Type::parseString("\"$string\"")->getId());
     }
 
     public function testSingleLiteralString(): void


### PR DESCRIPTION
I found `Type:: parseString(`,  surprisingly it includes space after `::`.
https://github.com/vimeo/psalm/blob/4.12.0/tests/TypeParseTest.php

It can be forbid by `Squiz.Classes.SelfMemberReference.SpaceAfter`.

I belive whole `Squiz.Classes.SelfMemberReference` rule would be applicatable.