### PR TITLE
allow phpcodesniffer-composer-installer plugin

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,7 +62,8 @@
     "config": {
         "allow-plugins": {
             "bamarni/composer-bin-plugin": true,
-            "composer/package-versions-deprecated": true
+            "composer/package-versions-deprecated": true,
+            "dealerdirect/phpcodesniffer-composer-installer": true
         },
         "optimize-autoloader": true,
         "sort-packages": true,


### PR DESCRIPTION
Looks like CI has switched on composer 2.2 and it now warns that a plugin is not allowed.

I'm not sure what the source of the plugin is but I guess there is no reason not to allow it, given it was executed before