### PR TITLE
fix empty string not quoted in keyed array offset

### DIFF
--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -430,7 +430,7 @@ class TKeyedArray extends Atomic
      */
     private function escapeAndQuote($name)
     {
-        if (is_string($name) && preg_match('/[^a-zA-Z0-9_]/', $name)) {
+        if (is_string($name) && ($name === '' || preg_match('/[^a-zA-Z0-9_]/', $name))) {
             $name = '\'' . str_replace("\n", '\n', addslashes($name)) . '\'';
         }
 

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -1921,6 +1921,32 @@ class AssertAnnotationTest extends TestCase
                     function requiresString(string $_str): void {}
                 ',
             ],
+            'assertWithEmptyStringOnKeyedArray' => [
+                '<?php
+                    class A
+                    {
+                        function test(): void
+                        {
+                            $a = ["" => ""];
+
+                            /** @var array<string, mixed> $b */
+                            $b = [];
+
+                            $this->assertSame($a, $b);
+                        }
+
+                        /**
+                         * @template T
+                         * @param T      $expected
+                         * @psalm-assert =T $actual
+                         */
+                        public function assertSame(mixed $expected, mixed $actual): void
+                        {
+                            return;
+                        }
+                    }
+                ',
+            ],
         ];
     }
 

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -1938,9 +1938,10 @@ class AssertAnnotationTest extends TestCase
                         /**
                          * @template T
                          * @param T      $expected
+                         * @param mixed $actual
                          * @psalm-assert =T $actual
                          */
-                        public function assertSame(mixed $expected, mixed $actual): void
+                        public function assertSame($expected, $actual): void
                         {
                             return;
                         }


### PR DESCRIPTION
This will fix an error I thought about while looking for another bug.

The error can be seen [here ](https://psalm.dev/r/3e6d50f022) but it applies more widely, for example on psalter fixes for MissingReturnType with the same structure