### PR TITLE
[FEATURE] Allow to intercept adding issue in IssueBuffer

### DIFF
--- a/docs/running_psalm/plugins/authoring_plugins.md
+++ b/docs/running_psalm/plugins/authoring_plugins.md
@@ -81,6 +81,7 @@ class SomePlugin implements \Psalm\Plugin\EventHandler\AfterStatementAnalysisInt
 - `AfterFunctionLikeAnalysisInterface` - called after Psalm has completed its analysis of a given function-like.
 - `AfterMethodCallAnalysisInterface` - called after Psalm analyzes a method call.
 - `AfterStatementAnalysisInterface` - called after Psalm evaluates an statement.
+- `BeforeAddIssueInterface` - called before Psalm adds an item to it's internal `IssueBuffer`, allows handling code issues individually
 - `BeforeFileAnalysisInterface` - called before Psalm analyzes a file.
 - `FunctionExistenceProviderInterface` - can be used to override Psalm's builtin function existence checks for one or more functions.
 - `FunctionParamsProviderInterface.php` - can be used to override Psalm's builtin function parameter lookup for one or more functions.

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -16,6 +16,7 @@ use Psalm\Issue\MixedIssue;
 use Psalm\Issue\TaintedInput;
 use Psalm\Issue\UnusedPsalmSuppress;
 use Psalm\Plugin\EventHandler\Event\AfterAnalysisEvent;
+use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
 use Psalm\Report\CheckstyleReport;
 use Psalm\Report\CodeClimateReport;
 use Psalm\Report\CompactReport;
@@ -249,6 +250,11 @@ class IssueBuffer
     public static function add(CodeIssue $e, bool $is_fixable = false): bool
     {
         $config = Config::getInstance();
+
+        $event = new BeforeAddIssueEvent($e, $is_fixable);
+        if ($config->eventDispatcher->dispatchBeforeAddIssue($event) === false) {
+            return false;
+        };
 
         $fqcn_parts = explode('\\', get_class($e));
         $issue_type = array_pop($fqcn_parts);

--- a/src/Psalm/Plugin/EventHandler/BeforeAddIssueInterface.php
+++ b/src/Psalm/Plugin/EventHandler/BeforeAddIssueInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Plugin\EventHandler;
+
+use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
+
+interface BeforeAddIssueInterface
+{
+    /**
+     * Called before adding a code issue.
+     *
+     * @param BeforeAddIssueEvent $event
+     * @return null|bool $event How and whether to continue:
+     *  + `null` continues with next event handler
+     *  + `true` stops event handling & keeps issue
+     *  + `false` stops event handling & ignores issue
+     */
+    public static function beforeAddIssue(BeforeAddIssueEvent $event): ?bool;
+}

--- a/src/Psalm/Plugin/EventHandler/BeforeAddIssueInterface.php
+++ b/src/Psalm/Plugin/EventHandler/BeforeAddIssueInterface.php
@@ -11,6 +11,10 @@ interface BeforeAddIssueInterface
     /**
      * Called before adding a code issue.
      *
+     * Note that event handlers are called in the order they were registered, and thus
+     * the handler registered earlier may prevent subsequent handlers from running by
+     * returning a boolean value.
+     *
      * @param BeforeAddIssueEvent $event
      * @return null|bool $event How and whether to continue:
      *  + `null` continues with next event handler

--- a/src/Psalm/Plugin/EventHandler/Event/BeforeAddIssueEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/BeforeAddIssueEvent.php
@@ -18,6 +18,7 @@ final class BeforeAddIssueEvent
      */
     private bool $fixable;
 
+    /** @internal */
     public function __construct(CodeIssue $issue, bool $fixable)
     {
         $this->issue = $issue;

--- a/src/Psalm/Plugin/EventHandler/Event/BeforeAddIssueEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/BeforeAddIssueEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Plugin\EventHandler\Event;
+
+use Psalm\Issue\CodeIssue;
+
+class BeforeAddIssueEvent
+{
+    /**
+     * @var CodeIssue
+     */
+    private CodeIssue $issue;
+
+    /**
+     * @var bool
+     */
+    private bool $fixable;
+
+    public function __construct(CodeIssue $issue, bool $fixable)
+    {
+        $this->issue = $issue;
+        $this->fixable = $fixable;
+    }
+
+    public function getIssue(): CodeIssue
+    {
+        return $this->issue;
+    }
+
+    public function isFixable(): bool
+    {
+        return $this->fixable;
+    }
+}

--- a/src/Psalm/Plugin/EventHandler/Event/BeforeAddIssueEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/BeforeAddIssueEvent.php
@@ -6,7 +6,7 @@ namespace Psalm\Plugin\EventHandler\Event;
 
 use Psalm\Issue\CodeIssue;
 
-class BeforeAddIssueEvent
+final class BeforeAddIssueEvent
 {
     /**
      * @var CodeIssue


### PR DESCRIPTION
This change introduces new `BeforeAddIssueEvent` which is invoked
from `IssueBuffer::add`, which allows to collect and intercept code
issue in a generic way.

Resolves: #7528
