### PR TITLE
add ", but" for InvalidArgument error message where a type is provided

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -181,7 +181,7 @@ class ArgumentAnalyzer
                     IssueBuffer::maybeAdd(
                         new InvalidLiteralArgument(
                             'Argument ' . ($argument_offset + 1) . ' of ' . $cased_method_id
-                                . ' expects a non-literal value, ' . $arg_value_type->getId() . ' provided',
+                                . ' expects a non-literal value, but ' . $arg_value_type->getId() . ' provided',
                             new CodeLocation($statements_analyzer->getSource(), $arg->value),
                             $cased_method_id
                         ),
@@ -976,7 +976,7 @@ class ArgumentAnalyzer
                 IssueBuffer::maybeAdd(
                     new MixedArgumentTypeCoercion(
                         'Argument ' . ($argument_offset + 1) . $method_identifier . ' expects ' . $param_type->getId() .
-                            ', parent type ' . $input_type->getId() . ' provided',
+                            ', but parent type ' . $input_type->getId() . ' provided',
                         $arg_location,
                         $cased_method_id,
                         $origin_location
@@ -987,7 +987,7 @@ class ArgumentAnalyzer
                 IssueBuffer::maybeAdd(
                     new ArgumentTypeCoercion(
                         'Argument ' . ($argument_offset + 1) . $method_identifier . ' expects ' . $param_type->getId() .
-                            ', parent type ' . $input_type->getId() . ' provided',
+                            ', but parent type ' . $input_type->getId() . ' provided',
                         $arg_location,
                         $cased_method_id
                     ),
@@ -1000,7 +1000,7 @@ class ArgumentAnalyzer
             IssueBuffer::maybeAdd(
                 new ImplicitToStringCast(
                     'Argument ' . ($argument_offset + 1) . $method_identifier . ' expects ' .
-                        $param_type->getId() . ', ' . $input_type->getId() . ' provided with a __toString method',
+                        $param_type->getId() . ', but ' . $input_type->getId() . ' provided with a __toString method',
                     $arg_location
                 ),
                 $statements_analyzer->getSuppressedIssues()
@@ -1022,7 +1022,7 @@ class ArgumentAnalyzer
                     IssueBuffer::maybeAdd(
                         new InvalidScalarArgument(
                             'Argument ' . ($argument_offset + 1) . $method_identifier . ' expects ' .
-                                $param_type->getId() . ', ' . $type . ' provided',
+                                $param_type->getId() . ', but ' . $type . ' provided',
                             $arg_location,
                             $cased_method_id
                         ),
@@ -1033,7 +1033,7 @@ class ArgumentAnalyzer
                 IssueBuffer::maybeAdd(
                     new PossiblyInvalidArgument(
                         'Argument ' . ($argument_offset + 1) . $method_identifier . ' expects ' . $param_type->getId() .
-                            ', possibly different type ' . $type . ' provided',
+                            ', but possibly different type ' . $type . ' provided',
                         $arg_location,
                         $cased_method_id
                     ),
@@ -1043,7 +1043,7 @@ class ArgumentAnalyzer
                 IssueBuffer::maybeAdd(
                     new InvalidArgument(
                         'Argument ' . ($argument_offset + 1) . $method_identifier . ' expects ' . $param_type->getId() .
-                            ', ' . $type . ' provided',
+                            ', but ' . $type . ' provided',
                         $arg_location,
                         $cased_method_id
                     ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php
@@ -893,7 +893,8 @@ class ArrayFunctionArgumentsAnalyzer
                     IssueBuffer::maybeAdd(
                         new MixedArgumentTypeCoercion(
                             'Parameter ' . ($i + 1) . ' of closure passed to function ' . $method_id . ' expects ' .
-                                $closure_param_type->getId() . ', parent type ' . $input_type->getId() . ' provided',
+                                $closure_param_type->getId() .
+                                ', but parent type ' . $input_type->getId() . ' provided',
                             new CodeLocation($statements_analyzer->getSource(), $closure_arg),
                             $method_id
                         ),
@@ -903,7 +904,8 @@ class ArrayFunctionArgumentsAnalyzer
                     IssueBuffer::maybeAdd(
                         new ArgumentTypeCoercion(
                             'Parameter ' . ($i + 1) . ' of closure passed to function ' . $method_id . ' expects ' .
-                                $closure_param_type->getId() . ', parent type ' . $input_type->getId() . ' provided',
+                                $closure_param_type->getId() .
+                                ', but parent type ' . $input_type->getId() . ' provided',
                             new CodeLocation($statements_analyzer->getSource(), $closure_arg),
                             $method_id
                         ),
@@ -923,7 +925,7 @@ class ArrayFunctionArgumentsAnalyzer
                     IssueBuffer::maybeAdd(
                         new InvalidScalarArgument(
                             'Parameter ' . ($i + 1) . ' of closure passed to function ' . $method_id . ' expects ' .
-                                $closure_param_type->getId() . ', ' . $input_type->getId() . ' provided',
+                                $closure_param_type->getId() . ', but ' . $input_type->getId() . ' provided',
                             new CodeLocation($statements_analyzer->getSource(), $closure_arg),
                             $method_id
                         ),
@@ -933,7 +935,7 @@ class ArrayFunctionArgumentsAnalyzer
                     IssueBuffer::maybeAdd(
                         new PossiblyInvalidArgument(
                             'Parameter ' . ($i + 1) . ' of closure passed to function ' . $method_id . ' expects '
-                                . $closure_param_type->getId() . ', possibly different type '
+                                . $closure_param_type->getId() . ', but possibly different type '
                                 . $input_type->getId() . ' provided',
                             new CodeLocation($statements_analyzer->getSource(), $closure_arg),
                             $method_id
@@ -943,7 +945,7 @@ class ArrayFunctionArgumentsAnalyzer
                 } elseif (IssueBuffer::accepts(
                     new InvalidArgument(
                         'Parameter ' . ($i + 1) . ' of closure passed to function ' . $method_id . ' expects ' .
-                            $closure_param_type->getId() . ', ' . $input_type->getId() . ' provided',
+                            $closure_param_type->getId() . ', but ' . $input_type->getId() . ' provided',
                         new CodeLocation($statements_analyzer->getSource(), $closure_arg),
                         $method_id
                     ),

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -1149,7 +1149,7 @@ class ClosureTest extends TestCase
 
                     takesA($getAButReallyB());
                     takesB($getAButReallyB());',
-                'error_message' => 'ArgumentTypeCoercion - src' . DIRECTORY_SEPARATOR . 'somefile.php:13:28 - Argument 1 of takesB expects B, parent type A provided',
+                'error_message' => 'ArgumentTypeCoercion - src' . DIRECTORY_SEPARATOR . 'somefile.php:13:28 - Argument 1 of takesB expects B, but parent type A provided',
             ],
             'closureByRefUseToMixed' => [
                 '<?php

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1500,7 +1500,7 @@ class ReturnTypeTest extends TestCase
 
                 $res = map(function(int $i): string { return (string) $i; })([1,2,3]);
                 ',
-                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:13:54 - Argument 1 expects T:fn-map as mixed, int provided',
+                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:13:54 - Argument 1 expects T:fn-map as mixed, but int provided',
             ],
             'cannotInferReturnClosureWithDifferentReturnTypes' => [
                 '<?php

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -3936,7 +3936,7 @@ class ClassTemplateTest extends TestCase
                             type($closure);
                         }
                     }',
-                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:20:34 - Argument 1 of type expects string, callable(State):(T:AlmostFooMap as mixed)&Foo provided',
+                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:20:34 - Argument 1 of type expects string, but callable(State):(T:AlmostFooMap as mixed)&Foo provided',
             ],
             'templateWithNoReturn' => [
                 '<?php
@@ -4118,7 +4118,7 @@ class ClassTemplateTest extends TestCase
                     $mario = new CharacterRow(["id" => 5, "name" => "Mario", "height" => 3.5]);
 
                     $mario->ame = "Luigi";',
-                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:47:29 - Argument 1 of CharacterRow::__set expects "height"|"id"|"name", "ame" provided',
+                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:47:29 - Argument 1 of CharacterRow::__set expects "height"|"id"|"name", but "ame" provided',
             ],
             'specialiseTypeBeforeReturning' => [
                 '<?php

--- a/tests/TypeReconciliation/TypeTest.php
+++ b/tests/TypeReconciliation/TypeTest.php
@@ -1519,7 +1519,7 @@ class TypeTest extends TestCase
 
                     function takesB(B $i): void {}',
                 'error_message' => 'ArgumentTypeCoercion - src' . DIRECTORY_SEPARATOR . 'somefile.php:14:32 - Argument 1 of takesB expects B,'
-                    . ' parent type A&static provided',
+                    . ' but parent type A&static provided',
             ],
             'intersectionTypeInterfaceCheckAfterInstanceof' => [
                 '<?php
@@ -1540,7 +1540,7 @@ class TypeTest extends TestCase
                     interface I {}
 
                     function takesI(I $i): void {}',
-                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:12:32 - Argument 1 of takesI expects I, A&static provided',
+                'error_message' => 'InvalidArgument - src' . DIRECTORY_SEPARATOR . 'somefile.php:12:32 - Argument 1 of takesI expects I, but A&static provided',
             ],
         ];
     }

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -3451,7 +3451,7 @@ class UnusedVariableTest extends TestCase
                         $arr = [$a];
                         takesArrayOfString($arr);
                     }',
-                'error_message' => 'MixedArgumentTypeCoercion - src' . DIRECTORY_SEPARATOR . 'somefile.php:12:44 - Argument 1 of takesArrayOfString expects array<array-key, string>, parent type array{mixed} provided. Consider improving the type at src' . DIRECTORY_SEPARATOR . 'somefile.php:10:41'
+                'error_message' => 'MixedArgumentTypeCoercion - src' . DIRECTORY_SEPARATOR . 'somefile.php:12:44 - Argument 1 of takesArrayOfString expects array<array-key, string>, but parent type array{mixed} provided. Consider improving the type at src' . DIRECTORY_SEPARATOR . 'somefile.php:10:41'
             ],
             'warnAboutUnusedVariableInTryReassignedInCatch' => [
                 '<?php


### PR DESCRIPTION
Added a "but" after the "," in InvalidArgument errors, so one can easily find where the provided type starts. If the function has a param with array{} with many parameters and nested array{}, it is often very hard to find where the expected type ends and the provided type starts.

This is a very simple example, in reality I often had cases with 25+ keys.
https://psalm.dev/r/2e6a506272