### PR TITLE
Multiple variables in @psalm-trace

### DIFF
--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -382,7 +382,7 @@ class StatementsAnalyzer extends SourceAnalyzer
 
             if (isset($statements_analyzer->parsed_docblock->tags['psalm-trace'])) {
                 foreach ($statements_analyzer->parsed_docblock->tags['psalm-trace'] as $traced_variable_line) {
-                    $possible_traced_variable_names = preg_split('/[\s]+/', $traced_variable_line);
+                    $possible_traced_variable_names = preg_split('/\s+/', $traced_variable_line);
                     if ($possible_traced_variable_names) {
                         $traced_variables = array_merge(
                             $traced_variables,

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -61,6 +61,7 @@ use function strtolower;
 use function substr;
 use function trim;
 
+use const PREG_SPLIT_NO_EMPTY;
 use const STDERR;
 
 /**
@@ -382,12 +383,9 @@ class StatementsAnalyzer extends SourceAnalyzer
 
             if (isset($statements_analyzer->parsed_docblock->tags['psalm-trace'])) {
                 foreach ($statements_analyzer->parsed_docblock->tags['psalm-trace'] as $traced_variable_line) {
-                    $possible_traced_variable_names = preg_split('/(?:\s*,\s*|\s+)/', $traced_variable_line);
+                    $possible_traced_variable_names = preg_split('/(?:\s*,\s*|\s+)/', $traced_variable_line, -1, PREG_SPLIT_NO_EMPTY);
                     if ($possible_traced_variable_names) {
-                        $traced_variables = array_merge(
-                            $traced_variables,
-                            array_filter($possible_traced_variable_names)
-                        );
+                        $traced_variables = array_merge($traced_variables, $possible_traced_variable_names);
                     }
                 }
             }

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -382,7 +382,7 @@ class StatementsAnalyzer extends SourceAnalyzer
 
             if (isset($statements_analyzer->parsed_docblock->tags['psalm-trace'])) {
                 foreach ($statements_analyzer->parsed_docblock->tags['psalm-trace'] as $traced_variable_line) {
-                    $possible_traced_variable_names = preg_split('/\s+/', $traced_variable_line);
+                    $possible_traced_variable_names = preg_split('/(?:\s*,\s*|\s+)/', $traced_variable_line);
                     if ($possible_traced_variable_names) {
                         $traced_variables = array_merge(
                             $traced_variables,

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -47,7 +47,6 @@ use Psalm\Type;
 use function array_change_key_case;
 use function array_column;
 use function array_combine;
-use function array_filter;
 use function array_keys;
 use function array_merge;
 use function fwrite;
@@ -383,7 +382,12 @@ class StatementsAnalyzer extends SourceAnalyzer
 
             if (isset($statements_analyzer->parsed_docblock->tags['psalm-trace'])) {
                 foreach ($statements_analyzer->parsed_docblock->tags['psalm-trace'] as $traced_variable_line) {
-                    $possible_traced_variable_names = preg_split('/(?:\s*,\s*|\s+)/', $traced_variable_line, -1, PREG_SPLIT_NO_EMPTY);
+                    $possible_traced_variable_names = preg_split(
+                        '/(?:\s*,\s*|\s+)/',
+                        $traced_variable_line,
+                        -1,
+                        PREG_SPLIT_NO_EMPTY
+                    );
                     if ($possible_traced_variable_names) {
                         $traced_variables = array_merge($traced_variables, $possible_traced_variable_names);
                     }

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -44,6 +44,7 @@ use function mkdir;
 use function number_format;
 use function ob_get_clean;
 use function ob_start;
+use function preg_match;
 use function sha1;
 use function sprintf;
 use function str_repeat;
@@ -234,7 +235,13 @@ class IssueBuffer
             fwrite(STDERR, "\nEmitting {$e->getShortLocation()} $issue_type {$e->message}\n$trace\n");
         }
 
+        // Make issue type for trace variable specific ("Trace" => "Trace~$var").
+        $trace_var = $issue_type === 'Trace' && preg_match('/^(\$.+?):/', $e->message, $m) === 1
+            ? '~' . $m[1]
+            : '';
+
         $emitted_key = $issue_type
+            . $trace_var
             . '-' . $e->getShortLocation()
             . ':' . $e->code_location->getColumn()
             . ' ' . $e->dupe_key;

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -236,7 +236,7 @@ class IssueBuffer
         }
 
         // Make issue type for trace variable specific ("Trace" => "Trace~$var").
-        $trace_var = $issue_type === 'Trace' && preg_match('/^(\$.+?):/', $e->message, $m) === 1
+        $trace_var = $issue_type === 'Trace' && preg_match('/^(\$.+?):/', $e->message, $m) === 1 && isset($m[1])
             ? '~' . $m[1]
             : '';
 

--- a/tests/TraceTest.php
+++ b/tests/TraceTest.php
@@ -17,6 +17,20 @@ class TraceTest extends TestCase
                     $a = getmypid();',
                 'error_message' => 'Trace',
             ],
+            'traceVariables' => [
+                '<?php
+                    /** @psalm-trace $a $b */
+                    $a = getmypid();
+                    $b = getmypid();',
+                'error_message' => 'Trace',
+            ],
+            'traceVariablesComma' => [
+                '<?php
+                    /** @psalm-trace $a, $b */
+                    $a = getmypid();
+                    $b = getmypid();',
+                'error_message' => 'Trace',
+            ],
             'undefinedTraceVariable' => [
                 '<?php
                     /** @psalm-trace $b */


### PR DESCRIPTION
Psalm did allow multiple variables in ``@psalm-trace`` but failed to add multiple trace issues to the same place.

That way, both cases in this example fail:

https://psalm.dev/r/31262a113f

Additional to fixing this bug, I’ve added the ability to use a comma as separator, so this line is valid also:
```
/** @psalm-trace $a, $b */
```

This is probably more natural for some people.

*Caveat:*

- I don’t know if my fix is the best way to allow multiple traces or if changing the format of ``$emitted_key`` for that case breaks something elsewhere. But no included test fails (at least none related to my changes) and using this codebase in another project worked as expected.
- The additional tests test only half of the addition. I don’t know if is possible to expect multiple errors in the test framework. At least the test asserts that adding two variables doesn’t break getting the first.
