### PR TITLE
Use igbinary for communication between processes if possible

### DIFF
--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -424,6 +424,7 @@ class Analyzer
             // Run analysis one file at a time, splitting the set of
             // files up among a given number of child processes.
             $pool = new Pool(
+                $this->config,
                 $process_file_paths,
                 function (): void {
                     $project_analyzer = ProjectAnalyzer::getInstance();

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -360,6 +360,7 @@ class Scanner
             // Run scanning one file at a time, splitting the set of
             // files up among a given number of child processes.
             $pool = new Pool(
+                $this->config,
                 $process_file_paths,
                 function (): void {
                     $this->progress->debug('Initialising forked process for scanning' . PHP_EOL);

--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -3,6 +3,7 @@ namespace Psalm\Internal\Fork;
 
 use Closure;
 use Exception;
+use Psalm\Config;
 use Throwable;
 
 use function array_fill_keys;
@@ -24,6 +25,8 @@ use function fread;
 use function fwrite;
 use function get_class;
 use function gettype;
+use function igbinary_serialize;
+use function igbinary_unserialize;
 use function in_array;
 use function ini_get;
 use function pcntl_fork;
@@ -69,6 +72,9 @@ class Pool
     private const EXIT_SUCCESS = 0;
     private const EXIT_FAILURE = 1;
 
+    /** @var Config */
+    private $config;
+
     /** @var int[] */
     private $child_pid_list = [];
 
@@ -88,6 +94,7 @@ class Pool
         . 'Relevant info: https://bugs.php.net/bug.php?id=77260';
 
     /**
+     * @param Config $config
      * @param array<int, array<int, mixed>> $process_task_data_iterator
      * An array of task data items to be divided up among the
      * workers. The size of this is the number of forked processes.
@@ -104,6 +111,7 @@ class Pool
      * @psalm-suppress MixedAssignment
      */
     public function __construct(
+        Config $config,
         array $process_task_data_iterator,
         Closure $startup_closure,
         Closure $task_closure,
@@ -112,6 +120,7 @@ class Pool
     ) {
         $pool_size = count($process_task_data_iterator);
         $this->task_done_closure = $task_done_closure;
+        $this->config = $config;
 
         assert(
             $pool_size > 1,
@@ -201,7 +210,12 @@ class Pool
                 $task_result = $task_closure($i, $task_data);
 
                 $task_done_message = new ForkTaskDoneMessage($task_result);
-                $serialized_message = $task_done_buffer . base64_encode(serialize($task_done_message)) . "\n";
+                if ($this->config->use_igbinary) {
+                    $encoded_message = base64_encode(igbinary_serialize($task_done_message));
+                } else {
+                    $encoded_message = base64_encode(serialize($task_done_message));
+                }
+                $serialized_message = $task_done_buffer . $encoded_message . "\n";
 
                 if (strlen($serialized_message) > 200) {
                     $bytes_written = @fwrite($write_stream, $serialized_message);
@@ -233,7 +247,12 @@ class Pool
             );
         }
 
-        $serialized_message = $task_done_buffer . base64_encode(serialize($process_done_message)) . "\n";
+        if ($this->config->use_igbinary) {
+            $encoded_message = base64_encode(igbinary_serialize($process_done_message));
+        } else {
+            $encoded_message = base64_encode(serialize($process_done_message));
+        }
+        $serialized_message = $task_done_buffer . $encoded_message . "\n";
 
         $bytes_to_write = strlen($serialized_message);
         $bytes_written = 0;
@@ -356,7 +375,11 @@ class Pool
                     $content[(int)$file] = array_pop($serialized_messages);
 
                     foreach ($serialized_messages as $serialized_message) {
-                        $message = unserialize(base64_decode($serialized_message, true));
+                        if ($this->config->use_igbinary) {
+                            $message = igbinary_unserialize(base64_decode($serialized_message, true));
+                        } else {
+                            $message = unserialize(base64_decode($serialized_message, true));
+                        }
 
                         if ($message instanceof ForkProcessDoneMessage) {
                             $terminationMessages[] = $message->data;


### PR DESCRIPTION
When using `--threads=N`, communications between processes are done by serialization, but igbinary isn't used there even if available.
This fix reduces the size of `fwrite()` to sockets during communication, thus lowering the overhead.
