### PR TITLE
Bump up phpunit,prophecy, and introduced phpspec/prophecy-phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,13 +47,13 @@
         "nunomaduro/mock-final-classes": "^1.1",
         "php-parallel-lint/php-parallel-lint": "^1.2",
         "phpmyadmin/sql-parser": "5.1.0||dev-master",
-        "phpspec/prophecy": ">=1.10.2",
-        "phpunit/phpunit": "^9.0",
+        "phpspec/prophecy": "^1.15",
+        "phpspec/prophecy-phpunit": "^2.0",
+        "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16",
         "slevomat/coding-standard": "^7.0",
         "squizlabs/php_codesniffer": "^3.6",
-        "symfony/process": "^4.3 || ^5.0 || ^6.0",
-        "weirdan/prophecy-shim": "^1.0 || ^2.0"
+        "symfony/process": "^4.3 || ^5.0 || ^6.0"
     },
     "suggest": {
         "ext-igbinary": "^2.0.5 is required, used to serialize caching data",


### PR DESCRIPTION
no longer, it seems no need to use weirdan/prophecy-shim