### PR TITLE
Contextual type inference for high order function arg

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -357,6 +357,8 @@ class ArgumentsAnalyzer
 
             if ($function_like_call instanceof PhpParser\Node\Expr\MethodCall &&
                 $function_like_call->var instanceof PhpParser\Node\Expr\Variable &&
+                $function_like_call->name instanceof PhpParser\Node\Identifier &&
+                is_string($function_like_call->var->name) &&
                 isset($context->vars_in_scope['$' . $function_like_call->var->name])
             ) {
                 $lhs_type = $context->vars_in_scope['$' . $function_like_call->var->name]->getSingleAtomic();
@@ -367,7 +369,7 @@ class ArgumentsAnalyzer
 
                 $method_id = new MethodIdentifier(
                     $lhs_type->value,
-                    (string)$function_like_call->name
+                    strtolower((string)$function_like_call->name)
                 );
 
                 return $codebase->methods->getStorage($method_id);
@@ -378,7 +380,7 @@ class ArgumentsAnalyzer
             ) {
                 $method_id = new MethodIdentifier(
                     (string)$function_like_call->class->getAttribute('resolvedName'),
-                    $function_like_call->name->name
+                    strtolower($function_like_call->name->name)
                 );
 
                 return $codebase->methods->getStorage($method_id);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -394,7 +394,7 @@ class ArgumentsAnalyzer
             return null;
         }
 
