### PR TITLE
Allow null to ArrayAccess::offsetSet $offset param

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -101,7 +101,7 @@ interface ArrayAccess {
      * Offset to set
      * @link http://php.net/manual/en/arrayaccess.offsetset.php
      *
-     * @param TKey $offset The offset to assign the value to.
+     * @param TKey|null $offset The offset to assign the value to.
      * @param TValue $value The value to set.
      * @return void
      *

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1735,6 +1735,24 @@ class ArrayAssignmentTest extends TestCase
                 [],
                 '8.1'
             ],
+            'allowsArrayAccessNullOffset' => [
+                '<?php
+                    /**
+                     * @template-implements ArrayAccess<int, string>
+                     */
+                    class C implements ArrayAccess {
+                        public function offsetExists(int $offset) : bool { return true; }
+
+                        public function offsetGet($offset) : string { return "";}
+
+                        public function offsetSet(int $offset, string $value) : void {}
+
+                        public function offsetUnset(int $offset) : void { }
+                    }
+
+                    $c = new C();
+                    $c[] = "hello";'
+            ],
         ];
     }
 
@@ -1850,25 +1868,6 @@ class ArrayAssignmentTest extends TestCase
                         $arr["foo"][0] = "5";
                     }',
                 'error_message' => 'MixedArrayAssignment',
-            ],
-            'implementsArrayAccessPreventNullOffset' => [
-                '<?php
-                    /**
-                     * @template-implements ArrayAccess<int, string>
-                     */
-                    class C implements ArrayAccess {
-                        public function offsetExists(int $offset) : bool { return true; }
-
-                        public function offsetGet($offset) : string { return "";}
-
-                        public function offsetSet(int $offset, string $value) : void {}
-
-                        public function offsetUnset(int $offset) : void { }
-                    }
-
-                    $c = new C();
-                    $c[] = "hello";',
-                'error_message' => 'NullArgument',
             ],
             'storageKeyMustBeObject' => [
                 '<?php


### PR DESCRIPTION
`$offset` can be null: https://www.php.net/manual/en/arrayaccess.offsetset.php#refsect1-arrayaccess.offsetset-notes

related to https://github.com/doctrine/collections/pull/296#discussion_r820219863

**Update**: There was a test checking the `NullArgument` error 🤔 