### PR TITLE
Errors on superior/inferior reconciliation

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master">
+<files psalm-version="4.9999999.9999999.9999999-dev">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset occurrences="2">
       <code>$comment_block-&gt;tags['variablesfrom'][0]</code>
@@ -420,6 +420,13 @@
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$stmt-&gt;props[0]</code>
     </PossiblyUndefinedIntArrayOffset>
+  </file>
+  <file src="src/Psalm/Internal/LanguageServer/LanguageClient.php">
+    <DocblockTypeContradiction occurrences="3">
+      <code>$type &lt; 1</code>
+      <code>$type &lt; 1 || $type &gt; 4</code>
+      <code>$type &gt; 4</code>
+    </DocblockTypeContradiction>
   </file>
   <file src="src/Psalm/Internal/LanguageServer/Message.php">
     <PossiblyUndefinedIntArrayOffset occurrences="1">

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1653,6 +1653,7 @@ class SimpleAssertionReconciler extends Reconciler
 
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
+                    // if the range contains the assertion, the range must be adapted
                     $did_remove_type = true;
                     $existing_var_type->removeType($atomic_type->getKey());
                     if ($atomic_type->min_bound === null) {
@@ -1664,6 +1665,12 @@ class SimpleAssertionReconciler extends Reconciler
                         );
                     }
                     $existing_var_type->addType($atomic_type);
