### PR TITLE
Callmap validation ignore list cleanup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,6 +113,7 @@
         "lint": "parallel-lint ./src ./tests",
         "phpunit": "paratest --runner=WrapperRunner",
         "phpunit-std": "phpunit",
+        "verify-callmap": "phpunit tests/Internal/Codebase/InternalCallMapHandlerTest.php",
         "psalm": "@php ./psalm --find-dead-code",
         "tests": [
             "@lint",


### PR DESCRIPTION
This PR:

- Cleans up the ignore list in the callmap validation
- Replaces prefix ignores with individual ignores
- Add a "negative" test to ensure that ignored functions still need to be ignored