### PR TITLE
refactor description of types in Atomic

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1553,7 +1553,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
             $message .= ' - consider ' . str_replace(
                 ['<array-key, mixed>', '<never, never>'],
                 '',
-                (string)$suggested_type
+                $suggested_type->getId(false)
             );
         }
 

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -621,7 +621,7 @@ class TypeParser
             || $generic_type_value === 'interface-string'
             || $generic_type_value === 'enum-string'
         ) {
-            $class_name = (string)$generic_params[0];
+            $class_name = $generic_params[0]->getId(false);
 
             if (isset($template_type_map[$class_name])) {
                 $first_class = array_keys($template_type_map[$class_name])[0];
@@ -685,7 +685,7 @@ class TypeParser
         }
 
         if ($generic_type_value === 'key-of') {
-            $param_name = (string)$generic_params[0];
+            $param_name = $generic_params[0]->getId(false);
 
             if (isset($template_type_map[$param_name])) {
                 $defining_class = array_keys($template_type_map[$param_name])[0];
@@ -716,7 +716,7 @@ class TypeParser
         }
 
         if ($generic_type_value === 'value-of') {
-            $param_name = (string)$generic_params[0];
+            $param_name = $generic_params[0]->getId(false);
 
             $param_union_types = array_values($generic_params[0]->getAtomicTypes());
 

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -250,7 +250,7 @@ abstract class FunctionLikeStorage
                 array_map(
                     fn(FunctionLikeParameter $param): string =>
                         ($newlines ? '    ' : '')
-                        . ($param->type ?: 'mixed')
+                        . ($param->type ? $param->type->getId(false) : 'mixed')
                         . ' $' . $param->name,
                     $this->params
                 )

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -77,8 +77,6 @@ use function strtolower;
 
 abstract class Atomic implements TypeNode
 {
-    public const KEY = 'atomic';
-
     /**
      * Whether or not the type has been checked yet
      *
@@ -325,6 +323,10 @@ abstract class Atomic implements TypeNode
         return new TNamedObject($value);
     }
 
+    /**
+     * This is the string that will be used to represent the type in Union::$types. This means that two types sharing
+     * the same getKey value will override themselves in an Union
+     */
     abstract public function getKey(bool $include_extra = true): string;
 
     public function isNumericType(): bool
@@ -548,9 +550,9 @@ abstract class Atomic implements TypeNode
         }
     }
 
-    public function __toString(): string
+    final public function __toString(): string
     {
-        return '';
+        return $this->getId();
     }
 
     public function __clone()
@@ -572,18 +574,27 @@ abstract class Atomic implements TypeNode
         }
     }
 
-    public function getId(bool $nested = false): string
+    /**
+     * This is the true identifier for the type. It defaults to self::getKey() but can be overrided to be more precise
+     */
+    public function getId(bool $exact = true, bool $nested = false): string
     {
-        return $this->__toString();
+        return $this->getKey();
     }
-
+    /**
+     * This string is used in order to transform a type into an string assertion for the assertion module
+     * Default to self::getId()
+     */
     public function getAssertionString(): string
     {
         return $this->getId();
     }
 
     /**
-     * @param  array<lowercase-string, string> $aliased_classes
+     * Returns the detailed description of the type, either in phpdoc standard format or Psalm format depending on flag
+     * Default to self::getKey()
+     *
+     * @param array<lowercase-string, string> $aliased_classes
      */
     public function toNamespacedString(
         ?string $namespace,
@@ -595,6 +606,9 @@ abstract class Atomic implements TypeNode
     }
 
     /**
+     * Returns a string representation of the type compatible with php signature or null if the type can't be expressed
+     *  with the given php version
+     *
      * @param  array<lowercase-string, string> $aliased_classes
      */
     abstract public function toPhpString(

--- a/src/Psalm/Type/Atomic/CallableTrait.php
+++ b/src/Psalm/Type/Atomic/CallableTrait.php
@@ -63,7 +63,30 @@ trait CallableTrait
 
     public function getKey(bool $include_extra = true): string
     {
-        return $this->__toString();
+        $param_string = '';
+        $return_type_string = '';
+
+        if ($this->params !== null) {
+            $param_string .= '(';
+            foreach ($this->params as $i => $param) {
+                if ($i) {
+                    $param_string .= ', ';
+                }
+
+                $param_string .= $param->getId();
+            }
+
+            $param_string .= ')';
+        }
+
+        if ($this->return_type !== null) {
+            $return_type_multiple = count($this->return_type->getAtomicTypes()) > 1;
+            $return_type_string = ':' . ($return_type_multiple ? '(' : '')
+                . $this->return_type->getId() . ($return_type_multiple ? ')' : '');
+        }
+
+        return ($this->is_pure ? 'pure-' : ($this->is_pure === null ? '' : 'impure-'))
+            . $this->value . $param_string . $return_type_string;
     }
 
     /**
@@ -147,7 +170,7 @@ trait CallableTrait
         return $this->value;
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         $param_string = '';
         $return_type_string = '';
@@ -168,16 +191,11 @@ trait CallableTrait
         if ($this->return_type !== null) {
             $return_type_multiple = count($this->return_type->getAtomicTypes()) > 1;
             $return_type_string = ':' . ($return_type_multiple ? '(' : '')
-                . $this->return_type->getId() . ($return_type_multiple ? ')' : '');
+                . $this->return_type->getId($exact) . ($return_type_multiple ? ')' : '');
         }
 
         return ($this->is_pure ? 'pure-' : ($this->is_pure === null ? '' : 'impure-'))
             . $this->value . $param_string . $return_type_string;
-    }
-
-    public function __toString(): string
-    {
-        return $this->getId();
     }
 
     public function replaceTemplateTypesWithStandins(

--- a/src/Psalm/Type/Atomic/GenericTrait.php
+++ b/src/Psalm/Type/Atomic/GenericTrait.php
@@ -21,27 +21,11 @@ use function substr;
 
 trait GenericTrait
 {
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         $s = '';
         foreach ($this->type_params as $type_param) {
-            $s .= $type_param . ', ';
-        }
-
-        $extra_types = '';
-
-        if ($this instanceof TNamedObject && $this->extra_types) {
-            $extra_types = '&' . implode('&', $this->extra_types);
-        }
-
-        return $this->value . '<' . substr($s, 0, -2) . '>' . $extra_types;
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        $s = '';
-        foreach ($this->type_params as $type_param) {
-            $s .= $type_param->getId() . ', ';
+            $s .= $type_param->getId($exact) . ', ';
         }
 
         $extra_types = '';
@@ -51,7 +35,7 @@ trait GenericTrait
                 $extra_types = '&' . implode(
                     '&',
                     array_map(
-                        fn($type) => $type->getId(true),
+                        fn($type) => $type->getId($exact, true),
                         $this->extra_types
                     )
                 );

--- a/src/Psalm/Type/Atomic/TArrayKey.php
+++ b/src/Psalm/Type/Atomic/TArrayKey.php
@@ -7,11 +7,6 @@ namespace Psalm\Type\Atomic;
  */
 class TArrayKey extends Scalar
 {
-    public function __toString(): string
-    {
-        return 'array-key';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'array-key';

--- a/src/Psalm/Type/Atomic/TBool.php
+++ b/src/Psalm/Type/Atomic/TBool.php
@@ -7,11 +7,6 @@ namespace Psalm\Type\Atomic;
  */
 class TBool extends Scalar
 {
-    public function __toString(): string
-    {
-        return 'bool';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'bool';

--- a/src/Psalm/Type/Atomic/TCallableObject.php
+++ b/src/Psalm/Type/Atomic/TCallableObject.php
@@ -7,11 +7,6 @@ namespace Psalm\Type\Atomic;
  */
 class TCallableObject extends TObject
 {
-    public function __toString(): string
-    {
-        return 'callable-object';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'callable-object';

--- a/src/Psalm/Type/Atomic/TCallableString.php
+++ b/src/Psalm/Type/Atomic/TCallableString.php
@@ -13,11 +13,6 @@ class TCallableString extends TNonFalsyString
         return 'callable-string';
     }
 
-    public function getId(bool $nested = false): string
-    {
-        return $this->getKey();
-    }
-
     public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
         return false;

--- a/src/Psalm/Type/Atomic/TClassConstant.php
+++ b/src/Psalm/Type/Atomic/TClassConstant.php
@@ -27,12 +27,7 @@ class TClassConstant extends Atomic
         return 'class-constant(' . $this->fq_classlike_name . '::' . $this->const_name . ')';
     }
 
-    public function __toString(): string
-    {
-        return $this->fq_classlike_name . '::' . $this->const_name;
-    }
-
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return $this->fq_classlike_name . '::' . $this->const_name;
     }

--- a/src/Psalm/Type/Atomic/TClassString.php
+++ b/src/Psalm/Type/Atomic/TClassString.php
@@ -61,12 +61,7 @@ class TClassString extends TString
         return $key . ($this->as === 'object' ? '' : '<' . $this->as_type . '>');
     }
 
-    public function __toString(): string
-    {
-        return $this->getKey();
-    }
-
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         if ($this->is_interface) {
             $key = 'interface-string';

--- a/src/Psalm/Type/Atomic/TClassStringMap.php
+++ b/src/Psalm/Type/Atomic/TClassStringMap.php
@@ -34,8 +34,6 @@ class TClassStringMap extends Atomic
      */
     public $value_param;
 
-    public const KEY = 'class-string-map';
-
     /**
      * Constructs a new instance of a list
      */
@@ -46,29 +44,15 @@ class TClassStringMap extends Atomic
         $this->as_type = $as_type;
     }
 
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
-        /** @psalm-suppress MixedOperand */
-        return static::KEY
+        return 'class-string-map'
             . '<'
             . $this->param_name
             . ' as '
-            . ($this->as_type ? (string) $this->as_type : 'object')
+            . ($this->as_type ? $this->as_type->getId($exact) : 'object')
             . ', '
-            . ((string) $this->value_param)
-            . '>';
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        /** @psalm-suppress MixedOperand */
-        return static::KEY
-            . '<'
-            . $this->param_name
-            . ' as '
-            . ($this->as_type ? (string) $this->as_type : 'object')
-            . ', '
-            . $this->value_param->getId()
+            . $this->value_param->getId($exact)
             . '>';
     }
 
@@ -97,8 +81,7 @@ class TClassStringMap extends Atomic
                 );
         }
 
