### PR TITLE
skip a test because we removed the feature for now

### DIFF
--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -1550,7 +1550,7 @@ class MethodSignatureTest extends TestCase
                 ',
                 'error_message' => 'MethodSignatureMismatch',
             ],
-            'noMixedTypehintInDescendant' => [
+            'SKIPPED-noMixedTypehintInDescendant' => [
                 'code' => '<?php
                     class a {
                         public function test(): mixed {


### PR DESCRIPTION
Not sure why this test doesn't explode on 4.x but we removed this feature for now due to shenanigans with stubs from plugins and this makes master branch fail