### PR TITLE
quote more chars in keyed array names

### DIFF
--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -430,7 +430,7 @@ class TKeyedArray extends Atomic
      */
     private function escapeAndQuote($name)
     {
-        if (is_string($name) && preg_match('/[ "\'\\\\.\n:]/', $name)) {
+        if (is_string($name) && preg_match('/[^a-zA-Z0-9_]/', $name)) {
             $name = '\'' . str_replace("\n", '\n', addslashes($name)) . '\'';
         }
 

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -1684,6 +1684,40 @@ class AssertAnnotationTest extends TestCase
                         }
                     }',
             ],
+            'assertOnKeyedArrayWithSpecialCharsInNames' => [
+                '<?php
+
+                    class Foo {
+                        /** @var array<string, int> */
+                        public array $bar;
+
+                        /**
+                         * @param array<string, int> $bar
+                         */
+                        public function __construct(array $bar) {
+                            $this->bar = $bar;
+                        }
+                    }
+
+                    $expected = [
+                        "#[]" => 21,
+                        "<<>>" => 6,
+                    ];
+
+                    $foo = new Foo($expected);
+                    assertSame($expected, $foo->bar);
+
+                    /**
+                     * @psalm-template ExpectedType
+                     * @psalm-param ExpectedType $expected
+                     * @psalm-assert =ExpectedType $actual
+                     */
+                    function assertSame($expected, $actual): void {
+                        if ($expected !== $actual) {
+                            throw new Exception("Expected doesn\'t match actual");
+                        }
+                    }',
+            ],
         ];
     }
 

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -1710,6 +1710,7 @@ class AssertAnnotationTest extends TestCase
                     /**
                      * @psalm-template ExpectedType
                      * @psalm-param ExpectedType $expected
+                     * @psalm-param mixed $actual
                      * @psalm-assert =ExpectedType $actual
                      */
                     function assertSame($expected, $actual): void {


### PR DESCRIPTION
This PR changes the detection of chars needing to be quoted from a forbidden list of chars to an allowed list. 

Aside from alphanumeric chars and underscore, every other char present in the string will make Psalm add quotes to the string

This will fix #7222