### PR TITLE
Support multiple <issueHandlers> elements

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1184,21 +1184,23 @@ class Config
         }
 
         if (isset($config_xml->issueHandlers)) {
-            /** @var SimpleXMLElement $issue_handler */
-            foreach ($config_xml->issueHandlers->children() as $key => $issue_handler) {
-                if ($key === 'PluginIssue') {
-                    $custom_class_name = (string) $issue_handler['name'];
-                    /** @var string $key */
-                    $config->issue_handlers[$custom_class_name] = IssueHandler::loadFromXMLElement(
-                        $issue_handler,
-                        $base_dir
-                    );
-                } else {
-                    /** @var string $key */
-                    $config->issue_handlers[$key] = IssueHandler::loadFromXMLElement(
-                        $issue_handler,
-                        $base_dir
-                    );
+            foreach ($config_xml->issueHandlers as $issue_handlers) {
+                /** @var SimpleXMLElement $issue_handler */
+                foreach ($issue_handlers->children() as $key => $issue_handler) {
+                    if ($key === 'PluginIssue') {
+                        $custom_class_name = (string) $issue_handler['name'];
+                        /** @var string $key */
+                        $config->issue_handlers[$custom_class_name] = IssueHandler::loadFromXMLElement(
+                            $issue_handler,
+                            $base_dir
+                        );
+                    } else {
+                        /** @var string $key */
+                        $config->issue_handlers[$key] = IssueHandler::loadFromXMLElement(
+                            $issue_handler,
+                            $base_dir
+                        );
+                    }
                 }
             }
         }

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -356,6 +356,34 @@ class ConfigTest extends TestCase
         $this->assertFalse($config->reportIssueInFile('MissingReturnType', realpath('src/Psalm/Type.php')));
     }
 
+    public function testMultipleIssueHandlers(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            Config::loadFromXML(
+                dirname(__DIR__, 2),
+                '<?xml version="1.0"?>
+                <psalm>
+                    <projectFiles>
+                        <directory name="src" />
+                        <directory name="tests" />
+                    </projectFiles>
+
+                    <issueHandlers>
+                        <MissingReturnType errorLevel="suppress" />
+                    </issueHandlers>
+                    <issueHandlers>
+                        <UndefinedClass errorLevel="suppress" />
+                    </issueHandlers>
+                </psalm>'
+            )
+        );
+
+        $config = $this->project_analyzer->getConfig();
+
+        $this->assertFalse($config->reportIssueInFile('MissingReturnType', realpath(__FILE__)));
+        $this->assertFalse($config->reportIssueInFile('UndefinedClass', realpath(__FILE__)));
+    }
+
     public function testIssueHandlerWithCustomErrorLevels(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(


### PR DESCRIPTION
Fixes part of #7353 

This does not handle deep merging issue handler configs. When defining the same issue handler in 2 `<issueHandlers>` elements, the latter overrides the first. This is the same behavior as when defining the same issue handler twice in a single `<issueHandlers>` element.