### PR TITLE
fix wrong handling of flags in context

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -223,6 +223,8 @@ class ForeachAnalyzer
         $was_inside_general_use = $context->inside_general_use;
         $context->inside_general_use = true;
         if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->expr, $context) === false) {
+            $context->inside_general_use = $was_inside_general_use;
+
             return false;
         }
         $context->inside_general_use = $was_inside_general_use;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
@@ -163,13 +163,15 @@ class IfConditionalAnalyzer
             $referenced_var_ids = $first_cond_referenced_var_ids;
             $if_conditional_context->referenced_var_ids = [];
 
+            $was_inside_conditional = $if_conditional_context->inside_conditional;
+
             $if_conditional_context->inside_conditional = true;
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $cond, $if_conditional_context) === false) {
                 throw new ScopeAnalysisException();
             }
 
-            $if_conditional_context->inside_conditional = false;
+            $if_conditional_context->inside_conditional = $was_inside_conditional;
 
             /** @var array<string, bool> */
             $more_cond_referenced_var_ids = $if_conditional_context->referenced_var_ids;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
@@ -134,9 +134,7 @@ class IfConditionalAnalyzer
             $first_cond_referenced_var_ids
         );
 
-        if (!$was_inside_conditional) {
-            $outer_context->inside_conditional = false;
-        }
+        $outer_context->inside_conditional = $was_inside_conditional;
 
         if (!$if_context) {
             $if_context = clone $outer_context;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
@@ -622,6 +622,8 @@ class LoopAnalyzer
         $pre_referenced_var_ids = $loop_context->referenced_var_ids;
         $loop_context->referenced_var_ids = [];
 
+        $was_inside_conditional = $loop_context->inside_conditional;
+
         $loop_context->inside_conditional = true;
 
         $suppressed_issues = $statements_analyzer->getSuppressedIssues();
@@ -637,10 +639,12 @@ class LoopAnalyzer
         }
 
         if (ExpressionAnalyzer::analyze($statements_analyzer, $pre_condition, $loop_context) === false) {
+            $loop_context->inside_conditional = $was_inside_conditional;
+            
             return [];
         }
 
-        $loop_context->inside_conditional = false;
+        $loop_context->inside_conditional = $was_inside_conditional;
 
         $new_referenced_var_ids = $loop_context->referenced_var_ids;
         $loop_context->referenced_var_ids = array_merge($pre_referenced_var_ids, $new_referenced_var_ids);

--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php
@@ -31,12 +31,17 @@ class SwitchAnalyzer
     ): void {
         $codebase = $statements_analyzer->getCodebase();
 
+        $was_inside_conditional = $context->inside_conditional;
+
         $context->inside_conditional = true;
+
         if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->cond, $context) === false) {
+            $context->inside_conditional = $was_inside_conditional;
+
             return;
         }
 
-        $context->inside_conditional = false;
+        $context->inside_conditional = $was_inside_conditional;
 
         $switch_var_id = ExpressionIdentifier::getArrayVarId(
             $stmt->cond,

--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
@@ -114,9 +114,7 @@ class SwitchCaseAnalyzer
                 return false;
             }
 
-            if (!$was_inside_conditional) {
-                $case_context->inside_conditional = false;
-            }
+            $case_context->inside_conditional = $was_inside_conditional;
 
             $statements_analyzer->node_data = clone $statements_analyzer->node_data;
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -311,6 +311,8 @@ class ArrayAnalyzer
             $was_inside_general_use = $context->inside_general_use;
             $context->inside_general_use = true;
             if (ExpressionAnalyzer::analyze($statements_analyzer, $item->key, $context) === false) {
+                $context->inside_general_use = $was_inside_general_use;
+
                 return;
             }
             $context->inside_general_use = $was_inside_general_use;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -712,6 +712,8 @@ class ArrayAssignmentAnalyzer
                     $child_stmt->dim,
                     $context
                 ) === false) {
+                    $context->inside_general_use = $was_inside_general_use;
+
                     return;
                 }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php
