### PR TITLE
fix: Return `TNever` for class intersections

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -264,6 +264,7 @@
             <xs:element name="InvalidFalsableReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidFunctionCall" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidGlobal" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidIntersectionType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidIterator" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidLiteralArgument" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidMethodCall" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -73,6 +73,7 @@
  - [InvalidFalsableReturnType](issues/InvalidFalsableReturnType.md)
  - [InvalidFunctionCall](issues/InvalidFunctionCall.md)
  - [InvalidGlobal](issues/InvalidGlobal.md)
+ - [InvalidIntersectionType](issues/InvalidIntersectionType.md)
  - [InvalidIterator](issues/InvalidIterator.md)
  - [InvalidLiteralArgument](issues/InvalidLiteralArgument.md)
  - [InvalidMethodCall](issues/InvalidMethodCall.md)

--- a/docs/running_psalm/issues/InvalidIntersectionType.md
+++ b/docs/running_psalm/issues/InvalidIntersectionType.md
@@ -1,0 +1,13 @@
+# InvalidIntersectionType
+
+Emitted when an intersection type is invalid.
+
+```php
+<?php
+
+class Foo {}
+class Bar {}
+class Baz {
+    private Foo&Bar $foobar;
+}
+```

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -12,6 +12,7 @@ use Psalm\Aliases;
 use Psalm\CodeLocation;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Issue\InvalidIntersectionType;
 use Psalm\Issue\ParseError;
 use Psalm\IssueBuffer;
 use Psalm\Storage\ClassLikeStorage;
@@ -113,8 +114,20 @@ class TypeHintResolver
                 $type = Type::intersectUnionTypes($resolved_type, $type, $codebase);
             }
 
