### PR TITLE
Set allow-plugins for Composer 2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
     },
     "config": {
         "allow-plugins": {
-            "bamarni/composer-bin-plugin": true
+            "bamarni/composer-bin-plugin": true,
+            "composer/package-versions-deprecated": true
         },
         "optimize-autoloader": true,
         "sort-packages": true,

--- a/composer.json
+++ b/composer.json
@@ -60,6 +60,9 @@
         "ext-curl": "In order to send data to shepherd"
     },
     "config": {
+        "allow-plugins": {
+            "bamarni/composer-bin-plugin": true
+        },
         "optimize-autoloader": true,
         "sort-packages": true,
         "platform-check": false


### PR DESCRIPTION
This new configuration has been introduced with Composer 2.2: https://github.com/composer/composer/releases/tag/2.2.0-RC1

See also the documentation: https://getcomposer.org/doc/06-config.md#allow-plugins