### PR TITLE
always use lock when writing/reading cache data to/from file

### DIFF
--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -3,13 +3,13 @@
 namespace Psalm\Internal\Provider;
 
 use Psalm\Config;
+use Psalm\Internal\Provider\Providers;
 use Psalm\Storage\ClassLikeStorage;
 use UnexpectedValueException;
 
 use function array_merge;
 use function dirname;
 use function file_exists;
-use function file_get_contents;
 use function file_put_contents;
 use function filemtime;
 use function get_class;
@@ -25,6 +25,7 @@ use function unlink;
 use function unserialize;
 
 use const DIRECTORY_SEPARATOR;
+use const LOCK_EX;
 use const PHP_VERSION_ID;
 
 /**
@@ -86,9 +87,9 @@ class ClassLikeStorageCacheProvider
 
         $cache_location = $this->getCacheLocationForClass($fq_classlike_name_lc, $file_path, true);
         if ($this->config->use_igbinary) {
-            file_put_contents($cache_location, igbinary_serialize($storage));
+            file_put_contents($cache_location, igbinary_serialize($storage), LOCK_EX);
         } else {
-            file_put_contents($cache_location, serialize($storage));
+            file_put_contents($cache_location, serialize($storage), LOCK_EX);
         }
     }
 
@@ -132,7 +133,7 @@ class ClassLikeStorageCacheProvider
 
         if (file_exists($cache_location)) {
             if ($this->config->use_igbinary) {
-                $storage = igbinary_unserialize((string)file_get_contents($cache_location));
+                $storage = igbinary_unserialize(Providers::safeFileGetContents($cache_location));
 
                 if ($storage instanceof ClassLikeStorage) {
                     return $storage;
@@ -141,7 +142,7 @@ class ClassLikeStorageCacheProvider
                 return null;
             }
 
-            $storage = unserialize((string)file_get_contents($cache_location));
+            $storage = unserialize(Providers::safeFileGetContents($cache_location));
 
             if ($storage instanceof ClassLikeStorage) {
                 return $storage;

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -4,10 +4,10 @@ namespace Psalm\Internal\Provider;
 
 use Psalm\Config;
 use Psalm\Internal\Codebase\Analyzer;
+use Psalm\Internal\Provider\Providers;
 use UnexpectedValueException;
 
 use function file_exists;
-use function file_get_contents;
 use function file_put_contents;
 use function igbinary_serialize;
 use function igbinary_unserialize;
@@ -18,6 +18,7 @@ use function serialize;
 use function unserialize;
 
 use const DIRECTORY_SEPARATOR;
+use const LOCK_EX;
 
 /**
  * @psalm-import-type  FileMapType from Analyzer
@@ -84,9 +85,9 @@ class FileReferenceCacheProvider
         }
 
         if ($this->config->use_igbinary) {
-            $reference_cache = igbinary_unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = igbinary_unserialize(Providers::safeFileGetContents($reference_cache_location));
         } else {
-            $reference_cache = unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = unserialize(Providers::safeFileGetContents($reference_cache_location));
         }
 
         if (!is_array($reference_cache)) {
@@ -114,9 +115,9 @@ class FileReferenceCacheProvider
         }
 
         if ($this->config->use_igbinary) {
-            $reference_cache = igbinary_unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = igbinary_unserialize(Providers::safeFileGetContents($reference_cache_location));
         } else {
-            $reference_cache = unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = unserialize(Providers::safeFileGetContents($reference_cache_location));
         }
 
         if (!is_array($reference_cache)) {
@@ -144,9 +145,9 @@ class FileReferenceCacheProvider
         }
 
         if ($this->config->use_igbinary) {
-            $reference_cache = igbinary_unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = igbinary_unserialize(Providers::safeFileGetContents($reference_cache_location));
         } else {
-            $reference_cache = unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = unserialize(Providers::safeFileGetContents($reference_cache_location));
         }
 
         if (!is_array($reference_cache)) {
@@ -174,9 +175,9 @@ class FileReferenceCacheProvider
         }
 
         if ($this->config->use_igbinary) {
-            $reference_cache = igbinary_unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = igbinary_unserialize(Providers::safeFileGetContents($reference_cache_location));
         } else {
-            $reference_cache = unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = unserialize(Providers::safeFileGetContents($reference_cache_location));
         }
 
         if (!is_array($reference_cache)) {
@@ -203,7 +204,7 @@ class FileReferenceCacheProvider
             return null;
         }
 
-        $class_member_reference_cache = (string) file_get_contents($class_member_cache_location);
+        $class_member_reference_cache = Providers::safeFileGetContents($class_member_cache_location);
         if ($this->config->use_igbinary) {
             $class_member_reference_cache = igbinary_unserialize($class_member_reference_cache);
         } else {
@@ -235,7 +236,7 @@ class FileReferenceCacheProvider
             return null;
         }
 
-        $method_dependencies_cache = (string) file_get_contents($method_dependencies_cache_location);
+        $method_dependencies_cache = Providers::safeFileGetContents($method_dependencies_cache_location);
         if ($this->config->use_igbinary) {
             $method_dependencies_cache = igbinary_unserialize($method_dependencies_cache);
         } else {
@@ -266,7 +267,7 @@ class FileReferenceCacheProvider
             return null;
         }
 
-        $class_member_reference_cache = (string) file_get_contents($class_member_cache_location);
+        $class_member_reference_cache = Providers::safeFileGetContents($class_member_cache_location);
         if ($this->config->use_igbinary) {
             $class_member_reference_cache = igbinary_unserialize($class_member_reference_cache);
         } else {
@@ -297,7 +298,7 @@ class FileReferenceCacheProvider
             return null;
         }
 
-        $class_member_reference_cache = (string) file_get_contents($class_member_cache_location);
+        $class_member_reference_cache = Providers::safeFileGetContents($class_member_cache_location);
         if ($this->config->use_igbinary) {
             $class_member_reference_cache = igbinary_unserialize($class_member_reference_cache);
         } else {
@@ -328,7 +329,7 @@ class FileReferenceCacheProvider
             return null;
         }
 
-        $class_member_reference_cache = (string) file_get_contents($class_member_cache_location);
+        $class_member_reference_cache = Providers::safeFileGetContents($class_member_cache_location);
         if ($this->config->use_igbinary) {
             $class_member_reference_cache = igbinary_unserialize($class_member_reference_cache);
         } else {
@@ -359,7 +360,7 @@ class FileReferenceCacheProvider
             return null;
         }
 
-        $file_class_member_reference_cache = (string) file_get_contents($file_class_member_cache_location);
+        $file_class_member_reference_cache = Providers::safeFileGetContents($file_class_member_cache_location);
         if ($this->config->use_igbinary) {
             $file_class_member_reference_cache = igbinary_unserialize($file_class_member_reference_cache);
         } else {
@@ -392,7 +393,7 @@ class FileReferenceCacheProvider
             return null;
         }
 
-        $file_class_member_reference_cache = (string) file_get_contents($file_class_member_cache_location);
+        $file_class_member_reference_cache = Providers::safeFileGetContents($file_class_member_cache_location);
         if ($this->config->use_igbinary) {
             $file_class_member_reference_cache = igbinary_unserialize($file_class_member_reference_cache);
         } else {
@@ -425,7 +426,7 @@ class FileReferenceCacheProvider
             return null;
         }
 
-        $file_class_member_reference_cache = (string) file_get_contents($file_class_member_cache_location);
+        $file_class_member_reference_cache = Providers::safeFileGetContents($file_class_member_cache_location);
         if ($this->config->use_igbinary) {
             $file_class_member_reference_cache = igbinary_unserialize($file_class_member_reference_cache);
         } else {
@@ -457,7 +458,7 @@ class FileReferenceCacheProvider
             return null;
         }
 
-        $file_class_member_reference_cache = (string) file_get_contents($file_class_member_cache_location);
+        $file_class_member_reference_cache = Providers::safeFileGetContents($file_class_member_cache_location);
         if ($this->config->use_igbinary) {
             $file_class_member_reference_cache = igbinary_unserialize($file_class_member_reference_cache);
         } else {
@@ -489,9 +490,9 @@ class FileReferenceCacheProvider
         }
 
         if ($this->config->use_igbinary) {
-            $reference_cache = igbinary_unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = igbinary_unserialize(Providers::safeFileGetContents($reference_cache_location));
         } else {
-            $reference_cache = unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = unserialize(Providers::safeFileGetContents($reference_cache_location));
         }
 
         if (!is_array($reference_cache)) {
@@ -519,9 +520,9 @@ class FileReferenceCacheProvider
         }
 
         if ($this->config->use_igbinary) {
-            $reference_cache = igbinary_unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = igbinary_unserialize(Providers::safeFileGetContents($reference_cache_location));
         } else {
-            $reference_cache = unserialize((string) file_get_contents($reference_cache_location));
+            $reference_cache = unserialize(Providers::safeFileGetContents($reference_cache_location));
         }
 
         if (!is_array($reference_cache)) {
@@ -549,9 +550,9 @@ class FileReferenceCacheProvider
         }
 
         if ($this->config->use_igbinary) {
-            $issues_cache = igbinary_unserialize((string) file_get_contents($issues_cache_location));
+            $issues_cache = igbinary_unserialize(Providers::safeFileGetContents($issues_cache_location));
         } else {
-            $issues_cache = unserialize((string) file_get_contents($issues_cache_location));
+            $issues_cache = unserialize(Providers::safeFileGetContents($issues_cache_location));
         }
 
         if (!is_array($issues_cache)) {
@@ -572,9 +573,9 @@ class FileReferenceCacheProvider
         $reference_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::REFERENCE_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($reference_cache_location, igbinary_serialize($file_references));
+            file_put_contents($reference_cache_location, igbinary_serialize($file_references), LOCK_EX);
         } else {
-            file_put_contents($reference_cache_location, serialize($file_references));
+            file_put_contents($reference_cache_location, serialize($file_references), LOCK_EX);
         }
     }
 
@@ -589,9 +590,9 @@ class FileReferenceCacheProvider
         $reference_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CLASSLIKE_FILE_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($reference_cache_location, igbinary_serialize($file_references));
+            file_put_contents($reference_cache_location, igbinary_serialize($file_references), LOCK_EX);
         } else {
-            file_put_contents($reference_cache_location, serialize($file_references));
+            file_put_contents($reference_cache_location, serialize($file_references), LOCK_EX);
         }
     }
 
@@ -606,9 +607,9 @@ class FileReferenceCacheProvider
         $reference_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::NONMETHOD_CLASS_REFERENCE_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($reference_cache_location, igbinary_serialize($file_class_references));
+            file_put_contents($reference_cache_location, igbinary_serialize($file_class_references), LOCK_EX);
         } else {
-            file_put_contents($reference_cache_location, serialize($file_class_references));
+            file_put_contents($reference_cache_location, serialize($file_class_references), LOCK_EX);
         }
     }
 
@@ -623,9 +624,9 @@ class FileReferenceCacheProvider
         $reference_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::METHOD_CLASS_REFERENCE_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($reference_cache_location, igbinary_serialize($method_class_references));
+            file_put_contents($reference_cache_location, igbinary_serialize($method_class_references), LOCK_EX);
         } else {
-            file_put_contents($reference_cache_location, serialize($method_class_references));
+            file_put_contents($reference_cache_location, serialize($method_class_references), LOCK_EX);
         }
     }
 
@@ -640,9 +641,9 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CLASS_METHOD_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($member_cache_location, igbinary_serialize($member_references));
+            file_put_contents($member_cache_location, igbinary_serialize($member_references), LOCK_EX);
         } else {
-            file_put_contents($member_cache_location, serialize($member_references));
+            file_put_contents($member_cache_location, serialize($member_references), LOCK_EX);
         }
     }
 
@@ -657,9 +658,9 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::METHOD_DEPENDENCIES_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($member_cache_location, igbinary_serialize($member_references));
+            file_put_contents($member_cache_location, igbinary_serialize($member_references), LOCK_EX);
         } else {
-            file_put_contents($member_cache_location, serialize($member_references));
+            file_put_contents($member_cache_location, serialize($member_references), LOCK_EX);
         }
     }
 
@@ -674,9 +675,9 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CLASS_PROPERTY_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($member_cache_location, igbinary_serialize($property_references));
+            file_put_contents($member_cache_location, igbinary_serialize($property_references), LOCK_EX);
         } else {
-            file_put_contents($member_cache_location, serialize($property_references));
+            file_put_contents($member_cache_location, serialize($property_references), LOCK_EX);
         }
     }
 
@@ -691,9 +692,9 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CLASS_METHOD_RETURN_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($member_cache_location, igbinary_serialize($method_return_references));
+            file_put_contents($member_cache_location, igbinary_serialize($method_return_references), LOCK_EX);
         } else {
-            file_put_contents($member_cache_location, serialize($method_return_references));
+            file_put_contents($member_cache_location, serialize($method_return_references), LOCK_EX);
         }
     }
 
@@ -708,9 +709,9 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::METHOD_MISSING_MEMBER_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($member_cache_location, igbinary_serialize($member_references));
+            file_put_contents($member_cache_location, igbinary_serialize($member_references), LOCK_EX);
         } else {
-            file_put_contents($member_cache_location, serialize($member_references));
+            file_put_contents($member_cache_location, serialize($member_references), LOCK_EX);
         }
     }
 
@@ -725,9 +726,9 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::FILE_CLASS_MEMBER_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($member_cache_location, igbinary_serialize($member_references));
+            file_put_contents($member_cache_location, igbinary_serialize($member_references), LOCK_EX);
         } else {
-            file_put_contents($member_cache_location, serialize($member_references));
+            file_put_contents($member_cache_location, serialize($member_references), LOCK_EX);
         }
     }
 
@@ -742,9 +743,9 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::FILE_CLASS_PROPERTY_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($member_cache_location, igbinary_serialize($property_references));
+            file_put_contents($member_cache_location, igbinary_serialize($property_references), LOCK_EX);
         } else {
-            file_put_contents($member_cache_location, serialize($property_references));
+            file_put_contents($member_cache_location, serialize($property_references), LOCK_EX);
         }
     }
 
@@ -759,9 +760,9 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::FILE_METHOD_RETURN_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($member_cache_location, igbinary_serialize($method_return_references));
+            file_put_contents($member_cache_location, igbinary_serialize($method_return_references), LOCK_EX);
         } else {
-            file_put_contents($member_cache_location, serialize($method_return_references));
+            file_put_contents($member_cache_location, serialize($method_return_references), LOCK_EX);
         }
     }
 
@@ -776,9 +777,9 @@ class FileReferenceCacheProvider
         $member_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::FILE_MISSING_MEMBER_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($member_cache_location, igbinary_serialize($member_references));
+            file_put_contents($member_cache_location, igbinary_serialize($member_references), LOCK_EX);
         } else {
-            file_put_contents($member_cache_location, serialize($member_references));
+            file_put_contents($member_cache_location, serialize($member_references), LOCK_EX);
         }
     }
 
@@ -793,9 +794,9 @@ class FileReferenceCacheProvider
         $reference_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::UNKNOWN_MEMBER_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($reference_cache_location, igbinary_serialize($references));
+            file_put_contents($reference_cache_location, igbinary_serialize($references), LOCK_EX);
         } else {
-            file_put_contents($reference_cache_location, serialize($references));
+            file_put_contents($reference_cache_location, serialize($references), LOCK_EX);
         }
     }
 
@@ -810,9 +811,9 @@ class FileReferenceCacheProvider
         $reference_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::METHOD_PARAM_USE_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($reference_cache_location, igbinary_serialize($uses));
+            file_put_contents($reference_cache_location, igbinary_serialize($uses), LOCK_EX);
         } else {
-            file_put_contents($reference_cache_location, serialize($uses));
+            file_put_contents($reference_cache_location, serialize($uses), LOCK_EX);
         }
     }
 
@@ -827,9 +828,9 @@ class FileReferenceCacheProvider
         $issues_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::ISSUES_CACHE_NAME;
 
         if ($this->config->use_igbinary) {
-            file_put_contents($issues_cache_location, igbinary_serialize($issues));
+            file_put_contents($issues_cache_location, igbinary_serialize($issues), LOCK_EX);
         } else {
-            file_put_contents($issues_cache_location, serialize($issues));
+            file_put_contents($issues_cache_location, serialize($issues), LOCK_EX);
         }
     }
 
@@ -847,10 +848,10 @@ class FileReferenceCacheProvider
         ) {
             if ($this->config->use_igbinary) {
                 /** @var array<string, array<string, int>> */
