### PR TITLE
Fix invalid casts int and float

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -462,6 +462,7 @@
             <xs:element name="RedundantIdentityWithTrue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ReferenceConstraintViolation" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ReservedWord" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="RiskyCast" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="StringIncrement" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TaintedCallable" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TaintedCookie" type="IssueHandlerType" minOccurs="0" />

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -11714,7 +11714,7 @@ return [
 'rewind' => ['bool', 'stream'=>'resource'],
 'rewinddir' => ['null|false', 'dir_handle='=>'resource'],
 'rmdir' => ['bool', 'directory'=>'string', 'context='=>'resource'],
-'round' => ['float', 'num'=>'float', 'precision='=>'int', 'mode='=>'int'],
+'round' => ['float', 'num'=>'float', 'precision='=>'int', 'mode='=>'0|positive-int'],
 'rpm_close' => ['bool', 'rpmr'=>'resource'],
 'rpm_get_tag' => ['mixed', 'rpmr'=>'resource', 'tagnum'=>'int'],
 'rpm_is_valid' => ['bool', 'filename'=>'string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -14751,7 +14751,7 @@ return [
     'rewind' => ['bool', 'stream'=>'resource'],
     'rewinddir' => ['null|false', 'dir_handle='=>'resource'],
     'rmdir' => ['bool', 'directory'=>'string', 'context='=>'resource'],
-    'round' => ['float', 'num'=>'float', 'precision='=>'int', 'mode='=>'int'],
+    'round' => ['float', 'num'=>'float', 'precision='=>'int', 'mode='=>'0|positive-int'],
     'rpm_close' => ['bool', 'rpmr'=>'resource'],
     'rpm_get_tag' => ['mixed', 'rpmr'=>'resource', 'tagnum'=>'int'],
     'rpm_is_valid' => ['bool', 'filename'=>'string'],

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -187,6 +187,7 @@ These issues are treated as errors at level 3 and below.
  - [PossiblyUndefinedMethod](issues/PossiblyUndefinedMethod.md)
  - [PossiblyUndefinedVariable](issues/PossiblyUndefinedVariable.md)
  - [PropertyTypeCoercion](issues/PropertyTypeCoercion.md)
+ - [RiskyCast](issues/RiskyCast.md)
 
 ## Errors ignored at level 5 and higher
 

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -214,6 +214,7 @@
  - [RedundantPropertyInitializationCheck](issues/RedundantPropertyInitializationCheck.md)
  - [ReferenceConstraintViolation](issues/ReferenceConstraintViolation.md)
  - [ReservedWord](issues/ReservedWord.md)
+ - [RiskyCast](issues/RiskyCast.md)
  - [StringIncrement](issues/StringIncrement.md)
  - [TaintedCallable](issues/TaintedCallable.md)
  - [TaintedCookie](issues/TaintedCookie.md)

--- a/docs/running_psalm/issues/RiskyCast.md
+++ b/docs/running_psalm/issues/RiskyCast.md
@@ -1,0 +1,17 @@
+# RiskyCast
+
+Emitted when attempting to cast an array to int or float
+
+```php
+<?php
+
+$foo = (int) array( 'hello' );
+```
+
+## Why this is bad
+
+The value resulting from the cast depends on if the array is empty or not and can easily lead to off-by-one errors
+
+## How to fix
+
+Don't cast arrays to int or float.

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -23,6 +23,7 @@ use Psalm\Type;
 use Psalm\Type\Atomic\Scalar;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TBool;
+use Psalm\Type\Atomic\TClosedResource;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;
@@ -33,6 +34,9 @@ use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNonEmptyArray;
+use Psalm\Type\Atomic\TNonEmptyList;
+use Psalm\Type\Atomic\TNonEmptyString;
 use Psalm\Type\Atomic\TNonspecificLiteralInt;
 use Psalm\Type\Atomic\TNonspecificLiteralString;
 use Psalm\Type\Atomic\TNull;
@@ -42,6 +46,7 @@ use Psalm\Type\Atomic\TObjectWithProperties;
 use Psalm\Type\Atomic\TResource;
 use Psalm\Type\Atomic\TString;
 use Psalm\Type\Atomic\TTemplateParam;
+use Psalm\Type\Atomic\TTrue;
 use Psalm\Type\Union;
 
 use function array_merge;
@@ -352,8 +357,28 @@ class CastAnalyzer
                 continue;
             }
 
+            if ($atomic_type instanceof TTrue
+            ) {
+                $valid_strings[] = new TLiteralString('1');
+                continue;
+            }
+
+            if ($atomic_type instanceof TBool
+            ) {
+                $valid_strings[] = new TLiteralString('1');
+                $valid_strings[] = new TLiteralString('');
+                continue;
+            }
+
+            if ($atomic_type instanceof TClosedResource
+               || $atomic_type instanceof TResource
+            ) {
+                $castable_types[] = new TNonEmptyString();
+
+                continue;
+            }
+
             if ($atomic_type instanceof TMixed
-                || $atomic_type instanceof TResource
                 || $atomic_type instanceof Scalar
             ) {
                 $castable_types[] = new TString();

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -17,6 +17,7 @@ use Psalm\Issue\InvalidCast;
 use Psalm\Issue\PossiblyInvalidCast;
 use Psalm\Issue\RedundantCast;
 use Psalm\Issue\RedundantCastGivenDocblockType;
+use Psalm\Issue\RiskyCast;
 use Psalm\Issue\UnrecognizedExpression;
 use Psalm\IssueBuffer;
 use Psalm\Type;
@@ -298,7 +299,7 @@ class CastAnalyzer
     ): Union {
         $codebase = $statements_analyzer->getCodebase();
 
-        $possibly_unwanted_cast = [];
+        $risky_cast = [];
         $invalid_casts = [];
         $valid_ints = [];
         $castable_types = [];
@@ -445,7 +446,7 @@ class CastAnalyzer
             if ($atomic_type instanceof TNonEmptyArray
                 || $atomic_type instanceof TNonEmptyList
             ) {
-                $possibly_unwanted_cast[] = $atomic_type->getId();
+                $risky_cast[] = $atomic_type->getId();
 
                 $valid_ints[] = new TLiteralInt(1);
 
@@ -458,7 +459,7 @@ class CastAnalyzer
             ) {
                 // if type is not specific, it can be both 0 or 1, depending on whether the array has data or not
                 // welcome to off-by-one hell if that happens :-)
-                $possibly_unwanted_cast[] = $atomic_type->getId();
+                $risky_cast[] = $atomic_type->getId();
 
                 $valid_ints[] = new TLiteralInt(0);
                 $valid_ints[] = new TLiteralInt(1);
@@ -486,10 +487,10 @@ class CastAnalyzer
                 ),
                 $statements_analyzer->getSuppressedIssues()
             );
-        } elseif (!empty($possibly_unwanted_cast)) {
+        } elseif ($risky_cast) {
             IssueBuffer::maybeAdd(
-                new PossiblyInvalidCast(
-                    'Casting ' . $possibly_unwanted_cast[0] . ' to int has possibly unintended value of 1',
+                new RiskyCast(
+                    'Casting ' . $risky_cast[0] . ' to int has possibly unintended value of 0/1',
                     new CodeLocation($statements_analyzer->getSource(), $stmt)
                 ),
                 $statements_analyzer->getSuppressedIssues()
@@ -525,7 +526,7 @@ class CastAnalyzer
     ): Union {
         $codebase = $statements_analyzer->getCodebase();
 
-        $possibly_unwanted_cast = [];
+        $risky_cast = [];
         $invalid_casts = [];
         $valid_floats = [];
         $castable_types = [];
@@ -671,7 +672,7 @@ class CastAnalyzer
             if ($atomic_type instanceof TNonEmptyArray
                 || $atomic_type instanceof TNonEmptyList
             ) {
-                $possibly_unwanted_cast[] = $atomic_type->getId();
+                $risky_cast[] = $atomic_type->getId();
 
                 $valid_floats[] = new TLiteralFloat(1.0);
 
@@ -684,7 +685,7 @@ class CastAnalyzer
             ) {
                 // if type is not specific, it can be both 0 or 1, depending on whether the array has data or not
                 // welcome to off-by-one hell if that happens :-)
-                $possibly_unwanted_cast[] = $atomic_type->getId();
+                $risky_cast[] = $atomic_type->getId();
 
                 $valid_floats[] = new TLiteralFloat(0.0);
                 $valid_floats[] = new TLiteralFloat(1.0);
@@ -712,10 +713,10 @@ class CastAnalyzer
                 ),
                 $statements_analyzer->getSuppressedIssues()
             );
-        } elseif (!empty($possibly_unwanted_cast)) {
+        } elseif ($risky_cast) {
             IssueBuffer::maybeAdd(
-                new PossiblyInvalidCast(
-                    'Casting ' . $possibly_unwanted_cast[0] . ' to float has possibly unintended value of 1.0',
+                new RiskyCast(
+                    'Casting ' . $risky_cast[0] . ' to float has possibly unintended value of 0.0/1.0',
                     new CodeLocation($statements_analyzer->getSource(), $stmt)
                 ),
                 $statements_analyzer->getSuppressedIssues()

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -471,32 +471,25 @@ class CastAnalyzer
                 continue;
             }
 
+            // always 1 for "error" cases
+            $valid_ints[] = new TLiteralInt(1);
+
             $invalid_casts[] = $atomic_type->getId();
         }
 
         if ($invalid_casts) {
-            if ( $valid_ints || $castable_types ) {
-                IssueBuffer::maybeAdd(
-                    new PossiblyInvalidCast(
-                        $invalid_casts[0] . ' cannot be cast to int',
-                        new CodeLocation( $statements_analyzer->getSource(), $stmt )
-                    ),
-                    $statements_analyzer->getSuppressedIssues()
-                );
-            } else {
-                IssueBuffer::maybeAdd(
-                    new InvalidCast(
-                        $invalid_casts[0] . ' cannot be cast to int',
-                        new CodeLocation( $statements_analyzer->getSource(), $stmt )
-                    ),
-                    $statements_analyzer->getSuppressedIssues()
-                );
-            }
+            IssueBuffer::maybeAdd(
+                new InvalidCast(
+                    $invalid_casts[0] . ' cannot be cast to int',
+                    new CodeLocation($statements_analyzer->getSource(), $stmt)
+                ),
+                $statements_analyzer->getSuppressedIssues()
+            );
         } elseif (!empty($possibly_unwanted_cast)) {
             IssueBuffer::maybeAdd(
                 new PossiblyInvalidCast(
                     'Casting ' . $possibly_unwanted_cast[0] . ' to int has possibly unintended value of 1',
-                    new CodeLocation( $statements_analyzer->getSource(), $stmt )
+                    new CodeLocation($statements_analyzer->getSource(), $stmt)
                 ),
                 $statements_analyzer->getSuppressedIssues()
             );
@@ -703,32 +696,25 @@ class CastAnalyzer
                 continue;
             }
 
+            // always 1.0 for "error" cases
+            $valid_floats[] = new TLiteralFloat(1.0);
+
             $invalid_casts[] = $atomic_type->getId();
         }
 
         if ($invalid_casts) {
-            if ( $valid_floats || $castable_types ) {
-                IssueBuffer::maybeAdd(
-                    new PossiblyInvalidCast(
-                        $invalid_casts[0] . ' cannot be cast to float',
-                        new CodeLocation( $statements_analyzer->getSource(), $stmt )
-                    ),
-                    $statements_analyzer->getSuppressedIssues()
-                );
-            } else {
-                IssueBuffer::maybeAdd(
-                    new InvalidCast(
-                        $invalid_casts[0] . ' cannot be cast to float',
-                        new CodeLocation( $statements_analyzer->getSource(), $stmt )
-                    ),
-                    $statements_analyzer->getSuppressedIssues()
-                );
-            }
+            IssueBuffer::maybeAdd(
+                new InvalidCast(
+                    $invalid_casts[0] . ' cannot be cast to float',
+                    new CodeLocation($statements_analyzer->getSource(), $stmt)
+                ),
+                $statements_analyzer->getSuppressedIssues()
+            );
         } elseif (!empty($possibly_unwanted_cast)) {
             IssueBuffer::maybeAdd(
                 new PossiblyInvalidCast(
                     'Casting ' . $possibly_unwanted_cast[0] . ' to float has possibly unintended value of 1.0',
-                    new CodeLocation( $statements_analyzer->getSource(), $stmt )
+                    new CodeLocation($statements_analyzer->getSource(), $stmt)
                 ),
                 $statements_analyzer->getSuppressedIssues()
             );

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -331,13 +331,14 @@ class CastAnalyzer
             }
 
             if ($atomic_type instanceof TString) {
-                if ($atomic_type instanceof TLiteralString && (int) $atomic_type->value !== 0) {
+                if ($atomic_type instanceof TLiteralString) {
                     $valid_ints[] = new TLiteralInt((int) $atomic_type->value);
                 } elseif ($atomic_type instanceof TNumericString) {
                     $castable_types[] = new TInt();
                 } else {
-                    // any normal string
-                    $valid_ints[] = new TLiteralInt(0);
+                    // any normal string is technically $valid_int[] = new TLiteralInt(0);
+                    // however we cannot be certain that it's not inferred, therefore less strict
+                    $castable_types[] = new TInt();
                 }
 
                 continue;
@@ -416,14 +417,14 @@ class CastAnalyzer
                             }
 
                             foreach ($return_type->getAtomicTypes() as $sub_atomic_type) {
-                                if ($sub_atomic_type instanceof TLiteralString
-                                    && (int) $sub_atomic_type->value !== 0
-                                ) {
+                                if ($sub_atomic_type instanceof TLiteralString) {
                                     $valid_ints[] = new TLiteralInt((int) $sub_atomic_type->value);
                                 } elseif ($sub_atomic_type instanceof TNumericString) {
                                     $castable_types[] = new TInt();
                                 } else {
-                                    $valid_ints[] = new TLiteralInt(0);
+                                    // any normal string is technically $valid_int[] = new TLiteralInt(0);
+                                    // however we cannot be certain that it's not inferred, therefore less strict
+                                    $castable_types[] = new TInt();
                                 }
                             }
 
@@ -557,13 +558,14 @@ class CastAnalyzer
             }
 
             if ($atomic_type instanceof TString) {
-                if ($atomic_type instanceof TLiteralString && (float) $atomic_type->value !== 0.0) {
+                if ($atomic_type instanceof TLiteralString) {
                     $valid_floats[] = new TLiteralFloat((float) $atomic_type->value);
                 } elseif ($atomic_type instanceof TNumericString) {
                     $castable_types[] = new TFloat();
                 } else {
-                    // any normal string
-                    $valid_floats[] = new TLiteralFloat(0.0);
+                    // any normal string is technically $valid_floats[] = new TLiteralFloat(0.0);
+                    // however we cannot be certain that it's not inferred, therefore less strict
+                    $castable_types[] = new TFloat();
                 }
 
                 continue;
@@ -641,14 +643,14 @@ class CastAnalyzer
                             }
 
                             foreach ($return_type->getAtomicTypes() as $sub_atomic_type) {
-                                if ($sub_atomic_type instanceof TLiteralString
-                                    && (float) $sub_atomic_type->value !== 0.0
-                                ) {
+                                if ($sub_atomic_type instanceof TLiteralString) {
                                     $valid_floats[] = new TLiteralFloat((float) $sub_atomic_type->value);
                                 } elseif ($sub_atomic_type instanceof TNumericString) {
                                     $castable_types[] = new TFloat();
                                 } else {
-                                    $valid_floats[] = new TLiteralFloat(0.0);
+                                    // any normal string is technically $valid_int[] = new TLiteralInt(0);
+                                    // however we cannot be certain that it's not inferred, therefore less strict
+                                    $castable_types[] = new TFloat();
                                 }
                             }
 

--- a/src/Psalm/Internal/Cli/LanguageServer.php
+++ b/src/Psalm/Internal/Cli/LanguageServer.php
@@ -32,6 +32,7 @@ use function implode;
 use function in_array;
 use function ini_set;
 use function is_array;
+use function is_numeric;
 use function is_string;
 use function preg_replace;
 use function realpath;
@@ -298,7 +299,7 @@ HELP;
             $find_unused_code = 'auto';
         }
 
-        if (isset($options['disable-on-change'])) {
+        if (isset($options['disable-on-change']) && is_numeric($options['disable-on-change'])) {
             $project_analyzer->onchange_line_limit = (int) $options['disable-on-change'];
         }
 

--- a/src/Psalm/Internal/Cli/Psalter.php
+++ b/src/Psalm/Internal/Cli/Psalter.php
@@ -45,6 +45,7 @@ use function in_array;
 use function ini_set;
 use function is_array;
 use function is_dir;
+use function is_numeric;
 use function is_string;
 use function microtime;
 use function pathinfo;
@@ -230,7 +231,7 @@ HELP;
             chdir($current_dir);
         }
 
-        $threads = isset($options['threads']) ? (int)$options['threads'] : 1;
+        $threads = isset($options['threads']) && is_numeric($options['threads']) ? (int)$options['threads'] : 1;
 
         if (isset($options['no-cache'])) {
             $providers = new Providers(

--- a/src/Psalm/Internal/Cli/Refactor.php
+++ b/src/Psalm/Internal/Cli/Refactor.php
@@ -35,6 +35,7 @@ use function implode;
 use function in_array;
 use function ini_set;
 use function is_array;
+use function is_numeric;
 use function is_string;
 use function max;
 use function microtime;
@@ -284,7 +285,7 @@ HELP;
             chdir($current_dir);
         }
 
-        $threads = isset($options['threads'])
+        $threads = isset($options['threads']) && is_numeric($options['threads'])
             ? (int)$options['threads']
             : max(1, ProjectAnalyzer::getCpuCount() - 2);
 

--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -35,6 +35,7 @@ use Psalm\Internal\Provider\ReturnTypeProvider\MinMaxReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\MktimeReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\ParseUrlReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\RandReturnTypeProvider;
+use Psalm\Internal\Provider\ReturnTypeProvider\RoundReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\StrReplaceReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\StrTrReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\TriggerErrorReturnTypeProvider;
@@ -109,6 +110,7 @@ class FunctionReturnTypeProvider
         $this->registerClass(TriggerErrorReturnTypeProvider::class);
         $this->registerClass(RandReturnTypeProvider::class);
         $this->registerClass(InArrayReturnTypeProvider::class);
+        $this->registerClass(RoundReturnTypeProvider::class);
     }
 
     /**

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/RoundReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/RoundReturnTypeProvider.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Provider\ReturnTypeProvider;
+
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+
+use function array_values;
+use function count;
+use function round;
+
+use const PHP_ROUND_HALF_UP;
+
+/**
+ * @internal
+ */
+class RoundReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+    /**
+     * @return array<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return ['round'];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Type\Union
+    {
+        $call_args = $event->getCallArgs();
+        if (count($call_args) === 0) {
+            return null;
+        }
+
+        $statements_source = $event->getStatementsSource();
+        $nodeTypeProvider = $statements_source->getNodeTypeProvider();
+
+        $num_arg = $nodeTypeProvider->getType($call_args[0]->value);
+
+        $precision_val = 0;
+        if ($statements_source instanceof StatementsAnalyzer && count($call_args) > 1) {
+            $type = $statements_source->node_data->getType($call_args[1]->value);
+
+            if ($type !== null && $type->isSingle()) {
+                $atomic_type = array_values($type->getAtomicTypes())[0];
+                if ($atomic_type instanceof Type\Atomic\TLiteralInt) {
+                    $precision_val = $atomic_type->value;
+                }
+            }
+        }
+
+        $mode_val = PHP_ROUND_HALF_UP;
+        if ($statements_source instanceof StatementsAnalyzer && count($call_args) > 2) {
+            $type = $statements_source->node_data->getType($call_args[2]->value);
+
+            if ($type !== null && $type->isSingle()) {
+                $atomic_type = array_values($type->getAtomicTypes())[0];
+                if ($atomic_type instanceof Type\Atomic\TLiteralInt) {
+                    /** @var positive-int|0 $mode_val */
+                    $mode_val = $atomic_type->value;
+                }
+            }
+        }
+
+        if ($num_arg !== null && $num_arg->isSingle()) {
+            $num_type = array_values($num_arg->getAtomicTypes())[0];
+            if ($num_type instanceof Type\Atomic\TLiteralFloat || $num_type instanceof Type\Atomic\TLiteralInt) {
+                $rounded_val = round($num_type->value, $precision_val, $mode_val);
+                return new Type\Union([new Type\Atomic\TLiteralFloat($rounded_val)]);
+            }
+        }
+
+        return new Type\Union([new Type\Atomic\TFloat()]);
+    }
+}

