### PR TITLE
Fix conflicting array_map return provider fake variables.

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -29,6 +29,7 @@ use function array_map;
 use function array_slice;
 use function count;
 use function is_string;
+use function mt_rand;
 use function reset;
 use function spl_object_id;
 
@@ -185,13 +186,15 @@ class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderInterfa
                 if ($array_arg && $mapping_function_ids) {
                     $assertions = [];
 
+                    $fake_var_id = mt_rand();
                     ArrayMapReturnTypeProvider::getReturnTypeFromMappingIds(
                         $statements_source,
                         $mapping_function_ids,
                         $context,
                         $function_call_arg,
                         array_slice($call_args, 0, 1),
-                        $assertions
+                        $assertions,
+                        $fake_var_id
                     );
 
                     $array_var_id = ExpressionIdentifier::getArrayVarId(
@@ -200,10 +203,12 @@ class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderInterfa
                         $statements_source
                     );
 
-                    if (isset($assertions[$array_var_id . '[$__fake_offset_var__]'])) {
+                    if (isset($assertions[$array_var_id . "[\$__fake_{$fake_var_id}_offset_var__]"])) {
                         $changed_var_ids = [];
 
-                        $assertions = ['$inner_type' => $assertions[$array_var_id . '[$__fake_offset_var__]']];
+                        $assertions = [
+                            '$inner_type' => $assertions[$array_var_id . "[\$__fake_{$fake_var_id}_offset_var__]"]
+                        ];
 
                         $reconciled_types = Reconciler::reconcileKeyedTypes(
                             $assertions,
@@ -221,6 +226,8 @@ class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderInterfa
                             $inner_type = $reconciled_types['$inner_type'];
                         }
                     }
+
+                    ArrayMapReturnTypeProvider::cleanContext($context, $fake_var_id);
                 }
             } elseif (($function_call_arg->value instanceof PhpParser\Node\Expr\Closure
                     || $function_call_arg->value instanceof PhpParser\Node\Expr\ArrowFunction)

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -186,7 +186,7 @@ class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderInterfa
                 if ($array_arg && $mapping_function_ids) {
                     $assertions = [];
 
-                    $fake_var_id = mt_rand();
+                    $fake_var_discriminator = mt_rand();
                     ArrayMapReturnTypeProvider::getReturnTypeFromMappingIds(
                         $statements_source,
                         $mapping_function_ids,
@@ -194,7 +194,7 @@ class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderInterfa
                         $function_call_arg,
                         array_slice($call_args, 0, 1),
                         $assertions,
-                        $fake_var_id
+                        $fake_var_discriminator
                     );
 
                     $array_var_id = ExpressionIdentifier::getArrayVarId(
@@ -203,11 +203,12 @@ class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderInterfa
                         $statements_source
                     );
 
-                    if (isset($assertions[$array_var_id . "[\$__fake_{$fake_var_id}_offset_var__]"])) {
+                    if (isset($assertions[$array_var_id . "[\$__fake_{$fake_var_discriminator}_offset_var__]"])) {
                         $changed_var_ids = [];
 
                         $assertions = [
-                            '$inner_type' => $assertions[$array_var_id . "[\$__fake_{$fake_var_id}_offset_var__]"]
+                            '$inner_type' =>
+                                $assertions["{$array_var_id}[\$__fake_{$fake_var_discriminator}_offset_var__]"],
                         ];
 
                         $reconciled_types = Reconciler::reconcileKeyedTypes(
@@ -227,7 +228,7 @@ class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderInterfa
                         }
                     }
 
-                    ArrayMapReturnTypeProvider::cleanContext($context, $fake_var_id);
+                    ArrayMapReturnTypeProvider::cleanContext($context, $fake_var_discriminator);
                 }
             } elseif (($function_call_arg->value instanceof PhpParser\Node\Expr\Closure
                     || $function_call_arg->value instanceof PhpParser\Node\Expr\ArrowFunction)

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
@@ -352,7 +352,7 @@ class ArrayMapReturnTypeProvider implements FunctionReturnTypeProviderInterface
         PhpParser\Node\Arg $function_call_arg,
         array $array_args,
         ?array &$assertions = null,
-        ?int $fake_var_id = null,
+        ?int $fake_var_id = null
     ): Union {
         $mapping_return_type = null;
 

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1065,6 +1065,29 @@ class ReturnTypeTest extends TestCase
                         }
                     }'
             ],
+            'nestedArrayMapReturnTypeDoesntCrash' => [
+                '<?php
+                    function bar(array $a): array {
+                        return $a;
+                    }
+
+                    /**
+                     * @param array[] $x
+                     *
+                     * @return array[]
+                     */
+                    function foo(array $x): array {
+                        return array_map(
+                            "array_merge",
+                            array_map(
+                                "bar",
+                                $x
+                            ),
+                            $x
+                        );
+                    }
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fix array_map return provider fake variables conflicting when nesting `array_map` calls (fixes #7164).
Ensure all fake variables are removed from context.