-            if ($type === null) {
-                throw new UnexpectedValueException('Intersection type could not be resolved');
+            if ($type->isNever()) {
+                IssueBuffer::maybeAdd(
+                    new InvalidIntersectionType(
+                        'Intersection types can never be satisfied',
+                        $code_location
+                    )
+                );
+            } elseif ($type === null) {
+                IssueBuffer::maybeAdd(
+                    new ParseError(
+                        'Intersection type could not be resolved',
+                        $code_location
+                    )
+                );
             }
 
             return $type;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -121,7 +121,7 @@ class TypeHintResolver
             if ($type->isNever()) {
                 IssueBuffer::maybeAdd(
                     new InvalidIntersectionType(
-                        'Intersection types can never be satisfied',
+                        'Intersection type can never be satisfied',
                         $code_location
                     )
                 );

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -114,17 +114,14 @@ class TypeHintResolver
                 $type = Type::intersectUnionTypes($resolved_type, $type, $codebase);
             }
 
+            if ($type === null) {
+                throw new UnexpectedValueException('Intersection type could not be resolved');
+            }
+
             if ($type->isNever()) {
                 IssueBuffer::maybeAdd(
                     new InvalidIntersectionType(
                         'Intersection types can never be satisfied',
-                        $code_location
-                    )
-                );
-            } elseif ($type === null) {
-                IssueBuffer::maybeAdd(
-                    new ParseError(
-                        'Intersection type could not be resolved',
                         $code_location
                     )
                 );

--- a/src/Psalm/Issue/InvalidIntersectionType.php
+++ b/src/Psalm/Issue/InvalidIntersectionType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+final class InvalidIntersectionType extends CodeIssue
+{
+    public const ERROR_LEVEL = 6;
+    public const SHORTCODE = 283;
+}

--- a/src/Psalm/Issue/InvalidIntersectionType.php
+++ b/src/Psalm/Issue/InvalidIntersectionType.php
@@ -5,5 +5,5 @@ namespace Psalm\Issue;
 final class InvalidIntersectionType extends CodeIssue
 {
     public const ERROR_LEVEL = 6;
-    public const SHORTCODE = 283;
+    public const SHORTCODE = 313;
 }

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -600,6 +600,9 @@ abstract class Type
                         );
 
                         if (null !== $intersection_atomic) {
+                            if ($intersection_atomic instanceof TNever) {
+                                return new Union([$intersection_atomic]);
+                            }
                             if (null === $combined_type) {
                                 $combined_type = new Union([$intersection_atomic]);
                             } else {
@@ -747,7 +750,7 @@ abstract class Type
                 $first_is_class = !$first->is_interface && !$first->is_trait;
                 $second_is_class = !$second->is_interface && !$second->is_trait;
                 if ($first_is_class && $second_is_class) {
-                    return $intersection_atomic;
+                    return $intersection_atomic ?? new TNever();
                 }
             }
             if ($intersection_atomic === null && $wider_type === null) {

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -310,6 +310,7 @@ class DocumentationTest extends TestCase
                 case 'DuplicateEnumCaseValue':
                 case 'InvalidEnumBackingType':
                 case 'InvalidEnumCaseValue':
+                case 'InvalidIntersectionType':
                 case 'NoEnumProperties':
                 case 'OverriddenFinalConstant':
                     $php_version = '8.1';

--- a/tests/NativeIntersectionsTest.php
+++ b/tests/NativeIntersectionsTest.php
@@ -83,6 +83,20 @@ class NativeIntersectionsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1'
             ],
+            'nativeTypeIntersectionNamedClasses' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    class Baz
+                    {
+                        public function __construct(private Foo&Bar $foobar) {}
+                    }
+                    new Baz(new Foo());
+                    ',
+                'error_message' => 'InvalidIntersectionType',
+                'ignored_issues' => [],
+                'php_version' => '8.1'
+            ],
             'mismatchDocblockNativeIntersectionArgument' => [
                 'code' => '<?php
                     interface A {

--- a/tests/NativeIntersectionsTest.php
+++ b/tests/NativeIntersectionsTest.php
@@ -63,7 +63,7 @@ class NativeIntersectionsTest extends TestCase
 
                     class Foobar
                     {
-                        /** @var (Foo&A)|(Bar&B) */
+                        /** @var (Foo&Bar)|(Bar&B) */
                         private $baz;
 
                         /** @param Bar&B $baz */
@@ -116,6 +116,28 @@ class NativeIntersectionsTest extends TestCase
                     new Baz(new Foo());
                     ',
                 'error_message' => 'InvalidIntersectionType',
+                'ignored_issues' => [],
+                'php_version' => '8.1'
+            ],
+            'docBlockIntersectionsMixedWithUnion' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    interface A {}
+                    interface B {}
+
+                    class Foobar
+                    {
+                        /** @var (Foo&Bar)|(Bar&B) */
+                        private $baz;
+
+                        /** @param Bar&A $baz */
+                        public function __construct($baz) {
+                            $this->baz = $baz;
+                        }
+                    }
+                ',
+                'error_message' => 'InvalidPropertyAssignmentValue',
                 'ignored_issues' => [],
                 'php_version' => '8.1'
             ],

--- a/tests/NativeIntersectionsTest.php
+++ b/tests/NativeIntersectionsTest.php
@@ -54,6 +54,28 @@ class NativeIntersectionsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1'
             ],
+            'docBlockIntersectionsMixedWithUnion' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    interface A {}
+                    interface B {}
+
+                    class Foobar
+                    {
+                        /** @var (Foo&A)|(Bar&B) */
+                        private $baz;
+
+                        /** @param Bar&B $baz */
+                        public function __construct($baz) {
+                            $this->baz = $baz;
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1'
+            ]
         ];
     }
 


### PR DESCRIPTION
Returns `TNever` for an intersection of 2 non-overlapping named classes instead of throwing an exception. Will raise a new `InvalidIntersectionType` in the case that this is detected.

I *think* this is all that's needed to fix this issue.

I've invented a new issue type - not sure whether there's a set process for this, but none of the existing types seemed to match.

Resolves #8333