### PR TITLE
Avoid json_encode when serializing non-UTF8 literals

### DIFF
--- a/src/Psalm/Internal/Clause.php
+++ b/src/Psalm/Internal/Clause.php
@@ -11,10 +11,10 @@ use function array_unique;
 use function array_values;
 use function count;
 use function implode;
-use function json_encode;
 use function ksort;
 use function md5;
 use function reset;
+use function serialize;
 use function sort;
 use function strpos;
 use function substr;
@@ -110,7 +110,7 @@ class Clause
                 sort($possibilities[$i]);
             }
 
-            $this->hash = md5((string) json_encode($possibilities));
+            $this->hash = md5(serialize($possibilities));
         }
     }
 

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2839,6 +2839,15 @@ class ConditionalTest extends TestCase
                         echo "false";
                     }',
             ],
+            'BinaryDataIsPassedSeeIssue7771' => [
+                'code' => '<?php
+                    function matches(string $value): bool {
+                        if ("\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1" !== $value) {
+                            return false;
+                        }
+                        return true;
+                    }'
+            ],
         ];
     }
 

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2839,8 +2839,8 @@ class ConditionalTest extends TestCase
                         echo "false";
                     }',
             ],
-            'BinaryDataIsPassedSeeIssue7771' => [
-                'code' => '<?php
+            '#7771: non-UTF8 binary data is passed' => [
+                '<?php
                     function matches(string $value): bool {
                         if ("\xD0\xCF\x11\xE0\xA1\xB1\x1A\xE1" !== $value) {
                             return false;


### PR DESCRIPTION
`\Psalm\Internal\Clause::$hash` basically holds a hash on arbitrary input literals, used for later comparison. Using `json_encode` fails when dealing with non-UTF8 literals, which has been replaced by plain PHP `serialize`.

Resolves: #7771