### PR TITLE
Fix failing case for const analyzer.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
+          ini-values: zend.assertions=1, assert.exception=1
           tools: composer:v2
           coverage: none
           extensions: decimal

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -49,6 +49,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.0'
+          ini-values: zend.assertions=1, assert.exception=1
           tools: composer:v2
           coverage: none
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
@@ -837,6 +837,10 @@ class ClassConstAnalyzer
             }
         }
 
+        if ($parent_const_storage === null) {
+            $parent_const_storage = $interface_const_storage;
+        }
+
         foreach ($interface_overrides as $_ => $issue) {
             IssueBuffer::maybeAdd(
                 $issue,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
@@ -759,7 +759,7 @@ class ClassConstAnalyzer
     /**
      * Get the const storage from the parent or interface that this class is overriding.
      *
-     * @return array{ClassLikeStorage, ?ClassConstantStorage}|null
+     * @return array{ClassLikeStorage, ClassConstantStorage}|null
      */
     private static function getOverriddenConstant(
         ClassLikeStorage $class_storage,
@@ -845,6 +845,7 @@ class ClassConstAnalyzer
         }
 
         if ($parent_classlike_storage !== null) {
+            assert($parent_const_storage !== null);
             return [$parent_classlike_storage, $parent_const_storage];
         }
         return null;

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -447,9 +447,9 @@ class ConstantTest extends TestCase
                             return self::C;
                         }
                     }',
-                [],
-                [],
-                '8.1',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
             'resolveCalculatedConstant' => [
                 'code' => '<?php
@@ -1364,9 +1364,9 @@ class ConstantTest extends TestCase
                         public const BAR="foobar";
                     }
                 ',
-                [],
-                [],
-                '8.1',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
             'inheritedConstDoesNotOverride' => [
                 'code' => '<?php
@@ -1822,6 +1822,25 @@ class ConstantTest extends TestCase
                     }
                 ',
                 'error_message' => 'OverriddenInterfaceConstant',
+            ],
+            'overrideClassConstFromInterfaceWithExtraIrrelevantInterface' => [
+                'code' => '<?php
+                    interface Foo
+                    {
+                        /** @var non-empty-string */
+                        public const BAR="baz";
+                    }
+
+                    interface Bar {}
+
+                    class Baz implements Foo, Bar
+                    {
+                        public const BAR="";
+                    }
+                ',
+                'error_message' => "LessSpecificClassConstantType",
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
         ];
     }


### PR DESCRIPTION
Adding an extra interface causes the constant storage to be set to null, so the analysis doesn't finish properly. This should fix that case, as well as enable assertions on CI runs so that failing assertions can be caught sooner.

Thanks @muglug for noticing! I'm running tests with assertions enabled locally from now on!