### PR TITLE
Fix some minor issues with references.

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -923,7 +923,7 @@ class AssignmentAnalyzer
                     )
                 );
             }
-            if (!empty($var_comments)) {
+            if (!empty($var_comments) && $var_comments[0]->type !== null && $var_comments[0]->var_id === null) {
                 IssueBuffer::maybeAdd(
                     new InvalidDocblock(
                         "Docblock type cannot be used for reference assignment",
@@ -1002,6 +1002,15 @@ class AssignmentAnalyzer
                     $stmt->var instanceof ArrayDimFetch
                         ? "offset-assignment-as-reference"
                         : "property-assignment-as-reference"
+                );
+            }
+
+            if ($root_var_id === '$this') {
+                // Variables on `$this` are always used
+                $statements_analyzer->data_flow_graph->addPath(
+                    $lhs_node,
+                    new DataFlowNode('variable-use', 'variable use', null),
+                    'variable-use',
                 );
             }
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -988,7 +988,8 @@ class AssignmentAnalyzer
 
         $context->vars_in_scope[$lhs_var_id]->parent_nodes[$lhs_node->id] = $lhs_node;
 
-        if (($stmt->var instanceof ArrayDimFetch || $stmt->var instanceof PropertyFetch)
+        if ($statements_analyzer->data_flow_graph !== null
+            && ($stmt->var instanceof ArrayDimFetch || $stmt->var instanceof PropertyFetch)
             && $stmt->var->var instanceof Variable
             && is_string($stmt->var->var->name)
         ) {

--- a/tests/ReferenceTest.php
+++ b/tests/ReferenceTest.php
@@ -247,6 +247,16 @@ class ReferenceTest extends TestCase
                 ',
                 'assertions' => [],
             ],
+            'allowDocblockTypingOtherVariable' => [
+                'code' => '<?php
+                    $a = 1;
+                    /** @var string $a */
+                    $b = &$a;
+                ',
+                'assertions' => [
+                    '$b' => 'string',
+                ],
+            ],
         ];
     }
 

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -2587,6 +2587,20 @@ class UnusedVariableTest extends TestCase
                         }
                     }',
             ],
+            'referenceInPropertyIsNotUnused' => [
+                'code' => '<?php
+                    class Foo
+                    {
+                        /** @var int|null */
+                        public $bar = null;
+
+                        public function setBarRef(int $ref): void
+                        {
+                            $this->bar = &$ref;
+                        }
+                    }
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
References assigned to properties on `$this` should never be unused.
Using a `@var` docblock before a reference should be allowed if it targets a variable instead of the assignment statement.