### PR TITLE
Lock event classes

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -122,6 +122,32 @@
 - [BC] Method `Psalm\Type\Union::hasFormerStaticObject()` was renamed to `hasStaticObject()`
 - [BC] Function assertions (from `@psalm-assert Foo $bar`) have been converted from strings to specific `Assertion` objects.
 - [BC] Property `Psalm\Storage\ClassLikeStorage::$invalid_dependencies` changed from `array<string>` to `array<string, true>`.
+- [BC] Event classes became final and their constructors were marked `@internal`:
+  - `Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterClassLikeAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterClassLikeExistenceCheckEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterClassLikeVisitEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterEveryFunctionCallAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterExpressionAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterFileAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterFunctionCallAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\AfterStatementAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\BeforeFileAnalysisEvent`
+  - `Psalm\Plugin\EventHandler\Event\FunctionExistenceProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\FunctionParamsProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\MethodExistenceProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\MethodParamsProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\MethodVisibilityProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\PropertyExistenceProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\PropertyTypeProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\PropertyVisibilityProviderEvent`
+  - `Psalm\Plugin\EventHandler\Event\StringInterpreterEvent`
 
 ## Removed
  - [BC] Property `Psalm\Codebase::$php_major_version` was removed, use

--- a/src/Psalm/Plugin/EventHandler/Event/AddRemoveTaintsEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AddRemoveTaintsEvent.php
@@ -7,7 +7,7 @@ use Psalm\Codebase;
 use Psalm\Context;
 use Psalm\StatementsSource;
 
