### PR TITLE
Fix ldap_set_rebind_proc signature

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -6824,7 +6824,7 @@ return [
 'ldap_sasl_bind' => ['bool', 'ldap'=>'LDAP\Connection', 'dn='=>'string', 'password='=>'string', 'mech='=>'string', 'realm='=>'string', 'authc_id='=>'string', 'authz_id='=>'string', 'props='=>'string'],
 'ldap_search' => ['LDAP\Connection|false', 'ldap'=>'LDAP\Connection|LDAP\Connection[]', 'base'=>'string', 'filter'=>'string', 'attributes='=>'array', 'attributes_only='=>'int', 'sizelimit='=>'int', 'timelimit='=>'int', 'deref='=>'int'],
 'ldap_set_option' => ['bool', 'ldap'=>'LDAP\Connection|null', 'option'=>'int', 'value'=>'mixed'],
-'ldap_set_rebind_proc' => ['bool', 'ldap'=>'LDAP\Connection', 'callback'=>'string'],
+'ldap_set_rebind_proc' => ['bool', 'ldap'=>'LDAP\Connection', 'callback'=>'?callable'],
 'ldap_start_tls' => ['bool', 'ldap'=>'resource'],
 'ldap_t61_to_8859' => ['string', 'value'=>'string'],
 'ldap_unbind' => ['bool', 'ldap'=>'resource'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -713,6 +713,10 @@ return [
       'old' => ['bool|string', 'ldap'=>'resource', 'user='=>'string', 'old_password='=>'string', 'new_password='=>'string', '&w_controls='=>'array'],
       'new' => ['bool|string', 'ldap'=>'resource', 'user='=>'string', 'old_password='=>'string', 'new_password='=>'string', '&w_controls='=>'array|null'],
     ],
+    'ldap_set_rebind_proc' => [
+      'old' => ['bool', 'ldap'=>'resource', 'callback'=>'callable'],
+      'new' => ['bool', 'ldap'=>'resource', 'callback'=>'?callable'],
+    ],
     'mb_check_encoding' => [
       'old' => ['bool', 'value='=>'array|string', 'encoding='=>'string'],
       'new' => ['bool', 'value='=>'array|string|null', 'encoding='=>'string|null'],

--- a/dictionaries/CallMap_81_delta.php
+++ b/dictionaries/CallMap_81_delta.php
@@ -633,8 +633,8 @@ return [
       'new' => ['bool', 'ldap'=>'LDAP\Connection|null', 'option'=>'int', 'value'=>'mixed'],
     ],
     'ldap_set_rebind_proc' => [
-      'old' => ['bool', 'ldap'=>'resource', 'callback'=>'string'],
-      'new' => ['bool', 'ldap'=>'LDAP\Connection', 'callback'=>'string'],
+      'old' => ['bool', 'ldap'=>'resource', 'callback'=>'?callable'],
+      'new' => ['bool', 'ldap'=>'LDAP\Connection', 'callback'=>'?callable'],
     ],
     'mysqli::connect' => [
       'old' => ['null|false', 'hostname='=>'string|null', 'username='=>'string|null', 'password='=>'string|null', 'database='=>'string|null', 'port='=>'int|null', 'socket='=>'string|null'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -12525,7 +12525,7 @@ return [
     'ldap_sasl_bind' => ['bool', 'ldap'=>'resource', 'dn='=>'string', 'password='=>'string', 'mech='=>'string', 'realm='=>'string', 'authc_id='=>'string', 'authz_id='=>'string', 'props='=>'string'],
     'ldap_search' => ['resource|false', 'ldap'=>'resource|resource[]', 'base'=>'string', 'filter'=>'string', 'attributes='=>'array', 'attributes_only='=>'int', 'sizelimit='=>'int', 'timelimit='=>'int', 'deref='=>'int'],
     'ldap_set_option' => ['bool', 'ldap'=>'resource|null', 'option'=>'int', 'value'=>'mixed'],
-    'ldap_set_rebind_proc' => ['bool', 'ldap'=>'resource', 'callback'=>'string'],
+    'ldap_set_rebind_proc' => ['bool', 'ldap'=>'resource', 'callback'=>'callable'],
     'ldap_sort' => ['bool', 'link_identifier'=>'resource', 'result_identifier'=>'resource', 'sortfilter'=>'string'],
     'ldap_start_tls' => ['bool', 'ldap'=>'resource'],
     'ldap_t61_to_8859' => ['string', 'value'=>'string'],


### PR DESCRIPTION
Hi,

This PR fixes a false positive about `ldap_set_rebind_proc()`:
```
Argument 2 of ldap_set_rebind_proc expects string, callable provided
```


See:
* Documentation: https://www.php.net/manual/en/function.ldap-set-rebind-proc.php
* phpstorm-stubs: https://github.com/JetBrains/phpstorm-stubs/blob/58c6b9d0308d6371be5b820c7063d1b7f8b9db1c/ldap/ldap.php#L1257