### PR TITLE
Add LiteralKeyUnshapedArray checks

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -290,6 +290,7 @@
             <xs:element name="LessSpecificClassConstantType" type="ClassConstantIssueHandlerType" minOccurs="0" />
             <xs:element name="LessSpecificImplementedReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="LessSpecificReturnStatement" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="LiteralKeyUnshapedArray" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="LessSpecificReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="LoopInvalidation" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MethodSignatureMismatch" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -130,6 +130,7 @@ These issues are treated as errors at level 2 and below.
  - [InvalidDocblockParamName](issues/InvalidDocblockParamName.md)
  - [InvalidFalsableReturnType](issues/InvalidFalsableReturnType.md)
  - [InvalidStringClass](issues/InvalidStringClass.md)
+ - [LiteralKeyUnshapedArray](issues/LiteralKeyUnshapedArray.md)
  - [MissingClosureParamType](issues/MissingClosureParamType.md)
  - [MissingClosureReturnType](issues/MissingClosureReturnType.md)
  - [MissingConstructor](issues/MissingConstructor.md)

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -100,6 +100,7 @@
  - [LessSpecificImplementedReturnType](issues/LessSpecificImplementedReturnType.md)
  - [LessSpecificReturnStatement](issues/LessSpecificReturnStatement.md)
  - [LessSpecificReturnType](issues/LessSpecificReturnType.md)
+ - [LiteralKeyUnshapedArray](issues/LiteralKeyUnshapedArray.md)
  - [LoopInvalidation](issues/LoopInvalidation.md)
  - [MethodSignatureMismatch](issues/MethodSignatureMismatch.md)
  - [MethodSignatureMustOmitReturnType](issues/MethodSignatureMustOmitReturnType.md)

--- a/docs/running_psalm/issues/LiteralKeyUnshapedArray.md
+++ b/docs/running_psalm/issues/LiteralKeyUnshapedArray.md
@@ -1,0 +1,63 @@
+# LiteralKeyUnshapedArray
+
+Emitted when a literal key is used on an unshaped array.  
+
+All known array shapes must be annotated using [array shape syntax](/docs/annotating_code/type_syntax/array_types/#object-like-arrays), to allow additional Psalm paradox checks on array keys and types.  
+
+When working with arrays whose shape is not known yet (i.e. user input), a **separate validation function** must be used with a function-level suppress.  
+
+By splitting validation and business logic, Psalm can make more and better typechecks of existing usages of the business logic.
+
+
+```php
+<?php
+
+class DTO {
+    /** @var array{0: string, 1: string} */
+    public array $key1;
+    /** @var positive-int */
+    public int $key2;
+
+    /**
+     * @param array{key1: array{0: string, 1: string}, key2: positive-int} $input
+     */
+    public function __construct(array $input) {
+        // DO NOT validate here, validate in DTO::validate!
+        $this->key1 = $input['key1'];
+        $this->key2 = $input['key2'];
+    }
+
+    /**
+     * @param array $input
+     * @return array{key1: array{0: string, 1: string}, key2: positive-int}
+     * 
+     * @psalm-suppress LiteralKeyUnshapedArray This is required in validation logic.
+     * 
+     * @throws AssertionError
+     */
+    public static function validate(array $input): array {
+        if (!isset($input['key1'])
+            || !is_array($input['key1'])
+            || !isset($input['key1'][0])
+            || !isset($input['key1'][1])
+            || !is_string($input['key1'][0])
+            || !is_string($input['key1'][1])
+        ) {
+            throw new AssertionError('Key1 is invalid!');
+        }
+        if (!isset($input['key2']) || !is_int($input['key2']) || $input['key2'] <= 0) {
+            throw new AssertionError('Key2 is invalid!');
+        }
+        return $input;
+    }
+}
+
+// OK!
+$dto = new DTO(DTO::validate($_GET));
+
+// In some old place in the codebase, a DTO was constructed incorrectly...
+// This is now a Psalm error!
+
+// ERROR: InvalidArgument - Argument 1 of DTO::__construct expects array{key1: array{0: string, 1: string}, key2: positive-int}, array{key1: "d", key2: -1} provided
+$dto2 = new DTO(['key1' => 'd', 'key2' => -1]);
+```

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -396,6 +396,11 @@ final class Context
 
     /**
      * @var bool
+     */
+    public $validator = false;
+
+    /**
+     * @var bool
      * Set by @psalm-immutable
      */
     public $mutation_free = false;

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -364,6 +364,10 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $context->pure = true;
         }
 
