### PR TITLE
Fix union assertions

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -795,15 +795,7 @@ class CallAnalyzer
                                     continue;
                                 }
                                 foreach ($intersection->getAtomicTypes() as $atomic_type) {
-                                    if ($assertion_type_atomic instanceof TTemplateParam
-                                        && $assertion_type_atomic->as->getId() === $atomic_type->getId()
-                                    ) {
-                                        continue;
-                                    }
-
-                                    $assertion_rule = clone $assertion_rule;
-                                    $assertion_rule->setAtomicType($atomic_type);
-                                    $orred_rules[] = $assertion_rule;
+                                    $orred_rules[] = new IsIdentical($atomic_type);
                                 }
                             } elseif ($assertion_rule instanceof IsType) {
                                 if (!UnionTypeComparator::canExpressionTypesBeIdentical(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -783,7 +783,8 @@ class CallAnalyzer
                                 if ($intersection === null) {
                                     IssueBuffer::maybeAdd(
                                         new TypeDoesNotContainType(
-                                            $asserted_type->getId() . ' is not contained by ' . $assertion_type->getId(),
+                                            $asserted_type->getId() . ' is not contained by '
+                                            . $assertion_type->getId(),
                                             new CodeLocation($statements_analyzer->getSource(), $expr),
                                             $asserted_type->getId() . ' ' . $assertion_type->getId()
                                         ),
@@ -812,7 +813,8 @@ class CallAnalyzer
                                 )) {
                                     IssueBuffer::maybeAdd(
                                         new TypeDoesNotContainType(
-                                            $asserted_type->getId() . ' is not contained by ' . $assertion_type->getId(),
+                                            $asserted_type->getId() . ' is not contained by '
+                                            . $assertion_type->getId(),
                                             new CodeLocation($statements_analyzer->getSource(), $expr),
                                             $asserted_type->getId() . ' ' . $assertion_type->getId()
                                         ),

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -701,7 +701,7 @@ abstract class Type
                 && ($int_intersection->min_bound !== null || $int_intersection->max_bound !== null)
             ) {
                 $intersection_performed = true;
-                if ($int_intersection->min_bound === $int_intersection->max_bound) {
+                if ($int_intersection->min_bound !== null && $int_intersection->min_bound === $int_intersection->max_bound) {
                     return new TLiteralInt($int_intersection->min_bound);
                 }
                 return $int_intersection;

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -693,18 +693,18 @@ abstract class Type
             }
         }
         if ($type_1_atomic instanceof TInt && $type_2_atomic instanceof TInt) {
-            $intersection_atomic = TIntRange::intersectIntRanges(
+            $int_intersection = TIntRange::intersectIntRanges(
                 TIntRange::convertToIntRange($type_1_atomic),
                 TIntRange::convertToIntRange($type_2_atomic)
             );
-            if ($intersection_atomic
-                && ($intersection_atomic->min_bound !== null || $intersection_atomic->max_bound !== null)
+            if ($int_intersection
+                && ($int_intersection->min_bound !== null || $int_intersection->max_bound !== null)
             ) {
                 $intersection_performed = true;
-                if ($intersection_atomic->min_bound === $intersection_atomic->max_bound) {
-                    return new TLiteralInt($intersection_atomic->min_bound);
+                if ($int_intersection->min_bound === $int_intersection->max_bound) {
+                    return new TLiteralInt($int_intersection->min_bound);
                 }
-                return $intersection_atomic;
+                return $int_intersection;
             }
         }
 

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -731,6 +731,15 @@ abstract class Type
         if (self::mayHaveIntersection($type_1_atomic, $codebase)
             && self::mayHaveIntersection($type_2_atomic, $codebase)
         ) {
+            if ($type_1_atomic instanceof TNamedObject && $type_2_atomic instanceof TNamedObject) {
+                $first = $codebase->classlike_storage_provider->get($type_1_atomic->value);
+                $second = $codebase->classlike_storage_provider->get($type_2_atomic->value);
+                $first_is_class = !$first->is_interface && !$first->is_trait;
+                $second_is_class = !$second->is_interface && !$second->is_trait;
+                if ($first_is_class && $second_is_class) {
+                    return $intersection_atomic;
+                }
+            }
             if ($intersection_atomic === null && $wider_type === null) {
                 $intersection_atomic = clone $type_1_atomic;
                 $wider_type = $type_2_atomic;

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -692,13 +692,15 @@ abstract class Type
                 $intersection_performed = true;
             }
         }
-        if ($type_1_atomic instanceof TIntRange && $type_2_atomic instanceof TIntRange) {
+        if ($type_1_atomic instanceof TInt && $type_2_atomic instanceof TInt) {
             $intersection_atomic = TIntRange::intersectIntRanges(
-                $type_1_atomic,
-                $type_2_atomic
+                TIntRange::convertToIntRange($type_1_atomic),
+                TIntRange::convertToIntRange($type_2_atomic)
             );
-            $intersection_performed = true;
-            return $intersection_atomic;
+            if ($intersection_atomic) {
+                $intersection_performed = true;
+                return $intersection_atomic;
+            }
         }
 
         if (null === $intersection_atomic) {
@@ -731,6 +733,7 @@ abstract class Type
         if (self::mayHaveIntersection($type_1_atomic, $codebase)
             && self::mayHaveIntersection($type_2_atomic, $codebase)
         ) {
+            /** @psalm-suppress TypeDoesNotContainType */
             if ($type_1_atomic instanceof TNamedObject && $type_2_atomic instanceof TNamedObject) {
                 $first = $codebase->classlike_storage_provider->get($type_1_atomic->value);
                 $second = $codebase->classlike_storage_provider->get($type_2_atomic->value);

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -701,7 +701,9 @@ abstract class Type
                 && ($int_intersection->min_bound !== null || $int_intersection->max_bound !== null)
             ) {
                 $intersection_performed = true;
-                if ($int_intersection->min_bound !== null && $int_intersection->min_bound === $int_intersection->max_bound) {
+                if ($int_intersection->min_bound !== null
+                    && $int_intersection->min_bound === $int_intersection->max_bound
+                ) {
                     return new TLiteralInt($int_intersection->min_bound);
                 }
                 return $int_intersection;

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -697,8 +697,13 @@ abstract class Type
                 TIntRange::convertToIntRange($type_1_atomic),
                 TIntRange::convertToIntRange($type_2_atomic)
             );
-            if ($intersection_atomic) {
+            if ($intersection_atomic
+                && ($intersection_atomic->min_bound !== null || $intersection_atomic->max_bound !== null)
+            ) {
                 $intersection_performed = true;
+                if ($intersection_atomic->min_bound === $intersection_atomic->max_bound) {
+                    return new TLiteralInt($intersection_atomic->min_bound);
+                }
                 return $intersection_atomic;
             }
         }

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -787,7 +787,7 @@ abstract class Type
     /**
      * @psalm-assert-if-true TIterable|TNamedObject|TTemplateParam|TObjectWithProperties $type
      */
-    public static function mayHaveIntersection(Atomic $type, Codebase $codebase): bool
+    private static function mayHaveIntersection(Atomic $type, Codebase $codebase): bool
     {
         if ($type instanceof TIterable
             || $type instanceof TTemplateParam

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -45,13 +45,4 @@ final class TLiteralFloat extends TFloat
     ): string {
         return 'float';
     }
-
-    public function equals(Atomic $other_type, bool $ensure_source_equality): bool
-    {
-        if (get_class($other_type) !== static::class) {
-            return false;
-        }
-
-        return $this->value === $other_type->value;
-    }
 }

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -2,10 +2,6 @@
 
 namespace Psalm\Type\Atomic;
 
-use Psalm\Type\Atomic;
-
-use function get_class;
-
 /**
  * Denotes a floating point value where the exact numeric value is known.
  */

--- a/src/Psalm/Type/Atomic/TLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TLiteralInt.php
@@ -2,10 +2,6 @@
 
 namespace Psalm\Type\Atomic;
 
-use Psalm\Type\Atomic;
-
-use function get_class;
-
 /**
  * Denotes an integer value where the exact numeric value is known.
  */

--- a/src/Psalm/Type/Atomic/TLiteralInt.php
+++ b/src/Psalm/Type/Atomic/TLiteralInt.php
@@ -50,19 +50,4 @@ final class TLiteralInt extends TInt
     ): string {
         return $use_phpdoc_format ? 'int' : (string) $this->value;
     }
-
-    public function equals(Atomic $other_type, bool $ensure_source_equality): bool
-    {
-        if (get_class($other_type) !== static::class) {
-            return false;
-        }
-
-        if (($this->from_docblock && $ensure_source_equality)
-            || ($other_type->from_docblock && $ensure_source_equality)
-        ) {
-            return false;
-        }
-
-        return $this->value === $other_type->value;
-    }
 }

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -2,10 +2,7 @@
 
 namespace Psalm\Type\Atomic;
 
-use Psalm\Type\Atomic;
-
 use function addcslashes;
-use function get_class;
 use function mb_strlen;
 use function mb_substr;
 

--- a/src/Psalm/Type/Atomic/TLiteralString.php
+++ b/src/Psalm/Type/Atomic/TLiteralString.php
@@ -58,19 +58,4 @@ class TLiteralString extends TString
     ): string {
         return $use_phpdoc_format ? 'string' : "'" . $this->value . "'";
     }
-
-    public function equals(Atomic $other_type, bool $ensure_source_equality): bool
-    {
-        if (get_class($other_type) !== static::class) {
-            return false;
-        }
-
-        if (($this->from_docblock && $ensure_source_equality)
-            || ($other_type->from_docblock && $ensure_source_equality)
-        ) {
-            return false;
-        }
-
-        return $this->value === $other_type->value;
-    }
 }

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -1268,6 +1268,9 @@ final class Union implements TypeNode
         return true;
     }
 
+    /**
+     * @psalm-suppress PossiblyUnusedMethod Public API
+     */
     public function allFloatLiterals(): bool
     {
         foreach ($this->types as $atomic_key_type) {

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1758,6 +1758,40 @@ class ArrayAssignmentTest extends TestCase
                     $c = new C();
                     $c[] = "hello";'
             ],
+            'conditionalRestrictedDocblockKeyAssignment' => [
+                'code' => '<?php
+
+
+                /**
+                 * @return array{booking: array{active: false, icon: "settings"}, phones: array{active: false, icon: "phone-tube"}, stat: array{active: false, icon: "review"}, support: array{active: false, icon: "help"}}
+                 */
+                function getSections(): array {
+                    return [
+                            "phones" => [
+                                "active" => false,
+                                "icon" => "phone-tube",
+                            ],
+                            "stat" => [
+                                "active" => false,
+                                "icon" => "review",
+                            ],
+                            "booking" => [
+                                "active" => false,
+                                "icon" => "settings",
+                            ],
+                            "support" => [
+                                "active" => false,
+                                "icon" => "help",
+                            ],
+                    ];
+                }
+                $items = getSections();
+                /** @var string */
+                $currentAction = "";
+                if (\array_key_exists($currentAction, $items)) {
+                    $items[$currentAction]["active"] = true;
+                }'
+            ]
         ];
     }
 

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -2061,7 +2061,7 @@ class AssertAnnotationTest extends TestCase
                      * @template T
                      * @param mixed $input
                      * @param array<array-key,T> $values
-                     * @psalm-assert T $input
+                     * @psalm-assert =T $input
                      */
                     function assertOneOf($input, array $values): void {}
 

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -641,8 +641,8 @@ class InterfaceTest extends TestCase
             ],
             'intersectIterators' => [
                 'code' => '<?php
-                    class A {} function takesA(A $p): void {}
-                    class B {} function takesB(B $p): void {}
+                    interface A {} function takesA(A $p): void {}
+                    interface B {} function takesB(B $p): void {}
 
                     /** @psalm-param iterable<A>&iterable<B> $i */
                     function takesIntersectionOfIterables(iterable $i): void {

--- a/tests/Template/FunctionTemplateAssertTest.php
+++ b/tests/Template/FunctionTemplateAssertTest.php
@@ -1123,6 +1123,27 @@ class FunctionTemplateAssertTest extends TestCase
                     }',
                 'error_message' => 'RedundantCondition',
             ],
+            'SKIPPED-assertNotSameClasses' => [
+                'code' => '<?php
+                    /**
+                     * Asserts that two variables are the same.
+                     *
+                     * @template T
+                     * @param T      $expected
+                     * @param mixed  $actual
+                     * @psalm-assert =T $actual
+                     */
+                    function assertSame($expected, $actual) : void {}
+
+                    class a {}
+                    class b {}
+                    class c {}
+
+                    $expected = rand(0, 1) ? new a : new b;
+                    $actual = new c;
+                    assertSame($expected, $actual);',
+                'error_message' => 'TypeDoesNotContainType',
+            ],
             'assertNotSameDifferentTypesExplicitString' => [
                 'code' => '<?php
                     /**

--- a/tests/Template/FunctionTemplateAssertTest.php
+++ b/tests/Template/FunctionTemplateAssertTest.php
@@ -167,7 +167,7 @@ class FunctionTemplateAssertTest extends TestCase
                      *
                      * @param mixed $value
                      * @param class-string<T> $type
-                     * 
+                     *
                      * @psalm-assert T $value
                      */
                     function assertInstanceOf($value, string $type): void {
@@ -1087,6 +1087,23 @@ class FunctionTemplateAssertTest extends TestCase
                     $c = 4.0;
                     $d = rand(0, 1) ? 5 : 6;
                     assertEqual($c, $d);',
+                'error_message' => 'TypeDoesNotContainType',
+            ],
+            'assertTemplateUnionParadox' => [
+                'code' => '<?php
+                    /**
+                     * Asserts that two variables are not the same.
+                     *
+                     * @template T
+                     * @param T      $expected
+                     * @param mixed  $actual
+                     * @psalm-assert T $actual
+                     */
+                    function assertSame($expected, $actual) : void {}
+
+                    $expected = rand(0, 1) ? 4 : 5;
+                    $actual = 6;
+                    assertSame($expected, $actual);',
                 'error_message' => 'TypeDoesNotContainType',
             ],
             'assertNotSameDifferentTypes' => [

--- a/tests/Template/FunctionTemplateAssertTest.php
+++ b/tests/Template/FunctionTemplateAssertTest.php
@@ -1123,7 +1123,7 @@ class FunctionTemplateAssertTest extends TestCase
                     }',
                 'error_message' => 'RedundantCondition',
             ],
-            'SKIPPED-assertNotSameClasses' => [
+            'assertNotSameClasses' => [
                 'code' => '<?php
                     /**
                      * Asserts that two variables are the same.
@@ -1137,7 +1137,7 @@ class FunctionTemplateAssertTest extends TestCase
 
                     class a {}
                     class b {}
-                    class c {}
+                    final class c {}
 
                     $expected = rand(0, 1) ? new a : new b;
                     $actual = new c;

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -213,6 +213,13 @@ class TypeParseTest extends TestCase
         $this->assertSame('array{a: int}', (string) Type::parseString('array{a: int}&array{a?: int}'));
     }
 
+
+    public function testIntersectionOfIntranges(): void
+    {
+        $this->assertSame('array{a: int<3, 4>}', (string) Type::parseString('array{a: int<2, 4>}&array{a: int<3, 6>}'));
+        $this->assertSame('array{a: 4}', Type::parseString('array{a: 4}&array{a: int<3, 6>}')->getId(true));
+    }
+
     public function testIntersectionOfTKeyedArrayWithConflictingProperties(): void
     {
         $this->expectException(TypeParseTreeException::class);


### PR DESCRIPTION
Fixes #8322, #8319 and a few other bugs introduced by #8077, by explicitly running the intersection logic only on IsIdentical assertions (due to the semantics of Type::intersectUnionTypes wasn't sure if we should run it on IsType assertions), and removing the custom intersection/equality logic which broke other stuff in the code.