### PR TITLE
Disable filepath formatting as a link for Drone CI's output

### DIFF
--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -659,6 +659,7 @@ HELP;
             || isset($_SERVER['JENKINS_URL'])
             || isset($_SERVER['SCRUTINIZER'])
             || isset($_SERVER['GITLAB_CI'])
-            || isset($_SERVER['GITHUB_WORKFLOW']);
+            || isset($_SERVER['GITHUB_WORKFLOW'])
+            || isset($_SERVER['DRONE']);
     }
 }


### PR DESCRIPTION
https://docs.drone.io/pipeline/environment/reference/

It seems, default console output was changed some time ago. It had been clear and easy-to-read, but then it turned into something like this:

```
ERROR: MissingReturnType - ]8;;file:///path/to/File.php#L9\src\File.php:9:30]8;;\ - Method App\File::canBuild does not have a return type (see https://psalm.dev/050)
        abstract public function canBuild();
```

Using `--long-progress` CLI option doesn't help, unfortunately.