### PR TITLE
Update return type for mysqli::connect_error

### DIFF
--- a/dictionaries/PropertyMap.php
+++ b/dictionaries/PropertyMap.php
@@ -256,7 +256,7 @@ return [
         'client_info' => 'string',
         'client_version' => 'int',
         'connect_errno' => 'int',
-        'connect_error' => 'string',
+        'connect_error' => '?string',
         'errno' => 'int',
         'error' => 'string',
         'error_list' => 'array',


### PR DESCRIPTION
Steps to reproduce: https://psalm.dev/r/62a046ceec ([documentation](https://www.php.net/manual/en/mysqli.connect-error.php)).

The [procedural stub](https://github.com/vimeo/psalm/blob/11e60fa261c682627e6b85300dd6f424b87520b1/dictionaries/CallMap.php#L8449) is already correct.