### PR TITLE
Avoiding double spaces

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
@@ -192,7 +192,7 @@ class InstancePropertyFetchAnalyzer
             ) {
                 IssueBuffer::maybeAdd(
                     new PossiblyNullPropertyFetch(
-                        'Cannot get property on possibly null variable ' . $stmt_var_id . ' of type ' . $stmt_var_type,
+                        rtrim('Cannot get property on possibly null variable ' . $stmt_var_id) . ' of type ' . $stmt_var_type,
                         new CodeLocation($statements_analyzer->getSource(), $stmt)
                     ),
                     $statements_analyzer->getSuppressedIssues()


### PR DESCRIPTION
When `$stmt_var_id` is empty, the message contained two spaces:
```
Cannot get property on possibly null variable  of type ...
```