### PR TITLE
Improve class constant static analysis

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -410,7 +410,6 @@
             <xs:element name="RedundantConditionGivenDocblockType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="RedundantFunctionCall" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="RedundantFunctionCallGivenDocblockType" type="IssueHandlerType" minOccurs="0" />
-            <xs:element name="RedundantPropertyInitializationCheck" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="RedundantIdentityWithTrue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="RedundantPropertyInitializationCheck" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ReferenceConstraintViolation" type="IssueHandlerType" minOccurs="0" />

--- a/config.xsd
+++ b/config.xsd
@@ -198,9 +198,9 @@
 
     <xs:complexType name="IssueHandlersType">
         <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element name="PluginIssue" type="PluginIssueHandlerType" minOccurs="0" />
             <xs:element name="AbstractInstantiation" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="AbstractMethodCall" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="AmbiguousConstantInheritance" type="ClassConstantIssueHandlerType" minOccurs="0" />
             <xs:element name="ArgumentTypeCoercion" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="AssignmentToVoid" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="CircularReference" type="IssueHandlerType" minOccurs="0" />
@@ -292,6 +292,7 @@
             <xs:element name="InvalidToString" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidTraversableImplementation" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidTypeImport" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="LessSpecificClassConstantType" type="ClassConstantIssueHandlerType" minOccurs="0" />
             <xs:element name="LessSpecificImplementedReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="LessSpecificReturnStatement" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="LessSpecificReturnType" type="IssueHandlerType" minOccurs="0" />
@@ -338,10 +339,10 @@
             <xs:element name="NamedArgumentNotAllowed" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="NoEnumProperties" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="NoInterfaceProperties" type="ClassIssueHandlerType" minOccurs="0" />
-            <xs:element name="NonStaticSelfCall" type="IssueHandlerType" minOccurs="0" />
-            <xs:element name="NoValue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NonInvariantDocblockPropertyType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NonInvariantPropertyType" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NonStaticSelfCall" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NoValue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NullableReturnStatement" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NullArgument" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="NullArrayAccess" type="IssueHandlerType" minOccurs="0" />
@@ -352,11 +353,13 @@
             <xs:element name="NullPropertyAssignment" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="NullPropertyFetch" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="NullReference" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="OverriddenInterfaceConstant" type="ClassConstantIssueHandlerType" minOccurs="0" />
             <xs:element name="OverriddenMethodAccess" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="OverriddenPropertyAccess" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="ParadoxicalCondition" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ParamNameMismatch" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ParentNotFound" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="PluginIssue" type="PluginIssueHandlerType" minOccurs="0" />
             <xs:element name="PossibleRawObjectIteration" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyFalseArgument" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyFalseIterator" type="IssueHandlerType" minOccurs="0" />
@@ -409,6 +412,7 @@
             <xs:element name="RedundantFunctionCallGivenDocblockType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="RedundantPropertyInitializationCheck" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="RedundantIdentityWithTrue" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="RedundantPropertyInitializationCheck" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ReferenceConstraintViolation" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ReservedWord" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="StringIncrement" type="IssueHandlerType" minOccurs="0" />
@@ -466,8 +470,8 @@
             <xs:element name="UnrecognizedStatement" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnresolvableConstant" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnresolvableInclude" type="IssueHandlerType" minOccurs="0" />
-            <xs:element name="UnsafeInstantiation" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnsafeGenericInstantiation" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="UnsafeInstantiation" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnusedClass" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="UnusedClosureParam" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnusedConstructor" type="MethodIssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -2,6 +2,7 @@
 
  - [AbstractInstantiation](issues/AbstractInstantiation.md)
  - [AbstractMethodCall](issues/AbstractMethodCall.md)
+ - [AmbiguousConstantInheritance](issues/AmbiguousConstantInheritance.md)
  - [ArgumentTypeCoercion](issues/ArgumentTypeCoercion.md)
  - [AssignmentToVoid](issues/AssignmentToVoid.md)
  - [CircularReference](issues/CircularReference.md)
@@ -93,6 +94,7 @@
  - [InvalidToString](issues/InvalidToString.md)
  - [InvalidTraversableImplementation](issues/InvalidTraversableImplementation.md)
  - [InvalidTypeImport](issues/InvalidTypeImport.md)
