### PR TITLE
Remove unused in-array assertions

### DIFF
--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -3,7 +3,6 @@
 namespace Psalm\Internal\Type;
 
 use Psalm\CodeLocation;
-use Psalm\Exception\TypeParseTreeException;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Analyzer\TraitAnalyzer;
 use Psalm\Internal\Type\Comparator\AtomicTypeComparator;
@@ -158,35 +157,29 @@ class NegatedAssertionReconciler extends Reconciler
 
             if (strpos($assertion, 'in-array-') === 0) {
                 $assertion = substr($assertion, 9);
-                $new_var_type = null;
-                try {
-                    $new_var_type = Type::parseString($assertion);
-                } catch (TypeParseTreeException $e) {
-                }
+                $new_var_type = Type::parseString($assertion);
 
-                if ($new_var_type) {
-                    $intersection = Type::intersectUnionTypes(
-                        $new_var_type,
-                        $existing_var_type,
-                        $statements_analyzer->getCodebase()
-                    );
+                $intersection = Type::intersectUnionTypes(
+                    $new_var_type,
+                    $existing_var_type,
+                    $statements_analyzer->getCodebase()
+                );
 
-                    if ($intersection === null) {
-                        if ($key && $code_location) {
-                            self::triggerIssueForImpossible(
-                                $existing_var_type,
-                                $existing_var_type->getId(),
-                                $key,
-                                '!' . $assertion,
-                                true,
-                                $negated,
-                                $code_location,
-                                $suppressed_issues
-                            );
-                        }
-
-                        $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
+                if ($intersection === null) {
+                    if ($key && $code_location) {
+                        self::triggerIssueForImpossible(
+                            $existing_var_type,
+                            $existing_var_type->getId(),
+                            $key,
+                            '!' . $assertion,
+                            true,
+                            $negated,
+                            $code_location,
+                            $suppressed_issues
+                        );
                     }
+
+                    $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
                 }
 
                 return $existing_var_type;

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -4,7 +4,6 @@ namespace Psalm\Internal\Type;
 
 use Psalm\CodeLocation;
 use Psalm\Codebase;
-use Psalm\Exception\TypeParseTreeException;
 use Psalm\Internal\Codebase\ClassConstantByWildcardResolver;
 use Psalm\Internal\Codebase\InternalCallMapHandler;
 use Psalm\Internal\Type\TypeCombiner;
@@ -1563,14 +1562,7 @@ class SimpleAssertionReconciler extends Reconciler
         array $suppressed_issues,
         int &$failed_reconciliation
     ): Union {
-        try {
-            $new_var_type = Type::parseString($assertion);
-        } catch (TypeParseTreeException $e) {
-            // Not all assertions can be parsed as type, it's fine.
-            // One particular case is variable array key (e. g. $arr[$key]), which end up as in-array-$arr assertion
-
-            return $existing_var_type;
-        }
+        $new_var_type = Type::parseString($assertion);
 
         $intersection = Type::intersectUnionTypes($new_var_type, $existing_var_type, $codebase);
 

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -415,12 +415,6 @@ class Reconciler
                         && $key_parts[2][0] !== '\''
                         && !is_numeric($key_parts[2])
                     ) {
-                        if (isset($new_types[$key_parts[2]])) {
-                            $new_types[$key_parts[2]][] = ['=in-array-' . $key_parts[0]];
-                        } else {
-                            $new_types[$key_parts[2]] = [['=in-array-' . $key_parts[0]]];
-                        }
-
                         if ($key_parts[0][0] === '$') {
                             if (isset($new_types[$key_parts[0]])) {
                                 $new_types[$key_parts[0]][] = ['=has-array-key-' . $key_parts[2]];


### PR DESCRIPTION
These assertions cannot be parsed, since the `in-array` assertion handler always tries to convert assertions to a type.

This should have a really small performance improvement for array_key_exists checks, but it also just simplifies the code in a pleasing fashion and removes a couple of now-unnecessary `try...catch` blocks.