### PR TITLE
Fixed composer branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "4.x-dev",
+            "dev-master": "5.x-dev",
+            "dev-4.x": "4.x-dev",
             "dev-3.x": "3.x-dev",
             "dev-2.x": "2.x-dev",
             "dev-1.x": "1.x-dev"


### PR DESCRIPTION
with composer.json
```json
{
    "prefer-stable": false,
    "minimum-stability": "dev",
    "require-dev": {
        "vimeo/psalm": "4.x"
    }
}
```

would install `- Installing vimeo/psalm (dev-master 3a298d0): Extracting archive`