### PR TITLE
Prevent NoValue when there is no phpdoc

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -464,7 +464,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $this->track_mutations = true;
         }
 
-        if ($this->function instanceof ArrowFunction && $storage->return_type && $storage->return_type->isNever()) {
+        if ($this->function instanceof ArrowFunction && (!$storage->return_type || $storage->return_type->isNever())) {
             // ArrowFunction perform a return implicitly so if the return type is never, we have to suppress the error
             // note: the never can only come from phpdoc. PHP will refuse short closures with never in signature
             $statements_analyzer->addSuppressedIssues(['NoValue']);


### PR DESCRIPTION
https://github.com/vimeo/psalm/pull/7326 was flawed. The implicit case was inferred to empty and prevented the NoValue for being thrown.

On Psalm 5, never and empty are the same so it broke. This will fix it. It suppresses NoValue inside an ArrowFunction when no return type is documented, so that possible implicit return of never are suppressed too