-                return igbinary_unserialize(file_get_contents($analyzed_methods_cache_location));
+                return igbinary_unserialize(Providers::safeFileGetContents($analyzed_methods_cache_location));
             } else {
                 /** @var array<string, array<string, int>> */
-                return unserialize(file_get_contents($analyzed_methods_cache_location));
+                return unserialize(Providers::safeFileGetContents($analyzed_methods_cache_location));
             }
         }
 
@@ -870,9 +871,9 @@ class FileReferenceCacheProvider
                 . self::ANALYZED_METHODS_CACHE_NAME;
 
             if ($this->config->use_igbinary) {
-                file_put_contents($analyzed_methods_cache_location, igbinary_serialize($analyzed_methods));
+                file_put_contents($analyzed_methods_cache_location, igbinary_serialize($analyzed_methods), LOCK_EX);
             } else {
-                file_put_contents($analyzed_methods_cache_location, serialize($analyzed_methods));
+                file_put_contents($analyzed_methods_cache_location, serialize($analyzed_methods), LOCK_EX);
             }
         }
     }
@@ -893,12 +894,12 @@ class FileReferenceCacheProvider
                 /**
                  * @var array<string, FileMapType>
                  */
-                $file_maps_cache = igbinary_unserialize(file_get_contents($file_maps_cache_location));
+                $file_maps_cache = igbinary_unserialize(Providers::safeFileGetContents($file_maps_cache_location));
             } else {
                 /**
                  * @var array<string, FileMapType>
                  */
-                $file_maps_cache = unserialize(file_get_contents($file_maps_cache_location));
+                $file_maps_cache = unserialize(Providers::safeFileGetContents($file_maps_cache_location));
             }
 
             return $file_maps_cache;
