### PR TITLE
Catch additional InvalidArgumentException

### DIFF
--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -6,6 +6,7 @@ namespace Psalm\Internal\LanguageServer\Server;
 
 use Amp\Promise;
 use Amp\Success;
+use InvalidArgumentException;
 use LanguageServerProtocol\CompletionList;
 use LanguageServerProtocol\Hover;
 use LanguageServerProtocol\Location;
@@ -367,7 +368,7 @@ class TextDocument
 
         try {
             $this->codebase->analyzer->analyzeFiles($this->project_analyzer, 1, false);
-        } catch (UnexpectedValueException $e) {
+        } catch (UnexpectedValueException | InvalidArgumentException $e) {
             error_log('codeAction errored on file ' . $file_path. ', Reason: '.$e->getMessage());
             return new Success(null);
         }


### PR DESCRIPTION
This fixes:

```
[Error - 8:54:14 PM] Request textDocument/codeAction failed.
  Message: InvalidArgumentException: Could not get class storage for app\http\controllers\provisionserver in /usr/src/app/vendor/vimeo/psalm/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php:46
```

So that the language server does not crash