### PR TITLE
resolve type alias and class const on UnionTypeComparator

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -362,7 +362,7 @@ class UnionTypeComparator
             return false;
         }
 
-        foreach ($container_type->getAtomicTypes() as $container_type_part) {
+        foreach (self::getTypeParts($codebase, $container_type) as $container_type_part) {
             if ($container_type_part instanceof TNull && $ignore_null) {
                 continue;
             }
@@ -371,7 +371,7 @@ class UnionTypeComparator
                 continue;
             }
 
-            foreach ($input_type->getAtomicTypes() as $input_type_part) {
+            foreach (self::getTypeParts($codebase, $input_type) as $input_type_part) {
                 $atomic_comparison_result = new TypeComparisonResult();
                 $is_atomic_contained_by = AtomicTypeComparator::isContainedBy(
                     $codebase,
@@ -411,8 +411,8 @@ class UnionTypeComparator
             return true;
         }
 
-        foreach ($type1->getAtomicTypes() as $type1_part) {
-            foreach ($type2->getAtomicTypes() as $type2_part) {
+        foreach (self::getTypeParts($codebase, $type1) as $type1_part) {
+            foreach (self::getTypeParts($codebase, $type2) as $type2_part) {
                 //special cases for TIntRange because it can contain a part of the other type.
                 //For exemple int<0,1> and positive-int can be identical but none contain the other
                 if (($type1_part instanceof TIntRange && $type2_part instanceof TPositiveInt)) {

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -1200,6 +1200,36 @@ class ConstantTest extends TestCase
                 [],
                 '8.1'
             ],
+            'classConstWithParamOut' => [
+                '<?php
+
+                    class Reconciler
+                    {
+                        public const RECONCILIATION_OK = 0;
+                        public const RECONCILIATION_EMPTY = 1;
+
+                        public static function reconcileKeyedTypes(): void
+                        {
+
+                            $failed_reconciliation = 0;
+
+                            self::boo($failed_reconciliation);
+
+                            if ($failed_reconciliation === self::RECONCILIATION_EMPTY) {
+                                echo "ici";
+                            }
+                        }
+
+                        /** @param-out Reconciler::RECONCILIATION_* $f */
+                        public static function boo(
+                            ?int &$f = self::RECONCILIATION_OK
+                        ): void {
+                            $f = self::RECONCILIATION_EMPTY;
+                        }
+                    }
+                    Reconciler::reconcileKeyedTypes();
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
This is the third part of #7283 and this should close #7283 at last!

There was multiple times where getTypeParts was not called in UnionTypeComparator, which made TypeAlias and ClassConstant not resolved.