### PR TITLE
Remove special handling for elseifs that breaks for else if

### DIFF
--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -459,7 +459,7 @@ final class Context
         array $vars_to_update,
         array &$updated_vars
     ): void {
-        foreach ($start_context->vars_in_scope as $var_id => $old_type) {
+        foreach ($start_context->vars_in_scope as $var_id => $_) {
             // this is only true if there was some sort of type negation
             if (in_array($var_id, $vars_to_update, true)) {
                 // if we're leaving, we're effectively deleting the possibility of the if types
@@ -469,30 +469,10 @@ final class Context
 
                 $existing_type = $this->vars_in_scope[$var_id] ?? null;
 
-                if (!$existing_type) {
-                    if ($new_type) {
-                        $this->vars_in_scope[$var_id] = clone $new_type;
-                        $updated_vars[$var_id] = true;
-                    }
-
-                    continue;
-                }
-
-                $existing_type = clone $existing_type;
-
-                // if the type changed within the block of statements, process the replacement
-                // also never allow ourselves to remove all types from a union
-                if ((!$new_type || !$old_type->equals($new_type))
-                    && ($new_type || count($existing_type->getAtomicTypes()) > 1)
-                ) {
-                    if ($new_type && $new_type->from_docblock) {
-                        $existing_type->setFromDocblock();
-                    }
-
+                if (!$existing_type && $new_type) {
+                    $this->vars_in_scope[$var_id] = clone $new_type;
                     $updated_vars[$var_id] = true;
                 }
-
-                $this->vars_in_scope[$var_id] = $existing_type;
             }
         }
     }

--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -485,8 +485,6 @@ final class Context
                 if ((!$new_type || !$old_type->equals($new_type))
                     && ($new_type || count($existing_type->getAtomicTypes()) > 1)
                 ) {
-                    $existing_type->substitute($old_type, $new_type);
-
                     if ($new_type && $new_type->from_docblock) {
                         $existing_type->setFromDocblock();
                     }

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
@@ -23,25 +23,20 @@ use Psalm\Node\Name\VirtualFullyQualified;
 use Psalm\Node\VirtualArg;
 use Psalm\Type;
 use Psalm\Type\Reconciler;
-use Psalm\Type\Union;
 
 use function array_combine;
 use function array_diff_key;
 use function array_filter;
-use function array_intersect;
 use function array_intersect_key;
 use function array_key_exists;
 use function array_keys;
 use function array_merge;
 use function array_reduce;
-use function array_unique;
 use function count;
 use function in_array;
 use function preg_match;
 use function preg_quote;
 use function spl_object_id;
-use function strpos;
-use function substr;
 
 /**
  * @internal
@@ -49,8 +44,6 @@ use function substr;
 class IfAnalyzer
 {
     /**
-     * @param  array<string, Union> $pre_assignment_else_redefined_vars
-     *
      * @return false|null
      */
     public static function analyze(
@@ -59,8 +52,7 @@ class IfAnalyzer
         IfScope $if_scope,
         IfConditionalScope $if_conditional_scope,
         Context $if_context,
-        Context $outer_context,
-        array $pre_assignment_else_redefined_vars
+        Context $outer_context
     ): ?bool {
         $cond_referenced_var_ids = $if_conditional_scope->cond_referenced_var_ids;
 
@@ -152,8 +144,6 @@ class IfAnalyzer
             $if_context->vars_possibly_in_scope,
             $outer_context->vars_possibly_in_scope
         );
-
-        $old_if_context = clone $if_context;
 
         $codebase = $statements_analyzer->getCodebase();
 
@@ -265,38 +255,6 @@ class IfAnalyzer
                     );
                 }
             }
-        }
-
-        // update the parent context as necessary, but only if we can safely reason about type negation.
-        // We only update vars that changed both at the start of the if block and then again by an assignment
-        // in the if statement.
-        if ($if_scope->negated_types) {
-            $vars_to_update = array_intersect(
-                array_keys($pre_assignment_else_redefined_vars),
-                array_keys($if_scope->negated_types)
-            );
-
-            $extra_vars_to_update = [];
-
-            // if there's an object-like array in there, we also need to update the root array variable
-            foreach ($vars_to_update as $var_id) {
-                $bracked_pos = strpos($var_id, '[');
-                if ($bracked_pos !== false) {
-                    $extra_vars_to_update[] = substr($var_id, 0, $bracked_pos);
-                }
-            }
-
-            if ($extra_vars_to_update) {
-                $vars_to_update = array_unique(array_merge($extra_vars_to_update, $vars_to_update));
-            }
-
-            $outer_context->update(
-                $old_if_context,
-                $if_context,
-                $has_leaving_statements,
-                $vars_to_update,
-                $if_scope->updated_vars
-            );
         }
 
         if (!$has_ending_statements) {

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
@@ -265,8 +265,7 @@ class IfElseAnalyzer
             $if_scope,
             $if_conditional_scope,
             $if_context,
-            $context,
-            $pre_assignment_else_redefined_vars
+            $context
         ) === false) {
             return false;
         }

--- a/tests/TypeReconciliation/TypeAlgebraTest.php
+++ b/tests/TypeReconciliation/TypeAlgebraTest.php
@@ -212,7 +212,7 @@ class TypeAlgebraTest extends TestCase
                         }
                     }',
             ],
-            'twoVarLogicNotNestedWithElseifCorrectlyReinforcedInIf' => [
+            'SKIPPED-twoVarLogicNotNestedWithElseifCorrectlyReinforcedInIf' => [
                 'code' => '<?php
                     class A {}
                     class B extends A {}

--- a/tests/TypeReconciliation/TypeAlgebraTest.php
+++ b/tests/TypeReconciliation/TypeAlgebraTest.php
@@ -212,6 +212,9 @@ class TypeAlgebraTest extends TestCase
                         }
                     }',
             ],
+            // skipping this old test because it breaks if the elseif becomes
+            // an else if, and I don't believe it's a pattern that happens often
+            // enough to warrant special-casing
             'SKIPPED-twoVarLogicNotNestedWithElseifCorrectlyReinforcedInIf' => [
                 'code' => '<?php
                     class A {}


### PR DESCRIPTION
This is a weird PR, because it breaks a niche existing analysis, but I think for the right reasons.

The test `twoVarLogicNotNestedWithElseifCorrectlyReinforcedInIf` breaks when the `elseif` is changed to `else if`, and the "elseif" version doesn't work online either: https://psalm.dev/r/a1f9a6439e for _unknown reasons_.

Generally I think it's bad when `elseif` and `else if` are treated differently (maybe I erred in having separate handling for `elseif`). Either way, I think this is a minimally-bad change, and it limits the use of the `Union::substitute` method, which I don't think should be used in if/else handling — if/else handling should just use regular type reconciliation everywhere.

I saw this mismatch when looking at Hack (which has no `elseif`)