### PR TITLE
Consistency for empty reconciliations

### DIFF
--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -39,6 +39,7 @@ use Psalm\Type\Atomic\TCallableObject;
 use Psalm\Type\Atomic\TCallableString;
 use Psalm\Type\Atomic\TClassConstant;
 use Psalm\Type\Atomic\TClassString;
+use Psalm\Type\Atomic\TEmptyMixed;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TInt;
@@ -806,7 +807,9 @@ class SimpleAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? new Union([new TEmptyMixed()])
+            : Type::getNever();
     }
 
     /**
@@ -899,7 +902,7 @@ class SimpleAssertionReconciler extends Reconciler
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
         return $existing_var_type->from_docblock
-            ? Type::getMixed()
+            ? new Union([new TEmptyMixed()])
             : Type::getNever();
     }
 
@@ -995,7 +998,7 @@ class SimpleAssertionReconciler extends Reconciler
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
         return $existing_var_type->from_docblock
-            ? Type::getMixed()
+            ? new Union([new TEmptyMixed()])
             : Type::getNever();
     }
 
@@ -1471,7 +1474,9 @@ class SimpleAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -1532,7 +1537,9 @@ class SimpleAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -1574,7 +1581,9 @@ class SimpleAssertionReconciler extends Reconciler
 
             $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-            return Type::getMixed();
+            return $existing_var_type->from_docblock
+                ? Type::getMixed()
+                : Type::getNever();
         }
 
         return $intersection;
@@ -2325,7 +2334,9 @@ class SimpleAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -2544,7 +2555,7 @@ class SimpleAssertionReconciler extends Reconciler
 
         if ($matched_class_constant_types === []) {
             $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
-            return Type::getMixed();
+            return Type::getNever();
         }
 
         return TypeCombiner::combine($matched_class_constant_types, $codebase);

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -494,7 +494,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -636,7 +638,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -704,7 +708,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -758,7 +764,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
             $failed_reconciliation = 2;
 
-            return Type::getNever();
+            return $existing_var_type->from_docblock
+                ? Type::getMixed()
+                : Type::getNever();
         }
 
         if (!$did_remove_type) {
@@ -974,7 +982,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -1077,7 +1087,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -1169,7 +1181,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -1271,7 +1285,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -1368,7 +1384,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -1474,7 +1492,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -1577,7 +1597,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**
@@ -1645,7 +1667,9 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
         $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
 
-        return Type::getMixed();
+        return $existing_var_type->from_docblock
+            ? Type::getMixed()
+            : Type::getNever();
     }
 
     /**


### PR DESCRIPTION
When Psalm tries to reconcile an assertion with a type, there are cases where the result is empty. (meaning every possible known value has been excluded by the assertion).

There was inconsistencies between returning never, returning mixed and a conditional that checks the from_docblock to return mixed or never.

I didn't see the goal of checking the from_docblock, but when I removed it, I realized the goal is to allow checking an expected type from a docblock (There is a Validator test for that). I changed every case into the conditional for consistency