### PR TITLE
Speed up Windows tests

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -3,13 +3,41 @@ name: Run unit tests on Windows
 on: [push, pull_request]
 
 jobs:
+  chunk-matrix:
+    name: Generate Chunk Matrix
+
+    runs-on: ubuntu-latest
+    env:
+      CHUNK_COUNT: 8
+
+    outputs:
+      count: ${{ steps.chunk-matrix.outputs.count }}
+      chunks: ${{ steps.chunk-matrix.outputs.chunks }}
+
+    steps:
+      - id: chunk-matrix
+        name: Generates the Chunk Matrix
+        run: |
+          echo "::set-output name=count::$(php -r 'echo json_encode([ ${{ env.CHUNK_COUNT }} ]);')"
+          echo "::set-output name=chunks::$(php -r 'echo json_encode(range(1, ${{ env.CHUNK_COUNT }} ));')"
+
   tests:
-    name: "Unit Tests"
+    name: "Unit Tests - ${{ matrix.chunk }}"
 
     runs-on: windows-latest
+    needs:
+      - chunk-matrix
 
     strategy:
       fail-fast: false
+      matrix:
+        count: ${{ fromJson(needs.chunk-matrix.outputs.count) }}
+        chunk: ${{ fromJson(needs.chunk-matrix.outputs.chunks) }}
+
+    env:
+      CHUNK_COUNT: "${{ matrix.count }}"
+      CHUNK_NUMBER: "${{ matrix.chunk }}"
+      PARALLEL_PROCESSES: 5
 
     steps:
       - name: Set git to use LF
@@ -47,5 +75,8 @@ jobs:
         env:
           COMPOSER_ROOT_VERSION: dev-master
 
+      - name: Generate test suits
+        run: php bin/generate_testsuites.php $env:CHUNK_COUNT
+
       - name: Run unit tests
-        run: vendor/bin/paratest --log-junit build/phpunit/phpunit.xml
+        run: vendor/bin/paratest --processes=$env:PARALLEL_PROCESSES --testsuite=chunk_$env:CHUNK_NUMBER --log-junit build/phpunit/phpunit.xml

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -37,7 +37,7 @@ jobs:
     env:
       CHUNK_COUNT: "${{ matrix.count }}"
       CHUNK_NUMBER: "${{ matrix.chunk }}"
-      PARALLEL_PROCESSES: 5
+      PARALLEL_PROCESSES: 4
 
     steps:
       - name: Set git to use LF

--- a/bin/generate_testsuites.php
+++ b/bin/generate_testsuites.php
@@ -1,0 +1,61 @@
+<?php
+
+if (count($argv) < 2) {
+    fwrite(STDERR, 'Usage: ' . $argv[0] . ' <number_of_chunks>' . PHP_EOL);
+    exit(1);
+}
+
+$number_of_chunks = (int) $argv[1];
+if ($number_of_chunks === 0) {
+    fwrite(STDERR, 'Usage: ' . $argv[0] . ' <number_of_chunks>' . PHP_EOL);
+    exit(1);
+}
+
+// find tests -name '*Test.php'
+$files = iterator_to_array(
+    new RegexIterator(
+        new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(
+                'tests',
+                FilesystemIterator::CURRENT_AS_PATHNAME|FilesystemIterator::SKIP_DOTS
+            ),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        ),
+        '/.*Test.php$/'
+    )
+);
+
+mt_srand(4); // chosen by fair dice roll.
+             // guaranteed to be random.
+             // -- xkcd:221
+
+$order = array_map(
+    function (): int {
+        return mt_rand();
+    },
+    $files
+);
+array_multisort($order, $files);
+
+$chunks = array_chunk($files, ceil(count($files) / $number_of_chunks));
+
+$phpunit_config = new DOMDocument('1.0', 'UTF-8');
+$phpunit_config->preserveWhiteSpace = false;
+$phpunit_config->load('phpunit.xml.dist');
+$suites_container = $phpunit_config->getElementsByTagName('testsuites')->item(0);
+
+while ($suites_container->firstChild) {
+    $suites_container->removeChild($suites_container->firstChild);
+}
+
+foreach ($chunks as $chunk_id => $chunk) {
+    $suite = $phpunit_config->createElement('testsuite');
+    $suite->setAttribute('name', 'chunk_' . ($chunk_id + 1));
+    foreach ($chunk as $file) {
+         $suite->appendChild($phpunit_config->createElement('file', $file));
+    }
+    $suites_container->appendChild($suite);
+}
+
+$phpunit_config->formatOutput = true;
+$phpunit_config->save('phpunit.xml');


### PR DESCRIPTION
Enable multiple workers for Windows, just like we do on Linux already.