### PR TITLE
PHP 8.1: Report missing typehints in overridden native methods

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -325,6 +325,7 @@
             <xs:element name="LoopInvalidation" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MethodSignatureMismatch" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MethodSignatureMustOmitReturnType" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MethodSignatureMustProvideReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MismatchingDocblockParamType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MismatchingDocblockPropertyType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MismatchingDocblockReturnType" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -56,6 +56,7 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
  - [InvalidThrow](issues/InvalidThrow.md)
  - [LoopInvalidation](issues/LoopInvalidation.md)
  - [MethodSignatureMustOmitReturnType](issues/MethodSignatureMustOmitReturnType.md)
+ - [MethodSignatureMustProvideReturnType](issues/MethodSignatureMustProvideReturnType.md)
  - [MissingDependency](issues/MissingDependency.md)
  - [MissingFile](issues/MissingFile.md)
  - [MissingImmutableAnnotation](issues/MissingImmutableAnnotation.md)

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -99,6 +99,7 @@
  - [LoopInvalidation](issues/LoopInvalidation.md)
  - [MethodSignatureMismatch](issues/MethodSignatureMismatch.md)
  - [MethodSignatureMustOmitReturnType](issues/MethodSignatureMustOmitReturnType.md)
+ - [MethodSignatureMustProvideReturnType](issues/MethodSignatureMustProvideReturnType.md)
  - [MismatchingDocblockParamType](issues/MismatchingDocblockParamType.md)
  - [MismatchingDocblockPropertyType](issues/MismatchingDocblockPropertyType.md)
  - [MismatchingDocblockReturnType](issues/MismatchingDocblockReturnType.md)

