### PR TITLE
Refactor Reconciler::handleLiteralEquality

### DIFF
--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1412,6 +1412,17 @@ class AssertionReconciler extends Reconciler
 
                 return new Union([$existing_var_atomic_type]);
             }
+
+            //here we'll accept any type that *could* possibly be valid on loose equality and return the original type
+            if ($is_loose_equality) {
+                if ($existing_var_atomic_type instanceof TInt) {
+                    return $existing_var_type;
+                }
+
+                if ($existing_var_atomic_type instanceof TFloat) {
+                    return $existing_var_type;
+                }
+            }
         }
 
         //if we're here, no type was eligible for the given literal. We'll emit an impossible error for this assertion

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -47,7 +47,6 @@ use Psalm\Type\Union;
 
 use function array_intersect_key;
 use function array_merge;
-use function array_push;
 use function count;
 use function explode;
 use function get_class;

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1243,7 +1243,7 @@ class AssertionReconciler extends Reconciler
                 return new Union([new TLiteralInt($value)]);
             }
 
-            if (get_class($existing_var_atomic_type) === TInt::class) {
+            if ($existing_var_atomic_type instanceof TInt && !$existing_var_atomic_type instanceof TLiteralInt) {
                 return new Union([new TLiteralInt($value)]);
             }
 

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1540,8 +1540,8 @@ class AssertionReconciler extends Reconciler
                     return $existing_var_type;
                 }
 
