### PR TITLE
Allow mocking final classes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,7 @@
         "ext-curl": "*",
         "bamarni/composer-bin-plugin": "^1.4",
         "brianium/paratest": "^4.0||^6.0",
+        "nunomaduro/mock-final-classes": "^1.1",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpdocumentor/reflection-docblock": "^5",
         "phpmyadmin/sql-parser": "5.1.0||dev-master",


### PR DESCRIPTION
This package intercepts file reads (including included files) and strips the `final` keyword when run under PHPUnit, allowing us to mock final classes (that magically become non-final).

One downside of this approach could be that some tests (like end-to-end tests) may legitimately need to read a file containing a `final` keyword.