### PR TITLE
Fix `imageinterlace` function signature

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -5410,7 +5410,7 @@ return [
 'imagegif' => ['bool', 'image'=>'GdImage', 'file='=>'string|resource|null'],
 'imagegrabscreen' => ['false|GdImage'],
 'imagegrabwindow' => ['false|GdImage', 'handle'=>'int', 'client_area='=>'int'],
-'imageinterlace' => ['int|false', 'image'=>'GdImage', 'enable='=>'int'],
+'imageinterlace' => ['bool', 'image'=>'GdImage', 'enable='=>'bool|null'],
 'imageistruecolor' => ['bool', 'image'=>'GdImage'],
 'imagejpeg' => ['bool', 'image'=>'GdImage', 'file='=>'string|resource|null', 'quality='=>'int'],
 'imagelayereffect' => ['bool', 'image'=>'GdImage', 'effect'=>'int'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -647,7 +647,7 @@ return [
     ],
     'imageinterlace' => [
       'old' => ['int|false', 'image'=>'resource', 'enable='=>'int'],
-      'new' => ['int|false', 'image'=>'GdImage', 'enable='=>'int'],
+      'new' => ['int|bool', 'image'=>'GdImage', 'enable='=>'bool|null'],
     ],
     'imageistruecolor' => [
       'old' => ['bool', 'image'=>'resource'],

--- a/dictionaries/CallMap_81_delta.php
+++ b/dictionaries/CallMap_81_delta.php
@@ -233,6 +233,10 @@ return [
       'old' => ['HashContext', 'algo'=>'string', 'flags='=>'int', 'key='=>'string'],
       'new' => ['HashContext', 'algo'=>'string', 'flags='=>'int', 'key='=>'string', 'options='=>'array'],
     ],
+    'imageinterlace' => [
+      'old' => ['int|bool', 'image'=>'GdImage', 'enable='=>'bool|null'],
+      'new' => ['bool', 'image'=>'GdImage', 'enable='=>'bool|null'],
+    ],
     'imap_append' => [
         'old' => ['bool', 'imap'=>'resource', 'folder'=>'string', 'message'=>'string', 'options='=>'string', 'internal_date='=>'string'],
         'new' => ['bool', 'imap'=>'IMAP\Connection', 'folder'=>'string', 'message'=>'string', 'options='=>'string', 'internal_date='=>'string'],

--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -112,7 +112,6 @@ class InternalCallMapHandlerTest extends TestCase
         'imagefilter',
         'imagegd',
         'imagegd2',
-        'imageinterlace',
         'imageopenpolygon',
         'imagepolygon',
         'imagerotate',


### PR DESCRIPTION
This PR fixes the function signature of [`imageinterlace`](https://www.php.net/manual/en/function.imageinterlace.php):

* The return type is `bool` since PHP 8.0.5.
* The type of the parameter `enable` is `bool|null` since PHP 8.0.0.