### PR TITLE
Fix invalid SoapClient::__doRequest() signature

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -12223,7 +12223,7 @@ return [
 'snmpwalkoid' => ['array|false', 'hostname'=>'string', 'community'=>'string', 'object_id'=>'string', 'timeout='=>'int', 'retries='=>'int'],
 'SoapClient::__call' => ['', 'function_name'=>'string', 'arguments'=>'array'],
 'SoapClient::__construct' => ['void', 'wsdl'=>'mixed', 'options='=>'array|null'],
-'SoapClient::__doRequest' => ['string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'int'],
+'SoapClient::__doRequest' => ['string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'bool'],
 'SoapClient::__getCookies' => ['array'],
 'SoapClient::__getFunctions' => ['array'],
 'SoapClient::__getLastRequest' => ['string'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -109,6 +109,10 @@ return [
       'old' => ['string|int|false', 'empty='=>'bool'],
       'new' => ['string|int', 'empty='=>'bool'],
     ],
+    'SoapClient::__doRequest' => [
+      'old' => ['string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'int'],
+      'new' => ['string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'bool'],
+    ],
     'XMLWriter::startAttributeNs' => [
       'old' => ['bool', 'prefix'=>'string', 'name'=>'string', 'namespace'=>'?string'],
       'new' => ['bool', 'prefix'=>'?string', 'name'=>'string', 'namespace'=>'?string'],

--- a/stubs/soap.phpstub
+++ b/stubs/soap.phpstub
@@ -244,30 +244,6 @@ class SoapClient  {
      public function __getCookies () {}
 
      /**
-      * Performs a SOAP request
-      * @link https://php.net/manual/en/soapclient.dorequest.php
-      * @param string $request <p>
-      * The XML SOAP request.
-      * </p>
-      * @param string $location <p>
-      * The URL to request.
-      * </p>
-      * @param string $action <p>
-      * The SOAP action.
-      * </p>
-      * @param int $version <p>
-      * The SOAP version.
-      * </p>
-      * @param int $one_way [optional] <p>
-      * If one_way is set to 1, this method returns nothing.
-      * Use this where a response is not expected.
-      * </p>
-      * @return string The XML SOAP response.
-      * @since 5.0.1
-      */
-     public function __doRequest ($request, $location, $action, $version, $one_way = 0) {}
-
-     /**
       * The __setCookie purpose
       * @link https://php.net/manual/en/soapclient.setcookie.php
       * @param string $name <p>


### PR DESCRIPTION
This PR fixes an invalid signature for `SoapClient::__doRequest()`

See https://github.com/vimeo/psalm/issues/6901