### PR TITLE
Remove `@psalm-generator-return` annotation

### DIFF
--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -24,7 +24,7 @@ final class DocComment
         'assert', 'assert-if-true', 'assert-if-false', 'suppress',
         'ignore-nullable-return', 'override-property-visibility',
         'override-method-visibility', 'seal-properties', 'seal-methods',
-        'generator-return', 'ignore-falsable-return', 'variadic', 'pure',
+        'ignore-falsable-return', 'variadic', 'pure',
         'ignore-variable-method', 'ignore-variable-property', 'internal',
         'taint-sink', 'taint-source', 'assert-untainted', 'scope-this',
         'mutation-free', 'external-mutation-free', 'immutable', 'readonly',

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -76,7 +76,6 @@ class DocumentationTest extends TestCase
         '@psalm-assert-untainted',
         '@psalm-consistent-constructor',
         '@psalm-flow',
-        '@psalm-generator-return',
         '@psalm-ignore-variable-method',
         '@psalm-ignore-variable-property',
         '@psalm-override-method-visibility',

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -53,20 +53,6 @@ class GeneratorTest extends TestCase
                     '$g' => 'Generator<int, stdClass, mixed, mixed>',
                 ],
             ],
-            'generatorWithReturn' => [
-                'code' => '<?php
-                    /**
-                     * @return Generator<int,int>
-                     * @psalm-generator-return string
-                     */
-                    function fooFoo(int $i): Generator {
-                        if ($i === 1) {
-                            return "bash";
-                        }
-
-                        yield 1;
-                    }',
-            ],
             'generatorSend' => [
                 'code' => '<?php
                     /** @return Generator<int, string, DateTimeInterface, void> */


### PR DESCRIPTION
While trying to shrink `DocumentationTest::WALL_OF_SHAME` (#7849, #7851), I stumbled upon `@psalm-generator-return` annotation.

The only references to it I could find are the aforementioned wall of shame, `DocComment::PSALM_ANNOTATIONS` and `GeneratorTest`:

https://github.com/vimeo/psalm/blob/eeb12bc285b3ebfeac7f6f8328a2917a2b0a1225/tests/GeneratorTest.php#L56-L69

I tried adding assertions to this test, and inferred types don't seem to be affected by `@psalm-generator-return` presence (I checked `fooFoo()` return type and `fooFoo()->getReturn()`).

The oldest reference to this annotation I can find is d71d439e25a44d5c2196187e84f0f7c38ed7ec5d (late 2016).

My guess is that at that point Psalm did not support `TSend` and `TReturn` for generators yet, so this annotation was meant to be a replacement for the latter, which ended up not being implemented.

I'm pretty sure that this annotation is no-op and can be safely removed. The only effect of this change should be throwing an unknown annotation error, that's why it's targeted at `master`.