### PR TITLE
Rename was_static property to is_static to be more accurate

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -298,7 +298,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
             $union = new Union($mixins);
 
             $static_self = new TNamedObject($storage->name);
-            $static_self->was_static = true;
+            $static_self->is_static = true;
 
             $union = TypeExpander::expandUnion(
                 $codebase,
@@ -1227,7 +1227,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
             $method_context->self = $fq_class_name;
 
             $this_atomic_object_type = new TNamedObject($fq_class_name);
-            $this_atomic_object_type->was_static = !$storage->final;
+            $this_atomic_object_type->is_static = !$storage->final;
 
             $method_context->vars_in_scope['$this'] = new Union([$this_atomic_object_type]);
             $method_context->vars_possibly_in_scope['$this'] = true;

--- a/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClosureAnalyzer.php
@@ -95,7 +95,7 @@ class ClosureAnalyzer extends FunctionLikeAnalyzer
                 $use_context->vars_in_scope['$this'] = clone $context->vars_in_scope['$this'];
             } elseif ($context->self) {
                 $this_atomic = new TNamedObject($context->self);
-                $this_atomic->was_static = true;
+                $this_atomic->is_static = true;
 
                 $use_context->vars_in_scope['$this'] = new Union([$this_atomic]);
             }

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1811,7 +1811,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                     $this_object_type = new TNamedObject($context->self);
                 }
 
-                $this_object_type->was_static = !$storage->final;
+                $this_object_type->is_static = !$storage->final;
 
                 if ($this->storage instanceof MethodStorage && $this->storage->if_this_is_type) {
                     $template_result = new TemplateResult($this->getTemplateTypeMap() ?? [], []);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -526,7 +526,7 @@ class NewAnalyzer extends CallAnalyzer
                     $generic_param_types
                 );
 
-                $result_atomic_type->was_static = $from_static;
+                $result_atomic_type->is_static = $from_static;
 
                 $statements_analyzer->node_data->setType(
                     $stmt,
@@ -553,7 +553,7 @@ class NewAnalyzer extends CallAnalyzer
                 )
             );
 
