### PR TITLE
Update $data argument types of file_put_contents

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -3227,7 +3227,7 @@ return [
 'file' => ['list<string>|false', 'filename'=>'string', 'flags='=>'int', 'context='=>'resource'],
 'file_exists' => ['bool', 'filename'=>'string'],
 'file_get_contents' => ['string|false', 'filename'=>'string', 'use_include_path='=>'bool', 'context='=>'?resource', 'offset='=>'int', 'length='=>'int'],
-'file_put_contents' => ['int|false', 'filename'=>'string', 'data'=>'mixed', 'flags='=>'int', 'context='=>'resource'],
+'file_put_contents' => ['int|false', 'filename'=>'string', 'data'=>'string|resource|array<string>', 'flags='=>'int', 'context='=>'resource'],
 'fileatime' => ['int|false', 'filename'=>'string'],
 'filectime' => ['int|false', 'filename'=>'string'],
 'filegroup' => ['int|false', 'filename'=>'string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -10838,7 +10838,7 @@ return [
     'file' => ['list<string>|false', 'filename'=>'string', 'flags='=>'int', 'context='=>'resource'],
     'file_exists' => ['bool', 'filename'=>'string'],
     'file_get_contents' => ['string|false', 'filename'=>'string', 'use_include_path='=>'bool', 'context='=>'?resource', 'offset='=>'int', 'length='=>'int'],
-    'file_put_contents' => ['int|false', 'filename'=>'string', 'data'=>'mixed', 'flags='=>'int', 'context='=>'resource'],
+    'file_put_contents' => ['int|false', 'filename'=>'string', 'data'=>'string|resource|array<string>', 'flags='=>'int', 'context='=>'resource'],
     'fileatime' => ['int|false', 'filename'=>'string'],
     'filectime' => ['int|false', 'filename'=>'string'],
     'filegroup' => ['int|false', 'filename'=>'string'],


### PR DESCRIPTION
The main aim is to exclude boolean false, which would be coerced into '' in the following cases:

```php
file_put_contents('outfile', file_get_contents('invalid_file')); // false instead of string
file_put_contents('outfile', fopen('invalid_file', 'r')); // false instead of resource
file_put_contents('outfile', file('invalid_file')); // false instead of array
```