### PR TITLE
forbid calling impure callable in immutable context

### DIFF
--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -353,11 +353,13 @@ class Context
 
     /**
      * @var bool
+     * Set by @psalm-immutable
      */
     public $mutation_free = false;
 
     /**
      * @var bool
+     * Set by @psalm-external-mutation-free
      */
     public $external_mutation_free = false;
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -642,7 +642,7 @@ class FunctionCallAnalyzer extends CallAnalyzer
                 }
 
                 if ($var_type_part instanceof TClosure || $var_type_part instanceof TCallable) {
-                    if (!$var_type_part->is_pure && $context->pure) {
+                    if (!$var_type_part->is_pure && ($context->pure || $context->mutation_free)) {
                         IssueBuffer::maybeAdd(
                             new ImpureFunctionCall(
                                 'Cannot call an impure function from a mutation-free context',

--- a/tests/PureAnnotationTest.php
+++ b/tests/PureAnnotationTest.php
@@ -876,6 +876,38 @@ class PureAnnotationTest extends TestCase
                     ',
                 'error_message' => 'ImpureMethodCall',
             ],
+            'impureCallableInImmutableContext' => [
+                '<?php
+
+                    /**
+                     * @psalm-immutable
+                     */
+                    class Either
+                    {
+                        /**
+                         * @psalm-param callable $_
+                         */
+                        public function fold($_): void
+                        {
+                            $_();
+                        }
+                    }
+
+                    class Whatever
+                    {
+                        public function __construct()
+                        {
+                            $either = new Either();
+                            $either->fold(
+                                function (): void {}
+                            );
+                        }
+                    }
+
+                    new Whatever();
+                    ',
+                'error_message' => 'ImpureFunctionCall',
+            ],
         ];
     }
 }

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -2991,7 +2991,7 @@ class ClassTemplateTest extends TestCase
 
                         /**
                          * @psalm-template TResult
-                         * @psalm-param callable(self::READ_UNCOMMITTED): TResult $readUncommitted
+                         * @psalm-param pure-callable(self::READ_UNCOMMITTED): TResult $readUncommitted
                          * @psalm-return TResult
                          */
                         public function resolve(callable $readUncommitted) {


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/6691

Note that we will hit an obstacle at one point because we don't have immutable callable/closure. This means it's not possible to call a callable/closure in an immutable context if the said callable/closure is not pure.