### PR TITLE
Enable more checks for native classes on PHP 8

### DIFF
--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -203,8 +203,7 @@ class MethodComparator
             );
         }
 
-        if ($guide_classlike_storage->user_defined
-            && ($guide_classlike_storage->is_interface
+        if (($guide_classlike_storage->is_interface
                 || $guide_classlike_storage->preserve_constructor_signature
                 || $implementer_method_storage->cased_name !== '__construct')
             && $implementer_method_storage->required_param_count > $guide_method_storage->required_param_count
@@ -526,7 +525,7 @@ class MethodComparator
             );
         }
 
-        if ($guide_classlike_storage->user_defined && $implementer_param->by_ref !== $guide_param->by_ref) {
+        if ($implementer_param->by_ref !== $guide_param->by_ref) {
             $config = Config::getInstance();
 
             IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -311,6 +311,9 @@ class Reflection
             $storage->setParams($callables[0]->params);
 
             $storage->return_type = $callables[0]->return_type;
+            if ($this->codebase->analysis_php_version_id >= 80000) {
+                $storage->signature_return_type = $storage->return_type;
+            }
             $storage->return_type->queueClassLikesForScanning($this->codebase);
         } else {
             $params = $method->getParameters();

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -311,7 +311,7 @@ class Reflection
             $storage->setParams($callables[0]->params);
 
             $storage->return_type = $callables[0]->return_type;
-            if ($this->codebase->analysis_php_version_id >= 80000) {
+            if ($this->codebase->analysis_php_version_id >= 8_00_00) {
                 $storage->signature_return_type = $storage->return_type;
             }
             $storage->return_type->queueClassLikesForScanning($this->codebase);

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -36,6 +36,7 @@ use Psalm\Storage\FunctionLikeStorage;
 use Psalm\Storage\MethodStorage;
 use Psalm\Storage\Possibilities;
 use Psalm\Type;
+use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TConditional;
 use Psalm\Type\Atomic\TKeyedArray;
@@ -44,6 +45,8 @@ use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\TaintKindGroup;
 use Psalm\Type\Union;
+use SplDoublyLinkedList;
+use SplQueue;
 
 use function array_filter;
 use function array_map;
@@ -1011,6 +1014,28 @@ class FunctionLikeDocblockScanner
                         $storage->return_type->addType(new TNull());
                     }
                 }
+            } elseif ($classlike_storage
+                && !$classlike_storage->user_defined
+                && $codebase->analysis_php_version_id >= 80000
+            ) {
+                $new = [];
+                /** @var SplQueue<array<string, Atomic>> */
+                $queue = new SplQueue;
+                $queue->enqueue($storage->return_type->getAtomicTypes());
+                $queue->setIteratorMode(SplDoublyLinkedList::IT_MODE_FIFO | SplDoublyLinkedList::IT_MODE_DELETE);
+                foreach ($queue as $types) {
+                    foreach ($types as $t) {
+                        if ($t instanceof TTemplateParam) {
+                            $queue->enqueue($t->as->getAtomicTypes());
+                        } else {
+                            $new []= $t;
+                        }
+                    }
+                }
+                if (!$new) {
+                    throw new \RuntimeException('Impossible!');
+                }
+                $storage->signature_return_type = new Union($new);
             }
 
             $storage->return_type->queueClassLikesForScanning($codebase, $file_storage);

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -45,6 +45,7 @@ use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\TaintKindGroup;
 use Psalm\Type\Union;
+use RuntimeException;
 use SplDoublyLinkedList;
 use SplQueue;
 
@@ -1033,7 +1034,7 @@ class FunctionLikeDocblockScanner
                     }
                 }
                 if (!$new) {
-                    throw new \RuntimeException('Impossible!');
+                    throw new RuntimeException('Impossible!');
                 }
                 $storage->signature_return_type = new Union($new);
             }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -1017,7 +1017,7 @@ class FunctionLikeDocblockScanner
                 }
             } elseif ($classlike_storage
                 && !$classlike_storage->user_defined
-                && $codebase->analysis_php_version_id >= 80000
+                && $codebase->analysis_php_version_id >= 8_00_00
             ) {
                 $new = [];
                 /** @var SplQueue<array<string, Atomic>> */

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -218,6 +218,7 @@ class AttributeTest extends TestCase
 
                     /**
                      * @psalm-suppress MissingTemplateParam
+                     * @psalm-suppress MethodSignatureMismatch
                      */
                     final class EmptyCollection implements IteratorAggregate
                     {

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -309,6 +309,10 @@ class DocumentationTest extends TestCase
                     $ignored_issues = ['UnusedVariable'];
                     break;
 
+                case 'InvalidToString':
+                    $ignored_issues = ['MethodSignatureMismatch'];
+                    break;
+
                 case 'AmbiguousConstantInheritance':
                 case 'DeprecatedConstant':
                 case 'DuplicateEnumCase':

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -974,6 +974,7 @@ class MethodCallTest extends TestCase
 
                     class Datetime extends \DateTime
                     {
+                        /** @psalm-suppress MethodSignatureMismatch */
                         public static function createFromInterface(\DatetimeInterface $datetime): \DateTime
                         {
                             return parent::createFromInterface($datetime);

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -974,14 +974,13 @@ class MethodCallTest extends TestCase
 
                     class Datetime extends \DateTime
                     {
-                        /** @psalm-suppress MethodSignatureMismatch */
                         public static function createFromInterface(\DatetimeInterface $datetime): \DateTime
                         {
                             return parent::createFromInterface($datetime);
                         }
                     }',
                 'assertions' => [],
-                'ignored_issues' => ['MixedReturnStatement', 'MixedInferredReturnType'],
+                'ignored_issues' => ['MixedReturnStatement', 'MixedInferredReturnType', 'MethodSignatureMismatch'],
                 'php_version' => '8.0'
             ],
             'nullsafeShortCircuit' => [

--- a/tests/ToStringTest.php
+++ b/tests/ToStringTest.php
@@ -178,6 +178,7 @@ class ToStringTest extends TestCase
                     function foo(Stringable $s): void {}
 
                     class Bar {
+                        /** @psalm-suppress MethodSignatureMismatch */
                         public function __toString() {
                             return "foo";
                         }
@@ -231,6 +232,7 @@ class ToStringTest extends TestCase
             'invalidToStringReturnType' => [
                 'code' => '<?php
                     class A {
+                        /** @psalm-suppress MethodSignatureMismatch */
                         function __toString(): void { }
                     }',
                 'error_message' => 'InvalidToString',
@@ -245,6 +247,7 @@ class ToStringTest extends TestCase
             'invalidInferredToStringReturnTypeWithTruePhp8' => [
                 'code' => '<?php
                     class A {
+                        /** @psalm-suppress MethodSignatureMismatch */
                         function __toString() {
                             /** @psalm-suppress InvalidReturnStatement */
                             return true;


### PR DESCRIPTION
Coupled with #7475, aims to reach feature parity with [phpstan](https://phpstan.org/r/050dffdd-aaab-431a-87cc-9261a166ce9c) vs [psalm](https://psalm.dev/r/66d598df84).

This PR enables these checks only on 8.1, and like phpstan it doesn't support suppression via the ReturnTypeWillChange attribute, which could possibly cause BC problems when seeking to support PHP 7 (unlike my earlier merged PR which does support ReturnTypeWillChange, but doesn't check for things like mismatched types).