### PR TITLE
ConsoleReport: Add hyperlinks to open file in editor

### DIFF
--- a/src/Psalm/Internal/Analyzer/DataFlowNodeData.php
+++ b/src/Psalm/Internal/Analyzer/DataFlowNodeData.php
@@ -30,6 +30,11 @@ class DataFlowNodeData
     /**
      * @var string
      */
+    public $file_path;
+
+    /**
+     * @var string
+     */
     public $snippet;
 
     /**
@@ -62,6 +67,7 @@ class DataFlowNodeData
         int $line_from,
         int $line_to,
         string $file_name,
+        string $file_path,
         string $snippet,
         int $from,
         int $to,
@@ -73,6 +79,7 @@ class DataFlowNodeData
         $this->line_from = $line_from;
         $this->line_to = $line_to;
         $this->file_name = $file_name;
+        $this->file_path = $file_path;
         $this->snippet = $snippet;
         $this->from = $from;
         $this->to = $to;

--- a/src/Psalm/Issue/TaintedInput.php
+++ b/src/Psalm/Issue/TaintedInput.php
@@ -66,6 +66,7 @@ abstract class TaintedInput extends CodeIssue
             $location->getLineNumber(),
             $location->getEndLineNumber(),
             $location->file_name,
+            $location->file_path,
             $location->getSnippet(),
             $selection_bounds[0],
             $selection_bounds[1],

--- a/src/Psalm/Report/ConsoleReport.php
+++ b/src/Psalm/Report/ConsoleReport.php
@@ -112,6 +112,12 @@ class ConsoleReport extends Report
      */
     private function getFileReference($data): string
     {
+        $reference = $data->file_name . ':' . $data->line_from . ':' . $data->column_from;
+
+        if (!$this->use_color) {
+            return $reference;
+        }
+
         if (null === $this->linkFormat) {
             // if xdebug is not enabled, use `get_cfg_var` to get the value directly from php.ini
             $this->linkFormat = ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')
@@ -119,7 +125,7 @@ class ConsoleReport extends Report
         }
 
         $link = strtr($this->linkFormat, ['%f' => $data->file_path, '%l' => $data->line_from]);
-        $reference = $data->file_name . ':' . $data->line_from . ':' . $data->column_from;
+        // $reference = $data->file_name . ':' . $data->line_from . ':' . $data->column_from;
 
         return "\033]8;;" . $link . "\033\\" . $reference . "\033]8;;\033\\";
     }

--- a/src/Psalm/Report/ConsoleReport.php
+++ b/src/Psalm/Report/ConsoleReport.php
@@ -3,12 +3,19 @@ namespace Psalm\Report;
 
 use Psalm\Config;
 use Psalm\Internal\Analyzer\DataFlowNodeData;
+use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
 