-        /** @psalm-suppress MixedOperand */
-        return static::KEY
+        return 'class-string-map'
             . '<'
             . $this->param_name
             . ($this->as_type ? ' as ' . $this->as_type : '')

--- a/src/Psalm/Type/Atomic/TClosedResource.php
+++ b/src/Psalm/Type/Atomic/TClosedResource.php
@@ -9,17 +9,7 @@ use Psalm\Type\Atomic;
  */
 class TClosedResource extends Atomic
 {
-    public function __toString(): string
-    {
-        return 'closed-resource';
-    }
-
     public function getKey(bool $include_extra = true): string
-    {
-        return 'closed-resource';
-    }
-
-    public function getId(bool $nested = false): string
     {
         return 'closed-resource';
     }

--- a/src/Psalm/Type/Atomic/TConditional.php
+++ b/src/Psalm/Type/Atomic/TConditional.php
@@ -59,16 +59,6 @@ class TConditional extends Atomic
         $this->else_type = $else_type;
     }
 
-    public function __toString(): string
-    {
-        return '('
-            . $this->param_name
-            . ' is ' . $this->conditional_type
-            . ' ? ' . $this->if_type
-            . ' : ' . $this->else_type
-            . ')';
-    }
-
     public function __clone()
     {
         $this->conditional_type = clone $this->conditional_type;
@@ -79,7 +69,7 @@ class TConditional extends Atomic
 
     public function getKey(bool $include_extra = true): string
     {
-        return $this->__toString();
+        return 'TConditional<' . $this->param_name . '>';
     }
 
     public function getAssertionString(): string
@@ -87,13 +77,13 @@ class TConditional extends Atomic
         return '';
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return '('
-            . $this->param_name . ':' . $this->defining_class
-            . ' is ' . $this->conditional_type->getId()
-            . ' ? ' . $this->if_type->getId()
-            . ' : ' . $this->else_type->getId()
+            . $this->param_name
+            . ' is ' . $this->conditional_type->getId($exact)
+            . ' ? ' . $this->if_type->getId($exact)
+            . ' : ' . $this->else_type->getId($exact)
             . ')';
     }
 

--- a/src/Psalm/Type/Atomic/TDependentGetClass.php
+++ b/src/Psalm/Type/Atomic/TDependentGetClass.php
@@ -31,12 +31,12 @@ class TDependentGetClass extends TString implements DependentType
         $this->as_type = $as_type;
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return $this->as_type->isMixed()
             || $this->as_type->hasObject()
             ? 'class-string'
-            : 'class-string<' . $this->as_type->getId() . '>';
+            : 'class-string<' . $this->as_type->getId($exact) . '>';
     }
 
     public function getKey(bool $include_extra = true): string

--- a/src/Psalm/Type/Atomic/TDependentListKey.php
+++ b/src/Psalm/Type/Atomic/TDependentListKey.php
@@ -24,7 +24,7 @@ class TDependentListKey extends TInt implements DependentType
         $this->var_id = $var_id;
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'list-key<' . $this->var_id . '>';
     }

--- a/src/Psalm/Type/Atomic/TEmptyMixed.php
+++ b/src/Psalm/Type/Atomic/TEmptyMixed.php
@@ -8,7 +8,7 @@ namespace Psalm\Type\Atomic;
  */
 class TEmptyMixed extends TMixed
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'empty-mixed';
     }

--- a/src/Psalm/Type/Atomic/TEmptyNumeric.php
+++ b/src/Psalm/Type/Atomic/TEmptyNumeric.php
@@ -7,7 +7,7 @@ namespace Psalm\Type\Atomic;
  */
 class TEmptyNumeric extends TNumeric
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'empty-numeric';
     }

--- a/src/Psalm/Type/Atomic/TEmptyScalar.php
+++ b/src/Psalm/Type/Atomic/TEmptyScalar.php
@@ -7,7 +7,7 @@ namespace Psalm\Type\Atomic;
  */
 class TEmptyScalar extends TScalar
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'empty-scalar';
     }

--- a/src/Psalm/Type/Atomic/TEnumCase.php
+++ b/src/Psalm/Type/Atomic/TEnumCase.php
@@ -24,7 +24,7 @@ class TEnumCase extends TNamedObject
         return 'enum(' . $this->value . '::' . $this->case_name . ')';
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'enum(' . $this->value . '::' . $this->case_name . ')';
     }

