### PR TITLE
Draft: Fix stdClass cast

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -200,10 +200,13 @@ class CastAnalyzer
 
                 foreach ($stmt_expr_type->getAtomicTypes() as $type) {
                     if ($type instanceof Scalar) {
-                        $objWithProps = new TObjectWithProperties(['scalar' => new Union([$type])]);
+                        $objWithProps = new TNamedObject('stdClass');
+                        $objWithProps->addIntersectionType(new TObjectWithProperties(['scalar' => new Union([$type])]));
                         $permissible_atomic_types[] = $objWithProps;
                     } elseif ($type instanceof TKeyedArray) {
-                        $permissible_atomic_types[] = new TObjectWithProperties($type->properties);
+                        $objWithProps = new TNamedObject('stdClass');
+                        $objWithProps->addIntersectionType(new TObjectWithProperties($type->properties));
+                        $permissible_atomic_types[] = $objWithProps;
                     } else {
                         $all_permissible = false;
                         break;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
@@ -16,6 +16,7 @@ use Psalm\Type\Atomic\TObjectWithProperties;
 use Psalm\Type\Union;
 use stdClass;
 
+use function count;
 use function reset;
 use function strtolower;
 
@@ -40,6 +41,14 @@ class GetObjectVarsReturnTypeProvider implements FunctionReturnTypeProviderInter
         if ($first_arg_type->isSingle()) {
             $atomics = $first_arg_type->getAtomicTypes();
             $object_type = reset($atomics);
+
+            if ($object_type instanceof TNamedObject
+                && strtolower($object_type->value) === strtolower(stdClass::class)
+                && count($intersection_types = $object_type->getIntersectionTypes() ?: []) === 1
+                && ($inner_object_type = reset($intersection_types)) instanceof TObjectWithProperties
+            ) {
+                $object_type = $inner_object_type;
+            }
 
             if ($object_type instanceof TObjectWithProperties) {
                 if ([] === $object_type->properties) {

--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -39,6 +39,7 @@ use function array_merge;
 use function array_values;
 use function count;
 use function get_class;
+use function reset;
 use function strtolower;
 
 /**
@@ -580,9 +581,13 @@ class AtomicTypeComparator
         if ($container_type_part instanceof TObject
             && $input_type_part instanceof TNamedObject
         ) {
-            if ($container_type_part instanceof TObjectWithProperties
-                && $input_type_part->value !== 'stdClass'
-            ) {
+            if ($container_type_part instanceof TObjectWithProperties && (
+                $input_type_part->value !== 'stdClass'
+                || (
+                    count($intersection_types = $input_type_part->getIntersectionTypes() ?: []) === 1
+                    && reset($intersection_types) instanceof TObjectWithProperties
+                )
+            )) {
                 return KeyedArrayComparator::isContainedByObjectWithProperties(
                     $codebase,
                     $input_type_part,

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -882,6 +882,14 @@ class ReturnTypeTest extends TestCase
                     '$obj' => 'stdClass&object{a:int}',
                 ],
             ],
+            'acceptsCastArrayForStdClass' => [
+                '<?php
+                    function acceptsStdClass(stdClass $_o): void {
+                    }
+
+                    $obj = (object)["a" => 1];
+                ',
+            ],
             'mixedAssignmentWithUnderscore' => [
                 '<?php
                     $gen = (function (): Generator {

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -864,7 +864,7 @@ class ReturnTypeTest extends TestCase
                     $obj = (object)returnsInt();
                 ',
                 'assertions' => [
-                    '$obj' => 'object{scalar:int}',
+                    '$obj' => 'stdClass&object{scalar:int}',
                 ],
             ],
             'infersObjectShapeOfCastArray' => [
@@ -879,7 +879,7 @@ class ReturnTypeTest extends TestCase
                     $obj = (object)returnsArray();
                 ',
                 'assertions' => [
-                    '$obj' => 'object{a:int}',
+                    '$obj' => 'stdClass&object{a:int}',
                 ],
             ],
             'mixedAssignmentWithUnderscore' => [


### PR DESCRIPTION
https://github.com/vimeo/psalm/issues/8187

I followed @orklah's suggestion of typing object casts as `stdClass&object{key:value}`, but my solution broke other tests. Turns out that `stdClass` seems to always "test positive" for existence of any property.

For starters, I added a silly check for the specific shape `stdClass & object{some properties here}`, but that doesn't seem right. I'd appreciate suggestions for improving that!