-        $replaced_actual_hof_atomic = clone $actual_func_param->type;
+        $replaced_actual_hof_atomic = new Union([clone $actual_hof_atomic]);
 
         TemplateInferredTypeReplacer::replace(
             $replaced_actual_hof_atomic,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -54,7 +54,6 @@ use UnexpectedValueException;
 use function array_map;
 use function array_reverse;
 use function array_slice;
-use function assert;
 use function count;
 use function in_array;
 use function is_string;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -203,7 +203,7 @@ class ArgumentsAnalyzer
                 && $param
                 && !$arg->value->getDocComment()
             ) {
-                $high_order_template_result = self::handlePartiallyAppliedClosureArg(
+                $high_order_template_result = self::handleHighOrderFuncCallArg(
                     $statements_analyzer,
                     $template_result ?? new TemplateResult([], []),
                     $arg->value,
@@ -359,7 +359,7 @@ class ArgumentsAnalyzer
      * // $result is list<1|2|3> because template T of id() was inferred by previous arg.
      * ```
      */
-    private static function handlePartiallyAppliedClosureArg(
+    private static function handleHighOrderFuncCallArg(
         StatementsAnalyzer $statements_analyzer,
         TemplateResult $inferred_template_result,
         PhpParser\Node\Expr\FuncCall $high_order_func_call,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -74,7 +74,8 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
         ?Atomic $static_type,
         bool $is_intersection,
         ?string $lhs_var_id,
-        AtomicMethodCallAnalysisResult $result
+        AtomicMethodCallAnalysisResult $result,
+        ?TemplateResult $inferred_template_result = null
     ): void {
         if ($lhs_type_part instanceof TTemplateParam
             && !$lhs_type_part->as->isMixed()
@@ -438,7 +439,8 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
             $static_type,
             $lhs_var_id,
             $method_id,
-            $result
+            $result,
+            $inferred_template_result
         );
 
         $statements_analyzer->node_data = $old_node_data;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -65,7 +65,8 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
         ?Atomic $static_type,
         ?string $lhs_var_id,
         MethodIdentifier $method_id,
-        AtomicMethodCallAnalysisResult $result
+        AtomicMethodCallAnalysisResult $result,
+        ?TemplateResult $inferred_template_result = null
     ): Union {
         $config = $codebase->config;
 
@@ -216,6 +217,10 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
 
         $template_result = new TemplateResult([], $class_template_params ?: []);
         $template_result->lower_bounds += $method_template_params;
+
+        if ($inferred_template_result) {
+            $template_result->lower_bounds += $inferred_template_result->lower_bounds;
+        }
 
         if ($codebase->store_node_types
             && !$context->collect_initializations

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -11,6 +11,7 @@ use Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\Type\TemplateResult;
 use Psalm\Issue\InvalidMethodCall;
 use Psalm\Issue\InvalidScope;
 use Psalm\Issue\NullReference;
@@ -43,7 +44,8 @@ class MethodCallAnalyzer extends CallAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\MethodCall $stmt,
         Context $context,
-        bool $real_method_call = true
+        bool $real_method_call = true,
+        ?TemplateResult $template_result = null
     ): bool {
         $was_inside_call = $context->inside_call;
 
@@ -194,7 +196,8 @@ class MethodCallAnalyzer extends CallAnalyzer
                     : null,
                 false,
                 $lhs_var_id,
-                $result
+                $result,
+                $template_result
             );
             if (isset($context->vars_in_scope[$lhs_var_id])
                 && ($possible_new_class_type = $context->vars_in_scope[$lhs_var_id]) instanceof Union

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
@@ -41,7 +41,8 @@ class StaticCallAnalyzer extends CallAnalyzer
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\StaticCall $stmt,
-        Context $context
+        Context $context,
+        ?TemplateResult $template_result = null
     ): bool {
         $method_id = null;
 
@@ -219,7 +220,8 @@ class StaticCallAnalyzer extends CallAnalyzer
                 $lhs_type->ignore_nullable_issues,
                 $moved_call,
                 $has_mock,
-                $has_existing_method
+                $has_existing_method,
+                $template_result
             );
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -22,6 +22,7 @@ use Psalm\Internal\Analyzer\Statements\Expression\Fetch\AtomicPropertyFetchAnaly
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\DeprecatedClass;
 use Psalm\Issue\ImpureMethodCall;
@@ -71,7 +72,8 @@ class AtomicStaticCallAnalyzer
         bool $ignore_nullable_issues,
         bool &$moved_call,
         bool &$has_mock,
-        bool &$has_existing_method
+        bool &$has_existing_method,
+        ?TemplateResult $inferred_template_result = null
     ): void {
         $intersection_types = [];
 
@@ -206,7 +208,8 @@ class AtomicStaticCallAnalyzer
                 $intersection_types ?: [],
                 $fq_class_name,
                 $moved_call,
-                $has_existing_method
+                $has_existing_method,
+                $inferred_template_result
             );
         } else {
             if ($stmt->name instanceof PhpParser\Node\Expr) {
@@ -268,7 +271,8 @@ class AtomicStaticCallAnalyzer
         array $intersection_types,
         string $fq_class_name,
         bool &$moved_call,
-        bool &$has_existing_method
+        bool &$has_existing_method,
+        ?TemplateResult $inferred_template_result = null
     ): bool {
         $codebase = $statements_analyzer->getCodebase();
 
@@ -827,7 +831,8 @@ class AtomicStaticCallAnalyzer
             $method_id,
             $cased_method_id,
             $class_storage,
-            $moved_call
+            $moved_call,
+            $inferred_template_result
         );
 
         return true;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -59,7 +59,8 @@ class ExistingAtomicStaticCallAnalyzer
         MethodIdentifier $method_id,
         string $cased_method_id,
         ClassLikeStorage $class_storage,
-        bool &$moved_call
+        bool &$moved_call,
+        ?TemplateResult $inferred_template_result = null
     ): void {
         $fq_class_name = $method_id->fq_class_name;
         $method_name_lc = $method_id->method_name;
@@ -181,6 +182,10 @@ class ExistingAtomicStaticCallAnalyzer
         }
 
         $template_result = new TemplateResult([], $found_generic_params ?: []);
+
+        if ($inferred_template_result) {
+            $template_result->lower_bounds += $inferred_template_result->lower_bounds;
+        }
 
         if (CallAnalyzer::checkMethodArgs(
             $method_id,

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -186,11 +186,11 @@ class ExpressionAnalyzer
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\MethodCall) {
-            return MethodCallAnalyzer::analyze($statements_analyzer, $stmt, $context);
+            return MethodCallAnalyzer::analyze($statements_analyzer, $stmt, $context, true, $template_result);
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\StaticCall) {
-            return StaticCallAnalyzer::analyze($statements_analyzer, $stmt, $context);
+            return StaticCallAnalyzer::analyze($statements_analyzer, $stmt, $context, $template_result);
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\ConstFetch) {

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -47,6 +47,7 @@ use Psalm\Internal\Codebase\TaintFlowGraph;
 use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\Internal\DataFlow\TaintSink;
 use Psalm\Internal\FileManipulation\FileManipulationBuffer;
+use Psalm\Internal\Type\TemplateResult;
 use Psalm\Issue\ForbiddenCode;
 use Psalm\Issue\UnrecognizedExpression;
 use Psalm\IssueBuffer;
@@ -70,7 +71,8 @@ class ExpressionAnalyzer
         Context $context,
         bool $array_assignment = false,
         ?Context $global_context = null,
-        bool $from_stmt = false
+        bool $from_stmt = false,
+        ?TemplateResult $template_result = null
     ): bool {
         $codebase = $statements_analyzer->getCodebase();
 
@@ -80,9 +82,9 @@ class ExpressionAnalyzer
             $context,
             $array_assignment,
             $global_context,
-            $from_stmt
-        ) === false
-        ) {
+            $from_stmt,
+            $template_result
+        ) === false) {
             return false;
         }
 
@@ -144,7 +146,8 @@ class ExpressionAnalyzer
         Context $context,
         bool $array_assignment,
         ?Context $global_context,
-        bool $from_stmt
+        bool $from_stmt,
+        ?TemplateResult $template_result = null
     ): bool {
         if ($stmt instanceof PhpParser\Node\Expr\Variable) {
             return VariableFetchAnalyzer::analyze(
@@ -295,7 +298,8 @@ class ExpressionAnalyzer
             return FunctionCallAnalyzer::analyze(
                 $statements_analyzer,
                 $stmt,
-                $context
+                $context,
+                $template_result
             );
         }
 

--- a/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
@@ -391,7 +391,9 @@ class CallableTypeComparator
                 $template_result = null;
 
                 if ($input_type_part instanceof Atomic\TGenericObject) {
-                    $invokable_storage = $codebase->methods->getClassLikeStorageForMethod($declaring_method_id);
+                    $invokable_storage = $codebase->methods->getClassLikeStorageForMethod(
+                        $declaring_method_id ?? $invoke_id
+                    );
                     $type_params = [];
 
                     foreach ($invokable_storage->template_types ?? [] as $template => $for_class) {
@@ -402,16 +404,18 @@ class CallableTypeComparator
                         }
                     }
 
-                    $input_with_templates = new Atomic\TGenericObject($input_type_part->value, $type_params);
-                    $template_result = new TemplateResult($invokable_storage->template_types ?? [], []);
+                    if (!empty($type_params)) {
+                        $input_with_templates = new Atomic\TGenericObject($input_type_part->value, $type_params);
+                        $template_result = new TemplateResult($invokable_storage->template_types ?? [], []);
 
-                    TemplateStandinTypeReplacer::replace(
-                        new Type\Union([$input_with_templates]),
-                        $template_result,
-                        $codebase,
-                        null,
-                        new Type\Union([$input_type_part])
-                    );
+                        TemplateStandinTypeReplacer::replace(
+                            new Type\Union([$input_with_templates]),
+                            $template_result,
+                            $codebase,
+                            null,
+                            new Type\Union([$input_type_part])
+                        );
+                    }
                 }
 
                 if ($declaring_method_id) {

--- a/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
@@ -10,6 +10,9 @@ use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Codebase\InternalCallMapHandler;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Provider\NodeDataProvider;
+use Psalm\Internal\Type\TemplateInferredTypeReplacer;
+use Psalm\Internal\Type\TemplateResult;
+use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\Type;
 use Psalm\Type\Atomic;
@@ -385,6 +388,31 @@ class CallableTypeComparator
 
             if ($codebase->methods->methodExists($invoke_id)) {
                 $declaring_method_id = $codebase->methods->getDeclaringMethodId($invoke_id);
+                $template_result = null;
+
+                if ($input_type_part instanceof Atomic\TGenericObject) {
+                    $invokable_storage = $codebase->methods->getClassLikeStorageForMethod($declaring_method_id);
+                    $type_params = [];
+
+                    foreach ($invokable_storage->template_types ?? [] as $template => $for_class) {
+                        foreach ($for_class as $type) {
+                            $type_params[] = new Type\Union([
+                                new TTemplateParam($template, $type, $input_type_part->value)
+                            ]);
+                        }
+                    }
+
+                    $input_with_templates = new Atomic\TGenericObject($input_type_part->value, $type_params);
+                    $template_result = new TemplateResult($invokable_storage->template_types ?? [], []);
+
+                    TemplateStandinTypeReplacer::replace(
+                        new Type\Union([$input_with_templates]),
+                        $template_result,
+                        $codebase,
+                        null,
+                        new Type\Union([$input_type_part])
+                    );
+                }
 
                 if ($declaring_method_id) {
                     $method_storage = $codebase->methods->getStorage($declaring_method_id);
@@ -400,12 +428,26 @@ class CallableTypeComparator
                         );
                     }
 
-                    return new TCallable(
+                    $callable = new TCallable(
                         'callable',
                         $method_storage->params,
                         $converted_return_type,
                         $method_storage->pure
                     );
+
+                    if ($template_result) {
+                        $replaced_callable = clone $callable;
+
+                        TemplateInferredTypeReplacer::replace(
+                            new Type\Union([$replaced_callable]),
+                            $template_result,
+                            $codebase
+                        );
+
+                        $callable = $replaced_callable;
+                    }
+
+                    return $callable;
                 }
             }
         }

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -262,6 +262,39 @@ class CallableTest extends TestCase
                     '$result' => 'list<int>',
                 ],
             ],
+            'inferTemplateOfHighOrderFunctionArgByPreviousArgInClassContext' => [
+                '<?php
+                    /**
+                     * @template A
+                     */
+                    final class ArrayList
+                    {
+                        /**
+                         * @template B
+                         *
+                         * @param callable(A): B $ab
+                         * @return ArrayList<B>
+                         */
+                        public function map(callable $ab) { throw new RuntimeException("???"); }
+                    }
+
+                    /**
+                     * @return ArrayList<int>
+                     */
+                    function getList() { throw new RuntimeException("???"); }
+
+                    /**
+                     * @template T
+                     * @return Closure(T): T
+                     */
+                    function id() { throw new RuntimeException("???"); }
+
+                    $result = getList()->map(id());
+                ',
+                'assertions' => [
+                    '$result' => 'ArrayList<int>',
+                ],
+            ],
             'inferPipelineWithPartiallyAppliedFunctions' => [
                 '<?php
                     /**

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -233,7 +233,36 @@ class CallableTest extends TestCase
                     '$inferred' => 'list<Foo>',
                 ],
             ],
-            'inferPartiallyAppliedClosureArgByPreviousFunctionArg' => [
+            'inferTemplateOfHighOrderFunctionArgByPreviousArg' => [
+                '<?php
+                    /**
+                     * @return list<int>
+                     */
+                    function getList() { throw new RuntimeException("???"); }
+
+                    /**
+                     * @template T
+                     * @return Closure(T): T
+                     */
+                    function id() { throw new RuntimeException("???"); }
+
+                    /**
+                     * @template A
+                     * @template B
+                     *
+                     * @param list<A> $_items
+                     * @param callable(A): B $_ab
+                     * @return list<B>
+                     */
+                    function map(array $_items, callable $_ab) { throw new RuntimeException("???"); }
+
+                    $result = map(getList(), id());
+                ',
+                'assertions' => [
+                    '$result' => 'list<int>',
+                ],
+            ],
+            'inferPipelineWithPartiallyAppliedFunctions' => [
                 '<?php
                     /**
                      * @template T

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -295,6 +295,77 @@ class CallableTest extends TestCase
                     '$result' => 'ArrayList<int>',
                 ],
             ],
+            'inferTemplateOfHighOrderFunctionFromMethodArgByPreviousArg' => [
+                '<?php
+                     final class Ops
+                     {
+                         /**
+                          * @template T
+                          * @return Closure(list<T>): T
+                          */
+                         public function flatten() { throw new RuntimeException("???"); }
+                     }
+                     /**
+                      * @return list<list<int>>
+                      */
+                     function getList() { throw new RuntimeException("???"); }
+                     /**
+                      * @template T
+                      * @return Closure(list<T>): T
+                      */
+                     function flatten() { throw new RuntimeException("???"); }
+                     /**
+                      * @template A
+                      * @template B
+                      *
+                      * @param list<A> $_a
+                      * @param callable(A): B $_ab
+                      * @return list<B>
+                      */
+                     function map(array $_a, callable $_ab) { throw new RuntimeException("???"); }
+
+                     $ops = new Ops;
+                     $result = map(getList(), $ops->flatten());
+                 ',
+                'assertions' => [
+                    '$result' => 'list<int>',
+                ],
+            ],
+            'inferTemplateOfHighOrderFunctionFromStaticMethodArgByPreviousArg' => [
+                '<?php
+                     final class StaticOps
+                     {
+                         /**
+                          * @template T
+                          * @return Closure(list<T>): T
+                          */
+                         public static function flatten() { throw new RuntimeException("???"); }
+                     }
+                     /**
+                      * @return list<list<int>>
+                      */
+                     function getList() { throw new RuntimeException("???"); }
+                     /**
+                      * @template T
+                      * @return Closure(list<T>): T
+                      */
+                     function flatten() { throw new RuntimeException("???"); }
+                     /**
+                      * @template A
+                      * @template B
+                      *
+                      * @param list<A> $_a
+                      * @param callable(A): B $_ab
+                      * @return list<B>
+                      */
+                     function map(array $_a, callable $_ab) { throw new RuntimeException("???"); }
+
+                     $result = map(getList(), StaticOps::flatten());
+                 ',
+                'assertions' => [
+                    '$result' => 'list<int>',
+                ],
+            ],
             'inferPipelineWithPartiallyAppliedFunctions' => [
                 '<?php
                     /**

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -366,6 +366,73 @@ class CallableTest extends TestCase
                     '$result' => 'list<int>',
                 ],
             ],
+            '' => [
+                '<?php
+                     /**
+                      * @template A
+                      * @template B
+                      */
+                     final class MapOperator
+                     {
+                         /**
+                          * @param Closure(A): B $ab
+                          */
+                         public function __construct(private Closure $ab) { }
+
+                         /**
+                          * @param list<A> $a
+                          * @return list<B>
+                          */
+                         public function __invoke($a): array
+                         {
+                             $b = [];
+
+                             foreach ($a as $item) {
+                                 $b[] = ($this->ab)($item);
+                             }
+
+                             return $b;
+                         }
+                     }
+                     /**
+                      * @template A
+                      * @template B
+                      *
+                      * @param Closure(A): B $ab
+                      * @return MapOperator<A, B>
+                      */
+                     function map(Closure $ab): MapOperator
+                     {
+                         return new MapOperator($ab);
+                     }
+                     /**
+                      * @template A
+                      * @template B
+                      *
+                      * @param A $_a
+                      * @param callable(A): B $_ab
+                      * @return B
+                      */
+                     function pipe(array $_a, callable $_ab): array
+                     {
+                         throw new RuntimeException("???");
+                     }
+                     $result1 = pipe(
+                         ["1", "2", "3"],
+                         map(fn ($i) => (int) $i)
+                     );
+                     $result2 = pipe(
+                         ["1", "2", "3"],
+                         new MapOperator(fn ($i) => (int) $i)
+                     );
+                 ',
+                'assertions' => [
+                    '$result1' => 'list<int>',
+                    '$result2' => 'list<int>',
+                ],
+                'error_levels' => [],
+                '8.0',
+            ],
             'inferPipelineWithPartiallyAppliedFunctions' => [
                 '<?php
                     /**


### PR DESCRIPTION
Since php doesn't have extension method functionality like C# then pipe function can be a good solution to the situation:

```php
<?php

$greaterThan100 = pipe2(
    [1, 2, 3],
    map(function ($i) {
        return $i > 1 ? $i + 1 : $i + 2;
    }),
    filter(function ($i) {
        return $i > 100;
    })
);
```

Before we can write generic pipe function we should support inference for partially applied closures (`fn($a) => fn($b) => $a + $b`)

This PR tries to implement inference of this kind.
P.S. I tried to do it through the plugin system. It didn't work out.