### PR TITLE
Add early file filtering to `FileProvider::getFilesInDir()`

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -316,9 +316,7 @@ class ProjectAnalyzer
             );
 
             foreach ($file_paths as $file_path) {
-                if ($this->config->isInProjectDirs($file_path)) {
-                    $this->addProjectFile($file_path);
-                }
+                $this->addProjectFile($file_path);
             }
         }
 
@@ -330,9 +328,7 @@ class ProjectAnalyzer
             );
 
             foreach ($file_paths as $file_path) {
-                if ($this->config->isInExtraDirs($file_path)) {
-                    $this->addExtraFile($file_path);
-                }
+                $this->addExtraFile($file_path);
             }
         }
 
@@ -1068,9 +1064,7 @@ class ProjectAnalyzer
         $files_to_scan = [];
 
         foreach ($file_paths as $file_path) {
-            if ($allow_non_project_files || $config->isInProjectDirs($file_path)) {
-                $files_to_scan[$file_path] = $file_path;
-            }
+            $files_to_scan[$file_path] = $file_path;
         }
 
         $this->codebase->addFilesToAnalyze($files_to_scan);

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1053,12 +1053,12 @@ class ProjectAnalyzer
     private function checkDirWithConfig(string $dir_name, Config $config, bool $allow_non_project_files = false): void
     {
         $file_extensions = $config->getFileExtensions();
-        $directory_filter = $allow_non_project_files ? null : [$this->config, 'isInProjectDirs'];
+        $filter = $allow_non_project_files ? null : [$this->config, 'isInProjectDirs'];
 
         $file_paths = $this->file_provider->getFilesInDir(
             $dir_name,
             $file_extensions,
-            $directory_filter
+            $filter
         );
 
         $files_to_scan = [];

--- a/src/Psalm/Internal/Provider/FakeFileProvider.php
+++ b/src/Psalm/Internal/Provider/FakeFileProvider.php
@@ -57,13 +57,13 @@ class FakeFileProvider extends FileProvider
 
     /**
      * @param array<string> $file_extensions
-     * @param null|callable(string):bool $directory_filter
+     * @param null|callable(string):bool $filter
      *
      * @return list<string>
      */
-    public function getFilesInDir(string $dir_path, array $file_extensions, callable $directory_filter = null): array
+    public function getFilesInDir(string $dir_path, array $file_extensions, callable $filter = null): array
     {
-        $file_paths = parent::getFilesInDir($dir_path, $file_extensions, $directory_filter);
+        $file_paths = parent::getFilesInDir($dir_path, $file_extensions, $filter);
 
         foreach ($this->fake_files as $file_path => $_) {
             if (strpos(strtolower($file_path), strtolower($dir_path)) === 0) {

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -118,11 +118,11 @@ class FileProvider
 
     /**
      * @param array<string> $file_extensions
-     * @param null|callable(string):bool $directory_filter
+     * @param null|callable(string):bool $filter
      *
      * @return list<string>
      */
-    public function getFilesInDir(string $dir_path, array $file_extensions, callable $directory_filter = null): array
+    public function getFilesInDir(string $dir_path, array $file_extensions, callable $filter = null): array
     {
         $file_paths = [];
 
@@ -131,12 +131,18 @@ class FileProvider
             FilesystemIterator::CURRENT_AS_PATHNAME | FilesystemIterator::SKIP_DOTS
         );
 
-        if ($directory_filter !== null) {
+        if ($filter !== null) {
             $iterator = new RecursiveCallbackFilterIterator(
                 $iterator,
                 /** @param mixed $_ */
-                function (string $current, $_, RecursiveIterator $iterator) use ($directory_filter): bool {
-                    return !$iterator->hasChildren() || $directory_filter($current . DIRECTORY_SEPARATOR);
+                function (string $current, $_, RecursiveIterator $iterator) use ($filter): bool {
+                    if ($iterator->hasChildren()) {
+                        $path = $current . DIRECTORY_SEPARATOR;
+                    } else {
+                        $path = $current;
+                    }
+
+                    return $filter($path);
                 }
             );
         }


### PR DESCRIPTION
Partially resolves .#7057

Extends the use of `callable $directory_filter` added via #7161 to additionally cover individual files, containing the _project/extra/ignored_ check logic within `FileProvider::getFilesInDir()`.