+                } elseif ($atomic_type->isLesserThan($assertion_value)) {
+                    // if the range is lesser than the assertion, the type must be removed
+                    $did_remove_type = true;
+                    $existing_var_type->removeType($atomic_type->getKey());
+                } elseif ($atomic_type->isGreaterThan($assertion_value)) {
+                    // if the range is greater than the assertion, the check is redundant
                 }
             } elseif ($atomic_type instanceof TLiteralInt) {
                 if ($atomic_type->value < $assertion_value) {
@@ -1751,6 +1758,7 @@ class SimpleAssertionReconciler extends Reconciler
 
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
+                    // if the range contains the assertion, the range must be adapted
                     $did_remove_type = true;
                     $existing_var_type->removeType($atomic_type->getKey());
                     if ($atomic_type->max_bound === null) {
@@ -1759,6 +1767,12 @@ class SimpleAssertionReconciler extends Reconciler
                         $atomic_type->max_bound = min($atomic_type->max_bound, $assertion_value);
                     }
                     $existing_var_type->addType($atomic_type);
+                } elseif ($atomic_type->isLesserThan($assertion_value)) {
+                    // if the range is lesser than the assertion, the check is redundant
+                } elseif ($atomic_type->isGreaterThan($assertion_value)) {
+                    // if the range is greater than the assertion, the type must be removed
+                    $did_remove_type = true;
+                    $existing_var_type->removeType($atomic_type->getKey());
                 }
             } elseif ($atomic_type instanceof TLiteralInt) {
                 if ($atomic_type->value > $assertion_value) {

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -35,6 +35,7 @@ use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNever;
 use Psalm\Type\Atomic\TNonEmptyArray;
 use Psalm\Type\Atomic\TNonEmptyList;
 use Psalm\Type\Atomic\TNonEmptyLowercaseString;
@@ -91,6 +92,8 @@ class SimpleAssertionReconciler extends Reconciler
             return $existing_var_type;
         }
 
+        $old_var_type_string = $existing_var_type->getId();
+
         if ($assertion === 'isset') {
             return self::reconcileIsset(
                 $existing_var_type,
@@ -133,16 +136,26 @@ class SimpleAssertionReconciler extends Reconciler
         if ($assertion[0] === '>') {
             return self::reconcileSuperiorTo(
                 $existing_var_type,
-                substr($assertion, 1),
-                $inside_loop
+                $assertion,
+                $inside_loop,
+                $old_var_type_string,
+                $key,
+                $negated,
+                $code_location,
+                $suppressed_issues
             );
         }
 
         if ($assertion[0] === '<') {
             return self::reconcileInferiorTo(
                 $existing_var_type,
-                substr($assertion, 1),
-                $inside_loop
+                $assertion,
+                $inside_loop,
+                $old_var_type_string,
+                $key,
+                $negated,
+                $code_location,
+                $suppressed_issues
             );
         }
 
@@ -1616,30 +1629,45 @@ class SimpleAssertionReconciler extends Reconciler
         return $existing_var_type;
     }
 
+    /**
+     * @param string[] $suppressed_issues
+     */
     private static function reconcileSuperiorTo(
-        Union $existing_var_type,
-        string $assertion,
-        bool $inside_loop
+        Union         $existing_var_type,
+        string        $assertion,
+        bool          $inside_loop,
+        string        $old_var_type_string,
+        ?string       $var_id,
+        bool          $negated,
+        ?CodeLocation $code_location,
+        array         $suppressed_issues
     ): Union {
-        $assertion_value = (int)$assertion;
+        $assertion_value = (int)substr($assertion, 1);
+
+        $did_remove_type = false;
+
         foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
             if ($inside_loop) {
                 continue;
             }
 
             if ($atomic_type instanceof TIntRange) {
-                $existing_var_type->removeType($atomic_type->getKey());
-                if ($atomic_type->min_bound === null) {
-                    $atomic_type->min_bound = $assertion_value;
-                } else {
-                    $atomic_type->min_bound = TIntRange::getNewHighestBound(
-                        $assertion_value,
-                        $atomic_type->min_bound
-                    );
+                if ($atomic_type->contains($assertion_value)) {
+                    $did_remove_type = true;
+                    $existing_var_type->removeType($atomic_type->getKey());
+                    if ($atomic_type->min_bound === null) {
+                        $atomic_type->min_bound = $assertion_value;
+                    } else {
+                        $atomic_type->min_bound = TIntRange::getNewHighestBound(
+                            $assertion_value,
+                            $atomic_type->min_bound
+                        );
+                    }
+                    $existing_var_type->addType($atomic_type);
                 }
-                $existing_var_type->addType($atomic_type);
             } elseif ($atomic_type instanceof TLiteralInt) {
                 if ($atomic_type->value < $assertion_value) {
+                    $did_remove_type = true;
                     $existing_var_type->removeType($atomic_type->getKey());
                 } /*elseif ($inside_loop) {
                     //when inside a loop, allow the range to extends the type
@@ -1652,39 +1680,89 @@ class SimpleAssertionReconciler extends Reconciler
                 }*/
             } elseif ($atomic_type instanceof TPositiveInt) {
                 if ($assertion_value > 1) {
+                    $did_remove_type = true;
                     $existing_var_type->removeType($atomic_type->getKey());
                     $existing_var_type->addType(new TIntRange($assertion_value, null));
                 }
             } elseif ($atomic_type instanceof TInt) {
+                $did_remove_type = true;
                 $existing_var_type->removeType($atomic_type->getKey());
                 $existing_var_type->addType(new TIntRange($assertion_value, null));
+            } else {
+                // we assume that other types may have been removed (empty strings? numeric strings?)
+                //It may be worth refining to improve reconciliation while keeping in mind we're on loose comparison
+                $did_remove_type = true;
             }
+        }
+
+        if (!$inside_loop && !$did_remove_type && $var_id && $code_location) {
+            self::triggerIssueForImpossible(
+                $existing_var_type,
+                $old_var_type_string,
+                $var_id,
+                $assertion,
+                true,
+                $negated,
+                $code_location,
+                $suppressed_issues
+            );
+        }
+
+        if ($existing_var_type->isUnionEmpty()) {
+            if ($var_id && $code_location) {
+                self::triggerIssueForImpossible(
+                    $existing_var_type,
+                    $old_var_type_string,
+                    $var_id,
+                    $assertion,
+                    false,
+                    $negated,
+                    $code_location,
+                    $suppressed_issues
+                );
+            }
+            $existing_var_type->addType(new TNever());
         }
 
         return $existing_var_type;
     }
 
+    /**
+     * @param string[] $suppressed_issues
+     */
     private static function reconcileInferiorTo(
-        Union $existing_var_type,
-        string $assertion,
-        bool $inside_loop
+        Union         $existing_var_type,
+        string        $assertion,
+        bool          $inside_loop,
+        string        $old_var_type_string,
+        ?string       $var_id,
+        bool          $negated,
+        ?CodeLocation $code_location,
+        array         $suppressed_issues
     ): Union {
-        $assertion_value = (int)$assertion;
+        $assertion_value = (int)substr($assertion, 1);
+
+        $did_remove_type = false;
+
         foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
             if ($inside_loop) {
                 continue;
             }
 
             if ($atomic_type instanceof TIntRange) {
-                $existing_var_type->removeType($atomic_type->getKey());
-                if ($atomic_type->max_bound === null) {
-                    $atomic_type->max_bound = $assertion_value;
-                } else {
-                    $atomic_type->max_bound = min($atomic_type->max_bound, $assertion_value);
+                if ($atomic_type->contains($assertion_value)) {
+                    $did_remove_type = true;
+                    $existing_var_type->removeType($atomic_type->getKey());
+                    if ($atomic_type->max_bound === null) {
+                        $atomic_type->max_bound = $assertion_value;
+                    } else {
+                        $atomic_type->max_bound = min($atomic_type->max_bound, $assertion_value);
+                    }
+                    $existing_var_type->addType($atomic_type);
                 }
-                $existing_var_type->addType($atomic_type);
             } elseif ($atomic_type instanceof TLiteralInt) {
                 if ($atomic_type->value > $assertion_value) {
+                    $did_remove_type = true;
                     $existing_var_type->removeType($atomic_type->getKey());
                 } /* elseif ($inside_loop) {
                     //when inside a loop, allow the range to extends the type
@@ -1696,14 +1774,49 @@ class SimpleAssertionReconciler extends Reconciler
                     }
                 }*/
             } elseif ($atomic_type instanceof TPositiveInt) {
+                $did_remove_type = true;
                 $existing_var_type->removeType($atomic_type->getKey());
                 if ($assertion_value >= 1) {
                     $existing_var_type->addType(new TIntRange(1, $assertion_value));
                 }
             } elseif ($atomic_type instanceof TInt) {
+                $did_remove_type = true;
                 $existing_var_type->removeType($atomic_type->getKey());
                 $existing_var_type->addType(new TIntRange(null, $assertion_value));
+            } else {
+                // we assume that other types may have been removed (empty strings? numeric strings?)
+                //It may be worth refining to improve reconciliation while keeping in mind we're on loose comparison
+                $did_remove_type = true;
             }
+        }
+
+        if (!$inside_loop && !$did_remove_type && $var_id && $code_location) {
+            self::triggerIssueForImpossible(
+                $existing_var_type,
+                $old_var_type_string,
+                $var_id,
+                $assertion,
+                true,
+                $negated,
+                $code_location,
+                $suppressed_issues
+            );
+        }
+
+        if ($existing_var_type->isUnionEmpty()) {
+            if ($var_id && $code_location) {
+                self::triggerIssueForImpossible(
+                    $existing_var_type,
+                    $old_var_type_string,
+                    $var_id,
+                    $assertion,
+                    false,
+                    $negated,
+                    $code_location,
+                    $suppressed_issues
+                );
+            }
+            $existing_var_type->addType(new TNever());
         }
 
         return $existing_var_type;

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -1638,6 +1638,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
+                    // if the range contains the assertion, the range must be adapted
                     $did_remove_type = true;
                     $existing_var_type->removeType($atomic_type->getKey());
                     if ($atomic_type->max_bound === null) {
@@ -1649,6 +1650,12 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                         );
                     }
                     $existing_var_type->addType($atomic_type);
+                } elseif ($atomic_type->isLesserThan($assertion_value)) {
+                    // if the range is lesser than the assertion, the check is redundant
+                } elseif ($atomic_type->isGreaterThan($assertion_value)) {
+                    // if the range is greater than the assertion, the type must be removed
+                    $did_remove_type = true;
+                    $existing_var_type->removeType($atomic_type->getKey());
                 }
             } elseif ($atomic_type instanceof TLiteralInt) {
                 if ($atomic_type->value > $assertion_value) {
@@ -1736,6 +1743,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
+                    // if the range contains the assertion, the range must be adapted
                     $did_remove_type = true;
                     $existing_var_type->removeType($atomic_type->getKey());
                     if ($atomic_type->min_bound === null) {
@@ -1744,6 +1752,12 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                         $atomic_type->min_bound = max($atomic_type->min_bound, $assertion_value);
                     }
                     $existing_var_type->addType($atomic_type);
+                } elseif ($atomic_type->isLesserThan($assertion_value)) {
+                    // if the range is lesser than the assertion, the type must be removed
+                    $did_remove_type = true;
+                    $existing_var_type->removeType($atomic_type->getKey());
+                } elseif ($atomic_type->isGreaterThan($assertion_value)) {
+                    // if the range is greater than the assertion, the check is redundant
                 }
             } elseif ($atomic_type instanceof TLiteralInt) {
                 if ($atomic_type->value < $assertion_value) {

--- a/src/Psalm/Type/Atomic/TIntRange.php
+++ b/src/Psalm/Type/Atomic/TIntRange.php
@@ -86,6 +86,22 @@ class TIntRange extends TInt
             ($this->min_bound <= $i && $this->max_bound >= $i);
     }
 
+    /**
+     * Returns true if every part of the Range is lesser than the given value
+     */
+    public function isLesserThan(int $i): bool
+    {
+        return $this->max_bound !== null && $this->max_bound < $i;
+    }
+
+    /**
+     * Returns true if every part of the Range is greater than the given value
+     */
+    public function isGreaterThan(int $i): bool
+    {
+        return $this->min_bound !== null && $this->min_bound > $i;
+    }
+
     public static function getNewLowestBound(?int $bound1, ?int $bound2): ?int
     {
         if ($bound1 === null || $bound2 === null) {

--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -892,6 +892,13 @@ class Reconciler
             $assertion = substr($assertion, 1);
         }
 
+        $operator = substr($assertion, 0, 1);
+        if ($operator === '>') {
+            $assertion = '>= '.substr($assertion, 1);
+        } elseif ($operator === '<') {
+            $assertion = '<= '.substr($assertion, 1);
+        }
+
         if ($negated) {
             $redundant = !$redundant;
             $not = !$not;

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1605,4 +1605,9 @@ class Union implements TypeNode
     {
         return reset($this->types);
     }
+
+    public function isUnionEmpty(): bool
+    {
+        return $this->types === [];
+    }
 }

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -702,6 +702,36 @@ class IntRangeTest extends TestCase
                     }',
                 'error_message' => 'InvalidReturnType',
             ],
