### PR TITLE
Fix `TypeCombiner::combine` to not modify TIntRange arguments.

### DIFF
--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -1201,6 +1201,7 @@ class TypeCombiner
                     $combination->value_types['int'] = new TInt();
                 }
             } elseif ($type instanceof TIntRange) {
+                $type = clone $type;
                 if ($combination->ints) {
                     foreach ($combination->ints as $int) {
                         if (!$type->contains($int->value)) {

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -2,13 +2,25 @@
 
 namespace Psalm\Tests;
 
+use Psalm\Internal\Type\TypeCombiner;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+use Psalm\Type\Atomic\TIntRange;
+use Psalm\Type\Atomic\TLiteralInt;
 
 class IntRangeTest extends TestCase
 {
     use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
+
+    public function testCombineIntRangeDoesntAffectOriginal(): void
+    {
+        $range = new TIntRange(5, 10);
+        TypeCombiner::combine([new TLiteralInt(1), new TLiteralInt(50), $range]);
+
+        $this->assertEquals(5, $range->min_bound);
+        $this->assertEquals(10, $range->max_bound);
+    }
 
     /**
      * @return iterable<string,array{string,assertions?:array<string,string>,error_levels?:string[]}>


### PR DESCRIPTION
This keeps coming up in obscure places, hopefully this fixes it once and for all. I would reeeaaally love to have an immutable type system at some point...