@@ -82,6 +82,8 @@ class StaticPropertyAssignmentAnalyzer
                 $context->inside_general_use = true;
 
                 if (ExpressionAnalyzer::analyze($statements_analyzer, $prop_name, $context) === false) {
+                    $context->inside_general_use = $was_inside_general_use;
+
                     return false;
                 }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -551,9 +551,7 @@ class AssignmentAnalyzer
 
                 $context->vars_in_scope[$var_id] = Type::getNull();
 
-                if (!$was_in_assignment) {
-                    $context->inside_assignment = false;
-                }
+                $context->inside_assignment = $was_in_assignment;
 
                 return $context->vars_in_scope[$var_id];
             }
@@ -571,9 +569,7 @@ class AssignmentAnalyzer
 
                 $context->vars_in_scope[$var_id] = Type::getEmpty();
 
-                if (!$was_in_assignment) {
-                    $context->inside_assignment = false;
-                }
+                $context->inside_assignment = $was_in_assignment;
 
                 return $context->vars_in_scope[$var_id];
             }
@@ -612,9 +608,7 @@ class AssignmentAnalyzer
             }
         }
 
-        if (!$was_in_assignment) {
-            $context->inside_assignment = false;
-        }
+        $context->inside_assignment = $was_in_assignment;
 
         return $assign_value_type;
     }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -236,6 +236,8 @@ class AssignmentAnalyzer
             }
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $assign_value, $context) === false) {
+                $context->inside_general_use = $was_inside_general_use;
+
                 if ($var_id) {
                     if ($array_var_id) {
                         $context->removeDescendents($array_var_id, null, $assign_value_type);
@@ -1501,10 +1503,14 @@ class AssignmentAnalyzer
             // this can happen when the user actually means to type $this-><autocompleted>, but there's
             // a variable on the next line
             if (ExpressionAnalyzer::analyze($statements_analyzer, $assign_var->var, $context) === false) {
+                $context->inside_general_use = $was_inside_general_use;
+
                 return;
             }
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $assign_var->name, $context) === false) {
+                $context->inside_general_use = $was_inside_general_use;
+
                 return;
             }
 
@@ -1693,6 +1699,8 @@ class AssignmentAnalyzer
             $context->inside_general_use = true;
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $assign_var->name, $context) === false) {
+                $context->inside_general_use = $was_inside_general_use;
+
                 return;
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -214,9 +214,7 @@ class ArgumentsAnalyzer
                 return false;
             }
 
-            if (!$was_inside_call) {
-                $context->inside_call = false;
-            }
+            $context->inside_call = $was_inside_call;
 
             if (($argument_offset === 0 && $method_id === 'array_filter' && count($args) === 2)
                 || ($argument_offset > 0 && $method_id === 'array_map' && count($args) >= 2)
@@ -1121,9 +1119,7 @@ class ArgumentsAnalyzer
                 return false;
             }
 
-            if (!$was_inside_call) {
-                $context->inside_call = false;
-            }
+            $context->inside_call = $was_inside_call;
         }
 
         if ($arg->value instanceof PhpParser\Node\Expr\PropertyFetch

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -211,6 +211,8 @@ class ArgumentsAnalyzer
             $context->inside_call = true;
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $arg->value, $context) === false) {
+                $context->inside_call = $was_inside_call;
+
                 return false;
             }
 
@@ -1116,6 +1118,8 @@ class ArgumentsAnalyzer
             $context->inside_call = true;
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $arg->value, $context) === false) {
+                $context->inside_call = $was_inside_call;
+
                 return false;
             }
 
@@ -1225,6 +1229,8 @@ class ArgumentsAnalyzer
                 $arg->value,
                 $context
             ) === false) {
+                $context->inside_assignment = $was_inside_assignment;
+
                 return false;
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
@@ -163,6 +163,8 @@ class ArrayFunctionArgumentsAnalyzer
                     $args[$i]->value,
                     $context
                 ) === false) {
+                    $context->inside_assignment = $was_inside_assignment;
+
                     return false;
                 }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -61,6 +61,8 @@ class MethodCallAnalyzer extends CallAnalyzer
         if ($existing_stmt_var_type) {
             $statements_analyzer->node_data->setType($stmt->var, $existing_stmt_var_type);
         } elseif (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->var, $context) === false) {
+            $context->inside_call = $was_inside_call;
+
             return false;
         }
 
