### PR TITLE
Fixed ignoreTypeStats & useStrictTypes flag value detection for directories in config

### DIFF
--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -111,12 +111,8 @@ class FileFilter
             /** @var array $directory */
             foreach ($config['directory'] as $directory) {
                 $directory_path = (string) ($directory['name'] ?? '');
-                $ignore_type_stats = strtolower(
-                    isset($directory['ignoreTypeStats']) ? (string) $directory['ignoreTypeStats'] : ''
-                ) === 'true';
-                $declare_strict_types = strtolower(
-                    isset($directory['useStrictTypes']) ? (string) $directory['useStrictTypes'] : ''
-                ) === 'true';
+                $ignore_type_stats = (bool) ($directory['ignoreTypeStats'] ?? false);
+                $declare_strict_types = (bool) ($directory['useStrictTypes'] ?? false);
 
                 if ($directory_path[0] === '/' && DIRECTORY_SEPARATOR === '/') {
                     $prospective_directory_path = $directory_path;
@@ -350,13 +346,8 @@ class FileFilter
             foreach ($e->directory as $directory) {
                 $config['directory'][] = [
                     'name' => (string) $directory['name'],
-                    'ignoreTypeStats' => strtolower(
-                        isset($directory['ignoreTypeStats']) ? (string) $directory['ignoreTypeStats'] : ''
-                    ) === 'true',
-
-                    'useStrictTypes' => strtolower(
-                        isset($directory['useStrictTypes']) ? (string) $directory['useStrictTypes'] : ''
-                    ) === 'true',
+                    'ignoreTypeStats' => strtolower((string) ($directory['ignoreTypeStats'] ?? '')) === 'true',
+                    'useStrictTypes' => strtolower((string) ($directory['useStrictTypes'] ?? '')) === 'true',
                 ];
             }
         }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -1483,4 +1483,70 @@ class ConfigTest extends TestCase
         self::assertSame(get_class($analyzerMock), $config->getFiletypeAnalyzers()[$extension] ?? null);
         self::assertNull($expectedExceptionCode, 'Expected exception code was not thrown');
     }
+
+    public function testTypeStatsForFileReporting(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            Config::loadFromXML(
+                (string) getcwd(),
+                '<?xml version="1.0"?>
+                <psalm>
+                    <projectFiles>
+                        <directory ignoreTypeStats="true" name="src/Psalm/Config" />
+                        <directory ignoreTypeStats="1" name="src/Psalm/Internal" />
+                        <directory ignoreTypeStats="true1" name="src/Psalm/Issue" />
+                        <directory ignoreTypeStats="false" name="src/Psalm/Node" />
+                        <directory ignoreTypeStats="invalid" name="src/Psalm/Plugin" />
+                        <directory ignoreTypeStats="0" name="src/Psalm/Progress" />
+                        <directory ignoreTypeStats="" name="src/Psalm/Report" />
+                        <directory name="src/Psalm/SourceControl" />
+                    </projectFiles>
+                </psalm>'
+            )
+        );
+
+        $config = $this->project_analyzer->getConfig();
+
+        $this->assertFalse($config->reportTypeStatsForFile(realpath('src/Psalm/Config') . DIRECTORY_SEPARATOR));
+        $this->assertTrue($config->reportTypeStatsForFile(realpath('src/Psalm/Internal') . DIRECTORY_SEPARATOR));
+        $this->assertTrue($config->reportTypeStatsForFile(realpath('src/Psalm/Issue') . DIRECTORY_SEPARATOR));
+        $this->assertTrue($config->reportTypeStatsForFile(realpath('src/Psalm/Node') . DIRECTORY_SEPARATOR));
+        $this->assertTrue($config->reportTypeStatsForFile(realpath('src/Psalm/Plugin') . DIRECTORY_SEPARATOR));
+        $this->assertTrue($config->reportTypeStatsForFile(realpath('src/Psalm/Progress') . DIRECTORY_SEPARATOR));
+        $this->assertTrue($config->reportTypeStatsForFile(realpath('src/Psalm/Report') . DIRECTORY_SEPARATOR));
+        $this->assertTrue($config->reportTypeStatsForFile(realpath('src/Psalm/SourceControl') . DIRECTORY_SEPARATOR));
+    }
+
+    public function testStrictTypesForFileReporting(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            Config::loadFromXML(
+                (string) getcwd(),
+                '<?xml version="1.0"?>
+                <psalm>
+                    <projectFiles>
+                        <directory useStrictTypes="true" name="src/Psalm/Config" />
+                        <directory useStrictTypes="1" name="src/Psalm/Internal" />
+                        <directory useStrictTypes="true1" name="src/Psalm/Issue" />
+                        <directory useStrictTypes="false" name="src/Psalm/Node" />
+                        <directory useStrictTypes="invalid" name="src/Psalm/Plugin" />
+                        <directory useStrictTypes="0" name="src/Psalm/Progress" />
+                        <directory useStrictTypes="" name="src/Psalm/Report" />
+                        <directory name="src/Psalm/SourceControl" />
+                    </projectFiles>
+                </psalm>'
+            )
+        );
+
+        $config = $this->project_analyzer->getConfig();
+
+        $this->assertTrue($config->useStrictTypesForFile(realpath('src/Psalm/Config') . DIRECTORY_SEPARATOR));
+        $this->assertFalse($config->useStrictTypesForFile(realpath('src/Psalm/Internal') . DIRECTORY_SEPARATOR));
+        $this->assertFalse($config->useStrictTypesForFile(realpath('src/Psalm/Issue') . DIRECTORY_SEPARATOR));
+        $this->assertFalse($config->useStrictTypesForFile(realpath('src/Psalm/Node') . DIRECTORY_SEPARATOR));
+        $this->assertFalse($config->useStrictTypesForFile(realpath('src/Psalm/Plugin') . DIRECTORY_SEPARATOR));
+        $this->assertFalse($config->useStrictTypesForFile(realpath('src/Psalm/Progress') . DIRECTORY_SEPARATOR));
+        $this->assertFalse($config->useStrictTypesForFile(realpath('src/Psalm/Report') . DIRECTORY_SEPARATOR));
+        $this->assertFalse($config->useStrictTypesForFile(realpath('src/Psalm/SourceControl') . DIRECTORY_SEPARATOR));
+    }
 }


### PR DESCRIPTION
I've noticed that setting any of `ignoreTypeStats="true"` or `useStrictTypes="true"` flag for directories in config file is ignored due to a bug in `Psalm\Config\FileFilter`

`FileFilter::loadFromXMLElement()` reads these flags and turns them into boolean values, then pass the config array to `FileFilter::loadFromArray()`. loadFromArray reads the flag value again, but this time the function treats the values as string instead of boolean. As a result, it cannot properly detect the value.

I've tried to fix the behavior with this PR.

Note: I wasn't able to understand the purpose of `useStrictTypes=true`. Can you please let me know what difference does it make?