### PR TITLE
Add --php-version to CLI help

### DIFF
--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -342,6 +342,9 @@ Basic configuration:
 
     --no-diff
         Turns off Psalm’s diff mode, checks all files regardless of whether they’ve changed.
+        
+    --php-version=PHP_VERSION
+        Explicitly set PHP version to analyse code against. 
 
 Surfacing issues:
     --show-info[=BOOLEAN]


### PR DESCRIPTION
As documented here: https://psalm.dev/docs/running_psalm/configuration/#phpversion