### PR TITLE
Php version consistency

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -10,4 +10,4 @@ jobs:
         with:
           mode: minimum
           count: 1
-          labels: "release:typo, release:fix, release:feature, release:deprecation, release:internal, release:docs"
+          labels: "release:typo, release:fix, release:feature, release:deprecation, release:internal, release:docs, release:removed"

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,123 @@
+# Upgrading from Psalm 4 to Psalm 5
+## Changed
+ - [BC] The parameter `$php_version` of `Psalm\Type\Atomic::create()` renamed
+   to `$analysis_php_version_id` and changed from `array|null` to `int|null`.
+   Previously it accepted PHP version as `array{major_version, minor_version}`
+   while now it accepts version ID, similar to how [`PHP_VERSION_ID` is
+   calculated](https://www.php.net/manual/en/reserved.constants.php#constant.php-version-id).
+
+ - [BC] The parameter `$php_version` of `Psalm\Type::parseString()` renamed to
+   `$analysis_php_version_id` and changed from `array|null` to `int|null`.
+   Previously it accepted PHP version as `array{major_version, minor_version}`
+   while now it accepts version ID.
+
+ - [BC] Parameter 0 of `canBeFullyExpressedInPhp()` of the classes listed below
+   changed name from `php_major_version` to `analysis_php_version_id`.
+   Previously it accepted major PHP version as int (e.g. `7`), while now it
+   accepts version ID. Classes affected:
+    - `Psalm\Type\Atomic`
+    - `Psalm\Type\Atomic\Scalar`
+    - `Psalm\Type\Atomic\TArray`
+    - `Psalm\Type\Atomic\TArrayKey`
+    - `Psalm\Type\Atomic\TAssertionFalsy`
+    - `Psalm\Type\Atomic\TCallable`
+    - `Psalm\Type\Atomic\TCallableObject`
+    - `Psalm\Type\Atomic\TCallableString`
+    - `Psalm\Type\Atomic\TClassConstant`
+    - `Psalm\Type\Atomic\TClassString`
+    - `Psalm\Type\Atomic\TClassStringMap`
+    - `Psalm\Type\Atomic\TClosedResource`
+    - `Psalm\Type\Atomic\TClosure`
+    - `Psalm\Type\Atomic\TConditional`
+    - `Psalm\Type\Atomic\TDependentGetClass`
+    - `Psalm\Type\Atomic\TDependentGetDebugType`
+    - `Psalm\Type\Atomic\TDependentGetType`
+    - `Psalm\Type\Atomic\TDependentListKey`
+    - `Psalm\Type\Atomic\TEnumCase`
+    - `Psalm\Type\Atomic\TFalse`
+    - `Psalm\Type\Atomic\TGenericObject`
+    - `Psalm\Type\Atomic\THtmlEscapedString`
+    - `Psalm\Type\Atomic\TIntMask`
+    - `Psalm\Type\Atomic\TIntMaskOf`
+    - `Psalm\Type\Atomic\TIntRange`
+    - `Psalm\Type\Atomic\TIterable`
+    - `Psalm\Type\Atomic\TKeyedArray`
+    - `Psalm\Type\Atomic\TKeyOfClassConstant`
+    - `Psalm\Type\Atomic\TList`
+    - `Psalm\Type\Atomic\TLiteralClassString`
+    - `Psalm\Type\Atomic\TLowercaseString`
+    - `Psalm\Type\Atomic\TMixed`
+    - `Psalm\Type\Atomic\TNamedObject`
+    - `Psalm\Type\Atomic\TNever`
+    - `Psalm\Type\Atomic\TNonEmptyLowercaseString`
+    - `Psalm\Type\Atomic\TNonspecificLiteralInt`
+    - `Psalm\Type\Atomic\TNonspecificLiteralString`
+    - `Psalm\Type\Atomic\TNull`
+    - `Psalm\Type\Atomic\TNumeric`
+    - `Psalm\Type\Atomic\TNumericString`
+    - `Psalm\Type\Atomic\TObject`
+    - `Psalm\Type\Atomic\TObjectWithProperties`
+    - `Psalm\Type\Atomic\TPositiveInt`
+    - `Psalm\Type\Atomic\TResource`
+    - `Psalm\Type\Atomic\TScalar`
+    - `Psalm\Type\Atomic\TTemplateIndexedAccess`
+    - `Psalm\Type\Atomic\TTemplateParam`
+    - `Psalm\Type\Atomic\TTraitString`
+    - `Psalm\Type\Atomic\TTrue`
+    - `Psalm\Type\Atomic\TTypeAlias`
+    - `Psalm\Type\Atomic\TValueOfClassConstant`
+    - `Psalm\Type\Atomic\TVoid`
+    - `Psalm\Type\Union`
+
+ - [BC] Parameter 3 of `toPhpString()` of methods listed below changed name
+   from `php_major_version` to `analysis_php_version_id`. Previously it
+   accepted major PHP version as int (e.g. `7`), while now it accepts version
+   ID. Classes affected:
+    - `Psalm\Type\Atomic`
+    - `Psalm\Type\Atomic\CallableTrait`
+    - `Psalm\Type\Atomic\TAnonymousClassInstance`
+    - `Psalm\Type\Atomic\TArray`
+    - `Psalm\Type\Atomic\TArrayKey`
+    - `Psalm\Type\Atomic\TAssertionFalsy`
+    - `Psalm\Type\Atomic\TBool`
+    - `Psalm\Type\Atomic\TCallable`
+    - `Psalm\Type\Atomic\TCallableObject`
+    - `Psalm\Type\Atomic\TClassConstant`
+    - `Psalm\Type\Atomic\TClassString`
+    - `Psalm\Type\Atomic\TClassStringMap`
+    - `Psalm\Type\Atomic\TClosedResource`
+    - `Psalm\Type\Atomic\TConditional`
+    - `Psalm\Type\Atomic\TEmpty`
+    - `Psalm\Type\Atomic\TEnumCase`
+    - `Psalm\Type\Atomic\TFloat`
+    - `Psalm\Type\Atomic\TGenericObject`
+    - `Psalm\Type\Atomic\TInt`
+    - `Psalm\Type\Atomic\TIterable`
+    - `Psalm\Type\Atomic\TKeyedArray`
+    - `Psalm\Type\Atomic\TKeyOfClassConstant`
+    - `Psalm\Type\Atomic\TList`
+    - `Psalm\Type\Atomic\TLiteralClassString`
+    - `Psalm\Type\Atomic\TMixed`
+    - `Psalm\Type\Atomic\TNamedObject`
+    - `Psalm\Type\Atomic\TNever`
+    - `Psalm\Type\Atomic\TNull`
+    - `Psalm\Type\Atomic\TNumeric`
+    - `Psalm\Type\Atomic\TObject`
+    - `Psalm\Type\Atomic\TObjectWithProperties`
+    - `Psalm\Type\Atomic\TResource`
+    - `Psalm\Type\Atomic\TScalar`
+    - `Psalm\Type\Atomic\TString`
+    - `Psalm\Type\Atomic\TTemplateIndexedAccess`
+    - `Psalm\Type\Atomic\TTemplateParam`
+    - `Psalm\Type\Atomic\TTraitString`
+    - `Psalm\Type\Atomic\TTypeAlias`
+    - `Psalm\Type\Atomic\TValueOfClassConstant`
+    - `Psalm\Type\Atomic\TVoid`
+    - `Psalm\Type\Union`
+
+## Removed
+ - [BC] Property `Psalm\Codebase::$php_major_version` was removed, use
+   `Psalm\Codebase::$analysis_php_version_id`.
+ - [BC] Property `Psalm\Codebase::$php_minor_version` was removed, use
+   `Psalm\Codebase::$analysis_php_version_id`.
+

--- a/examples/TemplateScanner.php
+++ b/examples/TemplateScanner.php
@@ -25,7 +25,7 @@ class TemplateScanner extends Psalm\Internal\Scanner\FileScanner
     ): void {
         $stmts = $codebase->statements_provider->getStatementsForFile(
             $file_storage->file_path,
-            '7.4',
+            70400,
             $progress
         );
 

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -77,6 +77,7 @@ use function error_log;
 use function explode;
 use function implode;
 use function in_array;
+use function intdiv;
 use function is_numeric;
 use function is_string;
 use function krsort;
@@ -90,8 +91,6 @@ use function strtolower;
 use function substr;
 use function substr_count;
 
-use const PHP_MAJOR_VERSION;
-use const PHP_MINOR_VERSION;
 use const PHP_VERSION_ID;
 
 class Codebase
@@ -304,18 +303,6 @@ class Codebase
      * @var bool
      */
     public $allow_backwards_incompatible_changes = true;
-
-    /**
-     * @var int
-     * @deprecated Removed in Psalm 5, use Codebase::$analysis_php_version_id
-     */
-    public $php_major_version = PHP_MAJOR_VERSION;
-
-    /**
-     * @var int
-     * @deprecated Removed in Psalm 5, use Codebase::$analysis_php_version_id
-     */
-    public $php_minor_version = PHP_MINOR_VERSION;
 
     /** @var int */
     public $analysis_php_version_id = PHP_VERSION_ID;
@@ -534,7 +521,7 @@ class Codebase
     {
         return $this->statements_provider->getStatementsForFile(
             $file_path,
-            $this->php_major_version . '.' . $this->php_minor_version,
+            $this->analysis_php_version_id,
             $this->progress
         );
     }
@@ -2009,5 +1996,20 @@ class Codebase
         );
 
         $this->taint_flow_graph->addSink($sink);
