### PR TITLE
Feature: allow non-union assertion types

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -1139,6 +1139,6 @@ class CallAnalyzer
             return true;
         }
 
-        return $new_type->allLiterals();
+        return !$old_type->isSingle();
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -793,10 +793,10 @@ class CallAnalyzer
                                     );
                                 }
                             }
-                        } else if (isset($arg_var_id, $context->vars_in_scope[$arg_var_id])) {
+                        } elseif (isset($arg_var_id) && isset($context->vars_in_scope[$arg_var_id])) {
                             $other_type = $context->vars_in_scope[$arg_var_id];
                             if (self::isNewTypeNarrowingDownOldType($other_type, $union)) {
-                                foreach($union->getAtomicTypes() as $atomic_type) {
+                                foreach ($union->getAtomicTypes() as $atomic_type) {
                                     if ($assertion_type instanceof TTemplateParam
                                         && $assertion_type->as->getId() === $atomic_type->getId()
                                     ) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -1135,10 +1135,23 @@ class CallAnalyzer
      */
     private static function isNewTypeNarrowingDownOldType(Union $old_type, Union $new_type): bool
     {
+        // non-mixed is always better than mixed
         if ($old_type->isMixed() && !$new_type->hasMixed()) {
             return true;
         }
 
-        return !$old_type->isSingle();
+        // non-nullable is always better than nullable
+        if ($old_type->isNullable() && !$new_type->isNullable()) {
+            return true;
+        }
+
+        // Literals might always replace non-literals (even tho the old type could already contain a literal)
+        if (($old_type->isString() && $new_type->allStringLiterals())
+            || ($old_type->isInt() && $new_type->allIntLiterals())
+            || ($old_type->isFloat() && $new_type->allFloatLiterals())) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -763,7 +763,9 @@ class CallAnalyzer
                             $codebase
                         );
 
-                        if ($union->isSingle() || $union->allLiterals()) {
+                        $arg_var_type = $context->vars_in_scope[$assertion_var_id];
+
+                        if (self::isNewTypeNarrowingDownOldType($arg_var_type, $union)) {
                             foreach ($union->getAtomicTypes() as $atomic_type) {
                                 if ($assertion_type instanceof TTemplateParam
                                     && $assertion_type->as->getId() === $atomic_type->getId()
@@ -1116,5 +1118,25 @@ class CallAnalyzer
                 }
             }
         }
+    }
+
+    /**
+     * This method should detect if the new type narrows down the old type.
+     */
+    private static function isNewTypeNarrowingDownOldType(Union $old_type, Union $new_type): bool
+    {
+        if ($new_type->isSingle()) {
+            return true;
+        }
+
+        if ($old_type->hasMixed() && !$new_type->hasMixed()) {
+            return true;
+        }
+
+        if ($old_type->isSingleAndMaybeNullable() && !$new_type->isNullable()) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -763,7 +763,7 @@ class CallAnalyzer
                             $codebase
                         );
 
-                        if (!$union->hasMixed()) {
+                        if ($union->isSingle() || $union->allLiterals()) {
                             foreach ($union->getAtomicTypes() as $atomic_type) {
                                 if ($assertion_type instanceof TTemplateParam
                                     && $assertion_type->as->getId() === $atomic_type->getId()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -793,8 +793,8 @@ class CallAnalyzer
                                     );
                                 }
                             }
-                        } elseif (isset($arg_var_id) && isset($context->vars_in_scope[$arg_var_id])) {
-                            $other_type = $context->vars_in_scope[$arg_var_id];
+                        } elseif (isset($context->vars_in_scope[$assertion_var_id])) {
+                            $other_type = $context->vars_in_scope[$assertion_var_id];
                             if (self::isNewTypeNarrowingDownOldType($other_type, $union)) {
                                 foreach ($union->getAtomicTypes() as $atomic_type) {
                                     if ($assertion_type instanceof TTemplateParam

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -764,10 +764,13 @@ class CallAnalyzer
                         );
 
                         if ($union->isSingle()) {
-                            $atomic_type = $union->getSingleAtomic();
-                            if (!$assertion_type instanceof TTemplateParam
-                                || $assertion_type->as->getId() !== $atomic_type->getId()
-                            ) {
+                            foreach ($union->getAtomicTypes() as $atomic_type) {
+                                if ($assertion_type instanceof TTemplateParam
+                                    && $assertion_type->as->getId() === $atomic_type->getId()
+                                ) {
+                                    continue;
+                                }
+
                                 $assertion_rule = clone $assertion_rule;
                                 $assertion_rule->setAtomicType($atomic_type);
                                 $orred_rules[] = $assertion_rule;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -763,13 +763,14 @@ class CallAnalyzer
                             $codebase
                         );
 
-                        if ($union->isSingle()) {
+                        if (!$union->hasMixed()) {
                             foreach ($union->getAtomicTypes() as $atomic_type) {
                                 if ($assertion_type instanceof TTemplateParam
                                     && $assertion_type->as->getId() === $atomic_type->getId()
                                 ) {
                                     continue;
                                 }
+
                                 $assertion_rule = clone $assertion_rule;
                                 $assertion_rule->setAtomicType($atomic_type);
                                 $orred_rules[] = $assertion_rule;

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -2,6 +2,10 @@
 
 namespace Psalm\Type\Atomic;
 
+use Psalm\Type\Atomic;
+
+use function get_class;
+
 /**
  * Denotes a floating point value where the exact numeric value is known.
  */
@@ -40,5 +44,20 @@ final class TLiteralFloat extends TFloat
         bool $use_phpdoc_format
     ): string {
         return 'float';
+    }
+
+    public function equals(Atomic $other_type, bool $ensure_source_equality): bool
+    {
+        if (get_class($other_type) !== static::class) {
+            return false;
+        }
+
+        if (($this->from_docblock && $ensure_source_equality)
+            || ($other_type->from_docblock && $ensure_source_equality)
+        ) {
+            return false;
+        }
+
+        return $this->value === $other_type->value;
     }
 }

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -52,12 +52,6 @@ final class TLiteralFloat extends TFloat
             return false;
         }
 
-        if (($this->from_docblock && $ensure_source_equality)
-            || ($other_type->from_docblock && $ensure_source_equality)
-        ) {
-            return false;
-        }
-
         return $this->value === $other_type->value;
     }
 }

--- a/src/Psalm/Type/Atomic/TLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TLiteralInt.php
@@ -2,6 +2,10 @@
 
 namespace Psalm\Type\Atomic;
 
+use Psalm\Type\Atomic;
+
+use function get_class;
+
 /**
  * Denotes an integer value where the exact numeric value is known.
  */
@@ -45,5 +49,20 @@ final class TLiteralInt extends TInt
         bool $use_phpdoc_format
     ): string {
         return $use_phpdoc_format ? 'int' : (string) $this->value;
+    }
+
+    public function equals(Atomic $other_type, bool $ensure_source_equality): bool
+    {
+        if (get_class($other_type) !== static::class) {
+            return false;
+        }
+
+        if (($this->from_docblock && $ensure_source_equality)
+            || ($other_type->from_docblock && $ensure_source_equality)
+        ) {
+            return false;
+        }
+
+        return $this->value === $other_type->value;
     }
 }

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -2,7 +2,10 @@
 
 namespace Psalm\Type\Atomic;
 
+use Psalm\Type\Atomic;
+
 use function addcslashes;
+use function get_class;
 use function mb_strlen;
 use function mb_substr;
 
@@ -54,5 +57,20 @@ class TLiteralString extends TString
         bool $use_phpdoc_format
     ): string {
         return $use_phpdoc_format ? 'string' : "'" . $this->value . "'";
+    }
+
+    public function equals(Atomic $other_type, bool $ensure_source_equality): bool
+    {
+        if (get_class($other_type) !== static::class) {
+            return false;
+        }
+
+        if (($this->from_docblock && $ensure_source_equality)
+            || ($other_type->from_docblock && $ensure_source_equality)
+        ) {
+            return false;
+        }
+
+        return $this->value === $other_type->value;
     }
 }

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1267,6 +1267,17 @@ final class Union implements TypeNode
         return true;
     }
 
+    public function allFloatLiterals(): bool
+    {
+        foreach ($this->types as $atomic_key_type) {
+            if (!$atomic_key_type instanceof TLiteralFloat) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public function allLiterals(): bool
     {
         foreach ($this->types as $atomic_key_type) {

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -2055,6 +2055,34 @@ class AssertAnnotationTest extends TestCase
                         return $input;
                     }',
             ],
+            'assertOneOfValuesWithinArray' => [
+                'code' => '<?php
+
+                    /**
+                     * @template T
+                     * @param mixed $input
+                     * @param array<array-key,T> $values
+                     * @psalm-assert T $input
+                     */
+                    function assertOneOf($input, array $values): void {}
+
+                    /** @param literal-string $value */
+                    function consumeLiteralStringValue(string $value): void {}
+
+                    function consumeAnyIntegerValue(int $value): void {}
+
+                    /** @var string $string */
+                    $string;
+                    /** @var mixed $mixed */
+                    $mixed;
+
+                    assertOneOf($string, ["a"]);
+                    consumeLiteralStringValue($string);
+
+                    assertOneOf($mixed, [1, 2, 3]);
+                    consumeAnyIntegerValue($mixed);
+                '
+            ],
         ];
     }
 

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -90,7 +90,6 @@ class AssertAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
-
     /**
      * @return iterable<string,array{code:string,assertions?:array<string,string>,ignored_issues?:list<string>}>
      */
@@ -2082,6 +2081,9 @@ class AssertAnnotationTest extends TestCase
                     /** @var string $anotherString */
                     $anotherString;
 
+                    /** @var null|string $nullableString */
+                    $nullableString;
+
                     /** @var mixed $maybeInt */
                     $maybeInt;
                     /** @var mixed $maybeFloat */
@@ -2093,11 +2095,22 @@ class AssertAnnotationTest extends TestCase
                     assertOneOf($anotherString, ["a", "b", "c"]);
                     consumeLiteralStringValue($anotherString);
 
+                    assertOneOf($nullableString, ["a", "b", "c"]);
+                    assertOneOf($nullableString, ["a", "c"]);
+
                     assertOneOf($maybeInt, [1, 2, 3]);
                     consumeAnyIntegerValue($maybeInt);
 
                     assertOneOf($maybeFloat, [1.5, 2.5, 3.5]);
                     consumeAnyFloatValue($maybeFloat);
+
+                    /** @var "a"|"b"|"c" $abc */
+                    $abc;
+
+                    /** @param "a"|"b" $aOrB */
+                    function consumeAOrB(string $aOrB): void {}
+                    assertOneOf($abc, ["a", "b"]);
+                    consumeAOrB($abc);
                 '
             ],
         ];

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -2074,19 +2074,30 @@ class AssertAnnotationTest extends TestCase
 
                     function consumeAnyIntegerValue(int $value): void {}
 
