### PR TITLE
Invalid SoapClient::__doRequest() response type

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -12223,7 +12223,7 @@ return [
 'snmpwalkoid' => ['array|false', 'hostname'=>'string', 'community'=>'string', 'object_id'=>'string', 'timeout='=>'int', 'retries='=>'int'],
 'SoapClient::__call' => ['', 'function_name'=>'string', 'arguments'=>'array'],
 'SoapClient::__construct' => ['void', 'wsdl'=>'mixed', 'options='=>'array|null'],
-'SoapClient::__doRequest' => ['string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'bool'],
+'SoapClient::__doRequest' => ['?string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'bool'],
 'SoapClient::__getCookies' => ['array'],
 'SoapClient::__getFunctions' => ['array'],
 'SoapClient::__getLastRequest' => ['string'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -110,8 +110,8 @@ return [
       'new' => ['string|int', 'empty='=>'bool'],
     ],
     'SoapClient::__doRequest' => [
-      'old' => ['string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'int'],
-      'new' => ['string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'bool'],
+      'old' => ['?string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'int'],
+      'new' => ['?string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'bool'],
     ],
     'XMLWriter::startAttributeNs' => [
       'old' => ['bool', 'prefix'=>'string', 'name'=>'string', 'namespace'=>'?string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -6821,7 +6821,7 @@ return [
     'SoapClient::SoapClient' => ['object', 'wsdl'=>'mixed', 'options='=>'array|null'],
     'SoapClient::__call' => ['', 'function_name'=>'string', 'arguments'=>'array'],
     'SoapClient::__construct' => ['void', 'wsdl'=>'mixed', 'options='=>'array|null'],
-    'SoapClient::__doRequest' => ['string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'int'],
+    'SoapClient::__doRequest' => ['?string', 'request'=>'string', 'location'=>'string', 'action'=>'string', 'version'=>'int', 'one_way='=>'int'],
     'SoapClient::__getCookies' => ['array'],
     'SoapClient::__getFunctions' => ['array'],
     'SoapClient::__getLastRequest' => ['string'],


### PR DESCRIPTION
Fixes #6901

The return type of SoapClient::__doRequest() is actually `?string` instead of `string`.
See

* https://www.php.net/manual/en/soapclient.dorequest.php
* https://github.com/php-soap/ext-soap-engine/issues/3