+    }
+
+    public function getMinorAnalysisPhpVersion(): int
+    {
+        return self::transformPhpVersionId($this->analysis_php_version_id % 10000, 100);
+    }
+
+    public function getMajorAnalysisPhpVersion(): int
+    {
+        return self::transformPhpVersionId($this->analysis_php_version_id, 10000);
+    }
+
+    public static function transformPhpVersionId(int $php_version_id, int $div): int
+    {
+        return intdiv($php_version_id, $div);
     }
 }

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1871,7 +1871,7 @@ class Config
 
         $core_generic_files = [];
 
-        if (PHP_VERSION_ID < 80000 && $codebase->php_major_version >= 8) {
+        if (PHP_VERSION_ID < 80000 && $codebase->analysis_php_version_id >= 80000) {
             $stringable_path = dirname(__DIR__, 2) . '/stubs/Php80.phpstub';
 
             if (!file_exists($stringable_path)) {
@@ -1881,7 +1881,7 @@ class Config
             $core_generic_files[] = $stringable_path;
         }
 
-        if (PHP_VERSION_ID < 80100 && $codebase->php_major_version >= 8 && $codebase->php_minor_version >= 1) {
+        if (PHP_VERSION_ID < 80100 && $codebase->analysis_php_version_id >= 80100) {
             $stringable_path = dirname(__DIR__, 2) . '/stubs/Php81.phpstub';
 
             if (!file_exists($stringable_path)) {
@@ -1932,12 +1932,12 @@ class Config
             $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'SPL.phpstub',
         ];
 
-        if (PHP_VERSION_ID >= 80000 && $codebase->php_major_version >= 8) {
+        if (PHP_VERSION_ID >= 80000 && $codebase->analysis_php_version_id >= 80000) {
             $stringable_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'Php80.phpstub';
             $this->internal_stubs[] = $stringable_path;
         }
 
-        if (PHP_VERSION_ID >= 80100 && $codebase->php_major_version >= 8 && $codebase->php_minor_version >= 1) {
+        if (PHP_VERSION_ID >= 80100 && $codebase->analysis_php_version_id >= 80100) {
             $stringable_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'Php81.phpstub';
             $this->internal_stubs[] = $stringable_path;
         }

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1608,8 +1608,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         $codebase = $project_analyzer->getCodebase();
 
         $allow_native_type = !$docblock_only
-            && $codebase->php_major_version >= 7
-            && ($codebase->php_major_version > 7 || $codebase->php_minor_version >= 4)
+            && $codebase->analysis_php_version_id >= 70400
             && $codebase->allow_backwards_incompatible_changes;
 
         $manipulator->setType(
@@ -1618,8 +1617,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                     $source->getNamespace(),
                     $source->getAliasedClassesFlipped(),
                     $source->getFQCLN(),
-                    $codebase->php_major_version,
-                    $codebase->php_minor_version
+                    $codebase->analysis_php_version_id
                 ) : null,
             $inferred_type->toNamespacedString(
                 $source->getNamespace(),
@@ -1633,7 +1631,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                 $source->getFQCLN(),
                 true
             ),
-            $inferred_type->canBeFullyExpressedInPhp($codebase->php_major_version, $codebase->php_minor_version)
+            $inferred_type->canBeFullyExpressedInPhp($codebase->analysis_php_version_id)
         );
     }
 

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -942,7 +942,7 @@ class ReturnTypeAnalyzer
         }
 
         $allow_native_type = !$docblock_only
-            && $codebase->php_major_version >= 7
+            && $codebase->analysis_php_version_id >= 70000
             && (
                 $codebase->allow_backwards_incompatible_changes
                 || $is_final
@@ -955,8 +955,7 @@ class ReturnTypeAnalyzer
                     $source->getNamespace(),
                     $source->getAliasedClassesFlipped(),
                     $source->getFQCLN(),
-                    $codebase->php_major_version,
-                    $codebase->php_minor_version
+                    $codebase->analysis_php_version_id
                 ) : null,
             $inferred_return_type->toNamespacedString(
                 $source->getNamespace(),
@@ -970,7 +969,7 @@ class ReturnTypeAnalyzer
                 $source->getFQCLN(),
                 true
             ),
-            $inferred_return_type->canBeFullyExpressedInPhp($codebase->php_major_version, $codebase->php_minor_version),
+            $inferred_return_type->canBeFullyExpressedInPhp($codebase->analysis_php_version_id),
             $function_like_storage->return_type_description ?? null
         );
     }

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1443,7 +1443,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         }
 
         $allow_native_type = !$docblock_only
-            && $codebase->php_major_version >= 7
+            && $codebase->analysis_php_version_id >= 70000
             && (
                 $codebase->allow_backwards_incompatible_changes
                 || $is_final
@@ -1457,8 +1457,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                     $this->source->getNamespace(),
                     $this->source->getAliasedClassesFlipped(),
                     $this->source->getFQCLN(),
-                    $project_analyzer->getCodebase()->php_major_version,
-                    $project_analyzer->getCodebase()->php_minor_version
+                    $project_analyzer->getCodebase()->analysis_php_version_id
                 ) : null,
             $inferred_return_type->toNamespacedString(
                 $this->source->getNamespace(),

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -92,7 +92,7 @@ class MethodComparator
             $cased_implementer_method_id,
             $prevent_method_signature_mismatch,
             $prevent_abstract_override,
-            $codebase->php_major_version >= 8,
+            $codebase->analysis_php_version_id >= 80000,
             $code_location,
             $suppressed_issues
         );
@@ -559,9 +559,7 @@ class MethodComparator
             $implementer_classlike_storage->parent_class
         );
 
