### PR TITLE
Fix closure to have storage bug in codeAction

### DIFF
--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -103,6 +103,11 @@ class LanguageServer extends Dispatcher
      */
     protected $onchange_paths_to_analyze = [];
 
+    /**
+     * @var array<string, list<IssueData>>
+     */
+    protected $current_issues = [];
+
     public function __construct(
         ProtocolReader $reader,
         ProtocolWriter $writer,
@@ -365,6 +370,7 @@ class LanguageServer extends Dispatcher
     public function emitIssues(array $uris): void
     {
         $data = IssueBuffer::clear();
+        $this->current_issues = $data;
 
         foreach ($uris as $file_path => $uri) {
             $diagnostics = array_map(
@@ -559,5 +565,15 @@ class LanguageServer extends Dispatcher
         }
 
         return $filepath;
+    }
+
+    /**
+     * Get the value of current_issues
+     *
+     * @return array<string, list<IssueData>>
+     */
+    public function getCurrentIssues(): array
+    {
+        return $this->current_issues;
     }
 }

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -24,7 +24,6 @@ use Psalm\Codebase;
 use Psalm\Exception\UnanalyzedFileException;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\LanguageServer\LanguageServer;
-use Psalm\IssueBuffer;
 use UnexpectedValueException;
 
 use function array_combine;
@@ -365,9 +364,15 @@ class TextDocument
         $this->codebase->analyzer->addFilesToAnalyze(
             array_combine($all_file_paths_to_analyze, $all_file_paths_to_analyze)
         );
-        $this->codebase->analyzer->analyzeFiles($this->project_analyzer, 1, false);
 
-        $issues = IssueBuffer::clear();
+        try {
+            $this->codebase->analyzer->analyzeFiles($this->project_analyzer, 1, false);
+        } catch (UnexpectedValueException $e) {
+            error_log('codeAction errored on file ' . $file_path. ', Reason: '.$e->getMessage());
+            return new Success(null);
+        }
+
+        $issues = $this->server->getCurrentIssues();
 
         if (empty($issues[$file_path])) {
             return new Success(null);


### PR DESCRIPTION
This PR fixes the following bug introduced into codeAction as a result of the underlying cache being empty when creating new files while using the language server

```
[Error - 11:05:08 PM] Request textDocument/codeAction failed.
  Message: UnexpectedValueException: Expecting /project/myTestFile.php:27:531:-:closure to have storage in /project/myTestFile.php in /project/vendor/vimeo/psalm/src/Psalm/Codebase.php:650
```

It's actually almost the same as #7247 except I didn't add the try/catch to my own code!  🤕 

Additionally this adds a quick speedup to `codeAction` by adding a cache when`emitIssues` is called so that we don't have to run the `IssueBuffer` everytime `codeAction` is called (which in vscode is a lot because every time the mouse or cursor moves a codeAction is sent). Instead we just ask the LanguageServer to give us the previous issues returned from IssueBuffer through the use of the method `getCurrentIssues`

Sorry for the other PR. I didn't realize you started work on v5 and set the default branch to 4.x