### PR TITLE
improving error message for Could not resolve config path

### DIFF
--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -170,8 +170,7 @@ class FileFilter
                     }
 
                     throw new ConfigException(
-                        'Could not resolve config path to ' . $base_dir
-                        . DIRECTORY_SEPARATOR . $directory_path
+                        'Could not resolve config path to ' . $prospective_directory_path
                     );
                 }
 


### PR DESCRIPTION
$directory_path is false, so better use $prospective_directory_path in the error message.