### PR TITLE
keep class-strings through array_merge

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMergeReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMergeReturnTypeProvider.php
@@ -50,6 +50,7 @@ class ArrayMergeReturnTypeProvider implements FunctionReturnTypeProviderInterfac
         $codebase = $statements_source->getCodebase();
 
         $generic_properties = [];
+        $class_strings = [];
         $all_keyed_arrays = true;
         $all_int_offsets = true;
         $all_nonempty_lists = true;
@@ -105,6 +106,10 @@ class ArrayMergeReturnTypeProvider implements FunctionReturnTypeProviderInterfac
                                 if (!is_string($key)) {
                                     $generic_properties[] = $type;
                                     continue;
+                                }
+
+                                if (isset($unpacked_type_part->class_strings[$key])) {
+                                    $class_strings[$key] = true;
                                 }
 
                                 if (!isset($generic_properties[$key]) || !$type->possibly_undefined) {
@@ -217,6 +222,10 @@ class ArrayMergeReturnTypeProvider implements FunctionReturnTypeProviderInterfac
                 || $generic_property_count < 16)
         ) {
             $objectlike = new TKeyedArray($generic_properties);
+
+            if ($class_strings !== []) {
+                $objectlike->class_strings = $class_strings;
+            }
 
             if ($all_nonempty_lists || $all_int_offsets) {
                 $objectlike->is_list = true;

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -2121,7 +2121,7 @@ class ArrayFunctionCallTest extends TestCase
                         return $a;
                     }',
             ],
-            'arrayUnshiftOnEmptyArrayMeansNonEmptyList' => [
+            'keepClassStringInOffsetThroughArrayMerge' => [
                 '<?php
 
                     class A {

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -2121,6 +2121,24 @@ class ArrayFunctionCallTest extends TestCase
                         return $a;
                     }',
             ],
+            'arrayUnshiftOnEmptyArrayMeansNonEmptyList' => [
+                '<?php
+
+                    class A {
+                        /** @var array<class-string, string> */
+                        private array $a;
+
+                        public function __construct() {
+                            $this->a = [];
+                        }
+
+                        public function handle(): void {
+                            $b = [A::class => "d"];
+                            $this->a = array_merge($this->a, $b);
+                        }
+                    }
+                    ',
+            ],
         ];
     }
 


### PR DESCRIPTION
This should fix #7352

The class-string info was not kept when inferring the return of array_merge