### PR TITLE
Psalm considers most readline functions as pure, but they have side effects

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -404,7 +404,7 @@ class Functions
             'opendir', 'readdir', 'closedir', 'rewinddir', 'scandir',
             'fopen', 'fread', 'fwrite', 'fclose', 'touch', 'fpassthru', 'fputs', 'fscanf', 'fseek', 'flock',
             'ftruncate', 'fprintf', 'symlink', 'mkdir', 'unlink', 'rename', 'rmdir', 'popen', 'pclose',
-            'fgetcsv', 'fputcsv', 'umask', 'finfo_open', 'finfo_close', 'finfo_file', 'readline_add_history',
+            'fgetcsv', 'fputcsv', 'umask', 'finfo_open', 'finfo_close', 'finfo_file',
             'stream_set_timeout', 'fgets', 'fflush', 'move_uploaded_file', 'file_exists', 'realpath', 'glob',
             'is_readable', 'is_dir', 'is_file',
 
@@ -512,6 +512,10 @@ class Functions
         }
 
         if (strpos($function_id, 'image') === 0) {
+            return false;
+        }
+
+        if (strpos($function_id, 'readline') === 0) {
             return false;
         }
 


### PR DESCRIPTION
Psalm considers most of the readline functions as pure, but all readline functions have side effects.

This leads to spurious UnusedFunctionCall errors as can be seen here:
https://psalm.dev/r/eb33a31483

This PR makes psalm treat all readline functions as impure.