### PR TITLE
fix missing case for displaying varId

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
@@ -216,6 +216,10 @@ class ExpressionIdentifier
             }
         }
 
+        if ($stmt instanceof PhpParser\Node\Expr\ConstFetch) {
+            return implode('\\', $stmt->name->parts);
+        }
+
         return self::getVarId($stmt, $this_class_name, $source);
     }
 }

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -3,6 +3,7 @@ namespace Psalm\Type;
 
 use Psalm\CodeLocation;
 use Psalm\Codebase;
+use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ConstFetchAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Type\AssertionReconciler;
 use Psalm\Issue\DocblockTypeContradiction;
@@ -543,7 +544,13 @@ class Reconciler
         $key_parts = self::breakUpPathIntoParts($key);
 
         if (count($key_parts) === 1) {
-            return isset($existing_keys[$key_parts[0]]) ? clone $existing_keys[$key_parts[0]] : null;
+            if (isset($existing_keys[$key_parts[0]])) {
+                return clone $existing_keys[$key_parts[0]];
+            }
+
+            if ($type = ConstFetchAnalyzer::getGlobalConstType($codebase, $key_parts[0], $key_parts[0])) {
+                return $type;
+            }
         }
 
         $base_key = array_shift($key_parts);


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/6933

The message is a little weird because it says `Cannot access value on variable ARR` when it's a constant, but it's not a big deal.

Didn't add test because this is just a wording issue