### PR TITLE
More attribute fixes.

### DIFF
--- a/src/Psalm/Internal/Analyzer/AttributesAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/AttributesAnalyzer.php
@@ -54,7 +54,7 @@ class AttributesAnalyzer
 
     /**
      * @param array<array-key, AttributeGroup> $attribute_groups
-     * @param 1|2|4|8|16|32|40 $target
+     * @param key-of<self::TARGET_DESCRIPTIONS> $target
      * @param array<array-key, string> $suppressed_issues
      */
     public static function analyze(

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -402,7 +402,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
             $class_context,
             $storage,
             $class->attrGroups,
-            1,
+            AttributesAnalyzer::TARGET_CLASS,
             $storage->suppressed_issues + $this->getSuppressedIssues()
         );
 
@@ -1526,7 +1526,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
             $context,
             $property_storage,
             $stmt->attrGroups,
-            8,
+            AttributesAnalyzer::TARGET_PROPERTY,
             $property_storage->suppressed_issues + $this->getSuppressedIssues()
         );
 

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -824,7 +824,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $context,
             $storage,
             $this->function->attrGroups,
-            $storage instanceof MethodStorage ? 4 : 2,
+            $storage instanceof MethodStorage ? AttributesAnalyzer::TARGET_METHOD : AttributesAnalyzer::TARGET_FUNCTION,
             $storage->suppressed_issues + $this->getSuppressedIssues()
         );
 
@@ -1272,7 +1272,8 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 $context,
                 $function_param,
                 $param_stmts[$offset]->attrGroups,
-                $function_param->promoted_property ? 40 : 32,
+                AttributesAnalyzer::TARGET_PARAMETER
+                    | ($function_param->promoted_property ? AttributesAnalyzer::TARGET_PROPERTY : 0),
                 $storage->suppressed_issues + $this->getSuppressedIssues()
             );
         }

--- a/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
@@ -102,7 +102,7 @@ class InterfaceAnalyzer extends ClassLikeAnalyzer
             $interface_context,
             $class_storage,
             $this->class->attrGroups,
-            1,
+            AttributesAnalyzer::TARGET_CLASS,
             $class_storage->suppressed_issues + $this->getSuppressedIssues()
         );
 

--- a/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/TraitAnalyzer.php
@@ -69,7 +69,7 @@ class TraitAnalyzer extends ClassLikeAnalyzer
             $context,
             $storage,
             $stmt->attrGroups,
-            1,
+            AttributesAnalyzer::TARGET_CLASS,
             $storage->suppressed_issues + $statements_analyzer->getSuppressedIssues()
         );
     }

--- a/src/Psalm/Storage/AttributeStorage.php
+++ b/src/Psalm/Storage/AttributeStorage.php
@@ -18,11 +18,15 @@ class AttributeStorage
 
     /**
      * @var CodeLocation
+     *
+     * @psalm-suppress PossiblyUnusedProperty part of public API
      */
     public $location;
 
     /**
      * @var CodeLocation
+     *
+     * @psalm-suppress PossiblyUnusedProperty part of public API
      */
     public $name_location;
 

--- a/src/Psalm/Storage/HasAttributesInterface.php
+++ b/src/Psalm/Storage/HasAttributesInterface.php
@@ -10,6 +10,8 @@ interface HasAttributesInterface
      * Returns a list of AttributeStorages with the same order they appear in the AttributeGroups they come from.
      *
      * @return list<AttributeStorage>
+     *
+     * @psalm-suppress PossiblyUnusedMethod part of public API
      */
     public function getAttributeStorages(): array;
 }

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -2,6 +2,7 @@
 
 namespace Psalm\Tests;
 
+use Psalm\Context;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
@@ -11,6 +12,29 @@ class AttributeTest extends TestCase
 {
     use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
+
+    public function testStubsWithDifferentAttributes(): void
+    {
+        $this->addStubFile(
+            'stubOne.phpstub',
+            '<?php
+                #[Attribute]
+                class Attr {}
+
+                #[Attr]
+                class Foo {}
+            '
+        );
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                class Foo {}
+            '
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
 
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>
@@ -699,6 +723,33 @@ class AttributeTest extends TestCase
                     class Baz {}
                 ',
                 'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:5:28 - Attribute Foo is not repeatable',
+            ],
+            'invalidAttributeConstructionWithReturningFunction' => [
+                '<?php
+                    enum Enumm
+                    {
+                        case SOME_CASE;
+                    }
+
+                    #[Attribute]
+                    final class Attr
+                    {
+                        public function __construct(public Enumm $e) {}
+                    }
+
+                    final class SomeClass
+                    {
+                        #[Attr(Enumm::WRONG_CASE)]
+                        public function anotherMethod(): string
+                        {
+                            return "";
+                        }
+                    }
+                ',
+                'error_message' => 'UndefinedConstant',
+                [],
+                false,
+                '8.1',
             ],
         ];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -104,6 +104,16 @@ class TestCase extends BaseTestCase
     }
 
     /**
+     * @param string $file_path
+     * @param string $contents
+     */
+    public function addStubFile($file_path, $contents): void
+    {
+        $this->file_provider->registerFile($file_path, $contents);
+        $this->project_analyzer->getConfig()->addStubFile($file_path);
+    }
+
+    /**
      * @param  string         $file_path
      *
      */


### PR DESCRIPTION
 - Fix case where attributes from stubs don't match declarations in the code (fixes #7751)
 - Fix returning function not analyzing attribute construction (fixes #7756)
 - Use constants for attribute targets
 
AttributeStorage isn't really used anymore, but it's still around for plugins.