### PR TITLE
Config threads: add to config.xsd

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -128,6 +128,7 @@
         <xs:attribute name="limitMethodComplexity" type="xs:boolean" default="false" />
         <xs:attribute name="disableSuppressAll" type="xs:boolean" default="false" />
         <xs:attribute name="triggerErrorExits" type="TriggerErrorExitsType" default="default" />
+        <xs:attribute name="threads" type="xs:integer" />
     </xs:complexType>
 
     <xs:complexType name="ProjectFilesType">

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1252,8 +1252,8 @@ class Config
             }
         }
 
-        if (isset($config_xml->threads)) {
-            $config->threads = (int)$config_xml->threads;
+        if (isset($config_xml['threads'])) {
+            $config->threads = (int)$config_xml['threads'];
         }
 
         return $config;


### PR DESCRIPTION
Resolves a bug caused by https://github.com/vimeo/psalm/pull/7633

That work didn't add to the `config.xsd` file - this was missed as the test config wasn't altered to use threads, and the unit tests for config don't attempt a validation of a file against the xsd file.

If possible this could go out in a point release as it will prevent Psalm running if `threads` is used in the config.