### PR TITLE
fix #7178 again

### DIFF
--- a/stubs/Reflection.phpstub
+++ b/stubs/Reflection.phpstub
@@ -51,7 +51,7 @@ class ReflectionClass implements Reflector {
      * @since 8.0
      * @template TClass as object
      * @param class-string<TClass>|null $name
-     * @return (TClass is object ? array<ReflectionAttribute<TClass>> : array<ReflectionAttribute<object>>)
+     * @return ($name is null ? array<ReflectionAttribute<object>> : array<ReflectionAttribute<TClass>>)
      */
     public function getAttributes(?string $name = null, int $flags = 0): array {}
 }

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -104,26 +104,15 @@ class AttributeTest extends TestCase
             ],
             'testReflectingAllAttributes' => [
                 '<?php
+                    /** @var class-string $a */
+                    $cs = stdClass::class;
 
-                    final class a
-                    {
-                        /**
-                         * @psalm-param class-string $className
-                         */
-                        public function a(string $className): void
-                        {
-                            $a = new ReflectionClass($className);
-                            $b = $a->getAttributes();
-                            scope($b);
-                        }
-                    }
-
-                    /** @param array<ReflectionAttribute<object>> $_a */
-                    function scope($_a):void{
-
-                    }
+                    $a = new ReflectionClass($cs);
+                    $b = $a->getAttributes();
                     ',
-                [],
+                'assertions' => [
+                    '$b' => 'array<array-key, ReflectionAttribute<object>>',
+                ],
                 [],
                 '8.0'
             ],


### PR DESCRIPTION
The fix in #7180 for #7178 was not correct. The test I made was passing because `array<ReflectionAttribute<empty>>` is an acceptable value for `array<ReflectionAttribute<object>>`. This PR should fix the issue and fix the test