### PR TITLE
Fixed PSR-4 warnings

### DIFF
--- a/tests/Template/KeyOfTemplateTest.php
+++ b/tests/Template/KeyOfTemplateTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Psalm\Tests;
+namespace Psalm\Tests\Template;
 
+use Psalm\Tests\TestCase;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 

--- a/tests/Template/ValueOfTemplateTest.php
+++ b/tests/Template/ValueOfTemplateTest.php
@@ -2,8 +2,9 @@
 
 declare(strict_types=1);
 
-namespace Psalm\Tests;
+namespace Psalm\Tests\Template;
 
+use Psalm\Tests\TestCase;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 


### PR DESCRIPTION
Fixes the following warnings that were emitted by `composer install`:

```
Generating optimized autoload files
Class Psalm\Tests\KeyOfTemplateTest located in ./tests/Template/KeyOfTemplateTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Psalm\Tests\ValueOfTemplateTest located in ./tests/Template/ValueOfTemplateTest.php does not comply with psr-4 autoloading standard. Skipping.
```