### PR TITLE
Performance: cut the selected_text from snippet

### DIFF
--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -296,7 +296,9 @@ class CodeLocation
         }
 
         $this->snippet = mb_strcut($file_contents, $this->preview_start, $this->preview_end - $this->preview_start);
-        $this->text = mb_strcut($file_contents, $this->selection_start, $this->selection_end - $this->selection_start);
+        // text is within snippet. It's 50% faster to cut it from the snippet than from the full text
+        $selection_length = $this->selection_end - $this->selection_start;
+        $this->text = mb_strcut($this->snippet, $this->selection_start - $this->preview_start, $selection_length);
 
         // reset preview start to beginning of line
         if ($file_contents !== '') {


### PR DESCRIPTION
instead of from full text

50% faster than cutting from full text, improves psalm performance up to 3% depending on file length and number of errors in file