### PR TITLE
Add BitwiseNot and BooleanNot operators to SimpleTypeInferer

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -249,7 +249,9 @@ class SimpleTypeInferer
                 $fq_classlike_name
             );
 
-            if ($stmt_expr_type === null || $stmt_expr_type->isAlwaysFalsy()) {
+            if ($stmt_expr_type === null) {
+                return null;
+            } elseif ($stmt_expr_type->isAlwaysFalsy()) {
                 return Type::getTrue();
             } elseif ($stmt_expr_type->isAlwaysTruthy()) {
                 return Type::getFalse();

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -203,6 +203,61 @@ class SimpleTypeInferer
             }
         }
 
+        if ($stmt instanceof PhpParser\Node\Expr\BitwiseNot) {
+            $stmt_expr_type = self::infer(
+                $codebase,
+                $nodes,
+                $stmt->expr,
+                $aliases,
+                $file_source,
+                $existing_class_constants,
+                $fq_classlike_name
+            );
+
+            if ($stmt_expr_type === null) {
+                return null;
+            }
+
+            $invalidTypes = clone $stmt_expr_type;
+            $invalidTypes->removeType('string');
+            $invalidTypes->removeType('int');
+            $invalidTypes->removeType('float');
+
+            if (!$invalidTypes->isUnionEmpty()) {
+                return null;
+            }
+
+            $types = [];
+            if ($stmt_expr_type->hasString()) {
+                $types[] = Type::getString();
+            }
+            if ($stmt_expr_type->hasInt() || $stmt_expr_type->hasFloat()) {
+                $types[] = Type::getInt();
+            }
+
+            return $types ? Type::combineUnionTypeArray($types, null) : null;
+        }
+
+        if ($stmt instanceof PhpParser\Node\Expr\BooleanNot) {
+            $stmt_expr_type = self::infer(
+                $codebase,
+                $nodes,
+                $stmt->expr,
+                $aliases,
+                $file_source,
+                $existing_class_constants,
+                $fq_classlike_name
+            );
+
+            if ($stmt_expr_type === null || $stmt_expr_type->isAlwaysFalsy()) {
+                return Type::getTrue();
+            } elseif ($stmt_expr_type->isAlwaysTruthy()) {
+                return Type::getFalse();
+            } else {
+                return Type::getBool();
+            }
+        }
+
         if ($stmt instanceof PhpParser\Node\Expr\ConstFetch) {
             $name = strtolower($stmt->name->parts[0]);
             if ($name === 'false') {

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -998,6 +998,60 @@ class ConstantTest extends TestCase
                     '$c' => 'int',
                 ]
             ],
+            'bitwiseAndClassConstant' => [
+                'code' => '<?php
+                    class X {
+                        public const A = 1;
+                        public const B = 2;
+                        public const C = self::A & self::B;
+                    }
+
+                    $c = X::C;',
+                'assertions' => [
+                    '$c' => 'int',
+                ]
+            ],
+            'bitwiseXorClassConstant' => [
+                'code' => '<?php
+                    class X {
+                        public const A = 1;
+                        public const B = 2;
+                        public const C = self::A ^ self::B;
+                    }
+
+                    $c = X::C;',
+                'assertions' => [
+                    '$c' => 'int',
+                ]
+            ],
+            'bitwiseNotClassConstant' => [
+                'code' => '<?php
+                    class X {
+                        public const A = ~0;
+                        public const B = ~"aa";
+                    }
+
+                    $a = X::A;
+                    $b = X::B;',
+                'assertions' => [
+                    '$a' => 'int',
+                    '$b' => 'string',
+                ]
+            ],
+            'booleanNotClassConstant' => [
+                'code' => '<?php
+                    class X {
+                        public const A = !true;
+                        public const B = !false;
+                    }
+
+                    $a = X::A;
+                    $b = X::B;',
+                'assertions' => [
+                    '$a' => 'false',
+                    '$b' => 'true',
+                ]
+            ],
             'protectedClassConstantAccessibilitySameNameInChild' => [
                 'code' => '<?php
                     class A {


### PR DESCRIPTION
`BitwiseNot` and `BooleanNot` operators were missing from the `SimpleTypeInferer`. This PR adds them.

This should fix #8307.

Thanks to @AndrolGenhald for pointing me in the right direction.