### PR TITLE
detect unevaluated inline-html code after an rearly return

### DIFF
--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -343,7 +343,6 @@ class StatementsAnalyzer extends SourceAnalyzer
             && !$context->collect_initializations
             && !$context->collect_mutations
             && !($stmt instanceof PhpParser\Node\Stmt\Nop)
-            && !($stmt instanceof PhpParser\Node\Stmt\InlineHTML)
             && !($stmt instanceof PhpParser\Node\Stmt\Function_)
             && !($stmt instanceof PhpParser\Node\Stmt\Class_)
             && !($stmt instanceof PhpParser\Node\Stmt\Interface_)

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1574,6 +1574,13 @@ class UnusedCodeTest extends TestCase
                 ',
                 'error_message' => 'UnevaluatedCode',
             ],
+            'exitInlineHtml' => [
+                '<?php
+                    exit(0);
+                    ?'.'>foo
+                ',
+                'error_message' => 'UnevaluatedCode',
+            ],
         ];
     }
 }


### PR DESCRIPTION
this is a followup after #6876

this fixes #6877