### PR TITLE
Fixes #7246, wrap getTypeContextAtPosition in try/catch

### DIFF
--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -6,7 +6,6 @@ namespace Psalm\Internal\LanguageServer\Server;
 
 use Amp\Promise;
 use Amp\Success;
-use Exception;
 use LanguageServerProtocol\CompletionList;
 use LanguageServerProtocol\Hover;
 use LanguageServerProtocol\Location;
@@ -285,8 +284,9 @@ class TextDocument
 
                 return new Success([]);
             }
-        } catch(UnexpectedValueException $e) {
-            error_log('completion not found at ' . $position->line . ':' . $position->character.', Reason: '.$e->getMessage());
+        } catch (UnexpectedValueException $e) {
+            error_log('completion errored at ' . $position->line . ':' . $position->character.
+                ', Reason: '.$e->getMessage());
             return new Success([]);
         }
 

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -278,18 +278,16 @@ class TextDocument
 
         try {
             $type_context = $this->codebase->getTypeContextAtPosition($file_path, $position);
-
-            if (!$completion_data && !$type_context) {
-                error_log('completion not found at ' . $position->line . ':' . $position->character);
-
-                return new Success([]);
-            }
         } catch (UnexpectedValueException $e) {
             error_log('completion errored at ' . $position->line . ':' . $position->character.
                 ', Reason: '.$e->getMessage());
             return new Success([]);
         }
 
+        if (!$completion_data && !$type_context) {
+            error_log('completion not found at ' . $position->line . ':' . $position->character);
+            return new Success([]);
+        }
 
         if ($completion_data) {
             [$recent_type, $gap, $offset] = $completion_data;


### PR DESCRIPTION
See #7246 and https://github.com/psalm/psalm-vscode-plugin/issues/107

Specifically if something crashes deep in Psalm we should try to catch most of these crashes in the language server and continue (if possible). This is one such instance where continuing is fine as the error comes from the result of live typing so the code completion (that is erroring) is wrong as the time of typing the letters.

This is really hard to actually give a code reproduction because it relies on Psalm having a live cache and then that cache changing while live typing. You can see this in the reference issue against psalm-vscode-plugin