### PR TITLE
Fix syntax check failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
+      - name: Drop incompatible packages
+        run: composer remove --no-interaction --dev phpunit/phpunit brianium/paratest psalm/plugin-phpunit weirdan/prophecy-shim
+
       - name: Run composer install
-        run: composer install -o --ignore-platform-reqs
+        run: composer install -o
         env:
           COMPOSER_ROOT_VERSION: dev-master
 


### PR DESCRIPTION
They were caused by installing packages with `--ignore-platform-reqs`
which brought PHP 8.1 autoloaded packages and caused fatal errors when
running php-parallel-lint. Instead of ignoring platform requirements we
now remove packages that are incompatible with PHP 7.1 (phpunit and its
dependents).
