### PR TITLE
No longer require declare reflection-docblock:^5 as dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,6 @@
         "brianium/paratest": "^4.0||^6.0",
         "nunomaduro/mock-final-classes": "^1.1",
         "php-parallel-lint/php-parallel-lint": "^1.2",
-        "phpdocumentor/reflection-docblock": "^5",
         "phpmyadmin/sql-parser": "5.1.0||dev-master",
         "phpspec/prophecy": ">=1.10.2",
         "phpunit/phpunit": "^9.0",


### PR DESCRIPTION
see https://github.com/vimeo/psalm/pull/3967
prophecy upper version always require phpdocumentor/reflection-docblock:^5.0.