### PR TITLE
Support for properties in interfaces extending `\UnitEnum` & `\BackedEnum`

### DIFF
--- a/stubs/Php81.phpstub
+++ b/stubs/Php81.phpstub
@@ -11,7 +11,7 @@ namespace {
         public static function cases(): array;
     }
 
-    interface BackedEnum
+    interface BackedEnum extends UnitEnum
     {
         public readonly int|string $value;
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -371,7 +371,7 @@ class EnumTest extends TestCase
                 [],
                 '8.1',
             ],
-            'InterfacesWithProperties' => [
+            'PHP81-InterfacesWithProperties' => [
                 '<?php
 
                     static fn (\UnitEnum $tag): string => $tag->name;

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -371,7 +371,7 @@ class EnumTest extends TestCase
                 [],
                 '8.1',
             ],
-            'PHP81-InterfacesWithProperties' => [
+            'InterfacesWithProperties' => [
                 '<?php
 
                     static fn (\UnitEnum $tag): string => $tag->name;

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -377,6 +377,12 @@ class EnumTest extends TestCase
                     static fn (\UnitEnum $tag): string => $tag->name;
 
                     static fn (\BackedEnum $tag): string|int => $tag->value;
+
+                    interface ExtendedUnitEnum extends \UnitEnum {}
+                    static fn (ExtendedUnitEnum $tag): string => $tag->name;
+
+                    interface ExtendedBackedEnum extends \BackedEnum {}
+                    static fn (ExtendedBackedEnum $tag): string|int => $tag->value;
                     ',
                 'assertions' => [],
                 [],

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -55,6 +55,10 @@ trait ValidCodeAnalysisTestTrait
             if (version_compare(PHP_VERSION, '8.0.0', '<')) {
                 $this->markTestSkipped('Test case requires PHP 8.0.');
             }
+        } elseif (strpos($test_name, 'PHP81-') !== false) {
+            if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+                $this->markTestSkipped('Test case requires PHP 8.1.');
+            }
         } elseif (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
         }


### PR DESCRIPTION
Fixes https://github.com/vimeo/psalm/issues/7551