### PR TITLE
store origin location by ID to speed up psalm by up to 75%

### DIFF
--- a/src/Psalm/Internal/Codebase/VariableUseGraph.php
+++ b/src/Psalm/Internal/Codebase/VariableUseGraph.php
@@ -18,6 +18,9 @@ class VariableUseGraph extends DataFlowGraph
     /** @var array<string, DataFlowNode> */
     private $nodes = [];
 
+    /** @var array<string, list<CodeLocation>> */
+    private $origin_locations_by_id = [];
+
     public function addNode(DataFlowNode $node): void
     {
         $this->nodes[$node->id] = $node;
@@ -94,6 +97,10 @@ class VariableUseGraph extends DataFlowGraph
      */
     public function getOriginLocations(DataFlowNode $assignment_node): array
     {
+        if (isset($this->origin_locations_by_id[$assignment_node->id])) {
+            return $this->origin_locations_by_id[$assignment_node->id];
+        }
+
         $visited_child_ids = [];
 
         $origin_locations = [];
@@ -127,6 +134,8 @@ class VariableUseGraph extends DataFlowGraph
 
             $child_nodes = $new_parent_nodes;
         }
+
+        $this->origin_locations_by_id[$assignment_node->id] = $origin_locations;
 
         return $origin_locations;
     }


### PR DESCRIPTION
In some instances with particularly nested/bad code, psalm can spend minutes on a single file (and it's includes) with getOriginLocations being called over and over again on the same thing.
This runtime caches the locations in a private variable, to speed up psalm up to 75% (worst file I tested)

Similar to https://github.com/vimeo/psalm/pull/8011