### PR TITLE
Added backward compatibility check

### DIFF
--- a/.github/workflows/bcc.yml
+++ b/.github/workflows/bcc.yml
@@ -1,0 +1,47 @@
+name: Check backward compatibility
+
+on: pull_request
+jobs:
+  bcc:
+    name: Check backward compatibility
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer:v2
+          coverage: none
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Get Composer Cache Directories
+        id: composer-cache
+        run: |
+          echo "::set-output name=files_cache::$(composer config cache-files-dir)"
+          echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+
+      - name: Cache composer cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ steps.composer-cache.outputs.files_cache }}
+            ${{ steps.composer-cache.outputs.vcs_cache }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Run composer install
+        run: | 
+          composer install -o
+          composer bin bcc install
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
+
+      - name: Run BCC
+        run: vendor/bin/roave-backward-compatibility-check --from="origin/$GITHUB_BASE_REF" --format=github-actions
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
+

--- a/vendor-bin/bcc/composer.json
+++ b/vendor-bin/bcc/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "roave/backward-compatibility-check": "^6.1"
+    }
+}


### PR DESCRIPTION
This PR adds an automated check to ensure we preserve backward compatibility during the 5.x release cycle. For now, checks are run on pull requests and only analyse changes in the pull request. Once we release a stable 5.x, we need to reconfigure it to also run it on pushes and to compare API to 5.0

Failure demo: https://github.com/vimeo/psalm/actions/runs/1792863207