### PR TITLE
Replace deprecated File Path Utility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,8 +35,7 @@
         "openlss/lib-array2xml": "^1.0",
         "sebastian/diff": "^3.0 || ^4.0",
         "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
-        "symfony/filesystem": "^6.0",
-        "webmozart/path-util": "^2.3"
+        "symfony/filesystem": "^6.0"
     },
     "provide": {
         "psalm/psalm": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "openlss/lib-array2xml": "^1.0",
         "sebastian/diff": "^3.0 || ^4.0",
         "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
+        "symfony/filesystem": "^6.0",
         "webmozart/path-util": "^2.3"
     },
     "provide": {

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -35,9 +35,9 @@ use Psalm\Progress\Progress;
 use Psalm\Progress\VoidProgress;
 use SimpleXMLElement;
 use SimpleXMLIterator;
+use Symfony\Component\Filesystem\Path;
 use Throwable;
 use UnexpectedValueException;
-use Webmozart\PathUtil\Path;
 use XdgBaseDir\Xdg;
 use stdClass;
 

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -29,7 +29,7 @@ use Psalm\Progress\VoidProgress;
 use Psalm\Report;
 use Psalm\Report\ReportOptions;
 use RuntimeException;
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 use function array_filter;
 use function array_key_exists;

--- a/src/functions.php
+++ b/src/functions.php
@@ -1,7 +1,7 @@
 <?php
 namespace Psalm;
 
-use Webmozart\PathUtil\Path;
+use Symfony\Component\Filesystem\Path;
 
 /**
  * @deprecated Use {@see Webmozart\PathUtil\Path::isAbsolute}. No longer used by Psalm, going to be removed in Psalm 5

--- a/src/functions.php
+++ b/src/functions.php
@@ -4,7 +4,8 @@ namespace Psalm;
 use Symfony\Component\Filesystem\Path;
 
 /**
- * @deprecated Use {@see Webmozart\PathUtil\Path::isAbsolute}. No longer used by Psalm, going to be removed in Psalm 5
+ * @deprecated Use {@see Symfony\Component\Filesystem\Path::isAbsolute}.
+ *             No longer used by Psalm, going to be removed in Psalm 5
  */
 function isAbsolutePath(string $path): bool
 {


### PR DESCRIPTION
Replace deprecated [File Path Utility](https://github.com/webmozart/path-util) with suggested [Symfony Filesystem Component](https://github.com/symfony/filesystem)

>Deprecation
>This package has been merged into the Symfony Filesystem Component 5.4. It is not maintained anymore.
