### PR TITLE
[TASK] Add AfterFunctionLikeAnalysisEvent::getFunctionlikeStorage

### DIFF
--- a/src/Psalm/Internal/EventDispatcher.php
+++ b/src/Psalm/Internal/EventDispatcher.php
@@ -578,7 +578,7 @@ class EventDispatcher
             $file_replacements = $event->getFileReplacements();
             if ($handler::afterStatementAnalysis(
                 $event->getStmt(),
-                $event->getClasslikeStorage(),
+                $event->getFunctionlikeStorage(),
                 $event->getStatementsSource(),
                 $event->getCodebase(),
                 $file_replacements

--- a/src/Psalm/Plugin/EventHandler/Event/AfterFunctionLikeAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterFunctionLikeAnalysisEvent.php
@@ -19,7 +19,7 @@ class AfterFunctionLikeAnalysisEvent
     /**
      * @var FunctionLikeStorage
      */
-    private $classlike_storage;
+    private $functionlike_storage;
     /**
      * @var StatementsSource
      */
@@ -48,7 +48,7 @@ class AfterFunctionLikeAnalysisEvent
      */
     public function __construct(
         Node\FunctionLike $stmt,
-        FunctionLikeStorage $classlike_storage,
+        FunctionLikeStorage $functionlike_storage,
         StatementsSource $statements_source,
         Codebase $codebase,
         array $file_replacements,
@@ -56,7 +56,7 @@ class AfterFunctionLikeAnalysisEvent
         Context $context
     ) {
         $this->stmt = $stmt;
-        $this->classlike_storage = $classlike_storage;
+        $this->functionlike_storage = $functionlike_storage;
         $this->statements_source = $statements_source;
         $this->codebase = $codebase;
         $this->file_replacements = $file_replacements;
@@ -69,9 +69,17 @@ class AfterFunctionLikeAnalysisEvent
         return $this->stmt;
     }
 
+    /**
+     * @deprecated Will be removed in Psalm v5.0, use getFunctionlikeStorage() instead
+     */
     public function getClasslikeStorage(): FunctionLikeStorage
     {
-        return $this->classlike_storage;
+        return $this->functionlike_storage;
+    }
+
+    public function getFunctionlikeStorage(): FunctionLikeStorage
+    {
+        return $this->functionlike_storage;
     }
 
     public function getStatementsSource(): StatementsSource


### PR DESCRIPTION
AfterFunctionLikeAnalysisEvent's method `getClasslikeStorage` actually
returned the current `FunctionLikeStorage`. This change streamlines the
naming and adds corresponding `getFunctionlikeStorage` method.

Method `getClasslikeStorage` is deprecated in will be removed
in Psalm v5.0.

Releases: 4.x, 5.0