### PR TITLE
Use InvalidScalarArgument only when we can be sure PHP attempts coercion

### DIFF
--- a/docs/running_psalm/issues/InvalidScalarArgument.md
+++ b/docs/running_psalm/issues/InvalidScalarArgument.md
@@ -1,6 +1,10 @@
 # InvalidScalarArgument
 
-Emitted when a scalar value is passed to a method that expected another scalar type
+Emitted when a scalar value is passed to a method that expected another scalar type.
+
+This is only emitted in situations where Psalm can be sure that PHP tries to coerce one scalar type to another.
+
+In all other cases `InvalidArgument` is emitted.
 
 ```php
 <?php

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -983,7 +983,7 @@ class ArgumentAnalyzer
                     ),
                     $statements_analyzer->getSuppressedIssues()
                 );
-            } else {
+            } elseif ($cased_method_id !== 'echo' && $cased_method_id !== 'print') {
                 IssueBuffer::maybeAdd(
                     new ArgumentTypeCoercion(
                         'Argument ' . ($argument_offset + 1) . $method_identifier . ' expects ' . $param_type->getId() .

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -27,6 +27,7 @@ use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNonEmptyLowercaseString;
 use Psalm\Type\Atomic\TNonEmptyNonspecificLiteralString;
+use Psalm\Type\Atomic\TNonEmptyScalar;
 use Psalm\Type\Atomic\TNonEmptyString;
 use Psalm\Type\Atomic\TNonFalsyString;
 use Psalm\Type\Atomic\TNonspecificLiteralInt;
@@ -297,7 +298,7 @@ class ScalarTypeComparator
             if ($atomic_comparison_result) {
                 $atomic_comparison_result->type_coerced = true;
                 $atomic_comparison_result->type_coerced_from_mixed = true;
-                $atomic_comparison_result->scalar_type_match_found = true;
+                $atomic_comparison_result->scalar_type_match_found = !$container_type_part->from_docblock;
             }
 
             return false;
@@ -619,7 +620,8 @@ class ScalarTypeComparator
         if ($input_type_part instanceof TNumeric) {
             if ($container_type_part->isNumericType()) {
                 if ($atomic_comparison_result) {
-                    $atomic_comparison_result->scalar_type_match_found = true;
+                    $atomic_comparison_result->type_coerced = true;
+                    $atomic_comparison_result->scalar_type_match_found = !$container_type_part->from_docblock;
                 }
             }
         }
@@ -630,7 +632,10 @@ class ScalarTypeComparator
                 && !$container_type_part instanceof TLiteralFloat
             ) {
                 if ($atomic_comparison_result) {
-                    $atomic_comparison_result->scalar_type_match_found = true;
+                    $atomic_comparison_result->type_coerced
+                        = $atomic_comparison_result->type_coerced_from_scalar
+                        = ($input_type_part instanceof TScalar || $input_type_part instanceof TNonEmptyScalar);
+                    $atomic_comparison_result->scalar_type_match_found = !$container_type_part->from_docblock;
                 }
             }
         }

--- a/src/Psalm/Internal/Type/Comparator/TypeComparisonResult.php
+++ b/src/Psalm/Internal/Type/Comparator/TypeComparisonResult.php
@@ -7,7 +7,12 @@ use Psalm\Type\Union;
 
 class TypeComparisonResult
 {
-    /** @var ?bool */
+    /**
+     * This is used to trigger `InvalidScalarArgument` in situations where we know PHP
+     * will try to coerce one scalar type to another.
+     *
+     * @var ?bool
+     */
     public $scalar_type_match_found;
 
     /** @var ?bool */

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1864,7 +1864,7 @@ class AnnotationTest extends TestCase
 
                     $a = 1;
                     foo($a);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'spreadOperatorByRefAnnotationBadCall2' => [
                 '<?php
@@ -1873,7 +1873,7 @@ class AnnotationTest extends TestCase
 
                     $b = 2;
                     foo($b);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'spreadOperatorByRefAnnotationBadCall3' => [
                 '<?php
@@ -1882,7 +1882,7 @@ class AnnotationTest extends TestCase
 
                     $c = 3;
                     foo($c);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'identifyReturnType' => [
                 '<?php

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -160,9 +160,9 @@ class ArgTest extends TestCase
                     function foo($b) : void {}
                     foo(null);',
             ],
-            'allowArrayIntScalarForArrayStringWithScalarIgnored' => [
+            'allowArrayIntScalarForArrayStringWithArgumentTypeCoercionIgnored' => [
                 '<?php
-                    /** @param array<int|string> $arr */
+                    /** @param array<array-key> $arr */
                     function foo(array $arr) : void {
                     }
 
@@ -171,10 +171,10 @@ class ArgTest extends TestCase
                       return [];
                     }
 
-                    /** @psalm-suppress InvalidScalarArgument */
+                    /** @psalm-suppress ArgumentTypeCoercion */
                     foo(bar());',
             ],
-            'allowArrayScalarForArrayStringWithScalarIgnored' => [
+            'allowArrayScalarForArrayStringWithArgumentTypeCoercionIgnored' => [
                 '<?php declare(strict_types=1);
                     /** @param array<string> $arr */
                     function foo(array $arr) : void {}
@@ -184,7 +184,7 @@ class ArgTest extends TestCase
                         return [];
                     }
 
-                    /** @psalm-suppress InvalidScalarArgument */
+                    /** @psalm-suppress ArgumentTypeCoercion */
                     foo(bar());',
             ],
             'unpackObjectlikeListArgs' => [

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1887,7 +1887,7 @@ class ArrayAssignmentTest extends TestCase
                     $a[] = 2;
 
                     takesArray($a);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'listUsedAsArrayWrongListType' => [
                 '<?php
@@ -1899,7 +1899,7 @@ class ArrayAssignmentTest extends TestCase
                     $a[] = 2;
 
                     takesArray($a);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'nonEmptyAssignmentToListElementChangeType' => [
                 '<?php

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -1390,7 +1390,7 @@ class CallableTest extends TestCase
                     function foo(string $c) : void {
                         takesCallableReturningString([$c, "bar"]);
                     }',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'inexistantCallableinCallableString' => [
                 '<?php

--- a/tests/DocblockInheritanceTest.php
+++ b/tests/DocblockInheritanceTest.php
@@ -173,7 +173,7 @@ class DocblockInheritanceTest extends TestCase
                     }
 
                     (new X())->boo([1, 2]);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
         ];
     }

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1941,7 +1941,7 @@ class FunctionCallTest extends TestCase
                     }
 
                     a(["a" => "hello"]);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'objectLikeKeyChecksAgainstDifferentTKeyedArray' => [
                 '<?php

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -722,7 +722,7 @@ class IncludeTest extends TestCase
                 'files_to_check' => [
                     getcwd() . DIRECTORY_SEPARATOR . 'file2.php',
                 ],
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'namespacedRequireFunction' => [
                 'files' => [

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -813,7 +813,7 @@ class MagicMethodAnnotationTest extends TestCase
                     $child = new Child();
 
                     $child->setString("five");',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'unionAnnotationInvalidArg' => [
                 '<?php
@@ -829,7 +829,7 @@ class MagicMethodAnnotationTest extends TestCase
                     $child = new Child();
 
                     $b = $child->setBool("hello", 5);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'validAnnotationWithInvalidVariadicCall' => [
                 '<?php

--- a/tests/Template/ClassTemplateExtendsTest.php
+++ b/tests/Template/ClassTemplateExtendsTest.php
@@ -4626,7 +4626,7 @@ class ClassTemplateExtendsTest extends TestCase
                     class AppUser extends User {}
 
                     $au = new AppUser("string");',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'extendsTwiceDifferentNameBrokenChain' => [
                 '<?php

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -3822,7 +3822,7 @@ class ClassTemplateTest extends TestCase
 
                     takesStringCollection($collection);
                     takesIntCollection($collection);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'argumentExpectsFleshOutTIndexedAccess' => [
                 '<?php

--- a/tests/Template/FunctionTemplateTest.php
+++ b/tests/Template/FunctionTemplateTest.php
@@ -1811,7 +1811,7 @@ class FunctionTemplateTest extends TestCase
                     function takesReturnTCallable(callable $s) {}
 
                     takesReturnTCallable($b);',
-                'error_message' => 'InvalidScalarArgument',
+                'error_message' => 'InvalidArgument',
             ],
             'multipleArgConstraintWithMoreRestrictiveFirstArg' => [
                 '<?php


### PR DESCRIPTION
This is an alternative to https://github.com/vimeo/psalm/pull/7181

It narrows the occasions where `InvalidScalarArgument` is emitted to only the places where we're sure that PHP will attempt to coerce one scalar type to another. This matches the original intent of `InvalidScalarArgument` — a lesser issue than `InvalidArgument`, for when the PHP runtime may not care.