### PR TITLE
Composer 2.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '7.1'
-          tools: composer:v2
+          tools: composer:v2.1
           coverage: none
 
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
-          tools: composer:v2
+          tools: composer:v2.1
           coverage: none
           extensions: decimal
 


### PR DESCRIPTION
*This is a draft not meant to be merged for now*

This reverts the CI to run on Composer 2.1. For a mysterious reason, Composer 2.2 makes CI hangs.

https://blog.packagist.com/composer-2-2/ warned that:

> Please beware, the prompt may hang CI/build pipelines if they aren't using the --no-interaction (-n) option, as they should. (PR #10314)

But it should happen at the install stage, not after phpunit finished, and I don't see why it happens only on test 4 and 7