### PR TITLE
Improved `preg_match()` output param type inference

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -10273,7 +10273,7 @@ return [
 'preg_filter' => ['null|string|string[]', 'pattern'=>'mixed', 'replacement'=>'mixed', 'subject'=>'mixed', 'limit='=>'int', '&w_count='=>'int'],
 'preg_grep' => ['array|false', 'pattern'=>'string', 'array'=>'array', 'flags='=>'int'],
 'preg_last_error' => ['int'],
-'preg_match' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_matches='=>'string[]', 'flags='=>'0|', 'offset='=>'int'],
+'preg_match' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_matches='=>'string[]', 'flags='=>'0', 'offset='=>'int'],
 'preg_match\'1' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_matches='=>'array', 'flags='=>'int', 'offset='=>'int'],
 'preg_match_all' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_matches='=>'array', 'flags='=>'int', 'offset='=>'int'],
 'preg_quote' => ['string', 'str'=>'string', 'delimiter='=>'string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -14454,7 +14454,7 @@ return [
     'preg_filter' => ['null|string|string[]', 'pattern'=>'mixed', 'replacement'=>'mixed', 'subject'=>'mixed', 'limit='=>'int', '&w_count='=>'int'],
     'preg_grep' => ['array|false', 'pattern'=>'string', 'array'=>'array', 'flags='=>'int'],
     'preg_last_error' => ['int'],
-    'preg_match' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_matches='=>'string[]', 'flags='=>'0|', 'offset='=>'int'],
+    'preg_match' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_matches='=>'string[]', 'flags='=>'0', 'offset='=>'int'],
     'preg_match\'1' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_matches='=>'array', 'flags='=>'int', 'offset='=>'int'],
     'preg_match_all' => ['int|false', 'pattern'=>'string', 'subject'=>'string', '&w_matches='=>'array', 'flags='=>'int', 'offset='=>'int'],
     'preg_quote' => ['string', 'str'=>'string', 'delimiter='=>'string'],

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -259,14 +259,14 @@ class CodeLocation
             }
 
             if (preg_match($regex, $preview_snippet, $matches, PREG_OFFSET_CAPTURE)) {
-                if (!isset($matches[1]) || (int)$matches[1][1] === -1) {
+                if (!isset($matches[1]) || $matches[1][1] === -1) {
                     throw new \LogicException(
                         "Failed to match anything to 1st capturing group, "
                         . "or regex doesn't contain 1st capturing group, regex type " . $this->regex_type
                     );
                 }
-                $this->selection_start = $this->selection_start + (int)$matches[1][1];
-                $this->selection_end = $this->selection_start + strlen((string)$matches[1][0]);
+                $this->selection_start = $this->selection_start + $matches[1][1];
+                $this->selection_end = $this->selection_start + strlen($matches[1][0]);
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -635,7 +635,7 @@ class ArgumentsAnalyzer
             }
         }
 
-        if ($method_id === 'preg_match_all' && count($args) > 3) {
+        if (($method_id === 'preg_match_all' || $method_id === 'preg_match') && count($args) > 3) {
             $args = array_reverse($args, true);
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -325,7 +325,7 @@ class ClassLikeDocblockParser
                 $end_of_method_regex = '/(?<!array\()\) ?(\: ?(\??[\\\\a-zA-Z0-9_]+))?/';
 
                 if (preg_match($end_of_method_regex, $method_entry, $matches, PREG_OFFSET_CAPTURE)) {
-                    $method_entry = substr($method_entry, 0, (int) $matches[0][1] + strlen((string) $matches[0][0]));
+                    $method_entry = substr($method_entry, 0, $matches[0][1] + strlen($matches[0][0]));
                 }
 
                 $method_entry = str_replace([', ', '( '], [',', '('], $method_entry);

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -965,6 +965,24 @@ function preg_match_all($pattern, $subject, &$matches = [], int $flags = 1, int 
 
 /**
  * @psalm-pure
+ * @template TFlags as int-mask<0, 256, 512>
+ *
+ * @param string $pattern
+ * @param string $subject
+ * @param mixed $matches
+ * @param TFlags $flags
+ * @param-out (TFlags is 256 ? array<array-key, array{string, 0|positive-int}|array{'', -1}> :
+ *             TFlags is 512 ? array<array-key, string|null> :
+ *             TFlags is 768 ? array<array-key, array{string, 0|positive-int}|array{null, -1}> :
+ *                             array<array-key, string>
+ *            ) $matches
+ * @return 1|0|false
+ * @psalm-ignore-falsable-return
+ */
+function preg_match($pattern, $subject, &$matches = [], int $flags = 0, int $offset = 0) {}
+
+/**
+ * @psalm-pure
  *
  * @return (PHP_MAJOR_VERSION is 5|7 ? string|false : string)
  * @psalm-ignore-falsable-return

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1339,7 +1339,7 @@ class FunctionCallTest extends TestCase
                     '$matches===' => 'array<array-key, array{string, int}>',
                 ],
             ],
-            'pregMatchWithFlagUnMatchedAsNull' => [
+            'PHP72-pregMatchWithFlagUnmatchedAsNull' => [
                 '<?php
                     $r = preg_match("{foo}", "foo", $matches, PREG_UNMATCHED_AS_NULL);',
                 'assertions' => [
@@ -1347,9 +1347,9 @@ class FunctionCallTest extends TestCase
                     '$matches===' => 'array<array-key, null|string>',
                 ],
             ],
-            'pregMatchWithFlagOffsetCaptureAndUnMatchedAsNull' => [
+            'PHP72-pregMatchWithFlagOffsetCaptureAndUnmatchedAsNull' => [
                 '<?php
-                    $r = preg_match("{foo}", "foo", $matches, PREG_OFFSET_CAPTURE  | PREG_UNMATCHED_AS_NULL);',
+                    $r = preg_match("{foo}", "foo", $matches, PREG_OFFSET_CAPTURE | PREG_UNMATCHED_AS_NULL);',
                 'assertions' => [
                     '$r===' => '0|1|false',
                     '$matches===' => 'array<array-key, array{null|string, int}>',

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1305,10 +1305,6 @@ class FunctionCallTest extends TestCase
                     function takesInt(int $i) : void {}
 
                     if (preg_match("{foo}", "this is foo", $matches, PREG_OFFSET_CAPTURE)) {
-                        /**
-                         * @psalm-suppress MixedArrayAccess
-                         * @psalm-suppress MixedArgument
-                         */
                         takesInt($matches[0][1]);
                     }',
             ],
@@ -1449,7 +1445,10 @@ class FunctionCallTest extends TestCase
             ],
             'writeArgsAllowed' => [
                 '<?php
-                    /** @return false|int */
+                    /**
+                     * @param 0|256|512|768 $flags
+                     * @return false|int
+                     */
                     function safeMatch(string $pattern, string $subject, ?array $matches = null, int $flags = 0) {
                         return \preg_match($pattern, $subject, $matches, $flags);
                     }

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1282,6 +1282,13 @@ class FunctionCallTest extends TestCase
 
                     takesInt(preg_match("{foo}", "foo"));',
             ],
+            'pregMatch2' => [
+                '<?php
+                    $r = preg_match("{foo}", "foo");',
+                'assertions' => [
+                    '$r===' => '0|1|false',
+                ],
+            ],
             'pregMatchWithMatches' => [
                 '<?php
                     /** @param string[] $matches */
@@ -1290,6 +1297,14 @@ class FunctionCallTest extends TestCase
                     preg_match("{foo}", "foo", $matches);
 
                     takesMatches($matches);',
+            ],
+            'pregMatchWithMatches2' => [
+                '<?php
+                    $r = preg_match("{foo}", "foo", $matches);',
+                'assertions' => [
+                    '$r===' => '0|1|false',
+                    '$matches===' => 'array<array-key, string>',
+                ],
             ],
             'pregMatchWithOffset' => [
                 '<?php
@@ -1300,6 +1315,14 @@ class FunctionCallTest extends TestCase
 
                     takesMatches($matches);',
             ],
+            'pregMatchWithOffset2' => [
+                '<?php
+                    $r = preg_match("{foo}", "foo", $matches, 0, 10);',
+                'assertions' => [
+                    '$r===' => '0|1|false',
+                    '$matches===' => 'array<array-key, string>',
+                ],
+            ],
             'pregMatchWithFlags' => [
                 '<?php
                     function takesInt(int $i) : void {}
@@ -1307,6 +1330,30 @@ class FunctionCallTest extends TestCase
                     if (preg_match("{foo}", "this is foo", $matches, PREG_OFFSET_CAPTURE)) {
                         takesInt($matches[0][1]);
                     }',
+            ],
+            'pregMatchWithFlagOffsetCapture' => [
+                '<?php
+                    $r = preg_match("{foo}", "foo", $matches, PREG_OFFSET_CAPTURE);',
+                'assertions' => [
+                    '$r===' => '0|1|false',
+                    '$matches===' => 'array<array-key, array{string, int}>',
+                ],
+            ],
+            'pregMatchWithFlagUnMatchedAsNull' => [
+                '<?php
+                    $r = preg_match("{foo}", "foo", $matches, PREG_UNMATCHED_AS_NULL);',
+                'assertions' => [
+                    '$r===' => '0|1|false',
+                    '$matches===' => 'array<array-key, null|string>',
+                ],
+            ],
+            'pregMatchWithFlagOffsetCaptureAndUnMatchedAsNull' => [
+                '<?php
+                    $r = preg_match("{foo}", "foo", $matches, PREG_OFFSET_CAPTURE  | PREG_UNMATCHED_AS_NULL);',
+                'assertions' => [
+                    '$r===' => '0|1|false',
+                    '$matches===' => 'array<array-key, array{null|string, int}>',
+                ],
             ],
             'pregReplaceCallback' => [
                 '<?php

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -35,13 +35,17 @@ trait ValidCodeAnalysisTestTrait
         string $php_version = '7.3'
     ): void {
         $test_name = $this->getTestName();
-        if (strpos($test_name, 'PHP73-') !== false) {
-            if (version_compare(PHP_VERSION, '7.3.0', '<')) {
-                $this->markTestSkipped('Test case requires PHP 7.3.');
-            }
-        } elseif (strpos($test_name, 'PHP71-') !== false) {
+        if (strpos($test_name, 'PHP71-') !== false) {
             if (version_compare(PHP_VERSION, '7.1.0', '<')) {
                 $this->markTestSkipped('Test case requires PHP 7.1.');
+            }
+        } elseif (strpos($test_name, 'PHP72-') !== false) {
+            if (version_compare(PHP_VERSION, '7.2.0', '<')) {
+                $this->markTestSkipped('Test case requires PHP 7.2.');
+            }
+        } elseif (strpos($test_name, 'PHP73-') !== false) {
+            if (version_compare(PHP_VERSION, '7.3.0', '<')) {
+                $this->markTestSkipped('Test case requires PHP 7.3.');
             }
         } elseif (strpos($test_name, 'PHP80-') !== false) {
             if (version_compare(PHP_VERSION, '8.0.0', '<')) {


### PR DESCRIPTION
This PR adds a stub for ``preg_match()`` that takes flags into account.
Fixes #6914

For reference:

- [Return Values ](https://www.php.net/manual/en/function.preg-match.php#refsect1-function.preg-match-returnvalues)
  - ``1`` if the pattern matches given subject
  - ``0`` if the pattern does not match given subject
  - ``false`` on failure

- **$matches with flag: 0**
  ```php
  preg_match('/(foo)(not)?(?<name>bar)/', 'foobarbaz', $matches);
  ```
  $matches:
  ```
  [
    0      => 'foobar',
    1      => 'foo',
    2      => '',
    'name' => 'bar',
    3      => 'bar',
  ]
  ```
  :arrow_right: ``array<array-key, string>``

- **$matches with flag: PREG_OFFSET_CAPTURE = 256**
  ```php
  preg_match('/(foo)(not)?(?<name>bar)/', 'foobarbaz', $matches, PREG_OFFSET_CAPTURE);
  ```
  $matches:
  ```
  [
    0      => [0 => 'foobar', 1 =>  0],
    1      => [0 => 'foo',    1 =>  0],
    2      => [0 => '',       1 => -1],
    'name' => [0 => 'bar',    1 =>  3],
    3      => [0 => 'bar',    1 =>  3],
  ]
  ```
  :arrow_right: ``array<array-key, array{string, 0|positive-int}|array{'', -1}>``
  :arrow_right_hook: ``array<array-key, array{string, int}>``

- **$matches with flag: PREG_UNMATCHED_AS_NULL = 512**
  ```php
  preg_match('/(foo)(not)?(?<name>bar)/', 'foobarbaz', $matches, PREG_UNMATCHED_AS_NULL);
  ```
  $matches:
  ```
  [
    0      => 'foobar',
    1      => 'foo',
    2      => null,
    'name' => 'bar',
    3      => 'bar',
  ]
  ```
  :arrow_right: ``array<array-key, string|null>``

- **$matches with flag: PREG_OFFSET_CAPTURE | PREG_UNMATCHED_AS_NULL = 768**
  ```php
  preg_match('/(foo)(not)?(?<name>bar)/', 'foobarbaz', $matches, PREG_OFFSET_CAPTURE | PREG_UNMATCHED_AS_NULL);
  ```
  $matches:
  ```
  [
    0      => [0 => 'foobar', 1 =>  0],
    1      => [0 => 'foo',    1 =>  0],
    2      => [0 => null,     1 => -1],
    'name' => [0 => 'bar',    1 =>  3],
    3      => [0 => 'bar',    1 =>  3],
  ]
  ```
  :arrow_right: ``array<array-key, array{string, 0|positive-int}|array{null, -1}>``
  :arrow_right_hook: ``array<array-key, array{null|string, int}>``

- **$matches on error**
  On error an ``E_WARNING`` is emitted. ``$matches`` is not altered then. This case is not handled in this PR.

_Legend:_
:arrow_right_hook: = expression simplified by Psalm