### PR TITLE
don't crash when pushing a template to in_array

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -3556,7 +3556,7 @@ class AssertionFinder
                         // - The array may have one of the types but not the others.
                         //
                         // NOTE: the negation of the negation is the original assertion.
-                        if ($value_type->getId() !== '' && !$value_type->isMixed()) {
+                        if ($value_type->getId() !== '' && !$value_type->isMixed() && !$value_type->hasTemplate()) {
                             $assertions[] = 'in-array-' . $value_type->getId();
                         }
                     } else {

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -1898,6 +1898,29 @@ class AssertAnnotationTest extends TestCase
                     function requiresString(string $_str): void {}
                 ',
             ],
+            'assertInArrayWithTemplateDontCrash' => [
+                '<?php
+                    class A{
+                        /**
+                         * @template T
+                         * @param array<T> $objects
+                         * @return array<T>
+                         */
+                        private function uniquateObjects(array $objects) : array
+                        {
+                            $uniqueObjects = [];
+                            foreach ($objects as $object) {
+                                if (in_array($object, $uniqueObjects, true)) {
+                                    continue;
+                                }
+                                $uniqueObjects[] = $object;
+                            }
+
+                            return array_values($uniqueObjects);
+                        }
+                    }
+                ',
+            ],
             'assertionOnMagicProperty' => [
                 '<?php
                     /**

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -1916,7 +1916,7 @@ class AssertAnnotationTest extends TestCase
                                 $uniqueObjects[] = $object;
                             }
 
-                            return array_values($uniqueObjects);
+                            return $uniqueObjects;
                         }
                     }
                 ',


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/7295

There's probably more types that will generate unparsable assertions, but I'm not sure which how to make a comprehensive list, so it'll stay like that for now