### PR TITLE
Allow XdebugHandler version 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "amphp/byte-stream": "^1.5",
         "composer/package-versions-deprecated": "^1.8.0",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
-        "composer/xdebug-handler": "^1.1 || ^2.0",
+        "composer/xdebug-handler": "^2.0 || ^3.0",
         "dnoegel/php-xdg-base-dir": "^0.1.1",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
         "felixfbecker/language-server-protocol": "^1.5",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "amphp/byte-stream": "^1.5",
         "composer/package-versions-deprecated": "^1.8.0",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
-        "composer/xdebug-handler": "^2.0 || ^3.0",
+        "composer/xdebug-handler": "^1.1 || ^2.0 || ^3.0",
         "dnoegel/php-xdg-base-dir": "^0.1.1",
         "felixfbecker/advanced-json-rpc": "^3.0.3",
         "felixfbecker/language-server-protocol": "^1.5",

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -32,6 +32,7 @@ class PsalmRestarter extends XdebugHandler
     }
 
     /**
+     * No type hint to allow xdebug-handler v2 usage
      * @param bool $default
      */
     protected function requiresRestart($default): bool
@@ -47,7 +48,8 @@ class PsalmRestarter extends XdebugHandler
     }
 
     /**
-     * @param mixed $command
+     * No type hint to allow xdebug-handler v2 usage
+     * @param string[] $command
      */
     protected function restart($command): void
     {
@@ -60,7 +62,6 @@ class PsalmRestarter extends XdebugHandler
             file_put_contents($this->tmpIni, $content);
         }
 
-        /** @psalm-suppress MixedArgument */
         parent::restart($command);
     }
 }

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -32,7 +32,7 @@ class PsalmRestarter extends XdebugHandler
     }
 
     /**
-     * No type hint to allow xdebug-handler v2 usage
+     * No type hint to allow xdebug-handler v1 and v2 usage
      * @param bool $default
      */
     protected function requiresRestart($default): bool
@@ -48,8 +48,8 @@ class PsalmRestarter extends XdebugHandler
     }
 
     /**
-     * No type hint to allow xdebug-handler v2 usage
-     * @param string[] $command
+     * No type hint to allow xdebug-handler v1 and v2 usage
+     * @param string|string[] $command
      */
     protected function restart($command): void
     {

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -62,6 +62,7 @@ class PsalmRestarter extends XdebugHandler
             file_put_contents($this->tmpIni, $content);
         }
 
+        /** @psalm-suppress PossiblyInvalidArgument */
         parent::restart($command);
     }
 }


### PR DESCRIPTION
composer/xdebug-handler version 3 provides the same functionality as version 2 but removes support for older PHP versions (< 7.2.25). It will be shipped with the impending Composer 2.3 release.

xdebug-handler version 2 will be supported for the lifetime of  [Composer 2.2 LTS](https://blog.packagist.com/composer-2-2/).