+            'assertOutOfRange' => [
+                '<?php
+                    /**
+                     * @param int<1, 5> $a
+                     */
+                    function scope(int $a): void{
+                        assert($a === 0);
+                    }',
+                'error_message' => 'DocblockTypeContradiction',
+            ],
+            'assertRedundantInferior' => [
+                '<?php
+                    /**
+                     * @param int<min, 5> $a
+                     */
+                    function scope(int $a): void{
+                        assert($a < 10);
+                    }',
+                'error_message' => 'RedundantConditionGivenDocblockType',
+            ],
+            'assertImpossibleInferior' => [
+                '<?php
+                    /**
+                     * @param int<5, max> $a
+                     */
+                    function scope(int $a): void{
+                        assert($a < 4);
+                    }',
+                'error_message' => 'DocblockTypeContradiction',
+            ],
         ];
     }
 }

--- a/tests/PureAnnotationTest.php
+++ b/tests/PureAnnotationTest.php
@@ -323,7 +323,7 @@ class PureAnnotationTest extends TestCase
                         if ($sum > 9000) {
                             throw MyException::hello();
                         }
-                        if ($sum > 90001) {
+                        if ($sum > 900) {
                             throw new MyException();
                         }
                         return $sum;


### PR DESCRIPTION
This will add errors when the reconciliation failed when dealing with superior/inferior assertions. It also fix errors that were present in the way the reconciliation is done