### PR TITLE
recognize `@psalm-allow-private-mutation` in PHP 8+ constructors

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -606,6 +606,7 @@ class FunctionLikeNodeScanner
                 $doc_comment = $param->getDocComment();
                 $var_comment_type = null;
                 $var_comment_readonly = false;
+                $var_comment_allow_private_mutation = false;
                 if ($doc_comment) {
                     $var_comments = CommentAnalyzer::getTypeFromComment(
                         $doc_comment,
@@ -620,6 +621,7 @@ class FunctionLikeNodeScanner
                     if ($var_comment !== null) {
                         $var_comment_type = $var_comment->type;
                         $var_comment_readonly = $var_comment->readonly;
+                        $var_comment_allow_private_mutation = $var_comment->allow_private_mutation;
                     }
                 }
 
@@ -652,6 +654,7 @@ class FunctionLikeNodeScanner
                 $property_storage->has_default = (bool)$param->default;
                 $param_type_readonly = (bool)($param->flags & PhpParser\Node\Stmt\Class_::MODIFIER_READONLY);
                 $property_storage->readonly = $param_type_readonly ?: $var_comment_readonly;
+                $property_storage->allow_private_mutation = $var_comment_allow_private_mutation;
                 $param_storage->promoted_property = true;
                 $property_storage->is_promoted = true;
 

--- a/tests/ReadonlyPropertyTest.php
+++ b/tests/ReadonlyPropertyTest.php
@@ -64,13 +64,48 @@ class ReadonlyPropertyTest extends TestCase
 
                     echo (new A)->bar;'
             ],
-            'readonlyPublicPropertySetInAnotherMEthod' => [
+            'readonlyPublicPropertySetInAnotherMethod' => [
                 '<?php
                     class A {
                         /**
                          * @psalm-readonly-allow-private-mutation
                          */
                         public ?string $bar = null;
+
+                        public function setBar(string $s) : void {
+                            $this->bar = $s;
+                        }
+                    }
+
+                    echo (new A)->bar;'
+            ],
+            'docblockReadonlyWithPrivateMutationsAllowedConstructorPropertySetInAnotherMethod' => [
+                '<?php
+                    class A {
+                        public function __construct(
+                            /**
+                             * @readonly
+                             * @psalm-allow-private-mutation
+                             */
+                            public ?string $bar = null,
+                        ) {}
+
+                        public function setBar(string $s) : void {
+                            $this->bar = $s;
+                        }
+                    }
+
+                    echo (new A)->bar;'
+            ],
+            'readonlyPublicConstructorPropertySetInAnotherMethod' => [
+                '<?php
+                    class A {
+                        public function __construct(
+                            /**
+                             * @psalm-readonly-allow-private-mutation
+                             */
+                            public ?string $bar = null,
+                        ) {}
 
                         public function setBar(string $s) : void {
                             $this->bar = $s;


### PR DESCRIPTION
fixes #7731 