-            $result_atomic_type->was_static = $from_static;
+            $result_atomic_type->is_static = $from_static;
 
             $statements_analyzer->node_data->setType(
                 $stmt,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -158,7 +158,7 @@ class ClassConstFetchAnalyzer
 
                 if ($first_part_lc === 'static') {
                     $static_named_object = new TNamedObject($fq_class_name);
-                    $static_named_object->was_static = true;
+                    $static_named_object->is_static = true;
 
                     $statements_analyzer->node_data->setType(
                         $stmt,

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -628,7 +628,7 @@ class AssertionReconciler extends Reconciler
         }
 
         if ($type_1_atomic instanceof TNamedObject) {
-            $type_1_atomic->was_static = false;
+            $type_1_atomic->is_static = false;
         }
 
         $atomic_comparison_results = new TypeComparisonResult();

--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -301,8 +301,8 @@ class AtomicTypeComparator
 
             if ($container_type_part instanceof TNamedObject
                 && $input_type_part instanceof TNamedObject
-                && $container_type_part->was_static
-                && !$input_type_part->was_static
+                && $container_type_part->is_static
+                && !$input_type_part->is_static
             ) {
                 if ($atomic_comparison_result) {
                     $atomic_comparison_result->type_coerced = true;
@@ -596,8 +596,8 @@ class AtomicTypeComparator
 
         if ($container_type_part instanceof TNamedObject
             && $input_type_part instanceof TNamedObject
-            && $container_type_part->was_static
-            && !$input_type_part->was_static
+            && $container_type_part->is_static
+            && !$input_type_part->is_static
         ) {
             if ($atomic_comparison_result) {
                 $atomic_comparison_result->type_coerced = true;

--- a/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
@@ -192,8 +192,8 @@ class GenericTypeComparator
                             $allow_interface_equality
                         ) || $param_comparison_result->type_coerced
                         ) {
-                            if ($container_param->hasFormerStaticObject()
-                                && $input_param->isFormerStaticObject()
+                            if ($container_param->hasStaticObject()
+                                && $input_param->isStaticObject()
                                 && UnionTypeComparator::isContainedBy(
                                     $codebase,
                                     $input_param,

--- a/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ObjectComparator.php
@@ -45,7 +45,7 @@ class ObjectComparator
             } elseif ($intersection_container_type instanceof TTemplateParam) {
                 $intersection_container_type_lower = null;
             } else {
-                $container_was_static = $intersection_container_type->was_static;
+                $container_was_static = $intersection_container_type->is_static;
 
                 $intersection_container_type_lower = strtolower(
                     $codebase->classlikes->getUnAliasedName(
@@ -203,7 +203,7 @@ class ObjectComparator
 
             if ($intersection_container_type instanceof TNamedObject) {
                 // this is extra check is redundant since we're comparing to a template as type
-                $intersection_container_type->was_static = false;
+                $intersection_container_type->is_static = false;
             }
 
             return UnionTypeComparator::isContainedBy(
@@ -224,7 +224,7 @@ class ObjectComparator
         } elseif ($intersection_input_type instanceof TObjectWithProperties) {
             $intersection_input_type_lower = 'object';
         } else {
-            $input_was_static = $intersection_input_type->was_static;
+            $input_was_static = $intersection_input_type->is_static;
 
             $intersection_input_type_lower = strtolower(
                 $codebase->classlikes->getUnAliasedName(

--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -270,7 +270,7 @@ class TypeCombiner
             $generic_object = new TGenericObject($generic_type, $generic_type_params);
 
             if ($combination->object_static[$generic_type] ?? false) {
-                $generic_object->was_static = true;
+                $generic_object->is_static = true;
             }
 
             /** @psalm-suppress PropertyTypeCoercion */
@@ -513,11 +513,11 @@ class TypeCombiner
 
         if ($type instanceof TNamedObject) {
             if (array_key_exists($type->value, $combination->object_static)) {
-                if ($combination->object_static[$type->value] && !$type->was_static) {
+                if ($combination->object_static[$type->value] && !$type->is_static) {
                     $combination->object_static[$type->value] = false;
                 }
             } else {
-                $combination->object_static[$type->value] = $type->was_static;
+                $combination->object_static[$type->value] = $type->is_static;
             }
         }
 

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -641,9 +641,9 @@ class TypeExpander
             }
 
             if (!$final && $return_type instanceof TNamedObject) {
-                $return_type->was_static = true;
+                $return_type->is_static = true;
             }
-        } elseif ($return_type->was_static
+        } elseif ($return_type->is_static
             && ($static_class_type instanceof TNamedObject
                 || $static_class_type instanceof TTemplateParam)
         ) {
@@ -661,9 +661,9 @@ class TypeExpander
                     $return_type->extra_types[$extra_static_type->getKey()] = clone $extra_static_type;
                 }
             }
-        } elseif ($return_type->was_static && is_string($static_class_type) && $final) {
+        } elseif ($return_type->is_static && is_string($static_class_type) && $final) {
             $return_type->value = $static_class_type;
-            $return_type->was_static = false;
+            $return_type->is_static = false;
         } elseif ($self_class && $return_type_lc === 'self') {
             $return_type->value = $self_class;
         } elseif ($parent_class && $return_type_lc === 'parent') {

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -1084,7 +1084,7 @@ class TypeParser
             if ($intersect_static
                 && $first_type instanceof TNamedObject
             ) {
-                $first_type->was_static = true;
+                $first_type->is_static = true;
             }
 
             if ($keyed_intersection_types) {

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -127,10 +127,10 @@ abstract class Type
         array $aliased_classes,
         ?string $this_class,
         bool $allow_self = false,
-        bool $was_static = false
+        bool $is_static = false
     ): string {
         if ($allow_self && $value === $this_class) {
-            if ($was_static) {
+            if ($is_static) {
                 return 'static';
             }
             return 'self';

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -64,7 +64,7 @@ trait GenericTrait
                 );
             }
 
-            if ($this->was_static) {
+            if ($this->is_static) {
                 $extra_types .= '&static';
             }
         }

--- a/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
+++ b/src/Psalm/Type/Atomic/TAnonymousClassInstance.php
@@ -15,9 +15,9 @@ class TAnonymousClassInstance extends TNamedObject
     /**
      * @param string $value the name of the object
      */
-    public function __construct(string $value, bool $was_static = false, ?string $extends = null)
+    public function __construct(string $value, bool $is_static = false, ?string $extends = null)
     {
-        parent::__construct($value, $was_static);
+        parent::__construct($value, $is_static);
 
         $this->extends = $extends;
     }

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -27,7 +27,7 @@ class TNamedObject extends Atomic
     /**
      * @var bool
      */
-    public $was_static = false;
+    public $is_static = false;
 
     /**
      * Whether or not this type can represent a child of the class named in $value
@@ -38,14 +38,14 @@ class TNamedObject extends Atomic
     /**
      * @param string $value the name of the object
      */
-    public function __construct(string $value, bool $was_static = false, bool $definite_class = false)
+    public function __construct(string $value, bool $is_static = false, bool $definite_class = false)
     {
         if ($value[0] === '\\') {
             $value = substr($value, 1);
         }
 
         $this->value = $value;
-        $this->was_static = $was_static;
+        $this->is_static = $is_static;
         $this->definite_class = $definite_class;
     }
 
@@ -75,7 +75,7 @@ class TNamedObject extends Atomic
             );
         }
 
-        return $this->was_static ? $this->value . '&static' : $this->value;
+        return $this->is_static ? $this->value . '&static' : $this->value;
     }
 
     /**
@@ -105,7 +105,7 @@ class TNamedObject extends Atomic
             $aliased_classes,
             $this_class,
             true,
-            $this->was_static
+            $this->is_static
         ) . $intersection_types;
     }
 
@@ -122,7 +122,7 @@ class TNamedObject extends Atomic
             return $analysis_php_version_id >= 8_00_00 ? 'static' : null;
         }
 
-        if ($this->was_static && $this->value === $this_class) {
+        if ($this->is_static && $this->value === $this_class) {
             return $analysis_php_version_id >= 8_00_00 ? 'static' : 'self';
         }
 
@@ -136,7 +136,7 @@ class TNamedObject extends Atomic
 
     public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
-        return ($this->value !== 'static' && $this->was_static === false) || $analysis_php_version_id >= 8_00_00;
+        return ($this->value !== 'static' && $this->is_static === false) || $analysis_php_version_id >= 8_00_00;
     }
 
     public function replaceTemplateTypesWithArgTypes(

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -763,11 +763,11 @@ class Union implements TypeNode
         return false;
     }
 
-    public function isFormerStaticObject(): bool
+    public function isStaticObject(): bool
     {
         foreach ($this->types as $type) {
             if (!$type instanceof TNamedObject
-                || !$type->was_static
+                || !$type->is_static
             ) {
                 return false;
             }
@@ -776,11 +776,11 @@ class Union implements TypeNode
         return true;
     }
 
-    public function hasFormerStaticObject(): bool
+    public function hasStaticObject(): bool
     {
         foreach ($this->types as $type) {
             if ($type instanceof TNamedObject
-                && $type->was_static
+                && $type->is_static
             ) {
                 return true;
             }
@@ -926,7 +926,7 @@ class Union implements TypeNode
             $this->types,
             fn(Atomic $type): bool => $type instanceof TTemplateParam
                 || ($type instanceof TNamedObject
-                    && ($type->was_static
+                    && ($type->is_static
                         || ($type->extra_types
                             && array_filter(
                                 $type->extra_types,


### PR DESCRIPTION
Using `"was"` here doesn't make much sense, because the type being analysed _is_ `static` aka `this`. 