### PR TITLE
Fix side effect when loading config

### DIFF
--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -1531,6 +1531,7 @@ class ConfigTest extends TestCase
 
     public function testConfigFileWithXIncludeWithoutFallbackShouldThrowException(): void
     {
+        $this->expectException(ConfigException::class);
         $this->expectExceptionMessageMatches('/and no fallback was found/');
         ErrorHandler::install();
         Config::loadFromXML(


### PR DESCRIPTION
Loading the config currently sets `libxml_use_internal_errors(true)` and never changes it back. This fixes that side effect and also ensures that xml errors from `loadDomDocument` get thrown as `ConfigException` rather than `RuntimeException`.