### PR TITLE
Register openssl_sign function to impure functions

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -454,7 +454,7 @@ class Functions
 
             // well-known functions
             'libxml_use_internal_errors', 'libxml_disable_entity_loader', 'curl_exec',
-            'mt_srand', 'openssl_pkcs7_sign',
+            'mt_srand', 'openssl_pkcs7_sign', 'openssl_sign',
             'mt_rand', 'rand', 'random_int', 'random_bytes',
             'wincache_ucache_delete', 'wincache_ucache_set', 'wincache_ucache_inc',
             'class_alias',


### PR DESCRIPTION
openssl_sign has $signature parameter that by reference that can re-used, eg:

```php
        $pkeyid = "some_public_key";
	openssl_sign("blah", $signature, $pkeyid);
 
        return $signature;
```
