### PR TITLE
Array-like-object comparison message improvement

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -529,11 +529,14 @@ class ReturnTypeAnalyzer
                             }
                         }
                     } else {
+                        $extension = $declared_return_type->getExtendedComparisonDescription($inferred_return_type);
+                        $extension = $extension ? '. '.$extension : '';
+
                         if (IssueBuffer::accepts(
                             new MoreSpecificReturnType(
                                 'The declared return type \'' . $declared_return_type->getId() . '\' for '
                                     . $cased_method_id . ' is more specific than the inferred return type '
-                                    . '\'' . $inferred_return_type->getId() . '\'',
+                                    . '\'' . $inferred_return_type->getId() . '\''.$extension,
                                 $return_type_location
                             ),
                             $suppressed_issues

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -1035,7 +1035,7 @@ class ArgumentAnalyzer
                     );
                 }
             } else {
-                $extension = self::extendKeyedArrayComparison($param_type, $input_type);
+                $extension = (string) $param_type->getExtendedComparisonDescription($input_type);
 
                 if ($types_can_be_identical) {
                     IssueBuffer::maybeAdd(
@@ -1634,35 +1634,5 @@ class ArgumentAnalyzer
         }
 
         return $input_type;
-    }
-
-    private static function extendKeyedArrayComparison(Union $param_type, Union $input_type): string
-    {
-        // Default value is an empty string
-        $extension = '';
-
-        // Not sure if there's a better or more robust way to do this
-        $param_types = $param_type->getAtomicTypes();
-        $input_types = $input_type->getAtomicTypes();
-
-        if (!isset($param_types['array'], $input_types['array'])) {
-            return $extension;
-        }
-
-        $first_param_type = $param_type->getAtomicTypes()['array'];
-        $first_input_type = $input_type->getAtomicTypes()['array'];
-        if (!$first_param_type instanceof TKeyedArray || !$first_input_type instanceof TKeyedArray) {
-            return $extension;
-        }
-
-        // There's many ways to illustrate this but this is the simplest and provides info
-        // without being too opinionated
-        $extension .= '. The differences are in the following keys: ';
-        $param_keys = array_keys($first_param_type->properties);
-        $input_keys = array_keys($first_input_type->properties);
-        $key_comparison = array_diff($param_keys, $input_keys);
-        $extension .= implode(', ', $key_comparison);
-
-        return $extension;
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -1642,17 +1642,26 @@ class ArgumentAnalyzer
         $extension = '';
 
         // Not sure if there's a better or more robust way to do this
+        $param_types = $param_type->getAtomicTypes();
+        $input_types = $input_type->getAtomicTypes();
+
+        if (!isset($param_types['array'], $input_types['array'])) {
+            return $extension;
+        }
+
         $first_param_type = $param_type->getAtomicTypes()['array'];
         $first_input_type = $input_type->getAtomicTypes()['array'];
-        if ($first_param_type instanceof TKeyedArray && $first_input_type instanceof TKeyedArray) {
-            // There's many ways to illustrate this but this is the simplest and provides info
-            // without being too opinionated
-            $extension .= '. The differences are in the following keys: ';
-            $param_keys = array_keys($first_param_type->properties);
-            $input_keys = array_keys($first_input_type->properties);
-            $key_comparison = array_diff($param_keys, $input_keys);
-            $extension .= implode(', ', $key_comparison);
+        if (!$first_param_type instanceof TKeyedArray || !$first_input_type instanceof TKeyedArray) {
+            return $extension;
         }
+
+        // There's many ways to illustrate this but this is the simplest and provides info
+        // without being too opinionated
+        $extension .= '. The differences are in the following keys: ';
+        $param_keys = array_keys($first_param_type->properties);
+        $input_keys = array_keys($first_input_type->properties);
+        $key_comparison = array_diff($param_keys, $input_keys);
+        $extension .= implode(', ', $key_comparison);
 
         return $extension;
     }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -60,12 +60,9 @@ use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
-use function array_diff;
-use function array_keys;
 use function array_merge;
 use function count;
 use function explode;
-use function implode;
 use function in_array;
 use function ord;
 use function preg_split;
@@ -989,10 +986,13 @@ class ArgumentAnalyzer
                     $statements_analyzer->getSuppressedIssues()
                 );
             } elseif ($cased_method_id !== 'echo' && $cased_method_id !== 'print') {
+                $extension = $param_type->getExtendedComparisonDescription($input_type);
+                $extension = $extension ? '. '.$extension : '';
+
                 IssueBuffer::maybeAdd(
                     new ArgumentTypeCoercion(
                         'Argument ' . ($argument_offset + 1) . $method_identifier . ' expects ' . $param_type->getId() .
-                            ', parent type ' . $input_type->getId() . ' provided',
+                            ', parent type ' . $input_type->getId() . ' provided'.$extension,
                         $arg_location,
                         $cased_method_id
                     ),
@@ -1035,7 +1035,8 @@ class ArgumentAnalyzer
                     );
                 }
             } else {
-                $extension = (string) $param_type->getExtendedComparisonDescription($input_type);
+                $extension = $param_type->getExtendedComparisonDescription($input_type);
+                $extension = $extension ? '. '.$extension : '';
 
                 if ($types_can_be_identical) {
                     IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -417,11 +417,14 @@ class ReturnAnalyzer
                                     }
                                 }
                             } else {
+                                $extension = $stmt_type->getExtendedComparisonDescription($local_return_type);
+                                $extension = $extension ? '. '.$extension : '';
+
                                 IssueBuffer::maybeAdd(
                                     new LessSpecificReturnStatement(
                                         'The type \'' . $stmt_type->getId() . '\' is more general than the'
                                             . ' declared return type \'' . $local_return_type->getId() . '\''
-                                            . ' for ' . $cased_method_id,
+                                            . ' for ' . $cased_method_id.$extension,
                                         new CodeLocation($source, $stmt->expr)
                                     ),
                                     $statements_analyzer->getSuppressedIssues()

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -28,6 +28,7 @@ use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TIntRange;
+use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TList;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
@@ -1584,5 +1585,32 @@ class Union implements TypeNode
     public function isUnionEmpty(): bool
     {
         return $this->types === [];
+    }
+
+    public function getExtendedComparisonDescription(Union $other_type): ?string
+    {
+        // Not sure if there's a better or more robust way to do this
+        $param_types = $this->getAtomicTypes();
+        $input_types = $other_type->getAtomicTypes();
+
+        if (!isset($param_types['array'], $input_types['array'])) {
+            return null;
+        }
+
+        $first_param_type = $param_types['array'];
+        $first_input_type = $input_types['array'];
+        if (!$first_param_type instanceof TKeyedArray || !$first_input_type instanceof TKeyedArray) {
+            return null;
+        }
+
+        // There's many ways to illustrate this but this is the simplest and provides info
+        // without being too opinionated
+        $text_diff = 'The differences are in the following keys: ';
+        $param_keys = array_keys($first_param_type->properties);
+        $input_keys = array_keys($first_input_type->properties);
+        $key_comparison = array_diff($param_keys, $input_keys);
+        $text_diff .= implode(', ', $key_comparison);
+
+        return $text_diff;
     }
 }

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1616,14 +1616,14 @@ class Union implements TypeNode
     }
 
     /**
-     * @param array<string, Union> $properties
-     * @return array<string, Union> $properties
+     * @param non-empty-array<int|string, Union> $properties
+     * @return non-empty-array<int|string, Union> $properties
      */
