### PR TITLE
allow marking enum cases as deprecated

### DIFF
--- a/docs/running_psalm/issues/DeprecatedConstant.md
+++ b/docs/running_psalm/issues/DeprecatedConstant.md
@@ -1,6 +1,6 @@
 # DeprecatedConstant
 
-Emitted when referring to a deprecated constant:
+Emitted when referring to a deprecated constant or enum case:
 
 ```php
 <?php
@@ -11,6 +11,13 @@ class A {
 }
 
 echo A::FOO;
+
+enum B {
+    /** @deprecated */
+    case B;
+}
+
+echo B::B;
 ```
 
 ## Why this is bad
@@ -19,4 +26,4 @@ The `@deprecated` tag is normally indicative of code that will stop working in t
 
 ## How to fix
 
-Don’t use the deprecated constant.
+Don’t use the deprecated constant or enum case

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -218,6 +218,18 @@ class ClassConstFetchAnalyzer
             }
 
             $const_class_storage = $codebase->classlike_storage_provider->get($fq_class_name);
+            if ($const_class_storage->is_enum) {
+                $case = $const_class_storage->enum_cases[(string)$stmt->name] ?? null;
+                if ($case && $case->deprecated) {
+                    IssueBuffer::maybeAdd(
+                        new DeprecatedConstant(
+                            "Enum Case $const_id is marked as deprecated",
+                            new CodeLocation($statements_analyzer->getSource(), $stmt)
+                        ),
+                        $statements_analyzer->getSuppressedIssues()
+                    );
+                }
+            }
 
             if ($fq_class_name === $context->self
                 || (

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -1345,10 +1345,20 @@ class ClassLikeNodeScanner
         $case_location = new CodeLocation($this->file_scanner, $stmt);
 
         if (!isset($storage->enum_cases[$stmt->name->name])) {
-            $storage->enum_cases[$stmt->name->name] = new EnumCaseStorage(
+            $case = new EnumCaseStorage(
                 $enum_value,
                 $case_location
             );
+
+            $comment = $stmt->getDocComment();
+            if ($comment) {
+                $comments = DocComment::parsePreservingLength($comment);
+
+                if (isset($comments->tags['deprecated'])) {
+                    $case->deprecated = true;
+                }
+            }
+            $storage->enum_cases[$stmt->name->name] = $case;
         } else {
             if (IssueBuffer::accepts(
                 new DuplicateEnumCase(

--- a/src/Psalm/Storage/EnumCaseStorage.php
+++ b/src/Psalm/Storage/EnumCaseStorage.php
@@ -15,6 +15,11 @@ class EnumCaseStorage
     public $stmt_location;
 
     /**
+     * @var bool
+     */
+    public $deprecated = false;
+
+    /**
      * @param int|string|null  $value
      */
     public function __construct(

--- a/tests/DeprecatedAnnotationTest.php
+++ b/tests/DeprecatedAnnotationTest.php
@@ -251,6 +251,22 @@ class DeprecatedAnnotationTest extends TestCase
                     ',
                 'error_message' => 'DeprecatedProperty',
             ],
+            'deprecatedEnumCaseFetch' => [
+                '<?php
+                    enum Foo {
+                        case A;
+
+                        /** @deprecated */
+                        case B;
+                    }
+
+                    Foo::B;
+                ',
+                'error_message' => 'DeprecatedConstant',
+                [],
+                false,
+                '8.1',
+            ]
         ];
     }
 }

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -314,6 +314,7 @@ class DocumentationTest extends TestCase
                 case 'DuplicateEnumCase':
                 case 'DuplicateEnumCaseValue':
                 case 'NoEnumProperties':
+                case 'DeprecatedConstant':
                     $php_version = '8.1';
                     break;
             }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -591,6 +591,22 @@ class EnumTest extends TestCase
                 false,
                 '8.1',
             ],
+            'deprecatedAttribute' => [
+                '<?php
+                    enum Foo {
+                        case A;
+
+                        #[Psalm\Deprecated]
+                        case B;
+                    }
+
+                    Foo::B;
+                    ',
+                'error_message' => 'DeprecatedConstant',
+                [],
+                false,
+                '8.1',
+            ],
         ];
     }
 }


### PR DESCRIPTION
This PR will allow an `@deprecated` annotation to be placed on enum cases which will then cause a `DeprecatedConstant` issue to be raised when the case is being referenced.

I'm unsure as to whether this is the correct way to do things as I'm not too familiar with the psalm internals, so I'm very happy about pointers in how to do this correctly.

~~Also, ideally, I would like to have supported the `#[Psalm\Deprecated]` attribute too, but I don't think the php parser is exposing attributes on enum cases - at least I could not get to them, but maybe I looked in the wrong spot.~~