### PR TITLE
Fix openssl_csr_export() signature

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -9313,7 +9313,7 @@ return [
 'opendir' => ['resource|false', 'directory'=>'string', 'context='=>'resource'],
 'openlog' => ['bool', 'prefix'=>'string', 'flags'=>'int', 'facility'=>'int'],
 'openssl_cipher_iv_length' => ['int|false', 'cipher_algo'=>'string'],
-'openssl_csr_export' => ['bool', 'csr'=>'OpenSSLCertificateSigningRequest|string', '&w_output'=>'OpenSSLAsymmetricKey', 'no_text='=>'bool'],
+'openssl_csr_export' => ['bool', 'csr'=>'OpenSSLCertificateSigningRequest|string', '&w_output'=>'string', 'no_text='=>'bool'],
 'openssl_csr_export_to_file' => ['bool', 'csr'=>'OpenSSLCertificateSigningRequest|string', 'output_filename'=>'string', 'no_text='=>'bool'],
 'openssl_csr_get_public_key' => ['OpenSSLAsymmetricKey|false', 'csr'=>'OpenSSLCertificateSigningRequest|string', 'short_names='=>'bool'],
 'openssl_csr_get_subject' => ['array|false', 'csr'=>'OpenSSLCertificateSigningRequest|string', 'short_names='=>'bool'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -971,7 +971,7 @@ return [
     ],
     'openssl_csr_export' => [
       'old' => ['bool', 'csr'=>'string|resource', '&w_output'=>'string', 'no_text='=>'bool'],
-      'new' => ['bool', 'csr'=>'OpenSSLCertificateSigningRequest|string', '&w_output'=>'OpenSSLAsymmetricKey', 'no_text='=>'bool'],
+      'new' => ['bool', 'csr'=>'OpenSSLCertificateSigningRequest|string', '&w_output'=>'string', 'no_text='=>'bool'],
     ],
     'openssl_csr_export_to_file' => [
       'old' => ['bool', 'csr'=>'string|resource', 'output_filename'=>'string', 'no_text='=>'bool'],


### PR DESCRIPTION
The documentation for [openssl_csr_export()](https://www.php.net/manual/en/function.openssl-csr-export.php) was [updated](https://github.com/php/doc-en/commit/3a2e96fcc0bd83370c3a4318aa773783a87110f8) recently, although it does not seem to be live yet.

This fixes the 2nd parameter `$output` of `openssl_csr_export()` signature in Psalm.

Example of what this should fix (there should be no errors): https://psalm.dev/r/03755de763