### PR TITLE
Fix class const issue when using floats declared in future consts (fixes #7973).

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
@@ -712,7 +712,6 @@ class ClassConstAnalyzer
                             "{$class_storage->name}::{$const->name->name}"
                         ),
                         $const_storage->suppressed_issues,
-                        true
                     );
                 }
             }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -191,7 +191,7 @@ class BinaryOperationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-    public function testDifferingNumericTypesAdditionInStrictMode(): void
+    public function testDifferingNumericLiteralTypesAdditionInStrictMode(): void
     {
         $config = Config::getInstance();
         $config->strict_binary_operands = true;
@@ -200,6 +200,25 @@ class BinaryOperationTest extends TestCase
             'somefile.php',
             '<?php
                     $a = 5 + 4.1;'
+        );
+
+        $this->expectException(CodeException::class);
+        $this->expectExceptionMessage('InvalidOperand');
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testDifferingNumericTypesAdditionInStrictMode(): void
+    {
+        $config = Config::getInstance();
+        $config->strict_binary_operands = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                /** @var float */
+                $b = 4.1;
+                $a = 5 + $b;'
         );
 
         $this->expectException(CodeException::class);
@@ -851,6 +870,12 @@ class BinaryOperationTest extends TestCase
                         }
                         return 1;
                     }',
+            ],
+            'calculateLiteralResultForFloats' => [
+                'code' => '<?php
+                    $foo = 1.0 + 2.0;
+                ',
+                'assertions' => ['$foo===' => 'float(3)'],
             ],
         ];
     }

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -1419,6 +1419,15 @@ class ConstantTest extends TestCase
                     interface Bar extends Foo {}
                 ',
             ],
+            'classConstsUsingFutureFloatDeclarationWithMultipleLevels' => [
+                'code' => '<?php
+                    class Foo {
+                        public const BAZ = self::BAR + 1.0;
+                        public const BAR = self::FOO + 1.0;
+                        public const FOO = 1.0;
+                    }
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
 - Calculate literal type for float arithmetic instead of only for int arithmetic
 - Fix copy/paste fail causing InvalidConstantAssignmentValue to be marked as fixable