### PR TITLE
Workaround for PHPUnit process isolation issue with composer 2.2

### DIFF
--- a/bin/tests-github-actions.sh
+++ b/bin/tests-github-actions.sh
@@ -13,7 +13,7 @@ function run {
 
   local -r phpunit_cmd='
 echo "::group::{}";
-vendor/bin/phpunit --log-junit build/phpunit/logs/{_}.xml --colors=always {};
+vendor/phpunit/phpunit/phpunit --log-junit build/phpunit/logs/{_}.xml --colors=always {};
 exit_code=$?;
 echo ::endgroup::;
 if [[ "$exit_code" -ne 0 ]]; then


### PR DESCRIPTION
This skips composer-generated proxy binaries, thus avoiding the issue introduced by composer 2.2