### PR TITLE
Fix crash when redefining method with fewer params (fixes #8141).

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1267,15 +1267,17 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 $context->hasVariable('$' . $function_param->name);
             }
 
-            AttributesAnalyzer::analyze(
-                $this,
-                $context,
-                $function_param,
-                $param_stmts[$offset]->attrGroups,
-                AttributesAnalyzer::TARGET_PARAMETER
-                    | ($function_param->promoted_property ? AttributesAnalyzer::TARGET_PROPERTY : 0),
-                $storage->suppressed_issues + $this->getSuppressedIssues()
-            );
+            if (count($param_stmts) === count($params)) {
+                AttributesAnalyzer::analyze(
+                    $this,
+                    $context,
+                    $function_param,
+                    $param_stmts[$offset]->attrGroups,
+                    AttributesAnalyzer::TARGET_PARAMETER
+                        | ($function_param->promoted_property ? AttributesAnalyzer::TARGET_PROPERTY : 0),
+                    $storage->suppressed_issues + $this->getSuppressedIssues()
+                );
+            }
         }
 
         return $check_stmts;

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -391,6 +391,16 @@ class AttributeTest extends TestCase
                     class Bar {}
                 ',
             ],
+            'dontCrashWhenRedefiningStubbedMethodWithFewerParams' => [
+                '<?php
+                    if (!class_exists(ArrayObject::class)) {
+                        class ArrayObject
+                        {
+                            public function __construct() {}
+                        }
+                    }
+                '
+            ],
         ];
     }
 


### PR DESCRIPTION
I think the way Psalm handles stubs and conditionally defined classes could be significantly improved if we rescanned the currently analyzed class separately and analyzed that result instead of using the class storage from the original full scan of the codebase. That way we could analyze each class declaration independently based only on that declaration. For now though, I just disabled the attribute analysis if it's going to cause a crash.