+                    function consumeAnyFloatValue(float $value): void {}
+
                     /** @var string $string */
                     $string;
-                    /** @var mixed $mixed */
-                    $mixed;
+
+                    /** @var string $anotherString */
+                    $anotherString;
+
+                    /** @var mixed $maybeInt */
+                    $maybeInt;
+                    /** @var mixed $maybeFloat */
+                    $maybeFloat;
 
                     assertOneOf($string, ["a"]);
                     consumeSpecificStringValue($string);
 
-                    assertOneOf($string, ["a", "b", "c"]);
-                    consumeLiteralStringValue($string);
+                    assertOneOf($anotherString, ["a", "b", "c"]);
+                    consumeLiteralStringValue($anotherString);
 
-                    assertOneOf($mixed, [1, 2, 3]);
-                    consumeAnyIntegerValue($mixed);
+                    assertOneOf($maybeInt, [1, 2, 3]);
+                    consumeAnyIntegerValue($maybeInt);
+
+                    assertOneOf($maybeFloat, [1.5, 2.5, 3.5]);
+                    consumeAnyFloatValue($maybeFloat);
                 '
             ],
         ];

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -2066,6 +2066,9 @@ class AssertAnnotationTest extends TestCase
                      */
                     function assertOneOf($input, array $values): void {}
 
+                    /** @param "a" $value */
+                    function consumeSpecificStringValue(string $value): void {}
+
                     /** @param literal-string $value */
                     function consumeLiteralStringValue(string $value): void {}
 
@@ -2077,6 +2080,9 @@ class AssertAnnotationTest extends TestCase
                     $mixed;
 
                     assertOneOf($string, ["a"]);
+                    consumeSpecificStringValue($string);
+
+                    assertOneOf($string, ["a", "b", "c"]);
                     consumeLiteralStringValue($string);
 
                     assertOneOf($mixed, [1, 2, 3]);


### PR DESCRIPTION
In #5657, I was wondering why `oneOf` does not work as expected.
That was due to the fact that psalm is simply not able to apply assertions for non-single union types.

This PR changes this and thus is declared as `feature` even tho the originating issue was flagged as a bug.