### PR TITLE
Add docblock tag to require functions to validate param types (fixes #8017).

### DIFF
--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -33,6 +33,7 @@ final class DocComment
         'taint-unescape', 'self-out', 'consistent-constructor', 'stub-override',
         'require-extends', 'require-implements', 'param-out', 'ignore-var',
         'consistent-templates', 'if-this-is', 'this-out', 'check-type', 'check-type-exact',
+        'require-param-validation',
     ];
 
     /**

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1014,7 +1014,11 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 );
             }
 
-            if ($function_param->type) {
+            if ($storage->require_param_validation || $function_param->type === null) {
+                $param_type = $function_param->signature_type !== null
+                    ? clone $function_param->signature_type
+                    : Type::getMixed();
+            } else {
                 $param_type = clone $function_param->type;
 
                 try {
@@ -1059,8 +1063,6 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                         $check_stmts = false;
                     }
                 }
-            } else {
-                $param_type = Type::getMixed();
             }
 
             $var_type = $param_type;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -160,6 +160,12 @@ class FunctionLikeDocblockParser
             }
         }
 
+        if (isset($parsed_docblock->tags['require-param-validation'])
+            || isset($parsed_docblock->tags['psalm-require-param-validation'])
+        ) {
+            $info->require_param_validation = true;
+        }
+
         foreach (['psalm-self-out', 'psalm-this-out'] as $alias) {
             if (isset($parsed_docblock->tags[$alias])) {
                 foreach ($parsed_docblock->tags[$alias] as $offset => $param) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -204,6 +204,8 @@ class FunctionLikeDocblockScanner
             }
         }
 
+        $storage->require_param_validation = $docblock_info->require_param_validation;
+
         if (!$config->use_docblock_types) {
             return;
         }

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -53,6 +53,13 @@ class FunctionDocblockComment
     public $params_out = [];
 
     /**
+     * Whether to force docblock param validation when analyzing the functionlike.
+     *
+     * @var bool
+     */
+    public $require_param_validation = false;
+
+    /**
      * @var array{type:string, line_number: int}|null
      */
     public $self_out;

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -39,6 +39,13 @@ abstract class FunctionLikeStorage implements HasAttributesInterface
     public $param_lookup = [];
 
     /**
+     * Whether to force docblock param validation when analyzing the functionlike.
+     *
+     * @var bool
+     */
+    public $require_param_validation = false;
+
+    /**
      * @var Union|null
      */
     public $return_type;

--- a/tests/ParamValidationTest.php
+++ b/tests/ParamValidationTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Psalm\Tests;
+
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+class ParamValidationTest extends TestCase
+{
+    use InvalidCodeAnalysisTestTrait;
+    use ValidCodeAnalysisTestTrait;
+
+    /**
+     * @return iterable<string,array{code:string,assertions?:array<string,string>,ignored_issues?:list<string>,php_version?:string}>
+     */
+    public function providerValidCodeParse(): iterable
+    {
+        yield 'functionCheckMixedIsInt' => [
+            'code' => '<?php
+                /**
+                 * @psalm-require-param-validation
+                 * @param int $bar
+                 */
+                function foo($bar): void
+                {
+                    if (!is_int($bar)) {
+                        throw new \InvalidArgumentException();
+                    }
+                    requiresInt($bar);
+                }
+
+                function requiresInt(int $_int): void {}
+            ',
+        ];
+        yield 'functionPhpTypeIsInt' => [
+            'code' => '<?php
+                /**
+                 * @psalm-require-param-validation
+                 */
+                function foo(int $bar): void
+                {
+                    requiresInt($bar);
+                }
+
+                function requiresInt(int $_int): void {}
+            ',
+        ];
+        yield 'methodCheckMixedIsInt' => [
+            'code' => '<?php
+                class Foo
+                {
+                    /**
+                     * @psalm-require-param-validation
+                     * @param int $bar
+                     */
+                    public function foo($bar): void
+                    {
+                        if (!is_int($bar)) {
+                            throw new \InvalidArgumentException();
+                        }
+                        requiresInt($bar);
+                    }
+                }
+
+                function requiresInt(int $_int): void {}
+            ',
+        ];
+        yield 'methodPhpTypeIsInt' => [
+            'code' => '<?php
+                class Foo
+                {
+                    /**
+                     * @psalm-require-param-validation
+                     */
+                    public function foo(int $bar): void
+                    {
+                        requiresInt($bar);
+                    }
+                }
+
+                function requiresInt(int $_int): void {}
+            ',
+        ];
+    }
+
+    /**
+     * @return iterable<string,array{code:string,error_message:string,ignored_issues?:list<string>,php_version?:string}>
+     */
+    public function providerInvalidCodeParse(): iterable
+    {
+        yield 'functionCheckMixedIsInt' => [
+            'code' => '<?php
+                /**
+                 * @psalm-require-param-validation
+                 * @param int $bar
+                 */
+                function foo($bar): void
+                {
+                    requiresInt($bar);
+                }
+
+                function requiresInt(int $_int): void {}
+            ',
+            'error_message' => 'MixedArgument',
+        ];
+        yield 'methodCheckMixedIsInt' => [
+            'code' => '<?php
+                class Foo
+                {
+                    /**
+                     * @psalm-require-param-validation
+                     * @param int $bar
+                     */
+                    public function foo($bar): void
+                    {
+                        requiresInt($bar);
+                    }
+                }
+
+                function requiresInt(int $_int): void {}
+            ',
+            'error_message' => 'MixedArgument',
+        ];
+        yield 'checkPositiveIntForDeclaredInt' => [
+            'code' => '<?php
+                /**
+                 * @psalm-require-param-validation
+                 * @param int $bar
+                 */
+                function foo(int $bar): void
+                {
+                    requiresPositiveInt($bar);
+                }
+
+                /** @param positive-int $_int */
+                function requiresPositiveInt(int $_int): void {}
+            ',
+            'error_message' => 'ArgumentTypeCoercion',
+        ];
+        yield 'typeIsStillCheckedForCaller' => [
+            'code' => '<?php
+                /**
+                 * @psalm-require-param-validation
+                 * @param int $bar
+                 */
+                function foo($bar): void
+                {
+                    if (!is_int($bar)) {
+                        throw new \InvalidArgumentException();
+                    }
+                    requiresInt($bar);
+                }
+
+                function requiresInt(int $_int): void {}
+
+                foo("notanint");
+            ',
+            'error_message' => 'InvalidArgument',
+        ];
+    }
+}


### PR DESCRIPTION
Not sure if this will be merged, there's ongoing discussion in #8017, but the implementation was simple and I thought it might be useful to show how I think it should work.