### PR TITLE
fix code where the offset was wrong

### DIFF
--- a/src/Psalm/Internal/Codebase/Properties.php
+++ b/src/Psalm/Internal/Codebase/Properties.php
@@ -327,12 +327,12 @@ class Properties
 
         if ($storage->type) {
             if ($property_set) {
-                if (isset($class_storage->pseudo_property_set_types[$property_name])) {
-                    return $class_storage->pseudo_property_set_types[$property_name];
+                if (isset($class_storage->pseudo_property_set_types['$'.$property_name])) {
+                    return $class_storage->pseudo_property_set_types['$'.$property_name];
                 }
             } else {
-                if (isset($class_storage->pseudo_property_get_types[$property_name])) {
-                    return $class_storage->pseudo_property_get_types[$property_name];
+                if (isset($class_storage->pseudo_property_get_types['$'.$property_name])) {
+                    return $class_storage->pseudo_property_get_types['$'.$property_name];
                 }
             }
 

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -3,6 +3,7 @@
 namespace Psalm\Internal\Codebase;
 
 use Exception;
+use LibXMLError;
 use LogicException;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
@@ -64,7 +65,7 @@ class Reflection
     {
         $class_name = $reflected_class->name;
 
-        if ($class_name === 'LibXMLError') {
+        if ($class_name === LibXMLError::class) {
             $class_name = 'libXMLError';
         }
 


### PR DESCRIPTION
This is a weird error I noticed when working on https://github.com/vimeo/psalm/pull/7461

These properties are always called with a $ in front of property name

It seems to be a net positive because it started to flag a case where a string was used instead of class-string, but it's in a stub and the property is present twice, once in a @property and one in real code. Weird that it wasn't triggered by the real code one