+        if ($storage->validator) {
+            $context->validator = true;
+        }
+
         if ($storage->mutation_free
             && $cased_method_id
             && !strpos($cased_method_id, '__construct')

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -20,6 +20,7 @@ use Psalm\FileSource;
 use Psalm\Internal\Algebra;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Analyzer\ClassLikeNameOptions;
+use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ArrayFetchAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Analyzer\TraitAnalyzer;
 use Psalm\Internal\Provider\ClassLikeStorageProvider;
@@ -3674,6 +3675,17 @@ class AssertionFinder
         FileSource $source,
         ?string $this_class_name
     ): array {
+        if ($first_var_type
+            && $source instanceof StatementsAnalyzer
+            && ($second_var_type = $source->node_data->getType($expr->getArgs()[1]->value))
+        ) {
+            ArrayFetchAnalyzer::validateArrayOffset(
+                $source,
+                $expr,
+                $second_var_type,
+                $first_var_type
+            );
+        }
         $if_types = [];
 
         $literal_assertions = [];

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -515,7 +515,7 @@ class ArrayFetchAnalyzer
             }
         }
 
-        if (!$in_assignment) {
+        if (!$in_assignment && !$context->validator) {
             self::validateArrayOffset(
                 $statements_analyzer,
                 $stmt,

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -486,7 +486,12 @@ class FunctionLikeDocblockParser
 
         $info->variadic = isset($parsed_docblock->tags['psalm-variadic']);
         $info->pure = isset($parsed_docblock->tags['psalm-pure'])
-            || isset($parsed_docblock->tags['pure']);
+            || isset($parsed_docblock->tags['pure'])
+            || isset($parsed_docblock->tags['psalm-validator']);
+
+        if (isset($parsed_docblock->tags['psalm-validator'])) {
+            $info->validator = true;
+        }
 
         if (isset($parsed_docblock->tags['psalm-mutation-free'])) {
             $info->mutation_free = true;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -140,6 +140,10 @@ class FunctionLikeDocblockScanner
             }
         }
 
+        if ($docblock_info->validator) {
+            $storage->validator = true;
+        }
+
         if ($docblock_info->specialize_call) {
             $storage->specialize_call = true;
         }

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -103,6 +103,13 @@ class FunctionDocblockComment
     public $pure = false;
 
     /**
+     * Whether or not the function is a validation function
+     *
+     * @var bool
+     */
+    public $validator = false;
+
+    /**
      * Whether or not to specialize a given call (useful for taint analysis)
      *
      * @var bool

--- a/src/Psalm/Issue/LiteralKeyUnshapedArray.php
+++ b/src/Psalm/Issue/LiteralKeyUnshapedArray.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+class LiteralKeyUnshapedArray extends CodeIssue
+{
+    public const ERROR_LEVEL = 2;
+    public const SHORTCODE = 282;
+}

--- a/src/Psalm/Issue/LiteralKeyUnshapedArray.php
+++ b/src/Psalm/Issue/LiteralKeyUnshapedArray.php
@@ -4,6 +4,6 @@ namespace Psalm\Issue;
 
 class LiteralKeyUnshapedArray extends CodeIssue
 {
-    public const ERROR_LEVEL = 2;
+    public const ERROR_LEVEL = 1;
     public const SHORTCODE = 282;
 }

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -182,6 +182,11 @@ abstract class FunctionLikeStorage implements HasAttributesInterface
     public $pure = false;
 
     /**
+     * @var bool
+     */
+    public $validator = false;
+
+    /**
      * Whether or not the function output is dependent solely on input - a function can be
      * impure but still have this property (e.g. var_export). Useful for taint analysis.
      *

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -230,6 +230,9 @@ class DocumentationTest extends TestCase
         foreach ($error_levels as $error_level) {
             $this->project_analyzer->getCodebase()->config->setCustomErrorLevel($error_level, Config::REPORT_SUPPRESS);
         }
+        if (strpos($error_message, 'LiteralKeyUnshapedArray') !== false) {
+            Config::getInstance()->setCustomErrorLevel('LiteralKeyUnshapedArray', Config::REPORT_SUPPRESS);
+        }
 
         $this->expectException(CodeException::class);
         $this->expectExceptionMessageMatches('/\b' . preg_quote($error_message, '/') . '\b/');

--- a/tests/Traits/InvalidCodeAnalysisTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisTestTrait.php
@@ -54,6 +54,7 @@ trait InvalidCodeAnalysisTestTrait
 
             Config::getInstance()->setCustomErrorLevel($issue_name, $error_level);
         }
+        Config::getInstance()->setCustomErrorLevel('LiteralKeyUnshapedArray', Config::REPORT_SUPPRESS);
 
         $this->project_analyzer->setPhpVersion($php_version, 'tests');
 


### PR DESCRIPTION
This has been really useful @ work to enforce shaping of arrays.
This will require some more tweaking to fix tests & psalm itself, in the meantime sending in a draft for review.

Phpstan already does something similar, by directly requiring an array shape in all array typehints (which is also what we've been doing, via a CS rule): https://phpstan.org/r/e02b117c-9c25-414e-ac51-949eb6ee70c8