### PR TITLE
[TASK] Add AfterFunctionLikeAnalysisEvent::getFunctionlikeStorage

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -209,3 +209,5 @@
    - `Psalm\PluginRegistrationSocket::getAdditionalFileExtensions` was removed
    - `Psalm\PluginRegistrationSocket::addFileExtension` was removed
    - :information_source: migration possible using `Psalm\PluginFileExtensionsSocket`
+ - [BC] Method `\Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent::getClasslikeStorage()` was removed,
+   use correct `\Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent::getFunctionlikeStorage()` instead

--- a/src/Psalm/Plugin/EventHandler/Event/AfterFunctionLikeAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterFunctionLikeAnalysisEvent.php
@@ -70,14 +70,6 @@ final class AfterFunctionLikeAnalysisEvent
         return $this->stmt;
     }
 
-    /**
-     * @deprecated Will be removed in Psalm v5.0, use getFunctionlikeStorage() instead
-     */
-    public function getClasslikeStorage(): FunctionLikeStorage
-    {
-        return $this->functionlike_storage;
-    }
-
     public function getFunctionlikeStorage(): FunctionLikeStorage
     {
         return $this->functionlike_storage;


### PR DESCRIPTION
AfterFunctionLikeAnalysisEvent's method `getClasslikeStorage` actually
returned the current `FunctionLikeStorage`. This change streamlines the
naming and adds corresponding `getFunctionlikeStorage` method.

Releases: 5.0

---
4.x deprecation: #7532