@@ -70,6 +72,8 @@ class MethodCallAnalyzer extends CallAnalyzer
             $context->inside_call = true;
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->name, $context) === false) {
+                $context->inside_call = $was_inside_call;
+
                 return false;
             }
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -186,6 +186,8 @@ class CastAnalyzer
             $was_inside_general_use = $context->inside_general_use;
             $context->inside_general_use = true;
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->expr, $context) === false) {
+                $context->inside_general_use = $was_inside_general_use;
+
                 return false;
             }
             $context->inside_general_use = $was_inside_general_use;
@@ -208,6 +210,8 @@ class CastAnalyzer
             $was_inside_general_use = $context->inside_general_use;
             $context->inside_general_use = true;
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->expr, $context) === false) {
+                $context->inside_general_use = $was_inside_general_use;
+
                 return false;
             }
             $context->inside_general_use = $was_inside_general_use;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -119,6 +119,9 @@ class ArrayFetchAnalyzer
             $context->inside_unset = false;
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->dim, $context) === false) {
+                $context->inside_unset = $was_inside_unset;
+                $context->inside_general_use = $was_inside_general_use;
+
                 return false;
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -380,6 +380,8 @@ class ClassConstFetchAnalyzer
         $context->inside_general_use = true;
 
         if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->class, $context) === false) {
+            $context->inside_general_use = $was_inside_general_use;
+
             return false;
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
@@ -51,6 +51,8 @@ class InstancePropertyFetchAnalyzer
         }
 
         if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->var, $context) === false) {
+            $context->inside_general_use = $was_inside_general_use;
+
             return false;
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
@@ -31,15 +31,12 @@ class IncDecExpressionAnalyzer
         $context->inside_assignment = true;
 
         if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->var, $context) === false) {
-            if (!$was_inside_assignment) {
-                $context->inside_assignment = false;
-            }
+            $context->inside_assignment = $was_inside_assignment;
+
             return false;
         }
 
-        if (!$was_inside_assignment) {
-            $context->inside_assignment = false;
-        }
+        $context->inside_assignment = $was_inside_assignment;
 
         $stmt_var_type = $statements_analyzer->node_data->getType($stmt->var);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -70,9 +70,7 @@ class IncludeAnalyzer
             return false;
         }
 
-        if (!$was_inside_call) {
-            $context->inside_call = false;
-        }
+        $context->inside_call = $was_inside_call;
 
         $stmt_expr_type = $statements_analyzer->node_data->getType($stmt->expr);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -67,6 +67,8 @@ class IncludeAnalyzer
         $context->inside_call = true;
 
         if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->expr, $context) === false) {
+            $context->inside_call = $was_inside_call;
+
             return false;
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/InstanceofAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/InstanceofAnalyzer.php
@@ -25,6 +25,8 @@ class InstanceofAnalyzer
         $context->inside_general_use = true;
 
         if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->expr, $context) === false) {
+            $context->inside_general_use = $was_inside_general_use;
+
             return false;
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/YieldFromAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/YieldFromAnalyzer.php
@@ -47,6 +47,8 @@ class YieldFromAnalyzer
                 $always_non_empty_array
             ) === false
             ) {
+                $context->inside_call = $was_inside_call;
+
                 return false;
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -453,6 +453,8 @@ class ExpressionAnalyzer
             $was_inside_call = $context->inside_call;
             $context->inside_call = true;
             if (PrintAnalyzer::analyze($statements_analyzer, $stmt, $context) === false) {
+                $context->inside_call = $was_inside_call;
+
                 return false;
             }
             $context->inside_call = $was_inside_call;

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -424,9 +424,7 @@ class Methods
                         );
                     }
 
-                    if (!$was_inside_call) {
-                        $context->inside_call = false;
-                    }
+                    $context->inside_call = $was_inside_call;
                 }
 
                 $matching_callable = InternalCallMapHandler::getMatchingCallableFromCallMapOptions(


### PR DESCRIPTION
This PR started when I noticed a weird handling of inside_conditional flag in switch. After looking for more I found a few.

After that, I noticed that we don't always unflag those before leaving an analyzer, mainly when the other analyzer we called returned false.

Not sure this will have any effect whatsoever, but it may fix a few edge cases here and there. It will be less confusing in any case