### PR TITLE
Add command to generate stubs for PHP extensions.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -24,3 +24,4 @@
 /.scrutinizer.yml export-ignore
 /tests export-ignore
 /vendor-bin export-ignore
+/stubs/extensions/reflection-generated export-ignore

--- a/docs/contributing/adding_an_extension.md
+++ b/docs/contributing/adding_an_extension.md
@@ -5,7 +5,7 @@ those extensions installed at runtime. When an extension isn't already supported
 Psalm will use reflection to support it as best as possible, but it's always better to have stubs. In addition to
 allowing analysis without having the extension installed, stubs can be more accurate. The gmp and decimal extensions
 have a lot of functions that use `numeric-string` instead of `string`, and many extension like Ds, DOM, and others use
-templates. Most extensions can be improved by using Psalm features that aren't possible from reflection alone.
+templates. Most extension stubs can be improved by using Psalm features that aren't possible from reflection alone.
 
 ## Using the stub generator
 

--- a/docs/contributing/adding_an_extension.md
+++ b/docs/contributing/adding_an_extension.md
@@ -32,7 +32,8 @@ the stub isn't missing anything that shows up in the reflection generated stub.
 
 When adding support for a different version of an extension, diff the reflection-generated
 stubs to see what has changed between the versions and update `stubs/extensions/[extension-name-lowercase].phpstub` as
