### PR TITLE
Fix bullet indentation in documentation

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -496,11 +496,11 @@ The  following configuration declares custom types for super-globals (`$GLOBALS`
 
 The example above declares global variables as shown below
 
-* `$GLOBALS`
-  + `DB` of type `MyVendor\DatabaseConnection`
-  + `VIEW` of type `MyVendor\TemplateView`
-* `$_GET`
-  + `data` e.g. like `["id" => "123", "title" => "Nice"]`
+- `$GLOBALS`
+    - `DB` of type `MyVendor\DatabaseConnection`
+    - `VIEW` of type `MyVendor\TemplateView`
+- `$_GET`
+    - `data` e.g. like `["id" => "123", "title" => "Nice"]`
 
 ## Accessing Psalm configuration in plugins
 

--- a/docs/running_psalm/issues/TaintedFile.md
+++ b/docs/running_psalm/issues/TaintedFile.md
@@ -9,17 +9,17 @@ The risk here depends on the actual operation that contains user-controlled inpu
 It could range from:
 
 - Creating files
-  - Example: `file_put_contents`
-  - Risk: Depending on the server configuration this may result in remote code execution. (e.g. writing a file in the web root)
+    - Example: `file_put_contents`
+    - Risk: Depending on the server configuration this may result in remote code execution. (e.g. writing a file in the web root)
 - Modifying files
-  - Example: `file_put_contents`
-  - Risk: Depending on the server configuration this may result in remote code execution. (e.g. modifying a PHP file)
-- Reading files 
-  - Example: `file_get_contents`
-  - Risk: Sensitive data could be exposed from the filesystem. (e.g. config values, source code, user-submitted files)
+    - Example: `file_put_contents`
+    - Risk: Depending on the server configuration this may result in remote code execution. (e.g. modifying a PHP file)
+- Reading files
+    - Example: `file_get_contents`
+    - Risk: Sensitive data could be exposed from the filesystem. (e.g. config values, source code, user-submitted files)
 - Deleting files
-  - Example: `unlink`
-  - Risk: Denial of Service or potentially RCE. (e.g. deleting application code, removing a .htaccess file)
+    - Example: `unlink`
+    - Risk: Denial of Service or potentially RCE. (e.g. deleting application code, removing a .htaccess file)
 
 ## Example
 

--- a/docs/running_psalm/language_server.md
+++ b/docs/running_psalm/language_server.md
@@ -46,7 +46,7 @@ In the "Server definitions" tab you should add a definition for Psalm:
  - Select `Executable`
  - Extension: `php`
  - Path: `<path-to-php-binary>` e.g. `/usr/local/bin/php` or `C:\php\php.exe`
-    - this should be an absolute path, not just `php`
+     - this should be an absolute path, not just `php`
  - Args: `vendor/bin/psalm-language-server` (on Windows use `vendor/vimeo/psalm/psalm-language-server`, or for a 'global' install '%APPDATA%' + `\Composer\vendor\vimeo\psalm\psalm-language-server`, where the '%APPDATA%' environment variable is probably something like `C:\Users\<homedir>\AppData\Roaming\`)
 
 In the "Timeouts" tab you can adjust the initialization timeout. This is important if you have a large project. You should set the "Init" value to the number of milliseconds you allow Psalm to scan your entire project and your project's dependencies. For opening a couple of projects that use large PHP frameworks, on a high end business laptop, try `240000` milliseconds for Init.


### PR DESCRIPTION
MkDocs requires 4 spaces for bullet indentation.

Searched with `/^( *)[*+-].*\n\1 {1,3}[*+-]/`. The language_server.md change is apparently not needed, I'm guessing since the non-indented bullets have a space in front of them as well it only requires 3 spaces, but that seems inconsistent, so I changed it anyway in case that's a bug in the markdown parser that might get fixed in the future.