### PR TITLE
Identify ints from TClassConstant when checking for LiteralEquality

### DIFF
--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1266,15 +1266,13 @@ class AssertionReconciler extends Reconciler
     ): Union {
         $value = (int) substr($assertion, $bracket_pos + 1, -1);
 
-        $existing_var_atomic_types = $existing_var_type->getAtomicTypes();
-
         $compatible_int_type = self::getCompatibleIntType($existing_var_type, $value, $is_loose_equality);
         if ($compatible_int_type !== null) {
             return $compatible_int_type;
         }
 
         $has_int = false;
-
+        $existing_var_atomic_types = $existing_var_type->getAtomicTypes();
         foreach ($existing_var_atomic_types as $existing_var_atomic_type) {
             if ($existing_var_atomic_type instanceof TInt) {
                 $has_int = true;
@@ -1299,11 +1297,26 @@ class AssertionReconciler extends Reconciler
                 );
 
                 if ($expanded instanceof Atomic) {
+                    $compatible_int_type = self::getCompatibleIntType($existing_var_type, $value, $is_loose_equality);
+                    if ($compatible_int_type !== null) {
+                        return $compatible_int_type;
+                    }
+
                     if ($expanded instanceof TInt) {
                         $has_int = true;
                     }
                 } else {
                     foreach ($expanded as $expanded_type) {
+                        $compatible_int_type = self::getCompatibleIntType(
+                            $existing_var_type,
+                            $value,
+                            $is_loose_equality
+                        );
+
+                        if ($compatible_int_type !== null) {
+                            return $compatible_int_type;
+                        }
+
                         if ($expanded_type instanceof TInt) {
                             $has_int = true;
                         }

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1252,6 +1252,9 @@ class AssertionReconciler extends Reconciler
         return $existing_var_type;
     }
 
+    /**
+     * @param  string[]          $suppressed_issues
+     */
     private static function handleLiteralEqualityWithInt(
         StatementsAnalyzer $statements_analyzer,
         string             $assertion,


### PR DESCRIPTION
This is the second part of fixing https://github.com/vimeo/psalm/issues/7283

This refactors the int case from handleLiteralEquality because I started using a piece of code multiple times (what's in getCompatibleIntType)

But it mainly add a TClassConstant resolution inside handleLiteralEquality for int cases. This should probably be done for other cases too but I couldn't find a way to make it clean, so this would probably need a refactor at some point.