--- a/src/Psalm/Type/Atomic/TFalse.php
+++ b/src/Psalm/Type/Atomic/TFalse.php
@@ -7,11 +7,6 @@ namespace Psalm\Type\Atomic;
  */
 class TFalse extends TBool
 {
-    public function __toString(): string
-    {
-        return 'false';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'false';

--- a/src/Psalm/Type/Atomic/TFloat.php
+++ b/src/Psalm/Type/Atomic/TFloat.php
@@ -7,11 +7,6 @@ namespace Psalm\Type\Atomic;
  */
 class TFloat extends Scalar
 {
-    public function __toString(): string
-    {
-        return 'float';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'float';

--- a/src/Psalm/Type/Atomic/TInt.php
+++ b/src/Psalm/Type/Atomic/TInt.php
@@ -7,11 +7,6 @@ namespace Psalm\Type\Atomic;
  */
 class TInt extends Scalar
 {
-    public function __toString(): string
-    {
-        return 'int';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'int';

--- a/src/Psalm/Type/Atomic/TIntMask.php
+++ b/src/Psalm/Type/Atomic/TIntMask.php
@@ -30,12 +30,12 @@ class TIntMask extends TInt
         return 'int-mask<' . substr($s, 0, -2) . '>';
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         $s = '';
 
         foreach ($this->values as $value) {
-            $s .= $value->getId() . ', ';
+            $s .= $value->getId($exact) . ', ';
         }
 
         return 'int-mask<' . substr($s, 0, -2) . '>';

--- a/src/Psalm/Type/Atomic/TIntMaskOf.php
+++ b/src/Psalm/Type/Atomic/TIntMaskOf.php
@@ -27,11 +27,6 @@ class TIntMaskOf extends TInt
         return 'int-mask-of<' . $this->value->getKey() . '>';
     }
 
-    public function getId(bool $nested = false): string
-    {
-        return $this->getKey();
-    }
-
     /**
      * @param array<lowercase-string, string> $aliased_classes
      */

--- a/src/Psalm/Type/Atomic/TIntRange.php
+++ b/src/Psalm/Type/Atomic/TIntRange.php
@@ -28,11 +28,6 @@ class TIntRange extends TInt
         $this->max_bound = $max_bound;
     }
 
-    public function __toString(): string
-    {
-        return $this->getKey();
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'int<' . ($this->min_bound ?? 'min') . ', ' . ($this->max_bound ?? 'max') . '>';

--- a/src/Psalm/Type/Atomic/TIterable.php
+++ b/src/Psalm/Type/Atomic/TIterable.php
@@ -61,11 +61,11 @@ class TIterable extends Atomic
         return 'iterable';
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         $s = '';
         foreach ($this->type_params as $type_param) {
-            $s .= $type_param->getId() . ', ';
+            $s .= $type_param->getId($exact) . ', ';
         }
 
         $extra_types = '';
@@ -75,11 +75,6 @@ class TIterable extends Atomic
         }
 
         return $this->value . '<' . substr($s, 0, -2) . '>' . $extra_types;
-    }
-
-    public function __toString(): string
-    {
-        return $this->getId();
     }
 
     /**

--- a/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TKeyOfClassConstant.php
@@ -30,16 +30,6 @@ class TKeyOfClassConstant extends Scalar
         return 'key-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
 
-    public function __toString(): string
-    {
-        return 'key-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        return $this->getKey();
-    }
-
     /**
      * @param  array<lowercase-string, string> $aliased_classes
      */

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -78,12 +78,12 @@ class TKeyedArray extends Atomic
         $this->class_strings = $class_strings;
     }
 
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         $property_strings = array_map(
-            function ($name, Union $type): string {
+            function ($name, Union $type) use ($exact): string {
                 if ($this->is_list && $this->sealed) {
-                    return (string) $type;
+                    return $type->getId($exact);
                 }
 
                 $class_string_suffix = '';
@@ -93,36 +93,8 @@ class TKeyedArray extends Atomic
 
                 $name = $this->escapeAndQuote($name);
 
-                return $name . $class_string_suffix . ($type->possibly_undefined ? '?' : '') . ': ' . $type;
-            },
-            array_keys($this->properties),
-            $this->properties
-        );
-
-        if (!$this->is_list) {
-            sort($property_strings);
-        }
-
-        /** @psalm-suppress MixedOperand */
-        return static::KEY . '{' . implode(', ', $property_strings) . '}';
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        $property_strings = array_map(
-            function ($name, Union $type): string {
-                if ($this->is_list && $this->sealed) {
-                    return $type->getId();
-                }
-
-                $class_string_suffix = '';
-                if (isset($this->class_strings[$name])) {
-                    $class_string_suffix = '::class';
-                }
-
-                $name = $this->escapeAndQuote($name);
-
-                return $name . $class_string_suffix . ($type->possibly_undefined ? '?' : '') . ': ' . $type->getId();
+                return $name . $class_string_suffix . ($type->possibly_undefined ? '?' : '')
+                    . ': ' . $type->getId($exact);
             },
             array_keys($this->properties),
             $this->properties
@@ -139,8 +111,8 @@ class TKeyedArray extends Atomic
                 . ($this->previous_value_type
                     && (!$this->previous_value_type->isMixed()
                         || ($this->previous_key_type && !$this->previous_key_type->isArrayKey()))
-                    ? '<' . ($this->previous_key_type ? $this->previous_key_type->getId() . ', ' : '')
-                        . $this->previous_value_type->getId() . '>'
+                    ? '<' . ($this->previous_key_type ? $this->previous_key_type->getId($exact) . ', ' : '')
+                        . $this->previous_value_type->getId($exact) . '>'
                     : '');
     }
 

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -36,16 +36,10 @@ class TList extends Atomic
         $this->type_param = $type_param;
     }
 
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         /** @psalm-suppress MixedOperand */
-        return static::KEY . '<' . $this->type_param . '>';
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        /** @psalm-suppress MixedOperand */
-        return static::KEY . '<' . $this->type_param->getId() . '>';
+        return static::KEY . '<' . $this->type_param->getId($exact) . '>';
     }
 
     public function __clone()

--- a/src/Psalm/Type/Atomic/TLiteralClassString.php
+++ b/src/Psalm/Type/Atomic/TLiteralClassString.php
@@ -25,11 +25,6 @@ class TLiteralClassString extends TLiteralString
         $this->definite_class = $definite_class;
     }
 
-    public function __toString(): string
-    {
-        return 'class-string';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'class-string(' . $this->value . ')';
@@ -52,8 +47,12 @@ class TLiteralClassString extends TLiteralString
         return false;
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
+        if (!$exact) {
+            return 'class-string';
+        }
+
         return $this->value . '::class';
     }
 

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -20,8 +20,12 @@ class TLiteralFloat extends TFloat
         return 'float(' . $this->value . ')';
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
+        if (!$exact) {
+            return 'float';
+        }
+
         return 'float(' . $this->value . ')';
     }
 

--- a/src/Psalm/Type/Atomic/TLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TLiteralInt.php
@@ -20,8 +20,12 @@ class TLiteralInt extends TInt
         return 'int(' . $this->value . ')';
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
+        if (!$exact) {
+            return 'int';
+        }
+
         return (string) $this->value;
     }
 

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -24,15 +24,18 @@ class TLiteralString extends TString
         return 'string(' . $this->value . ')';
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
+        if (!$exact) {
+            return 'string';
+        }
         // quote control characters, backslashes and double quote
         $no_newline_value = addcslashes($this->value, "\0..\37\\\"");
         if (mb_strlen($this->value) > 80) {
-            return '"' . mb_substr($no_newline_value, 0, 80) . '...' . '"';
+            return "'" . mb_substr($no_newline_value, 0, 80) . '...' . "'";
         }
 
