### PR TITLE
load the ReturnTypeWillChange stubs for all versions to allow using it on every PHP version

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -494,3 +494,10 @@ final class WeakMap implements ArrayAccess, Countable, IteratorAggregate, Traver
      */
     public function offsetUnset($offset) {}
 }
+
+
+#[Attribute]
+final class ReturnTypeWillChange
+{
+    public function __construct() {}
+}

--- a/stubs/Php81.phpstub
+++ b/stubs/Php81.phpstub
@@ -4,12 +4,6 @@ namespace {
         /** @return non-empty-list<static> */
         public static function cases(): array;
     }
-
-    #[Attribute]
-    final class ReturnTypeWillChange
-    {
-        public function __construct() {}
-    }
 }
 
 namespace FTP {

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -180,6 +180,48 @@ class AttributeTest extends TestCase
                         class Baz {}
                     }
                 '
+            ],
+            'returnTypeWillChange7.1' => [
+                '<?php
+
+                    namespace Rabus\PsalmReturnTypeWillChange;
+
+                    use EmptyIterator;
+                    use IteratorAggregate;
+                    use ReturnTypeWillChange;
+
+                    final class EmptyCollection implements IteratorAggregate
+                    {
+                        #[ReturnTypeWillChange]
+                        public function getIterator()
+                        {
+                            return new EmptyIterator();
+                        }
+                    }',
+                [],
+                [],
+                '7.1'
+            ],
+            'returnTypeWillChange8.1' => [
+                '<?php
+
+                    namespace Rabus\PsalmReturnTypeWillChange;
+
+                    use EmptyIterator;
+                    use IteratorAggregate;
+                    use ReturnTypeWillChange;
+
+                    final class EmptyCollection implements IteratorAggregate
+                    {
+                        #[ReturnTypeWillChange]
+                        public function getIterator()
+                        {
+                            return new EmptyIterator();
+                        }
+                    }',
+                [],
+                [],
+                '8.1'
             ]
         ];
     }


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/6854 and https://github.com/vimeo/psalm/issues/6849

Tests are not 100% real because this particular issue depends on php version used to run Psalm as much as version used to analyse but I tested this with 8.0 and 8.1RC5 on my machine and it works

Fixes #6854 
Fixes #6849 