### PR TITLE
Fix formatCurrency return type

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -9028,7 +9028,7 @@ return [
 'NumberFormatter::__construct' => ['void', 'locale'=>'string', 'style'=>'int', 'pattern='=>'string'],
 'NumberFormatter::create' => ['NumberFormatter|false', 'locale'=>'string', 'style'=>'int', 'pattern='=>'string'],
 'NumberFormatter::format' => ['string|false', 'num'=>'', 'type='=>'int'],
-'NumberFormatter::formatCurrency' => ['string', 'num'=>'float', 'currency'=>'string'],
+'NumberFormatter::formatCurrency' => ['string|false', 'num'=>'float', 'currency'=>'string'],
 'NumberFormatter::getAttribute' => ['int|false', 'attr'=>'int'],
 'NumberFormatter::getErrorCode' => ['int'],
 'NumberFormatter::getErrorMessage' => ['string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -4420,7 +4420,7 @@ return [
     'NumberFormatter::__construct' => ['void', 'locale'=>'string', 'style'=>'int', 'pattern='=>'string'],
     'NumberFormatter::create' => ['NumberFormatter|false', 'locale'=>'string', 'style'=>'int', 'pattern='=>'string'],
     'NumberFormatter::format' => ['string|false', 'num'=>'', 'type='=>'int'],
-    'NumberFormatter::formatCurrency' => ['string', 'num'=>'float', 'currency'=>'string'],
+    'NumberFormatter::formatCurrency' => ['string|false', 'num'=>'float', 'currency'=>'string'],
     'NumberFormatter::getAttribute' => ['int|false', 'attr'=>'int'],
     'NumberFormatter::getErrorCode' => ['int'],
     'NumberFormatter::getErrorMessage' => ['string'],


### PR DESCRIPTION
Hi @orklah, I just got an error `[TypeDoesNotContainType](https://psalm.dev/056) - 6:9 - string does not contain false`.

but NumberFormatter::formatCurrency can return false
See https://www.php.net/manual/fr/numberformatter.formatcurrency.php