### PR TITLE
Map LSP paths

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -23,6 +23,7 @@
             <xs:element name="universalObjectCrates" type="UniversalObjectCratesType" minOccurs="0" maxOccurs="1" />
             <xs:element name="enableExtensions" type="ExtensionsType" minOccurs="0" maxOccurs="1" />
             <xs:element name="disableExtensions" type="ExtensionsType" minOccurs="0" maxOccurs="1" />
+            <xs:element name="lsp" type="LspType" minOccurs="0" maxOccurs="1"></xs:element>
         </xs:choice>
 
         <xs:attribute name="autoloader" type="xs:string" />
@@ -735,5 +736,22 @@
 
     <xs:complexType name="ExtensionAttributeType">
         <xs:attribute name="name" type="ExtensionType" use="required" />
+    </xs:complexType>
+
+    <xs:complexType name="LspType">
+        <xs:sequence>
+            <xs:element name="pathMapping" maxOccurs="1" minOccurs="0" type="LspPathMappingType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="LspPathMappingType">
+        <xs:sequence>
+            <xs:element name="prefix" maxOccurs="unbounded" minOccurs="0" type="LspPathMappingPrefixType" />
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="LspPathMappingPrefixType">
+        <xs:attribute name="client" type="xs:string" use="required"/>
+        <xs:attribute name="server" type="xs:string" use="required"/>
     </xs:complexType>
 </xs:schema>

--- a/config.xsd
+++ b/config.xsd
@@ -746,7 +746,7 @@
 
     <xs:complexType name="LspPathMappingType">
         <xs:sequence>
-            <xs:element name="prefix" maxOccurs="unbounded" minOccurs="0" type="LspPathMappingPrefixType" />
+            <xs:element name="prefix" maxOccurs="unbounded" minOccurs="1" type="LspPathMappingPrefixType" />
         </xs:sequence>
     </xs:complexType>
 

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@6bcd3bffe3385bc33643a694c32af515395bf437">
+<files psalm-version="dev-master@29b654e3e5d59c0fb5cc008d9a24026f1fd8592d">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset>
       <code>$comment_block-&gt;tags['variablesfrom'][0]</code>
@@ -318,7 +318,6 @@
     <PossiblyUnusedParam>
       <code>$capabilities</code>
       <code>$processId</code>
-      <code>$rootPath</code>
     </PossiblyUnusedParam>
   </file>
   <file src="src/Psalm/Internal/LanguageServer/Message.php">

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -706,7 +706,7 @@ class Config
     public array $config_warnings = [];
 
     /** @var array<string, string> */
-    private $lsp_path_mapping = [];
+    private array $lsp_path_mapping = [];
 
     /** @internal */
     protected function __construct()

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -705,6 +705,9 @@ class Config
     /** @var list<string> */
     public array $config_warnings = [];
 
+    /** @var array<string, string> */
+    private $lsp_path_mapping = [];
+
     /** @internal */
     protected function __construct()
     {
@@ -1410,6 +1413,13 @@ class Config
 
         if (isset($config_xml['threads'])) {
             $config->threads = (int)$config_xml['threads'];
+        }
+
+        if (isset($config_xml->lsp->pathMapping->prefix)) {
+            /** @var SimpleXMLElement $prefix_mapping */
+            foreach ($config_xml->lsp->pathMapping->prefix as $prefix_mapping) {
+                $config->lsp_path_mapping[(string) $prefix_mapping['client']] = (string) $prefix_mapping['server'];
+            }
         }
 
         return $config;
@@ -2659,5 +2669,16 @@ class Config
     {
         /** @psalm-suppress UnresolvableInclude */
         require $this->autoloader;
+    }
+
+    public function hasLspPathMapping(): bool
+    {
+        return (bool) count($this->lsp_path_mapping);
+    }
+
+    /** @return array<string, string> */
+    public function getLspPathMapping(): array
+    {
+        return $this->lsp_path_mapping;
     }
 }

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -15,6 +15,7 @@ use Psalm\FileManipulation;
 use Psalm\Internal\Codebase\TaintFlowGraph;
 use Psalm\Internal\FileManipulation\FileManipulationBuffer;
 use Psalm\Internal\LanguageServer\LanguageServer;
+use Psalm\Internal\LanguageServer\PathMapper\NullMapper;
 use Psalm\Internal\LanguageServer\ProtocolStreamReader;
 use Psalm\Internal\LanguageServer\ProtocolStreamWriter;
 use Psalm\Internal\MethodIdentifier;
