### PR TITLE
allow calling mutation_free function inside a mutation_free context

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -1017,7 +1017,8 @@ class FunctionCallAnalyzer extends CallAnalyzer
 
             if ((!$function_call_info->in_call_map
                     && $function_call_info->function_storage
-                    && !$function_call_info->function_storage->pure)
+                    && !$function_call_info->function_storage->pure
+                    && !$function_call_info->function_storage->mutation_free)
                 || ($callmap_function_pure === false)
             ) {
                 if ($context->mutation_free || $context->external_mutation_free) {

--- a/tests/ImmutableAnnotationTest.php
+++ b/tests/ImmutableAnnotationTest.php
@@ -526,6 +526,26 @@ class ImmutableAnnotationTest extends TestCase
                         }
                     }',
             ],
+            'allowMutationFreeCallInMutationFreeContext' => [
+                '<?php
+
+                    /**
+                     * @psalm-mutation-free
+                     */
+                    function getData(): array {
+                        /** @var mixed $arr */
+                        $arr = $GLOBALS["cachedData"] ?? [];
+
+                        return is_array($arr) ? $arr : [];
+                    }
+
+                    /**
+                     * @psalm-mutation-free
+                     */
+                    function getDataItem(string $key): mixed {
+                        return getData()[$key] ?? null;
+                    }',
+            ],
         ];
     }
 

--- a/tests/ImmutableAnnotationTest.php
+++ b/tests/ImmutableAnnotationTest.php
@@ -541,8 +541,9 @@ class ImmutableAnnotationTest extends TestCase
 
                     /**
                      * @psalm-mutation-free
+                     * @return mixed
                      */
-                    function getDataItem(string $key): mixed {
+                    function getDataItem(string $key) {
                         return getData()[$key] ?? null;
                     }',
             ],


### PR DESCRIPTION
This should fix #5874

I'm pretty lost however on all the annotations of purity/mutability that exists, which can be applied on which symbols and which annotation can be called inside which one.

For example, :
- `pure` can only be annotated on a method/function
- `immutable` can be annotated on a class
- you can call `pure` functions in `immutable` scope
- can you call `external-mutation-free` class inside an `immutable` scope? 

It'd be great if someone could take the time to revamp the part of the doc that talks about all those: https://psalm.dev/docs/annotating_code/supported_annotations/#psalm-mutation-free

To explain the interactions between them. I'm pretty sure there are a lot of places with similar issues that I fixed here, partly because it's not very transparent what goes into what.