-        return '"' . $no_newline_value . '"';
+        return "'" . $no_newline_value . "'";
     }
 
     public function getAssertionString(): string

--- a/src/Psalm/Type/Atomic/TLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TLowercaseString.php
@@ -4,7 +4,7 @@ namespace Psalm\Type\Atomic;
 
 class TLowercaseString extends TString
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'lowercase-string';
     }

--- a/src/Psalm/Type/Atomic/TMixed.php
+++ b/src/Psalm/Type/Atomic/TMixed.php
@@ -17,11 +17,6 @@ class TMixed extends Atomic
         $this->from_loop_isset = $from_loop_isset;
     }
 
-    public function __toString(): string
-    {
-        return 'mixed';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'mixed';

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -49,11 +49,6 @@ class TNamedObject extends Atomic
         $this->definite_class = $definite_class;
     }
 
-    public function __toString(): string
-    {
-        return $this->getKey();
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         if ($include_extra && $this->extra_types) {
@@ -63,19 +58,19 @@ class TNamedObject extends Atomic
         return $this->value;
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         if ($this->extra_types) {
             return $this->value . '&' . implode(
                 '&',
                 array_map(
-                    fn($type) => $type->getId(true),
+                    fn($type) => $type->getId($exact, true),
                     $this->extra_types
                 )
             );
         }
 
-        return $this->is_static ? $this->value . '&static' : $this->value;
+        return $this->is_static && $exact ? $this->value . '&static' : $this->value;
     }
 
     /**

--- a/src/Psalm/Type/Atomic/TNever.php
+++ b/src/Psalm/Type/Atomic/TNever.php
@@ -10,11 +10,6 @@ use Psalm\Type\Atomic;
  */
 class TNever extends Atomic
 {
-    public function __toString(): string
-    {
-        return 'never';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'never';

--- a/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyLowercaseString.php
@@ -7,8 +7,12 @@ namespace Psalm\Type\Atomic;
  */
 class TNonEmptyLowercaseString extends TNonEmptyString
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
+        if (!$exact) {
+            return 'string';
+        }
+
         return 'non-empty-lowercase-string';
     }
 

--- a/src/Psalm/Type/Atomic/TNonEmptyMixed.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyMixed.php
@@ -8,7 +8,7 @@ namespace Psalm\Type\Atomic;
  */
 class TNonEmptyMixed extends TMixed
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'non-empty-mixed';
     }

--- a/src/Psalm/Type/Atomic/TNonEmptyNonspecificLiteralString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyNonspecificLiteralString.php
@@ -8,8 +8,12 @@ namespace Psalm\Type\Atomic;
  */
 class TNonEmptyNonspecificLiteralString extends TNonspecificLiteralString
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
+        if (!$exact) {
+            return 'string';
+        }
+
         return 'non-empty-literal-string';
     }
 }

--- a/src/Psalm/Type/Atomic/TNonEmptyScalar.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyScalar.php
@@ -7,7 +7,7 @@ namespace Psalm\Type\Atomic;
  */
 class TNonEmptyScalar extends TScalar
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'non-empty-scalar';
     }

--- a/src/Psalm/Type/Atomic/TNonEmptyString.php
+++ b/src/Psalm/Type/Atomic/TNonEmptyString.php
@@ -7,8 +7,12 @@ namespace Psalm\Type\Atomic;
  */
 class TNonEmptyString extends TString
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
+        if (!$exact) {
+            return 'string';
+        }
+
         return 'non-empty-string';
     }
 }

--- a/src/Psalm/Type/Atomic/TNonFalsyString.php
+++ b/src/Psalm/Type/Atomic/TNonFalsyString.php
@@ -7,8 +7,12 @@ namespace Psalm\Type\Atomic;
  */
 class TNonFalsyString extends TNonEmptyString
 {
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
+        if (!$exact) {
+            return 'string';
+        }
+
         return 'non-falsy-string';
     }
 }

--- a/src/Psalm/Type/Atomic/TNonspecificLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TNonspecificLiteralInt.php
@@ -8,7 +8,7 @@ namespace Psalm\Type\Atomic;
  */
 class TNonspecificLiteralInt extends TInt
 {
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = true): string
     {
         return 'literal-int';
     }

--- a/src/Psalm/Type/Atomic/TNonspecificLiteralString.php
+++ b/src/Psalm/Type/Atomic/TNonspecificLiteralString.php
@@ -8,8 +8,12 @@ namespace Psalm\Type\Atomic;
  */
 class TNonspecificLiteralString extends TString
 {
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = true): string
     {
+        if (!$exact) {
+            return 'string';
+        }
+
         return 'literal-string';
     }
 

