### PR TITLE
Organize extension requirements in composer.json

### DIFF
--- a/bin/composer-require-checker-config.json
+++ b/bin/composer-require-checker-config.json
@@ -18,8 +18,7 @@
     "pcntl",
     "posix",
     "filter",
-    "curl",
-    "PDO"
+    "curl"
   ],
   "scan-files" : []
 }

--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,9 @@
     },
     "suggest": {
         "ext-igbinary": "^2.0.5 is required, used to serialize caching data",
-        "ext-curl": "In order to send data to shepherd"
+        "ext-curl": "In order to send data to shepherd",
+        "ext-pcntl": "In order to run psalm-language-server",
+        "ext-posix": "In order to run psalm-language-server"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "ext-SimpleXML": "*",
         "ext-ctype": "*",
         "ext-dom": "*",
+        "ext-filter": "*",
         "ext-json": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -3,7 +3,6 @@
 namespace Psalm\Internal\Analyzer\Statements\Expression\Call\Method;
 
 use Exception;
-use PDOException;
 use PhpParser;
 use Psalm\CodeLocation;
 use Psalm\Codebase;
@@ -105,7 +104,7 @@ class MethodCallReturnTypeFetcher
                 || $codebase->interfaceExtends($premixin_method_id->fq_class_name, Throwable::class)
             )
         ) {
-            if ($premixin_method_id->fq_class_name === PDOException::class) {
+            if ($premixin_method_id->fq_class_name === 'PDOException') {
                 return Type::getString();
             } else {
                 return Type::getInt(true); // TODO: Remove the flag in Psalm 5


### PR DESCRIPTION
continuation of #6844 and #7632.

* Declare as "ext-filter" is require obviously.
* Added ext-pcntl, ext-posix to composer.json suggest property.
  * I added as "In order to run psalm-language-server".  If it is not correct, please pointed it.
* use PDOException literal instead of ::class to avoid taken as dependency
  * composer-require-checker guessed dependency "ext-PDO". But only use of `PDOException::class`. 