### PR TITLE
Deprecated `Codebase::$php_major_version` and `Codebase::$php_minor_version` properties

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@16a61a758e44158c19c779c8b0a1c2143e40d83e">
+<files psalm-version="dev-master@1c078136273a669d52d234251ddbae4cd0507d38">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset occurrences="2">
       <code>$comment_block-&gt;tags['variablesfrom'][0]</code>
@@ -13,10 +13,27 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Codebase.php">
+    <DeprecatedProperty occurrences="2">
+      <code>$this-&gt;php_major_version</code>
+      <code>$this-&gt;php_minor_version</code>
+    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="2">
       <code>$matches[0]</code>
       <code>$symbol_parts[1]</code>
     </PossiblyUndefinedIntArrayOffset>
+    <PossiblyUnusedProperty occurrences="1">
+      <code>$analysis_php_version_id</code>
+    </PossiblyUnusedProperty>
+  </file>
+  <file src="src/Psalm/Config.php">
+    <DeprecatedProperty occurrences="6">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Config/FileFilter.php">
     <PossiblyUndefinedIntArrayOffset occurrences="1">
@@ -31,6 +48,15 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/ClassAnalyzer.php">
+    <DeprecatedProperty occurrences="7">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="3">
       <code>$comments[0]</code>
       <code>$stmt-&gt;props[0]</code>
