### PR TITLE
Disabled coverage (and xdebug) for CI builds

### DIFF
--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -33,6 +33,7 @@ jobs:
         with:
           php-version: '7.4'
           tools: composer:v2
+          coverage: none
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ jobs:
         with:
           php-version: '7.1'
           tools: composer:v2
+          coverage: none
 
       - uses: actions/checkout@v2
 
@@ -79,6 +80,7 @@ jobs:
         with:
           php-version: '8.0'
           tools: composer:v2
+          coverage: none
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           php-version: '8.0'
           tools: composer:v2
+          coverage: none
 
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
I'd expect to see some performance gains here.