### PR TITLE
Infer mb_strtolower() result as string when encoding is specified

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -471,6 +471,16 @@ class FunctionCallReturnTypeFetcher
                     }
 
                     return $call_map_return_type;
+                case 'mb_strtolower':
+                    if (count($call_args) < 2) {
+                        return Type::getLowercaseString();
+                    } else {
+                        $second_arg_type = $statements_analyzer->node_data->getType($call_args[1]->value);
+                        if ($second_arg_type && $second_arg_type->isNull()) {
+                            return Type::getLowercaseString();
+                        }
+                    }
+                    return Type::getString();
             }
         }
 

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1676,6 +1676,26 @@ class FunctionCallTest extends TestCase
                         if (strpos(DateTime::class, $needle)) {}
                     }',
             ],
+            'mb_strtolowerProducesStringWithSecondArgument' => [
+                '<?php
+                    $r = mb_strtolower("École", "BASE64");
+                ',
+                'assertions' => [
+                    '$r===' => 'string',
+                ],
+            ],
+            'mb_strtolowerProducesLowercaseStringWithNullOrAbsentEncoding' => [
+                '<?php
+                    $a = mb_strtolower("AAA");
+                    $b = mb_strtolower("AAA", null);
+                ',
+                'assertions' => [
+                    '$a===' => 'lowercase-string',
+                    '$b===' => 'lowercase-string',
+                ],
+                [],
+                '8.1',
+            ],
         ];
     }
 


### PR DESCRIPTION
`mb_strtolower()` may return characters we generally consider uppercase when it's given the encoding argument. This PR makes Psalm to err on the side of caution and treat the return type as `string` rather than `lowercase-string` in this case

Refs vimeo/psalm#6908