-                if ($existing_var_atomic_type instanceof TFloat
-                    && !$existing_var_atomic_type instanceof TLiteralFloat
+                if ($existing_var_atomic_type instanceof TString
+                    && !$existing_var_atomic_type instanceof TLiteralString
                 ) {
                     return $existing_var_type;
                 }

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1045,7 +1045,6 @@ class AssertionReconciler extends Reconciler
             return self::handleLiteralEqualityWithFloat(
                 $statements_analyzer,
                 $assertion,
-                $scalar_type,
                 $bracket_pos,
                 $is_loose_equality,
                 $existing_var_type,
@@ -1430,7 +1429,6 @@ class AssertionReconciler extends Reconciler
     private static function handleLiteralEqualityWithFloat(
         StatementsAnalyzer $statements_analyzer,
         string             $assertion,
-        string             $scalar_type,
         int                $bracket_pos,
         bool               $is_loose_equality,
         Union              $existing_var_type,

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1010,6 +1010,7 @@ class AssertionReconciler extends Reconciler
 
         if ($scalar_type === 'int') {
             return self::handleLiteralEqualityWithInt(
+                $statements_analyzer,
                 $assertion,
                 $bracket_pos,
                 $is_loose_equality,
@@ -1189,6 +1190,7 @@ class AssertionReconciler extends Reconciler
      * @param string[]     $suppressed_issues
      */
     private static function handleLiteralEqualityWithInt(
+        StatementsAnalyzer $statements_analyzer,
         string             $assertion,
         int                $bracket_pos,
         bool               $is_loose_equality,
@@ -1262,9 +1264,22 @@ class AssertionReconciler extends Reconciler
                     return $compatible_int_type;
                 }
 
-                if ($existing_var_atomic_type->as->hasInt()) {
-                    return $literal_asserted_type;
-                }
+                $existing_var_atomic_type = clone $existing_var_atomic_type;
+
+                $existing_var_atomic_type->as = self::handleLiteralEquality(
+                    $statements_analyzer,
+                    $assertion,
+                    $bracket_pos,
+                    false,
+                    $existing_var_atomic_type->as,
+                    $old_var_type_string,
+                    $var_id,
+                    $negated,
+                    $code_location,
+                    $suppressed_issues
+                );
+
+                return new Union([$existing_var_atomic_type]);
             }
 
             if ($is_loose_equality

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1361,7 +1361,7 @@ class AssertionReconciler extends Reconciler
                 return new Union([new TLiteralString($value)]);
             }
 
-            if ($existing_var_atomic_type instanceof TString) {
+            if ($existing_var_atomic_type instanceof TString && !$existing_var_atomic_type instanceof TLiteralString) {
                 if ($scalar_type === 'class-string'
                     || $scalar_type === 'interface-string'
                     || $scalar_type === 'trait-string'

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1288,6 +1288,16 @@ class AssertionReconciler extends Reconciler
                 return new Union([$existing_var_atomic_type]);
             }
 
+            if ($is_loose_equality
+                && $existing_var_atomic_type instanceof TLiteralString
+                && (int)$existing_var_atomic_type->value === $value
+            ) {
+                return new Union([$existing_var_atomic_type]);
+            }
+        }
+
+        //here we'll accept non-literal type that *could* match on loose equality and return the original type
+        foreach ($existing_var_atomic_types as $existing_var_atomic_type) {
             //here we'll accept non-literal type that *could* match on loose equality and return the original type
             if ($is_loose_equality) {
                 if ($existing_var_atomic_type instanceof TString
@@ -1441,6 +1451,23 @@ class AssertionReconciler extends Reconciler
                 return new Union([$existing_var_atomic_type]);
             }
 
+            if ($is_loose_equality
+                && $existing_var_atomic_type instanceof TLiteralInt
+                && (string)$existing_var_atomic_type->value === $value
+            ) {
+                return new Union([$existing_var_atomic_type]);
+            }
+
+            if ($is_loose_equality
+                && $existing_var_atomic_type instanceof TLiteralFloat
+                && (string)$existing_var_atomic_type->value === $value
+            ) {
+                return new Union([$existing_var_atomic_type]);
+            }
+        }
+
+        //here we'll accept non-literal type that *could* match on loose equality and return the original type
+        foreach ($existing_var_atomic_types as $existing_var_atomic_type) {
             //here we'll accept non-literal type that *could* match on loose equality and return the original type
             if ($is_loose_equality) {
                 if ($existing_var_atomic_type instanceof TInt

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1636,7 +1636,7 @@ class AssertionReconciler extends Reconciler
     private static function getCompatibleFloatType(
         Union $existing_var_type,
         array $existing_var_atomic_types,
-        int $value,
+        float $value,
         bool $is_loose_equality
     ): ?Union {
         foreach ($existing_var_atomic_types as $existing_var_atomic_type) {

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1185,7 +1185,7 @@ class AssertionReconciler extends Reconciler
     }
 
     /**
-     * @param list<Atomic> $existing_var_atomic_types
+     * @param array<string, Atomic> $existing_var_atomic_types
      * @param string[]     $suppressed_issues
      */
     private static function handleLiteralEqualityWithInt(
@@ -1243,7 +1243,7 @@ class AssertionReconciler extends Reconciler
                 return new Union([new TLiteralInt($value)]);
             }
 
-            if ($existing_var_atomic_type instanceof TInt) {
+            if (get_class($existing_var_atomic_type) === TInt::class) {
                 return new Union([new TLiteralInt($value)]);
             }
 
@@ -1300,7 +1300,7 @@ class AssertionReconciler extends Reconciler
     }
 
     /**
-     * @param list<Atomic> $existing_var_atomic_types
+     * @param array<string, Atomic> $existing_var_atomic_types
      * @param string[]     $suppressed_issues
      */
     private static function handleLiteralEqualityWithString(
@@ -1432,7 +1432,7 @@ class AssertionReconciler extends Reconciler
     }
 
     /**
-     * @param list<Atomic> $existing_var_atomic_types
+     * @param array<string, Atomic> $existing_var_atomic_types
      */
     private static function getCompatibleIntType(
         Union $existing_var_type,
@@ -1458,7 +1458,7 @@ class AssertionReconciler extends Reconciler
     }
 
     /**
-     * @param list<Atomic> $existing_var_atomic_types
+     * @param array<string, Atomic> $existing_var_atomic_types
      */
     private static function getCompatibleStringType(
         Union $existing_var_type,

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1270,13 +1270,17 @@ class AssertionReconciler extends Reconciler
                 return new Union([$existing_var_atomic_type]);
             }
 
-            //here we'll accept any type that *could* possibly be valid on loose equality and return the original type
+            //here we'll accept non-literal type that *could* match on loose equality and return the original type
             if ($is_loose_equality) {
-                if ($existing_var_atomic_type instanceof TString) {
+                if ($existing_var_atomic_type instanceof TString
+                    && !$existing_var_atomic_type instanceof TLiteralString
+                ) {
                     return $existing_var_type;
                 }
 
-                if ($existing_var_atomic_type instanceof TFloat) {
+                if ($existing_var_atomic_type instanceof TFloat
+                    && !$existing_var_atomic_type instanceof TLiteralFloat
+                ) {
                     return $existing_var_type;
                 }
             }
@@ -1413,13 +1417,17 @@ class AssertionReconciler extends Reconciler
                 return new Union([$existing_var_atomic_type]);
             }
 
-            //here we'll accept any type that *could* possibly be valid on loose equality and return the original type
+            //here we'll accept non-literal type that *could* match on loose equality and return the original type
             if ($is_loose_equality) {
-                if ($existing_var_atomic_type instanceof TInt) {
+                if ($existing_var_atomic_type instanceof TInt
+                    && !$existing_var_atomic_type instanceof TLiteralInt
+                ) {
                     return $existing_var_type;
                 }
 
-                if ($existing_var_atomic_type instanceof TFloat) {
+                if ($existing_var_atomic_type instanceof TFloat
+                    && !$existing_var_atomic_type instanceof TLiteralFloat
+                ) {
                     return $existing_var_type;
                 }
             }

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1202,6 +1202,10 @@ class AssertionReconciler extends Reconciler
     ): Union {
         $value = (int) substr($assertion, $bracket_pos + 1, -1);
 
+        // we create the literal that is being asserted. We'll return this when we're sure this is the resulting type
+        $literal_asserted_type = new Union([new TLiteralInt($value)]);
+        $literal_asserted_type->from_docblock = $existing_var_type->from_docblock;
+
         $compatible_int_type = self::getCompatibleIntType(
             $existing_var_type,
             $existing_var_atomic_types,
@@ -1215,11 +1219,11 @@ class AssertionReconciler extends Reconciler
 
         foreach ($existing_var_atomic_types as $existing_var_atomic_type) {
             if ($existing_var_atomic_type instanceof TPositiveInt && $value > 0) {
-                return new Union([new TLiteralInt($value)]);
+                return $literal_asserted_type;
             }
 
             if ($existing_var_atomic_type instanceof TIntRange && $existing_var_atomic_type->contains($value)) {
-                return new Union([new TLiteralInt($value)]);
+                return $literal_asserted_type;
             }
 
             if ($existing_var_atomic_type instanceof TLiteralInt && $existing_var_atomic_type->value === $value) {
@@ -1240,11 +1244,11 @@ class AssertionReconciler extends Reconciler
                     }
                     return $existing_var_type;
                 }
-                return new Union([new TLiteralInt($value)]);
+                return $literal_asserted_type;
             }
 
             if ($existing_var_atomic_type instanceof TInt && !$existing_var_atomic_type instanceof TLiteralInt) {
-                return new Union([new TLiteralInt($value)]);
+                return $literal_asserted_type;
             }
 
             if ($existing_var_atomic_type instanceof TTemplateParam) {
@@ -1259,7 +1263,7 @@ class AssertionReconciler extends Reconciler
                 }
 
                 if ($existing_var_atomic_type->as->hasInt()) {
-                    return new Union([new TLiteralInt($value)]);
+                    return $literal_asserted_type;
                 }
             }
 
@@ -1323,6 +1327,12 @@ class AssertionReconciler extends Reconciler
     ): Union {
         $value = substr($assertion, $bracket_pos + 1, -1);
 
+        // we create the literal that is being asserted. We'll return this when we're sure this is the resulting type
+        $literal_asserted_type_string = new Union([new TLiteralString($value)]);
+        $literal_asserted_type_string->from_docblock = $existing_var_type->from_docblock;
+        $literal_asserted_type_classstring = new Union([new TLiteralClassString($value)]);
+        $literal_asserted_type_classstring->from_docblock = $existing_var_type->from_docblock;
+
         $compatible_string_type = self::getCompatibleStringType(
             $existing_var_type,
             $existing_var_atomic_types,
@@ -1359,10 +1369,10 @@ class AssertionReconciler extends Reconciler
                     || $scalar_type === 'interface-string'
                     || $scalar_type === 'trait-string'
                 ) {
-                    return new Union([new TLiteralClassString($value)]);
+                    return $literal_asserted_type_classstring;
                 }
 
-                return new Union([new TLiteralString($value)]);
+                return $literal_asserted_type_string;
             }
 
             if ($existing_var_atomic_type instanceof TString && !$existing_var_atomic_type instanceof TLiteralString) {
@@ -1370,10 +1380,10 @@ class AssertionReconciler extends Reconciler
                     || $scalar_type === 'interface-string'
                     || $scalar_type === 'trait-string'
                 ) {
-                    return new Union([new TLiteralClassString($value)]);
+                    return $literal_asserted_type_classstring;
                 }
 
-                return new Union([new TLiteralString($value)]);
+                return $literal_asserted_type_string;
             }
 
             if ($existing_var_atomic_type instanceof TTemplateParam) {
@@ -1393,10 +1403,10 @@ class AssertionReconciler extends Reconciler
                         || $scalar_type === 'interface-string'
                         || $scalar_type === 'trait-string'
                     ) {
-                        return new Union([new TLiteralClassString($value)]);
+                        return $literal_asserted_type_classstring;
                     }
 
-                    return new Union([new TLiteralString($value)]);
+                    return $literal_asserted_type_string;
                 }
 
                 $existing_var_atomic_type = clone $existing_var_atomic_type;
@@ -1469,7 +1479,9 @@ class AssertionReconciler extends Reconciler
                     return $existing_var_type;
                 }
 
-                return new Union([new TLiteralInt($value)]);
+                $asserted_type = new Union([new TLiteralInt($value)]);
+                $asserted_type->from_docblock = $existing_var_type->from_docblock;
+                return $asserted_type;
             }
         }
 
@@ -1499,10 +1511,14 @@ class AssertionReconciler extends Reconciler
                     || $scalar_type === 'interface-string'
                     || $scalar_type === 'trait-string'
                 ) {
-                    return new Union([new TLiteralClassString($value)]);
+                    $asserted_type = new Union([new TLiteralClassString($value)]);
+                    $asserted_type->from_docblock = $existing_var_type->from_docblock;
+                    return $asserted_type;
                 }
 
-                return new Union([new TLiteralString($value)]);
+                $asserted_type = new Union([new TLiteralString($value)]);
+                $asserted_type->from_docblock = $existing_var_type->from_docblock;
+                return $asserted_type;
             }
         }
 

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -1229,7 +1229,7 @@ class AssertionReconciler extends Reconciler
             }
 
             if ($existing_var_atomic_type instanceof TLiteralInt && $existing_var_atomic_type->value === $value) {
-                //if we're here, we check that we add at least another type in the union, otherwise it's redundant
+                //if we're here, we check that we had at least another type in the union, otherwise it's redundant
 
                 if ($existing_var_type->isSingleIntLiteral()) {
                     if ($var_id && $code_location) {
@@ -1362,7 +1362,7 @@ class AssertionReconciler extends Reconciler
 
         foreach ($existing_var_atomic_types as $existing_var_atomic_type) {
             if ($existing_var_atomic_type instanceof TLiteralString && $existing_var_atomic_type->value === $value) {
-                //if we're here, we check that we add at least another type in the union, otherwise it's redundant
+                //if we're here, we check that we had at least another type in the union, otherwise it's redundant
 
                 if ($existing_var_type->isSingleStringLiteral()) {
                     if ($var_id && $code_location) {

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -997,12 +997,14 @@ class AssertionReconciler extends Reconciler
                 );
 
                 if ($expanded instanceof Atomic) {
-                    $existing_var_atomic_types[] = $expanded;
+                    $existing_var_atomic_types[$expanded->getKey()] = $expanded;
                 } else {
-                    array_push($existing_var_atomic_types, ...$expanded);
+                    foreach ($expanded as $atomic_type) {
+                        $existing_var_atomic_types[$atomic_type->getKey()] = $atomic_type;
+                    }
                 }
             } else {
-                $existing_var_atomic_types[] = $existing_var_atomic_type;
+                $existing_var_atomic_types[$existing_var_atomic_type->getKey()] = $existing_var_atomic_type;
             }
         }
 

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -680,6 +680,9 @@ class IntRangeTest extends TestCase
 
                     assert($length === 1);
                     ',
+                'assertions' => [
+                    '$length===' => '1',
+                ],
             ],
         ];
     }


### PR DESCRIPTION
Sorry for this one, it won't be easy to review.

There is multiple goals here, all intertwined:
- fix some mistakes I made in https://github.com/vimeo/psalm/pull/7287 (mainly, the resolution here: https://github.com/vimeo/psalm/pull/7287/files#diff-7ff683939a23ffc517c44a710a76bfa18959b516c0b77b6c27fb241bc748d83dR1291 was flagging int as `has_int` but they did not match with know literals here: https://github.com/vimeo/psalm/pull/7287/files#diff-7ff683939a23ffc517c44a710a76bfa18959b516c0b77b6c27fb241bc748d83dR1332 so there were failures in some cases)
- improve the system by resolving the ClassConst at the very beggining (instead of just in int handling as I've done before)
- modernizing the code here. I suspect the code here was pretty old in Psalm history. There are way of checking things I never saw until now. For example instead of identifying a TLiteralInt and checking its value, the code here: https://github.com/vimeo/psalm/pull/7287/files#diff-7ff683939a23ffc517c44a710a76bfa18959b516c0b77b6c27fb241bc748d83dR1339 just uses the offset of the array of types (that contains the return of Atomic::getKey()) in order to check the equality with the assertion. I replaced that by a `$atomic instanceof TLiteralInt && $atomic->value === $assertion_value`. This is longer but infinitely more clear to read. We have a similar thing here: https://github.com/vimeo/psalm/pull/7287/files#diff-7ff683939a23ffc517c44a710a76bfa18959b516c0b77b6c27fb241bc748d83dR1388 where we just tweak `float(5)` to fetch the "5" value.

I wanted to keep a clear history of commits but this got out of control quickly. So I think I'll smash the majority of later commits together. I kept them for now for easier reading

I'll probably refactor the float case now that I started, to keep consistency. This has high chances of resolving some old bugs, but if I'm honest, it will probably create some (though they should be easier to fix). It will probably change some TypeDoesNotContainType into DocblockTypeContradiction or the other way around because I was more consistent with keeping the origin of the type than before.

I thought about pushing this on Psalm 5 instead, but I fear that if we do that, we'll have to move #7286, #7287 and #7288 too and I'm not sure if we should or if it's easy to do.

(My goal when I started those changes was to add `Reconciler::RECONCILIATION_*` in @param-out. If I knew I'd have to do all that, I may not have started!)