### PR TITLE
expand type aliases when comparing unions

### DIFF
--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -426,6 +426,25 @@ class TypeAnnotationTest extends TestCase
                      */
                     class C implements A {}',
             ],
+            'importedTypeAliasAsConstrainedTypeParameterForImplementation' => [
+                '<?php
+                    namespace Bar;
+
+                    /** @template T of string */
+                    interface A {}
+
+                    /**
+                     * @psalm-type Foo = "foo"
+                     */
+                    class B {}
+
+                    /**
+                     * @psalm-import-type Foo from B
+                     * @implements A<Foo>
+                     */
+                    class C implements A {}
+                '
+            ],
             'importedTypeAliasAsTypeParameterForExtendedClass' => [
                 '<?php
                     namespace Bar;


### PR DESCRIPTION
Fixes #6440.

With the proposed changes type aliases are expanded when comparing union types.

This should allow for type aliases being passed as constrained type parameters.









