### PR TITLE
Taint can't be transmitted through numerics nor bool

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -12,6 +12,7 @@ use Psalm\Context;
 use Psalm\Internal\Analyzer\FunctionLike\ReturnTypeAnalyzer;
 use Psalm\Internal\Analyzer\FunctionLike\ReturnTypeCollector;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
+use Psalm\Internal\Codebase\TaintFlowGraph;
 use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\Internal\FileManipulation\FunctionDocblockManipulator;
 use Psalm\Internal\Type\Comparator\TypeComparisonResult;
@@ -1032,7 +1033,9 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             if ($statements_analyzer->data_flow_graph
                 && $function_param->location
             ) {
-                if ($function_param->type === null
+                //don't add to taint flow graph if the type can't transmit taints
+                if (!$statements_analyzer->data_flow_graph instanceof TaintFlowGraph
+                    || $function_param->type === null
                     || !$function_param->type->isSingle()
                     || (!$function_param->type->isInt()
                         && !$function_param->type->isFloat()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -1505,10 +1505,10 @@ class ArgumentAnalyzer
             return $input_type;
         }
 
-        // numeric types can't be tainted
+        // numeric types can't be tainted, neither can bool
         if ($statements_analyzer->data_flow_graph instanceof TaintFlowGraph
             && $input_type->isSingle()
-            && ($input_type->isInt() || $input_type->isFloat())
+            && ($input_type->isInt() || $input_type->isFloat() || $input_type->isBool())
         ) {
             return $input_type;
         }

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -671,6 +671,36 @@ class TaintTest extends TestCase
                     $var = $input + 1;
                     var_dump($var);'
             ],
+            'NoTaintForIntTypeHintUsingAnnotatedSink' => [
+                '<?php // --taint-analysis
+                    function fetch(int $id): string
+                    {
+                        return query("SELECT * FROM table WHERE id=" . $id);
+                    }
+                    /**
+                     * @return string
+                     * @psalm-taint-sink sql $sql
+                     * @psalm-taint-specialize
+                     */
+                    function query(string $sql) {}
+                    $value = $_GET["value"];
+                    $result = fetch($value);'
+            ],
+            'NoTaintForIntTypeCastUsingAnnotatedSink' => [
+                '<?php // --taint-analysis
+                    function fetch($id): string
+                    {
+                        return query("SELECT * FROM table WHERE id=" . (int)$id);
+                    }
+                    /**
+                     * @return string
+                     * @psalm-taint-sink sql $sql
+                     * @psalm-taint-specialize
+                     */
+                    function query(string $sql) {}
+                    $value = $_GET["value"];
+                    $result = fetch($value);'
+            ],
         ];
     }
 


### PR DESCRIPTION
This will fix #6991 and fix #6992 (sorry, I'm not sure how to contribute to a previously made PR, so I just stole the tests :D)

We could improve this PR in the future: It's the second time I list int, bool and float for taint purpose. We could create a method on Union that would take a type and return if it can be a vector for taints (for example, we can exclude bool, int, float, probably numeric and numeric-string. Other are more unclear: what about resource? callable-string? etc...). It would also allow checking union types...

Once again, I was surprised, once I fixed the parameter type, the cast solved itself and it did not allow taint to pass anymore. I'm not completely sure what's going on here.