### PR TITLE
Run Shepherd with 8.0

### DIFF
--- a/.github/workflows/shepherd.yml
+++ b/.github/workflows/shepherd.yml
@@ -8,6 +8,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - uses: shivammathur/setup-php@v2
+      with:
+        php-version: '8.0'
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-suggest


### PR DESCRIPTION
Because installing packages with 8.1 and checking them as if we're
running 7.1 just doesn't work.
