### PR TITLE
Skip native classlike aliases

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -188,7 +188,7 @@ class ClassLikes
             /** @psalm-suppress ArgumentTypeCoercion */
             $reflection_class = new ReflectionClass($predefined_class);
 
-            if (!$reflection_class->isUserDefined()) {
+            if (!$reflection_class->isUserDefined() && $reflection_class->name === $predefined_class) {
                 $predefined_class_lc = strtolower($predefined_class);
                 $this->existing_classlikes_lc[$predefined_class_lc] = true;
                 $this->existing_classes_lc[$predefined_class_lc] = true;
@@ -204,7 +204,7 @@ class ClassLikes
             /** @psalm-suppress ArgumentTypeCoercion */
             $reflection_class = new ReflectionClass($predefined_interface);
 
-            if (!$reflection_class->isUserDefined()) {
+            if (!$reflection_class->isUserDefined() && $reflection_class->name === $predefined_interface) {
                 $predefined_interface_lc = strtolower($predefined_interface);
                 $this->existing_classlikes_lc[$predefined_interface_lc] = true;
                 $this->existing_interfaces_lc[$predefined_interface_lc] = true;


### PR DESCRIPTION
This pull request fixes reflection issues with extensions like https://github.com/jbboehr/php-psr which define class aliases.
With this pull request, native classlike aliases are simply ignored, and only the original native classlikes are loaded using reflection.

This fixes #8079 by letting Psalm fallback onto the userland polyfills, instead.