### PR TITLE
Add configuration option to disable `@psalm-suppress all`

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -109,6 +109,7 @@
         <xs:attribute name="reportInfo" type="xs:boolean" default="true" />
         <xs:attribute name="restrictReturnTypes" type="xs:boolean" default="false" />
         <xs:attribute name="limitMethodComplexity" type="xs:boolean" default="false" />
+        <xs:attribute name="disableSuppressAll" type="xs:boolean" default="false" />
         <xs:attribute name="triggerErrorExits" type="TriggerErrorExitsType" default="default" />
     </xs:complexType>
 

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -154,6 +154,15 @@ This flag is deprecated and will be removed in Psalm 5
 ```
 When `true`, strings can be used as classes, meaning `$some_string::someMethod()` is allowed. If `false`, only class constant strings (of the form `Foo\Bar::class`) can stand in for classes, otherwise an `InvalidStringClass` issue is emitted. Defaults to `false`.
 
+#### disableSuppressAll
+
+```xml
+<psalm
+  disableSuppressAll="[bool]"
+>
+```
+When `true`, disables wildcard suppression of all issues with `@psalm-suppress all`. Defaults to `false`.
+
 #### memoizeMethodCallResults
 
 ```xml

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -329,6 +329,11 @@ class Config
     /**
      * @var bool
      */
+    public $disable_suppress_all = false;
+
+    /**
+     * @var bool
+     */
     public $use_phpdoc_method_without_magic_or_parent = false;
 
     /**
@@ -910,6 +915,7 @@ class Config
             'rememberPropertyAssignmentsAfterCall' => 'remember_property_assignments_after_call',
             'allowPhpStormGenerics' => 'allow_phpstorm_generics',
             'allowStringToStandInForClass' => 'allow_string_standin_for_class',
+            'disableSuppressAll' => 'disable_suppress_all',
             'usePhpDocMethodsWithoutMagicCall' => 'use_phpdoc_method_without_magic_or_parent',
             'usePhpDocPropertiesWithoutMagicCall' => 'use_phpdoc_property_without_magic_or_parent',
             'memoizeMethodCallResults' => 'memoize_method_calls',

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -212,7 +212,9 @@ class IssueBuffer
             }
         }
 
-        $suppress_all_position = array_search('all', $suppressed_issues);
+        $suppress_all_position = $config->disable_suppress_all
+            ? false
+            : array_search('all', $suppressed_issues);
 
         if ($suppress_all_position !== false) {
             if (is_int($suppress_all_position)) {


### PR DESCRIPTION
Personally, I'd completely remove this feature in Psalm v5, it's way too dangerous, baselines+config are enough to suppress all issues in specific files of very legacy codebases.