### PR TITLE
Require `@internal` annotation on `Psalm\Internal` symbols

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -114,6 +114,8 @@
     - `Psalm\Type\Atomic\TValueOfClassConstant`
     - `Psalm\Type\Atomic\TVoid`
     - `Psalm\Type\Union`
+ - While not a BC break per se, all classes / interfaces / traits / enums under
+   `Psalm\Internal` namespace are now marked `@internal`.
 
 ## Removed
  - [BC] Property `Psalm\Codebase::$php_major_version` was removed, use

--- a/examples/plugins/InternalChecker.php
+++ b/examples/plugins/InternalChecker.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Psalm\Example\Plugin;
+
+use Psalm\DocComment;
+use Psalm\FileManipulation;
+use Psalm\Internal\Scanner\ParsedDocblock;
+use Psalm\Issue\InternalClass;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\EventHandler\AfterClassLikeAnalysisInterface;
+use Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent;
+
+use function strpos;
+
+class InternalChecker implements AfterClassLikeAnalysisInterface
+{
+    /** @return null|false */
+    public static function afterStatementAnalysis(AfterClassLikeAnalysisEvent $event)
+    {
+        $storage = $event->getClasslikeStorage();
+        if (!$storage->internal
+            && strpos($storage->name, 'Psalm\\Internal') === 0
+            && $storage->location
+        ) {
+            IssueBuffer::maybeAdd(
+                new InternalClass(
+                    "Class $storage->name must be marked @internal",
+                    $storage->location,
+                    $storage->name
+                ),
+                $event->getStatementsSource()->getSuppressedIssues(),
+                true
+            );
+
+            if (!$event->getCodebase()->alter_code) {
+                return null;
+            }
+
+            $stmt = $event->getStmt();
+            $docblock = $stmt->getDocComment();
+            if ($docblock) {
+                $docblock_start = $docblock->getStartFilePos();
+                $parsed_docblock = DocComment::parsePreservingLength($docblock);
+            } else {
+                $docblock_start = (int) $stmt->getAttribute('startFilePos');
+                $parsed_docblock = new ParsedDocblock('', []);
+            }
+            $docblock_end = (int) $stmt->getAttribute('startFilePos');
+
+            $parsed_docblock->tags['internal'] = [''];
+            $new_docblock_content = $parsed_docblock->render('');
+            $event->setFileReplacements([
+                new FileManipulation($docblock_start, $docblock_end, $new_docblock_content)
+            ]);
+        }
+        return null;
+    }
+}

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@1c078136273a669d52d234251ddbae4cd0507d38">
+<files psalm-version="dev-master">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset occurrences="2">
       <code>$comment_block-&gt;tags['variablesfrom'][0]</code>
@@ -13,27 +13,10 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Codebase.php">
-    <DeprecatedProperty occurrences="2">
-      <code>$this-&gt;php_major_version</code>
-      <code>$this-&gt;php_minor_version</code>
-    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="2">
       <code>$matches[0]</code>
       <code>$symbol_parts[1]</code>
     </PossiblyUndefinedIntArrayOffset>
-    <PossiblyUnusedProperty occurrences="1">
-      <code>$analysis_php_version_id</code>
-    </PossiblyUnusedProperty>
-  </file>
-  <file src="src/Psalm/Config.php">
-    <DeprecatedProperty occurrences="6">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Config/FileFilter.php">
     <PossiblyUndefinedIntArrayOffset occurrences="1">
@@ -48,15 +31,6 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/ClassAnalyzer.php">
-    <DeprecatedProperty occurrences="7">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="3">
       <code>$comments[0]</code>
       <code>$stmt-&gt;props[0]</code>
