### PR TITLE
Throw exception when baseline file is empty

### DIFF
--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -81,6 +81,10 @@ class ErrorBaseline
 
         $xmlSource = $fileProvider->getContents($baselineFile);
 
+        if ($xmlSource === '') {
+            throw new Exception\ConfigException('Baseline file is empty');
+        }
+
         $baselineDoc = new \DOMDocument();
         $baselineDoc->loadXML($xmlSource, LIBXML_NOBLANKS);
 


### PR DESCRIPTION
This should solve the error:

> Uncaught ValueError: DOMDocument::loadXML(): Argument #1 ($source) must not be empty in ...\vimeo\psalm\src\Psalm\ErrorBaseline.php:85