### PR TITLE
Added support for first-class callables

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -227,7 +227,7 @@ class AssertionFinder
             );
         }
 
-        if ($conditional instanceof PhpParser\Node\Expr\FuncCall) {
+        if ($conditional instanceof PhpParser\Node\Expr\FuncCall && !$conditional->isFirstClassCallable()) {
             return self::processFunctionCall(
                 $conditional,
                 $this_class_name,
@@ -237,8 +237,9 @@ class AssertionFinder
             );
         }
 
-        if ($conditional instanceof PhpParser\Node\Expr\MethodCall
-            || $conditional instanceof PhpParser\Node\Expr\StaticCall
+        if (($conditional instanceof PhpParser\Node\Expr\MethodCall
+            || $conditional instanceof PhpParser\Node\Expr\StaticCall)
+            && !$conditional->isFirstClassCallable()
         ) {
             $custom_assertions = self::processCustomAssertion($conditional, $this_class_name, $source);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -837,7 +837,7 @@ class FunctionCallAnalyzer extends CallAnalyzer
         $fake_method_call = new VirtualMethodCall(
             $function_name,
             new VirtualIdentifier('__invoke', $function_name->getAttributes()),
-            $stmt->isFirstClassCallable() ? [new PhpParser\Node\VariadicPlaceholder()] : $stmt->getArgs()
+            $stmt->args
         );
 
         $suppressed_issues = $statements_analyzer->getSuppressedIssues();

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -193,7 +193,7 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
 
         $method_id = new MethodIdentifier($fq_class_name, $method_name_lc);
 
-        $args = $stmt->getArgs();
+        $args = $stmt->isFirstClassCallable() ? [] : $stmt->getArgs();
 
         $naive_method_id = $method_id;
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -196,6 +196,19 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             );
         }
 
+        $is_first_class_callable = $stmt->isFirstClassCallable();
+
+        if (!$is_first_class_callable && self::checkMethodArgs(
+            $method_id,
+            $args,
+            $template_result,
+            $context,
+            new CodeLocation($source, $stmt_name),
+            $statements_analyzer
+        ) === false) {
+            return Type::getMixed();
+        }
+
         $declaring_method_id = $codebase->methods->getDeclaringMethodId($method_id);
 
         $return_type_candidate = MethodCallReturnTypeFetcher::fetch(
@@ -214,19 +227,8 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             $template_result
         );
 
-        if ($stmt->isFirstClassCallable()) {
+        if ($is_first_class_callable) {
             return $return_type_candidate;
-        }
-
-        if (self::checkMethodArgs(
-                $method_id,
-                $args,
-                $template_result,
-                $context,
-                new CodeLocation($source, $stmt_name),
-                $statements_analyzer
-            ) === false) {
-            return Type::getMixed();
         }
 
         $in_call_map = InternalCallMapHandler::inCallMap((string) ($declaring_method_id ?? $method_id));

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -196,17 +196,6 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             );
         }
 
-        if (self::checkMethodArgs(
-            $method_id,
-            $args,
-            $template_result,
-            $context,
-            new CodeLocation($source, $stmt_name),
-            $statements_analyzer
-        ) === false) {
-            return Type::getMixed();
-        }
-
         $declaring_method_id = $codebase->methods->getDeclaringMethodId($method_id);
 
         $return_type_candidate = MethodCallReturnTypeFetcher::fetch(
@@ -224,6 +213,21 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             $result,
             $template_result
         );
+
+        if ($stmt->isFirstClassCallable()) {
+            return $return_type_candidate;
+        }
+
+        if (self::checkMethodArgs(
+                $method_id,
+                $args,
+                $template_result,
+                $context,
+                new CodeLocation($source, $stmt_name),
+                $statements_analyzer
+            ) === false) {
+            return Type::getMixed();
+        }
 
         $in_call_map = InternalCallMapHandler::inCallMap((string) ($declaring_method_id ?? $method_id));
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -198,7 +198,10 @@ class MethodCallAnalyzer extends CallAnalyzer
                 $possible_new_class_types[] = $context->vars_in_scope[$lhs_var_id];
             }
         }
