### PR TITLE
Pretty print arrays in LSP hover

### DIFF
--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -231,17 +231,17 @@ class TextDocument
         }
 
         // Pretty print arrays (only).
-        if ( substr( $symbol_information['type'], 0, 6 ) === 'array{' ) {
-            $union = \Psalm\Type::parseString( $symbol_information['type'] );
+        if (substr( $symbol_information['type'], 0, 6 ) === 'array{') {
+            $union = \Psalm\Type::parseString($symbol_information['type']);
             $types = $union->getAtomicTypes();
             if ( count( $types ) === 1 ) {
                 /** @var \Psalm\Type\Atomic\TKeyedArray */
-                $keyed_array = reset( $types );
+                $keyed_array = reset($types);
 
                 $property_strings = array_map(
                     function ($name, \Psalm\Type\Union $type): string {
-                        if ( is_string( $name ) ) {
-                            $name = "'" . $name . "'";
+                        if (is_string($name) && preg_match('/[ "\'\\\\.\n:]/', $name)) {
+                            $name = '\'' . str_replace("\n", '\n', addslashes($name)) . '\'';
                         }
                         return "\t" . $name . ($type->possibly_undefined ? '?' : '') . ': ' . $type;
                     },
@@ -249,7 +249,7 @@ class TextDocument
                     $keyed_array->properties
                 );
 
-                $symbol_information['type'] = "array{\n" . implode(", \n", $property_strings) . "\n}";
+                $symbol_information['type'] = "<?php array{\n" . implode(", \n", $property_strings) . "\n}";
             }
         }
         $content = "```php\n" . $symbol_information['type'] . "\n```";

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -24,12 +24,14 @@ use UnexpectedValueException;
 
 use function addslashes;
 use function array_keys;
+use function array_map;
 use function count;
 use function error_log;
 use function implode;
 use function is_string;
 use function preg_match;
 use function reset;
+use function str_replace;
 use function substr;
 use function substr_count;
 
@@ -239,7 +241,7 @@ class TextDocument
         }
 
         // Pretty print keyed arrays (only).
-        if (substr( $symbol_information['type'], 0, 6 ) === 'array{') {
+        if (substr($symbol_information['type'], 0, 6) === 'array{') {
             $union = Type::parseString($symbol_information['type']);
             $types = $union->getAtomicTypes();
             if (count($types) === 1) {

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -19,6 +19,7 @@ use LanguageServerProtocol\VersionedTextDocumentIdentifier;
 use Psalm\Codebase;
 use Psalm\Exception\UnanalyzedFileException;
 use Psalm\Internal\LanguageServer\LanguageServer;
+use Psalm\Type;
 use UnexpectedValueException;
 
 use function count;
@@ -230,16 +231,16 @@ class TextDocument
             return new Success(null);
         }
 
-        // Pretty print arrays (only).
+        // Pretty print keyed arrays (only).
         if (substr( $symbol_information['type'], 0, 6 ) === 'array{') {
-            $union = \Psalm\Type::parseString($symbol_information['type']);
+            $union = Type::parseString($symbol_information['type']);
             $types = $union->getAtomicTypes();
             if ( count( $types ) === 1 ) {
-                /** @var \Psalm\Type\Atomic\TKeyedArray */
+                /** @var Type\Atomic\TKeyedArray */
                 $keyed_array = reset($types);
 
                 $property_strings = array_map(
-                    function ($name, \Psalm\Type\Union $type): string {
+                    function ($name, Type\Union $type): string {
                         if (is_string($name) && preg_match('/[ "\'\\\\.\n:]/', $name)) {
                             $name = '\'' . str_replace("\n", '\n', addslashes($name)) . '\'';
                         }

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -22,8 +22,15 @@ use Psalm\Internal\LanguageServer\LanguageServer;
 use Psalm\Type;
 use UnexpectedValueException;
 
+use function addslashes;
+use function array_keys;
 use function count;
 use function error_log;
+use function implode;
+use function is_string;
+use function preg_match;
+use function reset;
+use function substr;
 use function substr_count;
 
 /**

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -242,7 +242,7 @@ class TextDocument
         if (substr( $symbol_information['type'], 0, 6 ) === 'array{') {
             $union = Type::parseString($symbol_information['type']);
             $types = $union->getAtomicTypes();
-            if ( count( $types ) === 1 ) {
+            if (count($types) === 1) {
                 /** @var Type\Atomic\TKeyedArray */
                 $keyed_array = reset($types);
 


### PR DESCRIPTION
Currently hovering keyed array definitions is very unreadable. Opening this PR to discuss a good solution. I attached some code, but it's not great. The idea is to have this:

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2021-12-05-07-54-21.99-7nfVN8oFX9Q3ErfpKygsOJDUTYfs2n8o7MDkW0iINRQ9tIHgpI5YBf5RnJhBu63PLvPleQPLNP14HeQZbkbLB9QzdPzZomzh05dA.png)

Look like this:

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2021-12-05-07-55-15.02-4fRbE8xThSsDSIZjeHGctkco4ZrfBsPbwn40SbySdiDkwqa2Px0lUU8acnxJdcLhj7DMuEeqsCOqztuIGFvv82e8LqWVbjjYJEsT.png)

Somewhat inspired by how the TypeScript LSP shows object literals:

![](https://joehoyle-captured.s3.amazonaws.com/Screen-Shot-2021-12-05-07-56-41.86-wolTT97NaK3OCDZm9PJIucBaCXv4O3ep4uIiEseOfXGuAasveoJXHOPmC5uxszd72sz3BMTH92OR6VbH2xbPdbwuopU6cvxqUqwA.png)

---

The implementation here is not that good, ideally I think TKeyedArray should have a `prettyPrint` method perhaps. Also, there's other things to consider, like how to show `array{}` printing when then are embedded in `<list>` or `array<>` etc, where line breaks would go, etc.

This "re-parsing" of the type also is not great, this is because the file-maps (specifically the reference map) flattens type to their string representation. Because I _think_ that's potentially done in other threads, I'm assuming that's why.

Then there's the question of syntax highlighting for `array{}` which would help a lot with readability. The issue ultimately is that we rely on the LSP client to syntax highlght based off `<?php $type` code samples. Given that `array{}` is not valid PHP, then we don't send it as `<?php` prefixed, hence no formatting. One optino could be to actually encode it as `<?php [ "key" => "value" ]` style, though I'm not sure how something like `<?php [ "foo" => string ]` would render.
