### PR TITLE
Update .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,6 +6,8 @@
 /.circleci export-ignore
 /CODE_OF_CONDUCT.md export-ignore
 /CONTRIBUTING.md export-ignore
+/UPGRADING.md export-ignore
+/psalm-baseline.xml export-ignore
 /dictionaries/scripts export-ignore
 /docs export-ignore
 /.editorconfig export-ignore
@@ -24,3 +26,5 @@
 /.scrutinizer.yml export-ignore
 /tests export-ignore
 /vendor-bin export-ignore
+
+*.phpstub linguist-language=PHP


### PR DESCRIPTION
* Do not ship baseline and `UPGRADING.md` in dist packages
* Mark `.phpstub` as PHP to fix Github syntax highlighting