### PR TITLE
Fix @covers annotation.

### DIFF
--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -8,7 +8,7 @@ use Psalm\Tests\TestCase;
 class InternalCallMapHandlerTest extends TestCase
 {
     /**
-     * @covers InternalCallMapHandler::getCallMap
+     * @covers \Psalm\Internal\Codebase\InternalCallMapHandler::getCallMap
      */
     public function testGetcallmapReturnsAValidCallmap(): void
     {


### PR DESCRIPTION
Per the [documentation](https://phpunit.readthedocs.io/en/9.5/annotations.html#covers), `@covers` requires a FQCN.