### PR TITLE
allow signature type for promoted property as well as property docblock

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -606,7 +606,7 @@ class FunctionLikeNodeScanner
                 }
 
                 //both way to document type were used
-                if ($param_storage->type && $var_comment_type) {
+                if ($param_storage->type && $param_storage->type->from_docblock && $var_comment_type) {
                     if (IssueBuffer::accepts(
                         new InvalidDocblock(
                             'Param ' . $param_storage->name . ' of ' . $cased_function_id .
@@ -625,7 +625,7 @@ class FunctionLikeNodeScanner
 
                 $property_storage = $classlike_storage->properties[$param_storage->name] = new PropertyStorage();
                 $property_storage->is_static = false;
-                $property_storage->type = $param_storage->type ?? $var_comment_type;
+                $property_storage->type = $param_storage->type;
                 $property_storage->signature_type = $param_storage->signature_type;
                 $property_storage->signature_type_location = $param_storage->signature_type_location;
                 $property_storage->type_location = $param_storage->type_location;

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1319,6 +1319,19 @@ class AnnotationTest extends TestCase
                     new UserRole(new stdClass(), new stdClass());
                     '
             ],
+            'promotedPropertiesDocumentationForPropertyAndSignature' => [
+                '<?php
+                    final class A
+                    {
+                        public function __construct(
+                            /**
+                             * @var iterable<string>
+                             */
+                            private iterable $strings,
+                        ) {
+                        }
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/6857

Based on the discussion there, I simply fixed the issue at hand because we stated that there was no need to go very deep (by keeping param and property type separated).

There's at least one improvement that could be made on top of this: Psalm complains when using a param docblock that is not compatible with the signature type because it's checked at param analysis but it currently doesn't emit issues for incompatible property docblock.