### PR TITLE
resolve ClassConstant for both sides in isContainedBy

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -485,7 +485,9 @@ class UnionTypeComparator
                 true
             );
             if ($expanded instanceof Atomic) {
-                $atomic_types[] = $expanded;
+                if (!$expanded instanceof TTypeAlias && !$expanded instanceof TClassConstant) {
+                    $atomic_types[] = $expanded;
+                }
                 continue;
             }
 

--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -84,27 +84,6 @@ class UnionTypeComparator
                 continue;
             }
 
-            if ($input_type_part instanceof TClassConstant) {
-                $expanded = TypeExpander::expandAtomic(
-                    $codebase,
-                    $input_type_part,
-                    $input_type_part->fq_classlike_name,
-                    $input_type_part->fq_classlike_name,
-                    null,
-                    true,
-                    true
-                );
-
-                if ($expanded instanceof Atomic) {
-                    if (!$expanded instanceof TClassConstant) {
-                        $input_atomic_types[] = $expanded;
-                        continue;
-                    }
-                } else {
-                    $input_atomic_types = array_merge($expanded, $input_atomic_types);
-                    continue;
-                }
-            }
 
             $type_match_found = false;
             $scalar_type_match_found = false;
@@ -485,15 +464,22 @@ class UnionTypeComparator
     ): array {
         $atomic_types = [];
         foreach ($union_type->getAtomicTypes() as $atomic_type) {
-            if (!$atomic_type instanceof TTypeAlias) {
+            if (!$atomic_type instanceof TTypeAlias && !$atomic_type instanceof TClassConstant) {
                 $atomic_types[] = $atomic_type;
                 continue;
             }
+
+            if ($atomic_type instanceof TTypeAlias) {
+                $fq_classlike_name = $atomic_type->declaring_fq_classlike_name;
+            } else {
+                $fq_classlike_name = $atomic_type->fq_classlike_name;
+            }
+
             $expanded = TypeExpander::expandAtomic(
                 $codebase,
                 $atomic_type,
-                $atomic_type->declaring_fq_classlike_name,
-                $atomic_type->declaring_fq_classlike_name,
+                $fq_classlike_name,
+                $fq_classlike_name,
                 null,
                 true,
                 true


### PR DESCRIPTION
This is the first part for fixing #7283.

getTypeParts is called twice but TClassConstant was handled after only one of those. I removed the special handling for TClassConstant and mutualized it in getTypeParts  (that was already pretty close) so the two calls profit from this addition