### PR TITLE
[draft] Allow templated first class callables

### DIFF
--- a/refs/firstclass.php
+++ b/refs/firstclass.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types = 1);
+
+/**
+ * @template T
+ * @param T $param
+ * @return T
+ */
+function debug($param)
+{
+    return $param;
+}
+
+$firstClass = debug(...);
+$actualResult = $firstClass('x');
+
+/** @psalm-trace $firstClass, $actualResult */
+
+$boom = $actualResult/2;
+
+/** @psalm-suppress ForbiddenCode */
+var_dump($boom);
+
+

--- a/refs/firstclassmethod.php
+++ b/refs/firstclassmethod.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+class X {
+    /**
+     * @template T
+     * @param T $param
+     * @return T
+     */
+    public function debug($param)
+    {
+        return $param;
+    }
+}
+
+
+$firstClass = (new X)->debug(...);
+$actualResult = $firstClass('x');
+
+/** @psalm-trace $firstClass, $actualResult */
+
+$boom = $actualResult/2;
+
+/** @psalm-suppress ForbiddenCode */
+var_dump($boom);
+
+

--- a/refs/firstclassstaticmethod.php
+++ b/refs/firstclassstaticmethod.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types = 1);
+
+class X {
+    /**
+     * @template T
+     * @param T $param
+     * @return T
+     */
+    public static function debug($param)
+    {
+        return $param;
+    }
+}
+
+
+$firstClass = X::debug(...);
+$actualResult = $firstClass('x');
+
+/** @psalm-trace $firstClass, $actualResult */
+
+$boom = $actualResult/2;
+
+/** @psalm-suppress ForbiddenCode */
+var_dump($boom);
+
+

--- a/refs/simpleFromCallable.php
+++ b/refs/simpleFromCallable.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @template T
+ * @param T $param
+ * @return T
+ */
+function debug($param)
+{
+    return $param;
+}
+
+
+$anonymous = Closure::fromCallable('debug');
+$actualResult = $anonymous('x');
+
+/** @psalm-trace $anonymous, $actualResult */
+
+$boom = $actualResult/2;
+
+/** @psalm-suppress ForbiddenCode */
+var_dump($boom);
+

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -847,7 +847,7 @@ class ArgumentAnalyzer
                     $atomic_type,
                     null,
                     $statements_analyzer,
-                    true
+                    false // TODO : what would be the impact here ? Probably not ok to set it to false
                 );
 
                 if ($candidate_callable) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -23,6 +23,7 @@ use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\MixedMethodCall;
 use Psalm\IssueBuffer;
+use Psalm\Node\Expr\VirtualMethodCall;
 use Psalm\StatementsSource;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Type;
