### PR TITLE
Throw exception if file_put_contents failed

### DIFF
--- a/src/Psalm/Internal/PluginManager/ConfigFile.php
+++ b/src/Psalm/Internal/PluginManager/ConfigFile.php
@@ -143,6 +143,9 @@ class ConfigFile
             }
         }
 
-        file_put_contents($this->path, $new_file_contents);
+        $result = file_put_contents($this->path, $new_file_contents);
+        if ($result === false) {
+            throw new RuntimeException(sprintf('Unable to save xml to %s', $this->path));
+        }
     }
 }

--- a/src/Psalm/Internal/PluginManager/ConfigFile.php
+++ b/src/Psalm/Internal/PluginManager/ConfigFile.php
@@ -10,6 +10,7 @@ use RuntimeException;
 use function assert;
 use function file_get_contents;
 use function file_put_contents;
+use function sprintf;
 use function strpos;
 use function substr;
 


### PR DESCRIPTION
If `psalm.xml` is not writable, commands `vendor/bin/psalm-plugin enable|disable %some_plugin` will always response
```
 [OK] Plugin enabled 
``` 

with warning:
```
Warning: file_put_contents(/var/www/psalm.xml): Failed to open stream: Permission denied in /var/www/vendor/vimeo/psalm/src/Psalm/Internal/PluginManager/ConfigFile.php on line 146
```
For disabled warnings (`error_reporting=E_ERROR`) a coder will success without writing the result.
The PR throws an exceptions this case