### PR TITLE
Fix static::CONST type not being inferred.

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -360,12 +360,10 @@ class ClassConstFetchAnalyzer
                 );
             }
 
-            if ($first_part_lc !== 'static' || $const_class_storage->final) {
-                $stmt_type = clone $class_constant_type;
+            $stmt_type = clone $class_constant_type;
 
-                $statements_analyzer->node_data->setType($stmt, $stmt_type);
-                $context->vars_in_scope[$const_id] = $stmt_type;
-            }
+            $statements_analyzer->node_data->setType($stmt, $stmt_type);
+            $context->vars_in_scope[$const_id] = $stmt_type;
 
             return true;
         }

--- a/src/Psalm/Issue/CodeIssue.php
+++ b/src/Psalm/Issue/CodeIssue.php
@@ -111,8 +111,8 @@ abstract class CodeIssue
             $snippet_bounds[1],
             $location->getColumn(),
             $location->getEndColumn(),
-            (int) static::SHORTCODE,
-            (int) static::ERROR_LEVEL,
+            static::SHORTCODE,
+            static::ERROR_LEVEL,
             $this instanceof TaintedInput
                 ? $this->getTaintTrace()
                 : null,

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -1199,6 +1199,19 @@ class ConstantTest extends TestCase
                 [],
                 '8.1'
             ],
+            'inferStaticClassConst' => [
+                '<?php
+                    class Foo
+                    {
+                        public const BAR = "baz";
+
+                        public function foobar(): string
+                        {
+                            return static::BAR;
+                        }
+                    }
+                '
+            ],
         ];
     }
 

--- a/tests/Template/ClassTemplateExtendsTest.php
+++ b/tests/Template/ClassTemplateExtendsTest.php
@@ -35,7 +35,7 @@ class ClassTemplateExtendsTest extends TestCase
                          */
                         public function arity(): int
                         {
-                            return (int)static::ARITY;
+                            return static::ARITY;
                         }
 
                         /**
@@ -73,7 +73,7 @@ class ClassTemplateExtendsTest extends TestCase
                          */
                         public function arity(): int
                         {
-                            return (int)static::ARITY;
+                            return static::ARITY;
                         }
 
                         /**


### PR DESCRIPTION
Wish I knew why that check was there in the first place, but it doesn't seem to be necessary.