@@ -212,11 +213,14 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                     )) {
                         $method_storage = $codebase->methods->getStorage($method_identifier);
 
-                        $return_type_candidate = new Union([new TClosure(
-                            'Closure',
-                            $method_storage->params,
-                            $method_storage->return_type,
-                            $method_storage->pure
+                        $return_type_candidate = new Union([TClosure::forwardingTo(
+                            static fn ($args) => new VirtualMethodCall($stmt->var, $stmt->name, $args),
+                            new TClosure(
+                                'Closure',
+                                $method_storage->params,
+                                $method_storage->return_type,
+                                $method_storage->pure
+                            )
                         )]);
                     }
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallReturnTypeFetcher.php
@@ -21,6 +21,7 @@ use Psalm\Internal\Type\TemplateBound;
 use Psalm\Internal\Type\TemplateInferredTypeReplacer;
 use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TypeExpander;
+use Psalm\Node\Expr\VirtualMethodCall;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
 use Psalm\Type;
 use Psalm\Type\Atomic;
@@ -72,11 +73,14 @@ class MethodCallReturnTypeFetcher
 
         if ($stmt->isFirstClassCallable()) {
             if ($method_storage) {
-                return new Union([new TClosure(
-                    'Closure',
-                    $method_storage->params,
-                    $method_storage->return_type,
-                    $method_storage->pure
+                return new Union([TClosure::forwardingTo(
+                    static fn ($args) => new VirtualMethodCall($stmt->var, $stmt->name, $args),
+                    new TClosure(
+                        'Closure',
+                        $method_storage->params,
+                        $method_storage->return_type,
+                        $method_storage->pure
+                    )
                 )]);
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -34,6 +34,7 @@ use Psalm\IssueBuffer;
 use Psalm\Node\Expr\VirtualArray;
 use Psalm\Node\Expr\VirtualArrayItem;
 use Psalm\Node\Expr\VirtualMethodCall;
+use Psalm\Node\Expr\VirtualStaticCall;
 use Psalm\Node\Expr\VirtualVariable;
 use Psalm\Node\Scalar\VirtualString;
 use Psalm\Node\VirtualArg;
@@ -393,11 +394,14 @@ class AtomicStaticCallAnalyzer
                 ($class_storage->pseudo_static_methods[$method_name_lc] ?? null));
 
             if ($method_storage) {
-                $return_type_candidate = new Union([new TClosure(
-                    'Closure',
-                    $method_storage->params,
-                    $method_storage->return_type,
-                    $method_storage->pure
+                $return_type_candidate = new Union([TClosure::forwardingTo(
+                    static fn ($args) => new VirtualStaticCall($stmt->class, $stmt->name, $args),
+                    new TClosure(
+                        'Closure',
+                        $method_storage->params,
+                        $method_storage->return_type,
+                        $method_storage->pure
+                    )
                 )]);
             } else {
                 $return_type_candidate = Type::getClosure();

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -125,6 +125,22 @@ class TypeExpander
         return $fleshed_out_type;
     }
 
+    public static function expandUnionWithoutTemplates(Codebase $codebase, Union $type): Union
+    {
+        return self::expandUnion(
+            $codebase,
+            $type,
+            null,
+            null,
+            null,
+            true,
+            true,
+            false,
+            false,
+            true
+        );
+    }
+
     /**
      * @param  string|TNamedObject|TTemplateParam|null $static_class_type
      *

--- a/src/Psalm/Type/Atomic/TClosure.php
+++ b/src/Psalm/Type/Atomic/TClosure.php
@@ -2,6 +2,10 @@
 
 namespace Psalm\Type\Atomic;
 
+use PhpParser\Node\Expr\CallLike;
+use Psalm\Node\VirtualNode;
+use Psalm\Storage\FunctionLikeParameter;
+
 /**
  * Represents a closure where we know the return type and params
  */
@@ -12,8 +16,52 @@ final class TClosure extends TNamedObject
     /** @var array<string, bool> */
     public $byref_uses = [];
 
+    /**
+     * Can be used to better determine types by running another function.
+     * This can be used for example by first class functions and Closure::fromCallable().
+     * But it might as well be used if you provide your own higher order function wrappers.
+     *
+     * @var callable(list<FunctionLikeParameter>): CallLike & VirtualNode
+     */
+    public $forwarding_to = null;
+
     public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
+        return false;
+    }
+
+    /**
+     * @param callable(list<FunctionLikeParameter>): CallLike & VirtualNode $forwardTo
+     */
+    public static function forwardingTo($forwardTo, TClosure $closure): self
+    {
+        $new = new self($closure->value, $closure->params, $closure->return_type, $closure->is_pure);
+        $new->forwarding_to = $forwardTo;
+        $new->byref_uses = $closure->byref_uses;
+        return $new;
+    }
+
+    /**
+     * It only makes sense to forward the closure call to an expression if the closure contains a template type.
+     * If no return type is known, it probably also means that types need to be inferred.
+     * Otherwise, all types are already known on inferring the closure expression types.
+     */
+    public function makesSenseToForwardCall(): bool
+    {
+        if (!$this->forwarding_to) {
+            return false;
+        }
+
+        if (null === $this->params || !$this->return_type || $this->return_type->hasTemplate()) {
+            return true;
+        }
+
+        foreach ($this->params as $param) {
+            if ($param->type->hasTemplate()) {
+                return true;
+            }
+        }
+
         return false;
     }
 }

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -418,7 +418,7 @@ class ClosureTest extends TestCase
                     $closure = Closure::fromCallable("strlen");
                 ',
                 'assertions' => [
-                    '$closure' => 'pure-Closure(string):int<0, max>',
+                    '$closure' => 'pure-Closure(TGeneratedFromParam0:fn-strlen as string):(TGeneratedFromParam0 is string ? int : (TGeneratedFromParam0 is string ? int<1, max> : int<0, max>))',
                 ]
             ],
             'allowClosureWithNarrowerReturn' => [
@@ -583,8 +583,8 @@ class ClosureTest extends TestCase
                     $result = $closure("test");
                 ',
                 'assertions' => [
-                    '$closure' => 'pure-Closure(string):int<0, max>',
-                    '$result' => 'int<0, max>',
+                    '$closure' => 'pure-Closure(TGeneratedFromParam0:fn-strlen as string):(TGeneratedFromParam0 is string ? int : (TGeneratedFromParam0 is string ? int<1, max> : int<0, max>))',
+                    '$result' => 'int<1, max>',
                 ],
                 'ignored_issues' => [],
                 'php_version' => '8.1'
@@ -836,6 +836,169 @@ class ClosureTest extends TestCase
                 'code' => '<?php
                     /** @psalm-suppress UndefinedFunction */
                     unknown(...);',
+            ],
+            'templatedFirstClassCallableNamedFunctionLookup' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     * @param T $param
+                     * @return T
+                     */
+                    function debug($param)
+                    {
+                        return $param;
+                    }
+
+                    $firstClass = debug(...);
+                    $actualResult = $firstClass("x");',
+                'assertions' => [
+                    '$firstClass' => 'impure-Closure(T:fn-debug as mixed):T',
+                    '$actualResult' => 'string',
+                ],
+            ],
+            'templatedFirstClassCallableClassMethodLookup' => [
+                'code' => '<?php
+                    class X {
+                        /**
+                         * @template T
+                         * @param T $param
+                         * @return T
+                         */
+                        public function debug($param)
+                        {
+                            return $param;
+                        }
+                    }
+
+                    $firstClass = (new X)->debug(...);
+                    $actualResult = $firstClass("x");',
+                'assertions' => [
+                    '$firstClass' => 'impure-Closure(T:fn-x::debug as mixed):T',
+                    '$actualResult' => 'string',
+                ],
+            ],
+            'templatedFirstClassCallableClassStaticMethodLookup' => [
+                'code' => '<?php
+                    class X {
+                        /**
+                         * @template T
+                         * @param T $param
+                         * @return T
+                         */
+                        public static function debug($param)
+                        {
+                            return $param;
+                        }
+                    }
+
+                    $firstClass = X::debug(...);
+                    $actualResult = $firstClass("x");',
+                'assertions' => [
+                    '$firstClass' => 'impure-Closure(T:fn-x::debug as mixed):T',
+                    '$actualResult' => 'string',
+                ],
+            ],
+            'templatedFirstClassCallableNamedFunctionStringLookup' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     * @param T $param
+                     * @return T
+                     */
+                    function debug($param)
+                    {
+                        return $param;
+                    }
+
+                    $callable = "debug";
+                    $actualResult = $callable("x");',
+                'assertions' => [
+                    '$firstClass' => 'impure-Closure(T:fn-debug as mixed):T',
+                    '$actualResult' => 'string',
+                ],
+            ],
+            'templatedFirstClassCallableInvokableLookup' => [
+                'code' => '<?php
+                    class Debug {
+                        /**
+                         * @template T
+                         * @param T $param
+                         * @return T
+                         */
+                        function __invoke($param)
+                        {
+                            return $param;
+                        }
+                    }
+
+
+                    $firstClass = (new Debug())(...);
+                    $actualResult = $firstClass("x");',
+                'assertions' => [
+                    '$firstClass' => 'impure-Closure(T:fn-debug as mixed):T',
+                    '$actualResult' => 'string',
+                ],
+            ],
+            'templatedClosureFromCallableNamedFunctionLookup' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     * @param T $param
+                     * @return T
+                     */
+                    function debug($param)
+                    {
+                        return $param;
+                    }
+
+                    $firstClass = Closure::fromCallable("debug");
+                    $actualResult = $firstClass("x");',
+                'assertions' => [
+                    '$firstClass' => 'impure-Closure(T:fn-debug as mixed):T',
+                    '$actualResult' => 'string',
+                ],
+            ],
+            'templatedClosureFromCallableClassMethodLookup' => [
+                'code' => '<?php
+                    class X {
+                        /**
+                         * @template T
+                         * @param T $param
+                         * @return T
+                         */
+                        public function debug($param)
+                        {
+                            return $param;
+                        }
+                    }
+
+                    $firstClass = Closure::fromCallable([new X, "debug"]);
+                    $actualResult = $firstClass("x");',
+                'assertions' => [
+                    '$firstClass' => 'impure-Closure(T:fn-debug as mixed):T',
+                    '$actualResult' => 'string',
+                ],
+            ],
+            'templatedClosureFromCallableClassStaticMethodLookup' => [
+                'code' => '<?php
+                    class X {
+                        /**
+                         * @template T
+                         * @param T $param
+                         * @return T
+                         */
+                        public static function debug($param)
+                        {
+                            return $param;
+                        }
+                    }
+
+                    $firstClass = Closure::fromCallable(["X", "debug"]);
+                    $actualResult = $firstClass("x");',
+                'assertions' => [
+                    '$firstClass' => 'impure-Closure(T:fn-debug as mixed):T',
+                    '$actualResult' => 'string',
+                ],
             ],
         ];
     }


### PR DESCRIPTION
WIP 

This PR aims to fix the first class callable issue in #7244.

The idea is to set a new 'forwarding_to' prop on a `TClosure`.
This prop will be used during analyzing to do a `VirtualFunctionCall` to the forwarded function, with the arguments provided to the first class callable function.

So in this case:

```php

/**
 * @template T
 * @param T $param
 * @return T
 */
function debug($param)
{
    return $param;
}

$firstClass = debug(...);
$actualResult = $firstClass('x');

```

Template on `$firstClass` will be inferred like this during a function call:

* firstClass = `Closure(T): T` with `forward_to: debug` and args `['x']`
* fetch result type from `VirtualFunctionCall` to `debug('x')`
* Make sure to Untemplate first class callable arguments afterwards (to avoid other type errors)
* Mark `'x'` as the result type of the function call `firstClass('x')`


Feel free to point me in the right direction, because I am just trying out some things :)


Todo:

- [ ] write + fix test cases
- [x] first class callable methods
- [x] first class callable static methods
- [ ] first class invokables
- [ ] first class callable arrays - (static) method calls
- [ ] first class callable strings
- [x] Closure::fromCallable
- [ ] cleanup
- [ ] Nested lookups?
- [ ] how does it behave inside `pipe` combinator
