### PR TITLE
change nullable for array signature to be equal to param signature

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -12069,7 +12069,7 @@ return [
 'session_reset' => ['bool'],
 'session_save_path' => ['string', 'path='=>'string'],
 'session_set_cookie_params' => ['bool', 'lifetime'=>'int', 'path='=>'?string', 'domain='=>'?string', 'secure='=>'?bool', 'httponly='=>'?bool'],
-'session_set_cookie_params\'1' => ['bool', 'options'=>'array{lifetime?:int,path?:?string,domain?:?string,secure?:?bool,httponly?:?bool,samesite?:string}'],
+'session_set_cookie_params\'1' => ['bool', 'options'=>'array{lifetime?:?int,path?:?string,domain?:?string,secure?:?bool,httponly?:?bool,samesite?:?string}'],
 'session_set_save_handler' => ['bool', 'open'=>'callable(string,string):bool', 'close'=>'callable():bool', 'read'=>'callable(string):string', 'write'=>'callable(string,string):bool', 'destroy'=>'callable(string):bool', 'gc'=>'callable(string):bool', 'create_sid='=>'callable():string', 'validate_sid='=>'callable(string):bool', 'update_timestamp='=>'callable(string):bool'],
 'session_set_save_handler\'1' => ['bool', 'open'=>'SessionHandlerInterface', 'close='=>'bool'],
 'session_start' => ['bool', 'options='=>'array'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -12069,7 +12069,7 @@ return [
 'session_reset' => ['bool'],
 'session_save_path' => ['string', 'path='=>'string'],
 'session_set_cookie_params' => ['bool', 'lifetime'=>'int', 'path='=>'?string', 'domain='=>'?string', 'secure='=>'?bool', 'httponly='=>'?bool'],
-'session_set_cookie_params\'1' => ['bool', 'options'=>'array{lifetime?:int,path?:string,domain?:?string,secure?:bool,httponly?:bool,samesite?:string}'],
+'session_set_cookie_params\'1' => ['bool', 'options'=>'array{lifetime?:int,path?:?string,domain?:?string,secure?:?bool,httponly?:?bool,samesite?:string}'],
 'session_set_save_handler' => ['bool', 'open'=>'callable(string,string):bool', 'close'=>'callable():bool', 'read'=>'callable(string):string', 'write'=>'callable(string,string):bool', 'destroy'=>'callable(string):bool', 'gc'=>'callable(string):bool', 'create_sid='=>'callable():string', 'validate_sid='=>'callable(string):bool', 'update_timestamp='=>'callable(string):bool'],
 'session_set_save_handler\'1' => ['bool', 'open'=>'SessionHandlerInterface', 'close='=>'bool'],
 'session_start' => ['bool', 'options='=>'array'],

--- a/dictionaries/CallMap_73_delta.php
+++ b/dictionaries/CallMap_73_delta.php
@@ -42,7 +42,7 @@ return [
     'is_countable' => ['bool', 'value'=>'mixed'],
     'net_get_interfaces' => ['array<string,array<string,mixed>>|false'],
     'openssl_pkey_derive' => ['string|false', 'public_key'=>'mixed', 'private_key'=>'mixed', 'key_length='=>'?int'],
-    'session_set_cookie_params\'1' => ['bool', 'options'=>'array{lifetime?:int,path?:string,domain?:string,secure?:bool,httponly?:bool,samesite?:string}'],
+    'session_set_cookie_params\'1' => ['bool', 'options'=>'array{lifetime?:?int,path?:?string,domain?:?string,secure?:?bool,httponly?:?bool,samesite?:?string}'],
     'setcookie\'1' => ['bool', 'name'=>'string', 'value='=>'string', 'options='=>'array'],
     'setrawcookie\'1' => ['bool', 'name'=>'string', 'value='=>'string', 'options='=>'array'],
     'socket_wsaprotocol_info_export' => ['string|false', 'socket'=>'resource', 'process_id'=>'int'],

--- a/dictionaries/CallMap_73_delta.php
+++ b/dictionaries/CallMap_73_delta.php
@@ -7,7 +7,7 @@
  * The 'added' section contains function/method names from FunctionSignatureMap (And alternates, if applicable) that do not exist in php 7.2
  * The 'removed' section contains the signatures that were removed in php 7.3.
  * The 'changed' section contains functions for which the signature has changed for php 7.3.
- *     Each function in the 'changed' section has an 'old' and a 'new' section, 
+ *     Each function in the 'changed' section has an 'old' and a 'new' section,
  *     representing the function as it was in PHP 7.2 and in PHP 7.3, respectively
  *
  * @see CallMap.php
@@ -42,7 +42,7 @@ return [
     'is_countable' => ['bool', 'value'=>'mixed'],
     'net_get_interfaces' => ['array<string,array<string,mixed>>|false'],
     'openssl_pkey_derive' => ['string|false', 'public_key'=>'mixed', 'private_key'=>'mixed', 'key_length='=>'?int'],
-    'session_set_cookie_params\'1' => ['bool', 'options'=>'array{lifetime?:int,path?:string,domain?:?string,secure?:bool,httponly?:bool,samesite?:string}'],
+    'session_set_cookie_params\'1' => ['bool', 'options'=>'array{lifetime?:int,path?:string,domain?:string,secure?:bool,httponly?:bool,samesite?:string}'],
     'setcookie\'1' => ['bool', 'name'=>'string', 'value='=>'string', 'options='=>'array'],
     'setrawcookie\'1' => ['bool', 'name'=>'string', 'value='=>'string', 'options='=>'array'],
     'socket_wsaprotocol_info_export' => ['string|false', 'socket'=>'resource', 'process_id'=>'int'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -1133,6 +1133,10 @@ return [
       'old' => ['bool', 'lifetime'=>'int', 'path='=>'string', 'domain='=>'string', 'secure='=>'bool', 'httponly='=>'bool'],
       'new' => ['bool', 'lifetime'=>'int', 'path='=>'?string', 'domain='=>'?string', 'secure='=>'?bool', 'httponly='=>'?bool'],
     ],
+    'session_set_cookie_params\'1' => [
+        'old' => ['bool', 'options'=>'array{lifetime?:int,path?:string,domain?:string,secure?:bool,httponly?:bool,samesite?:string}'],
+        'new' => ['bool', 'options'=>'array{lifetime?:int,path?:?string,domain?:?string,secure?:?bool,httponly?:?bool,samesite?:string}'],
+    ],
     'socket_accept' => [
       'old' => ['resource|false', 'socket'=>'resource'],
       'new' => ['Socket|false', 'socket'=>'Socket'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -1133,10 +1133,6 @@ return [
       'old' => ['bool', 'lifetime'=>'int', 'path='=>'string', 'domain='=>'string', 'secure='=>'bool', 'httponly='=>'bool'],
       'new' => ['bool', 'lifetime'=>'int', 'path='=>'?string', 'domain='=>'?string', 'secure='=>'?bool', 'httponly='=>'?bool'],
     ],
-    'session_set_cookie_params\'1' => [
-        'old' => ['bool', 'options'=>'array{lifetime?:int,path?:string,domain?:string,secure?:bool,httponly?:bool,samesite?:string}'],
-        'new' => ['bool', 'options'=>'array{lifetime?:int,path?:?string,domain?:?string,secure?:?bool,httponly?:?bool,samesite?:string}'],
-    ],
     'socket_accept' => [
       'old' => ['resource|false', 'socket'=>'resource'],
       'new' => ['Socket|false', 'socket'=>'Socket'],


### PR DESCRIPTION
https://www.php.net/manual/en/function.session-set-cookie-params

Nullable had been set for `domain` in 7.3 but there is no indication in the docs for that.

Reading the docs again I would assume as `domain`, `path`, `secure` and `httponly` are nullable as of 8.0 the same is for the array signature:

> When using the second signature, an associative array which may have any of the keys lifetime, path, domain, secure, httponly and samesite**. The values have the same meaning as described for the parameters with the same name**. The value of the samesite element should be either Lax or Strict. If any of the allowed options are not given, their default values are the same as the default values of the explicit parameters. If the samesite element is omitted, no SameSite cookie attribute is set. 

Follow Up of #7215 