### PR TITLE
Fix nasty parameter storage corruption bug

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -1795,7 +1795,7 @@ class ArgumentsAnalyzer
                     }
 
                     TemplateStandinTypeReplacer::replace(
-                        $param->type,
+                        clone $param->type,
                         $template_result,
                         $codebase,
                         $statements_analyzer,


### PR DESCRIPTION
This fixes a very nasty parameter storage corruption bug, which lead to very hard to reproduce, order-dependent false positives and false negatives in our codebase.