--- a/src/Psalm/Issue/RiskyCast.php
+++ b/src/Psalm/Issue/RiskyCast.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+class RiskyCast extends CodeIssue
+{
+    public const ERROR_LEVEL = 3;
+    public const SHORTCODE = 313;
+}

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -31,7 +31,6 @@ class FunctionCallTest extends TestCase
                   }
                 '
             ],
-
             'typedArrayWithDefault' => [
                 '<?php
                     class A {}
@@ -1810,6 +1809,14 @@ class FunctionCallTest extends TestCase
                 ',
                 'assertions' => [
                     '$b===' => 'lowercase-string',
+                ],
+            ],
+            'round_literalValue' => [
+                '<?php
+                    $a = round(10.363, 2);
+                ',
+                'assertions' => [
+                    '$a===' => 'float(10.36)',
                 ],
             ],
         ];

--- a/tests/ToStringTest.php
+++ b/tests/ToStringTest.php
@@ -505,6 +505,18 @@ class ToStringTest extends TestCase
                 ',
                 'error_message' => 'ImplicitToStringCast'
             ],
+            'toStringTypecastNonString' => [
+                '<?php
+                    class A {
+                        function __toString(): string {
+                            return "ha";
+                        }
+                    }
+
+                    $foo = new A();
+                    echo (int) $foo;',
+                'error_message' => 'InvalidCast',
+            ],
         ];
     }
 }

