### PR TITLE
fix(stubs): UnitEnum::cases() can return an empty list

### DIFF
--- a/stubs/Php81.phpstub
+++ b/stubs/Php81.phpstub
@@ -6,7 +6,7 @@ namespace {
 
         /**
          * @psalm-pure
-         * @return non-empty-list<static>
+         * @return list<static>
          */
         public static function cases(): array;
     }


### PR DESCRIPTION
e.g:
```
enum Foo: string {}

$cases = Foo::cases();

```