### PR TITLE
remove the remaining dynamic property assignment

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php
@@ -225,11 +225,10 @@ class SimpleNameResolver extends NodeVisitorAbstract
 
     protected function addNamespacedName(Stmt\Class_ $node): void
     {
-        /** @psalm-suppress UndefinedPropertyAssignment */
-        $node->namespacedName = Name::concat(
+        $node->setAttribute('namespacedName', Name::concat(
             $this->nameContext->getNamespace(),
             (string)$node->name
-        );
+        ));
     }
 
     protected function resolveAttrGroups(Stmt\Class_ $node): void

--- a/tests/CodebaseTest.php
+++ b/tests/CodebaseTest.php
@@ -152,7 +152,7 @@ class CodebaseTest extends TestCase
                 $storage = $event->getStorage();
                 $codebase = $event->getCodebase();
                 if ($storage->name === 'Psalm\\CurrentTest\\C' && $stmt instanceof Class_) {
-                    $storage->custom_metadata['fqcn'] = (string)($stmt->namespacedName ?? $stmt->name);
+                    $storage->custom_metadata['fqcn'] = (string)($stmt->getAttribute('namespacedName') ?? $stmt->name);
                     $storage->custom_metadata['extends'] = $stmt->extends instanceof Name
                         ? (string)$stmt->extends->getAttribute('resolvedName')
                         : '';


### PR DESCRIPTION
The goal is to fix https://github.com/vimeo/psalm/issues/7007

But reading the issue again, I'm not sure I got it right the first time.

@TysonAndre , can you confirm this is what you had in mind? I was confused by `setAttribute('namespacedNameObject')`, why Object?

(On an unrelated note, the reason why I didn't find those two for #6656 is because there is a @property on PHP-Parser which messed with my detection)