### PR TITLE
Enhancing composer scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,11 +107,11 @@
             "@php ./psalm --find-dead-code",
             "phpunit"
         ],
-        "psalm": "@php ./psalm --find-dead-code",
-        "phpunit": "phpunit",
-        "phpunit-p": "paratest --runner=WrapperRunner",
         "cs": "phpcs -p",
         "cs-fix": "phpcbf -p",
+        "phpunit": "phpunit",
+        "phpunit-p": "paratest --runner=WrapperRunner",
+        "psalm": "@php ./psalm --find-dead-code",
         "tests": [
             "phpcs",
             "phpunit"
@@ -119,11 +119,11 @@
     },
     "scripts-descriptions": {
         "all-tests": "Runs all available tests.",
-        "psalm": "Runs static analysis.",
-        "phpunit": "Runs unit tests.",
-        "phpunit-p": "Runs unit tests in parallel.",
         "cs": "Checks that the code conforms to the coding standard.",
         "cs-fix": "Automatically correct coding standard violations.",
+        "phpunit": "Runs unit tests.",
+        "phpunit-p": "Runs unit tests in parallel.",
+        "psalm": "Runs static analysis.",
         "tests": "Checks coding style and runs unit tests."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,7 @@
         ],
         "psalm": "@php ./psalm --find-dead-code",
         "phpunit": "phpunit",
+        "phpunit-p": "paratest --runner=WrapperRunner",
         "cs": "phpcs -p",
         "cs-fix": "phpcbf -p",
         "tests": [
@@ -120,6 +121,7 @@
         "all-tests": "Runs all available tests.",
         "psalm": "Runs static analysis.",
         "phpunit": "Runs unit tests.",
+        "phpunit-p": "Runs unit tests in parallel.",
         "cs": "Checks that the code conforms to the coding standard.",
         "cs-fix": "Automatically correct coding standard violations.",
         "tests": "Checks coding style and runs unit tests."

--- a/composer.json
+++ b/composer.json
@@ -103,9 +103,9 @@
     ],
     "scripts": {
         "all-tests": [
-            "phpcs",
-            "@php ./psalm --find-dead-code",
-            "phpunit"
+            "@cs",
+            "@psalm",
+            "@phpunit"
         ],
         "cs": "phpcs -p",
         "cs-fix": "phpcbf -p",
@@ -113,8 +113,8 @@
         "phpunit-p": "paratest --runner=WrapperRunner",
         "psalm": "@php ./psalm --find-dead-code",
         "tests": [
-            "phpcs",
-            "phpunit"
+            "@cs",
+            "@phpunit"
         ]
     },
     "scripts-descriptions": {

--- a/composer.json
+++ b/composer.json
@@ -115,5 +115,13 @@
             "phpcs",
             "phpunit"
         ]
+    },
+    "scripts-descriptions": {
+        "all-tests": "Runs all available tests.",
+        "psalm": "Runs static analysis.",
+        "phpunit": "Runs unit tests.",
+        "cs": "Checks that the code conforms to the coding standard.",
+        "cs-fix": "Automatically correct coding standard violations.",
+        "tests": "Checks coding style and runs unit tests."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -103,12 +103,14 @@
     ],
     "scripts": {
         "all-tests": [
+            "@lint",
             "@cs",
             "@psalm",
             "@phpunit"
         ],
         "cs": "phpcs -p",
         "cs-fix": "phpcbf -p",
+        "lint": "parallel-lint ./src ./tests",
         "phpunit": "phpunit",
         "phpunit-p": "paratest --runner=WrapperRunner",
         "psalm": "@php ./psalm --find-dead-code",
@@ -121,6 +123,7 @@
         "all-tests": "Runs all available tests.",
         "cs": "Checks that the code conforms to the coding standard.",
         "cs-fix": "Automatically correct coding standard violations.",
+        "lint": "Runs unit tests.",
         "phpunit": "Runs unit tests.",
         "phpunit-p": "Runs unit tests in parallel.",
         "psalm": "Runs static analysis.",

--- a/composer.json
+++ b/composer.json
@@ -102,12 +102,6 @@
         "psalter"
     ],
     "scripts": {
-        "all-tests": [
-            "@lint",
-            "@cs",
-            "@psalm",
-            "@phpunit"
-        ],
         "cs": "phpcs -p",
         "cs-fix": "phpcbf -p",
         "lint": "parallel-lint ./src ./tests",
@@ -115,18 +109,19 @@
         "phpunit-std": "phpunit",
         "psalm": "@php ./psalm --find-dead-code",
         "tests": [
+            "@lint",
             "@cs",
+            "@psalm",
             "@phpunit"
         ]
     },
     "scripts-descriptions": {
-        "all-tests": "Runs all available tests.",
         "cs": "Checks that the code conforms to the coding standard.",
         "cs-fix": "Automatically correct coding standard violations.",
         "lint": "Runs unit tests.",
         "phpunit": "Runs unit tests in parallel.",
         "phpunit-std": "Runs unit tests.",
         "psalm": "Runs static analysis.",
-        "tests": "Checks coding style and runs unit tests."
+        "tests": "Runs all available tests."
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,7 @@
             "phpunit"
         ],
         "psalm": "@php ./psalm --find-dead-code",
