### PR TITLE
Remove "is not in project" warnings

### DIFF
--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -71,7 +71,6 @@ class TextDocument
         $file_path = LanguageServer::uriToPath($textDocument->uri);
 
         if (!$this->codebase->config->isInProjectDirs($file_path)) {
-            $this->server->verboseLog($file_path . ' is not in project');
             return;
         }
 
@@ -90,7 +89,6 @@ class TextDocument
         $file_path = LanguageServer::uriToPath($textDocument->uri);
 
         if (!$this->codebase->config->isInProjectDirs($file_path)) {
-            $this->server->verboseLog($file_path . ' is not in project');
             return;
         }
 
@@ -112,7 +110,6 @@ class TextDocument
         $file_path = LanguageServer::uriToPath($textDocument->uri);
 
         if (!$this->codebase->config->isInProjectDirs($file_path)) {
-            $this->server->verboseLog($file_path . ' is not in project');
             return;
         }
 


### PR DESCRIPTION
Remove the `$file_path . ' is not in project'` warnings in the Language Server. All they do is fill up the output buffer and they seem to bother users.

See:

https://github.com/psalm/psalm-vscode-plugin/issues/9
