### PR TITLE
Fix return type of ReflectionNamedType::getName()

### DIFF
--- a/stubs/Reflection.phpstub
+++ b/stubs/Reflection.phpstub
@@ -142,7 +142,7 @@ class ReflectionNamedType extends ReflectionType
     public function getName(): string {}
 
     /**
-     * @psalm-assert-if-false class-string $this->getName()
+     * @psalm-assert-if-false class-string|'self'|'static' $this->getName()
      */
     public function isBuiltin(): bool {}
 }


### PR DESCRIPTION
Fixes #8167