### PR TITLE
Make test runnable on plain windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -104,10 +104,10 @@
     "scripts": {
         "all-tests": [
             "phpcs",
-            "./psalm --find-dead-code",
+            "@php ./psalm --find-dead-code",
             "phpunit"
         ],
-        "psalm": "./psalm --find-dead-code",
+        "psalm": "@php ./psalm --find-dead-code",
         "cs": "phpcs -p",
         "cs-fix": "phpcbf -p",
         "tests": [


### PR DESCRIPTION
Running ``composer all-tests`` or ``composer psalm`` fails on (standard) Windows as it doesn’t care for the shebang.

[Executing the script](https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts) as in this patch should (hopefully, we’ll see :-) independent of the OS.