-necessary (support for multiple versions is very limited until #7512 is done).
+necessary (support for multiple versions is very limited until [#7512](https://github.com/vimeo/psalm/issues/7512) is
+done).
 
 ## Adding the extension to the supported extensions lists
 

--- a/docs/contributing/adding_an_extension.md
+++ b/docs/contributing/adding_an_extension.md
@@ -1,0 +1,28 @@
+# Adding an extension
+
+Psalm tries to support most extensions with stubs so that projects requiring extensions can be analyzed without having
+those extensions installed at runtime. When an extension isn't already supported by Psalm, if it is loaded at runtime
+Psalm will use reflection to support it as best as possible, but it's always better to have stubs. In addition to
+allowing analysis without having the extension installed, stubs can be more accurate. The gmp and decimal extensions
+have a lot of functions that use `numeric-string` instead of `string`, and many extension like Ds, DOM, and others use
+templates. Most extensions can be improved by using Psalm features that aren't possible from reflection alone.
+
+## Using the stub generator
+
+We try to make adding support for an extension as easy as possible by providing a simple way to generate stubs with
+reflection, but keep in mind that reflection can miss a lot of useful information:
+
+ - Which `@throws` tags should be added to a method
+ - Psalm specific types like `numeric-string`, `int<0, max>`, or `non-empty-list`.
+ - [Templates](../annotating_code/templated_annotations.md)
+
+To use the extension stub generator, simply run `psalm --generate-extension-stub [extension-name]`. If you're working on
+Psalm directly, you can direct the output like `psalm --generate-extension-stub [extension-name]
+>stubs/extensions/[extension-name-lowercase].phpstub`, otherwise you can copy the output into a GitHub issue or Gist to
+help us add support for the extension.
+
+## Adding the extension to the supported extensions lists
+
+There are two places each extension needs added for it to work, the `"ExtensionType"` element in config.xsd and the
+`$php_extensions` property in `Psalm\Config`. Once the extension is in both lists and the stubfile exists, the extension
+stubs will be loaded automatically based on a project's composer.json and psalm.xml.

--- a/docs/contributing/adding_an_extension.md
+++ b/docs/contributing/adding_an_extension.md
@@ -18,8 +18,21 @@ reflection, but keep in mind that reflection can miss a lot of useful informatio
 
 To use the extension stub generator, simply run `psalm --generate-extension-stub [extension-name]`. If you're working on
 Psalm directly, you can direct the output like `psalm --generate-extension-stub [extension-name]
->stubs/extensions/[extension-name-lowercase].phpstub`, otherwise you can copy the output into a GitHub issue or Gist to
-help us add support for the extension.
+>stubs/extensions/reflection-generated/[extension-name-lowercase]-[extension-version].phpstub`, otherwise you can copy
+the output into a GitHub issue or Gist to help us add support for the extension.
+
+## Updating stubs
+
+Generated stubs are kept for each version of an extension in `stubs/extensions/reflection-generated`.
+
+When adding a new extension, simply copy the generated stub to `stubs/extensions/[extension-name-lowercase].phpstub` and
+update as necessary with Psalm types. Alternatively, if the extension provides its own stub somewhere that includes
+things like `@throws` tags or other features reflection isn't able to provide, use that as a base, but make sure
+the stub isn't missing anything that shows up in the reflection generated stub.
+
+When adding support for a different version of an extension, diff the reflection-generated
+stubs to see what has changed between the versions and update `stubs/extensions/[extension-name-lowercase].phpstub` as
+necessary (support for multiple versions is very limited until #7512 is done).
 
 ## Adding the extension to the supported extensions lists
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -14,6 +14,8 @@ I've also put together [a list of Psalm’s complexities](what_makes_psalm_compl
 
 Are you looking for low-hanging fruit? Here are some [GitHub issues](https://github.com/vimeo/psalm/issues?q=is%3Aissue+is%3Aopen+label%3A%22easy+problems%22) that shouldn't be too difficult to resolve.
 
+[Adding support for an extension](adding_an_extension.md) is another easy way to get started.
+
 ### Don’t be afraid!
 
 One great thing about working on Psalm is that it’s _very_ hard to introduce any sort of type error in Psalm’s codebase. There are almost 5,000 PHPUnit tests, so the risk of you messing up (without the CI system noticing) is very small.

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -593,7 +593,10 @@ class Config
         "xdebug" => false,
     ];
 
-    protected function __construct()
+    /**
+     * @internal
+     */
+    public function __construct()
     {
         self::$instance = $this;
         $this->eventDispatcher = new EventDispatcher();

--- a/src/Psalm/Internal/Cli/GenerateExtensionStub.php
+++ b/src/Psalm/Internal/Cli/GenerateExtensionStub.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Psalm\Internal\Cli;
+
+use Composer\InstalledVersions;
+use Psalm\Internal\CliUtils;
+use Psalm\Internal\ExtensionStubGenerator\Command\GenerateExtensionStubCommand;
+use Symfony\Component\Console\Application;
+
+use function getcwd;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * @internal
+ */
+final class GenerateExtensionStub
+{
+    public static function run(): void
+    {
+        $current_dir = (string)getcwd() . DIRECTORY_SEPARATOR;
+        $vendor_dir = CliUtils::getVendorDir($current_dir);
+        CliUtils::requireAutoloaders($current_dir, false, $vendor_dir);
+
+        $app = new Application("generate-extension-stub", InstalledVersions::getVersion("vimeo/psalm") ?? "unknown");
+
+        $app->add(new GenerateExtensionStubCommand());
+
+        $app->setDefaultCommand("generate-extension-stub", true);
+        $app->run();
+    }
+}

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -1342,6 +1342,7 @@ final class Psalm
 
             --generate-extension-stub
                 Generate stubs for a PHP extension.
+                EXPERIMENTAL: This option may be removed in a future version.
 
         HELP;
     }

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -143,6 +143,7 @@ final class Psalm
         'php-version:',
         'generate-json-map:',
         'generate-stubs:',
+        'generate-extension-stub',
         'alter',
         'language-server',
         'refactor',
@@ -943,6 +944,12 @@ final class Psalm
             Refactor::run($argv);
             exit;
         }
+
+        if (isset($options['generate-extension-stub'])) {
+            require_once __dir__ . "/GenerateExtensionStub.php";
+            GenerateExtensionStub::run();
+            exit;
+        }
     }
 
     /**
@@ -1332,6 +1339,9 @@ final class Psalm
 
             --language-server
                 Run Psalm Language Server
+
+            --generate-extension-stub
+                Generate stubs for a PHP extension.
 
         HELP;
     }

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -54,11 +54,15 @@ class Reflection
      */
     private static $builtin_functions = [];
 
+    /**
+     * @var array<string, Union>
+     */
+    private static $builtin_constants = [];
+
     public function __construct(ClassLikeStorageProvider $storage_provider, Codebase $codebase)
     {
         $this->storage_provider = $storage_provider;
         $this->codebase = $codebase;
-        self::$builtin_functions = [];
     }
 
     public function registerClass(ReflectionClass $reflected_class): void
@@ -419,6 +423,16 @@ class Reflection
         return null;
     }
 
+    /**
+     * @param array|scalar|null $constant_type
+     */
+    public function registerConstant(string $constant_name, $constant_type): void
+    {
+        self::$builtin_constants[$constant_name] = new Union([
+            ConstantTypeResolver::getLiteralTypeFromScalarValue($constant_type),
+        ]);
+    }
+
     public static function getPsalmTypeFromReflectionType(?ReflectionType $reflection_type = null): Union
     {
         if (!$reflection_type) {
@@ -540,8 +554,17 @@ class Reflection
         return self::$builtin_functions;
     }
 
+    /**
+     * @return array<string, Union>
+     */
+    public function getConstants(): array
+    {
+        return self::$builtin_constants;
+    }
+
     public static function clearCache(): void
     {
         self::$builtin_functions = [];
+        self::$builtin_constants = [];
     }
 }

--- a/src/Psalm/Internal/ExtensionStubGenerator/Command/GenerateExtensionStubCommand.php
+++ b/src/Psalm/Internal/ExtensionStubGenerator/Command/GenerateExtensionStubCommand.php
@@ -67,7 +67,6 @@ class GenerateExtensionStubCommand extends Command
             return 1;
         }
 
-
         $extension_reflection = new ReflectionExtension($extension_name);
         $extension_version = $extension_reflection->getVersion();
 

--- a/src/Psalm/Internal/ExtensionStubGenerator/Command/GenerateExtensionStubCommand.php
+++ b/src/Psalm/Internal/ExtensionStubGenerator/Command/GenerateExtensionStubCommand.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Psalm\Internal\ExtensionStubGenerator\Command;
+
+use Psalm\Config;
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\Internal\Codebase\Reflection;
+use Psalm\Internal\Provider\FakeFileProvider;
+use Psalm\Internal\Provider\Providers;
+use Psalm\Internal\Stubs\Generator\StubsGenerator;
+use ReflectionExtension;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
+use Symfony\Component\Console\Output\NullOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use UnexpectedValueException;
+
+use function array_flip;
+use function array_intersect_key;
+use function array_map;
+use function assert;
+use function extension_loaded;
+use function is_array;
+use function is_scalar;
+use function is_string;
+
+use const PHP_VERSION;
+
+/**
+ * @internal
+ */
+class GenerateExtensionStubCommand extends Command
+{
+    public function __construct()
+    {
+        parent::__construct("generate-extension-stub");
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->setDescription('Generates stubs for an extension using the PHP Reflection API')
+            // Don't actually care about this, but it's required due to the way the command is forwarded
+            ->addOption("--generate-extension-stub")
+            ->addArgument(
+                'extensionName',
+                InputArgument::REQUIRED,
+                'Extension name'
+            )
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $errorOutput = $output instanceof ConsoleOutputInterface ? $output->getErrorOutput() : new NullOutput();
+
+        $extension_name = $input->getArgument('extensionName');
+        if (!is_string($extension_name)) {
+            throw new UnexpectedValueException('Extension name should be a string');
+        }
+
+        if (!extension_loaded($extension_name)) {
+            $errorOutput->writeln("Extension not loaded. An extension must be loaded to generate stubs for it.");
+            return 1;
+        }
+
+
+        $extension_reflection = new ReflectionExtension($extension_name);
+        $extension_version = $extension_reflection->getVersion();
+
+        $providers = new Providers(new FakeFileProvider());
+        $project_analyzer = new ProjectAnalyzer(new Config(), $providers);
+        $codebase = $project_analyzer->getCodebase();
+        $reflection = new Reflection($providers->classlike_storage_provider, $codebase);
+
+        foreach ($extension_reflection->getClasses() as $class_reflection) {
+            $reflection->registerClass($class_reflection);
+        }
+
+        // Registering classes also registers their parents, so we need to
+        // filter out parent classlikes that aren't defined by this extension.
+        $classlike_storages = array_intersect_key(
+            $providers->classlike_storage_provider->getAll(),
+            array_flip(array_map("strtolower", $extension_reflection->getClassNames())),
+        );
+
+        foreach ($extension_reflection->getFunctions() as $function_reflection) {
+            $function_name = $function_reflection->getName();
+            assert($function_name);
+            $reflection->registerFunction($function_name);
+        }
+
+        /** @var mixed $const_type */
+        foreach ($extension_reflection->getConstants() as $const_name => $const_type) {
+            if (!is_array($const_type) && !is_scalar($const_type) && $const_type !== null) {
+                throw new RuntimeException("Unexpected type for constant \"$const_name\"");
+            }
+            $reflection->registerConstant($const_name, $const_type);
+        }
+
+        $namespaced_nodes = [];
+        StubsGenerator::addConstantStubs($namespaced_nodes, $reflection->getConstants());
+        StubsGenerator::addFunctionStubs($namespaced_nodes, $reflection->getFunctions());
+        StubsGenerator::addClassLikeStubs($namespaced_nodes, $classlike_storages, $codebase);
+
+        $output->writeln(StubsGenerator::printNamespacedNodes(
+            $namespaced_nodes,
+            "// Stub generated with PHP " . PHP_VERSION . ", $extension_name $extension_version",
+        ));
+
+        return 0;
+    }
+}

--- a/tests/ExtensionStubGeneratorTest.php
+++ b/tests/ExtensionStubGeneratorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Psalm\Tests;
+
+use Psalm\Internal\ExtensionStubGenerator\Command\GenerateExtensionStubCommand;
+use Psalm\Internal\RuntimeCaches;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Exception\RuntimeException;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/** @group PluginManager */
+class ExtensionStubGeneratorTest extends TestCase
+{
+    /** @var Application */
+    private $app;
+
+    public function setUp(): void
+    {
+        RuntimeCaches::clearAll();
+        $this->app = new Application("extension-stub-generator", "0.1");
+        $this->app->add(new GenerateExtensionStubCommand());
+        $this->app->setDefaultCommand("generate-extension-stub", true);
+    }
+
+    public function testErrorWhenExtensionMissing(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage("Not enough arguments");
+
+        $command = new CommandTester($this->app->find("generate-extension-stub"));
+        $command->execute([]);
+    }
+
+    public function testErrorWhenExtensionNotEnabled(): void
+    {
+        $command = new CommandTester($this->app->find("generate-extension-stub"));
+        $command->execute(["extensionName" => "extension_thats_not_enabled"], ["capture_stderr_separately" => true]);
+
+        $output = $command->getErrorOutput();
+        $this->assertStringContainsString("Extension not loaded. An extension must be loaded to generate stubs for it.", $output);
+    }
+
+    public function testGenerateXmlStub(): void
+    {
+        $command = new CommandTester($this->app->find("generate-extension-stub"));
+        $command->execute(["extensionName" => "xml"], ["capture_stderr_separately" => true]);
+
+        $output = $command->getDisplay();
+
+        // Make sure at least one class, const, and function exists in the output
+        $this->assertStringContainsString("class XMLParser", $output);
+        $this->assertStringContainsString("const XML_ERROR_ASYNC_ENTITY", $output);
+        $this->assertStringContainsString("function xml_error_string(", $output);
+
+        // Make sure there were no warnings or errors
+        $this->assertEquals("", $command->getErrorOutput());
+    }
+}

--- a/tests/ExtensionStubGeneratorTest.php
+++ b/tests/ExtensionStubGeneratorTest.php
@@ -8,7 +8,6 @@ use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Exception\RuntimeException;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/** @group PluginManager */
 class ExtensionStubGeneratorTest extends TestCase
 {
     /** @var Application */


### PR DESCRIPTION
Fixes #7513.

I think extension stubs will require enough manual modification that using a different stubfile for each version will require too much duplicated effort. I'm thinking we should do something like this, using xml as an example:

Add a `stubs/extensions/reflection-generated/xml` directory. Stubs under the `reflection-generated` won't ever be loaded, they're just there for diffing.

When initially adding support, run `./psalm --generate-extension-stub xml >stubs/extensions/reflection-generated/xml/xml-7.4.0.phpstub` (using the extension's version, not PHP's version, but many extensions track the PHP version). Then copy that generated stub to `stubs/extensions/xml.phpstub` and modify it as necessary.

When updating an extension to support a new version, run `./psalm --generate-extension-stub xml >stubs/extensions/reflection-generated/xml/xml-8.1.0.phpstub`. Then the reflected stubs can be diffed with `diff stubs/extensions/reflection-generated/xml/xml-{7.4.0,8.1.0}.phpstub`, and that diff can be used as a starting point for what modifications will be needed in `stubs/extensions/xml.phpstub`.

Thoughts, criticisms, improvements?