### PR TITLE
Don't crash when checking purity of __callStatic in a trait

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -242,6 +242,7 @@ class AtomicStaticCallAnalyzer
 
     /**
      * @psalm-suppress UnusedReturnValue not used but seems important
+     * @psalm-suppress ComplexMethod to be refactored
      */
     private static function handleNamedCall(
         StatementsAnalyzer $statements_analyzer,

--- a/tests/PureAnnotationTest.php
+++ b/tests/PureAnnotationTest.php
@@ -445,6 +445,23 @@ class PureAnnotationTest extends TestCase
                         return MyEnum::FOO();
                     }',
             ],
+            'dontCrashWhileCheckingPurityOnCallStaticInATrait' => [
+                '<?php
+                    /**
+                     * @method static static tt()
+                     */
+                    trait Date {
+                        public static function __callStatic(string $_method, array $_parameters){
+                        }
+                    }
+
+                    class Date2{
+                        use Date;
+                    }
+
+                    Date2::tt();
+                    ',
+            ],
         ];
     }
 


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/7081 (where this crashes: https://psalm.dev/r/a36ee9d0d8)

It seems that using `getAppearingMethodId` doesn't return anything when the method only exists in a trait, so I handled this case.

Maybe I should have been using `getDeclaringMethodId` but I'm pretty sure this would have crashed another way, I'm not quite sure what's the best practice here, but I expect that the optimal case where 100% of edge cases are handled involve checking purity from `__callStatic` declared on interfaces and coded in traits or even declared abstract in traits and coded in implementation not visible from Psalm. I don't want to code a big system that no one will actually use for this trivial usage (And also, I don't like traits very much 😄 )