-    private static function rekeyPropertiesArray(array $properties) :array
+    private static function rekeyPropertiesArray(array $properties): array
     {
         $rekeyed = [];
         foreach ($properties as $key => $property) {
-            if ($property->possibly_undefined){
+            if ($property->possibly_undefined) {
                 $key = "?$key";
             }
             $rekeyed[$key] = $property;


### PR DESCRIPTION
I am opening this as a draft because I am unsure how we'd desire the implementation to work, but I feel it's helpful and it turned out not too hard to implement a basic case.

When dealing with a large object-like array it can be difficult to work out which keys are missing, e.g.

> Argument 1 of myFunction() expects array{chicken: bool, fish: bool, pasta: bool, bread: bool, bacon: bool, tea: bool, coffee: bool, beer: bool, onions: bool}, array{chicken: bool, fish: bool, pasta: bool, breead: bool, bacon: bool, tea: bool, coffee: bool, beer: bool, onions: bool} provided (see https://psalm.dev/193)

In this case the eagle-eyed may spot that the second argument has misspelled `bread` as `breead`.

The PR as currently implemented would augment this report as so:

> Argument 1 of myFunction() expects array{chicken: bool, fish: bool, pasta: bool, bread: bool, bacon: bool, tea: bool, coffee: bool, beer: bool, onions: bool}, array{chicken: bool, fish: bool, pasta: bool, breead: bool, bacon: bool, tea: bool, coffee: bool, beer: bool, onions: bool} provided. The differences are in the following keys: bread, breead (see https://psalm.dev/193)

This allows a simple check on the result that is much easier to track.

Currently it is implemented for ArgumentAnalyzer with PossiblyInvalidArgument and InvalidArgument. It will also likely benefit being added to ArgumentTypeCoercion and possibly others - we can discuss that if the basic premise seems worthwhile. I thought I'd open now to allow discussion and to see if this affects any parts of the CI build.

Will fix #7050