### PR TITLE
!!! Deprecate \Psalm\Plugin\RegistrationInterface methods

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -34,6 +34,11 @@
       <code>$codebase-&gt;php_minor_version</code>
       <code>$codebase-&gt;php_minor_version</code>
     </DeprecatedProperty>
+    <DeprecatedMethod occurrences="3">
+      <code>getAdditionalFileExtensions</code>
+      <code>getAdditionalFileTypeScanners</code>
+      <code>getAdditionalFileTypeAnalyzers</code>
+    </DeprecatedMethod>
   </file>
   <file src="src/Psalm/Config/FileFilter.php">
     <PossiblyUndefinedIntArrayOffset occurrences="1">
@@ -610,6 +615,12 @@
       <code>array_keys($template_type_map[$param_name])[0]</code>
       <code>array_keys($template_type_map[$template_param_name])[0]</code>
     </PossiblyUndefinedIntArrayOffset>
+  </file>
+  <file src="src/Psalm/PluginRegistrationSocket.php">
+    <DeprecatedMethod occurrences="2">
+      <code>addFileExtension</code>
+      <code>addFileExtension</code>
+    </DeprecatedMethod>
   </file>
   <file src="src/Psalm/Node/Stmt/VirtualClass.php">
     <PropertyNotSetInConstructor occurrences="1">

--- a/src/Psalm/Plugin/RegistrationInterface.php
+++ b/src/Psalm/Plugin/RegistrationInterface.php
@@ -17,12 +17,14 @@ interface RegistrationInterface
     /**
      * @param string $fileExtension e.g. `'html'`
      * @param class-string<FileScanner> $className
+     * @deprecated will be removed in v5.0, use \Psalm\Plugin\FileExtensionsInterface instead (#6788)
      */
     public function addFileTypeScanner(string $fileExtension, string $className): void;
 
     /**
      * @param string $fileExtension e.g. `'html'`
      * @param class-string<FileAnalyzer> $className
+     * @deprecated will be removed in v5.0, use \Psalm\Plugin\FileExtensionsInterface instead (#6788)
      */
     public function addFileTypeAnalyzer(string $fileExtension, string $className): void;
 }

--- a/src/Psalm/PluginRegistrationSocket.php
+++ b/src/Psalm/PluginRegistrationSocket.php
@@ -143,6 +143,7 @@ class PluginRegistrationSocket implements RegistrationInterface
     /**
      * @param string $fileExtension e.g. `'html'`
      * @param class-string<FileScanner> $className
+     * @deprecated will be removed in v5.0, use \Psalm\Plugin\FileExtensionsInterface instead (#6788)
      */
     public function addFileTypeScanner(string $fileExtension, string $className): void
     {
@@ -170,6 +171,7 @@ class PluginRegistrationSocket implements RegistrationInterface
 
     /**
      * @return array<string, class-string<FileScanner>>
+     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
      */
     public function getAdditionalFileTypeScanners(): array
     {
@@ -179,6 +181,7 @@ class PluginRegistrationSocket implements RegistrationInterface
     /**
      * @param string $fileExtension e.g. `'html'`
      * @param class-string<FileAnalyzer> $className
+     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
      */
     public function addFileTypeAnalyzer(string $fileExtension, string $className): void
     {
@@ -206,6 +209,7 @@ class PluginRegistrationSocket implements RegistrationInterface
 
     /**
      * @return array<string, class-string<FileAnalyzer>>
+     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
      */
     public function getAdditionalFileTypeAnalyzers(): array
     {
@@ -214,6 +218,7 @@ class PluginRegistrationSocket implements RegistrationInterface
 
     /**
      * @return list<string> e.g. `['html', 'perl']`
+     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
      */
     public function getAdditionalFileExtensions(): array
     {
@@ -222,6 +227,7 @@ class PluginRegistrationSocket implements RegistrationInterface
 
     /**
      * @param string $fileExtension e.g. `'html'`
+     * @deprecated will be removed in v5.0, use \Psalm\PluginFileExtensionsSocket instead (#6788)
      */
     private function addFileExtension(string $fileExtension): void
     {


### PR DESCRIPTION
Following `\Psalm\Plugin\RegistrationInterface` methods are deprecated
+ `addFileTypeScanner`
+ `addFileTypeAnalyzer`

Following `\Psalm\PluginRegistrationSocket` methods are deprecated
+ `addFileTypeScanner`
+ `getAdditionalFileTypeScanners`
+ `addFileTypeAnalyzer`
+ `getAdditionalFileTypeAnalyzers`
+ `getAdditionalFileExtensions`
+ `addFileExtension`

Mentioned methods will be removed in Psalm v5.0, corresponding
functionality will be provided by following new interfaces and classes
+ `\Psalm\Plugin\FileExtensionsInterface`
+ `\Psalm\PluginFileExtensionsSocket`

Related: #6788