### PR TITLE
Add vscode settings to project

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+    "recommendations": [
+        "getpsalm.psalm-vscode-plugin",
+        "obliviousharmony.vscode-php-codesniffer"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "psalm.psalmScriptPath": "psalm-language-server",
   "phpCodeSniffer.executable": "vendor/bin/phpcs",
   "phpCodeSniffer.standard": "Custom",
-  "phpCodeSniffer.standardCustom": "phpcs.xml"
+  "phpCodeSniffer.standardCustom": "phpcs.xml",
+  "editor.rulers": [120]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "psalm.configPaths": ["psalm.xml.dist"],
+  "psalm.psalmScriptPath": "psalm-language-server",
+  "phpCodeSniffer.executable": "vendor/bin/phpcs",
+  "phpCodeSniffer.standard": "Custom",
+  "phpCodeSniffer.standardCustom": "phpcs.xml"
+}


### PR DESCRIPTION
This adds recommended VS Code extensions (namely the supported Psalm one https://github.com/psalm/psalm-vscode-plugin) and additionally sets up settings.json for vscode to read. This gives the ability to use Psalm to analyze itself while in vscode which is helpful (note: the extension recommendations can be ignored so this will not force anything on anybody)