### PR TITLE
chore: enable psl tests again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,10 +71,9 @@ jobs:
       - run:
           name: Analyse PHPUnit
           command: bin/test-with-real-projects.sh phpunit
-      # PSL requires its own plugin that is not yet compatible with Psalm 5
-      # - run:
-          # name: Analyse Psl
-          # command: bin/test-with-real-projects.sh psl
+      - run:
+          name: Analyse Psl
+          command: bin/test-with-real-projects.sh psl
       - run:
           name: Analyse Collections
           command: bin/test-with-real-projects.sh collections

--- a/bin/test-with-real-projects.sh
+++ b/bin/test-with-real-projects.sh
@@ -32,7 +32,7 @@ psl)
 	git clone git@github.com:psalm/endtoend-test-psl.git
 	cd endtoend-test-psl
 	git checkout 1.9.x
-	composer require --dev php-standard-library/psalm-plugin --ignore-platform-reqs
+	composer require --dev php-standard-library/psalm-plugin:^1.1.4 --ignore-platform-reqs
 	cd tools/phpbench && composer install --ignore-platform-reqs && cd ../..
 	"$PSALM" --monochrome --config=tools/psalm/psalm.xml
 	;;


### PR DESCRIPTION
released psalm-plugin 1.1.4, and 2.0.1 fixing compatibility with psalm 5.

I also rebased [`psalm/endtoend-test-psl`](https://github.com/psalm/endtoend-test-psl) repository on the latest 1.9.x changes ( which remove forbidEcho configuration entry )