-class AddRemoveTaintsEvent
+final class AddRemoveTaintsEvent
 {
     /**
      * @var Expr
@@ -28,6 +28,7 @@ class AddRemoveTaintsEvent
 
     /**
      * Called after an expression has been checked
+     * @internal
      */
     public function __construct(
         Expr $expr,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterAnalysisEvent.php
@@ -6,7 +6,7 @@ use Psalm\Codebase;
 use Psalm\Internal\Analyzer\IssueData;
 use Psalm\SourceControl\SourceControlInfo;
 
-class AfterAnalysisEvent
+final class AfterAnalysisEvent
 {
     /**
      * @var Codebase
@@ -29,6 +29,7 @@ class AfterAnalysisEvent
      * Called after analysis is complete
      *
      * @param array<string, list<IssueData>> $issues
+     * @internal
      */
     public function __construct(
         Codebase $codebase,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterClassLikeAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterClassLikeAnalysisEvent.php
@@ -8,7 +8,7 @@ use Psalm\FileManipulation;
 use Psalm\StatementsSource;
 use Psalm\Storage\ClassLikeStorage;
 
-class AfterClassLikeAnalysisEvent
+final class AfterClassLikeAnalysisEvent
 {
     /**
      * @var Node\Stmt\ClassLike
@@ -35,6 +35,7 @@ class AfterClassLikeAnalysisEvent
      * Called after a statement has been checked
      *
      * @param  FileManipulation[]   $file_replacements
+     * @internal
      */
     public function __construct(
         Node\Stmt\ClassLike $stmt,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterClassLikeExistenceCheckEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterClassLikeExistenceCheckEvent.php
@@ -7,7 +7,7 @@ use Psalm\Codebase;
 use Psalm\FileManipulation;
 use Psalm\StatementsSource;
 
-class AfterClassLikeExistenceCheckEvent
+final class AfterClassLikeExistenceCheckEvent
 {
     /**
      * @var string
@@ -32,6 +32,7 @@ class AfterClassLikeExistenceCheckEvent
 
     /**
      * @param FileManipulation[] $file_replacements
+     * @internal
      */
     public function __construct(
         string $fq_class_name,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterClassLikeVisitEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterClassLikeVisitEvent.php
@@ -8,7 +8,7 @@ use Psalm\FileManipulation;
 use Psalm\FileSource;
 use Psalm\Storage\ClassLikeStorage;
 
-class AfterClassLikeVisitEvent
+final class AfterClassLikeVisitEvent
 {
     /**
      * @var ClassLike
@@ -33,6 +33,7 @@ class AfterClassLikeVisitEvent
 
     /**
      * @param  FileManipulation[] $file_replacements
+     * @internal
      */
     public function __construct(
         ClassLike $stmt,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterCodebasePopulatedEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterCodebasePopulatedEvent.php
@@ -4,7 +4,7 @@ namespace Psalm\Plugin\EventHandler\Event;
 
 use Psalm\Codebase;
 
-class AfterCodebasePopulatedEvent
+final class AfterCodebasePopulatedEvent
 {
     /**
      * @var Codebase
@@ -13,6 +13,7 @@ class AfterCodebasePopulatedEvent
 
     /**
      * Called after codebase has been populated
+     * @internal
      */
     public function __construct(Codebase $codebase)
     {

--- a/src/Psalm/Plugin/EventHandler/Event/AfterEveryFunctionCallAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterEveryFunctionCallAnalysisEvent.php
@@ -7,7 +7,7 @@ use Psalm\Codebase;
 use Psalm\Context;
 use Psalm\StatementsSource;
 
-class AfterEveryFunctionCallAnalysisEvent
+final class AfterEveryFunctionCallAnalysisEvent
 {
     /**
      * @var FuncCall
@@ -30,6 +30,7 @@ class AfterEveryFunctionCallAnalysisEvent
      */
     private $codebase;
 
+    /** @internal */
     public function __construct(
         FuncCall $expr,
         string $function_id,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterExpressionAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterExpressionAnalysisEvent.php
@@ -8,7 +8,7 @@ use Psalm\Context;
 use Psalm\FileManipulation;
 use Psalm\StatementsSource;
 
-class AfterExpressionAnalysisEvent
+final class AfterExpressionAnalysisEvent
 {
     /**
      * @var Expr
@@ -35,6 +35,7 @@ class AfterExpressionAnalysisEvent
      * Called after an expression has been checked
      *
      * @param  FileManipulation[]   $file_replacements
+     * @internal
      */
     public function __construct(
         Expr $expr,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterFileAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterFileAnalysisEvent.php
@@ -8,7 +8,7 @@ use Psalm\Context;
 use Psalm\StatementsSource;
 use Psalm\Storage\FileStorage;
 
-class AfterFileAnalysisEvent
+final class AfterFileAnalysisEvent
 {
     /**
      * @var StatementsSource
@@ -35,6 +35,7 @@ class AfterFileAnalysisEvent
      * Called after a file has been checked
      *
      * @param array<Stmt> $stmts
+     * @internal
      */
     public function __construct(
         StatementsSource $statements_source,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterFunctionCallAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterFunctionCallAnalysisEvent.php
@@ -9,7 +9,7 @@ use Psalm\FileManipulation;
 use Psalm\StatementsSource;
 use Psalm\Type\Union;
 
-class AfterFunctionCallAnalysisEvent
+final class AfterFunctionCallAnalysisEvent
 {
     /**
      * @var FuncCall
@@ -43,6 +43,7 @@ class AfterFunctionCallAnalysisEvent
     /**
      * @param non-empty-string $function_id
      * @param FileManipulation[] $file_replacements
+     * @internal
      */
     public function __construct(
         FuncCall $expr,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterFunctionLikeAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterFunctionLikeAnalysisEvent.php
@@ -10,7 +10,7 @@ use Psalm\NodeTypeProvider;
 use Psalm\StatementsSource;
 use Psalm\Storage\FunctionLikeStorage;
 
-class AfterFunctionLikeAnalysisEvent
+final class AfterFunctionLikeAnalysisEvent
 {
     /**
      * @var Node\FunctionLike
@@ -45,6 +45,7 @@ class AfterFunctionLikeAnalysisEvent
      * Called after a statement has been checked
      *
      * @param  FileManipulation[]   $file_replacements
+     * @internal
      */
     public function __construct(
         Node\FunctionLike $stmt,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterMethodCallAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterMethodCallAnalysisEvent.php
@@ -11,7 +11,7 @@ use Psalm\FileManipulation;
 use Psalm\StatementsSource;
 use Psalm\Type\Union;
 
-class AfterMethodCallAnalysisEvent
+final class AfterMethodCallAnalysisEvent
 {
     /**
      * @var MethodCall|StaticCall
@@ -53,6 +53,7 @@ class AfterMethodCallAnalysisEvent
     /**
      * @param  MethodCall|StaticCall $expr
      * @param  FileManipulation[] $file_replacements
+     * @internal
      */
     public function __construct(
         Expr $expr,

--- a/src/Psalm/Plugin/EventHandler/Event/AfterStatementAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterStatementAnalysisEvent.php
@@ -8,7 +8,7 @@ use Psalm\Context;
 use Psalm\FileManipulation;
 use Psalm\StatementsSource;
 
-class AfterStatementAnalysisEvent
+final class AfterStatementAnalysisEvent
 {
     /**
      * @var Stmt
@@ -35,6 +35,7 @@ class AfterStatementAnalysisEvent
      * Called after a statement has been checked
      *
      * @param  FileManipulation[]   $file_replacements
+     * @internal
      */
     public function __construct(
         Stmt $stmt,

--- a/src/Psalm/Plugin/EventHandler/Event/BeforeFileAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/BeforeFileAnalysisEvent.php
@@ -7,7 +7,7 @@ use Psalm\Context;
 use Psalm\StatementsSource;
 use Psalm\Storage\FileStorage;
 
-class BeforeFileAnalysisEvent
+final class BeforeFileAnalysisEvent
 {
     /**
      * @var StatementsSource
@@ -28,6 +28,7 @@ class BeforeFileAnalysisEvent
 
     /**
      * Called before a file has been checked
+     * @internal
      */
     public function __construct(
         StatementsSource $statements_source,

--- a/src/Psalm/Plugin/EventHandler/Event/FunctionExistenceProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/FunctionExistenceProviderEvent.php
@@ -4,7 +4,7 @@ namespace Psalm\Plugin\EventHandler\Event;
 
 use Psalm\StatementsSource;
 
-class FunctionExistenceProviderEvent
+final class FunctionExistenceProviderEvent
 {
     /**
      * @var StatementsSource
@@ -19,6 +19,8 @@ class FunctionExistenceProviderEvent
      * Use this hook for informing whether or not a global function exists. If you know the function does
      * not exist, return false. If you aren't sure if it exists or not, return null and the default analysis
      * will continue to determine if the function actually exists.
+     *
+     * @internal
      */
     public function __construct(
         StatementsSource $statements_source,

--- a/src/Psalm/Plugin/EventHandler/Event/FunctionParamsProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/FunctionParamsProviderEvent.php
@@ -7,7 +7,7 @@ use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\StatementsSource;
 
-class FunctionParamsProviderEvent
+final class FunctionParamsProviderEvent
 {
     /**
      * @var StatementsSource
@@ -32,6 +32,7 @@ class FunctionParamsProviderEvent
 
     /**
      * @param  list<PhpParser\Node\Arg>    $call_args
+     * @internal
      */
     public function __construct(
         StatementsSource $statements_source,

--- a/src/Psalm/Plugin/EventHandler/Event/FunctionReturnTypeProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/FunctionReturnTypeProviderEvent.php
@@ -7,7 +7,7 @@ use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\StatementsSource;
 
-class FunctionReturnTypeProviderEvent
+final class FunctionReturnTypeProviderEvent
 {
     /**
      * @var StatementsSource
@@ -36,6 +36,7 @@ class FunctionReturnTypeProviderEvent
      * if something should be returned, but can't be more specific.
      *
      * @param non-empty-string $function_id
+     * @internal
      */
     public function __construct(
         StatementsSource $statements_source,

--- a/src/Psalm/Plugin/EventHandler/Event/MethodExistenceProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/MethodExistenceProviderEvent.php
@@ -5,7 +5,7 @@ namespace Psalm\Plugin\EventHandler\Event;
 use Psalm\CodeLocation;
 use Psalm\StatementsSource;
 
-class MethodExistenceProviderEvent
+final class MethodExistenceProviderEvent
 {
     /**
      * @var string
@@ -28,6 +28,8 @@ class MethodExistenceProviderEvent
      * Use this hook for informing whether or not a method exists on a given object. If you know the method does
      * not exist, return false. If you aren't sure if it exists or not, return null and the default analysis will
      * continue to determine if the method actually exists.
+     *
+     * @internal
      */
     public function __construct(
         string $fq_classlike_name,

--- a/src/Psalm/Plugin/EventHandler/Event/MethodParamsProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/MethodParamsProviderEvent.php
@@ -7,7 +7,7 @@ use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\StatementsSource;
 
-class MethodParamsProviderEvent
+final class MethodParamsProviderEvent
 {
     /**
      * @var string
@@ -36,6 +36,7 @@ class MethodParamsProviderEvent
 
     /**
      * @param  list<PhpParser\Node\Arg>    $call_args
+     * @internal
      */
     public function __construct(
         string $fq_classlike_name,

--- a/src/Psalm/Plugin/EventHandler/Event/MethodReturnTypeProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/MethodReturnTypeProviderEvent.php
@@ -8,7 +8,7 @@ use Psalm\Context;
 use Psalm\StatementsSource;
 use Psalm\Type\Union;
 
-class MethodReturnTypeProviderEvent
+final class MethodReturnTypeProviderEvent
 {
     /**
      * @var StatementsSource
@@ -56,6 +56,8 @@ class MethodReturnTypeProviderEvent
      * @param  ?array<Union> $template_type_parameters
      * @param lowercase-string $method_name_lowercase
      * @param lowercase-string $called_method_name_lowercase
+     *
+     * @internal
      */
     public function __construct(
         StatementsSource $source,

--- a/src/Psalm/Plugin/EventHandler/Event/MethodVisibilityProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/MethodVisibilityProviderEvent.php
@@ -6,7 +6,7 @@ use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\StatementsSource;
 
-class MethodVisibilityProviderEvent
+final class MethodVisibilityProviderEvent
 {
     /**
      * @var StatementsSource
@@ -29,6 +29,7 @@ class MethodVisibilityProviderEvent
      */
     private $code_location;
 
+    /** @internal */
     public function __construct(
         StatementsSource $source,
         string $fq_classlike_name,

--- a/src/Psalm/Plugin/EventHandler/Event/PropertyExistenceProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/PropertyExistenceProviderEvent.php
@@ -6,7 +6,7 @@ use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\StatementsSource;
 
-class PropertyExistenceProviderEvent
+final class PropertyExistenceProviderEvent
 {
     /**
      * @var string
@@ -38,6 +38,7 @@ class PropertyExistenceProviderEvent
      * not exist, return false. If you aren't sure if it exists or not, return null and the default analysis will
      * continue to determine if the property actually exists.
      *
+     * @internal
      */
     public function __construct(
         string $fq_classlike_name,

--- a/src/Psalm/Plugin/EventHandler/Event/PropertyTypeProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/PropertyTypeProviderEvent.php
@@ -5,7 +5,7 @@ namespace Psalm\Plugin\EventHandler\Event;
 use Psalm\Context;
 use Psalm\StatementsSource;
 
-class PropertyTypeProviderEvent
+final class PropertyTypeProviderEvent
 {
     /**
      * @var string
@@ -28,6 +28,7 @@ class PropertyTypeProviderEvent
      */
     private $context;
 
+    /** @internal */
     public function __construct(
         string $fq_classlike_name,
         string $property_name,

--- a/src/Psalm/Plugin/EventHandler/Event/PropertyVisibilityProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/PropertyVisibilityProviderEvent.php
@@ -6,7 +6,7 @@ use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\StatementsSource;
 
-class PropertyVisibilityProviderEvent
+final class PropertyVisibilityProviderEvent
 {
     /**
      * @var StatementsSource
@@ -33,6 +33,7 @@ class PropertyVisibilityProviderEvent
      */
     private $code_location;
 
+    /** @internal */
     public function __construct(
         StatementsSource $source,
         string $fq_classlike_name,

--- a/src/Psalm/Plugin/EventHandler/Event/StringInterpreterEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/StringInterpreterEvent.php
@@ -2,7 +2,7 @@
 
 namespace Psalm\Plugin\EventHandler\Event;
 
-class StringInterpreterEvent
+final class StringInterpreterEvent
 {
     /**
      * @var string
@@ -11,6 +11,8 @@ class StringInterpreterEvent
 
     /**
      * Called after a statement has been checked
+     *
+     * @internal
      */
     public function __construct(string $value)
     {


### PR DESCRIPTION
This makes all event (`Psalm\Plugin\EventHandler\Event\*`) classes `final`, allowing us to add methods to them without breaking BC.

Additionally, all constructors of those classes are made `@internal` as plugins are not supposed to emit events.