--- a/src/Psalm/Type/Atomic/TNull.php
+++ b/src/Psalm/Type/Atomic/TNull.php
@@ -9,11 +9,6 @@ use Psalm\Type\Atomic;
  */
 class TNull extends Atomic
 {
-    public function __toString(): string
-    {
-        return 'null';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'null';

--- a/src/Psalm/Type/Atomic/TNumeric.php
+++ b/src/Psalm/Type/Atomic/TNumeric.php
@@ -7,11 +7,6 @@ namespace Psalm\Type\Atomic;
  */
 class TNumeric extends Scalar
 {
-    public function __toString(): string
-    {
-        return 'numeric';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'numeric';

--- a/src/Psalm/Type/Atomic/TNumericString.php
+++ b/src/Psalm/Type/Atomic/TNumericString.php
@@ -7,19 +7,18 @@ namespace Psalm\Type\Atomic;
  */
 class TNumericString extends TNonEmptyString
 {
+    public function getId(bool $exact = true, bool $nested = false): string
+    {
+        if (!$exact) {
+            return 'string';
+        }
+
+        return 'numeric-string';
+    }
+
     public function getKey(bool $include_extra = true): string
     {
         return 'numeric-string';
-    }
-
-    public function __toString(): string
-    {
-        return 'numeric-string';
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        return $this->getKey();
     }
 
     public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool

--- a/src/Psalm/Type/Atomic/TObject.php
+++ b/src/Psalm/Type/Atomic/TObject.php
@@ -9,11 +9,6 @@ use Psalm\Type\Atomic;
  */
 class TObject extends Atomic
 {
-    public function __toString(): string
-    {
-        return 'object';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'object';

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -46,7 +46,7 @@ class TObjectWithProperties extends TObject
         $this->methods = $methods;
     }
 
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         $extra_types = '';
 
@@ -60,41 +60,8 @@ class TObjectWithProperties extends TObject
                 /**
                  * @param  string|int $name
                  */
-                fn($name, Union $type): string => $name . ($type->possibly_undefined ? '?' : '') . ':' . $type,
-                array_keys($this->properties),
-                $this->properties
-            )
-        );
-
-        $methods_string = implode(
-            ', ',
-            array_map(
-                fn(string $name): string => $name . '()',
-                array_keys($this->methods)
-            )
-        );
-
-        return 'object{'
-            . $properties_string . ($methods_string && $properties_string ? ', ' : '')
-            . $methods_string
-            . '}' . $extra_types;
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        $extra_types = '';
-
-        if ($this->extra_types) {
-            $extra_types = '&' . implode('&', $this->extra_types);
-        }
-
-        $properties_string = implode(
-            ', ',
-            array_map(
-                /**
-                 * @param  string|int $name
-                 */
-                fn($name, Union $type): string => $name . ($type->possibly_undefined ? '?' : '') . ':' . $type->getId(),
+                fn($name, Union $type): string => $name . ($type->possibly_undefined ? '?' : '') . ':'
+                    . $type->getId($exact),
                 array_keys($this->properties),
                 $this->properties
             )

--- a/src/Psalm/Type/Atomic/TPositiveInt.php
+++ b/src/Psalm/Type/Atomic/TPositiveInt.php
@@ -7,12 +7,7 @@ namespace Psalm\Type\Atomic;
  */
 class TPositiveInt extends TInt
 {
-    public function getId(bool $nested = false): string
-    {
-        return 'positive-int';
-    }
-
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'positive-int';
     }

--- a/src/Psalm/Type/Atomic/TResource.php
+++ b/src/Psalm/Type/Atomic/TResource.php
@@ -9,11 +9,6 @@ use Psalm\Type\Atomic;
  */
 class TResource extends Atomic
 {
-    public function __toString(): string
-    {
-        return 'resource';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'resource';

--- a/src/Psalm/Type/Atomic/TScalar.php
+++ b/src/Psalm/Type/Atomic/TScalar.php
@@ -8,11 +8,6 @@ namespace Psalm\Type\Atomic;
  */
 class TScalar extends Scalar
 {
-    public function __toString(): string
-    {
-        return 'scalar';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'scalar';

--- a/src/Psalm/Type/Atomic/TString.php
+++ b/src/Psalm/Type/Atomic/TString.php
@@ -19,11 +19,6 @@ class TString extends Scalar
         return $analysis_php_version_id >= 7_00_00 ? 'string' : null;
     }
 
-    public function __toString(): string
-    {
-        return 'string';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'string';

--- a/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
+++ b/src/Psalm/Type/Atomic/TTemplateIndexedAccess.php
@@ -36,16 +36,6 @@ class TTemplateIndexedAccess extends Atomic
         return $this->array_param_name . '[' . $this->offset_param_name . ']';
     }
 
-    public function __toString(): string
-    {
-        return $this->getKey();
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        return $this->getKey();
-    }
-
     /**
      * @param  array<lowercase-string, string> $aliased_classes
      */

--- a/src/Psalm/Type/Atomic/TTemplateKeyOf.php
+++ b/src/Psalm/Type/Atomic/TTemplateKeyOf.php
@@ -39,14 +39,13 @@ class TTemplateKeyOf extends TArrayKey
         return 'key-of<' . $this->param_name . '>';
     }
 
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
-        return 'key-of<' . $this->param_name . '>';
-    }
+        if (!$exact) {
+            return 'key-of<' . $this->param_name . '>';
+        }
 
-    public function getId(bool $nested = false): string
-    {
-        return 'key-of<' . $this->param_name . ':' . $this->defining_class . ' as ' . $this->as->getId() . '>';
+        return 'key-of<' . $this->param_name . ':' . $this->defining_class . ' as ' . $this->as->getId($exact) . '>';
     }
 
     /**

--- a/src/Psalm/Type/Atomic/TTemplateParam.php
+++ b/src/Psalm/Type/Atomic/TTemplateParam.php
@@ -39,11 +39,6 @@ class TTemplateParam extends Atomic
         $this->defining_class = $defining_class;
     }
 
-    public function __toString(): string
-    {
-        return $this->param_name;
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         if ($include_extra && $this->extra_types) {
@@ -58,16 +53,20 @@ class TTemplateParam extends Atomic
         return $this->as->getId();
     }
 
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
+        if (!$exact) {
+            return $this->param_name;
+        }
+
         if ($this->extra_types) {
-            return '(' . $this->param_name . ':' . $this->defining_class . ' as ' . $this->as->getId()
-                . ')&' . implode('&', array_map(fn($type) => $type->getId(true), $this->extra_types));
+            return '(' . $this->param_name . ':' . $this->defining_class . ' as ' . $this->as->getId($exact)
+                . ')&' . implode('&', array_map(fn($type) => $type->getId($exact, true), $this->extra_types));
         }
 
         return ($nested ? '(' : '') . $this->param_name
             . ':' . $this->defining_class
-            . ' as ' . $this->as->getId() . ($nested ? ')' : '');
+            . ' as ' . $this->as->getId($exact) . ($nested ? ')' : '');
     }
 
     /**

--- a/src/Psalm/Type/Atomic/TTemplateParamClass.php
+++ b/src/Psalm/Type/Atomic/TTemplateParamClass.php
@@ -34,15 +34,10 @@ class TTemplateParamClass extends TClassString
         return 'class-string<' . $this->param_name . '>';
     }
 
-    public function __toString(): string
-    {
-        return 'class-string<' . $this->param_name . '>';
-    }
-
-    public function getId(bool $nested = false): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         return 'class-string<' . $this->param_name . ':' . $this->defining_class
-            . ' as ' . ($this->as_type ? $this->as_type->getId() : $this->as) . '>';
+            . ' as ' . ($this->as_type ? $this->as_type->getId($exact) : $this->as) . '>';
     }
 
     public function getAssertionString(): string

--- a/src/Psalm/Type/Atomic/TTraitString.php
+++ b/src/Psalm/Type/Atomic/TTraitString.php
@@ -12,16 +12,6 @@ class TTraitString extends TString
         return 'trait-string';
     }
 
-    public function __toString(): string
-    {
-        return $this->getKey();
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        return $this->getKey();
-    }
-
     /**
      * @param  array<lowercase-string, string> $aliased_classes
      */

--- a/src/Psalm/Type/Atomic/TTrue.php
+++ b/src/Psalm/Type/Atomic/TTrue.php
@@ -7,11 +7,6 @@ namespace Psalm\Type\Atomic;
  */
 class TTrue extends TBool
 {
-    public function __toString(): string
-    {
-        return 'true';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'true';

--- a/src/Psalm/Type/Atomic/TTypeAlias.php
+++ b/src/Psalm/Type/Atomic/TTypeAlias.php
@@ -31,28 +31,13 @@ class TTypeAlias extends Atomic
         return 'type-alias(' . $this->declaring_fq_classlike_name . '::' . $this->alias_name . ')';
     }
 
-    public function __toString(): string
+    public function getId(bool $exact = true, bool $nested = false): string
     {
         if ($this->extra_types) {
             return $this->getKey() . '&' . implode(
                 '&',
                 array_map(
-                    'strval',
-                    $this->extra_types
-                )
-            );
-        }
-
-        return $this->getKey();
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        if ($this->extra_types) {
-            return $this->getKey() . '&' . implode(
-                '&',
-                array_map(
-                    fn($type) => $type->getId(true),
+                    fn($type) => $type->getId($exact, true),
                     $this->extra_types
                 )
             );

--- a/src/Psalm/Type/Atomic/TValueOfClassConstant.php
+++ b/src/Psalm/Type/Atomic/TValueOfClassConstant.php
@@ -27,16 +27,6 @@ class TValueOfClassConstant extends Atomic
         return 'value-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
     }
 
-    public function __toString(): string
-    {
-        return 'value-of<' . $this->fq_classlike_name . '::' . $this->const_name . '>';
-    }
-
-    public function getId(bool $nested = false): string
-    {
-        return $this->getKey();
-    }
-
     /**
      * @param  array<lowercase-string, string> $aliased_classes
      */

--- a/src/Psalm/Type/Atomic/TVoid.php
+++ b/src/Psalm/Type/Atomic/TVoid.php
@@ -9,11 +9,6 @@ use Psalm\Type\Atomic;
  */
 class TVoid extends Atomic
 {
-    public function __toString(): string
-    {
-        return 'void';
-    }
-
     public function getKey(bool $include_extra = true): string
     {
         return 'void';

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -1105,7 +1105,7 @@ class ArrayAccessTest extends TestCase
                 $a = ["a", "b"];
                 unset($a[0]);
                 ',
-                'assertions' => ['$a===' => 'array{1: "b"}']
+                'assertions' => ['$a===' => "array{1: 'b'}"]
             ],
         ];
     }

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -824,7 +824,7 @@ class ArrayFunctionCallTest extends TestCase
                         ARRAY_FILTER_USE_KEY
                     );',
                 'assertions' => [
-                    '$foo' => 'array<string, pure-Closure():"baz">',
+                    '$foo' => 'array<string, pure-Closure():string>',
                 ],
             ],
             'ignoreFalsableCurrent' => [

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -671,12 +671,12 @@ class CallableTest extends TestCase
                     $e = array_map([$a_instance, "bar"], ["one", "two"]);
                     $f = array_map("baz", ["one", "two"]);',
                 'assertions' => [
-                    '$a' => 'array{string, string}',
-                    '$b' => 'array{string, string}',
-                    '$c' => 'array{string, string}',
-                    '$d' => 'array{string, string}',
-                    '$e' => 'array{string, string}',
-                    '$f' => 'array{string, string}',
+                    '$a' => 'array{string, string}<string>',
+                    '$b' => 'array{string, string}<string>',
+                    '$c' => 'array{string, string}<string>',
+                    '$d' => 'array{string, string}<string>',
+                    '$e' => 'array{string, string}<string>',
+                    '$f' => 'array{string, string}<string>',
                 ],
             ],
             'arrayCallableMethod' => [

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -98,7 +98,7 @@ class ClosureTest extends TestCase
                     $mirror = function(int $i) : int { return $i; };
                     $a = array_map($mirror, [1, 2, 3]);',
                 'assertions' => [
-                    '$a' => 'array{int, int, int}',
+                    '$a' => 'array{int, int, int}<int>',
                 ],
             ],
             'inlineCallableFunction' => [
@@ -344,7 +344,7 @@ class ClosureTest extends TestCase
                     $a = function() : Closure { return function() : string { return "hello"; }; };
                     $b = $a()();',
                 'assertions' => [
-                    '$a' => 'pure-Closure():pure-Closure():"hello"',
+                    '$a' => 'pure-Closure():pure-Closure():string',
                     '$b' => 'string',
                 ],
             ],
@@ -418,7 +418,7 @@ class ClosureTest extends TestCase
                     $closure = Closure::fromCallable("strlen");
                 ',
                 'assertions' => [
-                    '$closure' => 'pure-Closure(string):(0|positive-int)',
+                    '$closure' => 'pure-Closure(string):(int|positive-int)',
                 ]
             ],
             'allowClosureWithNarrowerReturn' => [
@@ -562,7 +562,7 @@ class ClosureTest extends TestCase
                     $maker = maker(stdClass::class);
                     $result = array_map($maker, ["abc"]);',
                 'assertions' => [
-                    '$result' => 'array{stdClass}'
+                    '$result' => 'array{stdClass}<stdClass>'
                 ],
             ],
             'FirstClassCallable:NamedFunction:is_int' => [
@@ -583,7 +583,7 @@ class ClosureTest extends TestCase
                     $result = $closure("test");
                 ',
                 'assertions' => [
-                    '$closure' => 'pure-Closure(string):(0|positive-int)',
+                    '$closure' => 'pure-Closure(string):(int|positive-int)',
                     '$result' => 'int|positive-int',
                 ],
                 'ignored_issues' => [],
@@ -660,7 +660,7 @@ class ClosureTest extends TestCase
                     $closure = $closure(...);
                 ',
                 'assertions' => [
-                    '$closure' => 'pure-Closure(string):(0|positive-int)',
+                    '$closure' => 'pure-Closure(string):(int|positive-int)',
                 ],
                 'ignored_issues' => [],
                 'php_version' => '8.1'
@@ -722,9 +722,9 @@ class ClosureTest extends TestCase
                     $result3 = array_map($closure(...), $array);
                 ',
                 'assertions' => [
-                    '$result1' => 'array{null, null, null}',
-                    '$result2' => 'array{string, string, string}',
-                    '$result3' => 'array{int, int, int}',
+                    '$result1' => 'array{null, null, null}<null>',
+                    '$result2' => 'array{string, string, string}<string>',
+                    '$result3' => 'array{int, int, int}<int>',
                 ],
                 'ignored_issues' => [],
                 'php_version' => '8.1'

--- a/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
+++ b/tests/Config/Plugin/Hook/StringProvider/TSqlSelectString.php
@@ -14,7 +14,7 @@ class TSqlSelectString extends TLiteralString
         return 'sql-select-string';
     }
 
-    public function getId(bool $nested = true): string
+    public function getId(bool $exact = true, bool $nested = true): string
     {
         return 'sql-select-string(' . $this->value . ')';
     }

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -327,7 +327,7 @@ class ConstantTest extends TestCase
 
                     $foo = new Foo();
                     $_trace = $foo::BAR;',
-                'assertions' => ['$_trace===' => '"bar"'],
+                'assertions' => ['$_trace===' => "'bar'"],
             ],
             'unsafeInferenceClassConstFetch' => [
                 'code' => '<?php
@@ -351,7 +351,7 @@ class ConstantTest extends TestCase
                     /** @var Foo $foo */
                     $foo = new stdClass();
                     $_trace = $foo::BAR;',
-                'assertions' => ['$_trace===' => '"bar"'],
+                'assertions' => ['$_trace===' => "'bar'"],
             ],
             'dynamicClassConstFetchClassString' => [
                 'code' => '<?php
@@ -1149,7 +1149,7 @@ class ConstantTest extends TestCase
                     $arr = C::A;
                 ',
                 'assertions' => [
-                    '$arr===' => 'array{10: "aa", 11: "zz", 5: "a", 6: "z"}',
+                    '$arr===' => "array{10: 'aa', 11: 'zz', 5: 'a', 6: 'z'}",
                 ],
             ],
             'arrayKeysSequenceContinuesAfterNonIntKey' => [
@@ -1160,7 +1160,7 @@ class ConstantTest extends TestCase
                     $arr = C::A;
                 ',
                 'assertions' => [
-                    '$arr===' => 'array{5: "a", 6: "aa", zz: "z"}',
+                    '$arr===' => "array{5: 'a', 6: 'aa', zz: 'z'}",
                 ],
             ],
             'unresolvedConstWithUnaryMinus' => [

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -114,7 +114,7 @@ class EnumTest extends TestCase
                     $a = Status::DRAFT->name;
                 ',
                 'assertions' => [
-                    '$a===' => '"DRAFT"',
+                    '$a===' => "'DRAFT'",
                 ],
                 'ignored_issues' => [],
                 'php_version' => '8.1'

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1490,12 +1490,12 @@ class FunctionCallTest extends TestCase
                     /** @psalm-suppress MixedArgument */
                     $F3 = date("F", $_GET["F3"]);',
                 'assertions' => [
-                    '$y' => 'numeric-string',
-                    '$m' => 'numeric-string',
-                    '$F' => 'string',
-                    '$y2' => 'numeric-string',
-                    '$F2' => 'string',
-                    '$F3' => 'false|string',
+                    '$y===' => 'numeric-string',
+                    '$m===' => 'numeric-string',
+                    '$F===' => 'string',
+                    '$y2===' => 'numeric-string',
+                    '$F2===' => 'string',
+                    '$F3===' => 'false|string',
                 ]
             ],
             'sscanfReturnTypeWithTwoParameters' => [

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -296,7 +296,7 @@ class GeneratorTest extends TestCase
                     $_a = function() { return new RuntimeException(yield "a"); };
                     ',
                 'assertions' => [
-                    '$_a' => 'pure-Closure():Generator<int, "a", mixed, RuntimeException>',
+                    '$_a' => 'pure-Closure():Generator<int, string, mixed, RuntimeException>',
                 ]
             ],
             'detectYieldInArray' => [
@@ -305,7 +305,7 @@ class GeneratorTest extends TestCase
                     $_a = function() { return [yield "a"]; };
                     ',
                 'assertions' => [
-                    '$_a' => 'pure-Closure():Generator<int, "a", mixed, array{"a"}>',
+                    '$_a' => 'pure-Closure():Generator<int, string, mixed, array{string}>',
                 ]
             ],
         ];

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -403,7 +403,7 @@ class IntRangeTest extends TestCase
                     $a = getInt();
                     $_arr[$a] = 12;',
                 'assertions' => [
-                    '$_arr===' => 'non-empty-array<int<0, max>, "a"|"b"|"c"|12>'
+                    '$_arr===' => "non-empty-array<int<0, max>, 'a'|'b'|'c'|12>"
                 ]
             ],
             'integrateExistingArrayNegative' => [
@@ -418,7 +418,7 @@ class IntRangeTest extends TestCase
                     $a = getInt();
                     $_arr[$a] = 12;',
                 'assertions' => [
-                    '$_arr===' => 'non-empty-array<int<min, 2>, "a"|"b"|"c"|12>'
+                    '$_arr===' => "non-empty-array<int<min, 2>, 'a'|'b'|'c'|12>"
                 ]
             ],
             'SKIPPED-statementsInLoopAffectsEverything' => [

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -104,7 +104,7 @@ class JsonOutputTest extends TestCase
                     function fooFoo() {
                         return "hello";
                     }',
-                'message' => 'Method fooFoo does not have a return type, expecting "hello"',
+                'message' => "Method fooFoo does not have a return type, expecting 'hello'",
                 'line' => 2,
                 'error' => 'fooFoo',
             ],
@@ -116,7 +116,7 @@ class JsonOutputTest extends TestCase
                     function fooFoo() {
                         return "hello";
                     }',
-                'message' => "The inferred type '\"hello\"' does not match the declared return type 'int' for fooFoo",
+                'message' => "The inferred type ''hello'' does not match the declared return type 'int' for fooFoo",
                 'line' => 6,
                 'error' => '"hello"',
             ],

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -845,8 +845,8 @@ class MagicMethodAnnotationTest extends TestCase
                     /** @var I<B> $i */
                     $c = $i->foo();',
                 [
-                    '$b' => 'A<B>',
-                    '$c' => 'I<B>',
+                    '$b' => 'A<B>&static',
+                    '$c' => 'I<B>&static',
                 ]
             ],
             'genericsOfInheritedMethodsShouldBeResolved' => [

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -768,7 +768,7 @@ class ReturnTypeTest extends TestCase
                     $res = map(function(int $i): string { return (string) $i; })([1,2,3]);
                 ',
                 'assertions' => [
-                    '$res' => 'iterable<int, numeric-string>',
+                    '$res===' => 'iterable<int, numeric-string>',
                 ],
             ],
             'infersArrowClosureReturnTypes' => [
@@ -808,7 +808,7 @@ class ReturnTypeTest extends TestCase
                     $res = map(function(int $i): string { return (string) $i; })([1,2,3]);
                 ',
                 'assertions' => [
-                    '$res' => 'iterable<int, numeric-string>',
+                    '$res===' => 'iterable<int, numeric-string>',
                 ],
             ],
             'infersCallableReturnTypes' => [
@@ -830,7 +830,7 @@ class ReturnTypeTest extends TestCase
                     $res = map(function(int $i): string { return (string) $i; })([1,2,3]);
                 ',
                 'assertions' => [
-                    '$res' => 'iterable<int, numeric-string>',
+                    '$res===' => 'iterable<int, numeric-string>',
                 ],
             ],
             'infersCallableReturnTypesWithPartialTypehinting' => [
@@ -852,7 +852,7 @@ class ReturnTypeTest extends TestCase
                     $res = map(function(int $i): string { return (string) $i; })([1,2,3]);
                 ',
                 'assertions' => [
-                    '$res' => 'iterable<int, numeric-string>',
+                    '$res===' => 'iterable<int, numeric-string>',
                 ],
             ],
             'mixedAssignmentWithUnderscore' => [

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -1049,7 +1049,7 @@ class ClassTemplateTest extends TestCase
 
                     $c = new C();',
                 'assertions' => [
-                    '$c===' => 'C<"hello">',
+                    '$c===' => "C<'hello'>",
                 ],
             ],
             'SKIPPED-templateDefaultConstant' => [
@@ -3921,7 +3921,7 @@ class ClassTemplateTest extends TestCase
                     $mario = new CharacterRow(["id" => 5, "name" => "Mario", "height" => 3.5]);
 
                     $mario->ame = "Luigi";',
-                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:47:29 - Argument 1 of CharacterRow::__set expects "height"|"id"|"name", "ame" provided',
+                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . "somefile.php:47:29 - Argument 1 of CharacterRow::__set expects 'height'|'id'|'name', 'ame' provided",
             ],
             'specialiseTypeBeforeReturning' => [
                 'code' => '<?php

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -79,10 +79,11 @@ trait ValidCodeAnalysisTestTrait
             }
 
             if (isset($context->vars_in_scope[$var])) {
+                $value = $context->vars_in_scope[$var]->getId($exact);
                 if ($exact) {
-                    $actual_vars[$var . '==='] = $context->vars_in_scope[$var]->getId();
+                    $actual_vars[$var . '==='] = $value;
                 } else {
-                    $actual_vars[$var] = (string)$context->vars_in_scope[$var];
+                    $actual_vars[$var] = $value;
                 }
             }
         }

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -370,28 +370,28 @@ class TypeCombinationTest extends TestCase
                 ],
             ],
             'combineObjectTypeWithIntKeyedArray' => [
-                'array<"a"|int, int|string>',
+                "array<'a'|int, int|string>",
                 [
                     'array{a: int}',
                     'array<int, string>',
                 ],
             ],
             'combineNestedObjectTypeWithTKeyedArrayIntKeyedArray' => [
-                'array{a: array<"a"|int, int|string>}',
+                "array{a: array<'a'|int, int|string>}",
                 [
                     'array{a: array{a: int}}',
                     'array{a: array<int, string>}',
                 ],
             ],
             'combineIntKeyedObjectTypeWithNestedIntKeyedArray' => [
-                'array<int, array<"a"|int, int|string>>',
+                "array<int, array<'a'|int, int|string>>",
                 [
                     'array<int, array{a:int}>',
                     'array<int, array<int, string>>',
                 ],
             ],
             'combineNestedObjectTypeWithNestedIntKeyedArray' => [
-                'array<"a"|int, array<"a"|int, int|string>>',
+                "array<'a'|int, array<'a'|int, int|string>>",
                 [
                     'array{a: array{a: int}}',
                     'array<int, array<int, string>>',
@@ -462,7 +462,7 @@ class TypeCombinationTest extends TestCase
                 ],
             ],
             'objectLikePlusArrayEqualsArray' => [
-                'array<"a"|"b"|"c", 1|2|3>',
+                "array<'a'|'b'|'c', 1|2|3>",
                 [
                     'array<"a"|"b"|"c", 1|2|3>',
                     'array{a: 1|2, b: 2|3, c: 1|3}',

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -516,7 +516,7 @@ class TypeParseTest extends TestCase
     {
         $this->assertSame(
             '(T is string|true ? int|string : int)',
-            (string) Type::parseString('(T is "hello"|true ? string|int : int)', null, ['T' => ['' => Type::getArray()]])
+            Type::parseString('(T is "hello"|true ? string|int : int)', null, ['T' => ['' => Type::getArray()]])->getId(false)
         );
     }
 
@@ -733,7 +733,7 @@ class TypeParseTest extends TestCase
     public function testCombineLiteralStringWithClassString(): void
     {
         $this->assertSame(
-            '"array"|class-string',
+            "'array'|class-string",
             Type::parseString('"array"|class-string')->getId()
         );
     }
@@ -758,7 +758,7 @@ class TypeParseTest extends TestCase
     {
         $this->assertSame(
             'key-of<T>',
-            (string)Type::parseString('key-of<T>', null, ['T' => ['' => Type::getArray()]])
+            Type::parseString('key-of<T>', null, ['T' => ['' => Type::getArray()]])->getId(false)
         );
     }
 
@@ -791,7 +791,7 @@ class TypeParseTest extends TestCase
     {
         $this->assertSame(
             'class-string-map<T as Foo, T>',
-            (string)Type::parseString('class-string-map<T as Foo, T>')
+            Type::parseString('class-string-map<T as Foo, T>')->getId(false)
         );
     }
 
@@ -881,15 +881,15 @@ class TypeParseTest extends TestCase
         $string = "АаБбВвГгДдЕеЁёЖжЗзИиЙйКкЛлМмНнОоПпРрСсТтУуФфХхЦцЧчШшЩщЪъЫыЬьЭэЮюЯя";
         $string .= $string;
         $expected = mb_substr($string, 0, 80);
-        $this->assertSame("\"$expected...\"", Type::parseString("'$string'")->getId());
-        $this->assertSame("\"$expected...\"", Type::parseString("\"$string\"")->getId());
+        $this->assertSame("'$expected...'", Type::parseString("'$string'")->getId());
+        $this->assertSame("'$expected...'", Type::parseString("\"$string\"")->getId());
     }
 
     public function testSingleLiteralString(): void
     {
         $this->assertSame(
-            'string',
-            (string)Type::parseString('"var"')
+            "'var'",
+            Type::parseString('"var"')->getId()
         );
     }
 
@@ -904,16 +904,16 @@ class TypeParseTest extends TestCase
     public function testSingleLiteralInt(): void
     {
         $this->assertSame(
-            'int',
-            (string)Type::parseString('6')
+            '6',
+            Type::parseString('6')->getId()
         );
     }
 
     public function testSingleLiteralFloat(): void
     {
         $this->assertSame(
-            'float',
-            (string)Type::parseString('6.315')
+            'float(6.315)',
+            Type::parseString('6.315')->getId()
         );
     }
 

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2679,7 +2679,7 @@ class ConditionalTest extends TestCase
                     $b = rand(0,1) ? "" : "a";
                     $b === "a" ? $_a = "Y" : $_a = "N";',
                 'assertions' => [
-                    '$_a===' => '"N"|"Y"',
+                    '$_a===' => "'N'|'Y'",
                 ]
             ],
             'assertionsWorksBothWays' => [

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -130,7 +130,7 @@ class ReconcilerTest extends TestCase
             'falsyWithSomeClassPipeBool' => ['false', new Falsy(), 'SomeClass|bool'],
             'falsyWithMixed' => ['empty-mixed', new Falsy(), 'mixed'],
             'falsyWithBool' => ['false', new Falsy(), 'bool'],
-            'falsyWithStringOrNull' => ['""|"0"|null', new Falsy(), 'string|null'],
+            'falsyWithStringOrNull' => ["''|'0'|null", new Falsy(), 'string|null'],
             'falsyWithScalarOrNull' => ['empty-scalar', new Falsy(), 'scalar'],
             'trueWithBool' => ['true', new IsType(new TTrue()), 'bool'],
             'falseWithBool' => ['false', new IsType(new TFalse()), 'bool'],
@@ -261,23 +261,23 @@ class ReconcilerTest extends TestCase
         return [
             'constant-with-prefix' => [
                 new IsType(new TClassConstant('ReconciliationTest\\Foo', 'PREFIX_*')),
-                '"bar"|"baz"',
+                "'bar'|'baz'",
             ],
             'single-class-constant' => [
                 new IsType(new TClassConstant('ReconciliationTest\\Foo', 'PREFIX_BAR')),
-                '"bar"',
+                "'bar'",
             ],
             'referencing-another-class-constant' => [
                 new IsType(new TClassConstant('ReconciliationTest\\Foo', 'PREFIX_QOO')),
-                '"bar"',
+                "'bar'",
             ],
             'referencing-all-class-constants' => [
                 new IsType(new TClassConstant('ReconciliationTest\\Foo', '*')),
-                '"bar"|"baz"',
+                "'bar'|'baz'",
             ],
             'referencing-some-class-constants-with-wildcard' => [
                 new IsType(new TClassConstant('ReconciliationTest\\Foo', 'PREFIX_B*')),
-                '"bar"|"baz"',
+                "'bar'|'baz'",
             ],
         ];
     }


