### PR TITLE
Ability to hide warnings in Language Server

### DIFF
--- a/src/Psalm/Internal/LanguageServer/Client/Workspace.php
+++ b/src/Psalm/Internal/LanguageServer/Client/Workspace.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\LanguageServer\Client;
+
+use Amp\Promise;
+use JsonMapper;
+use Psalm\Internal\LanguageServer\ClientHandler;
+
+/**
+ * Provides method handlers for all textDocument/* methods
+ */
+class Workspace
+{
+    /**
+     * @var ClientHandler
+     */
+    private $handler;
+
+    /**
+     * @var JsonMapper
+     * @psalm-suppress UnusedProperty
+     */
+    private $mapper;
+
+    public function __construct(ClientHandler $handler, JsonMapper $mapper)
+    {
+        $this->handler = $handler;
+        $this->mapper = $mapper;
+    }
+
+    /**
+     * The workspace/configuration request is sent from the server to the client to
+     * fetch configuration settings from the client. The request can fetch several
+     * configuration settings in one roundtrip. The order of the returned configuration
+     * settings correspond to the order of the passed ConfigurationItems (e.g. the first
+     * item in the response is the result for the first configuration item in the params).
+     *
+     * @param string $section The configuration section asked for.
+     * @param string|null $scopeUri The scope to get the configuration section for.
+     */
+    public function requestConfiguration(string $section, ?string $scopeUri = null): Promise
+    {
+        /** @var Promise<object> */
+        return $this->handler->request('workspace/configuration', [
+            'items' => [
+                [
+                    'section' => $section,
+                    'scopeUri' => $scopeUri,
+                ]
+            ]
+        ]);
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/ClientConfiguration.php
+++ b/src/Psalm/Internal/LanguageServer/ClientConfiguration.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\LanguageServer;
+
+class ClientConfiguration
+{
+
+    /**
+     * Hide Warnings or not
+     *
+     * @var boolean
+     */
+    protected $hideWarnings = false;
+
+
+
+    /**
+     * Should warnings be hidden or not
+     */
+    public function hideWarnings(): bool
+    {
+        return $this->hideWarnings;
+    }
+
+    /**
+     * Set the value of hideWarnings
+     */
+    public function setHideWarnings(bool $hideWarnings): self
+    {
+        $this->hideWarnings = $hideWarnings;
+
+        return $this;
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/ClientHandler.php
+++ b/src/Psalm/Internal/LanguageServer/ClientHandler.php
@@ -13,7 +13,6 @@ use Amp\Promise;
 use Generator;
 
 use function Amp\call;
-use function error_log;
 
 /**
  * @internal
@@ -69,7 +68,6 @@ class ClientHandler
 
                 $listener =
                     function (Message $msg) use ($id, $deferred, &$listener): void {
-                        error_log('request handler');
                         /**
                          * @psalm-suppress UndefinedPropertyFetch
                          * @psalm-suppress MixedArgument

--- a/src/Psalm/Internal/LanguageServer/LanguageClient.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageClient.php
@@ -43,7 +43,7 @@ class LanguageClient
      *
      * @var ClientCapabilities|null
      */
-    private ?ClientCapabilities $capabilities = null;
+    private ClientCapabilities $capabilities;
 
     /**
      * The Client Configuration

--- a/src/Psalm/Internal/LanguageServer/LanguageClient.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageClient.php
@@ -43,14 +43,14 @@ class LanguageClient
      *
      * @var ClientCapabilities|null
      */
-    private ClientCapabilities $capabilities;
+    private $capabilities;
 
     /**
      * The Client Configuration
      *
      * @var ClientConfiguration
      */
-    private ClientConfiguration $configuration;
+    private $configuration;
 
     public function __construct(ProtocolReader $reader, ProtocolWriter $writer)
     {

--- a/src/Psalm/Internal/LanguageServer/LanguageServerProtocol/ClientCapabilities.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServerProtocol/ClientCapabilities.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Psalm\Internal\LanguageServer\LanguageServerProtocol;
+
+class ClientCapabilities
+{
+    /**
+     * The client supports `workspace/configuration` requests.
+     *
+     * @var ClientCapabilitiesWorkspace|null
+     * @psalm-suppress PossiblyUnusedProperty
+     */
+    public $workspace;
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function __construct(ClientCapabilitiesWorkspace $workspace = null)
+    {
+        $this->workspace = $workspace;
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/LanguageServerProtocol/ClientCapabilitiesWorkspace.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServerProtocol/ClientCapabilitiesWorkspace.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Psalm\Internal\LanguageServer\LanguageServerProtocol;
+
+class ClientCapabilitiesWorkspace
+{
+    /**
+     * The client supports `workspace/configuration` requests.
+     *
+     * @var boolean|null
+     * @psalm-suppress PossiblyUnusedProperty
+     */
+    public $configuration;
+
+    /**
+     * The client has support for workspace folders.
+     *
+     * @var boolean|null
+     * @psalm-suppress PossiblyUnusedProperty
+     */
+    public $workspaceFolders;
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function __construct(bool $configuration = null, bool $workspaceFolders = null)
+    {
+        $this->configuration = $configuration;
+        $this->workspaceFolders = $workspaceFolders;
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/LanguageServerProtocol/ClientInfo.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServerProtocol/ClientInfo.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Psalm\Internal\LanguageServer\LanguageServerProtocol;
+
+/**
+ * @psalm-suppress UnusedClass
+ */
+class ClientInfo
+{
+    /**
+     * The name of the client as defined by the client.
+     *
+     * @var string|null
+     * @psalm-suppress PossiblyUnusedProperty
+     */
+    public $name;
+
+    /**
+     * The client's version as defined by the client.
+     *
+     * @var string|null
+     * @psalm-suppress PossiblyUnusedProperty
+     */
+    public $version;
+
+    /**
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function __construct(string $name = null, string $version = null)
+    {
+        $this->name = $name;
+        $this->version = $version;
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/Server/Workspace.php
+++ b/src/Psalm/Internal/LanguageServer/Server/Workspace.php
@@ -75,4 +75,15 @@ class Workspace
             }
         }
     }
+
+    /**
+     * A notification sent from the client to the server to signal the change of configuration settings.
+     *
+     * @param mixed $settings
+     * @psalm-suppress PossiblyUnusedMethod
+     */
+    public function didChangeConfiguration($settings): void
+    {
+        $this->server->client->refreshConfiguration();
+    }
 }


### PR DESCRIPTION
As it is currently warnings (eg if you have level set to 4 then levels 1-3 will be warnings in your IDE) are shown in IDEs utilizing language server. Users have requested the ability to disable that (https://github.com/psalm/psalm-vscode-plugin/issues/16)

This PR adds the ability to hideWarnings but it also follows the Language Server Protocol to ask the client what the current configuration is. This allows this setting to be changed without having to restart Psalm Language Server (which you have to do for all other settings because they are CLI flags). https://microsoft.github.io/language-server-protocol/specification#workspace_configuration