### PR TITLE
Make name property of enum cases return non-empty-strings

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -202,7 +202,7 @@ class AtomicPropertyFetchAnalyzer
                         new Type\Union([new Type\Atomic\TLiteralString($lhs_type_part->case_name)])
                     );
                 } else {
-                    $statements_analyzer->node_data->setType($stmt, Type::getString());
+                    $statements_analyzer->node_data->setType($stmt, Type::getNonEmptyString());
                 }
             } else {
                 self::handleNonExistentProperty(

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -126,6 +126,9 @@ class EnumTest extends TestCase
                         case PUBLISHED;
                         case ARCHIVED;
 
+                        /**
+                         * @return non-empty-string
+                         */
                         public function get(): string
                         {
                             return $this->name;


### PR DESCRIPTION
This is a follow-up for #6964 since the changes made there didn't have the desired outcome.