### PR TITLE
allow short closure to return never

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -464,6 +464,12 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $this->track_mutations = true;
         }
 
+        if ($this->function instanceof ArrowFunction && $storage->return_type && $storage->return_type->isNever()) {
+            // ArrowFunction perform a return implicitly so if the return type is never, we have to suppress the error
+            // note: the never can only come from phpdoc. PHP will refuse short closures with never in signature
+            $statements_analyzer->addSuppressedIssues(['NoValue']);
+        }
+
         $statements_analyzer->analyze($function_stmts, $context, $global_context, true);
 
         if ($codebase->alter_code

--- a/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ScopeAnalyzer.php
@@ -94,6 +94,16 @@ class ScopeAnalyzer
                 ($stmt instanceof PhpParser\Node\Stmt\Expression && $stmt->expr instanceof PhpParser\Node\Expr\Exit_)
             ) {
                 if (!$return_is_exit && $stmt instanceof PhpParser\Node\Stmt\Return_) {
+                    $stmt_return_type = null;
+                    if ($nodes && $stmt->expr) {
+                        $stmt_return_type = $nodes->getType($stmt->expr);
+                    }
+
+                    // don't consider a return if the expression never returns (e.g. a throw inside a short closure)
+                    if ($stmt_return_type && ($stmt_return_type->isNever() || $stmt_return_type->isEmpty())) {
+                        return array_values(array_unique(array_merge($control_actions, [self::ACTION_END])));
+                    }
+
                     return array_values(array_unique(array_merge($control_actions, [self::ACTION_RETURN])));
                 }
 

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -735,6 +735,31 @@ class ClosureTest extends TestCase
                 [],
                 '8.1',
             ],
+            'arrowFunctionReturnsNeverImplictly' => [
+                '<?php
+                    $bar = ["foo", "bar"];
+
+                    $bam = array_map(
+                        fn(string $a) => throw new Exception($a),
+                        $bar
+                    );',
+                'assertions' => [],
+                'error_levels' => [],
+                '8.1'
+            ],
+            'arrowFunctionReturnsNeverExplictly' => [
+                '<?php
+                    $bar = ["foo", "bar"];
+
+                    $bam = array_map(
+                        /** @return never */
+                        fn(string $a) => die(),
+                        $bar
+                    );',
+                'assertions' => [],
+                'error_levels' => [],
+                '8.1'
+            ],
         ];
     }
 


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/7323

There was 2 bugs:
- Psalm emitted a NoValue when a never returning statement was in the closure. This is due to short closure performing a return implicitly. The ReturnAnalyzer make sure to emit a NoValue when returning a Never. I fixed this by suppressing NoValue in the context of a short closure. It's not the most direct way but I couldn't see how to pass the info that I was in a short closure to the ReturnAnalyzer. Even a flag in Context would have been weird because they seem to be nestable.
- Kinda similarly, whenever there is a return in a functionlike scope and the functionlike declare returning void or never, an InvalidReturnStatement is emitted. I solved that by making sure a `return (never)` is seen as an exit instead of being seen as a return.