### PR TITLE
Add support of template for docblock methods

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -354,7 +354,8 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                     $context,
                     $codebase->config,
                     $all_intersection_return_type,
-                    $result
+                    $result,
+                    $lhs_type_part
                 );
 
                 if ($new_call_context) {
@@ -417,7 +418,8 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                 $all_intersection_existent_method_ids,
                 $intersection_method_id,
                 $cased_method_id,
-                $result
+                $result,
+                $lhs_type_part
             );
 
             return;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -8,9 +8,12 @@ use Psalm\Codebase;
 use Psalm\Config;
 use Psalm\Context;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\ArgumentsAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\Call\ClassTemplateParamCollector;
 use Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\TemplateInferredTypeReplacer;
+use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\Node\Expr\VirtualArray;
 use Psalm\Node\Expr\VirtualArrayItem;
@@ -19,6 +22,7 @@ use Psalm\Node\VirtualArg;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Storage\MethodStorage;
 use Psalm\Type;
+use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Union;
 
@@ -36,7 +40,8 @@ class MissingMethodCallHandler
         Context $context,
         Config $config,
         ?Union $all_intersection_return_type,
-        AtomicMethodCallAnalysisResult $result
+        AtomicMethodCallAnalysisResult $result,
+        ?Atomic $lhs_type_part
     ): ?AtomicCallContext {
         $fq_class_name = $method_id->fq_class_name;
         $method_name_lc = $method_id->method_name;
@@ -100,13 +105,23 @@ class MissingMethodCallHandler
 
             $pseudo_method_storage = $class_storage->pseudo_methods[$method_name_lc];
 
+            $found_generic_params = ClassTemplateParamCollector::collect(
+                $codebase,
+                $class_storage,
+                $class_storage,
+                $method_name_lc,
+                $lhs_type_part,
+                !$statements_analyzer->isStatic() && $method_id->fq_class_name === $context->self
+            );
+
             ArgumentsAnalyzer::analyze(
                 $statements_analyzer,
                 $stmt->getArgs(),
                 $pseudo_method_storage->params,
                 (string) $method_id,
                 true,
-                $context
+                $context,
+                $found_generic_params ? new TemplateResult([], $found_generic_params) : null
             );
 
             ArgumentsAnalyzer::checkArgumentsMatch(
@@ -116,13 +131,21 @@ class MissingMethodCallHandler
                 $pseudo_method_storage->params,
                 $pseudo_method_storage,
                 null,
-                null,
+                $found_generic_params ? new TemplateResult([], $found_generic_params) : null,
                 new CodeLocation($statements_analyzer, $stmt),
                 $context
             );
 
             if ($pseudo_method_storage->return_type) {
                 $return_type_candidate = clone $pseudo_method_storage->return_type;
+
+                if ($found_generic_params) {
+                    TemplateInferredTypeReplacer::replace(
+                        $return_type_candidate,
+                        new TemplateResult([], $found_generic_params),
+                        $codebase
+                    );
+                }
 
                 $return_type_candidate = TypeExpander::expandUnion(
                     $codebase,
@@ -222,7 +245,8 @@ class MissingMethodCallHandler
         array $all_intersection_existent_method_ids,
         ?string $intersection_method_id,
         string $cased_method_id,
-        AtomicMethodCallAnalysisResult $result
+        AtomicMethodCallAnalysisResult $result,
+        ?Atomic $lhs_type_part
     ): void {
         $fq_class_name = $method_id->fq_class_name;
         $method_name_lc = $method_id->method_name;
@@ -242,13 +266,23 @@ class MissingMethodCallHandler
                 return;
             }
 
+            $found_generic_params = ClassTemplateParamCollector::collect(
+                $codebase,
+                $class_storage,
+                $class_storage,
+                $method_name_lc,
+                $lhs_type_part,
+                !$statements_analyzer->isStatic() && $method_id->fq_class_name === $context->self
+            );
+
             if (ArgumentsAnalyzer::analyze(
                 $statements_analyzer,
                 $stmt->getArgs(),
                 $pseudo_method_storage->params,
                 (string) $method_id,
                 true,
-                $context
+                $context,
+                $found_generic_params ? new TemplateResult([], $found_generic_params) : null
             ) === false) {
                 return;
             }
@@ -260,7 +294,7 @@ class MissingMethodCallHandler
                 $pseudo_method_storage->params,
                 $pseudo_method_storage,
                 null,
-                null,
+                $found_generic_params ? new TemplateResult([], $found_generic_params) : null,
                 new CodeLocation($statements_analyzer, $stmt->name),
                 $context
             ) === false) {
@@ -269,6 +303,14 @@ class MissingMethodCallHandler
 
             if ($pseudo_method_storage->return_type) {
                 $return_type_candidate = clone $pseudo_method_storage->return_type;
+
+                if ($found_generic_params) {
+                    TemplateInferredTypeReplacer::replace(
+                        $return_type_candidate,
+                        new TemplateResult([], $found_generic_params),
+                        $codebase
+                    );
+                }
 
                 if ($all_intersection_return_type) {
                     $return_type_candidate = Type::intersectUnionTypes(

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -3580,6 +3580,46 @@ class ClassTemplateTest extends TestCase
                         foo($a, $b);
                     }'
             ],
+            'templateOnDocblockMethod' => [
+                '<?php
+                    /**
+                     * @template T
+                     * @method T get()
+                     * @method void set(T $value)
+                     */
+                    class Container
+                    {
+                        public function __call(string $name, array $args) {}
+                    }
+
+                    class A {}
+                    function foo(A $a): void {}
+
+                    /** @var Container<A> $container */
+                    $container = new Container();
+                    $container->set(new A());
+                    foo($container->get());
+                '
+            ],
+            'templateOnDocblockMethodOnInterface' => [
+                '<?php
+                    /**
+                     * @template T
+                     * @method T get()
+                     * @method void set(T $value)
+                     */
+                    interface Container
+                    {
+                    }
+
+                    class A {}
+                    function foo(A $a): void {}
+
+                    /** @var Container<A> $container */
+                    $container->set(new A());
+                    foo($container->get());
+                '
+            ],
         ];
     }
 
@@ -4338,6 +4378,26 @@ class ClassTemplateTest extends TestCase
                     function foo(Collection $c, object $d): void {
                         $c->add($d);
                     }',
+                'error_message' => 'InvalidArgument',
+            ],
+            'invalidTemplateArgumentOnDocblockMethod' => [
+                '<?php
+                    /**
+                     * @template T
+                     * @method void set(T $value)
+                     */
+                    class Container
+                    {
+                        public function __call(string $name, array $args) {}
+                    }
+
+                    class A {}
+                    class B {}
+
+                    /** @var Container<A> $container */
+                    $container = new Container();
+                    $container->set(new B());
+                ',
                 'error_message' => 'InvalidArgument',
             ],
         ];


### PR DESCRIPTION
See fix #7320

Add the support of template type on return type and parameter of a method declared using `@method` annotation, on class or interface : 

```php
<?php
/**
 * @template T
 * @method T get()
 * @method void set(T $value)
 */
class Container
{
    public function __call(string $name, array $args) {}
}

class A {}
function foo(A $a): void {}

/** @var Container<A> $container */
$container = new Container();
$container->set(new A());
foo($container->get());
```

Current version do not process template types, so calling those pseudo methods will always result to InvalidArgument error.