### PR TITLE
Fixed ini_set types for arg value

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -6153,7 +6153,7 @@ return [
 'ini_get' => ['string|false', 'option'=>'string'],
 'ini_get_all' => ['array|false', 'extension='=>'?string', 'details='=>'bool'],
 'ini_restore' => ['void', 'option'=>'string'],
-'ini_set' => ['string|false', 'option'=>'string', 'value'=>'string'],
+'ini_set' => ['string|false', 'option'=>'string', 'value'=>'string|int|float|bool|null'],
 'inotify_add_watch' => ['int', 'inotify_instance'=>'resource', 'pathname'=>'string', 'mask'=>'int'],
 'inotify_init' => ['resource|false'],
 'inotify_queue_len' => ['int', 'inotify_instance'=>'resource'],

--- a/dictionaries/CallMap_81_delta.php
+++ b/dictionaries/CallMap_81_delta.php
@@ -453,6 +453,10 @@ return [
         'old' => ['bool', 'imap'=>'resource', 'mailbox'=>'string'],
         'new' => ['bool', 'imap'=>'IMAP\Connection', 'mailbox'=>'string'],
     ],
+    'ini_set' => [
+        'old' => ['string|false', 'option'=>'string', 'value'=>'string'],
+        'new' => ['string|false', 'option'=>'string', 'value'=>'string|int|float|bool|null'],
+    ],
     'ldap_add' => [
       'old' => ['bool', 'ldap'=>'resource', 'dn'=>'string', 'entry'=>'array', 'controls='=>'array'],
       'new' => ['bool', 'ldap'=>'LDAP\Connection', 'dn'=>'string', 'entry'=>'array', 'controls='=>'?array'],


### PR DESCRIPTION
Hi guys,
in our codebase I have noticed that current version of Psalm has not updated `ini_set` types for the param `$value`. 
Since the 8.1 it is allowed to accept this set of types: `string|int|float|bool|null`. Not only `string`.

https://www.php.net/manual/en/function.ini-set

Best,
Honca