### PR TITLE
fix counting array properties when some are Never

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -341,10 +341,18 @@ class FunctionCallReturnTypeFetcher
                                     $min = 0;
                                     $max = 0;
                                     foreach ($atomic_types['array']->properties as $property) {
-                                        if (!$property->possibly_undefined) {
+                                        // empty, never and possibly undefined can't count for min value
+                                        if (!$property->possibly_undefined
+                                            && !$property->isEmpty()
+                                            && !$property->isNever()
+                                        ) {
                                             $min++;
                                         }
-                                        $max++;
+
+                                        //empty and never can't count for max value because we know keys are undefined
+                                        if (!$property->isEmpty() && !$property->isNever()) {
+                                            $max++;
+                                        }
                                     }
 
                                     if ($atomic_types['array']->sealed) {

--- a/tests/TypeReconciliation/RedundantConditionTest.php
+++ b/tests/TypeReconciliation/RedundantConditionTest.php
@@ -867,7 +867,19 @@ class RedundantConditionTest extends \Psalm\Tests\TestCase
 
                     }
                     '
-            ]
+            ],
+            'countWithNeverValuesInKeyedArray' => [
+                '<?php
+                    /** @var non-empty-array $report_data */
+                    $report_data = [];
+                    if ( array_key_exists( "A", $report_data ) ) {
+                    } elseif ( !empty( $report_data[0]["type"] ) && rand(0,1) ) {
+                        if ( rand(0,1) ) {}
+
+                        if ( count( $report_data ) === 1 ) {
+                        }
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/6969

There are still weird behaviours in here, for example in https://psalm.dev/r/522d483a64, removing the standalone `if(rand(0,1))` condition mask the issue, so I guess Psalm perform some simplifications in arrays shapes when closing a condition or something like that.

However, this change is not dirty nor harmful and will improve the situation, so it should not be an issue