### PR TITLE
[FEATURE] Introduce BeforeStatementAnalysisEvent

### DIFF
--- a/docs/running_psalm/plugins/authoring_plugins.md
+++ b/docs/running_psalm/plugins/authoring_plugins.md
@@ -80,6 +80,7 @@ class SomePlugin implements \Psalm\Plugin\EventHandler\AfterStatementAnalysisInt
 - `AfterFunctionCallAnalysisInterface` - called after Psalm evaluates a function call to any function defined within the project itself. Can alter the return type or perform modifications of the call.
 - `AfterFunctionLikeAnalysisInterface` - called after Psalm has completed its analysis of a given function-like.
 - `AfterMethodCallAnalysisInterface` - called after Psalm analyzes a method call.
+- `BeforeStatementAnalysisInterface` - called before Psalm evaluates an statement.
 - `AfterStatementAnalysisInterface` - called after Psalm evaluates an statement.
 - `BeforeFileAnalysisInterface` - called before Psalm analyzes a file.
 - `FunctionExistenceProviderInterface` - can be used to override Psalm's builtin function existence checks for one or more functions.

--- a/src/Psalm/Plugin/EventHandler/BeforeStatementAnalysisInterface.php
+++ b/src/Psalm/Plugin/EventHandler/BeforeStatementAnalysisInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Plugin\EventHandler;
+
+use Psalm\Plugin\EventHandler\Event\BeforeStatementAnalysisEvent;
+
+interface BeforeStatementAnalysisInterface
+{
+    /**
+     * Called before a statement has been checked
+     *
+     * @return null|false Whether to continue
+     *  + `null` continues with next event handler
+     *  + `false` stops analyzing current statement in StatementsAnalyzer
+     */
+    public static function beforeStatementAnalysis(BeforeStatementAnalysisEvent $event): ?bool;
+}

--- a/src/Psalm/Plugin/EventHandler/Event/BeforeStatementAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/BeforeStatementAnalysisEvent.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Plugin\EventHandler\Event;
+
+use PhpParser\Node\Stmt;
+use Psalm\Codebase;
+use Psalm\Context;
+use Psalm\FileManipulation;
+use Psalm\StatementsSource;
+
+final class BeforeStatementAnalysisEvent
+{
+    private Stmt $stmt;
+    private Context $context;
+    private StatementsSource $statements_source;
+    private Codebase $codebase;
+    /**
+     * @var list<FileManipulation>
+     */
+    private array $file_replacements;
+
+    /**
+     * Called after a statement has been checked
+     *
+     * @param list<FileManipulation> $file_replacements
+     */
+    public function __construct(
+        Stmt $stmt,
+        Context $context,
+        StatementsSource $statements_source,
+        Codebase $codebase,
+        array $file_replacements = []
+    ) {
+        $this->stmt = $stmt;
+        $this->context = $context;
+        $this->statements_source = $statements_source;
+        $this->codebase = $codebase;
+        $this->file_replacements = $file_replacements;
+    }
+
+    public function getStmt(): Stmt
+    {
+        return $this->stmt;
+    }
+
+    public function setStmt(Stmt $stmt): void
+    {
+        $this->stmt = $stmt;
+    }
+
+    public function getContext(): Context
+    {
+        return $this->context;
+    }
+
+    public function getStatementsSource(): StatementsSource
+    {
+        return $this->statements_source;
+    }
+
+    public function getCodebase(): Codebase
+    {
+        return $this->codebase;
+    }
+
+    /**
+     * @return list<FileManipulation>
+     */
+    public function getFileReplacements(): array
+    {
+        return $this->file_replacements;
+    }
+
+    /**
+     * @param list<FileManipulation> $file_replacements
+     */
+    public function setFileReplacements(array $file_replacements): void
+    {
+        $this->file_replacements = $file_replacements;
+    }
+}

--- a/src/Psalm/Plugin/EventHandler/Event/BeforeStatementAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/BeforeStatementAnalysisEvent.php
@@ -25,6 +25,7 @@ final class BeforeStatementAnalysisEvent
      * Called after a statement has been checked
      *
      * @param list<FileManipulation> $file_replacements
+     * @internal
      */
     public function __construct(
         Stmt $stmt,


### PR DESCRIPTION
As counterpart to existing `AfterStatementAnalysisEvent` - invoked in
`\Psalm\Internal\Analyzer\StatementsAnalyzer` - this changed introcued
a corresponding `BeforeStatementAnalysisEvent`.

Resolves: #7534