### PR TITLE
flag the context as "inside_conditional" when analyzing leftover cases to prevent emitting unused error

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php
@@ -320,11 +320,17 @@ class SwitchCaseAnalyzer
             );
 
             if ($new_case_equality_expr) {
+                $was_inside_conditional = $case_context->inside_conditional;
+
+                $case_context->inside_conditional = true;
+
                 ExpressionAnalyzer::analyze(
                     $statements_analyzer,
                     $new_case_equality_expr->getArgs()[1]->value,
                     $case_context
                 );
+
+                $case_context->inside_conditional = $was_inside_conditional;
 
                 $case_equality_expr = $new_case_equality_expr;
             }

--- a/tests/SwitchTypeTest.php
+++ b/tests/SwitchTypeTest.php
@@ -1075,6 +1075,18 @@ class SwitchTypeTest extends TestCase
                         throw new Exception();
                     }'
             ],
+            'switchWithLeftoverFunctionCallUsesTheFunction' => [
+                '<?php
+
+                    function bar (string $name): int {
+                        switch ($name) {
+                                case "a":
+                                case ucfirst("a"):
+                                    return 1;
+                        }
+                        return -1;
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
This should fix #6389

This was due to the analyzing the function call when no [insideUse](https://github.com/vimeo/psalm/blob/97e6511fab6622c1ca434c665dd895e77a0eeca2/src/Psalm/Context.php#L836) was flagged. Psalm emits an Unused error when it sees a pure function call that is not in a "use" context.