### PR TITLE
Support PHPStan notation for empty-arrays

### DIFF
--- a/src/Psalm/Internal/Type/ParseTreeCreator.php
+++ b/src/Psalm/Internal/Type/ParseTreeCreator.php
@@ -757,7 +757,10 @@ class ParseTreeCreator
                 if ($nexter_token !== null && $nexter_token[0] === '}') {
                     $new_leaf->terminated = true;
                     ++$this->t;
+                } elseif ($nexter_token === null) {
+                    throw new TypeParseTreeException('Unclosed bracket in keyed array');
                 }
+
                 break;
 
             case '(':

--- a/src/Psalm/Internal/Type/ParseTreeCreator.php
+++ b/src/Psalm/Internal/Type/ParseTreeCreator.php
@@ -751,6 +751,13 @@ class ParseTreeCreator
                     $new_parent
                 );
                 ++$this->t;
+
+                $nexter_token = $this->t + 1 < $this->type_token_count ? $this->type_tokens[$this->t + 1] : null;
+
+                if ($nexter_token !== null && $nexter_token[0] === '}') {
+                    $new_leaf->terminated = true;
+                    ++$this->t;
+                }
                 break;
 
             case '(':

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -1235,7 +1235,7 @@ class TypeParser
     /**
      * @param  array<string, array<string, Union>> $template_type_map
      * @param  array<string, TypeAlias> $type_aliases
-     * @return TCallableKeyedArray|TKeyedArray|TObjectWithProperties
+     * @return TCallableKeyedArray|TKeyedArray|TObjectWithProperties|TArray
      * @throws TypeParseTreeException
      */
     private static function getTypeFromKeyedArrayTree(
@@ -1314,7 +1314,7 @@ class TypeParser
         }
 
         if (!$properties) {
-            throw new TypeParseTreeException('No properties supplied for TKeyedArray');
+            return new TArray([Type::getNever(), Type::getNever()]);
         }
 
         if ($type === 'object') {

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1490,14 +1490,6 @@ class AnnotationTest extends TestCase
                     ',
                 'error_message' => 'UndefinedDocblockClass',
             ],
-            'preventBadTKeyedArrayFormat' => [
-                '<?php
-                    /**
-                     * @param array{} $arr
-                     */
-                    function bar(array $arr): void {}',
-                'error_message' => 'InvalidDocblock',
-            ],
             'noPhpStormAnnotationsThankYou' => [
                 '<?php
                     /** @param ArrayIterator|string[] $i */

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -893,6 +893,14 @@ class TypeParseTest extends TestCase
         );
     }
 
+    public function testEmptyArrayShape(): void
+    {
+        $this->assertSame(
+            'array<never, never>',
+            (string)Type::parseString('array{}')
+        );
+    }
+
     public function testSingleLiteralInt(): void
     {
         $this->assertSame(


### PR DESCRIPTION
This adds support for `array{}` as an alias for `array<never, never>` starting from Psalm 5

cc @ondrejmirtes

Thanks @weirdan for the help on the parser :)