### PR TITLE
fix: Fix parsing of invalid intersection types

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -264,6 +264,7 @@
             <xs:element name="InvalidFalsableReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidFunctionCall" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidGlobal" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidIntersectionType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidIterator" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidLiteralArgument" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidMethodCall" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -73,6 +73,7 @@
  - [InvalidFalsableReturnType](issues/InvalidFalsableReturnType.md)
  - [InvalidFunctionCall](issues/InvalidFunctionCall.md)
  - [InvalidGlobal](issues/InvalidGlobal.md)
+ - [InvalidIntersectionType](issues/InvalidIntersectionType.md)
  - [InvalidIterator](issues/InvalidIterator.md)
  - [InvalidLiteralArgument](issues/InvalidLiteralArgument.md)
  - [InvalidMethodCall](issues/InvalidMethodCall.md)

--- a/docs/running_psalm/issues/InvalidIntersectionType.md
+++ b/docs/running_psalm/issues/InvalidIntersectionType.md
@@ -1,0 +1,13 @@
+# InvalidIntersectionType
+
+Emitted when an intersection type is invalid.
+
+```php
+<?php
+
+class Foo {}
+class Bar {}
+class Baz {
+    private Foo&Bar $foobar;
+}
+```

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -12,6 +12,7 @@ use Psalm\Aliases;
 use Psalm\CodeLocation;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
+use Psalm\Issue\InvalidIntersectionType;
 use Psalm\Issue\ParseError;
 use Psalm\IssueBuffer;
 use Psalm\Storage\ClassLikeStorage;
@@ -113,8 +114,20 @@ class TypeHintResolver
                 $type = Type::intersectUnionTypes($resolved_type, $type, $codebase);
             }
 
-            if ($type === null) {
-                throw new UnexpectedValueException('Intersection type could not be resolved');
+            if ($type->isNever()) {
+                IssueBuffer::maybeAdd(
+                    new InvalidIntersectionType(
+                        'Intersection types can never be satisfied',
+                        $code_location
+                    )
+                );
+            } elseif ($type === null) {
+                IssueBuffer::maybeAdd(
+                    new ParseError(
+                        'Intersection type could not be resolved',
+                        $code_location
+                    )
+                );
             }
 
             return $type;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -118,7 +118,7 @@ class TypeHintResolver
                 throw new UnexpectedValueException('Intersection type could not be resolved');
             }
 