+ - [LessSpecificClassConstantType](issues/LessSpecificClassConstantType.md)
  - [LessSpecificImplementedReturnType](issues/LessSpecificImplementedReturnType.md)
  - [LessSpecificReturnStatement](issues/LessSpecificReturnStatement.md)
  - [LessSpecificReturnType](issues/LessSpecificReturnType.md)
@@ -153,6 +155,7 @@
  - [NullPropertyAssignment](issues/NullPropertyAssignment.md)
  - [NullPropertyFetch](issues/NullPropertyFetch.md)
  - [NullReference](issues/NullReference.md)
+ - [OverriddenInterfaceConstant](issues/OverriddenInterfaceConstant.md)
  - [OverriddenMethodAccess](issues/OverriddenMethodAccess.md)
  - [OverriddenPropertyAccess](issues/OverriddenPropertyAccess.md)
  - [ParadoxicalCondition](issues/ParadoxicalCondition.md)

--- a/docs/running_psalm/issues/AmbiguousConstantInheritance.md
+++ b/docs/running_psalm/issues/AmbiguousConstantInheritance.md
@@ -14,7 +14,6 @@ interface Foo
 interface Bar
 {
     /**
-     * @psalm-suppress OverriddenInterfaceConstant
      * @var non-empty-string
      */
     public const CONSTANT='bar';

--- a/docs/running_psalm/issues/AmbiguousConstantInheritance.md
+++ b/docs/running_psalm/issues/AmbiguousConstantInheritance.md
@@ -1,0 +1,42 @@
+# AmbiguousConstantInheritance
+
+Emitted when a constant is inherited from multiple sources.
+
+```php
+<?php
+
+interface Foo
+{
+    /** @var non-empty-string */
+    public const CONSTANT='foo';
+}
+
+interface Bar
+{
+    /**
+     * @psalm-suppress OverriddenInterfaceConstant
+     * @var non-empty-string
+     */
+    public const CONSTANT='bar';
+}
+
+interface Baz extends Foo, Bar {}
+```
+
+```php
+<?php
+
+interface Foo
+{
+    /** @var non-empty-string */
+    public const CONSTANT='foo';
+}
+
+class Bar
+{
+    /** @var non-empty-string */
+    public const CONSTANT='bar';
+}
+
+class Baz extends Bar implements Foo {}
+```

--- a/docs/running_psalm/issues/LessSpecificClassConstantType.md
+++ b/docs/running_psalm/issues/LessSpecificClassConstantType.md
@@ -1,0 +1,28 @@
+# LessSpecificClassConstantType
+
+Emitted when a constant type in a child is less specific than the type in the parent.
+
+```php
+<?php
+
+class Foo
+{
+    /** @var int<1,max> */
+    public const CONSTANT = 3;
+
+    public static function bar(): array
+    {
+        return str_split("foobar", static::CONSTANT);
+    }
+}
+
+class Bar extends Foo
+{
+    /** @var int */
+    public const CONSTANT = -1;
+}
+
+Bar::bar(); // Error: str_split argument 2 must be greater than 0
+```
+
+This issue will always show up when overriding a constant that doesn't have a docblock type. Psalm will infer the most specific type for the constant that it can, you have to add a type annotation to tell it what type constraint you wish to be applied. Otherwise Psalm has no way of telling if you mean for the constant to be a literal `1`, `int<1, max>`, `int`, `numeric`, etc.

--- a/docs/running_psalm/issues/OverriddenInterfaceConstant.md
+++ b/docs/running_psalm/issues/OverriddenInterfaceConstant.md
@@ -1,0 +1,17 @@
+# OverriddenInterfaceConstant
+
+Emitted when a constant declared on an interface is overridden by a child (illegal in PHP < 8.1).
+
+```php
+<?php
+
+interface Foo
+{
+    public const BAR='baz';
+}
+
+interface Bar extends Foo
+{
+    public const BAR='foobar';
+}
+```

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -17,6 +17,7 @@ use Psalm\Exception\DocblockParseException;
 use Psalm\FileManipulation;
 use Psalm\Internal\Analyzer\FunctionLike\ReturnTypeAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\ClassTemplateParamCollector;
+use Psalm\Internal\Analyzer\Statements\Expression\ClassConstAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Fetch\AtomicPropertyFetchAnalyzer;
 use Psalm\Internal\FileManipulation\FileManipulationBuffer;
 use Psalm\Internal\FileManipulation\PropertyDocblockManipulator;
@@ -532,6 +533,8 @@ class ClassAnalyzer extends ClassLikeAnalyzer
 
         $statements_analyzer = new StatementsAnalyzer($this, new NodeDataProvider());
         $statements_analyzer->analyze($member_stmts, $class_context, $global_context, true);
+
+        ClassConstAnalyzer::analyze($storage, $this->getCodebase());
 
         $config = Config::getInstance();
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
@@ -722,15 +722,14 @@ class ClassConstAnalyzer
     ): void {
         foreach ($class_storage->constants as $const_name => $const_storage) {
             // Check covariance
-            /** @psalm-suppress PossiblyNullArrayAccess https://github.com/vimeo/psalm/issues/7151 */
             [$parent_classlike_storage, $parent_const_storage] = self::getOverriddenConstant(
                 $class_storage,
                 $const_storage,
                 $const_name,
                 $codebase
             );
-            /** @psalm-suppress RedundantConditionGivenDocblockType https://github.com/vimeo/psalm/issues/7151 */
             if ($parent_const_storage !== null) {
+                assert($parent_classlike_storage !== null);
                 $location = $const_storage->type_location ?? $const_storage->stmt_location;
                 if ($location !== null
                     && $const_storage->type !== null
@@ -776,10 +775,7 @@ class ClassConstAnalyzer
             if ($parent_const_storage !== null) {
                 if ($const_storage->location
                     && $const_storage !== $parent_const_storage
-                    && (
-                        $codebase->php_major_version < 8
-                        || ($codebase->php_major_version === 8 && $codebase->php_minor_version < 1)
-                    )
+                    && $codebase->analysis_php_version_id < 8_01_00
                 ) {
                     $interface_overrides[strtolower($interface)] = new OverriddenInterfaceConstant(
                         "{$class_storage->name}::{$const_name} cannot override constant from $interface",

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace Psalm\Internal\Analyzer\Statements\Expression\Fetch;
+namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use InvalidArgumentException;
 use PhpParser;
 use Psalm\CodeLocation;
+use Psalm\Codebase;
 use Psalm\Context;
 use Psalm\Exception\CircularReferenceException;
 use Psalm\FileManipulation;
@@ -16,16 +17,21 @@ use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Analyzer\TraitAnalyzer;
 use Psalm\Internal\FileManipulation\FileManipulationBuffer;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
+use Psalm\Issue\AmbiguousConstantInheritance;
 use Psalm\Issue\CircularReference;
 use Psalm\Issue\DeprecatedClass;
 use Psalm\Issue\DeprecatedConstant;
 use Psalm\Issue\InaccessibleClassConstant;
 use Psalm\Issue\InternalClass;
 use Psalm\Issue\InvalidConstantAssignmentValue;
+use Psalm\Issue\LessSpecificClassConstantType;
 use Psalm\Issue\NonStaticSelfCall;
+use Psalm\Issue\OverriddenInterfaceConstant;
 use Psalm\Issue\ParentNotFound;
 use Psalm\Issue\UndefinedConstant;
 use Psalm\IssueBuffer;
+use Psalm\Storage\ClassConstantStorage;
+use Psalm\Storage\ClassLikeStorage;
 use Psalm\Type;
 use Psalm\Type\Atomic\TClassString;
 use Psalm\Type\Atomic\TLiteralClassString;
@@ -45,13 +51,13 @@ use function strtolower;
 /**
  * @internal
  */
-class ClassConstFetchAnalyzer
+class ClassConstAnalyzer
 {
     /**
      * @psalm-suppress ComplexMethod to be refactored. We should probably regroup the two big if about $stmt->class and
      * analyse the ::class int $stmt->name separately
      */
-    public static function analyze(
+    public static function analyzeFetch(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\ClassConstFetch $stmt,
         Context $context
@@ -672,17 +678,19 @@ class ClassConstFetchAnalyzer
         return true;
     }
 
-    public static function analyzeClassConstAssignment(
+    public static function analyzeAssignment(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Stmt\ClassConst $stmt,
         Context $context
     ): void {
+        assert($context->self !== null);
+        $class_storage = $statements_analyzer->getCodebase()->classlike_storage_provider->get($context->self);
+
         foreach ($stmt->consts as $const) {
             ExpressionAnalyzer::analyze($statements_analyzer, $const->value, $context);
-
-            assert($context->self !== null);
-            $class_storage = $statements_analyzer->getCodebase()->classlike_storage_provider->get($context->self);
             $const_storage = $class_storage->constants[$const->name->name];
+
+            // Check assigned type matches docblock type
             if ($assigned_type = $statements_analyzer->node_data->getType($const->value)) {
                 if ($const_storage->type !== null
                     && $const_storage->stmt_location !== null
@@ -695,10 +703,10 @@ class ClassConstFetchAnalyzer
                 ) {
                     IssueBuffer::maybeAdd(
                         new InvalidConstantAssignmentValue(
-                            "{$context->self}::{$const->name->name} with declared type {$const_storage->type->getId()} "
-                            . "cannot be assigned type {$assigned_type->getId()}",
+                            "{$class_storage->name}::{$const->name->name} with declared type "
+                            . "{$const_storage->type->getId()} cannot be assigned type {$assigned_type->getId()}",
                             $const_storage->stmt_location,
-                            "{$context->self}::{$const->name->name}"
+                            "{$class_storage->name}::{$const->name->name}"
                         ),
                         $const_storage->suppressed_issues,
                         true
@@ -706,5 +714,144 @@ class ClassConstFetchAnalyzer
                 }
             }
         }
+    }
+
+    public static function analyze(
+        ClassLikeStorage $class_storage,
+        Codebase $codebase
+    ): void {
+        foreach ($class_storage->constants as $const_name => $const_storage) {
+            // Check covariance
+            /** @psalm-suppress PossiblyNullArrayAccess https://github.com/vimeo/psalm/issues/7151 */
+            [$parent_classlike_storage, $parent_const_storage] = self::getOverriddenConstant(
+                $class_storage,
+                $const_storage,
+                $const_name,
+                $codebase
+            );
+            /** @psalm-suppress RedundantConditionGivenDocblockType https://github.com/vimeo/psalm/issues/7151 */
+            if ($parent_const_storage !== null) {
+                $location = $const_storage->type_location ?? $const_storage->stmt_location;
+                if ($location !== null
+                    && $const_storage->type !== null
+                    && $parent_const_storage->type !== null
+                    && !UnionTypeComparator::isContainedBy(
+                        $codebase,
+                        $const_storage->type,
+                        $parent_const_storage->type
+                    )
+                ) {
+                    IssueBuffer::maybeAdd(
+                        new LessSpecificClassConstantType(
+                            "The type '{$const_storage->type->getId()}' for {$class_storage->name}::"
+                                . "{$const_name} is more general than the type "
+                                . "'{$parent_const_storage->type->getId()}' inherited from "
+                                . "{$parent_classlike_storage->name}::{$const_name}",
+                            $location,
+                            "{$class_storage->name}::{$const_name}"
+                        ),
+                        $const_storage->suppressed_issues
+                    );
+                }
+            }
+        }
+    }
+
+    /**
+     * Get the const storage from the parent or interface that this class is overriding.
+     *
+     * @return array{ClassLikeStorage, ClassConstantStorage}|null
+     */
+    private static function getOverriddenConstant(
+        ClassLikeStorage $class_storage,
+        ClassConstantStorage $const_storage,
+        string $const_name,
+        Codebase $codebase
+    ): ?array {
+        $parent_classlike_storage = $interface_const_storage = $parent_const_storage = null;
+        $interface_overrides = [];
+        foreach ($class_storage->class_implements ?: $class_storage->direct_interface_parents as $interface) {
+            $interface_storage = $codebase->classlike_storage_provider->get($interface);
+            $parent_const_storage = $interface_storage->constants[$const_name] ?? null;
+            if ($parent_const_storage !== null) {
+                if ($const_storage->location
+                    && $const_storage !== $parent_const_storage
+                    && (
+                        $codebase->php_major_version < 8
+                        || ($codebase->php_major_version === 8 && $codebase->php_minor_version < 1)
+                    )
+                ) {
+                    $interface_overrides[strtolower($interface)] = new OverriddenInterfaceConstant(
+                        "{$class_storage->name}::{$const_name} cannot override constant from $interface",
+                        $const_storage->location,
+                        "{$class_storage->name}::{$const_name}"
+                    );
+                }
+                if ($interface_const_storage !== null && $const_storage->location !== null) {
+                    assert($parent_classlike_storage !== null);
+                    if (!isset($parent_classlike_storage->parent_interfaces[strtolower($interface)])
+                        && !isset($interface_storage->parent_interfaces[strtolower($parent_classlike_storage->name)])
+                    ) {
+                        IssueBuffer::maybeAdd(
+                            new AmbiguousConstantInheritance(
+                                "Ambiguous inheritance of {$class_storage->name}::{$const_name} from $interface and "
+                                    . $parent_classlike_storage->name,
+                                $const_storage->location,
+                                "{$class_storage->name}::{$const_name}"
+                            ),
+                            $const_storage->suppressed_issues
+                        );
+                    }
+                }
+                $interface_const_storage = $parent_const_storage;
+                $parent_classlike_storage = $interface_storage;
+            }
+        }
+
+        foreach ($class_storage->parent_classes as $parent_class) {
+            $parent_class_storage = $codebase->classlike_storage_provider->get($parent_class);
+            $parent_const_storage = $parent_class_storage->constants[$const_name] ?? null;
+            if ($parent_const_storage !== null) {
+                if ($const_storage->location !== null && $interface_const_storage !== null) {
+                    assert($parent_classlike_storage !== null);
+                    if (!isset($parent_class_storage->class_implements[strtolower($parent_classlike_storage->name)])) {
+                        IssueBuffer::maybeAdd(
+                            new AmbiguousConstantInheritance(
+                                "Ambiguous inheritance of {$class_storage->name}::{$const_name} from "
+                                    . "$parent_classlike_storage->name and $parent_class",
+                                $const_storage->location,
+                                "{$class_storage->name}::{$const_name}"
+                            ),
+                            $const_storage->suppressed_issues
+                        );
+                    }
+                }
+                foreach ($interface_overrides as $interface_lc => $_) {
+                    // If the parent is the one with the const that's overriding the interface const, and the parent
+                    // doesn't implement the interface, it's just an AmbiguousConstantInheritance, not an
+                    // OverriddenInterfaceConstant
+                    if (!isset($parent_class_storage->class_implements[$interface_lc])
+                        && $parent_const_storage === $const_storage
+                    ) {
+                        unset($interface_overrides[$interface_lc]);
+                    }
+                }
+                $parent_classlike_storage = $parent_class_storage;
+                break;
+            }
+        }
+
+        foreach ($interface_overrides as $_ => $issue) {
+            IssueBuffer::maybeAdd(
+                $issue,
+                $const_storage->suppressed_issues
+            );
+        }
+
+        if ($parent_classlike_storage !== null) {
+            assert($parent_const_storage !== null);
+            return [$parent_classlike_storage, $parent_const_storage];
+        }
+        return null;
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -19,13 +19,13 @@ use Psalm\Internal\Analyzer\Statements\Expression\Call\MethodCallAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\NewAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\StaticCallAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\CastAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\ClassConstAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\CloneAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\EmptyAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\EncapsulatedStringAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\EvalAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\ExitAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ArrayFetchAnalyzer;
-use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ClassConstFetchAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ConstFetchAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Fetch\InstancePropertyFetchAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Fetch\StaticPropertyFetchAnalyzer;
@@ -240,7 +240,7 @@ class ExpressionAnalyzer
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\ClassConstFetch) {
-            return ClassConstFetchAnalyzer::analyze($statements_analyzer, $stmt, $context);
+            return ClassConstAnalyzer::analyzeFetch($statements_analyzer, $stmt, $context);
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\PropertyFetch) {

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -23,7 +23,7 @@ use Psalm\Internal\Analyzer\Statements\ContinueAnalyzer;
 use Psalm\Internal\Analyzer\Statements\EchoAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Assignment\InstancePropertyAssignmentAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\AssignmentAnalyzer;
-use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ClassConstFetchAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\ClassConstAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ConstFetchAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Fetch\VariableFetchAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\SimpleTypeInferer;
@@ -577,7 +577,7 @@ class StatementsAnalyzer extends SourceAnalyzer
         } elseif ($stmt instanceof PhpParser\Node\Stmt\Property) {
             InstancePropertyAssignmentAnalyzer::analyzeStatement($statements_analyzer, $stmt, $context);
         } elseif ($stmt instanceof PhpParser\Node\Stmt\ClassConst) {
-            ClassConstFetchAnalyzer::analyzeClassConstAssignment($statements_analyzer, $stmt, $context);
+            ClassConstAnalyzer::analyzeAssignment($statements_analyzer, $stmt, $context);
         } elseif ($stmt instanceof PhpParser\Node\Stmt\Class_) {
             try {
                 $class_analyzer = new ClassAnalyzer(

--- a/src/Psalm/Issue/AmbiguousConstantInheritance.php
+++ b/src/Psalm/Issue/AmbiguousConstantInheritance.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Issue;
 
 class AmbiguousConstantInheritance extends ClassConstantIssue

--- a/src/Psalm/Issue/AmbiguousConstantInheritance.php
+++ b/src/Psalm/Issue/AmbiguousConstantInheritance.php
@@ -1,0 +1,8 @@
+<?php
+namespace Psalm\Issue;
+
+class AmbiguousConstantInheritance extends ClassConstantIssue
+{
+    public const ERROR_LEVEL = 6;
+    public const SHORTCODE = 305;
+}

--- a/src/Psalm/Issue/LessSpecificClassConstantType.php
+++ b/src/Psalm/Issue/LessSpecificClassConstantType.php
@@ -1,0 +1,8 @@
+<?php
+namespace Psalm\Issue;
+
+class LessSpecificClassConstantType extends ClassConstantIssue
+{
+    public const ERROR_LEVEL = 1;
+    public const SHORTCODE = 307;
+}

--- a/src/Psalm/Issue/LessSpecificClassConstantType.php
+++ b/src/Psalm/Issue/LessSpecificClassConstantType.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Issue;
 
 class LessSpecificClassConstantType extends ClassConstantIssue

--- a/src/Psalm/Issue/OverriddenInterfaceConstant.php
+++ b/src/Psalm/Issue/OverriddenInterfaceConstant.php
@@ -1,0 +1,8 @@
+<?php
+namespace Psalm\Issue;
+
+class OverriddenInterfaceConstant extends ClassConstantIssue
+{
+    public const ERROR_LEVEL = 6;
+    public const SHORTCODE = 306;
+}

--- a/src/Psalm/Issue/OverriddenInterfaceConstant.php
+++ b/src/Psalm/Issue/OverriddenInterfaceConstant.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Psalm\Issue;
 
 class OverriddenInterfaceConstant extends ClassConstantIssue

--- a/src/Psalm/Issue/TaintedInput.php
+++ b/src/Psalm/Issue/TaintedInput.php
@@ -8,6 +8,7 @@ use Psalm\Internal\Analyzer\DataFlowNodeData;
 abstract class TaintedInput extends CodeIssue
 {
     public const ERROR_LEVEL = -2;
+    /** @var int<0, max> */
     public const SHORTCODE = 205;
 
     /**

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -64,6 +64,7 @@ class TKeyedArray extends Atomic
      */
     public $is_list = false;
 
+    /** @var non-empty-lowercase-string */
     public const KEY = 'array';
 
     /**
@@ -104,7 +105,6 @@ class TKeyedArray extends Atomic
             sort($property_strings);
         }
 
-        /** @psalm-suppress MixedOperand */
         return static::KEY . '{' .
                 implode(', ', $property_strings) .
                 '}'
@@ -135,7 +135,6 @@ class TKeyedArray extends Atomic
             );
         }
 
-        /** @psalm-suppress MixedOperand */
         return static::KEY . '{' .
                 implode(
                     ', ',

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -39,7 +39,6 @@ class TList extends Atomic
 
     public function getId(bool $exact = true, bool $nested = false): string
     {
-        /** @psalm-suppress MixedOperand */
         return static::KEY . '<' . $this->type_param->getId($exact) . '>';
     }
 

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -26,6 +26,7 @@ class TList extends Atomic
      */
     public $type_param;
 
+    /** @var non-empty-lowercase-string */
     public const KEY = 'list';
 
     /**
@@ -67,7 +68,6 @@ class TList extends Atomic
                 );
         }
 
-        /** @psalm-suppress MixedOperand */
         return static::KEY
             . '<'
             . $this->type_param->toNamespacedString(

--- a/src/Psalm/Type/Atomic/TNonEmptyList.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyList.php
@@ -17,6 +17,7 @@ class TNonEmptyList extends TList
      */
     public $min_count;
 
+    /** @var non-empty-lowercase-string */
     public const KEY = 'non-empty-list';
 
     public function getAssertionString(): string

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -428,6 +428,7 @@ class ConstantTest extends TestCase
             'resolveClassConstToCurrentClass' => [
                 'code' => '<?php
                     interface I {
+                        /** @var string|array */
                         public const C = "a";
 
                         public function getC(): string;
@@ -446,6 +447,9 @@ class ConstantTest extends TestCase
                             return self::C;
                         }
                     }',
+                [],
+                [],
+                '8.1',
             ],
             'resolveCalculatedConstant' => [
                 'code' => '<?php
@@ -956,6 +960,7 @@ class ConstantTest extends TestCase
             'protectedClassConstantAccessibilitySameNameInChild' => [
                 'code' => '<?php
                     class A {
+                        /** @var int<1,max> */
                         protected const A = 1;
 
                         public static function test(): void {
@@ -972,7 +977,9 @@ class ConstantTest extends TestCase
             'referenceClassConstantWithSelf' => [
                 'code' => '<?php
                     abstract class A {
+                        /** @var array<non-empty-string, non-empty-string> */
                         public const KEYS = [];
+                        /** @var array<non-empty-string, non-empty-string> */
                         public const VALUES = [];
                     }
 
@@ -1320,6 +1327,57 @@ class ConstantTest extends TestCase
                     foo([...A::ARR]);
                 ',
             ],
+            'classConstCovariant' => [
+                '<?php
+                    abstract class A {
+                        /** @var string */
+                        public const COVARIANT = "";
+
+                        /** @var string */
+                        public const INVARIANT = "";
+                    }
+
+                    abstract class B extends A {}
+
+                    abstract class C extends B {
+                        /** @var non-empty-string */
+                        public const COVARIANT = "foo";
+
+                        /** @var string */
+                        public const INVARIANT = "";
+                    }
+                ',
+            ],
+            'overrideClassConstFromInterface' => [
+                '<?php
+                    interface Foo
+                    {
+                        /** @var non-empty-string */
+                        public const BAR="baz";
+                    }
+
+                    interface Bar extends Foo {}
+
+                    class Baz implements Bar
+                    {
+                        /** @var non-empty-string */
+                        public const BAR="foobar";
+                    }
+                ',
+                [],
+                [],
+                '8.1',
+            ],
+            'inheritedConstDoesNotOverride' => [
+                '<?php
+                    interface Foo
+                    {
+                        public const BAR="baz";
+                    }
+
+                    interface Bar extends Foo {}
+                ',
+            ],
         ];
     }
 
@@ -1415,6 +1473,9 @@ class ConstantTest extends TestCase
                         }
                     }',
                 'error_message' => 'InvalidReturnStatement',
+                [],
+                false,
+                '8.1',
             ],
             'outOfScopeDefinedConstant' => [
                 'code' => '<?php
@@ -1690,6 +1751,78 @@ class ConstantTest extends TestCase
                     }
                 ',
                 'error_message' => "InvalidConstantAssignmentValue",
+            ],
+            'classConstContravariant' => [
+                '<?php
+                    abstract class A {
+                        /** @var non-empty-string */
+                        public const CONTRAVARIANT = "foo";
+                    }
+
+                    abstract class B extends A {}
+
+                    abstract class C extends B {
+                        /** @var string */
+                        public const CONTRAVARIANT = "";
+                    }
+                ',
+                'error_message' => "LessSpecificClassConstantType",
+            ],
+            'classConstAmbiguousInherit' => [
+                '<?php
+                    interface Foo
+                    {
+                        /** @var non-empty-string */
+                        public const BAR="baz";
+                    }
+
+                    interface Bar extends Foo {}
+
+                    class Baz
+                    {
+                        /** @var non-empty-string */
+                        public const BAR="foobar";
+                    }
+
+                    class BarBaz extends Baz implements Bar
+                    {
+                    }
+                ',
+                'error_message' => 'AmbiguousConstantInheritance',
+            ],
+            'overrideClassConstFromInterface' => [
+                '<?php
+                    interface Foo
+                    {
+                        /** @var non-empty-string */
+                        public const BAR="baz";
+                    }
+
+                    interface Bar extends Foo {}
+
+                    class Baz implements Bar
+                    {
+                        /** @var non-empty-string */
+                        public const BAR="foobar";
+                    }
+                ',
+                'error_message' => 'OverriddenInterfaceConstant',
+            ],
+            'overrideClassConstFromInterfaceWithInterface' => [
+                '<?php
+                    interface Foo
+                    {
+                        /** @var non-empty-string */
+                        public const BAR="baz";
+                    }
+
+                    interface Bar extends Foo
+                    {
+                        /** @var non-empty-string */
+                        public const BAR="bar";
+                    }
+                ',
+                'error_message' => 'OverriddenInterfaceConstant',
             ],
         ];
     }

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -1328,7 +1328,7 @@ class ConstantTest extends TestCase
                 ',
             ],
             'classConstCovariant' => [
-                '<?php
+                'code' => '<?php
                     abstract class A {
                         /** @var string */
                         public const COVARIANT = "";
@@ -1349,7 +1349,7 @@ class ConstantTest extends TestCase
                 ',
             ],
             'overrideClassConstFromInterface' => [
-                '<?php
+                'code' => '<?php
                     interface Foo
                     {
                         /** @var non-empty-string */
@@ -1369,7 +1369,7 @@ class ConstantTest extends TestCase
                 '8.1',
             ],
             'inheritedConstDoesNotOverride' => [
-                '<?php
+                'code' => '<?php
                     interface Foo
                     {
                         public const BAR="baz";
@@ -1473,9 +1473,8 @@ class ConstantTest extends TestCase
                         }
                     }',
                 'error_message' => 'InvalidReturnStatement',
-                [],
-                false,
-                '8.1',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
             'outOfScopeDefinedConstant' => [
                 'code' => '<?php
@@ -1753,7 +1752,7 @@ class ConstantTest extends TestCase
                 'error_message' => "InvalidConstantAssignmentValue",
             ],
             'classConstContravariant' => [
-                '<?php
+                'code' => '<?php
                     abstract class A {
                         /** @var non-empty-string */
                         public const CONTRAVARIANT = "foo";
@@ -1769,7 +1768,7 @@ class ConstantTest extends TestCase
                 'error_message' => "LessSpecificClassConstantType",
             ],
             'classConstAmbiguousInherit' => [
-                '<?php
+                'code' => '<?php
                     interface Foo
                     {
                         /** @var non-empty-string */
@@ -1791,7 +1790,7 @@ class ConstantTest extends TestCase
                 'error_message' => 'AmbiguousConstantInheritance',
             ],
             'overrideClassConstFromInterface' => [
-                '<?php
+                'code' => '<?php
                     interface Foo
                     {
                         /** @var non-empty-string */
@@ -1809,7 +1808,7 @@ class ConstantTest extends TestCase
                 'error_message' => 'OverriddenInterfaceConstant',
             ],
             'overrideClassConstFromInterfaceWithInterface' => [
-                '<?php
+                'code' => '<?php
                     interface Foo
                     {
                         /** @var non-empty-string */

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -319,6 +319,7 @@ class DocumentationTest extends TestCase
                     $ignored_issues = ['UnusedVariable'];
                     break;
 
+                case 'AmbiguousConstantInheritance':
                 case 'InvalidEnumBackingType':
                 case 'InvalidEnumCaseValue':
                 case 'DuplicateEnumCase':


### PR DESCRIPTION
Add class const covariance support (fixes #5589).
Add check for overriding const from interface in PHP < 8.1 (fixes #7108).
Add check for ambiguous const inheritance.