@@ -68,44 +42,7 @@
       <code>$line_parts[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
-  <file src="src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php">
-    <DeprecatedProperty occurrences="5">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php">
-    <DeprecatedProperty occurrences="3">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$project_analyzer-&gt;getCodebase()-&gt;php_major_version</code>
-      <code>$project_analyzer-&gt;getCodebase()-&gt;php_minor_version</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/MethodComparator.php">
-    <DeprecatedProperty occurrences="9">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
-  </file>
   <file src="src/Psalm/Internal/Analyzer/ProjectAnalyzer.php">
-    <DeprecatedProperty occurrences="6">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_minor_version</code>
-      <code>$this-&gt;codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="4">
       <code>$destination_parts[1]</code>
       <code>$destination_parts[1]</code>
@@ -145,16 +82,6 @@
       <code>$catch_context-&gt;assigned_var_ids += $old_catch_assigned_var_ids</code>
     </InvalidPropertyAssignmentValue>
   </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php">
-    <DeprecatedProperty occurrences="6">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
-  </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php">
     <PossiblyUndefinedIntArrayOffset occurrences="34">
       <code>$assertion-&gt;rule[0]</code>
@@ -193,30 +120,13 @@
       <code>$gettype_expr-&gt;getArgs()[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php">
-    <DeprecatedMethod occurrences="1">
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-  </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php">
-    <DeprecatedMethod occurrences="4">
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
     <PossiblyUndefinedIntArrayOffset occurrences="2">
       <code>$invalid_left_messages[0]</code>
       <code>$invalid_right_messages[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php">
-    <DeprecatedProperty occurrences="4">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="3">
       <code>$non_existent_method_ids[0]</code>
       <code>$parts[1]</code>
@@ -230,12 +140,6 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php">
-    <DeprecatedClass occurrences="4">
-      <code>new TEmpty</code>
-      <code>new TEmpty</code>
-      <code>new TEmpty</code>
-      <code>new TEmpty</code>
-    </DeprecatedClass>
     <PossiblyUndefinedIntArrayOffset occurrences="4">
       <code>$args[0]</code>
       <code>$args[0]</code>
@@ -249,31 +153,6 @@
       <code>$stmt-&gt;getArgs()[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php">
-    <DeprecatedMethod occurrences="1">
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-    <DeprecatedProperty occurrences="3">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php">
-    <DeprecatedClass occurrences="1">
-      <code>TEmpty::class</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php">
-    <DeprecatedMethod occurrences="1">
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-    <DeprecatedProperty occurrences="3">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
-  </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php">
     <PossiblyUndefinedIntArrayOffset occurrences="6">
       <code>$result-&gt;invalid_method_call_types[0]</code>
@@ -284,21 +163,6 @@
       <code>$result-&gt;non_existent_magic_method_ids[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php">
-    <DeprecatedMethod occurrences="1">
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php">
-    <DeprecatedMethod occurrences="1">
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-    <DeprecatedProperty occurrences="3">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
-  </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php">
     <PossiblyUndefinedIntArrayOffset occurrences="3">
       <code>$assertion-&gt;rule[0]</code>
@@ -306,65 +170,15 @@
       <code>$callable_arg-&gt;items[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php">
-    <DeprecatedMethod occurrences="2">
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-    <DeprecatedProperty occurrences="1">
-      <code>$statements_analyzer-&gt;getCodebase()-&gt;php_major_version</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/ExitAnalyzer.php">
-    <DeprecatedMethod occurrences="1">
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php">
-    <DeprecatedClass occurrences="3">
-      <code>TMixed|TTemplateParam|TEmpty</code>
-      <code>new TEmpty</code>
-      <code>new TEmpty</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="2">
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-  </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php">
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$invalid_fetch_types[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php">
-    <DeprecatedMethod occurrences="1">
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$atomic_return_type-&gt;type_params[2]</code>
     </PossiblyUndefinedIntArrayOffset>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php">
-    <DeprecatedProperty occurrences="2">
-      <code>$statements_analyzer-&gt;getCodebase()-&gt;php_major_version</code>
-      <code>$statements_analyzer-&gt;getCodebase()-&gt;php_minor_version</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php">
-    <DeprecatedMethod occurrences="1">
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/ThrowAnalyzer.php">
-    <DeprecatedMethod occurrences="1">
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php">
-    <DeprecatedClass occurrences="2">
-      <code>new TEmpty</code>
-      <code>new TEmpty</code>
-    </DeprecatedClass>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php">
     <PossiblyUndefinedIntArrayOffset occurrences="6">
@@ -381,21 +195,7 @@
       <code>$stmt-&gt;expr-&gt;getArgs()[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
-  <file src="src/Psalm/Internal/Codebase/ConstantTypeResolver.php">
-    <DeprecatedClass occurrences="2">
-      <code>new TEmpty()</code>
-      <code>new TEmpty()</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="2">
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-  </file>
   <file src="src/Psalm/Internal/Codebase/InternalCallMapHandler.php">
-    <DeprecatedProperty occurrences="2">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="2">
       <code>$callables[0]</code>
       <code>$callables[0]</code>
@@ -454,10 +254,6 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php">
-    <DeprecatedProperty occurrences="2">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="4">
       <code>$doc_line_parts[1]</code>
       <code>$matches[0]</code>
@@ -466,22 +262,12 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php">
-    <DeprecatedProperty occurrences="2">
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="4">
       <code>$imported_type_data[3]</code>
       <code>$l[4]</code>
       <code>$r[4]</code>
       <code>$var_line_parts[0]</code>
     </PossiblyUndefinedIntArrayOffset>
-  </file>
-  <file src="src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php">
-    <DeprecatedProperty occurrences="2">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/ExpressionScanner.php">
     <PossiblyUndefinedIntArrayOffset occurrences="2">
@@ -504,82 +290,14 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php">
-    <DeprecatedProperty occurrences="11">
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-      <code>$this-&gt;codebase-&gt;php_minor_version</code>
-      <code>$this-&gt;codebase-&gt;php_minor_version</code>
-      <code>$this-&gt;codebase-&gt;php_minor_version</code>
-      <code>$this-&gt;codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$stmt-&gt;stmts[0]</code>
     </PossiblyUndefinedIntArrayOffset>
-  </file>
-  <file src="src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php">
-    <DeprecatedProperty occurrences="1">
-      <code>$this-&gt;codebase-&gt;php_major_version</code>
-    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php">
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$cs[0]</code>
     </PossiblyUndefinedIntArrayOffset>
-  </file>
-  <file src="src/Psalm/Internal/Scanner/FileScanner.php">
-    <DeprecatedProperty occurrences="2">
-      <code>$codebase-&gt;php_major_version</code>
-      <code>$codebase-&gt;php_minor_version</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Psalm/Internal/Type/Comparator/ArrayTypeComparator.php">
-    <DeprecatedClass occurrences="2">
-      <code>new TEmpty()</code>
-      <code>new TEmpty()</code>
-    </DeprecatedClass>
-  </file>
-  <file src="src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php">
-    <DeprecatedProperty occurrences="1">
-      <code>$codebase-&gt;php_major_version</code>
-    </DeprecatedProperty>
-  </file>
-  <file src="src/Psalm/Internal/Type/SimpleAssertionReconciler.php">
-    <DeprecatedClass occurrences="2">
-      <code>new TEmpty()</code>
-      <code>new TEmpty()</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="13">
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
-  </file>
-  <file src="src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php">
-    <DeprecatedClass occurrences="2">
-      <code>new TEmpty</code>
-      <code>new TEmpty</code>
-    </DeprecatedClass>
-    <DeprecatedMethod occurrences="4">
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-      <code>Type::getEmpty()</code>
-    </DeprecatedMethod>
   </file>
   <file src="src/Psalm/Internal/Type/TypeCombiner.php">
     <PossiblyUndefinedIntArrayOffset occurrences="6">
@@ -634,17 +352,7 @@
       <code>$rules[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
-  <file src="src/Psalm/Type.php">
-    <DeprecatedClass occurrences="3">
-      <code>new TEmpty</code>
-      <code>new TEmpty</code>
-      <code>new TEmpty()</code>
-    </DeprecatedClass>
-  </file>
   <file src="src/Psalm/Type/Atomic.php">
-    <DeprecatedClass occurrences="1">
-      <code>new TEmpty()</code>
-    </DeprecatedClass>
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>array_keys($template_type_map[$value])[0]</code>
     </PossiblyUndefinedIntArrayOffset>
@@ -655,12 +363,34 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Type/Reconciler.php">
-    <DeprecatedClass occurrences="1">
-      <code>new TEmpty</code>
-    </DeprecatedClass>
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$type[0]</code>
     </PossiblyUndefinedIntArrayOffset>
+  </file>
+  <file src="src/psalm-language-server.php">
+    <InternalMethod occurrences="1">
+      <code>LanguageServer::run($argv)</code>
+    </InternalMethod>
+  </file>
+  <file src="src/psalm-refactor.php">
+    <InternalMethod occurrences="1">
+      <code>Refactor::run($argv)</code>
+    </InternalMethod>
+  </file>
+  <file src="src/psalm.php">
+    <InternalMethod occurrences="1">
+      <code>Psalm::run($argv)</code>
+    </InternalMethod>
+  </file>
+  <file src="src/psalm_plugin.php">
+    <InternalMethod occurrences="1">
+      <code>Plugin::run()</code>
+    </InternalMethod>
+  </file>
+  <file src="src/psalter.php">
+    <InternalMethod occurrences="1">
+      <code>Psalter::run($argv)</code>
+    </InternalMethod>
   </file>
   <file src="vendor/nikic/php-parser/lib/PhpParser/Node/Expr/ArrowFunction.php">
     <PossiblyUndefinedStringArrayOffset occurrences="1">

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -46,6 +46,7 @@
     <plugins>
         <plugin filename="examples/plugins/FunctionCasingChecker.php"/>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+        <plugin filename="examples/plugins/InternalChecker.php"/>
     </plugins>
 
     <issueHandlers>

--- a/src/Psalm/Internal/Algebra.php
+++ b/src/Psalm/Internal/Algebra.php
@@ -18,6 +18,9 @@ use function in_array;
 use function mt_rand;
 use function substr;
 
+/**
+ * @internal
+ */
 class Algebra
 {
     /**

--- a/src/Psalm/Internal/Algebra/FormulaGenerator.php
+++ b/src/Psalm/Internal/Algebra/FormulaGenerator.php
@@ -19,6 +19,9 @@ use function spl_object_id;
 use function strlen;
 use function substr;
 
+/**
+ * @internal
+ */
 class FormulaGenerator
 {
      /**

--- a/src/Psalm/Internal/Analyzer/AttributeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/AttributeAnalyzer.php
@@ -21,6 +21,9 @@ use Psalm\Type\Union;
 
 use function reset;
 
+/**
+ * @internal
+ */
 class AttributeAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/ClassLikeNameOptions.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeNameOptions.php
@@ -2,6 +2,9 @@
 
 namespace Psalm\Internal\Analyzer;
 
+/**
+ * @internal
+ */
 class ClassLikeNameOptions
 {
     /** @var bool */

--- a/src/Psalm/Internal/Analyzer/DataFlowNodeData.php
+++ b/src/Psalm/Internal/Analyzer/DataFlowNodeData.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Analyzer;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class DataFlowNodeData
 {

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeCollector.php
@@ -19,6 +19,8 @@ use function array_merge;
 
 /**
  * A class for analysing a given method call's effects in relation to $this/self and also looking at return types
+ *
+ * @internal
  */
 class ReturnTypeCollector
 {

--- a/src/Psalm/Internal/Analyzer/IssueData.php
+++ b/src/Psalm/Internal/Analyzer/IssueData.php
@@ -6,6 +6,9 @@ use function str_pad;
 
 use const STR_PAD_LEFT;
 
+/**
+ * @internal
+ */
 class IssueData
 {
     /**

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -39,6 +39,9 @@ use function in_array;
 use function strpos;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class MethodComparator
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
@@ -28,6 +28,9 @@ use function array_merge;
 use function array_values;
 use function count;
 
+/**
+ * @internal
+ */
 class IfConditionalAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseAnalyzer.php
@@ -23,6 +23,9 @@ use function in_array;
 use function preg_match;
 use function preg_quote;
 
+/**
+ * @internal
+ */
 class ElseAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseIfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseIfAnalyzer.php
@@ -38,6 +38,9 @@ use function preg_match;
 use function preg_quote;
 use function spl_object_id;
 
+/**
+ * @internal
+ */
 class ElseIfAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
@@ -38,6 +38,9 @@ use function in_array;
 use function strpos;
 use function substr;
 
+/**
+ * @internal
+ */
 class IfAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/BreakAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/BreakAnalyzer.php
@@ -10,6 +10,9 @@ use Psalm\Type;
 
 use function end;
 
+/**
+ * @internal
+ */
 class BreakAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/ContinueAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ContinueAnalyzer.php
@@ -13,6 +13,9 @@ use Psalm\Type;
 
 use function end;
 
+/**
+ * @internal
+ */
 class ContinueAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/EchoAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/EchoAnalyzer.php
@@ -19,6 +19,9 @@ use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 use Psalm\Type\TaintKind;
 
+/**
+ * @internal
+ */
 class EchoAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayCreationInfo.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayCreationInfo.php
@@ -6,6 +6,9 @@ use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\Type\Atomic;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class ArrayCreationInfo
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/AssignedProperty.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/AssignedProperty.php
@@ -4,6 +4,9 @@ namespace Psalm\Internal\Analyzer\Statements\Expression\Assignment;
 
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class AssignedProperty
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BitwiseNotAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BitwiseNotAnalyzer.php
@@ -21,6 +21,9 @@ use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TString;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class BitwiseNotAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BooleanNotAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BooleanNotAnalyzer.php
@@ -8,6 +8,9 @@ use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Type;
 
+/**
+ * @internal
+ */
 class BooleanNotAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentMapPopulator.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentMapPopulator.php
@@ -18,6 +18,9 @@ use function strlen;
 use function substr;
 use function token_get_all;
 
+/**
+ * @internal
+ */
 class ArgumentMapPopulator
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
@@ -16,6 +16,9 @@ use function array_keys;
 use function array_merge;
 use function array_search;
 
+/**
+ * @internal
+ */
 class ClassTemplateParamCollector
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicCallContext.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicCallContext.php
@@ -5,6 +5,9 @@ namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 use PhpParser;
 use Psalm\Internal\MethodIdentifier;
 
+/**
+ * @internal
+ */
 class AtomicCallContext
 {
     /** @var MethodIdentifier */

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalysisResult.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalysisResult.php
@@ -5,6 +5,9 @@ namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class AtomicMethodCallAnalysisResult
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -56,6 +56,8 @@ use function strtolower;
  * methods.
  *
  * The happy path (i.e 99% of method calls) is handled in ExistingAtomicMethodCallAnalyzer
+ *
+ * @internal
  */
 class AtomicMethodCallAnalyzer extends CallAnalyzer
 {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -48,6 +48,9 @@ use function explode;
 use function in_array;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
@@ -11,6 +11,9 @@ use Psalm\Issue\DeprecatedMethod;
 use Psalm\Issue\InternalMethod;
 use Psalm\IssueBuffer;
 
+/**
+ * @internal
+ */
 class MethodCallProhibitionAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -19,6 +19,9 @@ use Psalm\Storage\ClassLikeStorage;
 use Psalm\Storage\MethodStorage;
 use Psalm\Type;
 
+/**
+ * @internal
+ */
 class MethodCallPurityAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -34,6 +34,9 @@ use function count;
 use function in_array;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class MethodCallReturnTypeFetcher
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
@@ -17,6 +17,9 @@ use function array_pop;
 use function end;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class MethodVisibilityAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -25,6 +25,9 @@ use Psalm\Type\Union;
 use function array_map;
 use function array_merge;
 
+/**
+ * @internal
+ */
 class MissingMethodCallHandler
 {
     public static function handleMagicMethod(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -60,6 +60,9 @@ use function count;
 use function in_array;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class AtomicStaticCallAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -44,6 +44,9 @@ use function strpos;
 use function strtolower;
 use function substr;
 
+/**
+ * @internal
+ */
 class ExistingAtomicStaticCallAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -49,6 +49,9 @@ use function array_values;
 use function count;
 use function get_class;
 
+/**
+ * @internal
+ */
 class CastAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
@@ -23,6 +23,9 @@ use Psalm\Type\Atomic\TTemplateParam;
 use function array_merge;
 use function array_pop;
 
+/**
+ * @internal
+ */
 class CloneAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/EmptyAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/EmptyAnalyzer.php
@@ -11,6 +11,9 @@ use Psalm\Issue\InvalidArgument;
 use Psalm\IssueBuffer;
 use Psalm\Type;
 
+/**
+ * @internal
+ */
 class EmptyAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
@@ -16,6 +16,9 @@ use Psalm\Type\Union;
 
 use function in_array;
 
+/**
+ * @internal
+ */
 class EncapsulatedStringAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ExitAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ExitAnalyzer.php
@@ -21,6 +21,9 @@ use Psalm\Type\Atomic\TString;
 use Psalm\Type\TaintKind;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class ExitAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ExpressionIdentifier.php
@@ -14,6 +14,9 @@ use function in_array;
 use function is_string;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class ExpressionIdentifier
 {
     public static function getVarId(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
@@ -17,6 +17,9 @@ use Psalm\Node\Expr\VirtualAssign;
 use Psalm\Node\Scalar\VirtualLNumber;
 use Psalm\Type;
 
+/**
+ * @internal
+ */
 class IncDecExpressionAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/InstanceofAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/InstanceofAnalyzer.php
@@ -14,6 +14,9 @@ use function implode;
 use function in_array;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class InstanceofAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
@@ -8,6 +8,9 @@ use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Type;
 
+/**
+ * @internal
+ */
 class IssetAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/MagicConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/MagicConstAnalyzer.php
@@ -16,6 +16,9 @@ use Psalm\Type\Atomic\TCallableString;
 use Psalm\Type\Atomic\TNonEmptyString;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class MagicConstAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/MatchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/MatchAnalyzer.php
@@ -40,6 +40,9 @@ use function in_array;
 use function spl_object_id;
 use function substr;
 
+/**
+ * @internal
+ */
 class MatchAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/PrintAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/PrintAnalyzer.php
@@ -18,6 +18,9 @@ use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 use Psalm\Type\TaintKind;
 
+/**
+ * @internal
+ */
 class PrintAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -42,6 +42,8 @@ use const PHP_INT_MAX;
 
 /**
  * This class takes a statement and return its type by analyzing each part of the statement if necessary
+ *
+ * @internal
  */
 class SimpleTypeInferer
 {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/UnaryPlusMinusAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/UnaryPlusMinusAnalyzer.php
@@ -20,6 +20,9 @@ use Psalm\Type\Atomic\TPositiveInt;
 use Psalm\Type\Atomic\TString;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class UnaryPlusMinusAnalyzer
 {
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php
@@ -22,6 +22,9 @@ use Psalm\Type;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TNamedObject;
 
+/**
+ * @internal
+ */
 class YieldAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/YieldFromAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/YieldFromAnalyzer.php
@@ -14,6 +14,9 @@ use Psalm\Type\Atomic\TKeyedArray;
 
 use function strtolower;
 
+/**
+ * @internal
+ */
 class YieldFromAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
@@ -15,6 +15,9 @@ use Psalm\IssueBuffer;
 
 use function is_string;
 
+/**
+ * @internal
+ */
 class GlobalAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
@@ -23,6 +23,9 @@ use UnexpectedValueException;
 
 use function is_string;
 
+/**
+ * @internal
+ */
 class StaticAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnsetAnalyzer.php
@@ -19,6 +19,9 @@ use Psalm\Type\Union;
 
 use function count;
 
+/**
+ * @internal
+ */
 class UnsetAnalyzer
 {
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
@@ -19,6 +19,9 @@ use function substr;
 use function token_get_all;
 use function trim;
 
+/**
+ * @internal
+ */
 class UnusedAssignmentRemover
 {
     /**

--- a/src/Psalm/Internal/Cli/LanguageServer.php
+++ b/src/Psalm/Internal/Cli/LanguageServer.php
@@ -52,6 +52,9 @@ require_once __DIR__ . '/../CliUtils.php';
 require_once __DIR__ . '/../Composer.php';
 require_once __DIR__ . '/../IncludeCollector.php';
 
+/**
+ * @internal
+ */
 final class LanguageServer
 {
     /** @param array<int,string> $argv */

--- a/src/Psalm/Internal/Cli/Plugin.php
+++ b/src/Psalm/Internal/Cli/Plugin.php
@@ -22,6 +22,9 @@ use const DIRECTORY_SEPARATOR;
 require_once __DIR__ . '/../CliUtils.php';
 require_once __DIR__ . '/../Composer.php';
 
+/**
+ * @internal
+ */
 final class Plugin
 {
     public static function run(): void

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -87,6 +87,9 @@ require_once __DIR__ . '/../Composer.php';
 require_once __DIR__ . '/../IncludeCollector.php';
 require_once __DIR__ . '/../../IssueBuffer.php';
 
+/**
+ * @internal
+ */
 final class Psalm
 {
     private const SHORT_OPTIONS = [

--- a/src/Psalm/Internal/Cli/Psalter.php
+++ b/src/Psalm/Internal/Cli/Psalter.php
@@ -71,6 +71,9 @@ require_once __DIR__ . '/../Composer.php';
 require_once __DIR__ . '/../IncludeCollector.php';
 require_once __DIR__ . '/../../IssueBuffer.php';
 
+/**
+ * @internal
+ */
 final class Psalter
 {
     private const SHORT_OPTIONS =  ['f:', 'm', 'h', 'r:', 'c:'];

--- a/src/Psalm/Internal/Cli/Refactor.php
+++ b/src/Psalm/Internal/Cli/Refactor.php
@@ -56,6 +56,9 @@ require_once __DIR__ . '/../Composer.php';
 require_once __DIR__ . '/../IncludeCollector.php';
 require_once __DIR__ . '/../../IssueBuffer.php';
 
+/**
+ * @internal
+ */
 final class Refactor
 {
     /** @param array<int,string> $argv */

--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -48,6 +48,9 @@ use const PHP_EOL;
 use const STDERR;
 use const STDIN;
 
+/**
+ * @internal
+ */
 final class CliUtils
 {
     public static function requireAutoloaders(

--- a/src/Psalm/Internal/Codebase/DataFlowGraph.php
+++ b/src/Psalm/Internal/Codebase/DataFlowGraph.php
@@ -15,6 +15,9 @@ use function strlen;
 use function strpos;
 use function substr;
 
+/**
+ * @internal
+ */
 abstract class DataFlowGraph
 {
     /** @var array<string, array<string, Path>> */

--- a/src/Psalm/Internal/Codebase/ReferenceMapGenerator.php
+++ b/src/Psalm/Internal/Codebase/ReferenceMapGenerator.php
@@ -4,6 +4,9 @@ namespace Psalm\Internal\Codebase;
 
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
 
+/**
+ * @internal
+ */
 class ReferenceMapGenerator
 {
     /**

--- a/src/Psalm/Internal/Codebase/TaintFlowGraph.php
+++ b/src/Psalm/Internal/Codebase/TaintFlowGraph.php
@@ -41,6 +41,9 @@ use function sort;
 use function strlen;
 use function substr;
 
+/**
+ * @internal
+ */
 class TaintFlowGraph extends DataFlowGraph
 {
     /** @var array<string, TaintSource> */

--- a/src/Psalm/Internal/Codebase/VariableUseGraph.php
+++ b/src/Psalm/Internal/Codebase/VariableUseGraph.php
@@ -10,6 +10,9 @@ use function abs;
 use function array_merge;
 use function count;
 
+/**
+ * @internal
+ */
 class VariableUseGraph extends DataFlowGraph
 {
     /** @var array<string, array<string, true>> */

--- a/src/Psalm/Internal/DataFlow/DataFlowNode.php
+++ b/src/Psalm/Internal/DataFlow/DataFlowNode.php
@@ -8,6 +8,8 @@ use function strtolower;
 
 /**
  * @psalm-consistent-constructor
+ *
+ * @internal
  */
 class DataFlowNode
 {

--- a/src/Psalm/Internal/DataFlow/Path.php
+++ b/src/Psalm/Internal/DataFlow/Path.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\DataFlow;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class Path
 {

--- a/src/Psalm/Internal/DataFlow/TaintSink.php
+++ b/src/Psalm/Internal/DataFlow/TaintSink.php
@@ -2,6 +2,9 @@
 
 namespace Psalm\Internal\DataFlow;
 
+/**
+ * @internal
+ */
 class TaintSink extends DataFlowNode
 {
 }

--- a/src/Psalm/Internal/DataFlow/TaintSource.php
+++ b/src/Psalm/Internal/DataFlow/TaintSource.php
@@ -2,6 +2,9 @@
 
 namespace Psalm\Internal\DataFlow;
 
+/**
+ * @internal
+ */
 class TaintSource extends DataFlowNode
 {
 }

--- a/src/Psalm/Internal/ErrorHandler.php
+++ b/src/Psalm/Internal/ErrorHandler.php
@@ -16,6 +16,9 @@ use const E_ALL;
 use const E_STRICT;
 use const STDERR;
 
+/**
+ * @internal
+ */
 final class ErrorHandler
 {
     /** @var bool */

--- a/src/Psalm/Internal/EventDispatcher.php
+++ b/src/Psalm/Internal/EventDispatcher.php
@@ -53,6 +53,9 @@ use function array_merge;
 use function count;
 use function is_subclass_of;
 
+/**
+ * @internal
+ */
 class EventDispatcher
 {
     /**

--- a/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/BuildInfoCollector.php
@@ -16,6 +16,8 @@ use function strtotime;
  * Environment variables collector for CI environment.
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
+ *
+ * @internal
  */
 class BuildInfoCollector
 {

--- a/src/Psalm/Internal/ExecutionEnvironment/GitInfoCollector.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/GitInfoCollector.php
@@ -19,6 +19,8 @@ use function trim;
  * Git repository info collector.
  *
  * @author Kitamura Satoshi <with.no.parachute@gmail.com>
+ *
+ * @internal
  */
 class GitInfoCollector
 {

--- a/src/Psalm/Internal/FileManipulation/CodeMigration.php
+++ b/src/Psalm/Internal/FileManipulation/CodeMigration.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\FileManipulation;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class CodeMigration
 {

--- a/src/Psalm/Internal/Fork/ForkProcessDoneMessage.php
+++ b/src/Psalm/Internal/Fork/ForkProcessDoneMessage.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Fork;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class ForkProcessDoneMessage implements ForkMessage
 {

--- a/src/Psalm/Internal/Fork/ForkProcessErrorMessage.php
+++ b/src/Psalm/Internal/Fork/ForkProcessErrorMessage.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Fork;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class ForkProcessErrorMessage implements ForkMessage
 {

--- a/src/Psalm/Internal/Fork/ForkTaskDoneMessage.php
+++ b/src/Psalm/Internal/Fork/ForkTaskDoneMessage.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Fork;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class ForkTaskDoneMessage implements ForkMessage
 {

--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -67,6 +67,8 @@ use const STREAM_SOCK_STREAM;
  *
  * Fork off to n-processes and divide up tasks between
  * each process.
+ *
+ * @internal
  */
 class Pool
 {

--- a/src/Psalm/Internal/IncludeCollector.php
+++ b/src/Psalm/Internal/IncludeCollector.php
@@ -17,6 +17,8 @@ use const PREG_GREP_INVERT;
  * Used to execute code that may cause file inclusions, and report what files have been included
  * NOTE: dependencies of this class should be kept at minimum, as it's used before autoloader is
  * registered.
+ *
+ * @internal
  */
 final class IncludeCollector
 {

--- a/src/Psalm/Internal/Json/Json.php
+++ b/src/Psalm/Internal/Json/Json.php
@@ -13,6 +13,8 @@ use const JSON_UNESCAPED_UNICODE;
 
 /**
  * Provides ability of pretty printed JSON output.
+ *
+ * @internal
  */
 class Json
 {

--- a/src/Psalm/Internal/LanguageServer/Client/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Client/TextDocument.php
@@ -16,6 +16,8 @@ use function Amp\call;
 
 /**
  * Provides method handlers for all textDocument/* methods
+ *
+ * @internal
  */
 class TextDocument
 {

--- a/src/Psalm/Internal/LanguageServer/IdGenerator.php
+++ b/src/Psalm/Internal/LanguageServer/IdGenerator.php
@@ -6,6 +6,8 @@ namespace Psalm\Internal\LanguageServer;
 
 /**
  * Generates unique, incremental IDs for use as request IDs
+ *
+ * @internal
  */
 class IdGenerator
 {

--- a/src/Psalm/Internal/LanguageServer/ProtocolStreamReader.php
+++ b/src/Psalm/Internal/LanguageServer/ProtocolStreamReader.php
@@ -18,6 +18,8 @@ use function trim;
 
 /**
  * Source: https://github.com/felixfbecker/php-language-server/tree/master/src/ProtocolStreamReader.php
+ *
+ * @internal
  */
 class ProtocolStreamReader implements ProtocolReader
 {

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -36,6 +36,8 @@ use function substr_count;
 
 /**
  * Provides method handlers for all textDocument/* methods
+ *
+ * @internal
  */
 class TextDocument
 {

--- a/src/Psalm/Internal/LanguageServer/Server/Workspace.php
+++ b/src/Psalm/Internal/LanguageServer/Server/Workspace.php
@@ -12,6 +12,8 @@ use Psalm\Internal\LanguageServer\LanguageServer;
 
 /**
  * Provides method handlers for all workspace/* methods
+ *
+ * @internal
  */
 class Workspace
 {

--- a/src/Psalm/Internal/MethodIdentifier.php
+++ b/src/Psalm/Internal/MethodIdentifier.php
@@ -12,6 +12,8 @@ use function strtolower;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class MethodIdentifier
 {

--- a/src/Psalm/Internal/PhpVisitor/CloningVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/CloningVisitor.php
@@ -14,6 +14,8 @@ use function array_map;
  * Visitor cloning all nodes and linking to the original nodes using an attribute.
  *
  * This visitor is required to perform format-preserving pretty prints.
+ *
+ * @internal
  */
 class CloningVisitor extends NodeVisitorAbstract
 {

--- a/src/Psalm/Internal/PhpVisitor/ConditionCloningVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ConditionCloningVisitor.php
@@ -9,6 +9,9 @@ use PhpParser\Node\Expr;
 use PhpParser\NodeVisitorAbstract;
 use Psalm\Internal\Provider\NodeDataProvider;
 
+/**
+ * @internal
+ */
 class ConditionCloningVisitor extends NodeVisitorAbstract
 {
     private $type_provider;

--- a/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/OffsetShifterVisitor.php
@@ -6,6 +6,8 @@ use PhpParser;
 
 /**
  * Shifts all nodes in a given AST by a set amount
+ *
+ * @internal
  */
 class OffsetShifterVisitor extends PhpParser\NodeVisitorAbstract
 {

--- a/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
@@ -25,6 +25,8 @@ use const PREG_SET_ORDER;
 /**
  * Given a list of file diffs, this scans an AST to find the sections it can replace, and parses
  * just those methods.
+ *
+ * @internal
  */
 class PartialParserVisitor extends PhpParser\NodeVisitorAbstract
 {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/AttributeResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/AttributeResolver.php
@@ -17,6 +17,9 @@ use Psalm\Type;
 
 use function strtolower;
 
+/**
+ * @internal
+ */
 class AttributeResolver
 {
     public static function resolve(

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -84,6 +84,9 @@ use function usort;
 use const PREG_SPLIT_DELIM_CAPTURE;
 use const PREG_SPLIT_NO_EMPTY;
 
+/**
+ * @internal
+ */
 class ClassLikeNodeScanner
 {
     /**

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionResolver.php
@@ -37,6 +37,9 @@ use function implode;
 use function interface_exists;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class ExpressionResolver
 {
     public static function getUnresolvedClassConstExpr(

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionScanner.php
@@ -32,6 +32,9 @@ use function substr;
 
 use const DIRECTORY_SEPARATOR;
 
+/**
+ * @internal
+ */
 class ExpressionScanner
 {
     public static function scan(

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -29,6 +29,9 @@ use function substr;
 use function substr_count;
 use function trim;
 
+/**
+ * @internal
+ */
 class FunctionLikeDocblockParser
 {
     /**

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -54,6 +54,9 @@ use function strtolower;
 use function substr;
 use function trim;
 
+/**
+ * @internal
+ */
 class FunctionLikeDocblockScanner
 {
     /**

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -64,6 +64,9 @@ use function strlen;
 use function strpos;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class FunctionLikeNodeScanner
 {
     /**

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -16,6 +16,9 @@ use UnexpectedValueException;
 use function implode;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class TypeHintResolver
 {
     /**

--- a/src/Psalm/Internal/PhpVisitor/TraitFinder.php
+++ b/src/Psalm/Internal/PhpVisitor/TraitFinder.php
@@ -14,6 +14,8 @@ use function trait_exists;
 /**
  * Given a list of file diffs, this scans an AST to find the sections it can replace, and parses
  * just those methods.
+ *
+ * @internal
  */
 class TraitFinder extends PhpParser\NodeVisitorAbstract
 {

--- a/src/Psalm/Internal/PhpVisitor/TypeMappingVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/TypeMappingVisitor.php
@@ -8,6 +8,9 @@ use PhpParser\Node;
 use PhpParser\NodeVisitorAbstract;
 use Psalm\Internal\Provider\NodeDataProvider;
 
+/**
+ * @internal
+ */
 class TypeMappingVisitor extends NodeVisitorAbstract
 {
     private $fake_type_provider;

--- a/src/Psalm/Internal/PluginManager/ComposerLock.php
+++ b/src/Psalm/Internal/PluginManager/ComposerLock.php
@@ -12,6 +12,9 @@ use function json_decode;
 use function json_last_error;
 use function json_last_error_msg;
 
+/**
+ * @internal
+ */
 class ComposerLock
 {
     /** @var string[] */

--- a/src/Psalm/Internal/PluginManager/ConfigFile.php
+++ b/src/Psalm/Internal/PluginManager/ConfigFile.php
@@ -12,6 +12,9 @@ use function file_put_contents;
 use function strpos;
 use function substr;
 
+/**
+ * @internal
+ */
 class ConfigFile
 {
     /** @var string */

--- a/src/Psalm/Internal/PluginManager/PluginList.php
+++ b/src/Psalm/Internal/PluginManager/PluginList.php
@@ -11,6 +11,9 @@ use function array_key_exists;
 use function array_search;
 use function strpos;
 
+/**
+ * @internal
+ */
 class PluginList
 {
     /** @var null|ConfigFile */

--- a/src/Psalm/Internal/PluginManager/PluginListFactory.php
+++ b/src/Psalm/Internal/PluginManager/PluginListFactory.php
@@ -12,6 +12,9 @@ use function urlencode;
 
 use const DIRECTORY_SEPARATOR;
 
+/**
+ * @internal
+ */
 class PluginListFactory
 {
     /** @var string */

--- a/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
+++ b/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
@@ -13,6 +13,9 @@ use function strtolower;
 
 use const ENT_QUOTES;
 
+/**
+ * @internal
+ */
 class HtmlFunctionTainter implements AddTaintsInterface, RemoveTaintsInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/FakeFileProvider.php
+++ b/src/Psalm/Internal/Provider/FakeFileProvider.php
@@ -6,6 +6,9 @@ use function microtime;
 use function strpos;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class FakeFileProvider extends FileProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -19,6 +19,9 @@ use function strtolower;
 
 use const DIRECTORY_SEPARATOR;
 
+/**
+ * @internal
+ */
 class FileProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -18,10 +18,12 @@ use function unserialize;
 use const DIRECTORY_SEPARATOR;
 
 /**
- * @psalm-import-type  FileMapType from Analyzer
+ * @psalm-import-type FileMapType from Analyzer
  *
  * Used to determine which files reference other files, necessary for using the --diff
  * option from the command line.
+ *
+ * @internal
  */
 class FileReferenceCacheProvider
 {

--- a/src/Psalm/Internal/Provider/FileReferenceProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceProvider.php
@@ -21,6 +21,8 @@ use function file_exists;
  *
  * Used to determine which files reference other files, necessary for using the --diff
  * option from the command line.
+ *
+ * @internal
  */
 class FileReferenceProvider
 {

--- a/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionExistenceProvider.php
@@ -11,6 +11,9 @@ use Psalm\StatementsSource;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class FunctionExistenceProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/FunctionParamsProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionParamsProvider.php
@@ -15,6 +15,9 @@ use Psalm\Storage\FunctionLikeParameter;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class FunctionParamsProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -48,6 +48,9 @@ use Psalm\Type\Union;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class FunctionReturnTypeProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/MethodExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/MethodExistenceProvider.php
@@ -12,6 +12,9 @@ use Psalm\StatementsSource;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class MethodExistenceProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/MethodParamsProvider.php
+++ b/src/Psalm/Internal/Provider/MethodParamsProvider.php
@@ -16,6 +16,9 @@ use Psalm\Storage\FunctionLikeParameter;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class MethodParamsProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/MethodReturnTypeProvider.php
@@ -20,6 +20,9 @@ use Psalm\Type\Union;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class MethodReturnTypeProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/MethodVisibilityProvider.php
@@ -13,6 +13,9 @@ use Psalm\StatementsSource;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class MethodVisibilityProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/NodeDataProvider.php
+++ b/src/Psalm/Internal/Provider/NodeDataProvider.php
@@ -16,6 +16,9 @@ use Psalm\Storage\Assertion;
 use Psalm\Type\Union;
 use SplObjectStorage;
 
+/**
+ * @internal
+ */
 class NodeDataProvider implements NodeTypeProvider
 {
     /** @var SplObjectStorage<Node, Union> */

--- a/src/Psalm/Internal/Provider/ProjectCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ProjectCacheProvider.php
@@ -17,6 +17,8 @@ use const DIRECTORY_SEPARATOR;
 /**
  * Used to determine which files reference other files, necessary for using the --diff
  * option from the command line.
+ *
+ * @internal
  */
 class ProjectCacheProvider
 {

--- a/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyExistenceProvider.php
@@ -13,6 +13,9 @@ use Psalm\StatementsSource;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class PropertyExistenceProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/PropertyTypeProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyTypeProvider.php
@@ -14,6 +14,9 @@ use Psalm\Type\Union;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class PropertyTypeProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/PropertyTypeProvider/DomDocumentPropertyTypeProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyTypeProvider/DomDocumentPropertyTypeProvider.php
@@ -12,6 +12,9 @@ use Psalm\Type\Union;
 
 use function strtolower;
 
+/**
+ * @internal
+ */
 class DomDocumentPropertyTypeProvider implements PropertyTypeProviderInterface
 {
     public static function getPropertyType(PropertyTypeProviderEvent $event): ?Union

--- a/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
+++ b/src/Psalm/Internal/Provider/PropertyVisibilityProvider.php
@@ -13,6 +13,9 @@ use Psalm\StatementsSource;
 use function is_subclass_of;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class PropertyVisibilityProvider
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayChunkReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayChunkReturnTypeProvider.php
@@ -15,6 +15,9 @@ use Psalm\Type\Union;
 
 use function count;
 
+/**
+ * @internal
+ */
 class ArrayChunkReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
@@ -16,6 +16,9 @@ use Psalm\Type\Union;
 use function count;
 use function reset;
 
+/**
+ * @internal
+ */
 class ArrayColumnReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFillReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFillReturnTypeProvider.php
@@ -13,6 +13,9 @@ use Psalm\Type\Atomic\TNonEmptyArray;
 use Psalm\Type\Atomic\TNonEmptyList;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class ArrayFillReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -33,6 +33,9 @@ use function mt_rand;
 use function reset;
 use function spl_object_id;
 
+/**
+ * @internal
+ */
 class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php
@@ -44,6 +44,9 @@ use function reset;
 use function strpos;
 use function substr;
 
+/**
+ * @internal
+ */
 class ArrayMapReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMergeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMergeReturnTypeProvider.php
@@ -24,6 +24,9 @@ use function count;
 use function is_string;
 use function max;
 
+/**
+ * @internal
+ */
 class ArrayMergeReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPadReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPadReturnTypeProvider.php
@@ -16,6 +16,9 @@ use Psalm\Type\Union;
 
 use function count;
 
+/**
+ * @internal
+ */
 class ArrayPadReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPointerAdjustmentReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPointerAdjustmentReturnTypeProvider.php
@@ -20,6 +20,9 @@ use UnexpectedValueException;
 use function array_merge;
 use function array_shift;
 
+/**
+ * @internal
+ */
 class ArrayPointerAdjustmentReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPopReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPopReturnTypeProvider.php
@@ -14,6 +14,9 @@ use Psalm\Type\Atomic\TNonEmptyList;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class ArrayPopReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayRandReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayRandReturnTypeProvider.php
@@ -12,6 +12,9 @@ use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TList;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class ArrayRandReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
@@ -27,6 +27,9 @@ use function strpos;
 use function strtolower;
 use function substr;
 
+/**
+ * @internal
+ */
 class ArrayReduceReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReverseReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReverseReturnTypeProvider.php
@@ -11,6 +11,9 @@ use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TList;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class ArrayReverseReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySliceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySliceReturnTypeProvider.php
@@ -16,6 +16,9 @@ use UnexpectedValueException;
 use function array_merge;
 use function array_shift;
 
+/**
+ * @internal
+ */
 class ArraySliceReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySpliceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySpliceReturnTypeProvider.php
@@ -11,6 +11,9 @@ use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TList;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class ArraySpliceReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayUniqueReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayUniqueReturnTypeProvider.php
@@ -13,6 +13,9 @@ use Psalm\Type\Atomic\TNonEmptyArray;
 use Psalm\Type\Atomic\TNonEmptyList;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class ArrayUniqueReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayValuesReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayValuesReturnTypeProvider.php
@@ -18,6 +18,9 @@ use UnexpectedValueException;
 use function array_merge;
 use function array_shift;
 
+/**
+ * @internal
+ */
 class ArrayValuesReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ClosureFromCallableReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ClosureFromCallableReturnTypeProvider.php
@@ -11,6 +11,9 @@ use Psalm\Type;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class ClosureFromCallableReturnTypeProvider implements MethodReturnTypeProviderInterface
 {
     public static function getClassLikeNames(): array

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/DomNodeAppendChild.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/DomNodeAppendChild.php
@@ -8,6 +8,9 @@ use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class DomNodeAppendChild implements MethodReturnTypeProviderInterface
 {
     public static function getClassLikeNames(): array

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ExplodeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ExplodeReturnTypeProvider.php
@@ -17,6 +17,9 @@ use Psalm\Type\Union;
 
 use function count;
 
+/**
+ * @internal
+ */
 class ExplodeReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterVarReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterVarReturnTypeProvider.php
@@ -27,6 +27,9 @@ use const FILTER_VALIDATE_MAC;
 use const FILTER_VALIDATE_REGEXP;
 use const FILTER_VALIDATE_URL;
 
+/**
+ * @internal
+ */
 class FilterVarReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FirstArgStringReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FirstArgStringReturnTypeProvider.php
@@ -9,6 +9,9 @@ use Psalm\Type;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class FirstArgStringReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetClassMethodsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetClassMethodsReturnTypeProvider.php
@@ -8,6 +8,9 @@ use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class GetClassMethodsReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
@@ -19,6 +19,9 @@ use stdClass;
 use function reset;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class GetObjectVarsReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/HexdecReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/HexdecReturnTypeProvider.php
@@ -8,6 +8,9 @@ use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class HexdecReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ImagickPixelColorReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ImagickPixelColorReturnTypeProvider.php
@@ -14,6 +14,9 @@ use Psalm\Type\Union;
 use function assert;
 use function in_array;
 
+/**
+ * @internal
+ */
 class ImagickPixelColorReturnTypeProvider implements MethodReturnTypeProviderInterface
 {
     public static function getClassLikeNames(): array

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/InArrayReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/InArrayReturnTypeProvider.php
@@ -11,6 +11,9 @@ use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TList;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class InArrayReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
@@ -20,6 +20,9 @@ use function array_merge;
 use function array_shift;
 use function assert;
 
+/**
+ * @internal
+ */
 class IteratorToArrayReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/MinMaxReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/MinMaxReturnTypeProvider.php
@@ -23,6 +23,9 @@ use function in_array;
 use function max;
 use function min;
 
+/**
+ * @internal
+ */
 class MinMaxReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/MktimeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/MktimeReturnTypeProvider.php
@@ -10,6 +10,9 @@ use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class MktimeReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ParseUrlReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ParseUrlReturnTypeProvider.php
@@ -26,6 +26,9 @@ use const PHP_URL_QUERY;
 use const PHP_URL_SCHEME;
 use const PHP_URL_USER;
 
+/**
+ * @internal
+ */
 class ParseUrlReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
@@ -17,6 +17,9 @@ use Psalm\Type\Union;
 
 use function class_exists;
 
+/**
+ * @internal
+ */
 class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterface
 {
     public static function getClassLikeNames(): array

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementSetFetchMode.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementSetFetchMode.php
@@ -10,6 +10,9 @@ use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Type;
 
+/**
+ * @internal
+ */
 class PdoStatementSetFetchMode implements MethodParamsProviderInterface
 {
     public static function getClassLikeNames(): array

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/RandReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/RandReturnTypeProvider.php
@@ -14,6 +14,9 @@ use Psalm\Type\Union;
 
 use function count;
 
+/**
+ * @internal
+ */
 class RandReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/SimpleXmlElementAsXml.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/SimpleXmlElementAsXml.php
@@ -9,6 +9,9 @@ use Psalm\Type\Union;
 
 use function count;
 
+/**
+ * @internal
+ */
 class SimpleXmlElementAsXml implements MethodReturnTypeProviderInterface
 {
     public static function getClassLikeNames(): array

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/StrReplaceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/StrReplaceReturnTypeProvider.php
@@ -12,6 +12,9 @@ use Psalm\Type\Union;
 use function count;
 use function in_array;
 
+/**
+ * @internal
+ */
 class StrReplaceReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/StrTrReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/StrTrReturnTypeProvider.php
@@ -12,6 +12,9 @@ use UnexpectedValueException;
 
 use function in_array;
 
+/**
+ * @internal
+ */
 class StrTrReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/TriggerErrorReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/TriggerErrorReturnTypeProvider.php
@@ -21,6 +21,9 @@ use const E_USER_ERROR;
 use const E_USER_NOTICE;
 use const E_USER_WARNING;
 
+/**
+ * @internal
+ */
 class TriggerErrorReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/VersionCompareReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/VersionCompareReturnTypeProvider.php
@@ -15,6 +15,9 @@ use Psalm\Type\Union;
 
 use function count;
 
+/**
+ * @internal
+ */
 class VersionCompareReturnTypeProvider implements FunctionReturnTypeProviderInterface
 {
     /**

--- a/src/Psalm/Internal/RuntimeCaches.php
+++ b/src/Psalm/Internal/RuntimeCaches.php
@@ -18,6 +18,9 @@ use Psalm\Internal\Scanner\ParsedDocblock;
 use Psalm\Internal\Type\TypeTokenizer;
 use Psalm\IssueBuffer;
 
+/**
+ * @internal
+ */
 abstract class RuntimeCaches
 {
     public static function clearAll(): void

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -19,6 +19,8 @@ use const PREG_OFFSET_CAPTURE;
 
 /**
  * This class will parse Docblocks in order to extract known tags from them
+ *
+ * @internal
  */
 class DocblockParser
 {

--- a/src/Psalm/Internal/Scanner/ParsedDocblock.php
+++ b/src/Psalm/Internal/Scanner/ParsedDocblock.php
@@ -5,6 +5,9 @@ namespace Psalm\Internal\Scanner;
 use function explode;
 use function trim;
 
+/**
+ * @internal
+ */
 class ParsedDocblock
 {
     /** @var string */

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayOffsetFetch.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayOffsetFetch.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class ArrayOffsetFetch extends UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ArraySpread.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ArraySpread.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class ArraySpread extends UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayValue.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ArrayValue.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class ArrayValue extends UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ClassConstant.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ClassConstant.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class ClassConstant extends UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/Constant.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/Constant.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class Constant extends UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/KeyValuePair.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/KeyValuePair.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class KeyValuePair extends UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/ScalarValue.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/ScalarValue.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class ScalarValue extends UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedAdditionOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedAdditionOp.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class UnresolvedAdditionOp extends UnresolvedBinaryOp
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBinaryOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBinaryOp.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 abstract class UnresolvedBinaryOp extends UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBitwiseAnd.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBitwiseAnd.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class UnresolvedBitwiseAnd extends UnresolvedBinaryOp
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBitwiseOr.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBitwiseOr.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class UnresolvedBitwiseOr extends UnresolvedBinaryOp
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBitwiseXor.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedBitwiseXor.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class UnresolvedBitwiseXor extends UnresolvedBinaryOp
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedConcatOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedConcatOp.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class UnresolvedConcatOp extends UnresolvedBinaryOp
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedDivisionOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedDivisionOp.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class UnresolvedDivisionOp extends UnresolvedBinaryOp
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedMultiplicationOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedMultiplicationOp.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class UnresolvedMultiplicationOp extends UnresolvedBinaryOp
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedSubtractionOp.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedSubtractionOp.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Scanner\UnresolvedConstant;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class UnresolvedSubtractionOp extends UnresolvedBinaryOp
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedTernary.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstant/UnresolvedTernary.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Scanner\UnresolvedConstantComponent;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class UnresolvedTernary extends UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Scanner/UnresolvedConstantComponent.php
+++ b/src/Psalm/Internal/Scanner/UnresolvedConstantComponent.php
@@ -4,6 +4,8 @@ namespace Psalm\Internal\Scanner;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 abstract class UnresolvedConstantComponent
 {

--- a/src/Psalm/Internal/Stubs/Generator/ClassLikeStubGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/ClassLikeStubGenerator.php
@@ -25,6 +25,9 @@ use UnexpectedValueException;
 use function array_slice;
 use function rtrim;
 
+/**
+ * @internal
+ */
 class ClassLikeStubGenerator
 {
     /**

--- a/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
@@ -107,6 +107,9 @@ use function is_int;
 use function rtrim;
 use function strpos;
 
+/**
+ * @internal
+ */
 class StubsGenerator
 {
     public static function getAll(

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -50,6 +50,9 @@ use function is_string;
 use function strpos;
 use function substr;
 
+/**
+ * @internal
+ */
 class AssertionReconciler extends Reconciler
 {
     /**

--- a/src/Psalm/Internal/Type/Comparator/TypeComparisonResult.php
+++ b/src/Psalm/Internal/Type/Comparator/TypeComparisonResult.php
@@ -5,6 +5,9 @@ namespace Psalm\Internal\Type\Comparator;
 use Psalm\Type\Atomic;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class TypeComparisonResult
 {
     /**

--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -29,6 +29,9 @@ use function strpos;
 use function strtolower;
 use function substr;
 
+/**
+ * @internal
+ */
 class NegatedAssertionReconciler extends Reconciler
 {
     /**

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -67,6 +67,8 @@ use function substr;
  * This class receives a known type and an assertion (probably coming from AssertionFinder). The goal is to refine
  * the known type using the assertion. For example: old type is `int` assertion is `>5` result is `int<6, max>`.
  * Complex reconciliation takes part in AssertionReconciler if this class couldn't handle the reconciliation
+ *
+ * @internal
  */
 class SimpleAssertionReconciler extends Reconciler
 {

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -55,6 +55,9 @@ use function max;
 use function strpos;
 use function substr;
 
+/**
+ * @internal
+ */
 class SimpleNegatedAssertionReconciler extends Reconciler
 {
     /**

--- a/src/Psalm/Internal/Type/TemplateBound.php
+++ b/src/Psalm/Internal/Type/TemplateBound.php
@@ -4,6 +4,9 @@ namespace Psalm\Internal\Type;
 
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class TemplateBound
 {
     /**

--- a/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
@@ -30,6 +30,9 @@ use function array_shift;
 use function array_values;
 use function strpos;
 
+/**
+ * @internal
+ */
 class TemplateInferredTypeReplacer
 {
     /**

--- a/src/Psalm/Internal/Type/TemplateResult.php
+++ b/src/Psalm/Internal/Type/TemplateResult.php
@@ -20,6 +20,8 @@ use function array_map;
  * parameters — given a parameter type `callable(): T2` and an argument typed as
  * `callable(): string`, `string` will be added as a _lower_ bound for the template
  * param `T2`.
+ *
+ * @internal
  */
 class TemplateResult
 {

--- a/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
@@ -45,6 +45,9 @@ use function strpos;
 use function substr;
 use function usort;
 
+/**
+ * @internal
+ */
 class TemplateStandinTypeReplacer
 {
     /**

--- a/src/Psalm/Internal/Type/TypeAlias/ClassTypeAlias.php
+++ b/src/Psalm/Internal/Type/TypeAlias/ClassTypeAlias.php
@@ -5,6 +5,9 @@ namespace Psalm\Internal\Type\TypeAlias;
 use Psalm\Internal\Type\TypeAlias;
 use Psalm\Type\Atomic;
 
+/**
+ * @internal
+ */
 class ClassTypeAlias implements TypeAlias
 {
     /**

--- a/src/Psalm/Internal/Type/TypeAlias/InlineTypeAlias.php
+++ b/src/Psalm/Internal/Type/TypeAlias/InlineTypeAlias.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Type\TypeAlias;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class InlineTypeAlias implements TypeAlias
 {

--- a/src/Psalm/Internal/Type/TypeAlias/LinkableTypeAlias.php
+++ b/src/Psalm/Internal/Type/TypeAlias/LinkableTypeAlias.php
@@ -6,6 +6,8 @@ use Psalm\Internal\Type\TypeAlias;
 
 /**
  * @psalm-immutable
+ *
+ * @internal
  */
 class LinkableTypeAlias implements TypeAlias
 {

--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -70,6 +70,9 @@ use function strpos;
 use function strtolower;
 use function substr;
 
+/**
+ * @internal
+ */
 class TypeCombiner
 {
     /**

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -92,6 +92,9 @@ use function strpos;
 use function strtolower;
 use function substr;
 
+/**
+ * @internal
+ */
 class TypeParser
 {
     /**

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -19,6 +19,9 @@ use function strlen;
 use function strpos;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class TypeTokenizer
 {
     /**

--- a/src/Psalm/Internal/TypeVisitor/ContainsClassLikeVisitor.php
+++ b/src/Psalm/Internal/TypeVisitor/ContainsClassLikeVisitor.php
@@ -10,6 +10,9 @@ use Psalm\Type\TypeNode;
 
 use function strtolower;
 
+/**
+ * @internal
+ */
 class ContainsClassLikeVisitor extends NodeVisitor
 {
     /**

--- a/src/Psalm/Internal/TypeVisitor/ContainsLiteralVisitor.php
+++ b/src/Psalm/Internal/TypeVisitor/ContainsLiteralVisitor.php
@@ -11,6 +11,9 @@ use Psalm\Type\Atomic\TTrue;
 use Psalm\Type\NodeVisitor;
 use Psalm\Type\TypeNode;
 
+/**
+ * @internal
+ */
 class ContainsLiteralVisitor extends NodeVisitor
 {
     /**

--- a/src/Psalm/Internal/TypeVisitor/FromDocblockSetter.php
+++ b/src/Psalm/Internal/TypeVisitor/FromDocblockSetter.php
@@ -8,6 +8,9 @@ use Psalm\Type\NodeVisitor;
 use Psalm\Type\TypeNode;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class FromDocblockSetter extends NodeVisitor
 {
     /**

--- a/src/Psalm/Internal/TypeVisitor/TemplateTypeCollector.php
+++ b/src/Psalm/Internal/TypeVisitor/TemplateTypeCollector.php
@@ -10,6 +10,9 @@ use Psalm\Type\NodeVisitor;
 use Psalm\Type\TypeNode;
 use Psalm\Type\Union;
 
+/**
+ * @internal
+ */
 class TemplateTypeCollector extends NodeVisitor
 {
     /**

--- a/src/Psalm/Internal/TypeVisitor/TypeChecker.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeChecker.php
@@ -39,6 +39,9 @@ use function md5;
 use function strpos;
 use function strtolower;
 
+/**
+ * @internal
+ */
 class TypeChecker extends NodeVisitor
 {
     /**

--- a/src/Psalm/Internal/TypeVisitor/TypeScanner.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeScanner.php
@@ -12,6 +12,9 @@ use Psalm\Type\TypeNode;
 
 use function strtolower;
 
+/**
+ * @internal
+ */
 class TypeScanner extends NodeVisitor
 {
     private $scanner;


### PR DESCRIPTION
Background: https://github.com/Roave/BackwardCompatibilityCheck/issues/382

This PR adds a plugin that enforces that all classlikes under `Psalm\Internal` namespace are marked `@internal`. The plugin also acts as a fixer (when it's used with `psalter`).