@@ -42,7 +68,44 @@
       <code>$line_parts[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
+  <file src="src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php">
+    <DeprecatedProperty occurrences="5">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
+  </file>
+  <file src="src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php">
+    <DeprecatedProperty occurrences="3">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$project_analyzer-&gt;getCodebase()-&gt;php_major_version</code>
+      <code>$project_analyzer-&gt;getCodebase()-&gt;php_minor_version</code>
+    </DeprecatedProperty>
+  </file>
+  <file src="src/Psalm/Internal/Analyzer/MethodComparator.php">
+    <DeprecatedProperty occurrences="9">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
+  </file>
   <file src="src/Psalm/Internal/Analyzer/ProjectAnalyzer.php">
+    <DeprecatedProperty occurrences="6">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_minor_version</code>
+      <code>$this-&gt;codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="4">
       <code>$destination_parts[1]</code>
       <code>$destination_parts[1]</code>
@@ -81,6 +144,16 @@
     <InvalidPropertyAssignmentValue occurrences="1">
       <code>$catch_context-&gt;assigned_var_ids += $old_catch_assigned_var_ids</code>
     </InvalidPropertyAssignmentValue>
+  </file>
+  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php">
+    <DeprecatedProperty occurrences="6">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php">
     <PossiblyUndefinedIntArrayOffset occurrences="34">
@@ -138,6 +211,12 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php">
+    <DeprecatedProperty occurrences="4">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="3">
       <code>$non_existent_method_ids[0]</code>
       <code>$parts[1]</code>
@@ -174,6 +253,11 @@
     <DeprecatedMethod occurrences="1">
       <code>Type::getEmpty()</code>
     </DeprecatedMethod>
+    <DeprecatedProperty occurrences="3">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php">
     <DeprecatedClass occurrences="1">
@@ -184,6 +268,11 @@
     <DeprecatedMethod occurrences="1">
       <code>Type::getEmpty()</code>
     </DeprecatedMethod>
+    <DeprecatedProperty occurrences="3">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php">
     <PossiblyUndefinedIntArrayOffset occurrences="6">
@@ -204,6 +293,11 @@
     <DeprecatedMethod occurrences="1">
       <code>Type::getEmpty()</code>
     </DeprecatedMethod>
+    <DeprecatedProperty occurrences="3">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php">
     <PossiblyUndefinedIntArrayOffset occurrences="3">
@@ -217,6 +311,9 @@
       <code>Type::getEmpty()</code>
       <code>Type::getEmpty()</code>
     </DeprecatedMethod>
+    <DeprecatedProperty occurrences="1">
+      <code>$statements_analyzer-&gt;getCodebase()-&gt;php_major_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/ExitAnalyzer.php">
     <DeprecatedMethod occurrences="1">
@@ -246,6 +343,12 @@
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$atomic_return_type-&gt;type_params[2]</code>
     </PossiblyUndefinedIntArrayOffset>
+  </file>
+  <file src="src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php">
+    <DeprecatedProperty occurrences="2">
+      <code>$statements_analyzer-&gt;getCodebase()-&gt;php_major_version</code>
+      <code>$statements_analyzer-&gt;getCodebase()-&gt;php_minor_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php">
     <DeprecatedMethod occurrences="1">
@@ -289,6 +392,10 @@
     </DeprecatedMethod>
   </file>
   <file src="src/Psalm/Internal/Codebase/InternalCallMapHandler.php">
+    <DeprecatedProperty occurrences="2">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="2">
       <code>$callables[0]</code>
       <code>$callables[0]</code>
@@ -347,6 +454,10 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php">
+    <DeprecatedProperty occurrences="2">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="4">
       <code>$doc_line_parts[1]</code>
       <code>$matches[0]</code>
@@ -355,12 +466,22 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php">
+    <DeprecatedProperty occurrences="2">
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="4">
       <code>$imported_type_data[3]</code>
       <code>$l[4]</code>
       <code>$r[4]</code>
       <code>$var_line_parts[0]</code>
     </PossiblyUndefinedIntArrayOffset>
+  </file>
+  <file src="src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php">
+    <DeprecatedProperty occurrences="2">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/ExpressionScanner.php">
     <PossiblyUndefinedIntArrayOffset occurrences="2">
@@ -383,20 +504,49 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php">
+    <DeprecatedProperty occurrences="11">
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+      <code>$this-&gt;codebase-&gt;php_minor_version</code>
+      <code>$this-&gt;codebase-&gt;php_minor_version</code>
+      <code>$this-&gt;codebase-&gt;php_minor_version</code>
+      <code>$this-&gt;codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$stmt-&gt;stmts[0]</code>
     </PossiblyUndefinedIntArrayOffset>
+  </file>
+  <file src="src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php">
+    <DeprecatedProperty occurrences="1">
+      <code>$this-&gt;codebase-&gt;php_major_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php">
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$cs[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
+  <file src="src/Psalm/Internal/Scanner/FileScanner.php">
+    <DeprecatedProperty occurrences="2">
+      <code>$codebase-&gt;php_major_version</code>
+      <code>$codebase-&gt;php_minor_version</code>
+    </DeprecatedProperty>
+  </file>
   <file src="src/Psalm/Internal/Type/Comparator/ArrayTypeComparator.php">
     <DeprecatedClass occurrences="2">
       <code>new TEmpty()</code>
       <code>new TEmpty()</code>
     </DeprecatedClass>
+  </file>
+  <file src="src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php">
+    <DeprecatedProperty occurrences="1">
+      <code>$codebase-&gt;php_major_version</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/Type/SimpleAssertionReconciler.php">
     <DeprecatedClass occurrences="2">

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -92,6 +92,7 @@ use function substr_count;
 
 use const PHP_MAJOR_VERSION;
 use const PHP_MINOR_VERSION;
+use const PHP_VERSION_ID;
 
 class Codebase
 {
@@ -306,13 +307,18 @@ class Codebase
 
     /**
      * @var int
+     * @deprecated Removed in Psalm 5, use Codebase::$analysis_php_version_id
      */
     public $php_major_version = PHP_MAJOR_VERSION;
 
     /**
      * @var int
+     * @deprecated Removed in Psalm 5, use Codebase::$analysis_php_version_id
      */
     public $php_minor_version = PHP_MINOR_VERSION;
+
+    /** @var int */
+    public $analysis_php_version_id = PHP_VERSION_ID;
 
     /** @var 'cli'|'config'|'composer'|'tests'|'runtime' */
     public $php_version_source = 'runtime';

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1307,6 +1307,7 @@ class ProjectAnalyzer
 
         $this->codebase->php_major_version = $php_major_version;
         $this->codebase->php_minor_version = $php_minor_version;
+        $this->codebase->analysis_php_version_id = $php_major_version * 10000 + $php_minor_version * 100;
         $this->codebase->php_version_source = $source;
     }
 


### PR DESCRIPTION
Removed in #6898 (Psalm 5)