### PR TITLE
"No errors found!" message is now printed within a nice green block

### DIFF
--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -686,7 +686,7 @@ class IssueBuffer
                     : $error_count . ' errors'
                 ) . ' found' . "\n";
             } else {
-                echo 'No errors found!' . "\n";
+                self::printSuccessMessage();
             }
 
             $show_info = $project_analyzer->stdout_report_options->show_info;
@@ -775,6 +775,37 @@ class IssueBuffer
         ) {
             exit(2);
         }
+    }
+
+    public static function printSuccessMessage(): void
+    {
+        // this message will be printed
+        $message = "No errors found!";
+
+        // color block will contain this amount of characters
+        $blockSize = 30;
+
+        // message with prepended and appended whitespace to be same as $blockSize
+        $messageWithPadding = str_repeat(' ', 7) . $message . str_repeat(' ', 7);
+
+        // top side of the color block
+        $paddingTop = str_repeat(' ', $blockSize);
+
+        // bottom side of the color block
+        $paddingBottom = str_repeat(' ', $blockSize);
+
+        // background color, 42 = green
+        $background = "42";
+
+        // foreground/text color, 30 = black
+        $foreground = "30";
+
+        // text style, 1 = bold
+        $style = "1";
+
+        echo "\e[{$background};{$style}m{$paddingTop}\e[0m" . "\n";
+        echo "\e[{$background};{$foreground};{$style}m{$messageWithPadding}\e[0m" . "\n";
+        echo "\e[{$background};{$style}m{$paddingBottom}\e[0m" . "\n";
     }
 
     /**

--- a/tests/IssueBufferTest.php
+++ b/tests/IssueBufferTest.php
@@ -110,4 +110,13 @@ class IssueBufferTest extends TestCase
         $this->assertStringNotContainsString("ERROR", $output, "all issues baselined");
         IssueBuffer::clear();
     }
+
+    public function testPrintSuccessMessageWorks(): void
+    {
+        ob_start();
+        IssueBuffer::printSuccessMessage();
+        $output = ob_get_clean();
+
+        $this->assertStringContainsString('No errors found!', $output);
+    }
 }


### PR DESCRIPTION
Last week, I introduced psalm+phpstan to some juniors and I noticed they liked visual feedback of phpstan better than psalm.
I have tried to find why is so.

When errors are found, psalm kinda punishes our eyes with all the red texts of error message, but when we fixed them all, it just prints some dull looking texts. I had to guide the juniors multiple time to just ignore all the texts and look for "No errors found!" among them.
Only way to know psalm run status at a glance is to check if terminal has red color text or not.

I think, psalm should have a success page with green (or similar) color which kinda works as a reward for fixing all the errors. We all love the dopamine hit.

So, I've prepared this PR that will print a nice green block when there are no errors to report.

`printSuccessMessage` could be made as more flexible, such as accepting arbitrary message and dynamically calculate padding size. But I think that would increase the complexity unnecessarily  since we are printing a hard-coded string anyway.

Let me know what do you think. Thanks.