### PR TITLE
Drop special handling of constant references on enums

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -210,53 +210,43 @@ class ClassConstFetchAnalyzer
 
             $const_class_storage = $codebase->classlike_storage_provider->get($fq_class_name);
 
-            if ($const_class_storage->is_enum) {
-                if (isset($const_class_storage->enum_cases[$stmt->name->name])) {
-                    $class_constant_type = new Type\Union([
-                        new Type\Atomic\TEnumCase($fq_class_name, $stmt->name->name)
-                    ]);
-                } else {
-                    $class_constant_type = null;
-                }
+            if ($fq_class_name === $context->self
+                || (
+                    $statements_analyzer->getSource()->getSource() instanceof TraitAnalyzer &&
+                    $fq_class_name === $statements_analyzer->getSource()->getFQCLN()
+                )
+            ) {
+                $class_visibility = \ReflectionProperty::IS_PRIVATE;
+            } elseif ($context->self &&
+                ($codebase->classlikes->classExtends($context->self, $fq_class_name)
+                    || $codebase->classlikes->classExtends($fq_class_name, $context->self))
+            ) {
+                $class_visibility = \ReflectionProperty::IS_PROTECTED;
             } else {
-                if ($fq_class_name === $context->self
-                    || (
-                        $statements_analyzer->getSource()->getSource() instanceof TraitAnalyzer &&
-                        $fq_class_name === $statements_analyzer->getSource()->getFQCLN()
-                    )
-                ) {
-                    $class_visibility = \ReflectionProperty::IS_PRIVATE;
-                } elseif ($context->self &&
-                    ($codebase->classlikes->classExtends($context->self, $fq_class_name)
-                        || $codebase->classlikes->classExtends($fq_class_name, $context->self))
-                ) {
-                    $class_visibility = \ReflectionProperty::IS_PROTECTED;
-                } else {
-                    $class_visibility = \ReflectionProperty::IS_PUBLIC;
+                $class_visibility = \ReflectionProperty::IS_PUBLIC;
+            }
+
+            try {
+                $class_constant_type = $codebase->classlikes->getClassConstantType(
+                    $fq_class_name,
+                    $stmt->name->name,
+                    $class_visibility,
+                    $statements_analyzer
+                );
+            } catch (\InvalidArgumentException $_) {
+                return true;
+            } catch (\Psalm\Exception\CircularReferenceException $e) {
+                if (IssueBuffer::accepts(
+                    new CircularReference(
+                        'Constant ' . $const_id . ' contains a circular reference',
+                        new CodeLocation($statements_analyzer->getSource(), $stmt)
+                    ),
+                    $statements_analyzer->getSuppressedIssues()
+                )) {
+                    // fall through
                 }
 
-                try {
-                    $class_constant_type = $codebase->classlikes->getClassConstantType(
-                        $fq_class_name,
-                        $stmt->name->name,
-                        $class_visibility,
-                        $statements_analyzer
-                    );
-                } catch (\InvalidArgumentException $_) {
-                    return true;
-                } catch (\Psalm\Exception\CircularReferenceException $e) {
-                    if (IssueBuffer::accepts(
-                        new CircularReference(
-                            'Constant ' . $const_id . ' contains a circular reference',
-                            new CodeLocation($statements_analyzer->getSource(), $stmt)
-                        ),
-                        $statements_analyzer->getSuppressedIssues()
-                    )) {
-                        // fall through
-                    }
-
-                    return true;
-                }
+                return true;
             }
 
             if (!$class_constant_type) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -509,53 +509,43 @@ class ClassConstFetchAnalyzer
 
             $const_class_storage = $codebase->classlike_storage_provider->get($fq_class_name);
 
-            if ($const_class_storage->is_enum) {
-                if (isset($const_class_storage->enum_cases[$stmt->name->name])) {
-                    $class_constant_type = new Type\Union([
-                        new Type\Atomic\TEnumCase($fq_class_name, $stmt->name->name)
-                    ]);
-                } else {
-                    $class_constant_type = null;
-                }
+            if ($fq_class_name === $context->self
+                || (
+                    $statements_analyzer->getSource()->getSource() instanceof TraitAnalyzer &&
+                    $fq_class_name === $statements_analyzer->getSource()->getFQCLN()
+                )
+            ) {
+                $class_visibility = \ReflectionProperty::IS_PRIVATE;
+            } elseif ($context->self &&
+                ($codebase->classlikes->classExtends($context->self, $fq_class_name)
+                    || $codebase->classlikes->classExtends($fq_class_name, $context->self))
+            ) {
+                $class_visibility = \ReflectionProperty::IS_PROTECTED;
             } else {
-                if ($fq_class_name === $context->self
-                    || (
-                        $statements_analyzer->getSource()->getSource() instanceof TraitAnalyzer &&
-                        $fq_class_name === $statements_analyzer->getSource()->getFQCLN()
-                    )
-                ) {
-                    $class_visibility = \ReflectionProperty::IS_PRIVATE;
-                } elseif ($context->self &&
-                    ($codebase->classlikes->classExtends($context->self, $fq_class_name)
-                        || $codebase->classlikes->classExtends($fq_class_name, $context->self))
-                ) {
-                    $class_visibility = \ReflectionProperty::IS_PROTECTED;
-                } else {
-                    $class_visibility = \ReflectionProperty::IS_PUBLIC;
+                $class_visibility = \ReflectionProperty::IS_PUBLIC;
+            }
+
+            try {
+                $class_constant_type = $codebase->classlikes->getClassConstantType(
+                    $fq_class_name,
+                    $stmt->name->name,
+                    $class_visibility,
+                    $statements_analyzer
+                );
+            } catch (\InvalidArgumentException $_) {
+                return true;
+            } catch (\Psalm\Exception\CircularReferenceException $e) {
+                if (IssueBuffer::accepts(
+                    new CircularReference(
+                        'Constant ' . $const_id . ' contains a circular reference',
+                        new CodeLocation($statements_analyzer->getSource(), $stmt)
+                    ),
+                    $statements_analyzer->getSuppressedIssues()
+                )) {
+                    // fall through
                 }
 
-                try {
-                    $class_constant_type = $codebase->classlikes->getClassConstantType(
-                        $fq_class_name,
-                        $stmt->name->name,
-                        $class_visibility,
-                        $statements_analyzer
-                    );
-                } catch (\InvalidArgumentException $_) {
-                    return true;
-                } catch (\Psalm\Exception\CircularReferenceException $e) {
-                    if (IssueBuffer::accepts(
-                        new CircularReference(
-                            'Constant ' . $const_id . ' contains a circular reference',
-                            new CodeLocation($statements_analyzer->getSource(), $stmt)
-                        ),
-                        $statements_analyzer->getSuppressedIssues()
-                    )) {
-                        // fall through
-                    }
-
-                    return true;
-                }
+                return true;
             }
 
             if (!$class_constant_type) {

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -194,6 +194,33 @@ class EnumTest extends TestCase
                 [],
                 '8.1',
             ],
+            'constantOfAVariableEnumClassString' => [
+                '<?php
+                    enum A { const C = 3; }
+                    $e = A::class;
+                    $_z = $e::C;
+                ',
+                'assertions' => [
+                    '$_z===' => '3',
+                ],
+                [],
+                '8.1',
+            ],
+            'constantOfAVariableEnumInstance' => [
+                '<?php
+                    enum A {
+                        const C = 3;
+                        case AA;
+                    }
+                    $e = A::AA;
+                    $_z = $e::C;
+                ',
+                'assertions' => [
+                    '$_z===' => '3',
+                ],
+                [],
+                '8.1',
+            ],
             'EnumCaseInAttribute' => [
                 '<?php
                     class CreateController {

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -174,6 +174,26 @@ class EnumTest extends TestCase
                 [],
                 '8.1',
             ],
+            'wildcardConstantsOnEnum' => [
+                '<?php
+                    enum A {
+                        const C_1 = 1;
+                        const C_2 = 2;
+                        const C_3 = 3;
+
+                        /**
+                         * @param self::C_* $i
+                         */
+                        public static function foo(int $i) : void {}
+                    }
+
+                    A::foo(A::C_1);
+                    A::foo(A::C_2);
+                    A::foo(A::C_3);',
+                'assertions' => [],
+                [],
+                '8.1',
+            ],
             'EnumCaseInAttribute' => [
                 '<?php
                     class CreateController {


### PR DESCRIPTION
Internally enum cases are constants, and they should be resolved as such.

Fixes vimeo/psalm#6994