### PR TITLE
Correct missing key-value for stream_get_meta_data function

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -13785,7 +13785,7 @@ return [
 'stream_get_contents' => ['string|false', 'stream'=>'resource', 'length='=>'int', 'offset='=>'int'],
 'stream_get_filters' => ['array'],
 'stream_get_line' => ['string|false', 'stream'=>'resource', 'length'=>'int', 'ending='=>'string'],
-'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string}', 'stream'=>'resource'],
+'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string,crypto?:mixed}', 'stream'=>'resource'],
 'stream_get_transports' => ['list<string>'],
 'stream_get_wrappers' => ['list<string>'],
 'stream_is_local' => ['bool', 'stream'=>'resource|string'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -13785,7 +13785,7 @@ return [
 'stream_get_contents' => ['string|false', 'stream'=>'resource', 'length='=>'int', 'offset='=>'int'],
 'stream_get_filters' => ['array'],
 'stream_get_line' => ['string|false', 'stream'=>'resource', 'length'=>'int', 'ending='=>'string'],
-'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string,crypto?:mixed}', 'stream'=>'resource'],
+'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string,crypto?:array{protocol:string,cipher_name:string,cipher_bits:int,cipher_version:string}}', 'stream'=>'resource'],
 'stream_get_transports' => ['list<string>'],
 'stream_get_wrappers' => ['list<string>'],
 'stream_is_local' => ['bool', 'stream'=>'resource|string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -15230,7 +15230,7 @@ return [
     'stream_get_contents' => ['string|false', 'stream'=>'resource', 'length='=>'int', 'offset='=>'int'],
     'stream_get_filters' => ['array'],
     'stream_get_line' => ['string|false', 'stream'=>'resource', 'length'=>'int', 'ending='=>'string'],
-    'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string}', 'stream'=>'resource'],
+    'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string,crypto?:mixed}', 'stream'=>'resource'],
     'stream_get_transports' => ['list<string>'],
     'stream_get_wrappers' => ['list<string>'],
     'stream_is_local' => ['bool', 'stream'=>'resource|string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -15230,7 +15230,7 @@ return [
     'stream_get_contents' => ['string|false', 'stream'=>'resource', 'length='=>'int', 'offset='=>'int'],
     'stream_get_filters' => ['array'],
     'stream_get_line' => ['string|false', 'stream'=>'resource', 'length'=>'int', 'ending='=>'string'],
-    'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string,crypto?:mixed}', 'stream'=>'resource'],
+    'stream_get_meta_data' => ['array{timed_out:bool,blocked:bool,eof:bool,unread_bytes:int,stream_type:string,wrapper_type:string,wrapper_data:mixed,mode:string,seekable:bool,uri:string,mediatype:string,crypto?:array{protocol:string,cipher_name:string,cipher_bits:int,cipher_version:string}}', 'stream'=>'resource'],
     'stream_get_transports' => ['list<string>'],
     'stream_get_wrappers' => ['list<string>'],
     'stream_is_local' => ['bool', 'stream'=>'resource|string'],


### PR DESCRIPTION
This PR addresses the issue I reported here: https://github.com/vimeo/psalm/issues/6947

Fixes #6947 