### PR TITLE
Ensure `trait_exists()` always returns `bool`

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -14855,7 +14855,7 @@ return [
 'trader_wclprice' => ['array', 'high'=>'array', 'low'=>'array', 'close'=>'array'],
 'trader_willr' => ['array', 'high'=>'array', 'low'=>'array', 'close'=>'array', 'timePeriod='=>'int'],
 'trader_wma' => ['array', 'real'=>'array', 'timePeriod='=>'int'],
-'trait_exists' => ['?bool', 'trait'=>'string', 'autoload='=>'bool'],
+'trait_exists' => ['bool', 'trait'=>'string', 'autoload='=>'bool'],
 'Transliterator::create' => ['?Transliterator', 'id'=>'string', 'direction='=>'int'],
 'Transliterator::createFromRules' => ['?Transliterator', 'rules'=>'string', 'direction='=>'int'],
 'Transliterator::createInverse' => ['Transliterator'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -15941,7 +15941,7 @@ return [
     'trader_wclprice' => ['array', 'high'=>'array', 'low'=>'array', 'close'=>'array'],
     'trader_willr' => ['array', 'high'=>'array', 'low'=>'array', 'close'=>'array', 'timePeriod='=>'int'],
     'trader_wma' => ['array', 'real'=>'array', 'timePeriod='=>'int'],
-    'trait_exists' => ['?bool', 'trait'=>'string', 'autoload='=>'bool'],
+    'trait_exists' => ['bool', 'trait'=>'string', 'autoload='=>'bool'],
     'transliterator_create' => ['?Transliterator', 'id'=>'string', 'direction='=>'int'],
     'transliterator_create_from_rules' => ['?Transliterator', 'rules'=>'string', 'direction='=>'int'],
     'transliterator_create_inverse' => ['Transliterator', 'transliterator'=>'Transliterator'],


### PR DESCRIPTION
Fixes #7478

As discussed in the upstream issue, `trait_exists()` always returns `bool`: while
it can return `null` when the arguments passed to it do not match (either no arguments, or
3 or more arguments), we do not support that scenario, as that already doesn't respect the
type signature of this function.

We cut to the point: always make it `bool`, which is the scenario that works under healthy
operational conditions.

Ref: https://github.com/Roave/BetterReflection/pull/983#discussion_r790908170
Ref: https://psalm.dev/r/c41a43805d
Ref: https://github.com/vimeo/psalm/issues/7478#issuecomment-1020330351
Ref: https://github.com/vimeo/psalm/issues/7478#issuecomment-1020337712
Ref: https://3v4l.org/XpHmh