### PR TITLE
Report deprecated config elements

### DIFF
--- a/src/Psalm/Internal/PluginManager/ConfigFile.php
+++ b/src/Psalm/Internal/PluginManager/ConfigFile.php
@@ -12,7 +12,6 @@ use function substr;
 
 class ConfigFile
 {
-    public const NS = 'https://getpsalm.org/schema/config';
     /** @var string */
     private $path;
 
@@ -94,7 +93,7 @@ class ConfigFile
 
         $plugin_class_element = $config_xml->createElement('pluginClass');
         if ($plugin_class_element) {
-            $plugin_class_element->setAttribute('xmlns', self::NS);
+            $plugin_class_element->setAttribute('xmlns', Config::CONFIG_NAMESPACE);
             $plugin_class_element->setAttribute('class', $plugin_class);
             if ($plugins_element) {
                 $plugins_element->appendChild($plugin_class_element);

--- a/tests/Config/ConfigFileTest.php
+++ b/tests/Config/ConfigFileTest.php
@@ -69,7 +69,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
             <psalm
                 name="bar"
             >
-                <plugins><pluginClass xmlns="' . ConfigFile::NS . '" class="a\b\c"/></plugins>
+                <plugins><pluginClass xmlns="' . Config::CONFIG_NAMESPACE . '" class="a\b\c"/></plugins>
             </psalm>',
             file_get_contents($this->file_path)
         ));
@@ -91,7 +91,7 @@ class ConfigFileTest extends \Psalm\Tests\TestCase
 
         $this->assertTrue(static::compareContentWithTemplateAndTrailingLineEnding(
             '<?xml version="1.0"?>
-            <psalm><plugins><pluginClass xmlns="' . ConfigFile::NS . '" class="a\b\c"/></plugins></psalm>',
+            <psalm><plugins><pluginClass xmlns="' . Config::CONFIG_NAMESPACE . '" class="a\b\c"/></plugins></psalm>',
             file_get_contents($this->file_path)
         ));
     }


### PR DESCRIPTION
This will make Psalm actually report deprecated config elements like `<exitFunctions>`

Fixes #6897 