### PR TITLE
Fix --enable-autocomplete=false

### DIFF
--- a/src/Psalm/Internal/Cli/LanguageServer.php
+++ b/src/Psalm/Internal/Cli/LanguageServer.php
@@ -68,7 +68,7 @@ final class LanguageServer
             'tcp:',
             'tcp-server',
             'disable-on-change::',
-            'enable-autocomplete',
+            'enable-autocomplete::',
             'use-extended-diagnostic-codes',
             'verbose'
         ];


### PR DESCRIPTION
Currently, `--enable-autocomplete` is defined as a bool option, so the it's either there or not, but it doesn't accept any arguments. This fix will allow `--enable-autocomplete=false` to work as expected, while still having the default of being enabled.

Closes #6879