### PR TITLE
add back empty keyword

### DIFF
--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -156,6 +156,7 @@ abstract class Atomic implements TypeNode
             case 'never-return':
             case 'never-returns':
             case 'no-return':
+            case 'empty':
                 return new TNever();
 
             case 'object':


### PR DESCRIPTION
The keyword `empty` changed meaning in a previous PR that was replacing the empty type by never. It became an assertion type at this moment.

Assertion types were removed by Matt on his object assertion PR and he removed the empty keyword altogether.

If projects used the empty keyword, it would be a big break. This PR adds back empty as an alias for never