### PR TITLE
Fix documentation for <globals> config.

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -489,8 +489,8 @@ The  following configuration declares custom types for super-globals (`$GLOBALS`
 
 ```xml
 <globals>
-  <var name="$GLOBALS" type="array{DB: MyVendor\DatabaseConnection, VIEW: MyVendor\TemplateView}" />
-  <var name="$_GET" type="array{data: array<string, string>}" />
+  <var name="GLOBALS" type="array{DB: MyVendor\DatabaseConnection, VIEW: MyVendor\TemplateView}" />
+  <var name="_GET" type="array{data: array<string, string>}" />
 </globals>
 ```
 


### PR DESCRIPTION
Config element should omit `$` from variable name.