### PR TITLE
fix wrong detection of purity

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -644,14 +644,23 @@ class FunctionCallAnalyzer extends CallAnalyzer
                 }
 
                 if ($var_type_part instanceof TClosure || $var_type_part instanceof TCallable) {
-                    if (!$var_type_part->is_pure && ($context->pure || $context->mutation_free)) {
-                        IssueBuffer::maybeAdd(
-                            new ImpureFunctionCall(
-                                'Cannot call an impure function from a mutation-free context',
-                                new CodeLocation($statements_analyzer->getSource(), $stmt)
-                            ),
-                            $statements_analyzer->getSuppressedIssues()
-                        );
+                    if (!$var_type_part->is_pure) {
+                        if ($context->pure || $context->mutation_free) {
+                            IssueBuffer::maybeAdd(
+                                new ImpureFunctionCall(
+                                    'Cannot call an impure function from a mutation-free context',
+                                    new CodeLocation($statements_analyzer->getSource(), $stmt)
+                                ),
+                                $statements_analyzer->getSuppressedIssues()
+                            );
+                        }
+
+                        if (!$function_call_info->function_storage) {
+                            $function_call_info->function_storage = new FunctionStorage();
+                        }
+
+                        $function_call_info->function_storage->pure = false;
+                        $function_call_info->function_storage->mutation_free = false;
                     }
 
                     $function_call_info->function_params = $var_type_part->params;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -39,6 +39,7 @@ use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
 use Psalm\Plugin\EventHandler\Event\AfterEveryFunctionCallAnalysisEvent;
 use Psalm\Storage\Assertion;
 use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Storage\FunctionStorage;
 use Psalm\Type;
 use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TArray;

--- a/tests/FileManipulation/PureAnnotationAdditionTest.php
+++ b/tests/FileManipulation/PureAnnotationAdditionTest.php
@@ -211,6 +211,19 @@ class PureAnnotationAdditionTest extends FileManipulationTestCase
                 ['MissingPureAnnotation'],
                 true,
             ],
+            'dontAddPureIfCallableNotPure' => [
+                '<?php
+                    function pure(callable $callable): string{
+                        return $callable();
+                    }',
+                '<?php
+                    function pure(callable $callable): string{
+                        return $callable();
+                    }',
+                '7.4',
+                ['MissingPureAnnotation'],
+                true,
+            ],
         ];
     }
 }


### PR DESCRIPTION
This should fix #4300. Impurity was correctly detected in order to emit an issue but was not registered where psalter looks to check if it can add the annotation