### PR TITLE
Remove mic-drop hack from if analysis

### DIFF
--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -349,7 +349,7 @@ class Context
     /**
      * @var Context|null
      */
-    public $if_context;
+    public $if_body_context;
 
     /**
      * @var bool

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
@@ -114,14 +114,12 @@ class IfConditionalAnalyzer
 
         $outer_context->inside_conditional = true;
 
-        if ($externally_applied_if_cond_expr) {
-            if (ExpressionAnalyzer::analyze(
-                $statements_analyzer,
-                $externally_applied_if_cond_expr,
-                $outer_context
-            ) === false) {
-                throw new ScopeAnalysisException();
-            }
+        if (ExpressionAnalyzer::analyze(
+            $statements_analyzer,
+            $externally_applied_if_cond_expr,
+            $outer_context
+        ) === false) {
+            throw new ScopeAnalysisException();
         }
 
         $first_cond_assigned_var_ids = $outer_context->assigned_var_ids;
@@ -236,7 +234,7 @@ class IfConditionalAnalyzer
      * Returns statements that are definitely evaluated before any statements after the end of the
      * if/elseif/else blocks
      */
-    private static function getDefinitelyEvaluatedExpressionAfterIf(PhpParser\Node\Expr $stmt): ?PhpParser\Node\Expr
+    private static function getDefinitelyEvaluatedExpressionAfterIf(PhpParser\Node\Expr $stmt): PhpParser\Node\Expr
     {
         if ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Equal
             || $stmt instanceof PhpParser\Node\Expr\BinaryOp\Identical
@@ -280,7 +278,7 @@ class IfConditionalAnalyzer
      * Returns statements that are definitely evaluated before any statements inside
      * the if block
      */
-    private static function getDefinitelyEvaluatedExpressionInsideIf(PhpParser\Node\Expr $stmt): ?PhpParser\Node\Expr
+    private static function getDefinitelyEvaluatedExpressionInsideIf(PhpParser\Node\Expr $stmt): PhpParser\Node\Expr
     {
         if ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Equal
             || $stmt instanceof PhpParser\Node\Expr\BinaryOp\Identical

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
@@ -141,7 +141,10 @@ class IfConditionalAnalyzer
         }
 
         $if_conditional_context = clone $if_context;
-        $if_conditional_context->if_context = $if_context;
+
+        // here we set up a context specifically for the statements in the first `if`, which can
+        // be affected by statements in the if condition
+        $if_conditional_context->if_body_context = $if_context;
 
         if ($codebase->alter_code) {
             $if_context->branch_point = $branch_point;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseAnalyzer.php
@@ -118,11 +118,11 @@ class ElseAnalyzer
 
         /** @var array<string, int> */
         $new_assigned_var_ids = $else_context->assigned_var_ids;
-        $else_context->assigned_var_ids = $pre_stmts_assigned_var_ids;
+        $else_context->assigned_var_ids += $pre_stmts_assigned_var_ids;
 
         /** @var array<string, bool> */
         $new_possibly_assigned_var_ids = $else_context->possibly_assigned_var_ids;
-        $else_context->possibly_assigned_var_ids = $pre_possibly_assigned_var_ids + $new_possibly_assigned_var_ids;
+        $else_context->possibly_assigned_var_ids += $pre_possibly_assigned_var_ids;
 
         if ($else) {
             foreach ($else_context->byref_constraints as $var_id => $byref_constraint) {
@@ -200,24 +200,21 @@ class ElseAnalyzer
 
             $possibly_assigned_var_ids = $new_possibly_assigned_var_ids;
 
-            if ($has_leaving_statements && $else_context->loop_scope) {
-                if (!$has_continue_statement && !$has_break_statement) {
-                    $if_scope->new_vars_possibly_in_scope = array_merge(
-                        $vars_possibly_in_scope,
-                        $if_scope->new_vars_possibly_in_scope
-                    );
+            if ($has_leaving_statements) {
+                if ($else_context->loop_scope) {
+                    if (!$has_continue_statement && !$has_break_statement) {
+                        $if_scope->new_vars_possibly_in_scope = array_merge(
+                            $vars_possibly_in_scope,
+                            $if_scope->new_vars_possibly_in_scope
+                        );
+                    }
 
-                    $if_scope->possibly_assigned_var_ids = array_merge(
-                        $possibly_assigned_var_ids,
-                        $if_scope->possibly_assigned_var_ids
+                    $else_context->loop_scope->vars_possibly_in_scope = array_merge(
+                        $vars_possibly_in_scope,
+                        $else_context->loop_scope->vars_possibly_in_scope
                     );
                 }
-
-                $else_context->loop_scope->vars_possibly_in_scope = array_merge(
-                    $vars_possibly_in_scope,
-                    $else_context->loop_scope->vars_possibly_in_scope
-                );
-            } elseif (!$has_leaving_statements) {
+            } else {
                 $if_scope->new_vars_possibly_in_scope = array_merge(
                     $vars_possibly_in_scope,
                     $if_scope->new_vars_possibly_in_scope

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseAnalyzer.php
@@ -59,16 +59,6 @@ class ElseAnalyzer
 
         $else_types = Algebra::getTruthsFromFormula($else_context->clauses);
 
-        if (!$else && !$else_types) {
-            $if_scope->final_actions = array_merge([ScopeAnalyzer::ACTION_NONE], $if_scope->final_actions);
-            $if_scope->assigned_var_ids = [];
-            $if_scope->new_vars = [];
-            $if_scope->redefined_vars = [];
-            $if_scope->reasonable_clauses = [];
-
-            return null;
-        }
-
         $original_context = clone $else_context;
 
         if ($else_types) {
@@ -120,10 +110,10 @@ class ElseAnalyzer
             ) {
                 return false;
             }
+        }
 
-            foreach ($else_context->parent_remove_vars as $var_id => $_) {
-                $outer_context->removeVarFromConflictingClauses($var_id);
-            }
+        foreach ($else_context->parent_remove_vars as $var_id => $_) {
+            $outer_context->removeVarFromConflictingClauses($var_id);
         }
 
         /** @var array<string, int> */
@@ -185,7 +175,7 @@ class ElseAnalyzer
                 $new_assigned_var_ids,
                 $new_possibly_assigned_var_ids,
                 [],
-                (bool) $else
+                true
             );
 
             $if_scope->reasonable_clauses = [];

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
@@ -28,11 +28,8 @@ use function array_intersect;
 use function array_intersect_key;
 use function array_keys;
 use function array_merge;
-use function array_unique;
 use function count;
 use function in_array;
-use function strpos;
-use function substr;
 
 /**
  * @internal
@@ -174,33 +171,6 @@ class IfAnalyzer
                 array_keys($pre_assignment_else_redefined_vars),
                 array_keys($if_scope->negated_types)
             );
-
-            $extra_vars_to_update = [];
-
-            // if there's an object-like array in there, we also need to update the root array variable
-            foreach ($vars_to_update as $var_id) {
-                $bracked_pos = strpos($var_id, '[');
-                if ($bracked_pos !== false) {
-                    $extra_vars_to_update[] = substr($var_id, 0, $bracked_pos);
-                }
-            }
-
-            if ($extra_vars_to_update) {
-                $vars_to_update = array_unique(array_merge($extra_vars_to_update, $vars_to_update));
-            }
-
-            //update $if_context vars to include the pre-assignment else vars
-            if (!$stmt->else && !$has_leaving_statements) {
-                foreach ($pre_assignment_else_redefined_vars as $var_id => $type) {
-                    if (isset($if_context->vars_in_scope[$var_id])) {
-                        $if_context->vars_in_scope[$var_id] = Type::combineUnionTypes(
-                            $if_context->vars_in_scope[$var_id],
-                            $type,
-                            $codebase
-                        );
-                    }
-                }
-            }
 
             $outer_context->update(
                 $old_if_context,

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
@@ -28,8 +28,11 @@ use function array_intersect;
 use function array_intersect_key;
 use function array_keys;
 use function array_merge;
+use function array_unique;
 use function count;
 use function in_array;
+use function strpos;
+use function substr;
 
 /**
  * @internal
@@ -171,6 +174,20 @@ class IfAnalyzer
                 array_keys($pre_assignment_else_redefined_vars),
                 array_keys($if_scope->negated_types)
             );
+
+            $extra_vars_to_update = [];
+
+            // if there's an object-like array in there, we also need to update the root array variable
+            foreach ($vars_to_update as $var_id) {
+                $bracked_pos = strpos($var_id, '[');
+                if ($bracked_pos !== false) {
+                    $extra_vars_to_update[] = substr($var_id, 0, $bracked_pos);
+                }
+            }
+
+            if ($extra_vars_to_update) {
+                $vars_to_update = array_unique(array_merge($extra_vars_to_update, $vars_to_update));
+            }
 
             $outer_context->update(
                 $old_if_context,

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
@@ -112,6 +112,7 @@ class IfElseAnalyzer
 
             $if_context = $if_conditional_scope->if_context;
 
+            // this is the context for stuff that happens after the `if` block
             $post_if_context = $if_conditional_scope->post_if_context;
             $cond_referenced_var_ids = $if_conditional_scope->cond_referenced_var_ids;
             $assigned_in_conditional_var_ids = $if_conditional_scope->assigned_in_conditional_var_ids;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
@@ -24,16 +24,12 @@ use Psalm\Node\Expr\VirtualBooleanNot;
 use Psalm\Type;
 use Psalm\Type\Reconciler;
 
-use function array_combine;
 use function array_diff;
-use function array_diff_key;
 use function array_filter;
 use function array_intersect_key;
-use function array_key_exists;
 use function array_keys;
 use function array_map;
 use function array_merge;
-use function array_reduce;
 use function array_unique;
 use function array_values;
 use function count;
@@ -110,11 +106,11 @@ class IfElseAnalyzer
                 $context->branch_point ?: (int) $stmt->getAttribute('startFilePos')
             );
 
+            // this is the context for stuff that happens within the `if` block
             $if_context = $if_conditional_scope->if_context;
 
             // this is the context for stuff that happens after the `if` block
             $post_if_context = $if_conditional_scope->post_if_context;
-            $cond_referenced_var_ids = $if_conditional_scope->cond_referenced_var_ids;
             $assigned_in_conditional_var_ids = $if_conditional_scope->assigned_in_conditional_var_ids;
         } catch (ScopeAnalysisException $e) {
             return false;
@@ -231,100 +227,6 @@ class IfElseAnalyzer
             )
         );
 
-        $active_if_types = [];
-
-        $reconcilable_if_types = Algebra::getTruthsFromFormula(
-            $if_context->clauses,
-            spl_object_id($stmt->cond),
-            $cond_referenced_var_ids,
-            $active_if_types
-        );
-
-        if (array_filter(
-            $context->clauses,
-            fn($clause): bool => (bool)$clause->possibilities
-        )) {
-            $omit_keys = array_reduce(
-                $context->clauses,
-                /**
-                 * @param array<string> $carry
-                 * @return array<string>
-                 */
-                fn(array $carry, Clause $clause): array => array_merge($carry, array_keys($clause->possibilities)),
-                []
-            );
-
-            $omit_keys = array_combine($omit_keys, $omit_keys);
-            $omit_keys = array_diff_key($omit_keys, Algebra::getTruthsFromFormula($context->clauses));
-
-            $cond_referenced_var_ids = array_diff_key(
-                $cond_referenced_var_ids,
-                $omit_keys
-            );
-        }
-
-        // if the if has an || in the conditional, we cannot easily reason about it
-        if ($reconcilable_if_types) {
-            $changed_var_ids = [];
-
-            $if_vars_in_scope_reconciled =
-                Reconciler::reconcileKeyedTypes(
-                    $reconcilable_if_types,
-                    $active_if_types,
-                    $if_context->vars_in_scope,
-                    $if_context->references_in_scope,
-                    $changed_var_ids,
-                    $cond_referenced_var_ids,
-                    $statements_analyzer,
-                    $statements_analyzer->getTemplateTypeMap() ?: [],
-                    $if_context->inside_loop,
-                    $context->check_variables
-                        ? new CodeLocation(
-                            $statements_analyzer->getSource(),
-                            $stmt->cond instanceof PhpParser\Node\Expr\BooleanNot
-                                ? $stmt->cond->expr
-                                : $stmt->cond,
-                            $context->include_location
-                        ) : null
-                );
-
-            $if_context->vars_in_scope = $if_vars_in_scope_reconciled;
-
-            foreach ($reconcilable_if_types as $var_id => $_) {
-                $if_context->vars_possibly_in_scope[$var_id] = true;
-            }
-
-            if ($changed_var_ids) {
-                $if_context->clauses = Context::removeReconciledClauses($if_context->clauses, $changed_var_ids)[0];
-
-                foreach ($changed_var_ids as $changed_var_id => $_) {
-                    foreach ($if_context->vars_in_scope as $var_id => $_) {
-                        if (preg_match('/' . preg_quote($changed_var_id, '/') . '[\]\[\-]/', $var_id)
-                            && !array_key_exists($var_id, $changed_var_ids)
-                            && !array_key_exists($var_id, $cond_referenced_var_ids)
-                        ) {
-                            $if_context->removePossibleReference($var_id);
-                        }
-                    }
-                }
-            }
-
-            $if_scope->if_cond_changed_var_ids = $changed_var_ids;
-        }
-
-        $if_context->reconciled_expression_clauses = [];
-
-        $old_if_context = clone $if_context;
-        $context->vars_possibly_in_scope = array_merge(
-            $if_context->vars_possibly_in_scope,
-            $context->vars_possibly_in_scope
-        );
-
-        $context->referenced_var_ids = array_merge(
-            $if_context->referenced_var_ids,
-            $context->referenced_var_ids
-        );
-
         $temp_else_context = clone $post_if_context;
 
         $changed_var_ids = [];
@@ -367,7 +269,6 @@ class IfElseAnalyzer
             $if_scope,
             $if_conditional_scope,
             $if_context,
-            $old_if_context,
             $context,
             $pre_assignment_else_redefined_vars
         ) === false) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
@@ -180,39 +180,38 @@ class AndAnalyzer
             );
         }
 
-        if ($context->if_context && !$context->inside_negation) {
-            $if_context = $context->if_context;
-
+        if ($context->if_body_context && !$context->inside_negation) {
+            $if_body_context = $context->if_body_context;
             $context->vars_in_scope = $right_context->vars_in_scope;
-            $if_context->vars_in_scope = array_merge(
-                $if_context->vars_in_scope,
+            $if_body_context->vars_in_scope = array_merge(
+                $if_body_context->vars_in_scope,
                 $context->vars_in_scope
             );
 
-            $if_context->referenced_var_ids = array_merge(
-                $if_context->referenced_var_ids,
+            $if_body_context->referenced_var_ids = array_merge(
+                $if_body_context->referenced_var_ids,
                 $context->referenced_var_ids,
             );
 
-            $if_context->assigned_var_ids = array_merge(
-                $if_context->assigned_var_ids,
+            $if_body_context->assigned_var_ids = array_merge(
+                $if_body_context->assigned_var_ids,
                 $context->assigned_var_ids,
             );
 
-            $if_context->reconciled_expression_clauses = array_merge(
-                $if_context->reconciled_expression_clauses,
+            $if_body_context->reconciled_expression_clauses = array_merge(
+                $if_body_context->reconciled_expression_clauses,
                 array_map(
                     fn($c) => $c->hash,
                     $partitioned_clauses[1]
                 )
             );
 
-            $if_context->vars_possibly_in_scope = array_merge(
-                $if_context->vars_possibly_in_scope,
+            $if_body_context->vars_possibly_in_scope = array_merge(
+                $if_body_context->vars_possibly_in_scope,
                 $context->vars_possibly_in_scope,
             );
 
-            $if_context->updateChecks($context);
+            $if_body_context->updateChecks($context);
         } else {
             $context->vars_in_scope = $left_context->vars_in_scope;
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/AndAnalyzer.php
@@ -181,25 +181,22 @@ class AndAnalyzer
         }
 
         if ($context->if_context && !$context->inside_negation) {
-            $context->vars_in_scope = $right_context->vars_in_scope;
             $if_context = $context->if_context;
 
-            foreach ($right_context->vars_in_scope as $var_id => $type) {
-                if (!isset($if_context->vars_in_scope[$var_id])) {
-                    $if_context->vars_in_scope[$var_id] = $type;
-                } elseif (isset($context->vars_in_scope[$var_id])) {
-                    $if_context->vars_in_scope[$var_id] = $context->vars_in_scope[$var_id];
-                }
-            }
+            $context->vars_in_scope = $right_context->vars_in_scope;
+            $if_context->vars_in_scope = array_merge(
+                $if_context->vars_in_scope,
+                $context->vars_in_scope
+            );
 
             $if_context->referenced_var_ids = array_merge(
+                $if_context->referenced_var_ids,
                 $context->referenced_var_ids,
-                $if_context->referenced_var_ids
             );
 
             $if_context->assigned_var_ids = array_merge(
+                $if_context->assigned_var_ids,
                 $context->assigned_var_ids,
-                $if_context->assigned_var_ids
             );
 
             $if_context->reconciled_expression_clauses = array_merge(
@@ -211,8 +208,8 @@ class AndAnalyzer
             );
 
             $if_context->vars_possibly_in_scope = array_merge(
+                $if_context->vars_possibly_in_scope,
                 $context->vars_possibly_in_scope,
-                $if_context->vars_possibly_in_scope
             );
 
             $if_context->updateChecks($context);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
@@ -102,7 +102,7 @@ class OrAnalyzer
             $post_leaving_if_context = clone $context;
 
             $left_context = clone $context;
-            $left_context->if_context = null;
+            $left_context->if_body_context = null;
             $left_context->assigned_var_ids = [];
 
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->left, $left_context) === false) {
@@ -261,7 +261,7 @@ class OrAnalyzer
             );
         }
 
-        $right_context->if_context = null;
+        $right_context->if_body_context = null;
 
         $pre_referenced_var_ids = $right_context->referenced_var_ids;
         $right_context->referenced_var_ids = [];
@@ -371,18 +371,18 @@ class OrAnalyzer
             $right_context->assigned_var_ids
         );
 
-        if ($context->if_context) {
-            $if_context = $context->if_context;
+        if ($context->if_body_context) {
+            $if_body_context = $context->if_body_context;
 
             foreach ($right_context->vars_in_scope as $var_id => $type) {
-                if (isset($if_context->vars_in_scope[$var_id])) {
-                    $if_context->vars_in_scope[$var_id] = Type::combineUnionTypes(
+                if (isset($if_body_context->vars_in_scope[$var_id])) {
+                    $if_body_context->vars_in_scope[$var_id] = Type::combineUnionTypes(
                         $type,
-                        $if_context->vars_in_scope[$var_id],
+                        $if_body_context->vars_in_scope[$var_id],
                         $codebase
                     );
                 } elseif (isset($left_context->vars_in_scope[$var_id])) {
-                    $if_context->vars_in_scope[$var_id] = Type::combineUnionTypes(
+                    $if_body_context->vars_in_scope[$var_id] = Type::combineUnionTypes(
                         $type,
                         $left_context->vars_in_scope[$var_id],
                         $codebase
@@ -390,17 +390,17 @@ class OrAnalyzer
                 }
             }
 
-            $if_context->referenced_var_ids = array_merge(
+            $if_body_context->referenced_var_ids = array_merge(
                 $context->referenced_var_ids,
-                $if_context->referenced_var_ids
+                $if_body_context->referenced_var_ids
             );
 
-            $if_context->assigned_var_ids = array_merge(
+            $if_body_context->assigned_var_ids = array_merge(
                 $context->assigned_var_ids,
-                $if_context->assigned_var_ids
+                $if_body_context->assigned_var_ids
             );
 
-            $if_context->updateChecks($context);
+            $if_body_context->updateChecks($context);
         }
 
         $context->vars_possibly_in_scope = array_merge(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/OrAnalyzer.php
@@ -64,6 +64,8 @@ class OrAnalyzer
 
         $post_leaving_if_context = null;
 
+        // we cap this at max depth of 4 to prevent quadratic behaviour
+        // when analysing <expr> || <expr> || <expr> || <expr> || <expr>
         if (!$stmt->left instanceof PhpParser\Node\Expr\BinaryOp\BooleanOr
             || !$stmt->left->left instanceof PhpParser\Node\Expr\BinaryOp\BooleanOr
             || !$stmt->left->left->left instanceof PhpParser\Node\Expr\BinaryOp\BooleanOr

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncDecExpressionAnalyzer.php
@@ -129,7 +129,7 @@ class IncDecExpressionAnalyzer
             if ($stmt instanceof PreInc || $stmt instanceof PreDec) {
                 $old_node_data->setType(
                     $stmt,
-                    $statements_analyzer->node_data->getType($operation) ?? Type::getMixed()
+                    $statements_analyzer->node_data->getType($fake_assignment) ?? Type::getMixed()
                 );
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -180,7 +180,9 @@ class ExpressionAnalyzer
                 $stmt->expr,
                 null,
                 $context,
-                $stmt->getDocComment()
+                $stmt->getDocComment(),
+                [],
+                !$from_stmt ? $stmt : null
             );
 
             if ($assignment_type === false) {

--- a/src/Psalm/Internal/Codebase/VariableUseGraph.php
+++ b/src/Psalm/Internal/Codebase/VariableUseGraph.php
@@ -160,6 +160,7 @@ class VariableUseGraph extends DataFlowGraph
                 || $path->type === 'use-inside-conditional'
                 || $path->type === 'use-inside-isset'
                 || $path->type === 'arg'
+                || $path->type === 'comparison'
             ) {
                 return null;
             }

--- a/src/Psalm/Internal/Scope/IfScope.php
+++ b/src/Psalm/Internal/Scope/IfScope.php
@@ -79,6 +79,11 @@ class IfScope
     /**
      * @var string[]
      */
+    public $if_actions = [];
+
+    /**
+     * @var string[]
+     */
     public $final_actions = [];
 
     /**

--- a/tests/Loop/DoTest.php
+++ b/tests/Loop/DoTest.php
@@ -121,6 +121,7 @@ class DoTest extends TestCase
                             break;
                         }
 
+                        /** @psalm-suppress MixedArgument */
                         foo($a);
                     }
                     while (rand(0,100) === 10);',

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2083,6 +2083,7 @@ class ConditionalTest extends TestCase
                         /**
                          * @psalm-suppress MixedReturnStatement
                          * @psalm-suppress MixedInferredReturnType
+                         * @psalm-suppress MixedArrayAccess
                          */
                         public static function get(string $k1, string $k2) : ?string {
                             if (!isset(static::$cache[$k1][$k2])) {

--- a/tests/TypeReconciliation/RedundantConditionTest.php
+++ b/tests/TypeReconciliation/RedundantConditionTest.php
@@ -1527,6 +1527,19 @@ class RedundantConditionTest extends TestCase
                     }',
                 'error_message' => 'RedundantCondition'
             ],
+            'secondFalsyTwiceWithoutChangeWithElse' => [
+                'code' => '<?php
+                    /**
+                     * @param array{a?:int,b?:string} $p
+                     */
+                    function f(array $p) : void {
+                        if (!$p) {
+                            throw new RuntimeException("");
+                        } else {}
+                        assert(!!$p);
+                    }',
+                'error_message' => 'RedundantCondition'
+            ],
         ];
     }
 }

--- a/tests/TypeReconciliation/TypeAlgebraTest.php
+++ b/tests/TypeReconciliation/TypeAlgebraTest.php
@@ -1194,8 +1194,6 @@ class TypeAlgebraTest extends TestCase
             ],
             'threeVarLogicWithException' => [
                 'code' => '<?php
-                    function takesString(string $s): void {}
-
                     function foo(?string $a, ?string $b, ?string $c): void {
                         if ($a !== null || $b !== null || $c !== null) {
                             if ($c !== null) {
@@ -1209,11 +1207,9 @@ class TypeAlgebraTest extends TestCase
                             } else {
                                 $d = $c;
                             }
-
-                            takesString($d);
                         }
                     }',
-                'error_message' => 'PossiblyNullArgument',
+                'error_message' => 'RedundantCondition',
             ],
             'invertedTwoVarLogicNotNestedWithVarChange' => [
                 'code' => '<?php

--- a/tests/TypeReconciliation/TypeAlgebraTest.php
+++ b/tests/TypeReconciliation/TypeAlgebraTest.php
@@ -19,18 +19,16 @@ class TypeAlgebraTest extends TestCase
         return [
             'twoVarLogicSimple' => [
                 'code' => '<?php
-                    function takesString(string $s): void {}
-
-                    function foo(?string $a, ?string $b): void {
+                    function foo(?string $a, ?string $b): string {
                         if ($a !== null || $b !== null) {
                             if ($a !== null) {
-                                $c = $a;
+                                return $a;
                             } else {
-                                $c = $b;
+                                return $b;
                             }
-
-                            takesString($c);
                         }
+
+                        return "foo";
                     }',
             ],
             'threeVarLogic' => [

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -2461,18 +2461,6 @@ class UnusedVariableTest extends TestCase
                         $a = false;
                     }'
             ],
-            'usedPlusInAddition' => [
-                'code' => '<?php
-                    function takesAnInt(): void {
-                        $i = 0;
-
-                        while (rand(0, 1)) {
-                            if (++$i > 10) {
-                                break;
-                            } else {}
-                        }
-                    }',
-            ],
             'referenceUseUsesReferencedVariable' => [
                 'code' => '<?php
                     $a = 1;
@@ -2536,6 +2524,30 @@ class UnusedVariableTest extends TestCase
 
                     function takesArray(array $_arr): void {}
                 ',
+            ],
+            'usedPlusInAddition' => [
+                'code' => '<?php
+                    function takesAnInt(): void {
+                        $i = 0;
+
+                        while (rand(0, 1)) {
+                            if (($i = $i + 1) > 10) {
+                                break;
+                            } else {}
+                        }
+                    }',
+            ],
+            'usedPlusInUnaryAddition' => [
+                'code' => '<?php
+                    function takesAnInt(): void {
+                        $i = 0;
+
+                        while (rand(0, 1)) {
+                            if (++$i > 10) {
+                                break;
+                            } else {}
+                        }
+                    }',
             ],
         ];
     }


### PR DESCRIPTION
Handling of `if` conditions had a path I called "mic drop" that dealt with the following code

```php
if (<expr>) {
  <some code>
  return;
} // no elseif or else
```

While a useful shortcut, this created a bunch of special cases that don't work if an empty ` else {}` is appended to the `if` condition — many examples in `tests/TypeReconciliation/TypeAlgebraTest.php` fail when that empty `else {}` is used.

This PR contains the necessary fixes to make most everything work as expected without the mic drop hack.