### PR TITLE
[TASK] Detect allowed_classes of unserialize function

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -15120,7 +15120,6 @@ return [
 'unlink' => ['bool', 'filename'=>'string', 'context='=>'resource'],
 'unpack' => ['array|false', 'format'=>'string', 'string'=>'string', 'offset='=>'int'],
 'unregister_tick_function' => ['void', 'callback'=>'callable'],
-'unserialize' => ['mixed', 'data'=>'string', 'options='=>'array{allowed_classes?:string[]|bool}'],
 'unset' => ['void', 'var='=>'mixed', '...args='=>'mixed'],
 'untaint' => ['bool', '&rw_string'=>'string', '&...rw_strings='=>'string'],
 'uopz_allow_exit' => ['void', 'allow'=>'bool'],

--- a/dictionaries/InternalTaintSinkMap.php
+++ b/dictionaries/InternalTaintSinkMap.php
@@ -57,7 +57,6 @@ return [
 'setcookie' => [['cookie'], ['cookie']],
 'shell_exec' => [['shell']],
 'system' => [['shell']],
-'unserialize' => [['unserialize']],
 'popen' => [['shell']],
 'proc_open' => [['shell']],
 'curl_init' => [['ssrf']],

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -25,6 +25,7 @@ use Psalm\Internal\Composer;
 use Psalm\Internal\EventDispatcher;
 use Psalm\Internal\IncludeCollector;
 use Psalm\Internal\Provider\AddRemoveTaints\HtmlFunctionTainter;
+use Psalm\Internal\Provider\AddRemoveTaints\UnserializeFunctionTainter;
 use Psalm\Internal\Scanner\FileScanner;
 use Psalm\Issue\ArgumentIssue;
 use Psalm\Issue\ClassIssue;
@@ -1405,9 +1406,11 @@ class Config
             $this->filetype_analyzers[$extension] = $className;
         }
 
-        new HtmlFunctionTainter();
-
+        // `class_exists` triggers class autoloader
+        class_exists(HtmlFunctionTainter::class);
+        class_exists(UnserializeFunctionTainter::class);
         $socket->registerHooksFromClass(HtmlFunctionTainter::class);
+        $socket->registerHooksFromClass(UnserializeFunctionTainter::class);
     }
 
     private static function requirePath(string $path): void

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -636,7 +636,8 @@ class FunctionCallReturnTypeFetcher
             }
         }
 