-        $is_contained_by = (($codebase->php_major_version === 7
-                    && $codebase->php_minor_version === 4)
-                || $codebase->php_major_version >= 8)
+        $is_contained_by = $codebase->analysis_php_version_id >= 70400
             && $guide_param_signature_type
             ? UnionTypeComparator::isContainedBy(
                 $codebase,
@@ -575,7 +573,7 @@ class MethodComparator
         if (!$is_contained_by) {
             $config = Config::getInstance();
 
-            if ($codebase->php_major_version >= 8
+            if ($codebase->analysis_php_version_id >= 80000
                 || $guide_classlike_storage->is_trait === $implementer_classlike_storage->is_trait
                 || !in_array($guide_classlike_storage->name, $implementer_classlike_storage->used_traits)
                 || $implementer_method_storage->defining_fqcln !== $implementer_classlike_storage->name
@@ -853,9 +851,7 @@ class MethodComparator
                 $implementer_classlike_storage->parent_class
             ) : null;
 
-        $is_contained_by = (($codebase->php_major_version === 7
-                    && $codebase->php_minor_version === 4)
-                || $codebase->php_major_version >= 8)
+        $is_contained_by = $codebase->analysis_php_version_id >= 70400
             && $implementer_signature_return_type
             ? UnionTypeComparator::isContainedBy(
                 $codebase,
@@ -865,7 +861,7 @@ class MethodComparator
             : UnionTypeComparator::isContainedByInPhp($implementer_signature_return_type, $guide_signature_return_type);
 
         if (!$is_contained_by) {
-            if ($codebase->php_major_version >= 8
+            if ($codebase->analysis_php_version_id >= 80000
                 || $guide_classlike_storage->is_trait === $implementer_classlike_storage->is_trait
                 || !in_array($guide_classlike_storage->name, $implementer_classlike_storage->used_traits)
                 || $implementer_method_storage->defining_fqcln !== $implementer_classlike_storage->name

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -569,7 +569,7 @@ class ProjectAnalyzer
     {
         $codebase = $this->codebase;
 
-        $version = $codebase->php_major_version . '.' . $codebase->php_minor_version;
+        $version = $codebase->getMajorAnalysisPhpVersion() . '.' . $codebase->getMinorAnalysisPhpVersion();
 
         switch ($codebase->php_version_source) {
             case 'cli':
@@ -1297,17 +1297,15 @@ class ProjectAnalyzer
         $php_major_version = (int) $php_major_version;
         $php_minor_version = (int) $php_minor_version;
 
-        if ($this->codebase->php_major_version !== $php_major_version
-            || $this->codebase->php_minor_version !== $php_minor_version
-        ) {
+        $analysis_php_version_id = $php_major_version * 10000 + $php_minor_version * 100;
+
+        if ($this->codebase->analysis_php_version_id !== $analysis_php_version_id) {
             // reset lexer and parser when php version changes
             StatementsProvider::clearLexer();
             StatementsProvider::clearParser();
         }
 
-        $this->codebase->php_major_version = $php_major_version;
-        $this->codebase->php_minor_version = $php_minor_version;
-        $this->codebase->analysis_php_version_id = $php_major_version * 10000 + $php_minor_version * 100;
+        $this->codebase->analysis_php_version_id = $analysis_php_version_id;
         $this->codebase->php_version_source = $source;
     }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -510,9 +510,7 @@ class ArrayAnalyzer
             if ($unpacked_atomic_type instanceof TKeyedArray) {
                 foreach ($unpacked_atomic_type->properties as $key => $property_value) {
                     if (is_string($key)) {
-                        if ($codebase->php_major_version < 8 ||
-                            ($codebase->php_major_version === 8 && $codebase->php_minor_version < 1)
-                        ) {
+                        if ($codebase->analysis_php_version_id <= 80000) {
                             IssueBuffer::maybeAdd(
                                 new DuplicateArrayKey(
                                     'String keys are not supported in unpacked arrays',
@@ -555,9 +553,7 @@ class ArrayAnalyzer
                     $array_creation_info->can_create_objectlike = false;
 
                     if ($unpacked_atomic_type->type_params[0]->hasString()) {
-                        if ($codebase->php_major_version < 8 ||
-                            ($codebase->php_major_version === 8 && $codebase->php_minor_version < 1)
-                        ) {
+                        if ($codebase->analysis_php_version_id <= 80000) {
                             IssueBuffer::maybeAdd(
                                 new DuplicateArrayKey(
                                     'String keys are not supported in unpacked arrays',

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -486,7 +486,7 @@ class ArgumentAnalyzer
 
                     if ($function_param->is_variadic) {
                         $arg_type = $unpacked_atomic_array->getGenericValueType();
-                    } elseif ($codebase->php_major_version >= 8
+                    } elseif ($codebase->analysis_php_version_id >= 80000
                         && $allow_named_args
                         && isset($unpacked_atomic_array->properties[$function_param->name])
                     ) {
@@ -552,7 +552,7 @@ class ArgumentAnalyzer
 
                             continue;
                         }
-                        if (($codebase->php_major_version < 8 || !$allow_named_args) && !$key_type->isInt()) {
+                        if (($codebase->analysis_php_version_id < 80000 || !$allow_named_args) && !$key_type->isInt()) {
                             $invalid_string_key = true;
 
                             continue;
@@ -578,7 +578,7 @@ class ArgumentAnalyzer
                             'Method ' . $cased_method_id
                                 . ' called with unpacked iterable ' . $arg_type->getId()
                                 . ' with invalid key (must be '
-                                . ($codebase->php_major_version < 8 ? 'int' : 'int|string') . ')',
+                                . ($codebase->analysis_php_version_id < 80000 ? 'int' : 'int|string') . ')',
                             new CodeLocation($statements_analyzer->getSource(), $arg->value),
                             $cased_method_id
                         ),
@@ -586,7 +586,7 @@ class ArgumentAnalyzer
                     );
                 }
                 if ($invalid_string_key) {
-                    if ($codebase->php_major_version < 8) {
+                    if ($codebase->analysis_php_version_id < 80000) {
                         IssueBuffer::maybeAdd(
                             new $issue_type(
                                 'String keys not supported in unpacked arguments',

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -125,7 +125,7 @@ class FunctionCallReturnTypeFetcher
                                 $template_result->lower_bounds[$template_name] = [
                                     'fn-' . $function_id => [
                                         new TemplateBound(
-                                            Type::getInt(false, $codebase->php_major_version)
+                                            Type::getInt(false, $codebase->getMajorAnalysisPhpVersion())
                                         )
                                     ]
                                 ];
@@ -135,8 +135,7 @@ class FunctionCallReturnTypeFetcher
                                         new TemplateBound(
                                             Type::getInt(
                                                 false,
-                                                10000 * $codebase->php_major_version
-                                                + 100 * $codebase->php_minor_version
+                                                $codebase->analysis_php_version_id
                                             )
                                         )
                                     ]

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -570,7 +570,7 @@ class MethodCallReturnTypeFetcher
                         $template_result->lower_bounds[$template_type->param_name] = [
                             'fn-' . strtolower((string) $method_id) => [
                                 new TemplateBound(
-                                    Type::getInt(false, $codebase->php_major_version)
+                                    Type::getInt(false, $codebase->getMajorAnalysisPhpVersion())
                                 )
                             ]
                         ];
@@ -580,8 +580,7 @@ class MethodCallReturnTypeFetcher
                                 new TemplateBound(
                                     Type::getInt(
                                         false,
-                                        10000 * $codebase->php_major_version
-                                        + 100 * $codebase->php_minor_version
+                                        $codebase->analysis_php_version_id
                                     )
                                 )
                             ]

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -504,7 +504,7 @@ class ExistingAtomicStaticCallAnalyzer
                             $template_result->lower_bounds[$template_type->param_name] = [
                                 'fn-' . strtolower((string)$method_id) => [
                                     new TemplateBound(
-                                        Type::getInt(false, $codebase->php_major_version)
+                                        Type::getInt(false, $codebase->getMajorAnalysisPhpVersion())
                                     )
                                 ]
                             ];
@@ -514,8 +514,7 @@ class ExistingAtomicStaticCallAnalyzer
                                     new TemplateBound(
                                         Type::getInt(
                                             false,
-                                            10000 * $codebase->php_major_version
-                                            + 100 * $codebase->php_minor_version
+                                            $codebase->analysis_php_version_id
                                         )
                                     )
                                 ]

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -261,7 +261,7 @@ class CastAnalyzer
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\Cast\Unset_
-            && $statements_analyzer->getCodebase()->php_major_version < 8
+            && $statements_analyzer->getCodebase()->analysis_php_version_id <= 70400
         ) {
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->expr, $context) === false) {
                 return false;

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -470,20 +470,20 @@ class ExpressionAnalyzer
             return YieldFromAnalyzer::analyze($statements_analyzer, $stmt, $context);
         }
 
-        $php_major_version = $statements_analyzer->getCodebase()->php_major_version;
-        $php_minor_version = $statements_analyzer->getCodebase()->php_minor_version;
+        $codebase = $statements_analyzer->getCodebase();
+        $analysis_php_version_id = $codebase->analysis_php_version_id;
 
-        if ($stmt instanceof PhpParser\Node\Expr\Match_ && $php_major_version >= 8) {
+        if ($stmt instanceof PhpParser\Node\Expr\Match_ && $analysis_php_version_id >= 80000) {
             return MatchAnalyzer::analyze($statements_analyzer, $stmt, $context);
         }
 
-        if ($stmt instanceof PhpParser\Node\Expr\Throw_ && $php_major_version >= 8) {
+        if ($stmt instanceof PhpParser\Node\Expr\Throw_ && $analysis_php_version_id >= 80000) {
             return ThrowAnalyzer::analyze($statements_analyzer, $stmt, $context);
         }
 
         if (($stmt instanceof PhpParser\Node\Expr\NullsafePropertyFetch
                 || $stmt instanceof PhpParser\Node\Expr\NullsafeMethodCall)
-            && $php_major_version >= 8
+            && $analysis_php_version_id >= 80000
         ) {
             return NullsafeAnalyzer::analyze($statements_analyzer, $stmt, $context);
         }
@@ -496,7 +496,7 @@ class ExpressionAnalyzer
         if (IssueBuffer::accepts(
             new UnrecognizedExpression(
                 'Psalm does not understand ' . get_class($stmt) . ' for PHP ' .
-                $php_major_version . ' ' . $php_minor_version,
+                $codebase->getMajorAnalysisPhpVersion() . '.' . $codebase->getMinorAnalysisPhpVersion(),
                 new CodeLocation($statements_analyzer->getSource(), $stmt)
             ),
             $statements_analyzer->getSuppressedIssues()

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -806,7 +806,10 @@ class ClassLikes
             throw new UnexpectedValueException('Storage should exist for ' . $fq_trait_name);
         }
 
-        $file_statements = $this->statements_provider->getStatementsForFile($storage->location->file_path, '7.4');
+        $file_statements = $this->statements_provider->getStatementsForFile(
+            $storage->location->file_path,
+            ProjectAnalyzer::getInstance()->getCodebase()->analysis_php_version_id
+        );
 
         $trait_finder = new TraitFinder($fq_trait_name);
 

--- a/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
+++ b/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
@@ -347,8 +347,8 @@ class InternalCallMapHandler
     public static function getCallMap(): array
     {
         $codebase = ProjectAnalyzer::getInstance()->getCodebase();
-        $analyzer_major_version = $codebase->php_major_version;
-        $analyzer_minor_version = $codebase->php_minor_version;
+        $analyzer_major_version = $codebase->getMajorAnalysisPhpVersion();
+        $analyzer_minor_version = $codebase->getMinorAnalysisPhpVersion();
 
         $analyzer_version = $analyzer_major_version . '.' . $analyzer_minor_version;
         $current_version = self::PHP_MAJOR_VERSION . '.' . self::PHP_MINOR_VERSION;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -422,7 +422,7 @@ class ClassLikeDocblockParser
 
                     $statements = StatementsProvider::parseStatements(
                         $php_string,
-                        $codebase->php_major_version . '.' . $codebase->php_minor_version,
+                        $codebase->analysis_php_version_id,
                         $has_errors
                     );
                 } catch (Exception $e) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -1495,8 +1495,7 @@ class ClassLikeNodeScanner
                 $this->file_storage,
                 $this->storage,
                 $this->aliases,
-                $this->codebase->php_major_version,
-                $this->codebase->php_minor_version
+                $this->codebase->analysis_php_version_id
             );
 
             $signature_type_location = new CodeLocation(

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
@@ -340,7 +340,7 @@ class ExpressionResolver
                     )
                 )
             ) {
-                $php_version_id = $codebase->php_major_version * 10000 + $codebase->php_minor_version * 100;
+                $php_version_id = $codebase->analysis_php_version_id;
                 $evaluator = new ConstExprEvaluator(function (Expr $expr) use ($php_version_id) {
                     if ($expr instanceof ConstFetch && $expr->name->parts === ['PHP_VERSION_ID']) {
                         return $php_version_id;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -434,8 +434,7 @@ class FunctionLikeNodeScanner
                 $this->file_storage,
                 $this->classlike_storage,
                 $this->aliases,
-                $this->codebase->php_major_version,
-                $this->codebase->php_minor_version
+                $this->codebase->analysis_php_version_id
             );
 
             $storage->return_type_location = new CodeLocation(
@@ -486,12 +485,14 @@ class FunctionLikeNodeScanner
 
             if ($docblock_info) {
                 if ($docblock_info->since_php_major_version && !$this->aliases->namespace) {
-                    if ($docblock_info->since_php_major_version > $this->codebase->php_major_version) {
+                    $analysis_major_php_version = $this->codebase->getMajorAnalysisPhpVersion();
+                    $analysis_minor_php_version = $this->codebase->getMajorAnalysisPhpVersion();
+                    if ($docblock_info->since_php_major_version > $analysis_major_php_version) {
                         return false;
                     }
 
-                    if ($docblock_info->since_php_major_version === $this->codebase->php_major_version
-                        && $docblock_info->since_php_minor_version > $this->codebase->php_minor_version
+                    if ($docblock_info->since_php_major_version === $analysis_major_php_version
+                        && $docblock_info->since_php_minor_version > $analysis_minor_php_version
                     ) {
                         return false;
                     }
@@ -828,8 +829,7 @@ class FunctionLikeNodeScanner
                 $this->file_storage,
                 $this->classlike_storage,
                 $this->aliases,
-                $this->codebase->php_major_version,
-                $this->codebase->php_minor_version
+                $this->codebase->analysis_php_version_id
             );
 
             if ($is_nullable) {
@@ -1043,11 +1043,14 @@ class FunctionLikeNodeScanner
                     }
                     if ($docblock_info) {
                         if ($docblock_info->since_php_major_version && !$this->aliases->namespace) {
-                            if ($docblock_info->since_php_major_version > $this->codebase->php_major_version) {
+                            $analysis_major_php_version = $this->codebase->getMajorAnalysisPhpVersion();
+                            $analysis_minor_php_version = $this->codebase->getMajorAnalysisPhpVersion();
+                            if ($docblock_info->since_php_major_version > $analysis_major_php_version) {
                                 return false;
                             }
-                            if ($docblock_info->since_php_major_version === $this->codebase->php_major_version
-                                && $docblock_info->since_php_minor_version > $this->codebase->php_minor_version
+
+                            if ($docblock_info->since_php_major_version === $analysis_major_php_version
+                                && $docblock_info->since_php_minor_version > $analysis_minor_php_version
                             ) {
                                 return false;
                             }
@@ -1072,7 +1075,7 @@ class FunctionLikeNodeScanner
             if ($method_name_lc === strtolower($class_name)
                 && !isset($classlike_storage->methods['__construct'])
                 && strpos($fq_classlike_name, '\\') === false
-                && $this->codebase->php_major_version < 8
+                && $this->codebase->analysis_php_version_id <= 70400
             ) {
                 $this->codebase->methods->setDeclaringMethodId(
                     $fq_classlike_name,

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -27,8 +27,7 @@ class TypeHintResolver
         FileStorage $file_storage,
         ?ClassLikeStorage $classlike_storage,
         Aliases $aliases,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): Union {
         if ($hint instanceof PhpParser\Node\UnionType) {
             $type = null;
@@ -44,8 +43,7 @@ class TypeHintResolver
                     $file_storage,
                     $classlike_storage,
                     $aliases,
-                    $php_major_version,
-                    $php_minor_version
+                    $analysis_php_version_id
                 );
 
                 $type = Type::combineUnionTypes($resolved_type, $type);
@@ -93,7 +91,7 @@ class TypeHintResolver
 
         $type = Type::parseString(
             $fq_type_string,
-            [$php_major_version, $php_minor_version],
+            $analysis_php_version_id,
             []
         );
 

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -237,7 +237,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements FileSour
             $this->functionlike_node_scanners[] = $functionlike_node_scanner;
 
             if ($classlike_storage
-                && $this->codebase->php_major_version >= 8
+                && $this->codebase->analysis_php_version_id >= 80000
                 && $node instanceof PhpParser\Node\Stmt\ClassMethod
                 && strtolower($node->name->name) === '__tostring'
             ) {

--- a/src/Psalm/Internal/Scanner/FileScanner.php
+++ b/src/Psalm/Internal/Scanner/FileScanner.php
@@ -59,7 +59,7 @@ class FileScanner implements FileSource
 
         $stmts = $codebase->statements_provider->getStatementsForFile(
             $file_storage->file_path,
-            $codebase->php_major_version . '.' . $codebase->php_minor_version,
+            $codebase->analysis_php_version_id,
             $progress
         );
 

--- a/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
@@ -384,7 +384,7 @@ class StubsGenerator
                 || $atomic_type instanceof TArray
                 || $atomic_type instanceof TIterable
             ) {
-                $identifier_string = $atomic_type->toPhpString(null, [], null, 8, 0);
+                $identifier_string = $atomic_type->toPhpString(null, [], null, 80000);
 
                 if ($identifier_string === null) {
                     throw new UnexpectedValueException(

--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -509,7 +509,7 @@ class AtomicTypeComparator
             if ($input_type_part instanceof TNamedObject) {
                 // check whether the object has a __toString method
                 if ($codebase->classOrInterfaceExists($input_type_part->value)) {
-                    if ($codebase->php_major_version >= 8
+                    if ($codebase->analysis_php_version_id >= 80000
                         && ($input_type_part->value === 'Stringable'
                             || ($codebase->classlikes->classExists($input_type_part->value)
                                 && $codebase->classlikes->classImplements($input_type_part->value, 'Stringable'))

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -105,7 +105,7 @@ class TypeParser
      */
     public static function parseTokens(
         array $type_tokens,
-        ?array $php_version = null,
+        ?int $analysis_php_version_id = null,
         array $template_type_map = [],
         array $type_aliases = []
     ): Union {
@@ -121,9 +121,9 @@ class TypeParser
                     throw new TypeParseTreeException("Invalid type '$only_token[0]'");
                 }
             } else {
-                $only_token[0] = TypeTokenizer::fixScalarTerms($only_token[0], $php_version);
+                $only_token[0] = TypeTokenizer::fixScalarTerms($only_token[0], $analysis_php_version_id);
 
-                $atomic = Atomic::create($only_token[0], $php_version, $template_type_map, $type_aliases);
+                $atomic = Atomic::create($only_token[0], $analysis_php_version_id, $template_type_map, $type_aliases);
                 $atomic->offset_start = 0;
                 $atomic->offset_end = strlen($only_token[0]);
                 $atomic->text = isset($only_token[2]) && $only_token[2] !== $only_token[0] ? $only_token[2] : null;
@@ -137,7 +137,7 @@ class TypeParser
         $parsed_type = self::getTypeFromTree(
             $parse_tree,
             $codebase,
-            $php_version,
+            $analysis_php_version_id,
             $template_type_map,
             $type_aliases
         );
@@ -150,18 +150,17 @@ class TypeParser
     }
 
     /**
-     * @param  array{int,int}|null   $php_version
      * @param  array<string, array<string, Union>> $template_type_map
-     * @param  array<string, TypeAlias> $type_aliases
+     * @param  array<string, TypeAlias>            $type_aliases
      *
      * @return  Atomic|Union
      */
     public static function getTypeFromTree(
         ParseTree $parse_tree,
-        Codebase $codebase,
-        ?array $php_version = null,
-        array $template_type_map = [],
-        array $type_aliases = []
+        Codebase  $codebase,
+        ?int      $analysis_php_version_id = null,
+        array     $template_type_map = [],
+        array     $type_aliases = []
     ): TypeNode {
         if ($parse_tree instanceof GenericTree) {
             return self::getTypeFromGenericTree(
@@ -378,9 +377,9 @@ class TypeParser
             throw new TypeParseTreeException('Invalid type \'' . $parse_tree->value . '\'');
         }
 
-        $atomic_type_string = TypeTokenizer::fixScalarTerms($parse_tree->value, $php_version);
+        $atomic_type_string = TypeTokenizer::fixScalarTerms($parse_tree->value, $analysis_php_version_id);
 
-        $atomic_type = Atomic::create($atomic_type_string, $php_version, $template_type_map, $type_aliases);
+        $atomic_type = Atomic::create($atomic_type_string, $analysis_php_version_id, $template_type_map, $type_aliases);
 
         $atomic_type->offset_start = $parse_tree->offset_start;
         $atomic_type->offset_end = $parse_tree->offset_end;

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -300,14 +300,11 @@ class TypeTokenizer
     }
 
     /**
-     * @param array{int,int}|null   $php_version
-     *
-     *
      * @psalm-pure
      */
     public static function fixScalarTerms(
         string $type_string,
-        ?array $php_version = null
+        ?int $analysis_php_version_id = null
     ): string {
         $type_string_lc = strtolower($type_string);
 
@@ -330,14 +327,14 @@ class TypeTokenizer
 
         switch ($type_string) {
             case 'boolean':
-                return $php_version !== null ? $type_string : 'bool';
+                return $analysis_php_version_id !== null ? $type_string : 'bool';
 
             case 'integer':
-                return $php_version !== null ? $type_string : 'int';
+                return $analysis_php_version_id !== null ? $type_string : 'int';
 
             case 'double':
             case 'real':
-                return $php_version !== null ? $type_string : 'float';
+                return $analysis_php_version_id !== null ? $type_string : 'float';
         }
 
         return $type_string;

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -75,14 +75,14 @@ abstract class Type
      */
     public static function parseString(
         string $type_string,
-        ?array $php_version = null,
+        ?int $analysis_php_version_id = null,
         array $template_type_map = []
     ): Union {
         return TypeParser::parseTokens(
             TypeTokenizer::tokenize(
                 $type_string
             ),
-            $php_version,
+            $analysis_php_version_id,
             $template_type_map
         );
     }

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -9,7 +9,6 @@ use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TypeAlias;
 use Psalm\Internal\Type\TypeAlias\LinkableTypeAlias;
 use Psalm\Type;
-use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TArrayKey;
 use Psalm\Type\Atomic\TAssertionFalsy;

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -113,15 +113,15 @@ abstract class Atomic implements TypeNode
     public $text;
 
     /**
-     * @param array{int,int}|null $php_version contains php version when the type comes from signature
+     * @param int $analysis_php_version_id contains php version when the type comes from signature
      * @param array<string, array<string, Union>> $template_type_map
      * @param array<string, TypeAlias> $type_aliases
      */
     public static function create(
         string $value,
-        ?array $php_version = null,
-        array $template_type_map = [],
-        array $type_aliases = []
+        ?int   $analysis_php_version_id = null,
+        array  $template_type_map = [],
+        array  $type_aliases = []
     ): Atomic {
         switch ($value) {
             case 'int':
@@ -137,10 +137,7 @@ abstract class Atomic implements TypeNode
                 return new TBool();
 
             case 'void':
-                if ($php_version === null
-                    || ($php_version[0] > 7)
-                    || ($php_version[0] === 7 && $php_version[1] >= 1)
-                ) {
+                if ($analysis_php_version_id === null || $analysis_php_version_id >= 70100) {
                     return new TVoid();
                 }
 
@@ -150,20 +147,14 @@ abstract class Atomic implements TypeNode
                 return new TArrayKey();
 
             case 'iterable':
-                if ($php_version === null
-                    || ($php_version[0] > 7)
-                    || ($php_version[0] === 7 && $php_version[1] >= 1)
-                ) {
+                if ($analysis_php_version_id === null || $analysis_php_version_id >= 70100) {
                     return new TIterable();
                 }
 
                 break;
 
             case 'never':
-                if ($php_version === null
-                    || ($php_version[0] > 8)
-                    || ($php_version[0] === 8 && $php_version[1] >= 1)
-                ) {
+                if ($analysis_php_version_id === null || $analysis_php_version_id >= 80100) {
                     return new TNever();
                 }
 
@@ -175,10 +166,7 @@ abstract class Atomic implements TypeNode
                 return new TNever();
 
             case 'object':
-                if ($php_version === null
-                    || ($php_version[0] > 7)
-                    || ($php_version[0] === 7 && $php_version[1] >= 2)
-                ) {
+                if ($analysis_php_version_id === null || $analysis_php_version_id >= 70200) {
                     return new TObject();
                 }
 
@@ -221,7 +209,7 @@ abstract class Atomic implements TypeNode
                 return new TNonEmptyLowercaseString();
 
             case 'resource':
-                return $php_version !== null ? new TNamedObject($value) : new TResource();
+                return $analysis_php_version_id !== null ? new TNamedObject($value) : new TResource();
 
             case 'resource (closed)':
             case 'closed-resource':
@@ -231,33 +219,33 @@ abstract class Atomic implements TypeNode
                 return new TPositiveInt();
 
             case 'numeric':
-                return $php_version !== null ? new TNamedObject($value) : new TNumeric();
+                return $analysis_php_version_id !== null ? new TNamedObject($value) : new TNumeric();
 
             case 'true':
-                return $php_version !== null ? new TNamedObject($value) : new TTrue();
+                return $analysis_php_version_id !== null ? new TNamedObject($value) : new TTrue();
 
             case 'false':
-                if ($php_version === null || $php_version[0] >= 8) {
+                if ($analysis_php_version_id === null || $analysis_php_version_id >= 80000) {
                     return new TFalse();
                 }
 
                 return new TNamedObject($value);
 
             case 'empty':
-                return $php_version !== null ? new TNamedObject($value) : new TEmpty();
+                return $analysis_php_version_id !== null ? new TNamedObject($value) : new TEmpty();
 
             case 'scalar':
-                return $php_version !== null ? new TNamedObject($value) : new TScalar();
+                return $analysis_php_version_id !== null ? new TNamedObject($value) : new TScalar();
 
             case 'null':
-                if ($php_version === null || $php_version[0] >= 8) {
+                if ($analysis_php_version_id === null || $analysis_php_version_id >= 80000) {
                     return new TNull();
                 }
 
                 return new TNamedObject($value);
 
             case 'mixed':
-                if ($php_version === null || $php_version[0] >= 8) {
+                if ($analysis_php_version_id === null || $analysis_php_version_id >= 80000) {
                     return new TMixed();
                 }
 
@@ -625,11 +613,10 @@ abstract class Atomic implements TypeNode
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string;
 
-    abstract public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool;
+    abstract public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool;
 
     public function replaceTemplateTypesWithStandins(
         TemplateResult $template_result,

--- a/src/Psalm/Type/Atomic/CallableTrait.php
+++ b/src/Psalm/Type/Atomic/CallableTrait.php
@@ -141,8 +141,7 @@ trait CallableTrait
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): string {
         if ($this instanceof TNamedObject) {
             return parent::toNamespacedString($namespace, $aliased_classes, $this_class, true);

--- a/src/Psalm/Type/Atomic/Scalar.php
+++ b/src/Psalm/Type/Atomic/Scalar.php
@@ -6,7 +6,7 @@ use Psalm\Type\Atomic;
 
 abstract class Scalar extends Atomic
 {
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return true;
     }

--- a/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
+++ b/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
@@ -26,12 +26,9 @@ class TAnonymousClassInstance extends TNamedObject
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version > 7
-            || ($php_major_version === 7 && $php_minor_version >= 2)
-            ? ($this->extends ?? 'object') : null;
+        return $analysis_php_version_id >= 70200 ? ($this->extends ?? 'object') : null;
     }
 
     /**

--- a/src/Psalm/Type/Atomic/TArray.php
+++ b/src/Psalm/Type/Atomic/TArray.php
@@ -47,13 +47,12 @@ class TArray extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): string {
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return $this->type_params[0]->isArrayKey() && $this->type_params[1]->isMixed();
     }

--- a/src/Psalm/Type/Atomic/TArrayKey.php
+++ b/src/Psalm/Type/Atomic/TArrayKey.php
@@ -24,13 +24,12 @@ class TArrayKey extends Scalar
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TAssertionFalsy.php
+++ b/src/Psalm/Type/Atomic/TAssertionFalsy.php
@@ -31,13 +31,12 @@ class TAssertionFalsy extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TBool.php
+++ b/src/Psalm/Type/Atomic/TBool.php
@@ -24,9 +24,8 @@ class TBool extends Scalar
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version >= 7 ? 'bool' : null;
+        return $analysis_php_version_id >= 70000 ? 'bool' : null;
     }
 }

--- a/src/Psalm/Type/Atomic/TCallable.php
+++ b/src/Psalm/Type/Atomic/TCallable.php
@@ -23,13 +23,12 @@ class TCallable extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): string {
         return 'callable';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return $this->params === null && $this->return_type === null;
     }

--- a/src/Psalm/Type/Atomic/TCallableObject.php
+++ b/src/Psalm/Type/Atomic/TCallableObject.php
@@ -24,15 +24,12 @@ class TCallableObject extends TObject
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version > 7
-            || ($php_major_version === 7 && $php_minor_version >= 2)
-            ? 'object' : null;
+        return $analysis_php_version_id >= 72000 ? 'object' : null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TCallableString.php
+++ b/src/Psalm/Type/Atomic/TCallableString.php
@@ -18,7 +18,7 @@ class TCallableString extends TNonEmptyString
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClassConstant.php
+++ b/src/Psalm/Type/Atomic/TClassConstant.php
@@ -49,13 +49,12 @@ class TClassConstant extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClassString.php
+++ b/src/Psalm/Type/Atomic/TClassString.php
@@ -66,8 +66,7 @@ class TClassString extends TString
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return 'string';
     }
@@ -104,7 +103,7 @@ class TClassString extends TString
         return 'class-string<\\' . $this->as . '>';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClassStringMap.php
+++ b/src/Psalm/Type/Atomic/TClassStringMap.php
@@ -126,13 +126,12 @@ class TClassStringMap extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): string {
         return 'array';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClosedResource.php
+++ b/src/Psalm/Type/Atomic/TClosedResource.php
@@ -31,13 +31,12 @@ class TClosedResource extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TClosure.php
+++ b/src/Psalm/Type/Atomic/TClosure.php
@@ -12,7 +12,7 @@ class TClosure extends TNamedObject
     /** @var array<string, bool> */
     public $byref_uses = [];
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TConditional.php
+++ b/src/Psalm/Type/Atomic/TConditional.php
@@ -106,8 +106,7 @@ class TConditional extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
@@ -130,7 +129,7 @@ class TConditional extends Atomic
         return [$this->conditional_type, $this->if_type, $this->else_type];
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TDependentGetClass.php
+++ b/src/Psalm/Type/Atomic/TDependentGetClass.php
@@ -56,7 +56,7 @@ class TDependentGetClass extends TString implements DependentType
         return new TClassString();
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TDependentGetDebugType.php
+++ b/src/Psalm/Type/Atomic/TDependentGetDebugType.php
@@ -39,7 +39,7 @@ class TDependentGetDebugType extends TString implements DependentType
         return new TString();
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TDependentGetType.php
+++ b/src/Psalm/Type/Atomic/TDependentGetType.php
@@ -22,7 +22,7 @@ class TDependentGetType extends TString
         $this->typeof = $typeof;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TDependentListKey.php
+++ b/src/Psalm/Type/Atomic/TDependentListKey.php
@@ -44,7 +44,7 @@ class TDependentListKey extends TInt implements DependentType
         return new TInt();
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TEmpty.php
+++ b/src/Psalm/Type/Atomic/TEmpty.php
@@ -26,8 +26,7 @@ class TEmpty extends Scalar
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }

--- a/src/Psalm/Type/Atomic/TEnumCase.php
+++ b/src/Psalm/Type/Atomic/TEnumCase.php
@@ -33,13 +33,12 @@ class TEnumCase extends TNamedObject
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return $this->value;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TFalse.php
+++ b/src/Psalm/Type/Atomic/TFalse.php
@@ -17,7 +17,7 @@ class TFalse extends TBool
         return 'false';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TFloat.php
+++ b/src/Psalm/Type/Atomic/TFloat.php
@@ -24,9 +24,8 @@ class TFloat extends Scalar
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version >= 7 ? 'float' : null;
+        return $analysis_php_version_id >= 70000 ? 'float' : null;
     }
 }

--- a/src/Psalm/Type/Atomic/TGenericObject.php
+++ b/src/Psalm/Type/Atomic/TGenericObject.php
@@ -57,7 +57,7 @@ class TGenericObject extends TNamedObject
         return $this->value . '<' . substr($s, 0, -2) . '>' . $extra_types;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }
@@ -69,16 +69,11 @@ class TGenericObject extends TNamedObject
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         $result = $this->toNamespacedString($namespace, $aliased_classes, $this_class, true);
         $intersection = strrpos($result, '&');
-        if ($intersection === false || (
-                ($php_major_version === 8 && $php_minor_version >= 1) ||
-                ($php_major_version >= 9)
-            )
-        ) {
+        if ($intersection === false || $analysis_php_version_id >= 80100) {
             return $result;
         }
         return substr($result, $intersection+1);

--- a/src/Psalm/Type/Atomic/THtmlEscapedString.php
+++ b/src/Psalm/Type/Atomic/THtmlEscapedString.php
@@ -17,7 +17,7 @@ class THtmlEscapedString extends TString
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TInt.php
+++ b/src/Psalm/Type/Atomic/TInt.php
@@ -24,9 +24,8 @@ class TInt extends Scalar
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version >= 7 ? 'int' : null;
+        return $analysis_php_version_id >= 70000 ? 'int' : null;
     }
 }

--- a/src/Psalm/Type/Atomic/TIntMask.php
+++ b/src/Psalm/Type/Atomic/TIntMask.php
@@ -64,7 +64,7 @@ class TIntMask extends TInt
         return 'int-mask<' . substr($s, 0, -2) . '>';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TIntMaskOf.php
+++ b/src/Psalm/Type/Atomic/TIntMaskOf.php
@@ -50,7 +50,7 @@ class TIntMaskOf extends TInt
             . '>';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TIntRange.php
+++ b/src/Psalm/Type/Atomic/TIntRange.php
@@ -38,7 +38,7 @@ class TIntRange extends TInt
         return 'int<' . ($this->min_bound ?? 'min') . ', ' . ($this->max_bound ?? 'max') . '>';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TIterable.php
+++ b/src/Psalm/Type/Atomic/TIterable.php
@@ -89,16 +89,12 @@ class TIterable extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version > 7
-            || ($php_major_version === 7 && $php_minor_version >= 1)
-            ? 'iterable'
-            : null;
+        return $analysis_php_version_id >= 70100 ? 'iterable' : null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return $this->type_params[0]->isMixed() && $this->type_params[1]->isMixed();
     }

--- a/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
@@ -47,13 +47,12 @@ class TKeyOfClassConstant extends Scalar
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -213,13 +213,12 @@ class TKeyedArray extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): string {
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -97,13 +97,12 @@ class TList extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): string {
         return 'array';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TLiteralClassString.php
+++ b/src/Psalm/Type/Atomic/TLiteralClassString.php
@@ -42,13 +42,12 @@ class TLiteralClassString extends TLiteralString
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): string {
         return 'string';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TLowercaseString.php
@@ -9,7 +9,7 @@ class TLowercaseString extends TString
         return 'lowercase-string';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TMixed.php
+++ b/src/Psalm/Type/Atomic/TMixed.php
@@ -34,15 +34,14 @@ class TMixed extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version >= 8 ? 'mixed' : null;
+        return $analysis_php_version_id >= 80000 ? 'mixed' : null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
-        return $php_major_version >= 8;
+        return $analysis_php_version_id >= 80000;
     }
 
     public function getAssertionString(bool $exact = false): string

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -118,32 +118,27 @@ class TNamedObject extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         if ($this->value === 'static') {
-            return $php_major_version >= 8 ? 'static' : null;
+            return $analysis_php_version_id >= 80000 ? 'static' : null;
         }
 
         if ($this->was_static && $this->value === $this_class) {
-            return $php_major_version >= 8 ? 'static' : 'self';
+            return $analysis_php_version_id >= 80000 ? 'static' : 'self';
         }
 
         $result = $this->toNamespacedString($namespace, $aliased_classes, $this_class, false);
         $intersection = strrpos($result, '&');
-        if ($intersection === false || (
-                ($php_major_version === 8 && $php_minor_version >= 1) ||
-                ($php_major_version >= 9)
-            )
-        ) {
+        if ($intersection === false || $analysis_php_version_id >= 80100) {
             return $result;
         }
         return substr($result, $intersection+1);
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
-        return ($this->value !== 'static' && $this->was_static === false) || $php_major_version >= 8;
+        return ($this->value !== 'static' && $this->was_static === false) || $analysis_php_version_id >= 80000;
     }
 
     public function replaceTemplateTypesWithArgTypes(

--- a/src/Psalm/Type/Atomic/TNever.php
+++ b/src/Psalm/Type/Atomic/TNever.php
@@ -27,13 +27,12 @@ class TNever extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
@@ -15,7 +15,7 @@ class TNonEmptyLowercaseString extends TNonEmptyString
     /**
      * @return false
      */
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNonspecificLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TNonspecificLiteralInt.php
@@ -13,7 +13,7 @@ class TNonspecificLiteralInt extends TInt
         return 'literal-int';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNonspecificLiteralString.php
+++ b/src/Psalm/Type/Atomic/TNonspecificLiteralString.php
@@ -13,7 +13,7 @@ class TNonspecificLiteralString extends TString
         return 'literal-string';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNull.php
+++ b/src/Psalm/Type/Atomic/TNull.php
@@ -26,13 +26,12 @@ class TNull extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNumeric.php
+++ b/src/Psalm/Type/Atomic/TNumeric.php
@@ -24,13 +24,12 @@ class TNumeric extends Scalar
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TNumericString.php
+++ b/src/Psalm/Type/Atomic/TNumericString.php
@@ -22,7 +22,7 @@ class TNumericString extends TNonEmptyString
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TObject.php
+++ b/src/Psalm/Type/Atomic/TObject.php
@@ -26,16 +26,12 @@ class TObject extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version > 7
-            || ($php_major_version === 7 && $php_minor_version >= 2)
-            ? $this->getKey()
-            : null;
+        return $analysis_php_version_id >= 70200 ? $this->getKey() : null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return true;
     }

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -175,13 +175,12 @@ class TObjectWithProperties extends TObject
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): string {
         return $this->getKey();
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TPositiveInt.php
+++ b/src/Psalm/Type/Atomic/TPositiveInt.php
@@ -20,7 +20,7 @@ class TPositiveInt extends TInt
     /**
      * @return false
      */
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TResource.php
+++ b/src/Psalm/Type/Atomic/TResource.php
@@ -26,13 +26,12 @@ class TResource extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TScalar.php
+++ b/src/Psalm/Type/Atomic/TScalar.php
@@ -25,13 +25,12 @@ class TScalar extends Scalar
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TString.php
+++ b/src/Psalm/Type/Atomic/TString.php
@@ -14,10 +14,9 @@ class TString extends Scalar
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version >= 7 ? 'string' : null;
+        return $analysis_php_version_id >= 70000 ? 'string' : null;
     }
 
     public function __toString(): string

--- a/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
+++ b/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
@@ -53,13 +53,12 @@ class TTemplateIndexedAccess extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTemplateParam.php
+++ b/src/Psalm/Type/Atomic/TTemplateParam.php
@@ -81,8 +81,7 @@ class TTemplateParam extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
@@ -121,7 +120,7 @@ class TTemplateParam extends Atomic
         return [$this->as];
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTraitString.php
+++ b/src/Psalm/Type/Atomic/TTraitString.php
@@ -29,8 +29,7 @@ class TTraitString extends TString
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return 'string';
     }
@@ -48,7 +47,7 @@ class TTraitString extends TString
         return 'trait-string';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTrue.php
+++ b/src/Psalm/Type/Atomic/TTrue.php
@@ -17,7 +17,7 @@ class TTrue extends TBool
         return 'true';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TTypeAlias.php
+++ b/src/Psalm/Type/Atomic/TTypeAlias.php
@@ -70,13 +70,12 @@ class TTypeAlias extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TValueOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TValueOfClassConstant.php
@@ -44,13 +44,12 @@ class TValueOfClassConstant extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
         return null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/src/Psalm/Type/Atomic/TVoid.php
+++ b/src/Psalm/Type/Atomic/TVoid.php
@@ -26,15 +26,12 @@ class TVoid extends Atomic
         ?string $namespace,
         array $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int $analysis_php_version_id
     ): ?string {
-        return $php_major_version > 7
-            || ($php_major_version === 7 && $php_minor_version >= 1)
-            ? $this->getKey() : null;
+        return $analysis_php_version_id >= 70100 ? $this->getKey() : null;
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return true;
     }

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -511,17 +511,16 @@ class Union implements TypeNode
      */
     public function toPhpString(
         ?string $namespace,
-        array $aliased_classes,
+        array   $aliased_classes,
         ?string $this_class,
-        int $php_major_version,
-        int $php_minor_version
+        int     $analysis_php_version_id
     ): ?string {
         if (!$this->isSingleAndMaybeNullable()) {
-            if ($php_major_version < 8) {
+            if ($analysis_php_version_id < 80000) {
                 return null;
             }
-        } elseif ($php_major_version < 7
-            || (isset($this->types['null']) && $php_major_version === 7 && $php_minor_version < 1)
+        } elseif ($analysis_php_version_id < 70000
+            || (isset($this->types['null']) && $analysis_php_version_id < 70100)
         ) {
             return null;
         }
@@ -551,8 +550,7 @@ class Union implements TypeNode
                 $namespace,
                 $aliased_classes,
                 $this_class,
-                $php_major_version,
-                $php_minor_version
+                $analysis_php_version_id
             );
 
             if (!$php_type) {
@@ -571,7 +569,7 @@ class Union implements TypeNode
             return implode('|', array_unique($php_types));
         }
 
-        if ($php_major_version < 8) {
+        if ($analysis_php_version_id < 80000) {
             return ($nullable ? '?' : '') . implode('|', array_unique($php_types));
         }
         if ($nullable) {
@@ -580,9 +578,9 @@ class Union implements TypeNode
         return implode('|', array_unique($php_types));
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
-        if (!$this->isSingleAndMaybeNullable() && $php_major_version < 8) {
+        if (!$this->isSingleAndMaybeNullable() && $analysis_php_version_id < 80000) {
             return false;
         }
 
@@ -598,8 +596,8 @@ class Union implements TypeNode
 
         return !array_filter(
             $types,
-            function ($atomic_type) use ($php_major_version, $php_minor_version) {
-                return !$atomic_type->canBeFullyExpressedInPhp($php_major_version, $php_minor_version);
+            function ($atomic_type) use ($analysis_php_version_id) {
+                return !$atomic_type->canBeFullyExpressedInPhp($analysis_php_version_id);
             }
         );
     }

--- a/tests/AlgebraTest.php
+++ b/tests/AlgebraTest.php
@@ -85,7 +85,7 @@ class AlgebraTest extends TestCase
 
         $has_errors = false;
 
-        $dnf_stmt = StatementsProvider::parseStatements($dnf, '7.4', $has_errors)[0];
+        $dnf_stmt = StatementsProvider::parseStatements($dnf, 70400, $has_errors)[0];
 
         $this->assertInstanceOf(PhpParser\Node\Stmt\Expression::class, $dnf_stmt);
 

--- a/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
+++ b/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
@@ -19,7 +19,7 @@ class TSqlSelectString extends TLiteralString
         return 'sql-select-string(' . $this->value . ')';
     }
 
-    public function canBeFullyExpressedInPhp(int $php_major_version, int $php_minor_version): bool
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;
     }

--- a/tests/FileDiffTest.php
+++ b/tests/FileDiffTest.php
@@ -37,8 +37,8 @@ class FileDiffTest extends TestCase
 
         $has_errors = false;
 
-        $a_stmts = StatementsProvider::parseStatements($a, '7.4', $has_errors);
-        $b_stmts = StatementsProvider::parseStatements($b, '7.4', $has_errors);
+        $a_stmts = StatementsProvider::parseStatements($a, 70400, $has_errors);
+        $b_stmts = StatementsProvider::parseStatements($b, 70400, $has_errors);
 
         $diff = FileStatementsDiffer::diff($a_stmts, $b_stmts, $a, $b);
 
@@ -101,7 +101,7 @@ class FileDiffTest extends TestCase
 
         $has_errors = false;
 
-        $a_stmts = StatementsProvider::parseStatements($a, '7.4', $has_errors);
+        $a_stmts = StatementsProvider::parseStatements($a, 70400, $has_errors);
 
         $traverser = new PhpParser\NodeTraverser;
         $traverser->addVisitor(new CloningVisitor);
@@ -111,8 +111,8 @@ class FileDiffTest extends TestCase
 
         $this->assertTreesEqual($a_stmts, $a_stmts_copy);
 
-        $b_stmts = StatementsProvider::parseStatements($b, '7.4', $has_errors, null, $a, $a_stmts_copy, $file_changes);
-        $b_clean_stmts = StatementsProvider::parseStatements($b, '7.4', $has_errors);
+        $b_stmts = StatementsProvider::parseStatements($b, 70400, $has_errors, null, $a, $a_stmts_copy, $file_changes);
+        $b_clean_stmts = StatementsProvider::parseStatements($b, 70400, $has_errors);
 
         $this->assertTreesEqual($b_clean_stmts, $b_stmts);
 


### PR DESCRIPTION
This brings consistency to the way we use php versions. Before that, sometimes we passed them under the X.Y format, sometimes as two int params and sometimes as an array of two ints...

It also get rid of those horrors:
```
if ($codebase->php_major_version < 8 ||
   ($codebase->php_major_version === 8 && $codebase->php_minor_version < 1)
) {
```

and it fixes a couple of bugs like 
`if (\PHP_VERSION_ID < 80100 && $codebase->php_major_version >= 8 && $codebase->php_minor_version >= 1) {`
that would have been a problem in version 9.0

However, it's probably a BC break for plugin users...