@@ -918,9 +919,9 @@ class FileReferenceCacheProvider
             $file_maps_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::FILE_MAPS_CACHE_NAME;
 
             if ($this->config->use_igbinary) {
-                file_put_contents($file_maps_cache_location, igbinary_serialize($file_maps));
+                file_put_contents($file_maps_cache_location, igbinary_serialize($file_maps), LOCK_EX);
             } else {
-                file_put_contents($file_maps_cache_location, serialize($file_maps));
+                file_put_contents($file_maps_cache_location, serialize($file_maps), LOCK_EX);
             }
         }
     }
@@ -939,10 +940,10 @@ class FileReferenceCacheProvider
         ) {
             if ($this->config->use_igbinary) {
                 /** @var array<string, array{int, int}> */
-                $type_coverage_cache = igbinary_unserialize(file_get_contents($type_coverage_cache_location));
+                $type_coverage_cache = igbinary_unserialize(Providers::safeFileGetContents($type_coverage_cache_location));
             } else {
                 /** @var array<string, array{int, int}> */
-                $type_coverage_cache = unserialize(file_get_contents($type_coverage_cache_location));
+                $type_coverage_cache = unserialize(Providers::safeFileGetContents($type_coverage_cache_location));
             }
 
             return $type_coverage_cache;
@@ -962,9 +963,9 @@ class FileReferenceCacheProvider
             $type_coverage_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::TYPE_COVERAGE_CACHE_NAME;
 
             if ($this->config->use_igbinary) {
-                file_put_contents($type_coverage_cache_location, igbinary_serialize($mixed_counts));
+                file_put_contents($type_coverage_cache_location, igbinary_serialize($mixed_counts), LOCK_EX);
             } else {
-                file_put_contents($type_coverage_cache_location, serialize($mixed_counts));
+                file_put_contents($type_coverage_cache_location, serialize($mixed_counts), LOCK_EX);
             }
         }
     }
