### PR TITLE
Refined `strlen()` return type to not include negative ints

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -739,9 +739,13 @@ function htmlspecialchars_decode(string $string, ?int $flags = null) : string {}
  * @psalm-pure
  *
  * @psalm-return (
- *     $string is non-empty-string
- *     ? positive-int
- *     : int
+ *     $string is ''
+ *     ? 0
+ *     : (
+ *          $string is non-empty-string
+ *              ? positive-int
+ *              : (0|positive-int)
+ *     )
  * )
  */
 function strlen(string $string) : int {}


### PR DESCRIPTION
Fixes vimeo/psalm#7062