@@ -438,6 +439,7 @@ class ProjectAnalyzer
                 new ProtocolStreamReader($socket),
                 new ProtocolStreamWriter($socket),
                 $this,
+                new NullMapper(),
             );
             Loop::run();
         } elseif ($socket_server_mode && $address) {
@@ -490,6 +492,7 @@ class ProjectAnalyzer
                             $reader,
                             new ProtocolStreamWriter($socket),
                             $this,
+                            new NullMapper(),
                         );
                         // Just for safety
                         exit(0);
@@ -501,6 +504,7 @@ class ProjectAnalyzer
                         new ProtocolStreamReader($socket),
                         new ProtocolStreamWriter($socket),
                         $this,
+                        new NullMapper(),
                     );
                     Loop::run();
                 }
@@ -512,6 +516,7 @@ class ProjectAnalyzer
                 new ProtocolStreamReader(STDIN),
                 new ProtocolStreamWriter(STDOUT),
                 $this,
+                new NullMapper(),
             );
             Loop::run();
         }
@@ -803,7 +808,7 @@ class ProjectAnalyzer
                         );
                     }
 
-                    $this->codebase->methods_to_move[$source_lc]= $destination;
+                    $this->codebase->methods_to_move[$source_lc] = $destination;
                 } else {
                     $this->codebase->methods_to_rename[$source_lc] = $destination_parts[1];
                 }

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -502,7 +502,7 @@ class LanguageServer extends Dispatcher
      *
      * @psalm-pure
      */
