### PR TITLE
Allow config to define thread count

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -402,8 +402,7 @@ Allows you to hard-code a serializer for Psalm to use when caching data. By defa
         threads="[int]"
 >
 ```
-Allows you to hard-code the number of threads Psalm will use (similar to `--threads` on the command line). This value will only be applied if it is lower than the number of threads Psalm would natively use (i.e. you cannot override other settings that force threads=1 or utilise more threads than detected on the machine)
-
+Allows you to hard-code the number of threads Psalm will use (similar to `--threads` on the command line). This value will be used in place of detecting threads from the host machine, but will be overridden by using `--threads` or `--debug` (which sets threads to 1) on the command line
 
 ## Project settings
 

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -402,7 +402,7 @@ Allows you to hard-code a serializer for Psalm to use when caching data. By defa
         threads="[int]"
 >
 ```
-Allows you to hard-code a serializer for Psalm to use when caching data. By default, Psalm uses `ext-igbinary` *if* the version is greater than or equal to 2.0.5, otherwise it defaults to PHP's built-in serializer.
+Allows you to hard-code the number of threads Psalm will use (similar to `--threads` on the command line). This value will only be applied if it is lower than the number of threads Psalm would natively use (i.e. you cannot override other settings that force threads=1 or utilise more threads than detected on the machine)
 
 
 ## Project settings

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -396,6 +396,14 @@ Whether or not to allow `require`/`include` calls in your PHP. Defaults to `true
 ```
 Allows you to hard-code a serializer for Psalm to use when caching data. By default, Psalm uses `ext-igbinary` *if* the version is greater than or equal to 2.0.5, otherwise it defaults to PHP's built-in serializer.
 
+#### threads
+```xml
+<psalm
+        threads="[int]"
+>
+```
+Allows you to hard-code a serializer for Psalm to use when caching data. By default, Psalm uses `ext-igbinary` *if* the version is greater than or equal to 2.0.5, otherwise it defaults to PHP's built-in serializer.
+
 
 ## Project settings
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -563,6 +563,9 @@ class Config
      */
     public $internal_stubs = [];
 
+    /** @var ?int */
+    public $threads;
+
     protected function __construct()
     {
         self::$instance = $this;
@@ -1220,6 +1223,10 @@ class Config
             foreach ($config_xml->globals->var as $var) {
                 $config->globals['$' . (string) $var['name']] = (string) $var['type'];
             }
+        }
+
+        if (isset($config_xml->threads)) {
+            $config->threads = (int)$config_xml->threads;
         }
 
         return $config;

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -1338,7 +1338,8 @@ final class Psalm
         HELP;
     }
 
-    private static function useThreads(array $options, bool $in_ci, Config $config): int{
+    private static function useThreads(array $options, bool $in_ci, Config $config): int
+    {
         $threads = self::detectThreads($options, $in_ci);
 
         if ($config->threads && $config->threads<$threads) {

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -249,7 +249,7 @@ final class Psalm
             $options['long-progress'] = true;
         }
 
-        $threads = self::useThreads($options, $in_ci, $config);
+        $threads = self::detectThreads($options, $config, $in_ci);
 
         self::emitMacPcreWarning($options, $threads);
 
@@ -913,12 +913,14 @@ final class Psalm
         }
     }
 
-    private static function detectThreads(array $options, bool $in_ci): int
+    private static function detectThreads(array $options, Config $config, bool $in_ci): int
     {
         if (isset($options['threads'])) {
             $threads = (int)$options['threads'];
         } elseif (isset($options['debug']) || $in_ci) {
             $threads = 1;
+        } elseif ($config->threads) {
+            $threads = $config->threads;
         } else {
             $threads = max(1, ProjectAnalyzer::getCpuCount() - 1);
         }
@@ -1336,16 +1338,5 @@ final class Psalm
                 Run Psalm Language Server
 
         HELP;
-    }
-
-    private static function useThreads(array $options, bool $in_ci, Config $config): int
-    {
-        $threads = self::detectThreads($options, $in_ci);
-
-        if ($config->threads && $config->threads<$threads) {
-            $threads = $config->threads;
-        }
-
-        return $threads;
     }
 }

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -249,7 +249,7 @@ final class Psalm
             $options['long-progress'] = true;
         }
 
-        $threads = self::detectThreads($options, $in_ci);
+        $threads = self::useThreads($options, $in_ci, $config);
 
         self::emitMacPcreWarning($options, $threads);
 
@@ -1336,5 +1336,15 @@ final class Psalm
                 Run Psalm Language Server
 
         HELP;
+    }
+
+    private static function useThreads(array $options, bool $in_ci, Config $config): int{
+        $threads = self::detectThreads($options, $in_ci);
+
+        if ($config->threads && $config->threads<$threads) {
+            $threads = $config->threads;
+        }
+
+        return $threads;
     }
 }


### PR DESCRIPTION
For large projects many systems will not handle multithreading correctly. For example if run in a container, the underlying machine may report 32 threads, but the container has access to 2. Or in large projects where there's a memory limit (e.g. our codebase takes 7GB) running with more than 1 thread, even if possible, consumes all available memory.

Whilst threads can be set on the command line, this isn't always possible. My specific example is the way that PhpStorm runs Psalm, but I imagine there are other tools which may run Psalm off a default config or with their own flags, where a user cannot configure what flags are set. Generally it's worth most flags being settable in a config file anyway, so that behaviour can be locked down - for example in our project for local developers, we have added a set of bash scripts to run Psalm with various flags, and all of them force threads=1.

This PR adds "threads" as a config option. If set, and if lower than the detected threads, it will be applied. If unset or higher than detected threads, existing behaviour is applied. Thus this cannot disrupt existing mechanisms of setting threads to 1.

I've been unable to run tests locally due to a weird bug with composer that's failing to unzip the symyony/filesystem plugin, so I will watch the CI build and make adjustments if required.