### PR TITLE
Fix for Exception->getCode return type provider

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -98,7 +98,7 @@ class MethodCallReturnTypeFetcher
         if ($premixin_method_id->method_name === 'getcode'
             && $premixin_method_id->fq_class_name !== Exception::class
             && (
-                in_array(Throwable::class, $class_storage->class_implements)
+                $codebase->classImplements($premixin_method_id->fq_class_name, Throwable::class)
                 || $codebase->interfaceExtends($premixin_method_id->fq_class_name, Throwable::class)
             )
         ) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -97,7 +97,11 @@ class MethodCallReturnTypeFetcher
 
         if ($premixin_method_id->method_name === 'getcode'
             && $premixin_method_id->fq_class_name !== Exception::class
-            && in_array(Throwable::class, $class_storage->class_implements)) {
+            && (
+                in_array(Throwable::class, $class_storage->class_implements)
+                || $codebase->interfaceExtends($premixin_method_id->fq_class_name, Throwable::class)
+            )
+        ) {
             if ($premixin_method_id->fq_class_name === PDOException::class) {
                 return Type::getString();
             } else {

--- a/tests/ReturnTypeProvider/ExceptionCodeTest.php
+++ b/tests/ReturnTypeProvider/ExceptionCodeTest.php
@@ -35,14 +35,23 @@ class ExceptionCodeTest extends TestCase
             ',
             [],
         ];
-        yield 'Exception' => [
+        yield 'CustomThrowable' => [
+            '<?php
+                interface CustomThrowable extends \Throwable {}
+
+                /** @var CustomThrowable $e */
+                $code = $e->getCode();
+            ',
+            ['$code' => 'int'],
+        ];
+        yield 'Throwable' => [
             '<?php
                 /** @var \Throwable $e */
                 $code = $e->getCode();
             ',
             ['$code' => 'int|string'],
         ];
-        yield 'Throwable' => [
+        yield 'Exception' => [
             '<?php
                 /** @var \Exception $e */
                 $code = $e->getCode();


### PR DESCRIPTION
@orklah, I found one case when the solution we implements doesn't work.

It's when you're working with an interface extending `Throwable`.
`getCode` is supposed to return `int`, but psalm doesn't understand it because 
```
in_array(Throwable::class, $class_storage->class_implements)
```
return false.