-    public static function pathToUri(string $filepath): string
+    public function pathToUri(string $filepath): string
     {
         $filepath = trim(str_replace('\\', '/', $filepath), '/');
         $parts = explode('/', $filepath);
@@ -521,7 +521,7 @@ class LanguageServer extends Dispatcher
     /**
      * Transforms URI into file path
      */
-    public static function uriToPath(string $uri): string
+    public function uriToPath(string $uri): string
     {
         $fragments = parse_url($uri);
         if ($fragments === false

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -102,13 +102,9 @@ class LanguageServer extends Dispatcher
      */
     protected JsonMapper $mapper;
 
-    /**
-     * @var PathMapperInterface
-     */
-    private $path_mapper;
+    private PathMapperInterface $path_mapper;
 
-    /** @var ?string */
-    private $root_path = null;
+    private ?string $root_path = null;
 
     public function __construct(
         ProtocolReader $reader,

--- a/src/Psalm/Internal/LanguageServer/PathMapper/NullMapper.php
+++ b/src/Psalm/Internal/LanguageServer/PathMapper/NullMapper.php
@@ -2,14 +2,15 @@
 
 namespace Psalm\Internal\LanguageServer\PathMapper;
 
+/** @internal */
 final class NullMapper implements PathMapperInterface
 {
-    public function mapFromClient(string $path): string
+    public function mapFromClient(string $path, string $client_root): string
     {
         return $path;
     }
 
-    public function mapToClient(string $path): string
+    public function mapToClient(string $path, string $client_root): string
     {
         return $path;
     }

--- a/src/Psalm/Internal/LanguageServer/PathMapper/NullMapper.php
+++ b/src/Psalm/Internal/LanguageServer/PathMapper/NullMapper.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Psalm\Internal\LanguageServer\PathMapper;
+
+final class NullMapper implements PathMapperInterface
+{
+    public function mapFromClient(string $path): string
+    {
+        return $path;
+    }
+
+    public function mapToClient(string $path): string
+    {
+        return $path;
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/PathMapper/PathMapperInterface.php
+++ b/src/Psalm/Internal/LanguageServer/PathMapper/PathMapperInterface.php
@@ -2,8 +2,9 @@
 
 namespace Psalm\Internal\LanguageServer\PathMapper;
 
+/** @internal */
 interface PathMapperInterface
 {
-    public function mapFromClient(string $path): string;
-    public function mapToClient(string $path): string;
+    public function mapFromClient(string $path, string $client_root): string;
+    public function mapToClient(string $path, string $client_root): string;
 }

--- a/src/Psalm/Internal/LanguageServer/PathMapper/PathMapperInterface.php
+++ b/src/Psalm/Internal/LanguageServer/PathMapper/PathMapperInterface.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Internal\LanguageServer\PathMapper;
+
+interface PathMapperInterface
+{
+    public function mapFromClient(string $path): string;
+    public function mapToClient(string $path): string;
+}

--- a/src/Psalm/Internal/LanguageServer/PathMapper/PrefixMapper.php
+++ b/src/Psalm/Internal/LanguageServer/PathMapper/PrefixMapper.php
@@ -12,10 +12,10 @@ use function uksort;
 final class PrefixMapper implements PathMapperInterface
 {
     /** @var array<string, string> */
-    private $client_to_server = [];
+    private array $client_to_server = [];
 
     /** @var array<string, string> */
-    private $server_to_client = [];
+    private array $server_to_client = [];
 
     /**
      * @param array<string, string> $mapping
@@ -24,9 +24,7 @@ final class PrefixMapper implements PathMapperInterface
     {
         uksort(
             $mapping,
-            function (string $a, string $b): int {
-                return strlen($b) - strlen($a);
-            }
+            fn(string $a, string $b) => strlen($a) <=> strlen($b),
         );
         $this->client_to_server = $mapping;
         $this->server_to_client = array_flip($mapping);

--- a/src/Psalm/Internal/LanguageServer/PathMapper/PrefixMapper.php
+++ b/src/Psalm/Internal/LanguageServer/PathMapper/PrefixMapper.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Psalm\Internal\LanguageServer\PathMapper;
+
+use SimpleXMLElement;
+
+use function array_flip;
+use function str_starts_with;
+use function strlen;
+use function substr;
+use function uksort;
+
+final class PrefixMapper implements PathMapperInterface
+{
+    /** @var array<string, string> */
+    private $client_to_server = [];
+
+    /** @var array<string, string> */
+    private $server_to_client = [];
+
+    /**
+     * @param array<string, string> $mapping
+     */
+    public function __construct(array $mapping)
+    {
+        uksort(
+            $mapping,
+            function (string $a, string $b): int {
+                return strlen($b) - strlen($a);
+            }
+        );
+        $this->client_to_server = $mapping;
+        $this->server_to_client = array_flip($mapping);
+    }
+
+    public function mapFromClient(string $path): string
+    {
+        return $this->map($this->client_to_server, $path);
+    }
+
+    public function mapToClient(string $path): string
+    {
+        return $this->map($this->server_to_client, $path);
+    }
+
+    /** @param array<string, string> $mapping */
+    private function map(array $mapping, string $path): string
+    {
+        foreach ($mapping as $from => $to) {
+            if (str_starts_with($path, $from)) {
+                return $to . substr($path, strlen($from));
+            }
+        }
+        return $path;
+    }
+
+    public static function fromConfigEntry(SimpleXMLElement $_elt): self
+    {
+        return new self([]);
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/PathMapper/PrefixMapper.php
+++ b/src/Psalm/Internal/LanguageServer/PathMapper/PrefixMapper.php
@@ -2,14 +2,13 @@
 
 namespace Psalm\Internal\LanguageServer\PathMapper;
 
-use SimpleXMLElement;
-
 use function array_flip;
 use function str_starts_with;
 use function strlen;
 use function substr;
 use function uksort;
 
+/** @internal */
 final class PrefixMapper implements PathMapperInterface
 {
     /** @var array<string, string> */
@@ -33,20 +32,12 @@ final class PrefixMapper implements PathMapperInterface
         $this->server_to_client = array_flip($mapping);
     }
 
-    public function mapFromClient(string $path): string
+    public function mapFromClient(string $path, string $client_root): string
     {
-        return $this->map($this->client_to_server, $path);
-    }
-
-    public function mapToClient(string $path): string
-    {
-        return $this->map($this->server_to_client, $path);
-    }
-
-    /** @param array<string, string> $mapping */
-    private function map(array $mapping, string $path): string
-    {
-        foreach ($mapping as $from => $to) {
+        foreach ($this->client_to_server as $from => $to) {
+            if (str_starts_with($from, '{root}')) {
+                $from = $client_root . substr($from, 6);
+            }
             if (str_starts_with($path, $from)) {
                 return $to . substr($path, strlen($from));
             }
@@ -54,8 +45,16 @@ final class PrefixMapper implements PathMapperInterface
         return $path;
     }
 
-    public static function fromConfigEntry(SimpleXMLElement $_elt): self
+    public function mapToClient(string $path, string $client_root): string
     {
-        return new self([]);
+        foreach ($this->server_to_client as $from => $to) {
+            if (str_starts_with($to, '{root}')) {
+                $to = $client_root . substr($to, 6);
+            }
+            if (str_starts_with($path, $from)) {
+                return $to . substr($path, strlen($from));
+            }
+        }
+        return $path;
     }
 }

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -68,7 +68,7 @@ class TextDocument
      */
     public function didOpen(TextDocumentItem $textDocument): void
     {
-        $file_path = LanguageServer::uriToPath($textDocument->uri);
+        $file_path = $this->server->uriToPath($textDocument->uri);
 
         if (!$this->codebase->config->isInProjectDirs($file_path)) {
             return;
@@ -87,7 +87,7 @@ class TextDocument
      */
     public function didSave(TextDocumentItem $textDocument, ?string $text): void
     {
-        $file_path = LanguageServer::uriToPath($textDocument->uri);
+        $file_path = $this->server->uriToPath($textDocument->uri);
 
         if (!$this->codebase->config->isInProjectDirs($file_path)) {
             return;
@@ -107,7 +107,7 @@ class TextDocument
      */
     public function didChange(VersionedTextDocumentIdentifier $textDocument, array $contentChanges): void
     {
-        $file_path = LanguageServer::uriToPath($textDocument->uri);
+        $file_path = $this->server->uriToPath($textDocument->uri);
 
         if (!$this->codebase->config->isInProjectDirs($file_path)) {
             return;
@@ -141,7 +141,7 @@ class TextDocument
      */
     public function didClose(TextDocumentIdentifier $textDocument): void
     {
-        $file_path = LanguageServer::uriToPath($textDocument->uri);
+        $file_path = $this->server->uriToPath($textDocument->uri);
 
         $this->codebase->file_provider->closeFile($file_path);
         $this->server->client->textDocument->publishDiagnostics($textDocument->uri, []);
@@ -157,7 +157,7 @@ class TextDocument
      */
     public function definition(TextDocumentIdentifier $textDocument, Position $position): Promise
     {
-        $file_path = LanguageServer::uriToPath($textDocument->uri);
+        $file_path = $this->server->uriToPath($textDocument->uri);
 
         try {
             $reference_location = $this->codebase->getReferenceAtPosition($file_path, $position);
@@ -182,7 +182,7 @@ class TextDocument
 
         return new Success(
             new Location(
-                LanguageServer::pathToUri($code_location->file_path),
+                $this->server->pathToUri($code_location->file_path),
                 new Range(
                     new Position($code_location->getLineNumber() - 1, $code_location->getColumn() - 1),
                     new Position($code_location->getEndLineNumber() - 1, $code_location->getEndColumn() - 1),
@@ -201,7 +201,7 @@ class TextDocument
      */
     public function hover(TextDocumentIdentifier $textDocument, Position $position): Promise
     {
-        $file_path = LanguageServer::uriToPath($textDocument->uri);
+        $file_path = $this->server->uriToPath($textDocument->uri);
 
         try {
             $reference_location = $this->codebase->getReferenceAtPosition($file_path, $position);
@@ -252,7 +252,7 @@ class TextDocument
      */
     public function completion(TextDocumentIdentifier $textDocument, Position $position): Promise
     {
-        $file_path = LanguageServer::uriToPath($textDocument->uri);
+        $file_path = $this->server->uriToPath($textDocument->uri);
         if (!$this->codebase->config->isInProjectDirs($file_path)) {
             return new Success([]);
         }
@@ -306,7 +306,7 @@ class TextDocument
      */
     public function signatureHelp(TextDocumentIdentifier $textDocument, Position $position): Promise
     {
-        $file_path = LanguageServer::uriToPath($textDocument->uri);
+        $file_path = $this->server->uriToPath($textDocument->uri);
 
         try {
             $argument_location = $this->codebase->getFunctionArgumentAtPosition($file_path, $position);
@@ -339,7 +339,7 @@ class TextDocument
      */
     public function codeAction(TextDocumentIdentifier $textDocument, Range $range): Promise
     {
-        $file_path = LanguageServer::uriToPath($textDocument->uri);
+        $file_path = $this->server->uriToPath($textDocument->uri);
         if (!$this->codebase->file_provider->isOpen($file_path)) {
             return new Success(null);
         }

--- a/src/Psalm/Internal/LanguageServer/Server/Workspace.php
+++ b/src/Psalm/Internal/LanguageServer/Server/Workspace.php
@@ -47,7 +47,7 @@ class Workspace
     public function didChangeWatchedFiles(array $changes): void
     {
         foreach ($changes as $change) {
-            $file_path = LanguageServer::uriToPath($change->uri);
+            $file_path = $this->server->uriToPath($change->uri);
 
             if ($change->type === FileChangeType::DELETED) {
                 $this->codebase->invalidateInformationForFile($file_path);


### PR DESCRIPTION
Allows mapping of paths passed over LSP protocol. This is useful where you need
to run Psalm language server inside a container where project paths differ from
those on host machine.

Partly addresses vimeo/psalm#6919 (for LSP only)
