### PR TITLE
fix proc_open stub for php >= 8.0

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -10291,7 +10291,7 @@ return [
 'proc_close' => ['int', 'process'=>'resource'],
 'proc_get_status' => ['array{command: string, pid: int, running: bool, signaled: bool, stopped: bool, exitcode: int, termsig: int, stopsig: int}', 'process'=>'resource'],
 'proc_nice' => ['bool', 'priority'=>'int'],
-'proc_open' => ['resource|false', 'cmd'=>'string|array', 'descriptorspec'=>'array', '&w_pipes'=>'resource[]', 'cwd='=>'?string', 'env='=>'?array', 'other_options='=>'array'],
+'proc_open' => ['resource|false', 'command'=>'string|array', 'descriptor_spec'=>'array', '&pipes'=>'resource[]', 'cwd='=>'?string', 'env_vars='=>'?array', 'options='=>'?array'],
 'proc_terminate' => ['bool', 'process'=>'resource', 'signal='=>'int'],
 'projectionObj::__construct' => ['void', 'projectionString'=>'string'],
 'projectionObj::getUnits' => ['int'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -1129,6 +1129,10 @@ return [
       'old' => ['array{command: string, pid: int, running: bool, signaled: bool, stopped: bool, exitcode: int, termsig: int, stopsig: int}|false', 'process'=>'resource'],
       'new' => ['array{command: string, pid: int, running: bool, signaled: bool, stopped: bool, exitcode: int, termsig: int, stopsig: int}', 'process'=>'resource'],
     ],
+    'proc_open' => [
+      'old' => ['resource|false', 'cmd'=>'string|array', 'descriptorspec'=>'array', '&w_pipes'=>'resource[]', 'cwd='=>'?string', 'env='=>'?array', 'other_options='=>'array'],
+      'new' => ['resource|false', 'command'=>'string|array', 'descriptor_spec'=>'array', '&pipes'=>'resource[]', 'cwd='=>'?string', 'env_vars='=>'?array', 'options='=>'?array'],
+    ],
     'session_set_cookie_params' => [
       'old' => ['bool', 'lifetime'=>'int', 'path='=>'string', 'domain='=>'string', 'secure='=>'bool', 'httponly='=>'bool'],
       'new' => ['bool', 'lifetime'=>'int', 'path='=>'?string', 'domain='=>'?string', 'secure='=>'?bool', 'httponly='=>'?bool'],

--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -18,5 +18,20 @@ class CoreStubsTest extends TestCase
 
             new RecursiveArrayIterator([], RecursiveArrayIterator::CHILD_ARRAYS_ONLY);'
         ];
+        yield 'proc_open() named arguments' => [
+            '<?php
+
+            proc_open(
+                command: "ls",
+                descriptor_spec: [],
+                pipes: $pipes,
+                cwd: null,
+                env_vars: null,
+                options: null
+            );',
+            'assertions' => [],
+            'error_levels' => [],
+            'php_version' => '8.0',
+        ];
     }
 }


### PR DESCRIPTION
https://psalm.dev/r/c0ebca79f2

The argument names are defined here:

https://github.com/php/php-src/blob/PHP-8.0.0/ext/standard/basic_functions_arginfo.h#L1773-L1780