### PR TITLE
allow destructuring on a possible null variable as long as there is an array alongside

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -1212,17 +1212,6 @@ class AssignmentAnalyzer
                     );
                 } elseif ($assign_value_atomic_type instanceof TNull) {
                     $has_null = true;
-
-                    if (IssueBuffer::accepts(
-                        new PossiblyNullArrayAccess(
-                            'Cannot access array value on null variable ' . $array_var_id,
-                            new CodeLocation($statements_analyzer->getSource(), $var)
-                        ),
-                        $statements_analyzer->getSuppressedIssues()
-                    )
-                    ) {
-                        // do nothing
-                    }
                 } elseif (!$assign_value_atomic_type instanceof TArray
                     && !$assign_value_atomic_type instanceof TKeyedArray
                     && !$assign_value_atomic_type instanceof TList
@@ -1407,6 +1396,16 @@ class AssignmentAnalyzer
 
 
             if (!$assigned) {
+                if ($has_null) {
+                    IssueBuffer::maybeAdd(
+                        new PossiblyNullArrayAccess(
+                            'Cannot access array value on null variable ' . $array_var_id,
+                            new CodeLocation($statements_analyzer->getSource(), $var)
+                        ),
+                        $statements_analyzer->getSuppressedIssues()
+                    );
+                }
+
                 foreach ($var_comments as $var_comment) {
                     if (!$var_comment->type) {
                         continue;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -1404,6 +1404,8 @@ class AssignmentAnalyzer
                 }
             }
 
+
+
             if (!$assigned) {
                 foreach ($var_comments as $var_comment) {
                     if (!$var_comment->type) {
@@ -1437,12 +1439,6 @@ class AssignmentAnalyzer
 
                 if ($list_var_id) {
                     $context->vars_in_scope[$list_var_id] = $new_assign_type ?: Type::getMixed();
-
-                    if (($context->error_suppressing && ($offset || $can_be_empty))
-                        || $has_null
-                    ) {
-                        $context->vars_in_scope[$list_var_id]->addType(new TNull);
-                    }
 
                     if ($statements_analyzer->data_flow_graph) {
                         $data_flow_graph = $statements_analyzer->data_flow_graph;
@@ -1483,6 +1479,14 @@ class AssignmentAnalyzer
                             }
                         }
                     }
+                }
+            }
+
+            if ($list_var_id) {
+                if (($context->error_suppressing && ($offset || $can_be_empty))
+                    || $has_null
+                ) {
+                    $context->vars_in_scope[$list_var_id]->addType(new TNull);
                 }
             }
         }

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1716,6 +1716,25 @@ class ArrayAssignmentTest extends TestCase
                 [],
                 '8.1'
             ],
+            'nullableDestructuring' => [
+                '<?php
+                    /**
+                     * @return array{"foo", "bar"}|null
+                     */
+                    function foobar(): ?array
+                    {
+                        return null;
+                    }
+
+                    [$_foo, $_bar] = foobar();
+                    ',
+                'assertions' => [
+                    '$_foo' => 'null|string',
+                    '$_bar' => 'null|string',
+                ],
+                [],
+                '8.1'
+            ],
         ];
     }
 


### PR DESCRIPTION
This PR will fix https://github.com/vimeo/psalm/issues/7151 by only emitting PossiblyNullArrayAccess if there was no successful destructuring (as this is not a PHP issue nor a user error)

Also, this adds `null` to the generated type if it was present on the source type