### PR DESCRIPTION
This PR propose to refactor the description of types in Atomic.

I always thought it was messy.

For example:
- In Atomic, getId() called __toString()
- In CallableTrait, __toString() called getId()
- In TCallableString, getId() called getKey()
- In TClassString, __toString() called getKey()
- In TConditional, getKey() called __toString

Aaand I'm already lost. Adding to that the fact that no documentation exists on that, it didn't help.

What I changed:
- __toString is now final in Atomic and calls getId() with default params
- getId() has a new param `$exact` who defaults to true. When true, it displays the most detailed type it can, otherwise, it displays a generic version (it depends widely on each type)
- getId() now calls getKey() by default unless overrided
- I added some documentation

almost every other change is a consequence of changing the things above. Mainly:
- getId() has now two different caches in Union for exact mode and non-exact mode. This may degrade memory a little but it could gain performances (where before, calls to __toString were not cached)
- __toString used to display the non-exact type, now it calls getId() with $exact = true, so wherever I needed, I removed the implicit calls to __toString for a getId(false)
- getId() on TLiteralString was using double quotes to display the types. This is not consistent with the rest of the types (in docblock for example) so I changed that

I'm still not completely satisfied. I think there is still too many redundancy between getId(), getKey(), toNamespacedString, toPhpString. I feel we should be able to go further but it's already a big step forward

@muglug Do you think this goes in the right direction? Maybe you have special insight here? I'm not sure what getId() was supposed to be. I also have difficulties understanding when getKey should be overrided and with what value