-        if (!$stmt->getArgs() && $lhs_var_id && $stmt->name instanceof PhpParser\Node\Identifier) {
+        if (!$stmt->isFirstClassCallable()
+            && !$stmt->getArgs()
+            && $lhs_var_id && $stmt->name instanceof PhpParser\Node\Identifier
+        ) {
             if ($codebase->config->memoize_method_calls || $result->can_memoize) {
                 $method_var_id = $lhs_var_id . '->' . strtolower($stmt->name->name) . '()';
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NamedFunctionCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NamedFunctionCallHandler.php
@@ -69,6 +69,10 @@ class NamedFunctionCallHandler
             return;
         }
 
+        if ($stmt->isFirstClassCallable()) {
+            return;
+        }
+
         $first_arg = $stmt->getArgs()[0] ?? null;
 
         if ($function_id === 'method_exists') {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
@@ -220,7 +220,7 @@ class StaticCallAnalyzer extends CallAnalyzer
             );
         }
 
-        if (!$has_existing_method) {
+        if (!$stmt->isFirstClassCallable() && !$has_existing_method) {
             return self::checkMethodArgs(
                 $method_id,
                 $stmt->getArgs(),

--- a/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
+++ b/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
@@ -26,6 +26,7 @@ class HtmlFunctionTainter implements AddTaintsInterface, RemoveTaintsInterface
 
         if (!$statements_analyzer instanceof StatementsAnalyzer
             || !$item instanceof PhpParser\Node\Expr\FuncCall
+            || $item->isFirstClassCallable()
             || !$item->name instanceof PhpParser\Node\Name
             || count($item->name->parts) !== 1
             || count($item->getArgs()) === 0
@@ -74,6 +75,7 @@ class HtmlFunctionTainter implements AddTaintsInterface, RemoveTaintsInterface
 
         if (!$statements_analyzer instanceof StatementsAnalyzer
             || !$item instanceof PhpParser\Node\Expr\FuncCall
+            || $item->isFirstClassCallable()
             || !$item->name instanceof PhpParser\Node\Name
             || count($item->name->parts) !== 1
             || count($item->getArgs()) === 0

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ClosureFromCallableReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ClosureFromCallableReturnTypeProvider.php
@@ -38,7 +38,8 @@ class ClosureFromCallableReturnTypeProvider implements MethodReturnTypeProviderI
                         $codebase,
                         $atomic_type,
                         null,
-                        $source
+                        $source,
+                        true
                     );
 
                     if ($candidate_callable) {

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -412,6 +412,14 @@ class ClosureTest extends TestCase
                         }
                     }',
             ],
+            'PHP71-closureFromCallableNamedFunction' => [
+                '<?php
+                    $closure = Closure::fromCallable("strlen");
+                ',
+                'assertions' => [
+                    '$closure' => 'pure-Closure(string):(0|positive-int)',
+                ]
+            ],
             'allowClosureWithNarrowerReturn' => [
                 '<?php
                     class A {}
@@ -555,6 +563,94 @@ class ClosureTest extends TestCase
                 'assertions' => [
                     '$result' => 'array{stdClass}'
                 ],
+            ],
+            'FirstClassCallable:NamedFunction:is_int' => [
+                '<?php
+                    $closure = is_int(...);
+                    $result = $closure(1);
+                ',
+                'assertions' => [
+                    '$closure' => 'pure-Closure(mixed):bool',
+                    '$result' => 'bool',
+                ],
+                [],
+                '8.1'
+            ],
+            'FirstClassCallable:NamedFunction:strlen' => [
+                '<?php
+                    $closure = strlen(...);
+                    $result = $closure("test");
+                ',
+                'assertions' => [
+                    '$closure' => 'pure-Closure(string):(0|positive-int)',
+                    '$result' => 'int|positive-int',
+                ],
+                [],
+                '8.1'
+            ],
+            'FirstClassCallable:InstanceMethod' => [
+                '<?php
+                    class Test {
+                        public function __construct(private readonly string $string) {
+                        }
+
+                        public function length(): int {
+                            return strlen($this->string);
+                        }
+                    }
+                    $test = new Test("test");
+                    $closure = $test->length(...);
+                    $length = $closure();
+                ',
+                'assertions' => [
+                    '$length' => 'int',
+                ],
+                [],
+                '8.1'
+            ],
+            'FirstClassCallable:StaticMethod' => [
+                '<?php
+                    class Test {
+                        public static function length(string $param): int {
+                            return strlen($param);
+                        }
+                    }
+                    $closure = Test::length(...);
+                    $length = $closure("test");
+                ',
+                'assertions' => [
+                    '$length' => 'int',
+                ],
+                [],
+                '8.1'
+            ],
+            'FirstClassCallable:InvokableObject' => [
+                '<?php
+                    class Test {
+                        public function __invoke(string $param): int {
+                            return strlen($param);
+                        }
+                    }
+                    $test = new Test();
+                    $closure = $test(...);
+                    $length = $closure("test");
+                ',
+                'assertions' => [
+                    '$length' => 'int',
+                ],
+                [],
+                '8.1'
+            ],
+            'FirstClassCallable:FromClosure' => [
+                '<?php
+                    $closure = fn (string $string): int => strlen($string);
+                    $closure = $closure(...);
+                ',
+                'assertions' => [
+                    '$closure' => 'pure-Closure(string):(0|positive-int)',
+                ],
+                [],
+                '8.1'
             ],
         ];
     }


### PR DESCRIPTION
Hopefully the approach here is appropriate. First-class callables are treated as a function call with a single placeholder argument, which necessitates special handling in the call analyzers to swap out the the return value to a closure and skip analyzing function arguments.

Closes #6412.