### PR TITLE
fix false positives for partially invalid phpdoc

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -3,12 +3,15 @@
 namespace Psalm\Internal\PhpVisitor\Reflector;
 
 use PhpParser;
+use Psalm\CodeLocation;
 use Psalm\DocComment;
 use Psalm\Exception\DocblockParseException;
 use Psalm\Exception\IncorrectDocblockException;
 use Psalm\Internal\Analyzer\CommentAnalyzer;
 use Psalm\Internal\Scanner\FunctionDocblockComment;
 use Psalm\Internal\Scanner\ParsedDocblock;
+use Psalm\Issue\InvalidDocblock;
+use Psalm\IssueBuffer;
 
 use function array_shift;
 use function array_unique;
@@ -34,8 +37,11 @@ class FunctionLikeDocblockParser
     /**
      * @throws DocblockParseException if there was a problem parsing the docblock
      */
-    public static function parse(PhpParser\Comment\Doc $comment): FunctionDocblockComment
-    {
+    public static function parse(
+        PhpParser\Comment\Doc $comment,
+        CodeLocation $code_location,
+        string $cased_function_id
+    ): FunctionDocblockComment {
         $parsed_docblock = DocComment::parsePreservingLength($comment);
 
         $comment_text = $comment->getText();
@@ -49,7 +55,9 @@ class FunctionLikeDocblockParser
             self::extractReturnType(
                 $comment,
                 $parsed_docblock->combined_tags['return'],
-                $info
+                $info,
+                $code_location,
+                $cased_function_id
             );
         }
 
@@ -107,7 +115,12 @@ class FunctionLikeDocblockParser
                         $info->params[] = $info_param;
                     }
                 } else {
-                    throw new DocblockParseException('Badly-formatted @param');
+                    IssueBuffer::maybeAdd(
+                        new InvalidDocblock(
+                            'Badly-formatted @param in docblock for ' . $cased_function_id,
+                            $code_location
+                        )
+                    );
                 }
             }
         }
@@ -152,7 +165,12 @@ class FunctionLikeDocblockParser
                         ];
                     }
                 } else {
-                    throw new DocblockParseException('Badly-formatted @param');
+                    IssueBuffer::maybeAdd(
+                        new InvalidDocblock(
+                            'Badly-formatted @param in docblock for ' . $cased_function_id,
+                            $code_location
+                        )
+                    );
                 }
             }
         }
@@ -335,7 +353,12 @@ class FunctionLikeDocblockParser
                         ];
                     }
                 } else {
-                    throw new DocblockParseException('Badly-formatted @param');
+                    IssueBuffer::maybeAdd(
+                        new InvalidDocblock(
+                            'Badly-formatted @param in docblock for ' . $cased_function_id,
+                            $code_location
+                        )
+                    );
                 }
             }
         }
@@ -542,7 +565,9 @@ class FunctionLikeDocblockParser
     private static function extractReturnType(
         PhpParser\Comment\Doc $comment,
         array $return_specials,
-        FunctionDocblockComment $info
+        FunctionDocblockComment $info,
+        CodeLocation $code_location,
+        string $cased_function_id
     ): void {
         foreach ($return_specials as $offset => $return_block) {
             $return_lines = explode("\n", $return_block);
@@ -581,7 +606,12 @@ class FunctionLikeDocblockParser
                 $info->return_type_start = $offset;
                 $info->return_type_end = $end;
             } else {
-                throw new DocblockParseException('Badly-formatted @return type');
+                IssueBuffer::maybeAdd(
+                    new InvalidDocblock(
+                        'Badly-formatted @param in docblock for ' . $cased_function_id,
+                        $code_location
+                    )
+                );
             }
 
             break;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -467,7 +467,8 @@ class FunctionLikeNodeScanner
 
         if ($doc_comment) {
             try {
-                $docblock_info = FunctionLikeDocblockParser::parse($doc_comment);
+                $code_location = new CodeLocation($this->file_scanner, $stmt, null, true);
+                $docblock_info = FunctionLikeDocblockParser::parse($doc_comment, $code_location, $cased_function_id);
             } catch (IncorrectDocblockException $e) {
                 $storage->docblock_issues[] = new MissingDocblockType(
                     $e->getMessage() . ' in docblock for ' . $cased_function_id,
@@ -1041,7 +1042,12 @@ class FunctionLikeNodeScanner
                 if ($doc_comment) {
                     $docblock_info = null;
                     try {
-                        $docblock_info = FunctionLikeDocblockParser::parse($doc_comment);
+                        $code_location = new CodeLocation($this->file_scanner, $stmt, null, true);
+                        $docblock_info = FunctionLikeDocblockParser::parse(
+                            $doc_comment,
+                            $code_location,
+                            $cased_function_id
+                        );
                     } catch (IncorrectDocblockException|DocblockParseException $e) {
                     }
                     if ($docblock_info) {


### PR DESCRIPTION
Fix 2 cases specified in https://github.com/vimeo/psalm/issues/7902

Can someone please help me fix the tests, since I don't know how to mock the CodeLocation in FunctionLikeDocblockParserTest.php?