### PR TITLE
prevent Psalm from considering throwing methods as unused just because they're immutable

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -112,6 +112,7 @@ class MethodCallPurityAnalyzer
                     && !$method_storage->assertions
                     && !$method_storage->if_true_assertions
                     && !$method_storage->if_false_assertions
+                    && !$method_storage->throws
                 ) {
                     if (IssueBuffer::accepts(
                         new \Psalm\Issue\UnusedMethodCall(

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1162,6 +1162,28 @@ class UnusedCodeTest extends TestCase
                     $a = new A();
                     echo $a->getVal(null);',
             ],
+            ,
+            'NotUnusedWhenThrows' => [
+                '<?php
+                    declare(strict_types=1);
+
+                    /** @psalm-immutable */
+                    final class UserList
+                    {
+                        /**
+                         * @throws InvalidArgumentException
+                         */
+                        public function validate(): void
+                        {
+                            // Some validation happens here
+                            throw new \InvalidArgumentException();
+                        }
+                    }
+
+                    $a = new UserList();
+                    $a->validate();
+                    ',
+            ],
             '__halt_compiler_no_usage_check' => [
                 '<?php
                     exit(0);

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1162,7 +1162,6 @@ class UnusedCodeTest extends TestCase
                     $a = new A();
                     echo $a->getVal(null);',
             ],
-            ,
             'NotUnusedWhenThrows' => [
                 '<?php
                     declare(strict_types=1);


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/6967

As discussed there, in the long term, we might want to reconsider the assumption that void and immutable methods are unused, given the current definition of immutability does not exclude at least some external side effects(like throwing an exception)