### PR TITLE
Add CI test for minimum dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           echo "::set-output name=chunks::$(php -r 'echo json_encode(range(1, ${{ env.CHUNK_COUNT }} ));')"
 
   tests:
-    name: "Unit Tests - ${{ matrix.chunk }}"
+    name: "Unit Tests - PHP ${{ matrix.php }} - deps ${{ matrix.deps }} - ${{ matrix.chunk }}"
 
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,8 @@ jobs:
       matrix:
         count: ${{ fromJson(needs.chunk-matrix.outputs.count) }}
         chunk: ${{ fromJson(needs.chunk-matrix.outputs.chunks) }}
+        php: ['7.1', '7.3', '7.4', '8.0', '8.1']
+        deps: ['high', 'low', 'stable']
 
     env:
       CHUNK_COUNT: "${{ matrix.count }}"
@@ -86,7 +88,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: ${{matrix.php}}
           tools: composer:v2
           coverage: none
           extensions: decimal
@@ -109,10 +111,23 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
-      - name: Run composer install
-        run: composer install -o
+      - name: Install composer dependencies (high deps)
+        run: composer update --prefer-dist --no-interaction
+        if: ${{ matrix.deps == 'high' }}
         env:
-          COMPOSER_ROOT_VERSION: dev-master
+            COMPOSER_ROOT_VERSION: dev-master
+
+      - name: Install composer dependencies (low deps)
+        run: composer update --prefer-dist --no-interaction --prefer-stable --prefer-lowest
+        if: ${{ matrix.deps == 'low' }}
+        env:
+            COMPOSER_ROOT_VERSION: dev-master
+
+      - name: Install composer dependencies (stable deps)
+        run: composer update --prefer-dist --no-interaction --prefer-stable
+        if: ${{ matrix.deps == 'stable' }}
+        env:
+            COMPOSER_ROOT_VERSION: dev-master
 
       - name: Run unit tests
         run: bin/tests-github-actions.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,6 +111,10 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-composer-
 
+      - name: Drop incompatible packages
+        run: composer remove --no-interaction --dev phpunit/phpunit brianium/paratest psalm/plugin-phpunit weirdan/prophecy-shim
+        if: ${{ matrix.php == '7.1' }}
+
       - name: Install composer dependencies (high deps)
         run: composer update --prefer-dist --no-interaction
         if: ${{ matrix.deps == 'high' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       matrix:
         count: ${{ fromJson(needs.chunk-matrix.outputs.count) }}
         chunk: ${{ fromJson(needs.chunk-matrix.outputs.chunks) }}
-        php: ['7.1', '7.3', '7.4', '8.0', '8.1']
+        php: ['7.3', '7.4', '8.0', '8.1']
         deps: ['high', 'low', 'stable']
 
     env:
@@ -110,10 +110,6 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
-
-      - name: Drop incompatible packages
-        run: composer remove --no-interaction --dev phpunit/phpunit brianium/paratest psalm/plugin-phpunit weirdan/prophecy-shim
-        if: ${{ matrix.php == '7.1' }}
 
       - name: Install composer dependencies (high deps)
         run: composer update --prefer-dist --no-interaction

--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,7 @@
         "phpdocumentor/reflection-docblock": "^5",
         "phpmyadmin/sql-parser": "5.1.0||dev-master",
         "phpspec/prophecy": ">=1.9.0",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^9.1",
         "psalm/plugin-phpunit": "^0.16",
         "slevomat/coding-standard": "^7.0",
         "squizlabs/php_codesniffer": "^3.5",


### PR DESCRIPTION
Given how long it takes I don't think we want to have this run on every commit and pull request, so I think after I get all of the issues fixed we'll probably want to split this into a separate workflow that runs before releases, and perhaps daily or weekly (probably with an extra check like [this](https://github.community/t/trigger-action-on-schedule-only-if-there-are-changes-to-the-branch/17887/4)).