### PR TITLE
Add capability to use inclusion files in a different directory (fix)

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -186,7 +186,7 @@
                 </xs:complexType>
             </xs:element>
         </xs:choice>
-        <xs:anyAttribute/>
+        <xs:anyAttribute processContents="skip"/>
     </xs:complexType>
 
     <xs:complexType name="IssueHandlersType">
@@ -482,7 +482,7 @@
             <xs:element name="UnusedReturnValue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnusedVariable" type="IssueHandlerType" minOccurs="0" />
         </xs:choice>
-        <xs:anyAttribute/>
+        <xs:anyAttribute processContents="skip"/>
     </xs:complexType>
 
     <xs:complexType name="IssueHandlerType">


### PR DESCRIPTION
This previous commit add the capability to use inclusion files in different directory: https://github.com/vimeo/psalm/commit/d2f3ff09ee49a052198f1d09c9ed5c8c836e4ffd
However, the change was missing for plugins and issueHandlers.
This new pull request fix this.