### PR TITLE
[5.x] Allow to specify an absolute URL for a custom Shepherd endpoint

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -845,3 +845,4 @@
    - :information_source: migration possible using `Psalm\PluginFileExtensionsSocket`
  - [BC] Method `\Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent::getClasslikeStorage()` was removed,
    use correct `\Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent::getFunctionlikeStorage()` instead
+ - [BC] Property `\Psalm\Config::$shepherd_host` was removed

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -782,6 +782,13 @@
  - [BC] Property `Psalm\Config::$universal_object_crates` changed default value
    from `array{'stdClass','SimpleXMLElement','SimpleXMLIterator'}` to `null`
 
+ - Changed a way how to specify a custom Shepherd host/endpoint:
+    - [BC] `--shepherd` CLI option now accepts absolute URLs. Previously it accepted domain names only.
+      Example: `--shepherd=https://your.domain/your-endpoint`.
+    - [BC] `PSALM_SHEPHERD_HOST` environment variable is not used anymore.
+      Instead, please use `PSALM_SHEPHERD_ENDPOINT` and specify an absolute URL
+      to your custom Shepherd endpoint.
+
 ## Removed
  - [BC] Property `Psalm\Codebase::$php_major_version` was removed, use
    `Psalm\Codebase::$analysis_php_version_id`.

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -523,7 +523,7 @@ class Config
     public $include_php_versions_in_error_baseline = false;
 
     /** @var string */
-    public $shepherd_host = 'shepherd.dev';
+    public $shepherd_endpoint = 'https://shepherd.dev/hooks/psalm';
 
     /**
      * @var array<string, string>

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -300,11 +300,11 @@ final class Psalm
         if (isset($options['shepherd']) || getenv('PSALM_SHEPHERD')) {
             if (isset($options['shepherd'])) {
                 if (is_string($options['shepherd'])) {
-                    $config->shepherd_host = $options['shepherd'];
+                    $config->shepherd_endpoint = $options['shepherd'];
                 }
             } elseif (getenv('PSALM_SHEPHERD')) {
-                if (false !== ($shepherd_host = getenv('PSALM_SHEPHERD_HOST'))) {
-                    $config->shepherd_host = $shepherd_host;
+                if (false !== ($shepherd_endpoint = getenv('PSALM_SHEPHERD_ENDPOINT'))) {
+                    $config->shepherd_endpoint = $shepherd_endpoint;
                 }
             }
             $shepherd_plugin = Path::canonicalize(__DIR__ . '/../../Plugin/Shepherd.php');

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -48,7 +48,7 @@ final class Shepherd implements AfterAnalysisInterface
         $source_control_info = $event->getSourceControlInfo();
 
         if (!function_exists('curl_init')) {
-            fwrite(STDERR, 'No curl found, cannot send data to ' . $codebase->config->shepherd_host . PHP_EOL);
+            fwrite(STDERR, 'No curl found, cannot send data to ' . $codebase->config->shepherd_endpoint . PHP_EOL);
 
             return;
         }
@@ -77,14 +77,14 @@ final class Shepherd implements AfterAnalysisInterface
 
             $payload = json_encode($data, JSON_THROW_ON_ERROR);
 
-            $base_address = $codebase->config->shepherd_host;
+            $url = $codebase->config->shepherd_endpoint;
 
-            if (parse_url($base_address, PHP_URL_SCHEME) === null) {
-                $base_address = 'https://' . $base_address;
+            if (parse_url($url, PHP_URL_SCHEME) === null) {
+                $url = 'https://' . $url;
             }
 
             // Prepare new cURL resource
-            $ch = curl_init($base_address . '/hooks/psalm');
+            $ch = curl_init($url);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLINFO_HEADER_OUT, true);
             curl_setopt($ch, CURLOPT_POST, true);
@@ -118,7 +118,7 @@ final class Shepherd implements AfterAnalysisInterface
                         . PHP_EOL;
                 }
             } else {
-                $short_address = str_replace('https://', '', $base_address);
+                $short_address = str_replace('https://', '', $url);
 
                 fwrite(STDERR, "🐑 results sent to $short_address 🐑" . PHP_EOL);
             }


### PR DESCRIPTION
--shepherd CLI option has an undocumented functionality - you can specify a custom Shepherd domain (instead of default `shepherd.dev`). The problem is that down the road the plugin automatically appends `/hooks/psalm` to this domain, so a user doesn't have an option to use use another URL on the custom domain, what is critical in some cases.

In this PR I have changed `--shepherd` option to accept absolute URL instead of domain.

For users, who used `--shepherd` option without a variable (custom domain), these changes are not BC.


Related discussion: https://github.com/vimeo/psalm/discussions/8127


PS: I'll create a new PR for documentation update - to mention this hidden feature in new docs for v5