### PR TITLE
Allow overriding the signature type by a param docblock for promoted properties

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -618,7 +618,7 @@ class FunctionLikeNodeScanner
                 }
 
                 //no docblock type was provided for param but we have one for property
-                if ($param_storage->type === null && $var_comment_type) {
+                if ($var_comment_type) {
                     $param_storage->type = $var_comment_type;
                 }
 

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1955,8 +1955,24 @@ class AnnotationTest extends TestCase
                     ',
                 'error_message' => 'InvalidDocblock',
             ],
+            'promotedPropertyWithParamDocblockAndSignatureType' => [
+                '<?php
 
+                    class A
+                    {
+                        public function __construct(
+                            /** @var "cti"|"basic"|"teams"|"" */
+                            public string $licenseType = "",
+                        ) {
+                        }
+                    }
 
+                    $a = new A("ladida");
+                    $a->licenseType = "dudidu";
+
+                    echo $a->licenseType;',
+                'error_message' => 'InvalidArgument',
+            ],
         ];
     }
 }


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/6951