### PR TITLE
get_class does not return false

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -3720,7 +3720,7 @@ return [
 'get_call_stack' => [''],
 'get_called_class' => ['class-string'],
 'get_cfg_var' => ['string|false', 'option'=>'string'],
-'get_class' => ['class-string|false', 'object='=>'object'],
+'get_class' => ['class-string', 'object='=>'object'],
 'get_class_methods' => ['list<string>|null', 'object_or_class'=>'mixed'],
 'get_class_vars' => ['array<string,mixed>', 'class'=>'string'],
 'get_current_user' => ['string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -11058,7 +11058,7 @@ return [
     'get_call_stack' => [''],
     'get_called_class' => ['class-string'],
     'get_cfg_var' => ['string|false', 'option'=>'string'],
-    'get_class' => ['class-string|false', 'object='=>'object'],
+    'get_class' => ['class-string', 'object='=>'object'],
     'get_class_methods' => ['list<string>|null', 'object_or_class'=>'mixed'],
     'get_class_vars' => ['array<string,mixed>', 'class'=>'string'],
     'get_current_user' => ['string'],


### PR DESCRIPTION
Technically all functions could return false or null when a wrong parameter is provided, but that was undefined behavour in PHP <8 and should not be relied upon.