### PR TITLE
usleep(0) is valid

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -15151,7 +15151,7 @@ return [
 'urlencode' => ['string', 'string'=>'string'],
 'use_soap_error_handler' => ['bool', 'enable='=>'bool'],
 'user_error' => ['void', 'message'=>'string', 'error_level='=>'int'],
-'usleep' => ['void', 'microseconds'=>'positive-int'],
+'usleep' => ['void', 'microseconds'=>'positive-int|0'],
 'usort' => ['bool', '&rw_array'=>'array', 'callback'=>'callable(mixed,mixed):int'],
 'utf8_decode' => ['string', 'string'=>'string'],
 'utf8_encode' => ['string', 'string'=>'string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -16189,7 +16189,7 @@ return [
     'urlencode' => ['string', 'string'=>'string'],
     'use_soap_error_handler' => ['bool', 'enable='=>'bool'],
     'user_error' => ['void', 'message'=>'string', 'error_level='=>'int'],
-    'usleep' => ['void', 'microseconds'=>'positive-int'],
+    'usleep' => ['void', 'microseconds'=>'positive-int|0'],
     'usort' => ['bool', '&rw_array'=>'array', 'callback'=>'callable(mixed,mixed):int'],
     'utf8_decode' => ['string', 'string'=>'string'],
     'utf8_encode' => ['string', 'string'=>'string'],


### PR DESCRIPTION
Similar to ef9858c45881cc7be8fbb5653797f8c0fa4844e2.

usleep() only throws the value is < 0:
```
Uncaught ValueError: usleep(): Argument #1 ($microseconds) must be greater than or equal to 0
```