### PR TITLE
Improve CliUtils $argv handling

### DIFF
--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -248,68 +248,66 @@ final class CliUtils
             }
         }
 
-        if ($input_paths) {
-            $filtered_input_paths = [];
+        $filtered_input_paths = [];
 
-            for ($i = 0, $iMax = count($input_paths); $i < $iMax; ++$i) {
-                /** @var string */
-                $input_path = $input_paths[$i];
+        for ($i = 0, $iMax = count($input_paths); $i < $iMax; ++$i) {
+            /** @var string */
+            $input_path = $input_paths[$i];
 
-                if ($input_path[0] === '-' && strlen($input_path) === 2) {
-                    if ($input_path[1] === 'c' || $input_path[1] === 'f') {
-                        ++$i;
-                    }
-                    continue;
+            if ($input_path[0] === '-' && strlen($input_path) === 2) {
+                if ($input_path[1] === 'c' || $input_path[1] === 'f') {
+                    ++$i;
                 }
-
-                if ($input_path[0] === '-' && $input_path[2] === '=') {
-                    continue;
-                }
-
-                if (strpos($input_path, '--') === 0 && strlen($input_path) > 2) {
-                    if (substr($input_path, 2) === 'config') {
-                        ++$i;
-                    }
-                    continue;
-                }
-
-                $filtered_input_paths[] = $input_path;
+                continue;
             }
 
-            if ($filtered_input_paths === ['-']) {
-                $meta = stream_get_meta_data(STDIN);
-                stream_set_blocking(STDIN, false);
-                if ($stdin = fgets(STDIN)) {
-                    $filtered_input_paths = preg_split('/\s+/', trim($stdin));
-                }
-                $blocked = $meta['blocked'];
-                stream_set_blocking(STDIN, $blocked);
+            if ($input_path[0] === '-' && $input_path[2] === '=') {
+                continue;
             }
 
-            foreach ($filtered_input_paths as $path_to_check) {
-                if ($path_to_check[0] === '-') {
-                    fwrite(STDERR, 'Invalid usage, expecting psalm [options] [file...]' . PHP_EOL);
-                    exit(1);
+            if (strpos($input_path, '--') === 0 && strlen($input_path) > 2) {
+                if (substr($input_path, 2) === 'config') {
+                    ++$i;
                 }
-
-                if (!file_exists($path_to_check)) {
-                    fwrite(STDERR, 'Cannot locate ' . $path_to_check . PHP_EOL);
-                    exit(1);
-                }
-
-                $path_to_check = realpath($path_to_check);
-
-                if (!$path_to_check) {
-                    fwrite(STDERR, 'Error getting realpath for file' . PHP_EOL);
-                    exit(1);
-                }
-
-                $paths_to_check[] = $path_to_check;
+                continue;
             }
 
-            if (!$paths_to_check) {
-                $paths_to_check = null;
+            $filtered_input_paths[] = $input_path;
+        }
+
+        if ($filtered_input_paths === ['-']) {
+            $meta = stream_get_meta_data(STDIN);
+            stream_set_blocking(STDIN, false);
+            if ($stdin = fgets(STDIN)) {
+                $filtered_input_paths = preg_split('/\s+/', trim($stdin));
             }
+            $blocked = $meta['blocked'];
+            stream_set_blocking(STDIN, $blocked);
+        }
+
+        foreach ($filtered_input_paths as $path_to_check) {
+            if ($path_to_check[0] === '-') {
+                fwrite(STDERR, 'Invalid usage, expecting psalm [options] [file...]' . PHP_EOL);
+                exit(1);
+            }
+
+            if (!file_exists($path_to_check)) {
+                fwrite(STDERR, 'Cannot locate ' . $path_to_check . PHP_EOL);
+                exit(1);
+            }
+
+            $path_to_check = realpath($path_to_check);
+
+            if (!$path_to_check) {
+                fwrite(STDERR, 'Error getting realpath for file' . PHP_EOL);
+                exit(1);
+            }
+
+            $paths_to_check[] = $path_to_check;
+        }
+
+        if (!$paths_to_check) {
+            $paths_to_check = null;
         }
 
         return $paths_to_check;

--- a/tests/Internal/CliUtilsTest.php
+++ b/tests/Internal/CliUtilsTest.php
@@ -7,6 +7,8 @@ use Psalm\Internal\CliUtils;
 
 use function realpath;
 
+use const DIRECTORY_SEPARATOR;
+
 class CliUtilsTest extends TestCase
 {
     /**
@@ -62,8 +64,13 @@ class CliUtilsTest extends TestCase
     /** @return iterable<string,array{list<string>|null,list<string>,fpaths?:list<string>}> */
     public function provideGetPathsToCheck(): iterable
     {
-        $psalm = __DIR__ . '/../../psalm';
-        $dummyProjectDir = (string)realpath(__DIR__ . '/../fixtures/DummyProject');
+        $psalm = __DIR__ . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . '..' . DIRECTORY_SEPARATOR . 'psalm';
+        $dummyProjectDir = (string)realpath(
+            __DIR__
+            . DIRECTORY_SEPARATOR . '..'
+            . DIRECTORY_SEPARATOR. 'fixtures'
+            . DIRECTORY_SEPARATOR . 'DummyProject'
+        );
         $currentDir = (string)realpath('.');
 
         yield 'withoutPaths' => [
@@ -77,13 +84,28 @@ class CliUtilsTest extends TestCase
         ];
 
         yield 'withPaths' => [
-            [$dummyProjectDir . '/Bar.php', $dummyProjectDir . '/Bat.php'],
-            [$psalm, $dummyProjectDir . '/Bar.php', $dummyProjectDir . '/Bat.php'],
+            [
+                $dummyProjectDir . DIRECTORY_SEPARATOR . 'Bar.php',
+                $dummyProjectDir . DIRECTORY_SEPARATOR . 'Bat.php',
+            ],
+            [
+                $psalm,
+                $dummyProjectDir . DIRECTORY_SEPARATOR . 'Bar.php',
+                $dummyProjectDir . DIRECTORY_SEPARATOR . 'Bat.php',
+            ],
         ];
 
         yield 'withPathsAndArgumentsMixed' => [
-            [$dummyProjectDir . '/Bar.php', $dummyProjectDir . '/Bat.php'],
-            [$psalm, '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', $dummyProjectDir . '/Bar.php', $dummyProjectDir . '/Bat.php'],
+            [
+                $dummyProjectDir . DIRECTORY_SEPARATOR . 'Bar.php',
+                $dummyProjectDir . DIRECTORY_SEPARATOR . 'Bat.php',
+            ],
+            [
+                $psalm,
+                '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php',
+                $dummyProjectDir . DIRECTORY_SEPARATOR . 'Bar.php',
+                $dummyProjectDir . DIRECTORY_SEPARATOR . 'Bat.php',
+            ],
         ];
 
         yield 'withFpathToCurrentDir' => [

--- a/tests/Internal/CliUtilsTest.php
+++ b/tests/Internal/CliUtilsTest.php
@@ -9,6 +9,9 @@ use function realpath;
 
 class CliUtilsTest extends TestCase
 {
+    /**
+     * @var array<int, string>
+     */
     private $argv = [];
 
     protected function setUp(): void
@@ -23,9 +26,7 @@ class CliUtilsTest extends TestCase
         $argv = $this->argv;
     }
 
-    /**
-     * @return iterable<array<list<string>>>
-     */
+    /** @return iterable<string,array{list<string>,list<string>}> */
     public function provideGetArguments(): iterable
     {
         $psalter = __DIR__ . '/../../psalter';
@@ -48,20 +49,23 @@ class CliUtilsTest extends TestCase
     /**
      * @dataProvider provideGetArguments
      * @param list<string> $expected
-     * @param list<string> $input
+     * @param list<string> $_input
      */
-    public function testGetArgumentsWillReturnExpectedValue(array $expected, array $input): void
+    public function testGetArgumentsWillReturnExpectedValue(array $expected, array $_input): void
     {
         global $argv;
-        $argv = $input;
+        $argv = $_input;
         $result = CliUtils::getArguments();
         self::assertEquals($expected, $result);
     }
 
+    /** @return iterable<string,array{list<string>|null,list<string>,fpaths?:list<string>}> */
     public function provideGetPathsToCheck(): iterable
     {
         $psalm = __DIR__ . '/../../psalm';
-        $dummyProjectDir = realpath(__DIR__ . '/../fixtures/DummyProject');
+        $dummyProjectDir = (string)realpath(__DIR__ . '/../fixtures/DummyProject');
+        $currentDir = (string)realpath('.');
+
         yield 'withoutPaths' => [
             null,
             [$psalm, '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
@@ -83,7 +87,7 @@ class CliUtilsTest extends TestCase
         ];
 
         yield 'withFpathToCurrentDir' => [
-            [realpath('.')],
+            [$currentDir],
             [$psalm, '-f', '.'],
             ['.']
         ];
@@ -98,12 +102,12 @@ class CliUtilsTest extends TestCase
     /**
      * @dataProvider provideGetPathsToCheck
      * @param list<string>|null $expected
-     * @param list<string> $input
+     * @param list<string> $_input
      */
-    public function testGetPathsToCheckWillReturnExpectedValue(?array $expected, array $input, array $fpaths = []): void
+    public function testGetPathsToCheckWillReturnExpectedValue(?array $expected, array $_input, array $fpaths = []): void
     {
         global $argv;
-        $argv = $input;
+        $argv = $_input;
         $result = CliUtils::getPathsToCheck($fpaths);
         self::assertEquals($expected, $result);
     }

--- a/tests/Internal/CliUtilsTest.php
+++ b/tests/Internal/CliUtilsTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Psalm\Tests\Internal;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\Internal\CliUtils;
+
+use function realpath;
+
+class CliUtilsTest extends TestCase
+{
+    private $argv = [];
+
+    protected function setUp(): void
+    {
+        global $argv;
+        $this->argv = $argv;
+    }
+
+    protected function tearDown(): void
+    {
+        global $argv;
+        $argv = $this->argv;
+    }
+
+    /**
+     * @return iterable<array<list<string>>>
+     */
+    public function provideGetArguments(): iterable
+    {
+        $psalter = __DIR__ . '/../../psalter';
+        yield 'standardCallWithPsalter' => [
+            ['--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
+            [$psalter, '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
+        ];
+
+        yield 'specialCaseWithBinary' => [
+            ['--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
+            ['/bin/true', '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
+        ];
+
+        yield 'specialCaseWhichWouldFail' => [
+            // ['--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
+            ['/directory-does-not-exist/file-does-not-exist', '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
+            ['/directory-does-not-exist/file-does-not-exist', '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetArguments
+     * @param list<string> $expected
+     * @param list<string> $input
+     */
+    public function testGetArgumentsWillReturnExpectedValue(array $expected, array $input): void
+    {
+        global $argv;
+        $argv = $input;
+        $result = CliUtils::getArguments();
+        self::assertEquals($expected, $result);
+    }
+
+    public function provideGetPathsToCheck(): iterable
+    {
+        $psalm = __DIR__ . '/../../psalm';
+        $dummyProjectDir = realpath(__DIR__ . '/../fixtures/DummyProject');
+        yield 'withoutPaths' => [
+            null,
+            [$psalm, '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
+        ];
+
+        yield 'withoutPathsAndArguments' => [
+            null,
+            [$psalm],
+        ];
+
+        yield 'withPaths' => [
+            [$dummyProjectDir . '/Bar.php', $dummyProjectDir . '/Bat.php'],
+            [$psalm, $dummyProjectDir . '/Bar.php', $dummyProjectDir . '/Bat.php'],
+        ];
+
+        yield 'withPathsAndArgumentsMixed' => [
+            [$dummyProjectDir . '/Bar.php', $dummyProjectDir . '/Bat.php'],
+            [$psalm, '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', $dummyProjectDir . '/Bar.php', $dummyProjectDir . '/Bat.php'],
+        ];
+
+        // this happened because of realpath(Phar::running(false)) will return the same as realpath('.')
+        // when not called in the Phar context, I think this case can be ignored in the future
+        yield 'withFpathToCurrentDir' => [
+            null, // ['.'],
+            [$psalm, '-f', '.'],
+            ['.']
+        ];
+
+        yield 'withFpathToProjectDir' => [
+            [$dummyProjectDir],
+            [$psalm, '-f', $dummyProjectDir],
+            [$dummyProjectDir]
+        ];
+    }
+
+    /**
+     * @dataProvider provideGetPathsToCheck
+     * @param list<string>|null $expected
+     * @param list<string> $input
+     */
+    public function testGetPathsToCheckWillReturnExpectedValue(?array $expected, array $input, array $fpaths = []): void
+    {
+        global $argv;
+        $argv = $input;
+        $result = CliUtils::getPathsToCheck($fpaths);
+        self::assertEquals($expected, $result);
+    }
+}

--- a/tests/Internal/CliUtilsTest.php
+++ b/tests/Internal/CliUtilsTest.php
@@ -40,8 +40,7 @@ class CliUtilsTest extends TestCase
         ];
 
         yield 'specialCaseWhichWouldFail' => [
-            // ['--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
-            ['/directory-does-not-exist/file-does-not-exist', '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
+            ['--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
             ['/directory-does-not-exist/file-does-not-exist', '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', '--dry-run'],
         ];
     }
@@ -83,10 +82,8 @@ class CliUtilsTest extends TestCase
             [$psalm, '--plugin=vendor/vimeo/psalm/examples/plugins/ClassUnqualifier.php', $dummyProjectDir . '/Bar.php', $dummyProjectDir . '/Bat.php'],
         ];
 
-        // this happened because of realpath(Phar::running(false)) will return the same as realpath('.')
-        // when not called in the Phar context, I think this case can be ignored in the future
         yield 'withFpathToCurrentDir' => [
-            null, // ['.'],
+            [realpath('.')],
             [$psalm, '-f', '.'],
             ['.']
         ];


### PR DESCRIPTION
This pull request aims to simplify the CliUtils handling by skipping the first value of the `$argv` array when trying to get the arguments and the paths to be checked.

I have also added a CliUtils test which covers some basic (and one not so basic) use cases of the two methods I changed. Some parts I couldn't test yet (for example when passing `-` as argument, I would have to "mock" STDIN).

This also solves an issue with composer 2.2 when the "bin-dir" config is set, because in with the proxies the value in `$argv[0]` is not covered anymore in the code where psalm "recognices" itself (the part of the code which I removed completely). See this gist on how to reproduce the issue: https://gist.github.com/vstm/40258de6df2991cf9309cd10e716089b