### PR TITLE
check __callStatic purity instead of the pseudoMethod purity

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -469,6 +469,7 @@ class AtomicStaticCallAnalyzer
                 true,
                 $context->insideUse()
             )) {
+                $callstatic_storage = $codebase->methods->getStorage($callstatic_id);
                 if ($codebase->methods->return_type_provider->has($fq_class_name)) {
                     $return_type_candidate = $codebase->methods->return_type_provider->getReturnType(
                         $statements_analyzer,
@@ -516,7 +517,7 @@ class AtomicStaticCallAnalyzer
                     }
 
                     if (!$context->inside_throw) {
-                        if ($context->pure && !$pseudo_method_storage->pure) {
+                        if ($context->pure && !$callstatic_storage->pure) {
                             if (IssueBuffer::accepts(
                                 new ImpureMethodCall(
                                     'Cannot call an impure method from a pure context',
@@ -526,7 +527,7 @@ class AtomicStaticCallAnalyzer
                             )) {
                                 // fall through
                             }
-                        } elseif ($context->mutation_free && !$pseudo_method_storage->mutation_free) {
+                        } elseif ($context->mutation_free&& !$callstatic_storage->mutation_free) {
                             if (IssueBuffer::accepts(
                                 new ImpureMethodCall(
                                     'Cannot call a possibly-mutating method from a mutation-free context',
@@ -539,9 +540,9 @@ class AtomicStaticCallAnalyzer
                         } elseif ($statements_analyzer->getSource()
                             instanceof \Psalm\Internal\Analyzer\FunctionLikeAnalyzer
                             && $statements_analyzer->getSource()->track_mutations
-                            && !$pseudo_method_storage->pure
+                            && !$callstatic_storage->pure
                         ) {
-                            if (!$pseudo_method_storage->mutation_free) {
+                            if (!$callstatic_storage->mutation_free) {
                                 $statements_analyzer->getSource()->inferred_has_mutation = true;
                             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -34,6 +34,7 @@ use Psalm\Type\Atomic\TNamedObject;
 
 use function array_filter;
 use function array_map;
+use function assert;
 use function count;
 use function in_array;
 use function strtolower;
@@ -469,7 +470,9 @@ class AtomicStaticCallAnalyzer
                 true,
                 $context->insideUse()
             )) {
-                $callstatic_storage = $codebase->methods->getStorage($callstatic_id);
+                $callstatic_appearing_id = $codebase->methods->getAppearingMethodId($callstatic_id);
+                assert($callstatic_appearing_id !== null);
+                $callstatic_storage =  $codebase->methods->getStorage($callstatic_appearing_id);
                 if ($codebase->methods->return_type_provider->has($fq_class_name)) {
                     $return_type_candidate = $codebase->methods->return_type_provider->getReturnType(
                         $statements_analyzer,

--- a/tests/PureAnnotationTest.php
+++ b/tests/PureAnnotationTest.php
@@ -413,6 +413,35 @@ class PureAnnotationTest extends TestCase
                        }
                     }'
             ],
+            'pureThroughCallStatic' => [
+                '<?php
+
+                    /**
+                     * @method static self FOO()
+                     * @method static static BAR()
+                     * @method static static BAZ()
+                     *
+                     * @psalm-immutable
+                     */
+                    class MyEnum
+                    {
+                        const FOO = "foo";
+                        const BAR = "bar";
+                        const BAZ = "baz";
+
+                        /** @psalm-pure */
+                        public static function __callStatic(string $name, array $params): static
+                        {
+                            throw new BadMethodCallException("not implemented");
+                        }
+                    }
+
+                    /** @psalm-pure */
+                    function gimmeFoo(): MyEnum
+                    {
+                        return MyEnum::FOO();
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
In https://github.com/vimeo/psalm/issues/3180, users reported that pseudo methods with `@method static` plus a return type were pure by default.

It was not accurate, it's just that impurity was not checked. In https://github.com/vimeo/psalm/pull/6724, I added code to check purity through __callStatic by checking the pure attribute of the pseudo method that was called.

It was successful in flagging impure calls in pure context but I did not see that the pure calls in pure context were now broken because I used the pure flag of the pseudo method (that is never flagged) instead of the pure flag of __callStatic itself.

This is now fixed and both way works, so this will fix https://github.com/vimeo/psalm/issues/6941