### PR TITLE
Ensure we recognize inherited static methods for the first-class callables

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -56,6 +56,7 @@ use Psalm\Type\Union;
 
 use function array_filter;
 use function array_map;
+use function array_values;
 use function assert;
 use function count;
 use function in_array;
@@ -369,39 +370,15 @@ class AtomicStaticCallAnalyzer
         if (!$naive_method_exists
             && $codebase->methods->existence_provider->has($fq_class_name)
         ) {
-            $method_exists = $codebase->methods->existence_provider->doesMethodExist(
+            $fake_method_exists = $codebase->methods->existence_provider->doesMethodExist(
                 $fq_class_name,
                 $method_id->method_name,
                 $statements_analyzer,
                 null
-            );
-
-            if ($method_exists) {
-                $fake_method_exists = true;
-            }
+            ) ?? false;
         }
 
-        if ($stmt->isFirstClassCallable()) {
-            $method_storage = ($class_storage->methods[$method_name_lc] ??
-                ($class_storage->pseudo_static_methods[$method_name_lc] ?? null));
-
-            if ($method_storage) {
-                $return_type_candidate = new Union([new TClosure(
-                    'Closure',
-                    $method_storage->params,
-                    $method_storage->return_type,
-                    $method_storage->pure
-                )]);
-            } else {
-                $return_type_candidate = Type::getClosure();
-            }
-
-            $statements_analyzer->node_data->setType($stmt, $return_type_candidate);
-
-            return true;
-        }
-
-        $args = $stmt->getArgs();
+        $args = $stmt->isFirstClassCallable() ? [] : $stmt->getArgs();
 
         if (!$naive_method_exists
             && $class_storage->mixin_declaring_fqcln
@@ -503,6 +480,42 @@ class AtomicStaticCallAnalyzer
             $class_storage,
             $method_name_lc
         );
+
+        if ($stmt->isFirstClassCallable()) {
+            if ($found_method_and_class_storage) {
+                [ $method_storage ] = $found_method_and_class_storage;
+
+                $return_type_candidate = new Union([new TClosure(
+                    'Closure',
+                    $method_storage->params,
+                    $method_storage->return_type,
+                    $method_storage->pure
+                )]);
+            } else {
+                $method_exists = $naive_method_exists
+                    || $fake_method_exists
+                    || isset($class_storage->methods[$method_name_lc])
+                    || isset($class_storage->pseudo_static_methods[$method_name_lc]);
+
+                if ($method_exists) {
+                    $declaring_method_id = $codebase->methods->getDeclaringMethodId($method_id) ?? $method_id;
+
+                    $return_type_candidate = new Union([new TClosure(
+                        'Closure',
+                        array_values($codebase->getMethodParams($method_id)),
+                        $codebase->getMethodReturnType($method_id, $fq_class_name),
+                        $codebase->methods->getStorage($declaring_method_id)->pure
+                    )]);
+                } else {
+                    // FIXME: perhaps Psalm should complain about nonexisting method here, or throw a logic exception?
+                    $return_type_candidate = Type::getClosure();
+                }
+            }
+
+            $statements_analyzer->node_data->setType($stmt, $return_type_candidate);
+
+            return true;
+        }
 
         if (!$naive_method_exists
             || !MethodAnalyzer::isMethodVisible(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -512,7 +512,18 @@ class AtomicStaticCallAnalyzer
                 }
             }
 
-            $statements_analyzer->node_data->setType($stmt, $return_type_candidate);
+            $expanded_return_type = TypeExpander::expandUnion(
+                $codebase,
+                $return_type_candidate,
+                $context->self,
+                $class_storage->name,
+                $context->parent,
+                true,
+                false,
+                true
+            );
+
+            $statements_analyzer->node_data->setType($stmt, $expanded_return_type);
 
             return true;
         }

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -751,6 +751,27 @@ class ClosureTest extends TestCase
                 [],
                 '8.1'
             ],
+            'FirstClassCallable:OverriddenStaticMethod' => [
+                '<?php
+
+                    abstract class A
+                    {
+                        public function foo(int $i): string
+                        {
+                            return (string) $i;
+                        }
+                    }
+
+                    class C extends A {}
+
+                    /** @param \Closure(int):string $_ */
+                    function takesIntToString(\Closure $_): void {}
+
+                    takesIntToString(C::foo(...));',
+                'assertions' => [],
+                [],
+                '8.1',
+            ],
             'FirstClassCallable:WithArrayMap' => [
                 '<?php
                     $array = [1, 2, 3];

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -751,7 +751,7 @@ class ClosureTest extends TestCase
                 [],
                 '8.1'
             ],
-            'FirstClassCallable:OverriddenStaticMethod' => [
+            'FirstClassCallable:InheritedStaticMethod' => [
                 '<?php
 
                     abstract class A
@@ -771,6 +771,34 @@ class ClosureTest extends TestCase
                 'assertions' => [],
                 [],
                 '8.1',
+            ],
+            'FirstClassCallable:InheritedStaticMethodWithStaticTypeParameter' => [
+                '<?php
+
+                    /** @template T */
+                    class Holder
+                    {
+                        /** @param T $value */
+                        public function __construct(public $value) {}
+                    }
+
+                    abstract class A
+                    {
+                        final public function __construct(public int $i) {}
+
+                        /** @return Holder<static> */
+                        public static function create(int $i): Holder
+                        {
+                            return new Holder(new static($i));
+                        }
+                    }
+
+                    class C extends A {}
+
+                    /** @param \Closure(int):Holder<C> $_ */
+                    function takesIntToHolder(\Closure $_): void {}
+
+                    takesIntToHolder(C::create(...));'
             ],
             'FirstClassCallable:WithArrayMap' => [
                 '<?php


### PR DESCRIPTION
fixes #8363

I have a strong feeling it's not the correct place where this functionality should belong.

For now first-class callables are implemented in the StaticCallAnalyzer just because they look like a static call syntax-wise (and are such from the perspective of `nikic/php-parser`). However, I am not sure where they should really belong: ClosureAnalyzer also seems odd here.