+use function get_cfg_var;
+use function ini_get;
+use function strtr;
 use function substr;
 
 class ConsoleReport extends Report
 {
+    /** @var string|null */
+    private $linkFormat;
+
     public function create(): string
     {
         $output = '';
@@ -34,7 +41,7 @@ class ConsoleReport extends Report
         $issue_reference = $issue_data->link ? ' (see ' . $issue_data->link . ')' : '';
 
         $issue_string .= ': ' . $issue_data->type
-            . ' - ' . $issue_data->file_name . ':' . $issue_data->line_from . ':' . $issue_data->column_from
+            . ' - ' . $this->getFileReference($issue_data)
             . ' - ' . $issue_data->message . $issue_reference . "\n";
 
 
@@ -75,10 +82,7 @@ class ConsoleReport extends Report
 
         foreach ($taint_trace as $node_data) {
             if ($node_data instanceof DataFlowNodeData) {
-                $snippets .= '  ' . $node_data->label
-                    . ' - ' . $node_data->file_name
-                    . ':' . $node_data->line_from
-                    . ':' . $node_data->column_from . "\n";
+                $snippets .= '  ' . $node_data->label . ' - ' . $this->getFileReference($node_data) . "\n";
 
                 if ($this->show_snippet) {
                     $snippet = $node_data->snippet;
@@ -101,5 +105,22 @@ class ConsoleReport extends Report
         }
 
         return $snippets;
+    }
+
+    /**
+     * @param IssueData|DataFlowNodeData $data
+     */
+    private function getFileReference($data): string
+    {
+        if (null === $this->linkFormat) {
+            // if xdebug is not enabled, use `get_cfg_var` to get the value directly from php.ini
+            $this->linkFormat = ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')
+                ?: 'file://%f#L%l';
+        }
+
+        $link = strtr($this->linkFormat, ['%f' => $data->file_path, '%l' => $data->line_from]);
+        $reference = $data->file_name . ':' . $data->line_from . ':' . $data->column_from;
+
+        return "\033]8;;" . $link . "\033\\" . $reference . "\033]8;;\033\\";
     }
 }

--- a/src/Psalm/Report/ConsoleReport.php
+++ b/src/Psalm/Report/ConsoleReport.php
@@ -14,7 +14,7 @@ use function substr;
 class ConsoleReport extends Report
 {
     /** @var string|null */
-    private $linkFormat;
+    private $link_format;
 
     public function create(): string
     {
@@ -118,13 +118,13 @@ class ConsoleReport extends Report
             return $reference;
         }
 
-        if (null === $this->linkFormat) {
+        if (null === $this->link_format) {
             // if xdebug is not enabled, use `get_cfg_var` to get the value directly from php.ini
-            $this->linkFormat = ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')
+            $this->link_format = ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')
                 ?: 'file://%f#L%l';
         }
 
-        $link = strtr($this->linkFormat, ['%f' => $data->file_path, '%l' => $data->line_from]);
+        $link = strtr($this->link_format, ['%f' => $data->file_path, '%l' => $data->line_from]);
         // $reference = $data->file_name . ':' . $data->line_from . ':' . $data->column_from;
 
         return "\033]8;;" . $link . "\033\\" . $reference . "\033]8;;\033\\";

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -1068,6 +1068,22 @@ INFO: PossiblyUndefinedGlobalVariable - somefile.php:17:6 - Possibly undefined g
         );
     }
 
+    public function testConsoleReportWithLinks(): void
+    {
+        $this->analyzeFileForReport();
+
+        $console_report_options = new Report\ReportOptions();
+        $console_report_options->show_snippet = false;
+        $console_report_options->use_color = true;
+
+        $output  = IssueBuffer::getOutput(IssueBuffer::getIssuesData(), $console_report_options);
+
+        $this->assertStringContainsString(
+            "\033]8;;file://somefile.php#L3\033\\somefile.php:3:10\033]8;;\033\\",
+            $output
+        );
+    }
+
     public function testCompactReport(): void
     {
         $this->analyzeFileForReport();


### PR DESCRIPTION
`ConsoleReport` adds hyperlinks to the file paths to open them in editor. It uses the file format from `xdebug.file_link_format` (you do not need xdebug extension for this) and falls back to generic `file://...` link.

Terminals not supporting hyperlinks should ignore these escape sequences, see https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda#backward-compatibility:

> Any terminal that correctly implements OSC parsing according to ECMA-48 is guaranteed not to suffer from compatibility issues. That is, even if explicit hyperlinks aren't supported, the target URI is silently ignored and the supposed-to-be-visible text is displayed, without artifacts.

psalm output (hover over one link, you can see the target at the bottom):

<img width="846" alt="Bildschirmfoto 2021-11-07 um 14 36 00" src="https://user-images.githubusercontent.com/330436/140647604-3a48108e-a605-4724-9564-9810bb0754a3.png">

taint analysis:

<img width="850" alt="Bildschirmfoto 2021-11-07 um 14 36 32" src="https://user-images.githubusercontent.com/330436/140647615-213c0d32-f4f9-421d-b2ec-f70d4b74028f.png">

This fixes https://github.com/vimeo/psalm/issues/5798