--- a/docs/running_psalm/issues/MethodSignatureMustProvideReturnType.md
+++ b/docs/running_psalm/issues/MethodSignatureMustProvideReturnType.md
@@ -1,0 +1,48 @@
+# MethodSignatureMustProvideReturnType
+
+In PHP 8.1+, [most non-final internal methods now require overriding methods to declare a compatible return type, otherwise a deprecated notice is emitted during inheritance validation](https://www.php.net/manual/en/migration81.incompatible.php#migration81.incompatible.core.type-compatibility-internal).  
+
+This issue is emitted when a method overriding a native method is defined without a return type.  
+
+
+```php
+<?php
+
+class A implements JsonSerializable {
+    public function jsonSerialize() {
+        return random_int(0, 1) ? 'test' : 123;
+    }
+}
+```
+
+Fix by specifying the correct typehint:  
+
+```php
+<?php
+
+class A implements JsonSerializable {
+    public function jsonSerialize(): string|int {
+        return random_int(0, 1) ? 'test' : 123;
+    }
+}
+```
+
+In case the return type cannot be declared for an overriding method due to PHP cross-version compatibility concerns, a `#[ReturnTypeWillChange]` attribute can be added to silence the PHP deprecation notice and Psalm issue. 
+
+```php
+<?php
+
+use ReturnTypeWillChange;
+
+class A implements JsonSerializable {
+    /**
+     * TODO: Remove this attribute once PHP 7 support is dropped.
+     * 
+     * @return "test"|123
+     */
+    #[ReturnTypeWillChange]
+    public function jsonSerialize() {
+        return random_int(0, 1) ? 'test' : 123;
+    }
+}
+```

--- a/docs/running_psalm/issues/MethodSignatureMustProvideReturnType.md
+++ b/docs/running_psalm/issues/MethodSignatureMustProvideReturnType.md
@@ -11,7 +11,7 @@ This issue is emitted when a method overriding a native method is defined withou
 
 class A implements JsonSerializable {
     public function jsonSerialize() {
-        return ['type' = 'A'];
+        return ['type' => 'A'];
     }
 }
 ```

--- a/docs/running_psalm/issues/MethodSignatureMustProvideReturnType.md
+++ b/docs/running_psalm/issues/MethodSignatureMustProvideReturnType.md
@@ -4,45 +4,14 @@ In PHP 8.1+, [most non-final internal methods now require overriding methods to 
 
 This issue is emitted when a method overriding a native method is defined without a return type.  
 
+**Only if** the return type cannot be declared to keep support for PHP 7, a `#[ReturnTypeWillChange]` attribute can be added to silence the PHP deprecation notice and Psalm issue.  
 
 ```php
 <?php
 
 class A implements JsonSerializable {
     public function jsonSerialize() {
-        return random_int(0, 1) ? 'test' : 123;
-    }
-}
-```
-
-Fix by specifying the correct typehint:  
-
-```php
-<?php
-
-class A implements JsonSerializable {
-    public function jsonSerialize(): string|int {
-        return random_int(0, 1) ? 'test' : 123;
-    }
-}
-```
-
-In case the return type cannot be declared for an overriding method due to PHP cross-version compatibility concerns, a `#[ReturnTypeWillChange]` attribute can be added to silence the PHP deprecation notice and Psalm issue. 
-
-```php
-<?php
-
-use ReturnTypeWillChange;
-
-class A implements JsonSerializable {
-    /**
-     * TODO: Remove this attribute once PHP 7 support is dropped.
-     * 
-     * @return "test"|123
-     */
-    #[ReturnTypeWillChange]
-    public function jsonSerialize() {
-        return random_int(0, 1) ? 'test' : 123;
+        return ['type' = 'A'];
     }
 }
 ```

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -124,7 +124,9 @@ class MethodComparator
             && !$implementer_method_storage->signature_return_type
             && !array_filter(
                 $implementer_method_storage->attributes,
-                fn (AttributeStorage $s) => $s->fq_class_name === 'ReturnTypeWillChange'
+                function (AttributeStorage $s) {
+                    return $s->fq_class_name === 'ReturnTypeWillChange';
+                }
             )
         ) {
             IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -118,6 +118,7 @@ class MethodComparator
 
         if (!$guide_classlike_storage->user_defined
             && $implementer_classlike_storage->user_defined
+            && $codebase->analysis_php_version_id >= 80100
             && ($guide_method_storage->return_type
                 || $guide_method_storage->signature_return_type
             )

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -117,7 +117,7 @@ class MethodComparator
 
         if (!$guide_classlike_storage->user_defined
             && $implementer_classlike_storage->user_defined
-            && $codebase->analysis_php_version_id >= 8_01_00
+            && $codebase->analysis_php_version_id >= 80100
             && ($guide_method_storage->return_type
                 || $guide_method_storage->signature_return_type
             )

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -890,7 +890,10 @@ class MethodComparator
             : (!$implementer_signature_return_type
                 && $guide_signature_return_type->isMixed()
                 ? false
-                : UnionTypeComparator::isContainedByInPhp($implementer_signature_return_type, $guide_signature_return_type)
+                : UnionTypeComparator::isContainedByInPhp(
+                    $implementer_signature_return_type,
+                    $guide_signature_return_type
+                )
             );
 
         if (!$is_contained_by) {

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -118,7 +118,6 @@ class MethodComparator
 
         if (!$guide_classlike_storage->user_defined
             && $implementer_classlike_storage->user_defined
-            && $codebase->analysis_php_version_id >= 80100
             && ($guide_method_storage->return_type
                 || $guide_method_storage->signature_return_type
             )

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -21,6 +21,7 @@ use Psalm\Issue\ImplementedParamTypeMismatch;
 use Psalm\Issue\ImplementedReturnTypeMismatch;
 use Psalm\Issue\LessSpecificImplementedReturnType;
 use Psalm\Issue\MethodSignatureMismatch;
+use Psalm\Issue\MethodSignatureMustProvideReturnType;
 use Psalm\Issue\MissingImmutableAnnotation;
 use Psalm\Issue\MoreSpecificImplementedParamType;
 use Psalm\Issue\OverriddenMethodAccess;
@@ -130,8 +131,8 @@ class MethodComparator
             )
         ) {
             IssueBuffer::maybeAdd(
-                new MethodSignatureMismatch(
-                    'Method ' . $cased_implementer_method_id . ' is missing a return type signature!',
+                new MethodSignatureMustProvideReturnType(
+                    'Method ' . $cased_implementer_method_id . ' must have a return type signature!',
                     $implementer_method_storage->location ?: $code_location
                 ),
                 $suppressed_issues + $implementer_classlike_storage->suppressed_issues

--- a/src/Psalm/Issue/MethodSignatureMustProvideReturnType.php
+++ b/src/Psalm/Issue/MethodSignatureMustProvideReturnType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+class MethodSignatureMustProvideReturnType extends CodeIssue
+{
+    public const ERROR_LEVEL = -1;
+    public const SHORTCODE = 282;
+}

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -218,6 +218,10 @@ class DocumentationTest extends TestCase
             $this->markTestSkipped();
         }
 
+        if (strpos($error_message, 'MethodSignatureMustProvideReturnType') !== false) {
+            $php_version = '8.1';
+        }
+
         $this->project_analyzer->setPhpVersion($php_version, 'tests');
 
         if ($check_references) {

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -1569,6 +1569,37 @@ class MethodSignatureTest extends TestCase
                 ',
                 'error_message' => 'MethodSignatureMismatch',
             ],
+            'noMixedTypehintInDescendant' => [
+                '<?php
+                    class a {
+                        public function test(): mixed {
+                            return 0;
+                        }
+                    }
+                    class b extends a {
+                        public function test() {
+                            return 0;
+                        }
+                    }
+                ',
+                'error_message' => 'MethodSignatureMismatch',
+                [],
+                false,
+                '8.0'
+            ],
+            'noTypehintInNativeDescendant' => [
+                '<?php
+                    class a implements JsonSerializable {
+                        public function jsonSerialize() {
+                            return 0;
+                        }
+                    }
+                ',
+                'error_message' => 'MethodSignatureMismatch',
+                [],
+                false,
+                '8.1'
+            ],
         ];
     }
 }

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -1582,7 +1582,7 @@ class MethodSignatureTest extends TestCase
                         }
                     }
                 ',
-                'error_message' => 'MethodSignatureMismatch',
+                'error_message' => 'MethodSignatureMustProvideReturnType',
                 [],
                 false,
                 '8.0'
@@ -1595,7 +1595,7 @@ class MethodSignatureTest extends TestCase
                         }
                     }
                 ',
-                'error_message' => 'MethodSignatureMismatch',
+                'error_message' => 'MethodSignatureMustProvideReturnType',
                 [],
                 false,
                 '8.1'

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -1582,7 +1582,7 @@ class MethodSignatureTest extends TestCase
                         }
                     }
                 ',
-                'error_message' => 'MethodSignatureMustProvideReturnType',
+                'error_message' => 'MethodSignatureMismatch',
                 [],
                 false,
                 '8.0'


### PR DESCRIPTION
Allows detection of ReturnTypeWIllChange warnings, also fixes #7362