### PR TITLE
InternalTaintSinkMap: Add `getimagesize` as SSRF sink

### DIFF
--- a/dictionaries/InternalTaintSinkMap.php
+++ b/dictionaries/InternalTaintSinkMap.php
@@ -62,4 +62,5 @@ return [
 'proc_open' => [['shell']],
 'curl_init' => [['ssrf']],
 'curl_setopt' => [[], [], ['ssrf']],
+'getimagesize' => [['ssrf']],
 ];


### PR DESCRIPTION
Hi, 

I hope this was the right place. I wasn't able to figure out which sinks go into `stubs/` and which into this map. :)

Demo of the sink:

![image](https://user-images.githubusercontent.com/45886910/151539885-c654ab4e-b7dd-4361-8e9c-8be6c299945f.png)


