### PR TITLE
Various minor improvements to speed up by ~10%

### DIFF
--- a/src/Psalm/Internal/Algebra.php
+++ b/src/Psalm/Internal/Algebra.php
@@ -136,6 +136,7 @@ class Algebra
             if (!$clause_a->reconcilable || $clause_a->wedge) {
                 continue;
             }
+            $clause_a_keys = array_keys($clause_a->possibilities);
 
             if (count($clause_a->possibilities) !== 1 || count(array_values($clause_a->possibilities)[0]) !== 1) {
                 foreach ($cloned_clauses as $clause_b) {
@@ -143,7 +144,7 @@ class Algebra
                         continue;
                     }
 
-                    if (array_keys($clause_a->possibilities) === array_keys($clause_b->possibilities)) {
+                    if ($clause_a_keys === array_keys($clause_b->possibilities)) {
                         $opposing_keys = [];
 
                         foreach ($clause_a->possibilities as $key => $a_possibilities) {

--- a/src/Psalm/Internal/Clause.php
+++ b/src/Psalm/Internal/Clause.php
@@ -120,8 +120,14 @@ class Clause
             return false;
         }
 
+        foreach ($other_clause->possibilities as $var => $_) {
+            if (!isset($this->possibilities[$var])) {
+                return false;
+            }
+        }
+
         foreach ($other_clause->possibilities as $var => $possible_types) {
-            if (!isset($this->possibilities[$var]) || count(array_diff($possible_types, $this->possibilities[$var]))) {
+            if (count(array_diff($possible_types, $this->possibilities[$var]))) {
                 return false;
             }
         }

--- a/src/Psalm/Internal/Clause.php
+++ b/src/Psalm/Internal/Clause.php
@@ -10,14 +10,16 @@ use function array_map;
 use function array_unique;
 use function array_values;
 use function count;
+use function hash;
 use function implode;
 use function ksort;
-use function md5;
 use function reset;
 use function serialize;
 use function sort;
 use function strpos;
 use function substr;
+
+use const PHP_VERSION_ID;
 
 /**
  * @internal
@@ -106,11 +108,15 @@ class Clause
         } else {
             ksort($possibilities);
 
-            foreach ($possibilities as $i => $_) {
+            foreach ($possibilities as $i => $v) {
+                if (count($v) < 2) {
+                    continue;
+                }
                 sort($possibilities[$i]);
             }
 
-            $this->hash = md5(serialize($possibilities));
+            $data = serialize($possibilities);
+            $this->hash = PHP_VERSION_ID >= 80100 ? hash('xxh128', $data) : hash('md4', $data);
         }
     }
 

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -110,9 +110,9 @@ class ClassLikeStorageCacheProvider
         return $cached_value;
     }
 
-    private function getCacheHash(?string $file_path, ?string $file_contents): string
+    private function getCacheHash(?string $_unused_file_path, ?string $file_contents): string
     {
-        $data = ($file_path ? $file_contents : '') . $this->modified_timestamps;
+        $data = $file_contents ? $file_contents : $this->modified_timestamps;
         return PHP_VERSION_ID >= 80100 ? hash('xxh128', $data) : hash('md4', $data);
     }
 

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -17,6 +17,7 @@ use function hash;
 use function igbinary_serialize;
 use function igbinary_unserialize;
 use function is_dir;
+use function is_null;
 use function mkdir;
 use function serialize;
 use function strtolower;
@@ -75,9 +76,15 @@ class ClassLikeStorageCacheProvider
     {
         $fq_classlike_name_lc = strtolower($storage->name);
 
-        $cache_location = $this->getCacheLocationForClass($fq_classlike_name_lc, $file_path, true);
         $storage->hash = $this->getCacheHash($file_path, $file_contents);
 
+        // check if we have it in cache already
+        $cached_value = $this->loadFromCache($fq_classlike_name_lc, $file_path);
+        if (!is_null($cached_value) && $cached_value->hash === $storage->hash) {
+            return;
+        }
+
+        $cache_location = $this->getCacheLocationForClass($fq_classlike_name_lc, $file_path, true);
         if ($this->config->use_igbinary) {
             file_put_contents($cache_location, igbinary_serialize($storage));
         } else {

--- a/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
@@ -117,9 +117,12 @@ class FileStorageCacheProvider
         }
     }
 
-    private function getCacheHash(string $file_path, string $file_contents): string
+    private function getCacheHash(string $_unused_file_path, string $file_contents): string
     {
-        $data = ($file_path ? $file_contents : '') . $this->modified_timestamps;
+        // do not concatenate, as $file_contents can be big and performance will be bad
+        // the timestamp is only needed if we don't have file contents
+        // as same contents should give same results, independent of when file was modified
+        $data = $file_contents ? $file_contents : $this->modified_timestamps;
         return PHP_VERSION_ID >= 80100 ? hash('xxh128', $data) : hash('md4', $data);
     }
 


### PR DESCRIPTION
Improve various minor things to speed up psalm performance by about 10%

No negative impact on memory consumption.

Will invalidate old caches (= most cache files created with any previous psalm versions will not be used anymore and new caches will be created on first run, since the cache hash changed for performance reasons)