### PR TITLE
Fix issue documentation links.

### DIFF
--- a/docs/running_psalm/issues/MissingConstructor.md
+++ b/docs/running_psalm/issues/MissingConstructor.md
@@ -2,15 +2,15 @@
 
 Unitialized properties are statically hard to analyze. To prevent mistakes, Psalm will enforce that all properties should be initialized.
 
-It does that through [PropertyNotSetInConstructor](issues/PropertyNotSetInConstructor.md) and this issue.
+It does that through [PropertyNotSetInConstructor](./PropertyNotSetInConstructor.md) and this issue.
 
 Psalm will then assume every property in the codebase is initialized.
 
-Doing that allows it to report missing initializations as well as [RedundantPropertyInitializationCheck](issues/RedundantPropertyInitializationCheck.md)
+Doing that allows it to report missing initializations as well as [RedundantPropertyInitializationCheck](./RedundantPropertyInitializationCheck.md)
 
 This issue is emitted when non-null properties without default values are defined in a class without a `__construct` method
 
-If your project rely on having uninitialized properties, it is advised to suppress this issue, as well as [PropertyNotSetInConstructor](issues/PropertyNotSetInConstructor.md) and [RedundantPropertyInitializationCheck](issues/RedundantPropertyInitializationCheck.md).
+If your project rely on having uninitialized properties, it is advised to suppress this issue, as well as [PropertyNotSetInConstructor](./PropertyNotSetInConstructor.md) and [RedundantPropertyInitializationCheck](./RedundantPropertyInitializationCheck.md).
 
 ```php
 <?php

--- a/docs/running_psalm/issues/PropertyNotSetInConstructor.md
+++ b/docs/running_psalm/issues/PropertyNotSetInConstructor.md
@@ -2,15 +2,15 @@
 
 Unitialized properties are hard to statically analyze. To prevent mistakes, Psalm will enforce that all properties should be initialized.
 
-It does that through [MissingConstructor](issues/MissingConstructor.md) and this issue.
+It does that through [MissingConstructor](./MissingConstructor.md) and this issue.
 
 Psalm will then assume every property in the codebase is initialized.
 
-Doing that allows it to report missing initializations as well as [RedundantPropertyInitializationCheck](issues/RedundantPropertyInitializationCheck.md)
+Doing that allows it to report missing initializations as well as [RedundantPropertyInitializationCheck](./RedundantPropertyInitializationCheck.md)
 
 This issue is emitted when a non-null property without a default value is declared but not set in the class’s constructor
 
-If your project relies on having uninitialized properties, it is advised to suppress this issue, as well as [MissingConstructor](issues/MissingConstructor.md) and [RedundantPropertyInitializationCheck](issues/RedundantPropertyInitializationCheck.md).
+If your project relies on having uninitialized properties, it is advised to suppress this issue, as well as [MissingConstructor](./MissingConstructor.md) and [RedundantPropertyInitializationCheck](./RedundantPropertyInitializationCheck.md).
 
 ```php
 <?php

--- a/docs/running_psalm/issues/RedundantPropertyInitializationCheck.md
+++ b/docs/running_psalm/issues/RedundantPropertyInitializationCheck.md
@@ -2,7 +2,7 @@
 
 Unitialized properties are hard to statically analyze. To prevent mistakes, Psalm will enforce that all properties should be initialized.
 
-It does that through [PropertyNotSetInConstructor](issues/PropertyNotSetInConstructor.md) and [MissingConstructor](issues/MissingConstructor.md).
+It does that through [PropertyNotSetInConstructor](./PropertyNotSetInConstructor.md) and [MissingConstructor](./MissingConstructor.md).
 
 Psalm will then assume every property in the codebase is initialized.
 
@@ -10,7 +10,7 @@ Doing that allows it to report missing initializations as well as this issue.
 
 This issue is emitted when checking `isset()` on a non-nullable property. Because every property is assumed to be initialized, this check is redundant
 
-If your project relies on having uninitialized properties, it is advised to suppress this issue, as well as [PropertyNotSetInConstructor](issues/PropertyNotSetInConstructor.md) and [MissingConstructor](issues/MissingConstructor.md).
+If your project relies on having uninitialized properties, it is advised to suppress this issue, as well as [PropertyNotSetInConstructor](./PropertyNotSetInConstructor.md) and [MissingConstructor](./MissingConstructor.md).
 
 ```php
 <?php


### PR DESCRIPTION
I noticed https://psalm.dev/docs/running_psalm/issues/ hadn't updated yet so I ran mkdocs locally to see if it was failing for some reason. It worked, but it had warning messages about these broken links.