### PR TITLE
replace `array<never, never>` as a way to detect empty arrays by a dedicated method

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -503,7 +503,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 && !$inferred_return_type->isSingleIntLiteral()
                 && !$inferred_return_type->isSingleStringLiteral()
                 && !$inferred_return_type->isTrue()
-                && $inferred_return_type->getId() !== 'array<never, never>'
+                && !$inferred_return_type->isEmptyArray()
             ) {
                 $manipulator->makePure();
             }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -1024,7 +1024,7 @@ class AssignmentAnalyzer
                     $by_ref_out_type->parent_nodes += $existing_type->parent_nodes;
                 }
 
-                if ($existing_type->getId() !== 'array<never, never>') {
+                if (!$existing_type->isEmptyArray()) {
                     $context->vars_in_scope[$var_id] = $by_ref_out_type;
 
                     if (!($stmt_type = $statements_analyzer->node_data->getType($stmt))

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -554,7 +554,7 @@ class SimpleAssertionReconciler extends Reconciler
                 if (!$array_atomic_type instanceof TNonEmptyArray
                     || ($array_atomic_type->count < $min_count)
                 ) {
-                    if ($array_atomic_type->getId() === 'array<never, never>') {
+                    if (!$array_atomic_type->isEmptyArray()) {
                         $existing_var_type->removeType('array');
                     } else {
                         $non_empty_array = new TNonEmptyArray(

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -554,7 +554,7 @@ class SimpleAssertionReconciler extends Reconciler
                 if (!$array_atomic_type instanceof TNonEmptyArray
                     || ($array_atomic_type->count < $min_count)
                 ) {
-                    if (!$array_atomic_type->isEmptyArray()) {
+                    if ($array_atomic_type->isEmptyArray()) {
                         $existing_var_type->removeType('array');
                     } else {
                         $non_empty_array = new TNonEmptyArray(

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -486,7 +486,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                 $did_remove_type = true;
 
                 $existing_var_type->removeType('array');
-            } elseif (!$array_atomic_type->isEmptyArray()) {
+            } elseif (!($array_atomic_type instanceof TArray && $array_atomic_type->isEmptyArray())) {
                 $did_remove_type = true;
 
                 if (!$min_count) {

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -486,7 +486,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                 $did_remove_type = true;
 
                 $existing_var_type->removeType('array');
-            } elseif ($array_atomic_type->getId() !== 'array<never, never>') {
+            } elseif (!$array_atomic_type->isEmptyArray()) {
                 $did_remove_type = true;
 
                 if (!$min_count) {

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -785,7 +785,7 @@ abstract class Atomic implements TypeNode
             return true;
         }
 
-        if ($this instanceof TArray && $this->getId() === 'array<never, never>') {
+        if ($this instanceof TArray && $this->isEmptyArray()) {
             return true;
         }
 

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1598,4 +1598,12 @@ class Union implements TypeNode
     {
         return reset($this->types);
     }
+
+    public function isEmptyArray(): bool
+    {
+        return count($this->types) === 1
+            && isset($this->types['array'])
+            && $this->types['array'] instanceof TArray
+            && $this->types['array']->isEmptyArray();
+    }
 }


### PR DESCRIPTION
This is a pattern we had on different places but it's not great because technically, `array<array-key, never>` is also an empty array.