### PR TITLE
remove totallyTyped

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -54,18 +54,6 @@
         <xs:attribute name="resolveFromConfigFile" type="xs:boolean" default="true" />
         <xs:attribute name="strictBinaryOperands" type="xs:boolean" default="false" />
         <xs:attribute name="throwExceptionOnError" type="xs:boolean" default="false" />
-        <xs:attribute name="totallyTyped" type="xs:boolean" default="false">
-            <xs:annotation>
-                <xs:documentation xml:lang="en">
-                    Setting `totallyTyped` to `"true"` is equivalent to setting `errorLevel` to `"1"`. Setting `totallyTyped` to `"false"` is equivalent to setting `errorLevel` to `"2"` and `reportMixedIssues` to `"false"`
-                </xs:documentation>
-
-                <!-- note: for PHPStorm to mark the attribute as deprecated the doc entry has to be *single line* and start with the word `deprecated` -->
-                <xs:documentation xml:lang="en">
-                    Deprecated. Replaced by `errorLevel` and `reportMixedIssues`.
-                </xs:documentation>
-            </xs:annotation>
-        </xs:attribute>
         <xs:attribute name="errorLevel" type="xs:integer" default="2" />
         <xs:attribute name="reportMixedIssues" type="xs:boolean" default="true" />
         <xs:attribute name="useDocblockTypes" type="xs:boolean" default="true" />

--- a/docs/annotating_code/type_syntax/atomic_types.md
+++ b/docs/annotating_code/type_syntax/atomic_types.md
@@ -57,7 +57,7 @@ Atomic types are the basic building block of all type information used in Psalm.
 
 ### `mixed`
 
-This is the _top type_ in PHP's type system, and represents a lack of type information. Psalm warns about `mixed` types when the `totallyTyped` flag is turned on, or when you're on level 1.
+This is the _top type_ in PHP's type system, and represents a lack of type information. Psalm warns about `mixed` types when the `reportMixedIssues` flag is turned on, or when you're on level 1.
 
 ### `never`
 It can be aliased to `no-return` or `never-return` in docblocks. Note: it replaced the old `empty` type that used to exist in Psalm

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -58,15 +58,7 @@ Setting this to `"false"` hides all issues with `Mixed` types in Psalm’s outpu
 
 #### totallyTyped
 
-```xml
-<psalm
-  totallyTyped="[bool]"
-/>
-```
-
-\(Deprecated\) Setting `totallyTyped` to `"true"` is equivalent to setting `errorLevel` to `"1"`. Setting `totallyTyped` to `"false"` is equivalent to setting `errorLevel` to `"2"` and `reportMixedIssues` to `"false"`
-
-
+\(Deprecated\) This setting has been replaced by `reportMixedIssues` which is automatically enabled when `errorLevel` is 1.
 
 #### resolveFromConfigFile
 

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -5,7 +5,6 @@ You can run Psalm in at different levels of strictness from 1 to 8.
 Level 1 is the most strict, level 8 is the most lenient.
 
 When no level is explicitly defined, psalm defaults to level 2.
-In case `totallyTyped` is enabled, psalm defaults to level 1.
 
 Some issues are [always treated as errors](#always-treated-as-errors). These are issues with a very low probability of false-positives.
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1111,18 +1111,6 @@ class Config
             }
 
             $config->level = $attribute_text;
-        } elseif (isset($config_xml['totallyTyped'])) {
-            $totally_typed = (string) $config_xml['totallyTyped'];
-
-            if ($totally_typed === 'true' || $totally_typed === '1') {
-                $config->level = 1;
-            } else {
-                $config->level = 2;
-
-                if ($config->show_mixed_issues === null) {
-                    $config->show_mixed_issues = false;
-                }
-            }
         } else {
             $config->level = 2;
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -108,7 +108,7 @@ class MethodCallReturnTypeFetcher
             if ($premixin_method_id->fq_class_name === PDOException::class) {
                 return Type::getString();
             } else {
-                return Type::getInt(true); // TODO: Remove the flag in Psalm 5
+                return Type::getInt();
             }
         }
 


### PR DESCRIPTION
This remove a widely used config that has been deprecated for quite some time in docs. I kept a small description for it in the docs for users who'll want to know how to migrate