### PR TITLE
Add extension documentation.

### DIFF
--- a/docs/contributing/adding_an_extension.md
+++ b/docs/contributing/adding_an_extension.md
@@ -1,0 +1,42 @@
+# Adding an extension
+
+Psalm tries to support most extensions with stubs so that projects requiring extensions can be analyzed without having
+those extensions installed at runtime. When an extension isn't already supported by Psalm, if it is loaded at runtime
+Psalm will use reflection to support it as best as possible, but it's always better to have stubs. In addition to
+allowing analysis without having the extension installed, stubs can be more accurate. The gmp and decimal extensions
+have a lot of functions that use `numeric-string` instead of `string`, and many extension like Ds, DOM, and others use
+templates. Most extension stubs can be improved by using Psalm features that aren't possible from reflection alone.
+
+## Using the stub generator
+
+We try to make adding support for an extension as easy as possible by providing a simple way to generate stubs with
+reflection, but keep in mind that reflection can miss a lot of useful information:
+
+ - Which `@throws` tags should be added to a method
+ - Psalm specific types like `numeric-string`, `int<0, max>`, or `non-empty-list`.
+ - [Templates](../annotating_code/templated_annotations.md)
+
+To use the extension stub generator, download the latest phar at
+https://github.com/AndrolGenhald/php-extension-stub-generator/releases and run `php-extension-stub-generator.phar dump
+[extension-name]`. Open a pull request to https://github.com/AndrolGenhald/php-extension-stub-generator to add the stub,
+or open a GitHub issue there and copy the output into the issue or a Gist.
+
+## Updating stubs
+
+Generated stubs are kept for each version of an extension at
+https://github.com/AndrolGenhald/php-extension-stub-generator/tree/master/generated_stubs.
+
+When adding a new extension, simply copy the generated stub to `stubs/extensions/[extension-name-lowercase].phpstub` and
+update as necessary with Psalm types. Alternatively, if the extension provides its own stub somewhere that includes
+things like `@throws` tags or other features reflection isn't able to provide, use that as a base, but make sure
+the stub isn't missing anything that shows up in the reflection generated stub.
+
+When adding support for a different version of an extension, diff the reflection-generated
+stubs to see what has changed between the versions and update `stubs/extensions/[extension-name-lowercase].phpstub` as
+necessary.
+
+## Adding the extension to the supported extensions lists
+
+There are two places each extension needs added for it to work, the `"ExtensionType"` element in config.xsd and the
+`$php_extensions` property in `Psalm\Config`. Once the extension is in both lists and the stubfile exists, the extension
+stubs will be loaded automatically based on a project's composer.json and psalm.xml.

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -14,6 +14,8 @@ I've also put together [a list of Psalm’s complexities](what_makes_psalm_compl
 
 Are you looking for low-hanging fruit? Here are some [GitHub issues](https://github.com/vimeo/psalm/issues?q=is%3Aissue+is%3Aopen+label%3A%22easy+problems%22) that shouldn't be too difficult to resolve.
 
+[Adding support for an extension](adding_an_extension.md) is another easy way to get started.
+
 ### Don’t be afraid!
 
 One great thing about working on Psalm is that it’s _very_ hard to introduce any sort of type error in Psalm’s codebase. There are almost 5,000 PHPUnit tests, so the risk of you messing up (without the CI system noticing) is very small.

--- a/stubs/extensions/decimal.phpstub
+++ b/stubs/extensions/decimal.phpstub
@@ -2,7 +2,7 @@
 namespace Decimal;
 
 /**
- * Copied from https://github.com/php-decimal/stubs/blob/master/Decimal.php
+ * Initially copied from https://github.com/php-decimal/stubs/blob/master/Decimal.php and updated for Psalm.
  *
  * The MIT License (MIT)
  * Copyright (c) 2018 Rudi Theunissen
@@ -52,7 +52,7 @@ final class Decimal implements \JsonSerializable
      *
      * Initializes a new instance using a given value and minimum precision.
      *
-     * @param Decimal|string|int $value
+     * @param Decimal|numeric-string|int $value
      * @param int                $precision
      *
      * @throws \BadMethodCallException if already constructed.
@@ -119,7 +119,7 @@ final class Decimal implements \JsonSerializable
      * The precision of the result will be the max of this decimal's precision
      * and the given value's precision, where scalar values assume the default.
      *
-     * @param Decimal|string|int $value
+     * @param Decimal|numeric-string|int $value
      *
      * @return Decimal the result of adding this decimal to the given value.
      *
@@ -135,7 +135,7 @@ final class Decimal implements \JsonSerializable
      * The precision of the result will be the max of this decimal's precision
      * and the given value's precision, where scalar values assume the default.
      *
-     * @param Decimal|string|int $value
+     * @param Decimal|numeric-string|int $value
      *
      * @return Decimal the result of subtracting a given value from this decimal.
      *
@@ -151,7 +151,7 @@ final class Decimal implements \JsonSerializable
      * The precision of the result will be the max of this decimal's precision
      * and the given value's precision, where scalar values assume the default.
      *
-     * @param Decimal|string|int $value
+     * @param Decimal|numeric-string|int $value
      *
      * @return Decimal the result of multiplying this decimal by the given value.
      *
@@ -167,7 +167,7 @@ final class Decimal implements \JsonSerializable
      * The precision of the result will be the max of this decimal's precision
      * and the given value's precision, where scalar values assume the default.
      *
-     * @param Decimal|string|int $value
+     * @param Decimal|numeric-string|int $value
      *
      * @return Decimal the result of dividing this decimal by the given value.
      *
@@ -187,7 +187,7 @@ final class Decimal implements \JsonSerializable
      *
      * @see Decimal::rem for the decimal remainder.
      *
-     * @param Decimal|string|int $value
+     * @param Decimal|numeric-string|int $value
      *
      * @return Decimal the remainder after dividing the integer value of this
      *                 decimal by the integer value of the given value
@@ -204,7 +204,7 @@ final class Decimal implements \JsonSerializable
      * The precision of the result will be the max of this decimal's precision
      * and the given value's precision, where scalar values assume the default.
      *
-     * @param Decimal|string|int $value
+     * @param Decimal|numeric-string|int $value
      *
      * @return Decimal the remainder after dividing this decimal by a given value.
      *
@@ -222,7 +222,7 @@ final class Decimal implements \JsonSerializable
      * The precision of the result will be the max of this decimal's precision
      * and the given value's precision, where scalar values assume the default.
      *
-     * @param Decimal|string|int $exponent The power to raise this decimal to.
+     * @param Decimal|numeric-string|int $exponent The power to raise this decimal to.
      *
      * @return Decimal the result of raising this decimal to a given power.
      *
@@ -399,7 +399,7 @@ final class Decimal implements \JsonSerializable
      * @param bool $commas   TRUE if thousands should be separated by a comma.
      * @param int  $rounding
      *
-     * @return string the value of this decimal formatted to a fixed number of
+     * @return numeric-string the value of this decimal formatted to a fixed number of
      *                decimal places, optionally with thousands comma-separated,
      *                using a given rounding mode.
      */
@@ -415,7 +415,7 @@ final class Decimal implements \JsonSerializable
      * this method does guarantee that a decimal instantiated by its output with
      * the same precision will be exactly equal to this decimal.
      *
-     * @return string the value of this decimal represented exactly, in either
+     * @return numeric-string the value of this decimal represented exactly, in either
      *                fixed or scientific form, depending on the value.
      */
     public function toString(): string {}
@@ -474,7 +474,7 @@ final class Decimal implements \JsonSerializable
      *
      * This method is equivalent to a cast to string, as well as `toString`.
      *
-     * @return string the value of this decimal represented exactly, in either
+     * @return numeric-string the value of this decimal represented exactly, in either
      *                fixed or scientific form, depending on the value.
      */
     public function __toString(): string {}
@@ -486,7 +486,13 @@ final class Decimal implements \JsonSerializable
      * `toString`. JSON does not have a decimal type so all decimals are encoded
      * as strings in the same format as `toString`.
      *
-     * @return string
+     * @return numeric-string
      */
     public function jsonSerialize() {}
+
+    /**
+     * @param Decimal|numeric-string|int $op1
+     * @param Decimal|numeric-string|int $op2
+     */
+    public function between($op1, $op2): bool {}
 }


### PR DESCRIPTION
Fixes #7513.

Psalm's stub generator had enough issues that I decided to fork https://github.com/sasezaki/php-extension-stub-generator and get it working again.

I added documentation on how to add/improve support for extensions, and some generated stubs for the extensions I have installed.