--- a/tests/ToStringTest.php
+++ b/tests/ToStringTest.php
@@ -517,6 +517,16 @@ class ToStringTest extends TestCase
                     echo (int) $foo;',
                 'error_message' => 'InvalidCast',
             ],
+            'riskyArrayToIntCast' => [
+                '<?php
+                    echo (int) array();',
+                'error_message' => 'RiskyCast',
+            ],
+            'riskyArrayToFloatCast' => [
+                '<?php
+                    echo (float) array(\'hello\');',
+                'error_message' => 'RiskyCast',
+            ],
         ];
     }
 }

--- a/tests/TypeReconciliation/ValueTest.php
+++ b/tests/TypeReconciliation/ValueTest.php
@@ -909,6 +909,14 @@ class ValueTest extends TestCase
                     $interval = \DateInterval::createFromDateString("30 дней");
                     if ($interval === false) {}',
             ],
+            'literalInt' => [
+                '<?php
+                    $a = (int)"5";
+                ',
+                'assertions' => [
+                    '$a===' => '5',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
e.g. https://psalm.dev/r/0d284c6f48 gives `Warning: Object of class stdClass could not be converted to int`

Since by default there cannot be any "PossiblyInvalidCasts", as we always get 0/0.0 in error case, added mostly unwanted typecasts that are a leading cause of off-by-one errors as PossiblyInvalidCasts

Fix: https://github.com/vimeo/psalm/issues/6966 (the remaining half + cherry-pick the other half from master to 4.x)