### PR TITLE
fix error with 0 being considered positive

### DIFF
--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -1193,7 +1193,7 @@ class TypeCombiner
 
                 if (!isset($combination->value_types['int'])) {
                     $combination->value_types['int'] = $all_nonnegative
-                        ? new TIntRange(1, null)
+                        ? new TIntRange(0, null) // improvement: use min and max literals to bound
                         : new TNonspecificLiteralInt();
                 }
             }

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -704,6 +704,18 @@ class IntRangeTest extends TestCase
                     '$_arr===' => 'non-empty-array<int<0, max>, int<0, max>>',
                 ],
             ],
+            'noErrorPushingBigShapeIntoConstant' => [
+                'code' => '<?php
+                        class DocComment
+                            {
+                                private const PSALM_ANNOTATIONS = [
+                                    "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "",
+                                    "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""
+                                ];
+                            }',
+                'assertions' => [
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
fix a bug introduced in https://github.com/vimeo/psalm/pull/7473. When combining ints, we were flagging 0, using TPositiveInt and then check if TPositiveInt to add 0 to the combination. When I removed TPositiveInt, I wrongly assumed this had become unused code