### PR TITLE
Report missing file path properly

### DIFF
--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -267,8 +267,7 @@ class FileFilter
 
                 if (!$file_path && !$allow_missing_files) {
                     throw new ConfigException(
-                        'Could not resolve config path to ' . $base_dir . DIRECTORY_SEPARATOR .
-                        $file_path
+                        'Could not resolve config path to ' . $prospective_file_path
                     );
                 }
 


### PR DESCRIPTION
If the file at the path is missing, `realpath` gives `false`. It makes no sense to try to put it into error message then. It's better to use `prospective_file_path` instead.