### PR TITLE
Prevent unnecessary filter_var() warnings on primitive types

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -677,6 +677,12 @@ function array_product(array $array) {}
  * 259 is FILTER_VALIDATE_FLOAT
  * @psalm-taint-escape ($filter is 259 ? 'html' : null)
  *
+ * 519 is FILTER_SANITIZE_NUMBER_INT
+ * @psalm-taint-escape ($filter is 519 ? 'html' : null)
+ *
+ * 520 is FILTER_SANITIZE_NUMBER_FLOAT
+ * @psalm-taint-escape ($filter is 520 ? 'html' : null)
+ *
  * @psalm-flow ($value, $filter, $options) -> return
  */
 function filter_var(mixed $value, int $filter = FILTER_DEFAULT, array|int $options = 0): mixed {}

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -232,7 +232,8 @@ class TaintTest extends TestCase
             ],
             'taintFilterVarInt' => [
                 'code' => '<?php
-                    echo filter_var($_GET["bad"], FILTER_VALIDATE_INT);'
+                    echo filter_var($_GET["bad"], FILTER_VALIDATE_INT);
+                    echo filter_var($_GET["bad"], FILTER_SANITIZE_NUMBER_INT);'
             ],
             'taintFilterVarBoolean' => [
                 'code' => '<?php
@@ -240,7 +241,8 @@ class TaintTest extends TestCase
             ],
             'taintFilterVarFloat' => [
                 'code' => '<?php
-                    echo filter_var($_GET["bad"], FILTER_VALIDATE_FLOAT);'
+                    echo filter_var($_GET["bad"], FILTER_VALIDATE_FLOAT);
+                    echo filter_var($_GET["bad"], FILTER_SANITIZE_NUMBER_FLOAT);'
             ],
             'taintLdapEscape' => [
                 'code' => '<?php


### PR DESCRIPTION
This is a follow-up to PR #6537 and issue #3689.