### PR TITLE
Improve @psalm-internal and prevent usage of IssueBuffer::add().

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -135,6 +135,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         }
     }
 
+    /** @return non-empty-string */
     public static function getAnonymousClassName(PhpParser\Node\Stmt\Class_ $class, string $file_path): string
     {
         return preg_replace('/[^A-Za-z0-9]/', '_', $file_path)
@@ -251,7 +252,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         }
 
         foreach ($storage->docblock_issues as $docblock_issue) {
-            IssueBuffer::add($docblock_issue);
+            IssueBuffer::maybeAdd($docblock_issue);
         }
 
         $classlike_storage_provider = $codebase->classlike_storage_provider;
@@ -1647,7 +1648,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         $config = Config::getInstance();
 
         if ($stmt->stmts === null && !$stmt->isAbstract()) {
-            IssueBuffer::add(
+            IssueBuffer::maybeAdd(
                 new ParseError(
                     'Non-abstract class method must have statements',
                     new CodeLocation($this, $stmt)
@@ -1660,7 +1661,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
         try {
             $method_analyzer = new MethodAnalyzer($stmt, $source);
         } catch (UnexpectedValueException $e) {
-            IssueBuffer::add(
+            IssueBuffer::maybeAdd(
                 new ParseError(
                     'Problem loading method: ' . $e->getMessage(),
                     new CodeLocation($this, $stmt)
@@ -2506,11 +2507,12 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                 );
             }
 
-            if (!NamespaceAnalyzer::isWithin($fq_class_name, $parent_class_storage->internal)) {
+            if (!NamespaceAnalyzer::isWithinAny($fq_class_name, $parent_class_storage->internal)) {
                 IssueBuffer::maybeAdd(
                     new InternalClass(
-                        $parent_fq_class_name . ' is internal to ' . $parent_class_storage->internal
-                        . ' but called from ' . $fq_class_name,
+                        $parent_fq_class_name . ' is internal to '
+                            . InternalClass::listToPhrase($parent_class_storage->internal)
+                            . ' but called from ' . $fq_class_name,
                         $code_location,
                         $parent_fq_class_name
                     ),

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -9,6 +9,7 @@ use Psalm\Exception\DocblockParseException;
 use Psalm\Exception\IncorrectDocblockException;
 use Psalm\Exception\TypeParseTreeException;
 use Psalm\FileSource;
+use Psalm\Internal\Scanner\DocblockParser;
 use Psalm\Internal\Scanner\ParsedDocblock;
 use Psalm\Internal\Scanner\VarDocblockComment;
 use Psalm\Internal\Type\TypeAlias;
@@ -21,7 +22,6 @@ use function count;
 use function preg_match;
 use function preg_replace;
 use function preg_split;
-use function reset;
 use function rtrim;
 use function str_replace;
 use function strlen;
@@ -236,14 +236,7 @@ class CommentAnalyzer
             }
         }
 
-        if (isset($parsed_docblock->tags['psalm-internal'])) {
-            $psalm_internal = trim(reset($parsed_docblock->tags['psalm-internal']));
-
-            if (!$psalm_internal) {
-                throw new DocblockParseException('psalm-internal annotation used without specifying namespace');
-            }
-
-            $var_comment->psalm_internal = $psalm_internal;
+        if (count($var_comment->psalm_internal = DocblockParser::handlePsalmInternal($parsed_docblock)) !== 0) {
             $var_comment->internal = true;
         }
 

--- a/src/Psalm/Internal/Analyzer/FileAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FileAnalyzer.php
@@ -196,7 +196,7 @@ class FileAnalyzer extends SourceAnalyzer
         $statements_analyzer = new StatementsAnalyzer($this, $this->node_data);
 
         foreach ($file_storage->docblock_issues as $docblock_issue) {
-            IssueBuffer::add($docblock_issue);
+            IssueBuffer::maybeAdd($docblock_issue);
         }
 
         // if there are any leftover statements, evaluate them,

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -209,7 +209,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         }
 
         foreach ($storage->docblock_issues as $docblock_issue) {
-            IssueBuffer::add($docblock_issue);
+            IssueBuffer::maybeAdd($docblock_issue);
         }
 
         $function_information = $this->getFunctionInformation(

--- a/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
@@ -133,7 +133,7 @@ class InterfaceAnalyzer extends ClassLikeAnalyzer
                     );
                 }
             } elseif ($stmt instanceof PhpParser\Node\Stmt\Property) {
-                IssueBuffer::add(
+                IssueBuffer::maybeAdd(
                     new ParseError(
                         'Interfaces cannot have properties',
                         new CodeLocation($this, $stmt)

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -74,7 +74,7 @@ class ArrayAnalyzer
 
         foreach ($stmt->items as $item) {
             if ($item === null) {
-                IssueBuffer::add(
+                IssueBuffer::maybeAdd(
                     new ParseError(
                         'Array element cannot be empty',
                         new CodeLocation($statements_analyzer, $stmt)

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -959,7 +959,7 @@ class AssertionFinder
                     }
                 } elseif ($assertion->var_id === '$this') {
                     if (!$expr instanceof PhpParser\Node\Expr\MethodCall) {
-                        IssueBuffer::add(
+                        IssueBuffer::maybeAdd(
                             new InvalidDocblock(
                                 'Assertion of $this can be done only on method of a class',
                                 new CodeLocation($source, $expr)

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -37,6 +37,7 @@ use Psalm\Issue\DeprecatedProperty;
 use Psalm\Issue\ImplicitToStringCast;
 use Psalm\Issue\ImpurePropertyAssignment;
 use Psalm\Issue\InaccessibleProperty;
+use Psalm\Issue\InternalClass;
 use Psalm\Issue\InternalProperty;
 use Psalm\Issue\InvalidPropertyAssignment;
 use Psalm\Issue\InvalidPropertyAssignmentValue;
@@ -420,7 +421,7 @@ class InstancePropertyAssignmentAnalyzer
         foreach ($stmt->props as $prop) {
             if ($prop->default) {
                 if ($stmt->isReadonly()) {
-                    IssueBuffer::add(
+                    IssueBuffer::maybeAdd(
                         new InvalidPropertyAssignment(
                             'Readonly property ' . $context->self . '::$' . $prop->name->name
                                 . ' cannot have a default',
@@ -1258,11 +1259,11 @@ class InstancePropertyAssignmentAnalyzer
                 );
             }
 
-            if ($context->self && !NamespaceAnalyzer::isWithin($context->self, $property_storage->internal)) {
+            if ($context->self && !NamespaceAnalyzer::isWithinAny($context->self, $property_storage->internal)) {
                 IssueBuffer::maybeAdd(
                     new InternalProperty(
-                        $property_id . ' is internal to ' . $property_storage->internal
-                        . ' but called from ' . $context->self,
+                        $property_id . ' is internal to ' . InternalClass::listToPhrase($property_storage->internal)
+                            . ' but called from ' . $context->self,
                         new CodeLocation($statements_analyzer->getSource(), $stmt),
                         $property_id
                     ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -271,7 +271,7 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
                 $codebase,
                 $context,
                 $method_id,
-                $statements_analyzer->getNamespace(),
+                $statements_analyzer->getFullyQualifiedFunctionMethodOrNamespaceName(),
                 $name_code_location,
                 $statements_analyzer->getSuppressedIssues()
             );

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallProhibitionAnalyzer.php
@@ -8,6 +8,7 @@ use Psalm\Context;
 use Psalm\Internal\Analyzer\NamespaceAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Issue\DeprecatedMethod;
+use Psalm\Issue\InternalClass;
 use Psalm\Issue\InternalMethod;
 use Psalm\IssueBuffer;
 
@@ -22,7 +23,7 @@ class MethodCallProhibitionAnalyzer
         Codebase $codebase,
         Context $context,
         MethodIdentifier $method_id,
-        ?string $namespace,
+        ?string $caller_identifier,
         CodeLocation $code_location,
         array $suppressed_issues
     ): ?bool {
@@ -51,12 +52,12 @@ class MethodCallProhibitionAnalyzer
         if (!$context->collect_initializations
             && !$context->collect_mutations
         ) {
-            if (!NamespaceAnalyzer::isWithin($namespace ?: '', $storage->internal)) {
+            if (!NamespaceAnalyzer::isWithinAny($caller_identifier ?? "", $storage->internal)) {
                 IssueBuffer::maybeAdd(
                     new InternalMethod(
                         'The method ' . $codebase_methods->getCasedMethodId($method_id)
-                            . ' is internal to ' . $storage->internal
-                            . ' but called from ' . ($context->self ?: 'root namespace'),
+                            . ' is internal to ' . InternalClass::listToPhrase($storage->internal)
+                            . ' but called from ' . ($caller_identifier ?: 'root namespace'),
                         $code_location,
                         (string) $method_id
                     ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -349,12 +349,12 @@ class NewAnalyzer extends CallAnalyzer
         if ($context->self
             && !$context->collect_initializations
             && !$context->collect_mutations
-            && !NamespaceAnalyzer::isWithin($context->self, $storage->internal)
+            && !NamespaceAnalyzer::isWithinAny($context->self, $storage->internal)
         ) {
             IssueBuffer::maybeAdd(
                 new InternalClass(
-                    $fq_class_name . ' is internal to ' . $storage->internal
-                    . ' but called from ' . $context->self,
+                    $fq_class_name . ' is internal to ' . InternalClass::listToPhrase($storage->internal)
+                        . ' but called from ' . $context->self,
                     new CodeLocation($statements_analyzer->getSource(), $stmt),
                     $fq_class_name
                 ),
@@ -411,16 +411,13 @@ class NewAnalyzer extends CallAnalyzer
             if ($declaring_method_id) {
                 $method_storage = $codebase->methods->getStorage($declaring_method_id);
 
-                $namespace = $statements_analyzer->getNamespace() ?: '';
-                if (!NamespaceAnalyzer::isWithin(
-                    $namespace,
-                    $method_storage->internal
-                )) {
+                $caller_identifier = $statements_analyzer->getFullyQualifiedFunctionMethodOrNamespaceName() ?: '';
+                if (!NamespaceAnalyzer::isWithinAny($caller_identifier, $method_storage->internal)) {
                     IssueBuffer::maybeAdd(
                         new InternalMethod(
                             'Constructor ' . $codebase->methods->getCasedMethodId($declaring_method_id)
-                            . ' is internal to ' . $method_storage->internal
-                            . ' but called from ' . ($namespace ?: 'root namespace'),
+                                . ' is internal to ' . InternalClass::listToPhrase($method_storage->internal)
+                                . ' but called from ' . ($caller_identifier ?: 'root namespace'),
                             new CodeLocation($statements_analyzer, $stmt),
                             (string) $method_id
                         ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -792,10 +792,10 @@ class AtomicStaticCallAnalyzer
             );
         }
 
-        if ($context->self && ! NamespaceAnalyzer::isWithin($context->self, $class_storage->internal)) {
+        if ($context->self && ! NamespaceAnalyzer::isWithinAny($context->self, $class_storage->internal)) {
             IssueBuffer::maybeAdd(
                 new InternalClass(
-                    $fq_class_name . ' is internal to ' . $class_storage->internal
+                    $fq_class_name . ' is internal to ' . InternalClass::listToPhrase($class_storage->internal)
                         . ' but called from ' . $context->self,
                     new CodeLocation($statements_analyzer->getSource(), $stmt),
                     $fq_class_name

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -71,7 +71,7 @@ class ExistingAtomicStaticCallAnalyzer
             $codebase,
             $context,
             $method_id,
-            $statements_analyzer->getNamespace(),
+            $statements_analyzer->getFullyQualifiedFunctionMethodOrNamespaceName(),
             new CodeLocation($statements_analyzer->getSource(), $stmt),
             $statements_analyzer->getSuppressedIssues()
         ) === false) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -693,7 +693,7 @@ class CallAnalyzer
                 $exploded = explode('->', $assertion->var_id);
 
                 if (count($exploded) < 2) {
-                    IssueBuffer::add(
+                    IssueBuffer::maybeAdd(
                         new InvalidDocblock(
                             'Assert notation is malformed',
                             new CodeLocation($statements_analyzer, $expr)
@@ -707,7 +707,7 @@ class CallAnalyzer
                 $var_id = is_numeric($var_id) ? (int) $var_id : $var_id;
 
                 if (!is_int($var_id) || !isset($args[$var_id])) {
-                    IssueBuffer::add(
+                    IssueBuffer::maybeAdd(
                         new InvalidDocblock(
                             'Variable ' . $var_id . ' is not an argument so cannot be asserted',
                             new CodeLocation($statements_analyzer, $expr)
@@ -722,7 +722,7 @@ class CallAnalyzer
                 $arg_var_id = ExpressionIdentifier::getArrayVarId($arg_value, null, $statements_analyzer);
 
                 if (!$arg_var_id) {
-                    IssueBuffer::add(
+                    IssueBuffer::maybeAdd(
                         new InvalidDocblock(
                             'Variable being asserted as argument ' . ($var_id+1) .  ' cannot be found in local scope',
                             new CodeLocation($statements_analyzer, $expr)
@@ -740,7 +740,7 @@ class CallAnalyzer
                     );
 
                     if (null !== $failedMessage) {
-                        IssueBuffer::add(
+                        IssueBuffer::maybeAdd(
                             new InvalidDocblock($failedMessage, new CodeLocation($statements_analyzer, $expr))
                         );
                         continue;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -29,6 +29,7 @@ use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\DeprecatedProperty;
 use Psalm\Issue\ImpurePropertyFetch;
+use Psalm\Issue\InternalClass;
 use Psalm\Issue\InternalProperty;
 use Psalm\Issue\MissingPropertyType;
 use Psalm\Issue\NoInterfaceProperties;
@@ -405,10 +406,10 @@ class AtomicPropertyFetchAnalyzer
 
             $property_storage = $declaring_class_storage->properties[$prop_name];
 
-            if ($context->self && !NamespaceAnalyzer::isWithin($context->self, $property_storage->internal)) {
+            if ($context->self && !NamespaceAnalyzer::isWithinAny($context->self, $property_storage->internal)) {
                 IssueBuffer::maybeAdd(
                     new InternalProperty(
-                        $property_id . ' is internal to ' . $property_storage->internal
+                        $property_id . ' is internal to ' . InternalClass::listToPhrase($property_storage->internal)
                             . ' but called from ' . $context->self,
                         new CodeLocation($statements_analyzer->getSource(), $stmt),
                         $property_id

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ClassConstFetchAnalyzer.php
@@ -343,12 +343,12 @@ class ClassConstFetchAnalyzer
             if ($context->self
                 && !$context->collect_initializations
                 && !$context->collect_mutations
-                && $const_class_storage->internal
-                && !NamespaceAnalyzer::isWithin($context->self, $const_class_storage->internal)
+                && !NamespaceAnalyzer::isWithinAny($context->self, $const_class_storage->internal)
             ) {
                 IssueBuffer::maybeAdd(
                     new InternalClass(
-                        $fq_class_name . ' is internal to ' . $const_class_storage->internal
+                        $fq_class_name . ' is internal to '
+                            . InternalClass::listToPhrase($const_class_storage->internal)
                             . ' but called from ' . $context->self,
                         new CodeLocation($statements_analyzer->getSource(), $stmt),
                         $fq_class_name
@@ -619,13 +619,13 @@ class ClassConstFetchAnalyzer
             if ($context->self
                 && !$context->collect_initializations
                 && !$context->collect_mutations
-                && $const_class_storage->internal
-                && !NamespaceAnalyzer::isWithin($context->self, $const_class_storage->internal)
+                && !NamespaceAnalyzer::isWithinAny($context->self, $const_class_storage->internal)
             ) {
                 IssueBuffer::maybeAdd(
                     new InternalClass(
-                        $fq_class_name . ' is internal to ' . $const_class_storage->internal
-                        . ' but called from ' . $context->self,
+                        $fq_class_name . ' is internal to '
+                            . InternalClass::listToPhrase($const_class_storage->internal)
+                            . ' but called from ' . $context->self,
                         new CodeLocation($statements_analyzer->getSource(), $stmt),
                         $fq_class_name
                     ),

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -65,6 +65,7 @@ use function array_combine;
 use function array_keys;
 use function array_merge;
 use function array_search;
+use function assert;
 use function count;
 use function fwrite;
 use function get_class;
@@ -1049,5 +1050,27 @@ class StatementsAnalyzer extends SourceAnalyzer
     public function getNodeTypeProvider(): NodeTypeProvider
     {
         return $this->node_data;
+    }
+
+    public function getFullyQualifiedFunctionMethodOrNamespaceName(): ?string
+    {
+        if ($this->source instanceof MethodAnalyzer) {
+            $fqcn = $this->getFQCLN();
+            $method_name = $this->source->getFunctionLikeStorage($this)->cased_name;
+            assert($fqcn !== null && $method_name !== null);
+
+            return "$fqcn::$method_name";
+        }
+
+        if ($this->source instanceof FunctionAnalyzer) {
+            $namespace = $this->getNamespace();
+            $namespace = $namespace === "" ? "" : "$namespace\\";
+            $function_name = $this->source->getFunctionLikeStorage($this)->cased_name;
+            assert($function_name !== null);
+
+            return "{$namespace}{$function_name}";
+        }
+
+        return $this->getNamespace();
     }
 }

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -29,7 +29,6 @@ use function array_merge;
 use function count;
 use function in_array;
 use function reset;
-use function strlen;
 use function strpos;
 use function strtolower;
 
@@ -258,16 +257,11 @@ class Populator
 
         if (!$storage->is_interface && !$storage->is_trait) {
             foreach ($storage->methods as $method) {
-                if (strlen($storage->internal) > strlen($method->internal)) {
-                    $method->internal = $storage->internal;
-                }
+                $method->internal = array_merge($storage->internal, $method->internal);
             }
 
-
             foreach ($storage->properties as $property) {
-                if (strlen($storage->internal) > strlen($property->internal)) {
-                    $property->internal = $storage->internal;
-                }
+                $property->internal = array_merge($storage->internal, $property->internal);
             }
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -16,6 +16,7 @@ use Psalm\Internal\Analyzer\CommentAnalyzer;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Provider\StatementsProvider;
 use Psalm\Internal\Scanner\ClassLikeDocblockComment;
+use Psalm\Internal\Scanner\DocblockParser;
 use Psalm\Internal\Type\ParseTree\MethodParamTree;
 use Psalm\Internal\Type\ParseTree\MethodTree;
 use Psalm\Internal\Type\ParseTree\MethodWithReturnTypeTree;
@@ -212,14 +213,7 @@ class ClassLikeDocblockParser
             $info->consistent_templates = true;
         }
 
-        if (isset($parsed_docblock->tags['psalm-internal'])) {
-            $psalm_internal = trim(reset($parsed_docblock->tags['psalm-internal']));
-
-            if (!$psalm_internal) {
-                throw new DocblockParseException('psalm-internal annotation used without specifying namespace');
-            }
-
-            $info->psalm_internal = $psalm_internal;
+        if (count($info->psalm_internal = DocblockParser::handlePsalmInternal($parsed_docblock)) !== 0) {
             $info->internal = true;
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -69,8 +69,8 @@ use function array_merge;
 use function array_pop;
 use function array_shift;
 use function array_values;
+use function assert;
 use function count;
-use function explode;
 use function get_class;
 use function implode;
 use function preg_match;
@@ -182,6 +182,7 @@ class ClassLikeNodeScanner
 
             $fq_classlike_name =
                 ($this->aliases->namespace ? $this->aliases->namespace . '\\' : '') . $node->name->name;
+            assert($fq_classlike_name !== "");
 
             $fq_classlike_name_lc = strtolower($fq_classlike_name);
 
@@ -251,7 +252,7 @@ class ClassLikeNodeScanner
             && isset($this->aliases->uses[strtolower($class_name)])
             && $this->aliases->uses[strtolower($class_name)] !== $fq_classlike_name
         ) {
-            IssueBuffer::add(
+            IssueBuffer::maybeAdd(
                 new ParseError(
                     'Class name ' . $class_name . ' clashes with a use statement alias',
                     $name_location ?? $class_location
@@ -616,13 +617,10 @@ class ClassLikeNodeScanner
 
             $storage->deprecated = $docblock_info->deprecated;
 
-            if ($docblock_info->internal
-                && !$docblock_info->psalm_internal
-                && $this->aliases->namespace
-            ) {
-                $storage->internal = explode('\\', $this->aliases->namespace)[0];
-            } else {
-                $storage->internal = $docblock_info->psalm_internal ?? '';
+            if (count($docblock_info->psalm_internal) !== 0) {
+                $storage->internal = $docblock_info->psalm_internal;
+            } elseif ($docblock_info->internal && $this->aliases->namespace) {
+                $storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($this->aliases->namespace)];
             }
 
             if ($docblock_info->final && !$storage->final) {
@@ -738,7 +736,7 @@ class ClassLikeNodeScanner
                 }
 
                 if ($attribute->fq_class_name === 'Psalm\\Internal' && !$storage->internal) {
-                    $storage->internal = NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name);
+                    $storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name)];
                 }
 
                 if ($attribute->fq_class_name === 'Psalm\\Immutable'
@@ -1436,6 +1434,9 @@ class ClassLikeNodeScanner
         return $storages;
     }
 
+    /**
+     * @param non-empty-string $fq_classlike_name
+     */
     private function visitPropertyDeclaration(
         PhpParser\Node\Stmt\Property $stmt,
         Config $config,
@@ -1534,9 +1535,9 @@ class ClassLikeNodeScanner
             $property_storage->has_default = (bool)$property->default;
             $property_storage->deprecated = $var_comment ? $var_comment->deprecated : false;
             $property_storage->suppressed_issues = $var_comment ? $var_comment->suppressed_issues : [];
-            $property_storage->internal = $var_comment ? $var_comment->psalm_internal ?? '' : '';
-            if (! $property_storage->internal && $var_comment && $var_comment->internal) {
-                $property_storage->internal = NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name);
+            $property_storage->internal = $var_comment ? $var_comment->psalm_internal : [];
+            if (count($property_storage->internal) === 0 && $var_comment && $var_comment->internal) {
+                $property_storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name)];
             }
             $property_storage->readonly = $stmt->isReadonly() || ($var_comment && $var_comment->readonly);
             $property_storage->allow_private_mutation = $var_comment ? $var_comment->allow_private_mutation : false;
@@ -1648,7 +1649,7 @@ class ClassLikeNodeScanner
                 }
 
                 if ($attribute->fq_class_name === 'Psalm\\Internal' && !$property_storage->internal) {
-                    $property_storage->internal = NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name);
+                    $property_storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name)];
                 }
 
                 if ($attribute->fq_class_name === 'Psalm\\Readonly') {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -8,6 +8,7 @@ use Psalm\DocComment;
 use Psalm\Exception\DocblockParseException;
 use Psalm\Exception\IncorrectDocblockException;
 use Psalm\Internal\Analyzer\CommentAnalyzer;
+use Psalm\Internal\Scanner\DocblockParser;
 use Psalm\Internal\Scanner\FunctionDocblockComment;
 use Psalm\Internal\Scanner\ParsedDocblock;
 use Psalm\Issue\InvalidDocblock;
@@ -381,14 +382,7 @@ class FunctionLikeDocblockParser
             $info->internal = true;
         }
 
-        if (isset($parsed_docblock->tags['psalm-internal'])) {
-            $psalm_internal = trim(reset($parsed_docblock->tags['psalm-internal']));
-
-            if (!$psalm_internal) {
-                throw new DocblockParseException('@psalm-internal annotation used without specifying namespace');
-            }
-
-            $info->psalm_internal = $psalm_internal;
+        if (count($info->psalm_internal = DocblockParser::handlePsalmInternal($parsed_docblock)) !== 0) {
             $info->internal = true;
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -10,6 +10,7 @@ use Psalm\Codebase;
 use Psalm\Config;
 use Psalm\Exception\InvalidMethodOverrideException;
 use Psalm\Exception\TypeParseTreeException;
+use Psalm\Internal\Analyzer\NamespaceAnalyzer;
 use Psalm\Internal\Scanner\FileScanner;
 use Psalm\Internal\Scanner\FunctionDocblockComment;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
@@ -96,17 +97,10 @@ class FunctionLikeDocblockScanner
             $storage->deprecated = true;
         }
 
-        if ($docblock_info->internal
-            && !$docblock_info->psalm_internal
-            && $aliases->namespace
-        ) {
-            $storage->internal = explode('\\', $aliases->namespace)[0];
-        } elseif (!$classlike_storage
-            || ($docblock_info->psalm_internal
-                && strlen($docblock_info->psalm_internal) > strlen($classlike_storage->internal)
-            )
-        ) {
-            $storage->internal = $docblock_info->psalm_internal ?? '';
+        if (count($docblock_info->psalm_internal) !== 0) {
+            $storage->internal = $docblock_info->psalm_internal;
+        } elseif ($docblock_info->internal && $aliases->namespace) {
+            $storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($aliases->namespace)];
         }
 
         if (($storage->internal || ($classlike_storage && $classlike_storage->internal))

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -51,6 +51,7 @@ use ReflectionFunction;
 use UnexpectedValueException;
 
 use function array_keys;
+use function array_merge;
 use function array_pop;
 use function array_search;
 use function count;
@@ -60,7 +61,6 @@ use function implode;
 use function in_array;
 use function is_string;
 use function spl_object_id;
-use function strlen;
 use function strpos;
 use function strtolower;
 
@@ -458,11 +458,8 @@ class FunctionLikeNodeScanner
         $doc_comment = $stmt->getDocComment();
 
 
-        if ($classlike_storage
-            && !$classlike_storage->is_trait
-            && strlen($classlike_storage->internal) > strlen($storage->internal)
-        ) {
-            $storage->internal = $classlike_storage->internal;
+        if ($classlike_storage && !$classlike_storage->is_trait) {
+            $storage->internal = array_merge($classlike_storage->internal, $storage->internal);
         }
 
         if ($doc_comment) {
@@ -594,7 +591,7 @@ class FunctionLikeNodeScanner
                 }
 
                 if (isset($classlike_storage->properties[$param_storage->name]) && $param_storage->location) {
-                    IssueBuffer::add(
+                    IssueBuffer::maybeAdd(
                         new ParseError(
                             'Promoted property ' . $param_storage->name . ' clashes with an existing property',
                             $param_storage->location
@@ -722,7 +719,7 @@ class FunctionLikeNodeScanner
                 }
 
                 if ($attribute->fq_class_name === 'Psalm\\Internal' && !$storage->internal && $fq_classlike_name) {
-                    $storage->internal = NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name);
+                    $storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($fq_classlike_name)];
                 }
 
                 if ($attribute->fq_class_name === 'Psalm\\ExternalMutationFree'

--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -498,7 +498,7 @@ class StatementsProvider
 
             foreach ($error_handler->getErrors() as $error) {
                 if ($error->hasColumnInfo()) {
-                    IssueBuffer::add(
+                    IssueBuffer::maybeAdd(
                         new ParseError(
                             $error->getMessage(),
                             new ParseErrorLocation(

--- a/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
@@ -33,9 +33,9 @@ class ClassLikeDocblockComment
     /**
      * If set, the class is internal to the given namespace.
      *
-     * @var null|string
+     * @var list<non-empty-string>
      */
-    public $psalm_internal;
+    public $psalm_internal = [];
 
     /**
      * @var string[]

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -2,8 +2,16 @@
 
 namespace Psalm\Internal\Scanner;
 
+use Psalm\Exception\DocblockParseException;
+
+use function array_filter;
+use function array_map;
+use function array_values;
+use function assert;
+use function count;
 use function explode;
 use function implode;
+use function is_string;
 use function min;
 use function preg_match;
 use function preg_replace;
@@ -255,5 +263,38 @@ class DocblockParser
                 = ($docblock->tags['param-out'] ?? [])
                 + ($docblock->tags['psalm-param-out'] ?? []);
         }
+    }
+
+    /**
+     * @return list<non-empty-string>
+     * @throws DocblockParseException when a @psalm-internal tag doesn't include a namespace
+     */
+    public static function handlePsalmInternal(ParsedDocblock $parsed_docblock): array
+    {
+        if (isset($parsed_docblock->tags['psalm-internal'])) {
+            $psalm_internal = array_map("trim", $parsed_docblock->tags['psalm-internal']);
+
+            if (count($psalm_internal) !== count(array_filter($psalm_internal))) {
+                throw new DocblockParseException('psalm-internal annotation used without specifying namespace');
+            }
+            // assert($psalm_internal === array_filter($psalm_internal)); // TODO get this to work
+            assert(self::assertArrayOfNonEmptyString($psalm_internal));
+
+            return array_values($psalm_internal);
+        }
+
+        return [];
+    }
+
+    /** @psalm-assert-if-true array<array-key, non-empty-string> $arr */
+    private static function assertArrayOfNonEmptyString(array $arr): bool
+    {
+        foreach ($arr as $val) {
+            if (!is_string($val) || $val === "") {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -77,9 +77,9 @@ class FunctionDocblockComment
     /**
      * If set, the function is internal to the given namespace.
      *
-     * @var null|string
+     * @var list<non-empty-string>
      */
-    public $psalm_internal;
+    public $psalm_internal = [];
 
     /**
      * Whether or not the function is internal

--- a/src/Psalm/Internal/Scanner/VarDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/VarDocblockComment.php
@@ -51,9 +51,9 @@ class VarDocblockComment
     /**
      * If set, the property is internal to the given namespace.
      *
-     * @var null|string
+     * @var list<non-empty-string>
      */
-    public $psalm_internal;
+    public $psalm_internal = [];
 
     /**
      * Whether or not the property is readonly

--- a/src/Psalm/Issue/InternalClass.php
+++ b/src/Psalm/Issue/InternalClass.php
@@ -2,8 +2,31 @@
 
 namespace Psalm\Issue;
 
+use function array_pop;
+use function count;
+use function implode;
+use function reset;
+
 class InternalClass extends ClassIssue
 {
     public const ERROR_LEVEL = 4;
     public const SHORTCODE = 174;
+
+    /** @param non-empty-list<non-empty-string> $words */
+    public static function listToPhrase(array $words): string
+    {
+        if (count($words) === 1) {
+            return reset($words);
+        }
+
+        if (count($words) === 2) {
+            return implode(" and ", $words);
+        }
+
+        $last_word = array_pop($words);
+        $phrase = implode(", ", $words);
+        $phrase = "$phrase, and $last_word";
+
+        return $phrase;
+    }
 }

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -244,7 +244,11 @@ class IssueBuffer
     }
 
     /**
-     * Add an issue to be emitted
+     * Add an issue to be emitted. This method should normally not be used! Use IssueBuffer::maybeAdd instead.
+     *
+     * @psalm-internal Psalm\IssueBuffer
+     * @psalm-internal Psalm\Type\Reconciler::getValueForKey
+     *
      * @throws  CodeException
      */
     public static function add(CodeIssue $e, bool $is_fixable = false): bool

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -45,9 +45,9 @@ class ClassLikeStorage implements HasAttributesInterface
     public $deprecated = false;
 
     /**
-     * @var string
+     * @var list<non-empty-string>
      */
-    public $internal = '';
+    public $internal = [];
 
     /**
      * @var TTemplateParam[]

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -74,9 +74,9 @@ abstract class FunctionLikeStorage implements HasAttributesInterface
     public $deprecated;
 
     /**
-     * @var string
+     * @var list<non-empty-string>
      */
-    public $internal = '';
+    public $internal = [];
 
     /**
      * @var bool

--- a/src/Psalm/Storage/PropertyStorage.php
+++ b/src/Psalm/Storage/PropertyStorage.php
@@ -78,9 +78,9 @@ class PropertyStorage implements HasAttributesInterface
     public $allow_private_mutation = false;
 
     /**
-     * @var string
+     * @var list<non-empty-string>
      */
-    public $internal = '';
+    public $internal = [];
 
     /**
      * @var ?string

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -556,6 +556,59 @@ class InternalAnnotationTest extends TestCase
                         }
                     }',
             ],
+            'psalmInternalMultipleNamespaces' => [
+                '<?php
+                    namespace A
+                    {
+                        class Foo
+                        {
+                            /**
+                             * @psalm-internal \B
+                             * @psalm-internal \C
+                             */
+                            public static function foobar(): void {}
+                        }
+                    }
+
+                    namespace B
+                    {
+                        \A\Foo::foobar();
+                    }
+
+                    namespace C
+                    {
+                        \A\Foo::foobar();
+                    }
+                ',
+            ],
+            'psalmInternalToClass' => [
+                '<?php
+                    namespace A
+                    {
+                        class Foo
+                        {
+                            /** @psalm-internal B\Bar */
+                            public static function foo(): void {}
+
+                            /** @psalm-internal B\Bar */
+                            public function bar(): void {}
+                        }
+                    }
+
+                    namespace B
+                    {
+                        class Bar
+                        {
+                            public function baz(): void
+                            {
+                                \A\Foo::foo();
+                                $foo = new \A\Foo();
+                                $foo->bar();
+                            }
+                        }
+                    }
+                '
+            ],
         ];
     }
 


### PR DESCRIPTION
I finally got around to investigating why I'm getting `ParseError`s from vendor files, so I decided to make sure stuff like that won't happen again.

 - Improve `@psalm-internal`
   - Allow multiple namespaces/identifiers
   - Allow specifying class names
   - Allow specifying functions and methods
 - Make `IssueBuffer::add()` internal so that it can't be used accidentally.