### PR TITLE
Added better stubs for `DateTimeImmutable`, highlighting how the constructor is **NOT** immutable

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1802,7 +1802,6 @@ return [
 'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
 'DateTimeImmutable::setTime' => ['static|false', 'hour'=>'int', 'minute'=>'int', 'second='=>'int', 'microseconds='=>'int'],
 'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
-'DateTimeImmutable::setTimezone' => ['static|false', 'timezone'=>'DateTimeZone'],
 'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTimeInterface::format' => ['string', 'format'=>'string'],
 'DateTimeInterface::getOffset' => ['int'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1796,7 +1796,6 @@ return [
 'DateTimeImmutable::__set_state' => ['static', 'array'=>'array'],
 'DateTimeImmutable::__wakeup' => ['void'],
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
-'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
 'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTimeInterface::format' => ['string', 'format'=>'string'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1802,7 +1802,6 @@ return [
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
 'DateTimeImmutable::getOffset' => ['int'],
 'DateTimeImmutable::getTimestamp' => ['int|false'],
-'DateTimeImmutable::getTimezone' => ['DateTimeZone|false'],
 'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
 'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
 'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1799,7 +1799,6 @@ return [
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
 'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
 'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
 'DateTimeImmutable::setTime' => ['static|false', 'hour'=>'int', 'minute'=>'int', 'second='=>'int', 'microseconds='=>'int'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1793,8 +1793,6 @@ return [
 'DateTime::setTimestamp' => ['static', 'unixtimestamp'=>'int'],
 'DateTime::setTimezone' => ['static', 'timezone'=>'DateTimeZone'],
 'DateTime::sub' => ['static', 'interval'=>'DateInterval'],
-'DateTimeImmutable::__construct' => ['void', 'time='=>'string'],
-'DateTimeImmutable::__construct\'1' => ['void', 'time'=>'?string', 'timezone'=>'?DateTimeZone'],
 'DateTimeImmutable::__set_state' => ['static', 'array'=>'array'],
 'DateTimeImmutable::__wakeup' => ['void'],
 'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1800,7 +1800,6 @@ return [
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
 'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
 'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
-'DateTimeImmutable::setTime' => ['static|false', 'hour'=>'int', 'minute'=>'int', 'second='=>'int', 'microseconds='=>'int'],
 'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
 'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTimeInterface::format' => ['string', 'format'=>'string'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1798,7 +1798,6 @@ return [
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
 'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
 'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
 'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1800,7 +1800,6 @@ return [
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-'DateTimeImmutable::getOffset' => ['int'],
 'DateTimeImmutable::getTimestamp' => ['int|false'],
 'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
 'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1800,7 +1800,6 @@ return [
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-'DateTimeImmutable::getTimestamp' => ['int|false'],
 'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
 'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
 'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1799,7 +1799,6 @@ return [
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
-'DateTimeImmutable::format' => ['string', 'format'=>'string'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
 'DateTimeImmutable::getOffset' => ['int'],
 'DateTimeImmutable::getTimestamp' => ['int|false'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1796,7 +1796,6 @@ return [
 'DateTimeImmutable::__set_state' => ['static', 'array'=>'array'],
 'DateTimeImmutable::__wakeup' => ['void'],
 'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],
-'DateTimeImmutable::createFromFormat' => ['static|false', 'format'=>'string', 'time'=>'string', 'timezone='=>'?DateTimeZone'],
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1811,7 +1811,6 @@ return [
 'DateTimeImmutable::setTime' => ['static|false', 'hour'=>'int', 'minute'=>'int', 'second='=>'int', 'microseconds='=>'int'],
 'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
 'DateTimeImmutable::setTimezone' => ['static|false', 'timezone'=>'DateTimeZone'],
-'DateTimeImmutable::sub' => ['static|false', 'interval'=>'DateInterval'],
 'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTimeInterface::format' => ['string', 'format'=>'string'],
 'DateTimeInterface::getOffset' => ['int'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1795,7 +1795,6 @@ return [
 'DateTime::sub' => ['static', 'interval'=>'DateInterval'],
 'DateTimeImmutable::__set_state' => ['static', 'array'=>'array'],
 'DateTimeImmutable::__wakeup' => ['void'],
-'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1798,7 +1798,6 @@ return [
 'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
-'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
 'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
 'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1798,7 +1798,6 @@ return [
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
 'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
 'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTimeInterface::format' => ['string', 'format'=>'string'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1798,7 +1798,6 @@ return [
 'DateTimeImmutable::createFromInterface' => ['self', 'object' => 'DateTimeInterface'],
 'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
 'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
 'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
 'DateTimeInterface::format' => ['string', 'format'=>'string'],
 'DateTimeInterface::getOffset' => ['int'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -41,10 +41,6 @@ return [
       'old' => ['string|false', 'format'=>'string'],
       'new' => ['string', 'format'=>'string'],
     ],
-    'DateTimeImmutable::format' => [
-      'old' => ['string|false', 'format'=>'string'],
-      'new' => ['string', 'format'=>'string'],
-    ],
     'DateTimeZone::listIdentifiers' => [
       'old' => ['list<string>|false', 'timezoneGroup='=>'int', 'countryCode='=>'string|null'],
       'new' => ['list<string>', 'timezoneGroup='=>'int', 'countryCode='=>'string|null'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1057,7 +1057,6 @@ return [
     'DateTime::sub' => ['static', 'interval'=>'DateInterval'],
     'DateTimeImmutable::__set_state' => ['static', 'array'=>'array'],
     'DateTimeImmutable::__wakeup' => ['void'],
-    'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
     'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeInterface::format' => ['string', 'format'=>'string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1060,7 +1060,6 @@ return [
     'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
-    'DateTimeImmutable::format' => ['string|false', 'format'=>'string'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
     'DateTimeImmutable::getOffset' => ['int'],
     'DateTimeImmutable::getTimestamp' => ['int|false'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1063,7 +1063,6 @@ return [
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
     'DateTimeImmutable::getOffset' => ['int'],
     'DateTimeImmutable::getTimestamp' => ['int|false'],
-    'DateTimeImmutable::getTimezone' => ['DateTimeZone|false'],
     'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
     'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
     'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1060,7 +1060,6 @@ return [
     'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-    'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
     'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
     'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
     'DateTimeImmutable::setTime' => ['static|false', 'hour'=>'int', 'minute'=>'int', 'second='=>'int', 'microseconds='=>'int'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1055,8 +1055,6 @@ return [
     'DateTime::setTimestamp' => ['static', 'unixtimestamp'=>'int'],
     'DateTime::setTimezone' => ['static', 'timezone'=>'DateTimeZone'],
     'DateTime::sub' => ['static', 'interval'=>'DateInterval'],
-    'DateTimeImmutable::__construct' => ['void', 'time='=>'string'],
-    'DateTimeImmutable::__construct\'1' => ['void', 'time'=>'?string', 'timezone'=>'?DateTimeZone'],
     'DateTimeImmutable::__set_state' => ['static', 'array'=>'array'],
     'DateTimeImmutable::__wakeup' => ['void'],
     'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1059,7 +1059,6 @@ return [
     'DateTimeImmutable::__wakeup' => ['void'],
     'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
-    'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
     'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
     'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1058,7 +1058,6 @@ return [
     'DateTimeImmutable::__set_state' => ['static', 'array'=>'array'],
     'DateTimeImmutable::__wakeup' => ['void'],
     'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],
-    'DateTimeImmutable::createFromFormat' => ['static|false', 'format'=>'string', 'time'=>'string', 'timezone='=>'?DateTimeZone'],
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeImmutable::format' => ['string|false', 'format'=>'string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1059,7 +1059,6 @@ return [
     'DateTimeImmutable::__wakeup' => ['void'],
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-    'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
     'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
     'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
     'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1057,7 +1057,6 @@ return [
     'DateTime::sub' => ['static', 'interval'=>'DateInterval'],
     'DateTimeImmutable::__set_state' => ['static', 'array'=>'array'],
     'DateTimeImmutable::__wakeup' => ['void'],
-    'DateTimeImmutable::add' => ['static', 'interval'=>'DateInterval'],
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
     'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1061,7 +1061,6 @@ return [
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
     'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
     'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
-    'DateTimeImmutable::setTime' => ['static|false', 'hour'=>'int', 'minute'=>'int', 'second='=>'int', 'microseconds='=>'int'],
     'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
     'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeInterface::format' => ['string', 'format'=>'string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1061,7 +1061,6 @@ return [
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-    'DateTimeImmutable::getTimestamp' => ['int|false'],
     'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
     'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],
     'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1061,7 +1061,6 @@ return [
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-    'DateTimeImmutable::getOffset' => ['int'],
     'DateTimeImmutable::getTimestamp' => ['int|false'],
     'DateTimeImmutable::modify' => ['static', 'modify'=>'string'],
     'DateTimeImmutable::setDate' => ['static|false', 'year'=>'int', 'month'=>'int', 'day'=>'int'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1072,7 +1072,6 @@ return [
     'DateTimeImmutable::setTime' => ['static|false', 'hour'=>'int', 'minute'=>'int', 'second='=>'int', 'microseconds='=>'int'],
     'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
     'DateTimeImmutable::setTimezone' => ['static|false', 'timezone'=>'DateTimeZone'],
-    'DateTimeImmutable::sub' => ['static|false', 'interval'=>'DateInterval'],
     'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeInterface::format' => ['string', 'format'=>'string'],
     'DateTimeInterface::getOffset' => ['int'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1059,7 +1059,6 @@ return [
     'DateTimeImmutable::__wakeup' => ['void'],
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-    'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
     'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
     'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeInterface::format' => ['string', 'format'=>'string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1059,7 +1059,6 @@ return [
     'DateTimeImmutable::__wakeup' => ['void'],
     'DateTimeImmutable::createFromMutable' => ['static', 'datetime'=>'DateTime'],
     'DateTimeImmutable::getLastErrors' => ['array{warning_count:int,warnings:array<int,string>,error_count:int,errors:array<int,string>}'],
-    'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
     'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeInterface::format' => ['string', 'format'=>'string'],
     'DateTimeInterface::getOffset' => ['int'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -1063,7 +1063,6 @@ return [
     'DateTimeImmutable::setISODate' => ['static|false', 'year'=>'int', 'week'=>'int', 'day='=>'int'],
     'DateTimeImmutable::setTime' => ['static|false', 'hour'=>'int', 'minute'=>'int', 'second='=>'int', 'microseconds='=>'int'],
     'DateTimeImmutable::setTimestamp' => ['static|false', 'unixtimestamp'=>'int'],
-    'DateTimeImmutable::setTimezone' => ['static|false', 'timezone'=>'DateTimeZone'],
     'DateTimeInterface::diff' => ['DateInterval', 'datetime2'=>'DateTimeInterface', 'absolute='=>'bool'],
     'DateTimeInterface::format' => ['string', 'format'=>'string'],
     'DateTimeInterface::getOffset' => ['int'],

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -91,7 +91,7 @@ class DateTimeImmutable implements DateTimeInterface
 
     /**
      * @psalm-mutation-free
-     * @return static|false
+     * @return static
      */
     public function setTimestamp(int $unixtimestamp) {}
 

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -1,11 +1,106 @@
 <?php
 
-/**
- * @psalm-immutable
- */
 class DateTimeImmutable implements DateTimeInterface
 {
     public function __construct(string $datetime = "now", DateTimeZone $timezone = null) {}
+
+    /**
+     * @psalm-pure
+     * @return static|false
+     */
+    public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null) {}
+
+    /**
+     * @psalm-pure
+     * @param string $format
+     * @return string
+     */
+    public function format($format) {}
+
+    /**
+     * @psalm-pure
+     * @return DateTimeZone
+     */
+    public function getTimezone() {}
+
+    /**
+     * @psalm-pure
+     * @return int
+     */
+    public function getOffset() {}
+
+    /**
+     * @psalm-pure
+     * @return int
+     */
+    public function getTimestamp() {}
+
+    /**
+     * @psalm-pure
+     * @param bool $absolute
+     * @return DateInterval
+     */
+    public function diff(DateTimeInterface $targetObject, $absolute = false) {}
+
+    /**
+     * @psalm-pure
+     * @return static
+     */
+    public function modify(string $modifier) {}
+
+    /**
+     * @psalm-pure
+     * @return static
+     */
+    public function add(DateInterval $interval) {}
+
+    /**
+     * @psalm-pure
+     * @return static
+     */
+    public function sub(DateInterval $interval) {}
+
+    /**
+     * @psalm-pure
+     * @return static|false
+     */
+    public function setTimezone(DateTimeZone $timezone) {}
+
+    /**
+     * @psalm-pure
+     * @return static|false
+     */
+    public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0) {}
+
+    /**
+     * @psalm-pure
+     * @return static|false
+     */
+    public function setDate(int $year, int $month, int $day) {}
+
+    /**
+     * @psalm-pure
+     * @return static|false
+     */
+    public function setISODate(int $year, int $week, int $dayOfWeek = 1) {}
+
+    /**
+     * @psalm-pure
+     * @return static|false
+     */
+    public function setTimestamp(int $unixtimestamp) {}
+
+    /**
+     * @psalm-pure
+     * @return static
+     */
+    public static function createFromMutable(DateTime $object) {}
+
+    /**
+     * @psalm-pure
+     * @return self
+     */
+    public static function createFromInterface(DateTimeInterface $object) {}
 }
 
 /**

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -5,99 +5,99 @@ class DateTimeImmutable implements DateTimeInterface
     public function __construct(string $datetime = "now", DateTimeZone $timezone = null) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static|false
      */
     public static function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @param string $format
      * @return string
      */
     public function format($format) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return DateTimeZone
      */
     public function getTimezone() {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return int
      */
     public function getOffset() {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return int
      */
     public function getTimestamp() {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @param bool $absolute
      * @return DateInterval
      */
     public function diff(DateTimeInterface $targetObject, $absolute = false) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static
      */
     public function modify(string $modifier) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static
      */
     public function add(DateInterval $interval) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static
      */
     public function sub(DateInterval $interval) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static|false
      */
     public function setTimezone(DateTimeZone $timezone) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static|false
      */
     public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static|false
      */
     public function setDate(int $year, int $month, int $day) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static|false
      */
     public function setISODate(int $year, int $week, int $dayOfWeek = 1) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static|false
      */
     public function setTimestamp(int $unixtimestamp) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return static
      */
     public static function createFromMutable(DateTime $object) {}
 
     /**
-     * @psalm-pure
+     * @psalm-mutation-free
      * @return self
      */
     public static function createFromInterface(DateTimeInterface $object) {}

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -15,7 +15,7 @@ class DateTimeImmutable implements DateTimeInterface
      *
      * @param string $format
      *
-     * @return (\PHP_MAJOR_VERSION is int<0, 7> ? string|false : string)
+     * @return ($format is non-empty-string ? non-empty-string : string)
      */
     public function format($format) {}
 

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -85,7 +85,7 @@ class DateTimeImmutable implements DateTimeInterface
 
     /**
      * @psalm-mutation-free
-     * @return static|false
+     * @return static
      */
     public function setISODate(int $year, int $week, int $dayOfWeek = 1) {}
 

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -67,7 +67,7 @@ class DateTimeImmutable implements DateTimeInterface
 
     /**
      * @psalm-mutation-free
-     * @return static|false
+     * @return static
      */
     public function setTimezone(DateTimeZone $timezone) {}
 

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -56,7 +56,10 @@ class DateTimeImmutable implements DateTimeInterface
 
     /**
      * @psalm-mutation-free
-     * @return static
+     * @return static|false this method can fail in case an {@see DateInterval} with relative
+     *                      week days is passed in.
+     *
+     * @see https://github.com/php/php-src/blob/534127d3b22b193ffb9511c4447584f0d2bd4e24/ext/date/php_date.c#L3157-L3160
      */
     public function sub(DateInterval $interval) {}
 

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -12,8 +12,10 @@ class DateTimeImmutable implements DateTimeInterface
 
     /**
      * @psalm-mutation-free
+     *
      * @param string $format
-     * @return string
+     *
+     * @return (\PHP_MAJOR_VERSION is int<0, 7> ? string|false : string)
      */
     public function format($format) {}
 

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -73,7 +73,7 @@ class DateTimeImmutable implements DateTimeInterface
 
     /**
      * @psalm-mutation-free
-     * @return static|false
+     * @return static
      */
     public function setTime(int $hour, int $minute, int $second = 0, int $microsecond = 0) {}
 

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -100,12 +100,6 @@ class DateTimeImmutable implements DateTimeInterface
      * @return static
      */
     public static function createFromMutable(DateTime $object) {}
-
-    /**
-     * @psalm-mutation-free
-     * @return self
-     */
-    public static function createFromInterface(DateTimeInterface $object) {}
 }
 
 /**

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -79,7 +79,7 @@ class DateTimeImmutable implements DateTimeInterface
 
     /**
      * @psalm-mutation-free
-     * @return static|false
+     * @return static
      */
     public function setDate(int $year, int $month, int $day) {}
 

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -46,7 +46,7 @@ class DateTimeImmutable implements DateTimeInterface
 
     /**
      * @psalm-mutation-free
-     * @return static
+     * @return static|false
      */
     public function modify(string $modifier) {}
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -264,7 +264,6 @@ class MethodCallTest extends TestCase
             ],
             'dateTimeImmutableStatic' => [
                 '<?php
-                    /** @psalm-immutable */
                     final class MyDate extends DateTimeImmutable {}
 
                     $today = new MyDate();

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -271,8 +271,8 @@ class MethodCallTest extends TestCase
 
                     $b = (new DateTimeImmutable())->modify("+3 hours");',
                 'assertions' => [
-                    '$yesterday' => 'MyDate',
-                    '$b' => 'DateTimeImmutable',
+                    '$yesterday' => 'MyDate|false',
+                    '$b' => 'DateTimeImmutable|false',
                 ],
             ],
             'magicCall' => [

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -271,7 +271,7 @@ class MethodCallTest extends TestCase
 
                     $b = (new DateTimeImmutable())->modify("+3 hours");',
                 'assertions' => [
-                    '$yesterday' => 'MyDate|false',
+                    '$yesterday' => 'MyDate',
                     '$b' => 'DateTimeImmutable',
                 ],
             ],


### PR DESCRIPTION
`DateTimeImmutable` is **almost** immutable: `DateTimeImmutable::__construct()` is in fact not a pure
method, since `new DateTimeImmutable('now')` produces a different value at each instantiation (by design).

This change makes sure that `DateTimeImmutable` loses its `@psalm-immutable` class-level marker,
preventing downstream misuse of the constructor inside otherwise referentially transparent code.

Note: only pure methods are stubbed here: all other methods declared by `DateTimeImmutable` (parent interface)
are NOT present here, and are either inferred from runtime reflection, or `CallMap*.php` definitions.

Methods are sorted in the order defined by reflection on PHP 8.1.8, at the time of writing this ( https://3v4l.org/3TGg8 ).

Following simplistic snippet was used to infer the current signature:

```php
<?php

$c = new \ReflectionClass(\DateTimeImmutable::class);

$methods = array_map(function ($m) {
    return $m->getName()
        . '(' . implode(',', array_map(function ($p) {
            return $p->getType()
                . ' $' . $p->getName()
                . ($p->isOptional() ? ' = ' . var_export($p->getDefaultValue(), true) : '');
        }, $m->getParameters())) . ')' . ($m->getReturnType() ? (': ' . $m->getReturnType()) : '');
}, $c->getMethods());

$properties = array_map(function ($m) {
    return $m->getName();
}, $c->getProperties());

var_dump($methods, $properties);
```