### PR TITLE
Stop using deprecated string interpolation syntax in StatementsProvider.php

### DIFF
--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -137,7 +137,7 @@ class StatementsProvider
         if (!$this->parser_cache_provider
             || (!$config->isInProjectDirs($file_path) && strpos($file_path, 'vendor'))
         ) {
-            $cache_key = "${file_content_hash}:${php_version}";
+            $cache_key = "{$file_content_hash}:{$php_version}";
             if ($this->statements_volatile_cache->has($cache_key)) {
                 return $this->statements_volatile_cache->get($cache_key);
             }


### PR DESCRIPTION
This fixed the following PHP 8.2 deprecation:

> Uncaught RuntimeException: PHP Error: Using ${var} in strings is deprecated, use {$var} instead in …/vimeo/psalm/src/Psalm/Internal/Provider/StatementsProvider.php:140

see: https://wiki.php.net/rfc/deprecate_dollar_brace_string_interpolation