### PR TITLE
fix #7606: Include composer files in phar

### DIFF
--- a/box.json.dist
+++ b/box.json.dist
@@ -12,5 +12,6 @@
     ],
     "compactors" : [
         "KevinGH\\Box\\Compactor\\PhpScoper"
-    ]
+    ],
+    "exclude-composer-files": false
 }


### PR DESCRIPTION
This change is completely untested! It will hopefully fix issue #7606 by allowing `PackageVersions\Versions::getVersion` to read version numbers from the composer files when using the CLI.

If successful, then:

- `composer.json` and `composer.lock` files will be included in the phar archive when built, and
- when running `php psalm.phar -v` from the command-line, the correct version number will be reported.