### PR TITLE
Bring back disableVarParsing option

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -55,6 +55,7 @@
         <xs:attribute name="resolveFromConfigFile" type="xs:boolean" default="true" />
         <xs:attribute name="strictBinaryOperands" type="xs:boolean" default="false" />
         <xs:attribute name="throwExceptionOnError" type="xs:boolean" default="false" />
+        <xs:attribute name="disableVarParsing" type="xs:boolean" default="false" />
         <xs:attribute name="errorLevel" type="xs:integer" default="2" />
         <xs:attribute name="reportMixedIssues" type="xs:boolean" default="true" />
         <xs:attribute name="useDocblockTypes" type="xs:boolean" default="true" />


### PR DESCRIPTION
Bring back the disableVarParsing option after it was accidentally removed from the config schema during a merge.