### PR TITLE
consistency in AssertionFinder

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -1782,7 +1782,7 @@ class AssertionFinder
     }
 
     /**
-     * @param Identical|Equal|Smaller|SmallerOrEqual|NotIdentical|NotEqual $conditional
+     * @param Identical|Equal|NotIdentical|NotEqual $conditional
      * @return false|int
      */
     protected static function hasTypedValueComparison(

--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -179,7 +179,7 @@ class NegatedAssertionReconciler extends Reconciler
                     clone $iterable->type_params[1],
                 ]
             ));
-        } elseif (get_class($assertion_type) === TInt::class
+        } elseif ($assertion_type !== null && get_class($assertion_type) === TInt::class
             && isset($existing_var_type->getAtomicTypes()['array-key'])
         ) {
             $existing_var_type->removeType('array-key');

--- a/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/NegatedAssertionReconciler.php
@@ -179,7 +179,7 @@ class NegatedAssertionReconciler extends Reconciler
                     clone $iterable->type_params[1],
                 ]
             ));
-        } elseif ($assertion_type instanceof TInt
+        } elseif (get_class($assertion_type) === TInt::class
             && isset($existing_var_type->getAtomicTypes()['array-key'])
         ) {
             $existing_var_type->removeType('array-key');


### PR DESCRIPTION
This doesn't do much, it only fixes a small phpdoc error and rearrange a few methods and params to have a good consistency between scrapeEqualityAssertions and scrapeInequalityAssertions

There's a few things that are not directly order changes:
- The call to getTrueEqualityAssertions didn't pass the inside_conditional value contrary to getTrueInequalityAssertions, getFalseEqualityAssertions and getFalseInequalityAssertions so I added it
- The count_equality_position check had been put after an early return when we were not dealing with a StatementsAnalyzer. I did that on an earlier PR because I needed the node provider for retrieving types. However, I only needed it for handling paradoxicalAssertions, so I put that back above, like the count_inequality_position check
- I added the check for paradoxicalAssertions in the count_inequality_position check. (it will possibly find some weird conditions in user code)

Nothing big but it will be cleaner for future changes