+        "phpunit": "phpunit",
         "cs": "phpcs -p",
         "cs-fix": "phpcbf -p",
         "tests": [

--- a/composer.json
+++ b/composer.json
@@ -111,8 +111,8 @@
         "cs": "phpcs -p",
         "cs-fix": "phpcbf -p",
         "lint": "parallel-lint ./src ./tests",
-        "phpunit": "phpunit",
-        "phpunit-p": "paratest --runner=WrapperRunner",
+        "phpunit": "paratest --runner=WrapperRunner",
+        "phpunit-std": "phpunit",
         "psalm": "@php ./psalm --find-dead-code",
         "tests": [
             "@cs",
@@ -124,8 +124,8 @@
         "cs": "Checks that the code conforms to the coding standard.",
         "cs-fix": "Automatically correct coding standard violations.",
         "lint": "Runs unit tests.",
-        "phpunit": "Runs unit tests.",
-        "phpunit-p": "Runs unit tests in parallel.",
+        "phpunit": "Runs unit tests in parallel.",
+        "phpunit-std": "Runs unit tests.",
         "psalm": "Runs static analysis.",
         "tests": "Checks coding style and runs unit tests."
     }

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -34,10 +34,6 @@ Lastly, working to improve static analysis tools will also make you a better PHP
 
 Before you send a pull request, make sure you follow these guidelines:
 
-Run integration checks locally:
-
-- `composer cs` - checks the code is properly linted
-- `vendor/bin/paratest` - runs PHPUnit tests in parallel
-- `./psalm` - runs Psalm on itself
+Run integration checks locally: `composer tests`
 
 If you're adding new features or fixing bugs, don’t forget to add tests!


### PR DESCRIPTION
Sofar done:

- Added ``phpunit`` script.
- Added ``phpunit-p`` script running paratest.
- Added scripts descriptions displayed e.g. by ``composer run -l``.
- Sorted alphabetically.
- Replaced multiple script runs by references to single tests.

Questions:

- At the moment the naming is mixed between generic names like ``cs`` and tool names like ``phpunit``. Would it be desirable to use generic names everywere or tool names erywhere or do we just don’t care?

- I've added paratest to the scripts and wonder if it should be used as the standard for ``tests`` and ``all-tests`` (``phpunit`` = paratest, ``phpunit-std`` = phpunit) as it’s much faster.

- I’ve noticed that ``php-parallel-lint`` gets installed. Is that still useful? – If yes, we should probably expose it in the scripts section and add it to ``tests`` and ``all-tests``. – If yes, what would be sensible calling options and how should it be named (``lint``, ``syntax-check``, , ``check-syntax``, …)?

- I wonder if it is reasonable to have ``tests`` and ``all-tests``. Would it ux wise be better to just have ``tests`` that runs all tests and single commands for distinctive tasks?