### PR TITLE
Fix first-class callables with built-in, magic, undefined methods and callable expressions

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -352,7 +352,12 @@ class ReturnTypeCollector
         if ($stmt instanceof PhpParser\Node\Expr\MethodCall
             || $stmt instanceof PhpParser\Node\Expr\FuncCall
             || $stmt instanceof PhpParser\Node\Expr\StaticCall
-            || $stmt instanceof PhpParser\Node\Expr\New_) {
+            || $stmt instanceof PhpParser\Node\Expr\New_
+        ) {
+            if ($stmt->isFirstClassCallable()) {
+                return [];
+            }
+
             $yield_types = [];
 
             foreach ($stmt->getArgs() as $arg) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -90,10 +90,12 @@ class FunctionCallAnalyzer extends CallAnalyzer
         $code_location = new CodeLocation($statements_analyzer->getSource(), $stmt);
         $config = $codebase->config;
 
+        $is_first_class_callable = $stmt->isFirstClassCallable();
+
         $real_stmt = $stmt;
 
         if ($function_name instanceof PhpParser\Node\Name
-            && !$stmt->isFirstClassCallable()
+            && !$is_first_class_callable
             && isset($stmt->getArgs()[0])
             && !$stmt->getArgs()[0]->unpack
         ) {
@@ -152,7 +154,6 @@ class FunctionCallAnalyzer extends CallAnalyzer
             }
         }
 
-        $is_first_class_callable = $stmt->isFirstClassCallable();
         $set_inside_conditional = false;
 
         if ($function_name instanceof PhpParser\Node\Name

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -382,7 +382,7 @@ class MethodCallAnalyzer extends CallAnalyzer
         }
 
         if (!$result->existent_method_ids) {
-            return self::checkMethodArgs(
+            return $stmt->isFirstClassCallable() || self::checkMethodArgs(
                 null,
                 $stmt->getArgs(),
                 null,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
@@ -199,6 +199,7 @@ class ExpressionIdentifier
 
         if ($stmt instanceof PhpParser\Node\Expr\MethodCall
             && $stmt->name instanceof PhpParser\Node\Identifier
+            && !$stmt->isFirstClassCallable()
             && !$stmt->getArgs()
         ) {
             $config = Config::getInstance();


### PR DESCRIPTION
This addresses issues discovered when attempting to use first-class callables with built-in class methods, undefined methods, magic methods, and as a the callable expression to functions such as `array_map`.

Closes #7196.