### PR TITLE
Fix extension capitalization issue, add extensions to version message.

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -59,6 +59,7 @@ use UnexpectedValueException;
 use function array_combine;
 use function array_diff;
 use function array_fill_keys;
+use function array_filter;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -590,7 +591,9 @@ class ProjectAnalyzer
                 break;
         }
 
-        return "Target PHP version: $version $source\n";
+        return "Target PHP version: $version $source Extensions enabled: "
+            . implode(", ", array_keys(array_filter($codebase->config->php_extensions))) . " (unsupported extensions: "
+            . implode(", ", array_keys($codebase->config->php_extensions_not_supported)) . ")\n";
     }
 
     public function check(string $base_dir, bool $is_diff = false): void

--- a/tests/EndToEnd/PsalmEndToEndTest.php
+++ b/tests/EndToEnd/PsalmEndToEndTest.php
@@ -20,6 +20,7 @@ use function preg_replace;
 use function readdir;
 use function rmdir;
 use function str_replace;
+use function substr_count;
 use function sys_get_temp_dir;
 use function tempnam;
 use function unlink;
@@ -168,7 +169,7 @@ class PsalmEndToEndTest extends TestCase
         $this->assertStringContainsString('InvalidReturnType', $result['STDOUT']);
         $this->assertStringContainsString('InvalidReturnStatement', $result['STDOUT']);
         $this->assertStringContainsString('3 errors', $result['STDOUT']);
-        $this->assertStringNotContainsString('E', $result['STDERR']);
+        $this->assertEquals(1, substr_count($result['STDERR'], 'E')); // Should only have 'E' from 'Extensions' in version message
 
         $this->assertSame(2, $result['CODE']);
 

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -40,6 +40,13 @@ class ProjectCheckerTest extends TestCase
     /** @var ProjectAnalyzer */
     protected $project_analyzer;
 
+    private const EXPECTED_OUTPUT = "Target PHP version: 8.1 (set by tests) Extensions enabled: dom (unsupported "
+        . "extensions: simplexml, ctype, json, libxml, mbstring, tokenizer)\n"
+        . "Scanning files...\n"
+        . "Analyzing files...\n"
+        . "\n"
+    ;
+
     public static function setUpBeforeClass(): void
     {
         self::$config = new TestConfig();
@@ -97,13 +104,7 @@ class ProjectCheckerTest extends TestCase
         $this->project_analyzer->check('tests/fixtures/DummyProject');
         $output = ob_get_clean();
 
-        $this->assertSame(
-            'Target PHP version: 8.1 (set by tests)' . "\n"
-            . 'Scanning files...' . "\n"
-            . 'Analyzing files...' . "\n"
-            . "\n",
-            $output
-        );
+        $this->assertSame(self::EXPECTED_OUTPUT, $output);
 
         $this->assertSame(0, IssueBuffer::getErrorCount());
 
@@ -289,13 +290,7 @@ class Bat
         $this->project_analyzer->checkDir('tests/fixtures/DummyProject');
         $output = ob_get_clean();
 
-        $this->assertSame(
-            'Target PHP version: 8.1 (set by tests)' . "\n"
-            . 'Scanning files...' . "\n"
-            . 'Analyzing files...' . "\n"
-            . "\n",
-            $output
-        );
+        $this->assertSame(self::EXPECTED_OUTPUT, $output);
 
         $this->assertSame(0, IssueBuffer::getErrorCount());
 
@@ -334,13 +329,7 @@ class Bat
         ]);
         $output = ob_get_clean();
 
-        $this->assertSame(
-            'Target PHP version: 8.1 (set by tests)' . "\n"
-            . 'Scanning files...' . "\n"
-            . 'Analyzing files...' . "\n"
-            . "\n",
-            $output
-        );
+        $this->assertSame(self::EXPECTED_OUTPUT, $output);
 
         $this->assertSame(0, IssueBuffer::getErrorCount());
 
@@ -379,13 +368,7 @@ class Bat
         ]);
         $output = ob_get_clean();
 
-        $this->assertSame(
-            'Target PHP version: 8.1 (set by tests)' . "\n"
-            . 'Scanning files...' . "\n"
-            . 'Analyzing files...' . "\n"
-            . "\n",
-            $output
-        );
+        $this->assertSame(self::EXPECTED_OUTPUT, $output);
 
         $this->assertSame(0, IssueBuffer::getErrorCount());
 


### PR DESCRIPTION
Adds a list of enabled and supported extensions, and enabled but unsupported extensions to the PHP version message that Psalm outputs. This should help with confusion resulting from #7107.

Also fixes capitalization, previously requiring `"ext-PDO"` wouldn't enable the extension due to the capitalization difference.