### PR TITLE
fix refining lowercase string and non-empty-string together

### DIFF
--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -45,8 +45,11 @@ use Psalm\Type\Atomic\TList;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNonEmptyLowercaseString;
+use Psalm\Type\Atomic\TNonEmptyString;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TNumeric;
 use Psalm\Type\Atomic\TObject;
@@ -791,6 +794,13 @@ class AssertionReconciler extends Reconciler
 
         if ($new_range !== null) {
             $matching_atomic_type = $new_range;
+        }
+
+        // Lowercase-string and non-empty-string are compatible but none is contained into the other completely
+        if (($type_2_atomic instanceof TLowercaseString && $type_1_atomic instanceof TNonEmptyString) ||
+            ($type_2_atomic instanceof TNonEmptyString && $type_1_atomic instanceof TLowercaseString)
+        ) {
+            $matching_atomic_type = new TNonEmptyLowercaseString();
         }
 
         if (!$atomic_comparison_results->type_coerced && $atomic_comparison_results->scalar_type_match_found) {

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -2038,6 +2038,23 @@ class AssertAnnotationTest extends TestCase
                     }
                 ',
             ],
+            'assertNonEmptyStringWithLowercaseString' => [
+                'code' => '<?php
+
+                    /** @psalm-assert non-empty-string $input */
+                    function assertLowerCase(string $input): void { throw new \Exception($input . " irrelevant"); }
+
+                    /**
+                     * @param lowercase-string $input
+                     * @return non-empty-lowercase-string
+                     */
+                    function makeLowerNonEmpty(string $input): string
+                    {
+                        assertLowerCase($input);
+
+                        return $input;
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/7843 (on Psalm 5 though...)

For the explanation: Psalm assertions works well when one of the two type is a super type of another (isContainedBy method). When that happens, Psalm just takes the narrower type and goes on. Issues arise when none of the type is completely included in another. (A great example is the condition just above with `int<0, 10>` and `int<5, 15>` which should result in `int<5, 10>` but need to be handled separately).

This is the same with non-empty-string and lowercase-string, the intersection of both is possible within Psalm's type system (non-empty-lowercase-string) but none is completely included in the other