### PR TITLE
Add configuration option to disable @var parsing everywhere except for properties.

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -109,6 +109,7 @@
                 </xs:documentation>
             </xs:annotation>
         </xs:attribute>
+        <xs:attribute name="disableVarParsing" type="xs:boolean" default="false" />
         <xs:attribute name="errorLevel" type="xs:integer" default="2" />
         <xs:attribute name="reportMixedIssues" type="xs:boolean" default="true" />
         <xs:attribute name="useDocblockTypes" type="xs:boolean" default="true" />

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -116,6 +116,16 @@ The PHPDoc `@method` annotation normally only applies to classes with a `__call`
 ```
 The PHPDoc `@property`, `@property-read` and `@property-write` annotations normally only apply to classes with `__get`/`__set` methods. Setting this to `true` allows you to use the `@property`, `@property-read` and `@property-write` annotations to override property existence checks and resulting property types. Defaults to `false`.
 
+#### disableVarParsing
+
+```xml
+<psalm
+  disableVarParsing="[bool]"
+/>
+```
+
+Disables parsing of `@var` PHPDocs everywhere except for properties. Setting this to `true` can remove many false positives due to outdated `@var` annotations, used before integrations of Psalm generics and proper typing, enforcing Single Source Of Truth principles. Defaults to `false`.
+
 #### strictBinaryOperands
 
 ```xml

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -376,6 +376,11 @@ class Config
     /**
      * @var bool
      */
+    public $disable_var_parsing = false;
+
+    /**
+     * @var bool
+     */
     public $check_for_throws_docblock = false;
 
     /**
@@ -920,6 +925,7 @@ class Config
             'allowFileIncludes' => 'allow_includes',
             'strictBinaryOperands' => 'strict_binary_operands',
             'rememberPropertyAssignmentsAfterCall' => 'remember_property_assignments_after_call',
+            'disableVarParsing' => 'disable_var_parsing',
             'allowPhpStormGenerics' => 'allow_phpstorm_generics',
             'allowStringToStandInForClass' => 'allow_string_standin_for_class',
             'disableSuppressAll' => 'disable_suppress_all',

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -155,13 +155,15 @@ class AssignmentAnalyzer
             $template_type_map = $statements_analyzer->getTemplateTypeMap();
 
             try {
-                $var_comments = CommentAnalyzer::getTypeFromComment(
-                    $doc_comment,
-                    $statements_analyzer->getSource(),
-                    $statements_analyzer->getAliases(),
-                    $template_type_map,
-                    $file_storage->type_aliases
-                );
+                $var_comments = $codebase->config->disable_var_parsing
+                    ? []
+                    : CommentAnalyzer::getTypeFromComment(
+                        $doc_comment,
+                        $statements_analyzer->getSource(),
+                        $statements_analyzer->getAliases(),
+                        $template_type_map,
+                        $file_storage->type_aliases
+                    );
             } catch (IncorrectDocblockException $e) {
                 IssueBuffer::maybeAdd(
                     new MissingDocblockType(

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -74,14 +74,16 @@ class ReturnAnalyzer
             $file_storage = $file_storage_provider->get($statements_analyzer->getFilePath());
 
             try {
-                $var_comments = CommentAnalyzer::arrayToDocblocks(
-                    $doc_comment,
-                    $parsed_docblock,
-                    $statements_analyzer->getSource(),
-                    $statements_analyzer->getAliases(),
-                    $statements_analyzer->getTemplateTypeMap(),
-                    $file_storage->type_aliases
-                );
+                $var_comments = $codebase->config->disable_var_parsing
+                    ? []
+                    : CommentAnalyzer::arrayToDocblocks(
+                        $doc_comment,
+                        $parsed_docblock,
+                        $statements_analyzer->getSource(),
+                        $statements_analyzer->getAliases(),
+                        $statements_analyzer->getTemplateTypeMap(),
+                        $file_storage->type_aliases
+                    );
             } catch (DocblockParseException $e) {
                 IssueBuffer::maybeAdd(
                     new InvalidDocblock(

--- a/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/StaticAnalyzer.php
@@ -57,13 +57,15 @@ class StaticAnalyzer
                 $var_comments = [];
 
                 try {
-                    $var_comments = CommentAnalyzer::arrayToDocblocks(
-                        $doc_comment,
-                        $parsed_docblock,
-                        $statements_analyzer->getSource(),
-                        $statements_analyzer->getSource()->getAliases(),
-                        $statements_analyzer->getSource()->getTemplateTypeMap()
-                    );
+                    $var_comments = $codebase->config->disable_var_parsing
+                        ? []
+                        : CommentAnalyzer::arrayToDocblocks(
+                            $doc_comment,
+                            $parsed_docblock,
+                            $statements_analyzer->getSource(),
+                            $statements_analyzer->getSource()->getAliases(),
+                            $statements_analyzer->getSource()->getTemplateTypeMap()
+                        );
                 } catch (IncorrectDocblockException $e) {
                     IssueBuffer::maybeAdd(
                         new MissingDocblockType(

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -442,14 +442,16 @@ class StatementsAnalyzer extends SourceAnalyzer
                 $var_comments = [];
 
                 try {
-                    $var_comments = CommentAnalyzer::arrayToDocblocks(
-                        $docblock,
-                        $statements_analyzer->parsed_docblock,
-                        $statements_analyzer->getSource(),
-                        $statements_analyzer->getAliases(),
-                        $template_type_map,
-                        $file_storage->type_aliases
-                    );
+                    $var_comments = $codebase->config->disable_var_parsing
+                        ? []
+                        : CommentAnalyzer::arrayToDocblocks(
+                            $docblock,
+                            $statements_analyzer->parsed_docblock,
+                            $statements_analyzer->getSource(),
+                            $statements_analyzer->getAliases(),
+                            $template_type_map,
+                            $file_storage->type_aliases
+                        );
                 } catch (IncorrectDocblockException $e) {
                     IssueBuffer::maybeAdd(
                         new MissingDocblockType(


### PR DESCRIPTION
Ondrej is already [planning to remove `@var` support in phpstan,](https://twitter.com/OndrejMirtes/status/1458020442258739206) and I also propose disabling parsing by default in Psalm v5.