@@ -981,7 +982,7 @@ class FileReferenceCacheProvider
         if ($cache_directory
             && file_exists($config_hash_cache_location)
         ) {
-            return file_get_contents($config_hash_cache_location);
+            return Providers::safeFileGetContents($config_hash_cache_location);
         }
 
         return false;
@@ -1000,7 +1001,8 @@ class FileReferenceCacheProvider
 
             file_put_contents(
                 $config_hash_cache_location,
-                $hash
+                $hash,
+                LOCK_EX
             );
         }
     }

--- a/src/Psalm/Internal/Provider/Providers.php
+++ b/src/Psalm/Internal/Provider/Providers.php
@@ -2,6 +2,17 @@
 
 namespace Psalm\Internal\Provider;
 
+use RuntimeException;
+
+use function fclose;
+use function filesize;
+use function flock;
+use function fopen;
+use function fread;
+use function usleep;
+
+use const LOCK_SH;
+
 /**
  * @internal
  */
@@ -62,5 +73,39 @@ class Providers
             $file_storage_cache_provider
         );
         $this->file_reference_provider = new FileReferenceProvider($file_reference_cache_provider);
+    }
+
+    public static function safeFileGetContents(string $path): string
+    {
+        // no readable validation as that must be done in the caller
+        $fp = fopen($path, 'r');
+        if ($fp === false) {
+            return '';
+        }
+        $max_wait_cycles = 5;
+        $has_lock = false;
+        while ($max_wait_cycles > 0) {
+            if (flock($fp, LOCK_SH)) {
+                $has_lock = true;
+                break;
+            }
+            $max_wait_cycles--;
+            usleep(50000);
+        }
+
+        if (!$has_lock) {
+            fclose($fp);
+            throw new RuntimeException('Could not acquire lock for ' . $path);
+        }
+
+        $file_size = filesize($path);
+        $content = '';
+        if ( $file_size > 0 ) {
+            $content = (string) fread($fp, $file_size);
+        }
+
+        fclose($fp);
+
+        return $content;
     }
 }


### PR DESCRIPTION
ran into igbinary end-of-data race condition with PHP 8.1 in a multi-threaded environment in some cases where the file was modified during reading

I just used `UnexpectedValueException` as that is what was there already in one case. If you prefer another exception, please let me know.