### PR TITLE
[TypeProvider] Provide argument types during FunctionParamsProviderEvent

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -1291,6 +1291,7 @@ class ArgumentsAnalyzer
             || $arg->value instanceof PhpParser\Node\Expr\FuncCall
             || $arg->value instanceof PhpParser\Node\Expr\MethodCall
             || $arg->value instanceof PhpParser\Node\Expr\StaticCall
+            || $arg->value instanceof PhpParser\Node\Expr\ArrowFunction
             || $arg->value instanceof PhpParser\Node\Expr\New_
             || $arg->value instanceof PhpParser\Node\Expr\Cast
             || $arg->value instanceof PhpParser\Node\Expr\Assign


### PR DESCRIPTION
Discussed in https://github.com/vimeo/psalm/discussions/7212

When adding following code in both a `FunctionParamsProviderInterface` and `FunctionReturnTypeProviderInterface` event handler.

```php
$nodeTypeProvider = $event->getStatementsSource()->getNodeTypeProvider();
$args = $event->getCallArgs();

$type = $nodeTypeProvider->getType($args[0]->value);
```


* The `getFunctionParams` hook always returns `null` on this call.
* The `getFunctionReturnType` hook always returns the detected type on this call. Something like `impure-Closure(string):int`


This PR mostly rearranges some code so that the `ArgumentsAnalyzer` runs  before the `FunctionParamsProviderInterface` hook is called.