-            if ($type->isNever()) {
+            if ($type === null) {
                 IssueBuffer::maybeAdd(
                     new InvalidIntersectionType(
                         'Intersection type can never be satisfied',

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -121,7 +121,7 @@ class TypeHintResolver
             if ($type->isNever()) {
                 IssueBuffer::maybeAdd(
                     new InvalidIntersectionType(
-                        'Intersection types can never be satisfied',
+                        'Intersection type can never be satisfied',
                         $code_location
                     )
                 );

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -114,17 +114,14 @@ class TypeHintResolver
                 $type = Type::intersectUnionTypes($resolved_type, $type, $codebase);
             }
 
+            if ($type === null) {
+                throw new UnexpectedValueException('Intersection type could not be resolved');
+            }
+
             if ($type->isNever()) {
                 IssueBuffer::maybeAdd(
                     new InvalidIntersectionType(
                         'Intersection types can never be satisfied',
-                        $code_location
-                    )
-                );
-            } elseif ($type === null) {
-                IssueBuffer::maybeAdd(
-                    new ParseError(
-                        'Intersection type could not be resolved',
                         $code_location
                     )
                 );

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -121,6 +121,8 @@ class TypeHintResolver
                         $code_location
                     )
                 );
+
+                return Type::getNever();
             }
 
             return $type;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -115,10 +115,6 @@ class TypeHintResolver
             }
 
             if ($type === null) {
-                throw new UnexpectedValueException('Intersection type could not be resolved');
-            }
-
-            if ($type === null) {
                 IssueBuffer::maybeAdd(
                     new InvalidIntersectionType(
                         'Intersection type can never be satisfied',

--- a/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/TypeHintResolver.php
@@ -111,7 +111,7 @@ class TypeHintResolver
                     );
                 }
 
-                $type = Type::intersectUnionTypes($resolved_type, $type, $codebase);
+                $type = $type ? Type::intersectUnionTypes($resolved_type, $type, $codebase) : $resolved_type;
             }
 
             if ($type === null) {

--- a/src/Psalm/Issue/InvalidIntersectionType.php
+++ b/src/Psalm/Issue/InvalidIntersectionType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+final class InvalidIntersectionType extends CodeIssue
+{
+    public const ERROR_LEVEL = 6;
+    public const SHORTCODE = 283;
+}

--- a/src/Psalm/Issue/InvalidIntersectionType.php
+++ b/src/Psalm/Issue/InvalidIntersectionType.php
@@ -5,5 +5,5 @@ namespace Psalm\Issue;
 final class InvalidIntersectionType extends CodeIssue
 {
     public const ERROR_LEVEL = 6;
-    public const SHORTCODE = 283;
+    public const SHORTCODE = 313;
 }

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -600,9 +600,6 @@ abstract class Type
                         );
 
                         if (null !== $intersection_atomic) {
-                            if ($intersection_atomic instanceof TNever) {
-                                return new Union([$intersection_atomic]);
-                            }
                             if (null === $combined_type) {
                                 $combined_type = new Union([$intersection_atomic]);
                             } else {
@@ -750,7 +747,7 @@ abstract class Type
                 $first_is_class = !$first->is_interface && !$first->is_trait;
                 $second_is_class = !$second->is_interface && !$second->is_trait;
                 if ($first_is_class && $second_is_class) {
-                    return $intersection_atomic ?? new TNever();
+                    return $intersection_atomic;
                 }
             }
             if ($intersection_atomic === null && $wider_type === null) {

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -540,27 +540,19 @@ abstract class Type
     /**
      * Combines two union types into one via an intersection
      *
-     *
+     * Returns null (not TNever) if the intersection is empty
      */
     public static function intersectUnionTypes(
-        ?Union $type_1,
-        ?Union $type_2,
+        Union $type_1,
+        Union $type_2,
         Codebase $codebase
     ): ?Union {
-        $type_1 = $type_1 && $type_1->isNever() ? null : $type_1;
-        $type_2 = $type_2 && $type_2->isNever() ? null : $type_2;
-        if ($type_2 === null && $type_1 === null) {
-            throw new UnexpectedValueException('At least one type must be provided to intersect');
-        }
-
-        if ($type_1 === null) {
+        if ($type_1->isNever()) {
             return $type_2;
         }
-
-        if ($type_2 === null) {
+        if ($type_2->isNever()) {
             return $type_1;
         }
-
         if ($type_1 === $type_2) {
             return $type_1;
         }

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -548,10 +548,10 @@ abstract class Type
         Codebase $codebase
     ): ?Union {
         if ($type_1->isNever()) {
-            return $type_2;
+            return null;
         }
         if ($type_2->isNever()) {
-            return $type_1;
+            return null;
         }
         if ($type_1 === $type_2) {
             return $type_1;

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -600,6 +600,9 @@ abstract class Type
                         );
 
                         if (null !== $intersection_atomic) {
+                            if ($intersection_atomic instanceof TNever) {
+                                return new Union([$intersection_atomic]);
+                            }
                             if (null === $combined_type) {
                                 $combined_type = new Union([$intersection_atomic]);
                             } else {
@@ -747,7 +750,7 @@ abstract class Type
                 $first_is_class = !$first->is_interface && !$first->is_trait;
                 $second_is_class = !$second->is_interface && !$second->is_trait;
                 if ($first_is_class && $second_is_class) {
-                    return $intersection_atomic;
+                    return $intersection_atomic ?? new TNever();
                 }
             }
             if ($intersection_atomic === null && $wider_type === null) {

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -547,20 +547,22 @@ abstract class Type
         ?Union $type_2,
         Codebase $codebase
     ): ?Union {
+        $type_1 = $type_1 && $type_1->isNever() ? null : $type_1;
+        $type_2 = $type_2 && $type_2->isNever() ? null : $type_2;
         if ($type_2 === null && $type_1 === null) {
-            throw new UnexpectedValueException('At least one type must be provided to combine');
+            throw new UnexpectedValueException('At least one type must be provided to intersect');
         }
 
         if ($type_1 === null) {
-            return $type_2->isNever() ? null : $type_2;
+            return $type_2;
         }
 
         if ($type_2 === null) {
-            return $type_1->isNever() ? null : $type_1;
+            return $type_1;
         }
 
         if ($type_1 === $type_2) {
-            return $type_1->isNever() ? null : $type_1;
+            return $type_1;
         }
 
         $intersection_performed = false;
@@ -576,10 +578,10 @@ abstract class Type
                 if ($type_2->failed_reconciliation) {
                     $both_failed_reconciliation = true;
                 } else {
-                    return $type_2->isNever() ? null : $type_2;
+                    return $type_2;
                 }
             } elseif ($type_2->failed_reconciliation) {
-                return $type_1->isNever() ? null : $type_1;
+                return $type_1;
             }
 
             if ($type_1_mixed) {
@@ -662,7 +664,7 @@ abstract class Type
             $combined_type->possibly_undefined = true;
         }
 
-        return $combined_type->isNever() ? null : $combined_type;
+        return $combined_type && $combined_type->isNever() ? null : $combined_type;
     }
 
     private static function intersectAtomicTypes(

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -552,15 +552,15 @@ abstract class Type
         }
 
         if ($type_1 === null) {
-            return $type_2;
+            return $type_2->isNever() ? null : $type_2;
         }
 
         if ($type_2 === null) {
-            return $type_1;
+            return $type_1->isNever() ? null : $type_1;
         }
 
         if ($type_1 === $type_2) {
-            return $type_1;
+            return $type_1->isNever() ? null : $type_1;
         }
 
         $intersection_performed = false;
@@ -576,10 +576,10 @@ abstract class Type
                 if ($type_2->failed_reconciliation) {
                     $both_failed_reconciliation = true;
                 } else {
-                    return $type_2;
+                    return $type_2->isNever() ? null : $type_2;
                 }
             } elseif ($type_2->failed_reconciliation) {
-                return $type_1;
+                return $type_1->isNever() ? null : $type_1;
             }
 
             if ($type_1_mixed) {
@@ -662,7 +662,7 @@ abstract class Type
             $combined_type->possibly_undefined = true;
         }
 
-        return $combined_type;
+        return $combined_type->isNever() ? null : $combined_type;
     }
 
     private static function intersectAtomicTypes(

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -310,6 +310,7 @@ class DocumentationTest extends TestCase
                 case 'DuplicateEnumCaseValue':
                 case 'InvalidEnumBackingType':
                 case 'InvalidEnumCaseValue':
+                case 'InvalidIntersectionType':
                 case 'NoEnumProperties':
                 case 'OverriddenFinalConstant':
                     $php_version = '8.1';

--- a/tests/NativeIntersectionsTest.php
+++ b/tests/NativeIntersectionsTest.php
@@ -83,6 +83,20 @@ class NativeIntersectionsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1'
             ],
+            'nativeTypeIntersectionNamedClasses' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    class Baz
+                    {
+                        public function __construct(private Foo&Bar $foobar) {}
+                    }
+                    new Baz(new Foo());
+                    ',
+                'error_message' => 'InvalidIntersectionType',
+                'ignored_issues' => [],
+                'php_version' => '8.1'
+            ],
             'mismatchDocblockNativeIntersectionArgument' => [
                 'code' => '<?php
                     interface A {

--- a/tests/NativeIntersectionsTest.php
+++ b/tests/NativeIntersectionsTest.php
@@ -119,6 +119,23 @@ class NativeIntersectionsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1'
             ],
+            'phpdocTypeIntersectionNamedClasses' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    class Baz
+                    {
+                        /**
+                         * @param Foo&Bar $foobar
+                         */
+                        public function test(Foo&Bar $foobar) {}
+                    }
+                    new Baz(new Foo());
+                    ',
+                'error_message' => 'InvalidIntersectionType',
+                'ignored_issues' => [],
+                'php_version' => '8.1'
+            ],
             'docBlockIntersectionsMixedWithUnion' => [
                 'code' => '<?php
                     class Foo {}

--- a/tests/NativeIntersectionsTest.php
+++ b/tests/NativeIntersectionsTest.php
@@ -63,7 +63,7 @@ class NativeIntersectionsTest extends TestCase
 
                     class Foobar
                     {
-                        /** @var (Foo&A)|(Bar&B) */
+                        /** @var (Foo&Bar)|(Bar&B) */
                         private $baz;
 
                         /** @param Bar&B $baz */
@@ -116,6 +116,28 @@ class NativeIntersectionsTest extends TestCase
                     new Baz(new Foo());
                     ',
                 'error_message' => 'InvalidIntersectionType',
+                'ignored_issues' => [],
+                'php_version' => '8.1'
+            ],
+            'docBlockIntersectionsMixedWithUnion' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    interface A {}
+                    interface B {}
+
+                    class Foobar
+                    {
+                        /** @var (Foo&Bar)|(Bar&B) */
+                        private $baz;
+
+                        /** @param Bar&A $baz */
+                        public function __construct($baz) {
+                            $this->baz = $baz;
+                        }
+                    }
+                ',
+                'error_message' => 'InvalidPropertyAssignmentValue',
                 'ignored_issues' => [],
                 'php_version' => '8.1'
             ],

--- a/tests/NativeIntersectionsTest.php
+++ b/tests/NativeIntersectionsTest.php
@@ -54,6 +54,28 @@ class NativeIntersectionsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1'
             ],
+            'docBlockIntersectionsMixedWithUnion' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    interface A {}
+                    interface B {}
+
+                    class Foobar
+                    {
+                        /** @var (Foo&A)|(Bar&B) */
+                        private $baz;
+
+                        /** @param Bar&B $baz */
+                        public function __construct($baz) {
+                            $this->baz = $baz;
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1'
+            ]
         ];
     }
 


### PR DESCRIPTION
This fixes #8333 properly, replacing #8384.
I feel that we need to be consistent with the return type of `Type::intersectUnionTypes`: if there is no possible intersection between the types, return null, otherwise return a Union with the types.
The previous PR incorrectly returned TNever only for certain invalid intersections: if we really want to go with that approach, then let's always return either a Union or a Union(TNever), and never `null` (but I would personally leave it as it is right now, as it's easier to tell if there's no intersection between the types this way).