### PR TITLE
Fix empty array

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -1099,10 +1099,7 @@ class ArrayFetchAnalyzer
     ): void {
         $has_array_access = true;
 
-        if ($in_assignment
-            && $type instanceof TArray
-            && $type->isEmptyArray()
-        ) {
+        if ($in_assignment && $type instanceof TArray) {
             $from_empty_array = $type->isEmptyArray();
 
             if (count($key_values) === 1) {

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -527,7 +527,16 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                 $did_remove_type = true;
 
                 $existing_var_type->removeType('array');
-            } elseif (!($array_atomic_type instanceof TArray && $array_atomic_type->isEmptyArray())) {
+            } elseif ($array_atomic_type instanceof TKeyedArray) {
+                $did_remove_type = true;
+
+                foreach ($array_atomic_type->properties as $property_type) {
+                    if (!$property_type->possibly_undefined) {
+                        $did_remove_type = false;
+                        break;
+                    }
+                }
+            } elseif (!$array_atomic_type instanceof TArray || !$array_atomic_type->isEmptyArray()) {
                 $did_remove_type = true;
 
                 if (!$min_count) {
@@ -537,15 +546,6 @@ class SimpleNegatedAssertionReconciler extends Reconciler
                             new Union([new TNever()]),
                         ]
                     ));
-                }
-            } elseif ($array_atomic_type instanceof TKeyedArray) {
-                $did_remove_type = true;
-
-                foreach ($array_atomic_type->properties as $property_type) {
-                    if (!$property_type->possibly_undefined) {
-                        $did_remove_type = false;
-                        break;
-                    }
                 }
             }
 

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -371,7 +371,7 @@ class ArrayAssignmentTest extends TestCase
                     $a = [];
                     $a["foo"] = ["bar" => "baz"];',
                 'assertions' => [
-                    '$a' => 'non-empty-array<string, non-empty-array<string, string>>',
+                    '$a' => 'array{foo: array{bar: string}}<string, array<string, string>>',
                 ],
             ],
             'additionWithEmpty' => [


### PR DESCRIPTION
This fixes two oddities  in the code that became visible after I introduced isEmptyArray on a previous PR.

First, on ArrayFetchAnalyzer.php we were setting two variables from_empty_array and from_mixed_array after we already stated that the array was empty. Those variables had only one possible value so I removed them

Second, on SimpleNegatedAssertionReconciler.php, the original code on line 530 was `$array_atomic_type->getId() !== 'array<never, never>'` that means that the only way not to enter the next conditional was to have an empty array but the next conditional checks `$array_atomic_type instanceof TKeyedArray` which is not compatible with `array<never, never>`, making it dead code.

However, I'm not sure my fixes are optimal.

On the first, the code was clearly meant for handling more than empty arrays, so maybe I should have dropped the isEmptyArray in conditional and that would have worked better

On the second, I just placed the dead condition up in the code but I didn't even read the code or tested it, so not sure it will work right.

I'm opening this not to forget about the issue and to open a discussion if someone has hints