-        if ($conditionally_removed_taints && $function_storage->location) {
+        $toBeRemovedTaints = array_merge($removed_taints, $conditionally_removed_taints);
+        if ($toBeRemovedTaints && $function_storage->location) {
             $assignment_node = DataFlowNode::getForAssignment(
                 $function_id . '-escaped',
                 $function_storage->signature_return_type_location ?: $function_storage->location,
@@ -648,7 +649,7 @@ class FunctionCallReturnTypeFetcher
                 $assignment_node,
                 'conditionally-escaped',
                 $added_taints,
-                array_merge($removed_taints, $conditionally_removed_taints)
+                $toBeRemovedTaints
             );
 
             $stmt_type->parent_nodes[$assignment_node->id] = $assignment_node;

--- a/src/Psalm/Internal/Codebase/OrphanForwardEdgesWorker.php
+++ b/src/Psalm/Internal/Codebase/OrphanForwardEdgesWorker.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Codebase;
+
+use Psalm\Internal\DataFlow\Path;
+
+use function array_filter;
+use function array_diff_key;
+use function array_keys;
+use function array_map;
+use function array_merge;
+use function array_unique;
+use function explode;
+use function in_array;
+use function preg_match;
+use function preg_quote;
+use function sprintf;
+
+use const ARRAY_FILTER_USE_KEY;
+
+class OrphanForwardEdgesWorker
+{
+    private const TYPE_ESCAPED = 'conditionally-escaped';
+    private const TYPE_ARGUMENT = 'arg';
+
+    /** @var array<string, array<string, Path>> */
+    private array $forwardEdges;
+    /** @var array<string, array<string, Path>> */
+    private array $orphanForwardEdges;
+    /** @var array<string, array<string, Path>> */
+    private array $potentialForwardEdges;
+
+    /**
+     * @param array<string, array<string, Path>> $forwardEdges
+     */
+    public function __construct(array $forwardEdges)
+    {
+        $this->forwardEdges = $forwardEdges;
+        $this->prepare();
+        $this->process();
+    }
+
+    private function prepare(): void
+    {
+        $originNames = array_keys($this->forwardEdges);
+        $this->orphanForwardEdges = array_filter(array_map(
+            fn(array $origin): array => array_filter(
+                $origin,
+                fn(string $destinationName): bool => !in_array($destinationName, $originNames),
+                ARRAY_FILTER_USE_KEY
+            ),
+            $this->forwardEdges
+        ));
+        $this->potentialForwardEdges = array_filter(array_map(
+            fn(array $origin): array => array_filter(
+                $origin,
+                fn(Path $desination): bool => $desination->type === self::TYPE_ESCAPED
+            ),
+            $this->forwardEdges
+        ));
+    }
+
+    private function process(): void
+    {
+        // filter out potential forward edges using same origin keys
+        $orphanForwardEdges = array_diff_key($this->orphanForwardEdges, $this->potentialForwardEdges);
+        foreach ($orphanForwardEdges as $orphanOriginName => $orphanDestinations) {
+            foreach ($orphanDestinations as $orphanDestinationName => $orphanDestination) {
+                if ($orphanDestination->type !== self::TYPE_ARGUMENT) {
+                    continue;
+                }
+                $orphanDestinationParts = explode('-', $orphanDestinationName, 2);
+                if (empty($orphanDestinationParts[1])) {
+                    continue;
+                }
+                [$identifier, $locationTrace] = $orphanDestinationParts;
+                if (preg_match('/^(?P<ref>.+)#(?P<argPos>\d+)$/', $identifier, $matches)) {
+                    $modification = $this->resolvePotentialModification($matches['ref'], $locationTrace);
+                    if ($modification !== null) {
+                        // cave: since `Path` instances are not cloned in constructor, changes are applied directly
+                        $this->applyModification($modification, $orphanDestination);
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * @param string $reference corresponding call reference, e.g. `unserialize` (without argPos `#123`)
+     * @param string $locationTrace corresponding call location trace, e.g. `src/somefile.php:95`
+     * @return Path|null
+     */
+    private function resolvePotentialModification(string $reference, string $locationTrace): ?Path
+    {
+        $unescapedTaints = [];
+        $escapedTaints = [];
+
+        // matching given reference, any alternative location trace (e.g. stubs) and the given location trace
+        $pattern = sprintf(
+            '/^%s-(?:escaped)(?:-[^:]+:\d+(-\d+)?)-%s$/',
+            preg_quote($reference, '/'),
+            preg_quote($locationTrace, '/')
+        );
+        // exact match (basically stripped of `argPos`)
+        $exactMatch = $reference . '-' . $locationTrace;
+        foreach ($this->potentialForwardEdges as $potentialOriginName => $potentialDestinations) {
+            if ($potentialOriginName !== $exactMatch) {
+                continue;
+            }
+            foreach ($potentialDestinations as $potentialDestinationName => $potentialDestination) {
+                if (!preg_match($pattern, $potentialDestinationName)) {
+                    continue;
+                }
+                if (!empty($potentialDestination->unescaped_taints)) {
+                    $unescapedTaints = array_merge($unescapedTaints, $potentialDestination->unescaped_taints);
+                }
+                if (!empty($potentialDestination->escaped_taints)) {
+                    $escapedTaints = array_merge($escapedTaints, $potentialDestination->escaped_taints);
+                }
+            }
+        }
+
+        $unescapedTaints = array_unique($unescapedTaints);
+        $escapedTaints = array_unique($escapedTaints);
+
+        if ($unescapedTaints === [] && $escapedTaints === []) {
+            return null;
+        }
+        return new Path('temp', 0, $unescapedTaints, $escapedTaints);
+    }
+
+    private function applyModification(Path $modification, Path $to): void
+    {
+        $to->unescaped_taints = array_unique(array_merge(
+            $target->unescaped_taints ?? [],
+            $modification->unescaped_taints ?? []
+        ));
+        $to->escaped_taints = array_unique(array_merge(
+            $target->escaped_taints ?? [],
+            $modification->escaped_taints ?? []
+        ));
+    }
+}

--- a/src/Psalm/Internal/Codebase/TaintFlowGraph.php
+++ b/src/Psalm/Internal/Codebase/TaintFlowGraph.php
@@ -202,6 +202,9 @@ class TaintFlowGraph extends DataFlowGraph
         $sources = $this->sources;
         $sinks = $this->sinks;
 
+        // tries to reorganize taints of "orphaned" forward edges
+        new OrphanForwardEdgesWorker($this->forward_edges);
+
         ksort($this->specializations);
         ksort($this->forward_edges);
 

--- a/src/Psalm/Internal/Provider/AddRemoveTaints/UnserializeFunctionTainter.php
+++ b/src/Psalm/Internal/Provider/AddRemoveTaints/UnserializeFunctionTainter.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace Psalm\Internal\Provider\AddRemoveTaints;
+
+use PhpParser\Node\Expr\ArrayItem;
+use PhpParser\Node\Expr\Array_;
+use PhpParser\Node\Expr\ClassConstFetch;
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Name;
+use PhpParser\Node\Scalar\String_;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
+use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
+use Psalm\Type\TaintKind;
+use stdClass;
+
+use function array_diff;
+use function count;
+use function is_array;
+
+/**
+ * @internal
+ */
+class UnserializeFunctionTainter implements RemoveTaintsInterface
+{
+    private const ALLOWED_CLASSES = [
+        stdClass::class
+    ];
+
+    /**
+     * @return list<string>
+     */
+    public static function removeTaints(AddRemoveTaintsEvent $event): array
+    {
+        $expr = $event->getExpr();
+        $statements_analyzer = $event->getStatementsSource();
+
+        if (!$statements_analyzer instanceof StatementsAnalyzer
+            || !$expr instanceof FuncCall
+            || !$expr->name instanceof Name
+            || (string)$expr->name !== 'unserialize'
+            || $expr->isFirstClassCallable()
+            || (count($expr->getArgs()) < 2)
+        ) {
+            return [];
+        }
+
+        $allowedClasses = self::resolveAllowedClasses($expr);
+        if ($allowedClasses === false
+            || is_array($allowedClasses) && array_diff($allowedClasses, self::ALLOWED_CLASSES) === []
+        ) {
+            return [TaintKind::INPUT_UNSERIALIZE];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param FuncCall $expr
+     * @return list<class-string|string>|false|null
+     */
+    private static function resolveAllowedClasses(FuncCall $expr)
+    {
+        $args = $expr->getArgs();
+        $options = $args[1]->value;
+        if (!$options instanceof Array_
+            || !isset($options->items[0]->key->value)
+            || !$options->items[0] instanceof ArrayItem
+            || !$options->items[0]->key->value === 'allowed_classes'
+        ) {
+            return null;
+        }
+
+        $value = $options->items[0]->value;
+        if ($value instanceof ConstFetch && (string)$value->name === 'false') {
+            return false;
+        }
+
+        if ($value instanceof Array_) {
+            $allowedClasses = [];
+            foreach ($value->items as $item) {
+                if ($item->value instanceof ClassConstFetch) {
+                    $allowedClasses[] = $item->value->class->getAttribute('resolvedName');
+                } elseif ($item->value instanceof String_) {
+                    $allowedClasses[] = $item->value->value;
+                }
+            }
+            return $allowedClasses;
+        }
+        return null;
+    }
+}

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -250,6 +250,17 @@ function uksort(array &$array, callable $callback): bool
 }
 
 /**
+ * @param $data string
+ * @param $options array{allowed_classes?:string[]|bool}
+ * @return mixed
+ * @psalm-taint-sink unserialize $data
+ * @psalm-taint-specialize
+ */
+function unserialize(string $data, array $options = [])
+{
+}
+
+/**
  * @psalm-pure
  *
  * @psalm-template K of array-key

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -6,6 +6,7 @@ use Psalm\Context;
 use Psalm\Exception\CodeException;
 use Psalm\Internal\Analyzer\IssueData;
 use Psalm\IssueBuffer;
+use stdClass;
 
 use function array_map;
 use function preg_quote;
@@ -705,6 +706,16 @@ class TaintTest extends TestCase
                     function query(string $sql) {}
                     $value = $_GET["value"];
                     $result = fetch($value);'
+            ],
+            'NoTaintedUnserialize having allowed_classes => false' => [
+                'code' => '<?php // --taint-analysis
+                    $payload = $_GET[\'payload\'];
+                    unserialize($payload, [\'allowed_classes\' => false]);'
+            ],
+            'NoTaintedUnserialize having allowed_classes => [stdClass]}' => [
+                'code' => '<?php // --taint-analysis
+                    $payload = $_GET[\'payload\'];
+                    unserialize($payload, [\'allowed_classes\' => [stdClass::class]]]);'
             ],
         ];
     }
@@ -1766,6 +1777,11 @@ class TaintTest extends TestCase
             'taintUnserialize' => [
                 'code' => '<?php
                     $cb = unserialize($_POST[\'x\']);',
+                'error_message' => 'TaintedUnserialize',
+            ],
+            'taintUnserialize having allowed_classes => UnknownClass' => [
+                'code' => '<?php
+                    $cb = unserialize($_POST[\'x\'], [\'allowed_classes\' => UnknownClass::class]);',
                 'error_message' => 'TaintedUnserialize',
             ],
             'taintCreateFunction' => [


### PR DESCRIPTION
⚠️ please review & test this change (especially `[FEATURE] Resolve orphaned forward edges in taint graph`) carefully

---

### [TASK] Detect allowed_classes of unserialize function

* adds stub for `unserialize`, replacing call and taint sink maps
* adds new `UnserializeFunctionTainter` resolving `allowed_classes`
* adds additional test cases for `unserialize` handling

### [FEATURE] Resolve orphaned forward edges in taint graph
### [TASK] Consider removed taints of AddRemoveTaintsEvent directly

---

Related: #5101
Maybe: #5849