### PR TITLE
Avoid json_encode when serializing non-UTF8 literals

### DIFF
--- a/src/Psalm/Internal/Clause.php
+++ b/src/Psalm/Internal/Clause.php
@@ -15,13 +15,11 @@ use function array_map;
 use function array_values;
 use function count;
 use function implode;
-use function json_encode;
 use function ksort;
 use function md5;
 use function reset;
+use function serialize;
 use function substr;
-
-use const JSON_THROW_ON_ERROR;
 
 /**
  * @internal
@@ -109,7 +107,7 @@ class Clause
                 $possibility_strings[$i] = array_keys($possibilities[$i]);
             }
 
-            $this->hash = md5(json_encode($possibility_strings, JSON_THROW_ON_ERROR));
+            $this->hash = md5(serialize($possibility_strings));
         }
 
         $this->possibilities = $possibilities;

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2840,6 +2840,15 @@ class ConditionalTest extends TestCase
                         echo "false";
                     }',
             ],
+            'BinaryDataIsPassedSeeIssue7771' => [
+                'code' => '<?php
+                    function matches(string $value): bool {
+                        if ("\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1" !== $value) {
+                            return false;
+                        }
+                        return true;
+                    }'
+            ],
         ];
     }
 


### PR DESCRIPTION
`\Psalm\Internal\Clause::$hash` basically holds a hash on arbitrary input literals, used for later comparison. Using `json_encode` fails when dealing with non-UTF8 literals, which has been replaced by plain PHP `serialize`.

Resolves: #7771