### PR TITLE
Performance only load files once

### DIFF
--- a/src/Psalm/Internal/Provider/FakeFileProvider.php
+++ b/src/Psalm/Internal/Provider/FakeFileProvider.php
@@ -4,7 +4,6 @@ namespace Psalm\Internal\Provider;
 
 use function microtime;
 use function strpos;
-use function strtolower;
 
 class FakeFileProvider extends FileProvider
 {
@@ -25,8 +24,8 @@ class FakeFileProvider extends FileProvider
 
     public function getContents(string $file_path, bool $go_to_source = false): string
     {
-        if (!$go_to_source && isset($this->temp_files[strtolower($file_path)])) {
-            return $this->temp_files[strtolower($file_path)];
+        if (!$go_to_source && isset($this->temp_files[$file_path])) {
+            return $this->temp_files[$file_path];
         }
 
         return $this->fake_files[$file_path] ?? parent::getContents($file_path);
@@ -39,8 +38,8 @@ class FakeFileProvider extends FileProvider
 
     public function setOpenContents(string $file_path, string $file_contents): void
     {
-        if (isset($this->fake_files[strtolower($file_path)])) {
-            $this->fake_files[strtolower($file_path)] = $file_contents;
+        if (isset($this->fake_files[$file_path])) {
+            $this->fake_files[$file_path] = $file_contents;
         }
     }
 
@@ -66,7 +65,7 @@ class FakeFileProvider extends FileProvider
         $file_paths = parent::getFilesInDir($dir_path, $file_extensions, $filter);
 
         foreach ($this->fake_files as $file_path => $_) {
-            if (strpos(strtolower($file_path), strtolower($dir_path)) === 0) {
+            if (strpos($file_path, $dir_path) === 0) {
                 $file_paths[] = $file_path;
             }
         }

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -15,31 +15,29 @@ use function file_put_contents;
 use function filemtime;
 use function in_array;
 use function is_dir;
-use function strtolower;
 
 use const DIRECTORY_SEPARATOR;
 
 class FileProvider
 {
     /**
-     * @var array<lowercase-string, string>
+     * @var array<string, string>
      */
     protected $temp_files = [];
 
     /**
-     * @var array<lowercase-string, string>
+     * @var array<string, string>
      */
     protected static $open_files = [];
 
     public function getContents(string $file_path, bool $go_to_source = false): string
     {
-        $file_path_lc = strtolower($file_path);
-        if (!$go_to_source && isset($this->temp_files[$file_path_lc])) {
-            return $this->temp_files[$file_path_lc];
+        if (!$go_to_source && isset($this->temp_files[$file_path])) {
+            return $this->temp_files[$file_path];
         }
 
-        if (isset(self::$open_files[$file_path_lc])) {
-            return self::$open_files[$file_path_lc];
+        if (isset(self::$open_files[$file_path])) {
+            return self::$open_files[$file_path];
         }
 
         if (!file_exists($file_path)) {
@@ -52,20 +50,19 @@ class FileProvider
 
         $file_contents = (string) file_get_contents($file_path);
 
-        self::$open_files[$file_path_lc] = $file_contents;
+        self::$open_files[$file_path] = $file_contents;
 
         return $file_contents;
     }
 
     public function setContents(string $file_path, string $file_contents): void
     {
-        $file_path_lc = strtolower($file_path);
-        if (isset(self::$open_files[$file_path_lc])) {
-            self::$open_files[$file_path_lc] = $file_contents;
+        if (isset(self::$open_files[$file_path])) {
+            self::$open_files[$file_path] = $file_contents;
         }
 
-        if (isset($this->temp_files[$file_path_lc])) {
-            $this->temp_files[$file_path_lc] = $file_contents;
+        if (isset($this->temp_files[$file_path])) {
+            $this->temp_files[$file_path] = $file_contents;
         }
 
         file_put_contents($file_path, $file_contents);
@@ -73,9 +70,8 @@ class FileProvider
 
     public function setOpenContents(string $file_path, string $file_contents): void
     {
-        $file_path_lc = strtolower($file_path);
-        if (isset(self::$open_files[$file_path_lc])) {
-            self::$open_files[$file_path_lc] = $file_contents;
+        if (isset(self::$open_files[$file_path])) {
+            self::$open_files[$file_path] = $file_contents;
         }
     }
 
@@ -90,29 +86,27 @@ class FileProvider
 
     public function addTemporaryFileChanges(string $file_path, string $new_content): void
     {
-        $this->temp_files[strtolower($file_path)] = $new_content;
+        $this->temp_files[$file_path] = $new_content;
     }
 
     public function removeTemporaryFileChanges(string $file_path): void
     {
-        unset($this->temp_files[strtolower($file_path)]);
+        unset($this->temp_files[$file_path]);
     }
 
     public function openFile(string $file_path): void
     {
-        self::$open_files[strtolower($file_path)] = $this->getContents($file_path, true);
+        self::$open_files[$file_path] = $this->getContents($file_path, true);
     }
 
     public function isOpen(string $file_path): bool
     {
-        $file_path_lc = strtolower($file_path);
-        return isset($this->temp_files[$file_path_lc]) || isset(self::$open_files[$file_path_lc]);
+        return isset($this->temp_files[$file_path]) || isset(self::$open_files[$file_path]);
     }
 
     public function closeFile(string $file_path): void
     {
-        $file_path_lc = strtolower($file_path);
-        unset($this->temp_files[$file_path_lc], self::$open_files[$file_path_lc]);
+        unset($this->temp_files[$file_path], self::$open_files[$file_path]);
     }
 
     public function fileExists(string $file_path): bool


### PR DESCRIPTION
Fixes https://github.com/vimeo/psalm/issues/8008

Speeds up psalm between 5-15%.

Also fixes an issue on Unix systems where A.php and a.php were treated equal, even though they are different files, since unix file names are case sensitive.