### PR TITLE
Fix faulty comparison with typed closure

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -165,40 +165,24 @@ class AtomicTypeComparator
             );
         }
 
-        if ($container_type_part instanceof TClosure && $input_type_part instanceof TCallable) {
-            if (CallableTypeComparator::isContainedBy(
-                $codebase,
-                $input_type_part,
-                $container_type_part,
-                $atomic_comparison_result
-            ) === false
-            ) {
-                return false;
-            }
+        if ($container_type_part instanceof TClosure) {
+            if ($input_type_part instanceof TCallable) {
+                if (CallableTypeComparator::isContainedBy(
+                    $codebase,
+                    $input_type_part,
+                    $container_type_part,
+                    $atomic_comparison_result
+                ) === false
+                ) {
+                    return false;
+                }
 
-            if ($atomic_comparison_result) {
-                $atomic_comparison_result->type_coerced = true;
+                if ($atomic_comparison_result) {
+                    $atomic_comparison_result->type_coerced = true;
+                }
             }
 
             return false;
-        }
-
-        if ($container_type_part instanceof TClosure) {
-            if (!$input_type_part instanceof TClosure) {
-                if ($atomic_comparison_result) {
-                    $atomic_comparison_result->type_coerced = true;
-                    $atomic_comparison_result->type_coerced_from_mixed = true;
-                }
-
-                return false;
-            }
-
-            return CallableTypeComparator::isContainedBy(
-                $codebase,
-                $input_type_part,
-                $container_type_part,
-                $atomic_comparison_result
-            );
         }
 
         if ($container_type_part instanceof TCallable && $input_type_part instanceof TClosure) {

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -1043,6 +1043,14 @@ class ClosureTest extends TestCase
                 false,
                 '7.4'
             ],
+            'closureInvalidArg' => [
+                '<?php
+                    /** @param Closure(int): string $c */
+                    function takesClosure(Closure $c): void {}
+
+                    takesClosure(5);',
+                'error_message' => 'InvalidArgument',
+            ],
         ];
     }
 }


### PR DESCRIPTION
When an explicit `Closure(Foo):Bar` type is given this code results in a `MixedArgumentTypeCoercion`.

It should just be an `InvalidArgument`: https://psalm.dev/r/0880d5dfe8

Seen in the course of my ongoing deep audit (rewriting most of the logic in Rust, with changes for Hack).