### PR TITLE
Array key exists assert both ways

### DIFF
--- a/tests/TypeReconciliation/ArrayKeyExistsTest.php
+++ b/tests/TypeReconciliation/ArrayKeyExistsTest.php
@@ -378,6 +378,35 @@ class ArrayKeyExistsTest extends TestCase
                         return true;
                     }'
             ],
+            'arrayKeyExistsAssertBothWays' => [
+                '<?php
+                    class a {
+                        const STATE_A = 0;
+                        const STATE_B = 1;
+                        const STATE_C = 2;
+                        /**
+                         * @return array<self::STATE_*, non-empty-string>
+                         * @psalm-pure
+                         */
+                        public static function getStateLabels(): array {
+                            return [
+                                self::STATE_A => "A",
+                                self::STATE_B => "B",
+                                self::STATE_C => "C",
+                            ];
+                        }
+                        /**
+                         * @param self::STATE_* $state
+                         */
+                        public static function getStateLabelIf(int $state): string {
+                            $states = self::getStateLabels();
+                            if (array_key_exists($state, $states)) {
+                                return $states[$state];
+                            }
+                            return "";
+                        }
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
This will fix https://github.com/vimeo/psalm/issues/7412

All the code was already there, but it was only using the keys from the array in second param to restrict the type of the first param.

Only when that was failing (the else I dropped), it tried to use the value of the first param to restrict the keys from the array in the second param.

This PR does both, always.