### PR TITLE
New "Count" Report Format

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -397,6 +397,7 @@ class ProjectAnalyzer
             '.pylint' => Report::TYPE_PYLINT,
             '.console' => Report::TYPE_CONSOLE,
             '.sarif' => Report::TYPE_SARIF,
+            'count.txt' => Report::TYPE_COUNT,
         ];
 
         foreach ($report_file_paths as $report_file_path) {

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -16,11 +16,11 @@ use Psalm\Issue\MixedIssue;
 use Psalm\Issue\TaintedInput;
 use Psalm\Issue\UnusedPsalmSuppress;
 use Psalm\Plugin\EventHandler\Event\AfterAnalysisEvent;
-use Psalm\Report;
 use Psalm\Report\CheckstyleReport;
 use Psalm\Report\CodeClimateReport;
 use Psalm\Report\CompactReport;
 use Psalm\Report\ConsoleReport;
+use Psalm\Report\CountReport;
 use Psalm\Report\EmacsReport;
 use Psalm\Report\GithubActionsReport;
 use Psalm\Report\JsonReport;
@@ -908,6 +908,13 @@ class IssueBuffer
             case Report::TYPE_CODECLIMATE:
                 $output = new CodeClimateReport($normalized_data, self::$fixable_issue_counts, $report_options);
                 break;
+
+            case Report::TYPE_COUNT:
+                $output = new CountReport($normalized_data, self::$fixable_issue_counts, $report_options);
+                break;
+
+            default:
+                throw new RuntimeException('Unexpected report format: ' . $report_options->format);
         }
 
         return $output->create();

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -28,24 +28,7 @@ abstract class Report
     public const TYPE_PHP_STORM = 'phpstorm';
     public const TYPE_SARIF = 'sarif';
     public const TYPE_CODECLIMATE = 'codeclimate';
-
-    public const SUPPORTED_OUTPUT_TYPES = [
-        self::TYPE_COMPACT,
-        self::TYPE_CONSOLE,
-        self::TYPE_PYLINT,
-        self::TYPE_JSON,
-        self::TYPE_JSON_SUMMARY,
-        self::TYPE_SONARQUBE,
-        self::TYPE_EMACS,
-        self::TYPE_XML,
-        self::TYPE_JUNIT,
-        self::TYPE_CHECKSTYLE,
-        self::TYPE_TEXT,
-        self::TYPE_GITHUB_ACTIONS,
-        self::TYPE_PHP_STORM,
-        self::TYPE_SARIF,
-        self::TYPE_CODECLIMATE,
-    ];
+    public const TYPE_COUNT = 'count';
 
     /**
      * @var array<int, IssueData>

--- a/src/Psalm/Report/CountReport.php
+++ b/src/Psalm/Report/CountReport.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Report;
+
+use Psalm\Report;
+
+use function array_key_exists;
+use function uksort;
+
+class CountReport extends Report
+{
+    public function create(): string
+    {
+        $issue_type_counts = [];
+        foreach ($this->issues_data as $issue_data) {
+            if (array_key_exists($issue_data->type, $issue_type_counts)) {
+                $issue_type_counts[$issue_data->type]++;
+            } else {
+                $issue_type_counts[$issue_data->type] = 1;
+            }
+        }
+        uksort($issue_type_counts, function (string $a, string $b) use ($issue_type_counts): int {
+            $cmp_result = $issue_type_counts[$a] <=> $issue_type_counts[$b];
+            if ($cmp_result === 0) {
+                return $a <=> $b;
+            } else {
+                return $cmp_result;
+            }
+        });
+
+        $output = '';
+        foreach ($issue_type_counts as $issue_type => $count) {
+            $output .= "{$issue_type}: {$count}\n";
+        }
+        return $output;
+    }
+}

--- a/src/Psalm/Report/ReportOptions.php
+++ b/src/Psalm/Report/ReportOptions.php
@@ -22,7 +22,7 @@ class ReportOptions
     public $show_info = true;
 
     /**
-     * @var value-of<Report::SUPPORTED_OUTPUT_TYPES>
+     * @var Report::TYPE_*
      */
     public $format = Report::TYPE_CONSOLE;
 

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -1269,6 +1269,26 @@ EOF;
         );
     }
 
+    public function testCountOutput(): void
+    {
+        $this->analyzeFileForReport();
+
+        $report_options = new ReportOptions();
+        $report_options->format = Report::TYPE_COUNT;
+        $expected_output = <<<'EOF'
+MixedInferredReturnType: 1
+MixedReturnStatement: 1
+PossiblyUndefinedGlobalVariable: 1
+UndefinedConstant: 1
+UndefinedVariable: 1
+
+EOF;
+        $this->assertSame(
+            $expected_output,
+            IssueBuffer::getOutput(IssueBuffer::getIssuesData(), $report_options)
+        );
+    }
+
     public function testEmptyReportIfNotError(): void
     {
         $this->addFile(


### PR DESCRIPTION
This is a format that displays the count of each issue type.
I requested this feature in #8225.

I look forward to being able to run: `psalm --ignore-baseline --output-format=count`

For example, the output of the above command on this code base is:
```txt
PossiblyUndefinedStringArrayOffset: 1
PossiblyUnusedProperty: 1
RedundantCondition: 1
ReferenceConstraintViolation: 1
UnusedClass: 1
UnusedPsalmSuppress: 1
InvalidPropertyAssignmentValue: 2
DocblockTypeContradiction: 3
PropertyNotSetInConstructor: 5
DeprecatedClass: 35
DeprecatedMethod: 44
DeprecatedProperty: 89
PossiblyUndefinedIntArrayOffset: 144
```