### PR TITLE
Consistent error logging for cache

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2298,19 +2298,28 @@ class Config
                     continue;
                 }
 
+                $full_path = $dir . '/' . $object;
+
                 // if it was deleted in the meantime/race condition with other psalm process
-                if (!file_exists($dir . '/' . $object)) {
+                if (!file_exists($full_path)) {
                     continue;
                 }
 
-                if (filetype($dir . '/' . $object) === 'dir') {
-                    self::removeCacheDirectory($dir . '/' . $object);
+                if (filetype($full_path) === 'dir') {
+                    self::removeCacheDirectory($full_path);
                 } else {
-                    unlink($dir . '/' . $object);
+                    try {
+                        unlink($full_path);
+                    } catch (RuntimeException $e) {
+                        clearstatcache(true, $full_path);
+                        if (file_exists($full_path)) {
+                            // rethrow the error with default message
+                            // it contains the reason why deletion failed
+                            throw $e;
+                        }
+                    }
                 }
             }
-
-            reset($objects);
 
             // may have been removed in the meantime
             clearstatcache(true, $dir);

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -5,6 +5,7 @@ namespace Psalm\Internal\Provider;
 use Psalm\Config;
 use Psalm\Internal\Provider\Providers;
 use Psalm\Storage\ClassLikeStorage;
+use RuntimeException;
 use UnexpectedValueException;
 
 use function array_merge;
@@ -168,7 +169,19 @@ class ClassLikeStorageCacheProvider
         $parser_cache_directory = $root_cache_directory . DIRECTORY_SEPARATOR . self::CLASS_CACHE_DIRECTORY;
 
         if ($create_directory && !is_dir($parser_cache_directory)) {
-            mkdir($parser_cache_directory, 0777, true);
+            try {
+                if (mkdir($parser_cache_directory, 0777, true) === false) {
+                    // any other error than directory already exists/permissions issue
+                    throw new RuntimeException('Failed to create ' . $parser_cache_directory . ' cache directory for unknown reasons');
+                }
+            } catch (RuntimeException $e) {
+                // Race condition (#4483)
+                if (!is_dir($parser_cache_directory)) {
+                    // rethrow the error with default message
+                    // it contains the reason why creation failed
+                    throw $e;
+                }
+            }
         }
 
         $data = $file_path ? strtolower($file_path) . ' ' : '';

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -5,6 +5,7 @@ namespace Psalm\Internal\Provider;
 use Psalm\Config;
 use Psalm\Internal\Codebase\Analyzer;
 use Psalm\Internal\Provider\Providers;
+use RuntimeException;
 use UnexpectedValueException;
 
 use function file_exists;
@@ -12,6 +13,7 @@ use function file_put_contents;
 use function igbinary_serialize;
 use function igbinary_unserialize;
 use function is_array;
+use function is_dir;
 use function is_readable;
 use function mkdir;
 use function serialize;
@@ -992,18 +994,32 @@ class FileReferenceCacheProvider
     {
         $cache_directory = Config::getInstance()->getCacheDirectory();
 
-        if ($cache_directory) {
-            if (!file_exists($cache_directory)) {
-                mkdir($cache_directory, 0777, true);
-            }
-
-            $config_hash_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CONFIG_HASH_CACHE_NAME;
-
-            file_put_contents(
-                $config_hash_cache_location,
-                $hash,
-                LOCK_EX
-            );
+        if (!$cache_directory) {
+            return;
         }
+
+        if (!is_dir($cache_directory)) {
+            try {
+                if (mkdir($cache_directory, 0777, true) === false) {
+                    // any other error than directory already exists/permissions issue
+                    throw new RuntimeException('Failed to create ' . $cache_directory . ' cache directory for unknown reasons');
+                }
+            } catch (RuntimeException $e) {
+                // Race condition (#4483)
+                if (!is_dir($cache_directory)) {
+                    // rethrow the error with default message
+                    // it contains the reason why creation failed
+                    throw $e;
+                }
+            }
+        }
+
+        $config_hash_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CONFIG_HASH_CACHE_NAME;
+
+        file_put_contents(
+            $config_hash_cache_location,
+            $hash,
+            LOCK_EX
+        );
     }
 }

--- a/src/Psalm/Internal/Provider/ParserCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ParserCacheProvider.php
@@ -7,12 +7,13 @@ use PhpParser\Node\Stmt;
 use Psalm\Config;
 use Psalm\Internal\Provider\Providers;
 use RuntimeException;
+use UnexpectedValueException;
 
 use function clearstatcache;
-use function error_log;
 use function file_put_contents;
 use function filemtime;
 use function gettype;
+use function hash;
 use function igbinary_serialize;
 use function igbinary_unserialize;
 use function is_array;
@@ -21,7 +22,6 @@ use function is_readable;
 use function is_writable;
 use function json_decode;
 use function json_encode;
-use function md5;
 use function mkdir;
 use function scandir;
 use function serialize;
@@ -43,30 +43,32 @@ class ParserCacheProvider
     private const FILE_CONTENTS_CACHE_DIRECTORY = 'file-caches';
 
     /**
+     * @var Config
+     */
+    private $config;
+
+    /**
      * A map of filename hashes to contents hashes
      *
      * @var array<string, string>|null
      */
-    private $existing_file_content_hashes;
+    protected $existing_file_content_hashes;
 
     /**
      * A map of recently-added filename hashes to contents hashes
      *
      * @var array<string, string>
      */
-    private $new_file_content_hashes = [];
+    protected $new_file_content_hashes = [];
 
     /**
      * @var bool
      */
     private $use_file_cache;
 
-    /** @var bool */
-    private $use_igbinary;
-
     public function __construct(Config $config, bool $use_file_cache = true)
     {
-        $this->use_igbinary = $config->use_igbinary;
+        $this->config = $config;
         $this->use_file_cache = $use_file_cache;
     }
 
@@ -78,28 +80,22 @@ class ParserCacheProvider
         int $file_modified_time,
         string $file_content_hash
     ): ?array {
-        $root_cache_directory = Config::getInstance()->getCacheDirectory();
-
-        if (!$root_cache_directory) {
+        if (!$this->use_file_cache) {
             return null;
         }
 
-        $file_cache_key = $this->getParserCacheKey(
-            $file_path
-        );
+        $cache_location = $this->getCacheLocationForPath($file_path, self::PARSER_CACHE_DIRECTORY);
 
-        $parser_cache_directory = $root_cache_directory . DIRECTORY_SEPARATOR . self::PARSER_CACHE_DIRECTORY;
+        $file_cache_key = $this->getParserCacheKey($file_path);
 
         $file_content_hashes = $this->new_file_content_hashes + $this->getExistingFileContentHashes();
-
-        $cache_location = $parser_cache_directory . DIRECTORY_SEPARATOR . $file_cache_key;
 
         if (isset($file_content_hashes[$file_cache_key])
             && $file_content_hash === $file_content_hashes[$file_cache_key]
             && is_readable($cache_location)
             && filemtime($cache_location) > $file_modified_time
         ) {
-            if ($this->use_igbinary) {
+            if ($this->config->use_igbinary) {
                 /** @var list<Stmt> */
                 $stmts = igbinary_unserialize(Providers::safeFileGetContents($cache_location));
             } else {
@@ -118,22 +114,14 @@ class ParserCacheProvider
      */
     public function loadExistingStatementsFromCache(string $file_path): ?array
     {
-        $root_cache_directory = Config::getInstance()->getCacheDirectory();
-
-        if (!$root_cache_directory) {
+        if (!$this->use_file_cache) {
             return null;
         }
 
-        $file_cache_key = $this->getParserCacheKey(
-            $file_path
-        );
-
-        $parser_cache_directory = $root_cache_directory . DIRECTORY_SEPARATOR . self::PARSER_CACHE_DIRECTORY;
-
-        $cache_location = $parser_cache_directory . DIRECTORY_SEPARATOR . $file_cache_key;
+        $cache_location = $this->getCacheLocationForPath($file_path, self::PARSER_CACHE_DIRECTORY);
 
         if (is_readable($cache_location)) {
-            if ($this->use_igbinary) {
+            if ($this->config->use_igbinary) {
                 /** @var list<Stmt> */
                 return igbinary_unserialize(Providers::safeFileGetContents($cache_location)) ?: null;
             }
@@ -151,19 +139,7 @@ class ParserCacheProvider
             return null;
         }
 
-        $root_cache_directory = Config::getInstance()->getCacheDirectory();
-
-        if (!$root_cache_directory) {
-            return null;
-        }
-
-        $file_cache_key = $this->getParserCacheKey(
-            $file_path
-        );
-
-        $parser_cache_directory = $root_cache_directory . DIRECTORY_SEPARATOR . self::FILE_CONTENTS_CACHE_DIRECTORY;
-
-        $cache_location = $parser_cache_directory . DIRECTORY_SEPARATOR . $file_cache_key;
+        $cache_location = $this->getCacheLocationForPath($file_path, self::FILE_CONTENTS_CACHE_DIRECTORY);
 
         if (is_readable($cache_location)) {
             return Providers::safeFileGetContents($cache_location);
@@ -177,35 +153,37 @@ class ParserCacheProvider
      */
     private function getExistingFileContentHashes(): array
     {
-        $config = Config::getInstance();
-        $root_cache_directory = $config->getCacheDirectory();
+        if (!$this->use_file_cache) {
+            return [];
+        }
 
         if ($this->existing_file_content_hashes === null) {
+            $root_cache_directory = $this->config->getCacheDirectory();
             $file_hashes_path = $root_cache_directory . DIRECTORY_SEPARATOR . self::FILE_HASHES;
 
-            if ($root_cache_directory && is_readable($file_hashes_path)) {
-                $hashes_encoded = Providers::safeFileGetContents($file_hashes_path);
-                if (!$hashes_encoded) {
-                    error_log('Unexpected value when loading from file content hashes');
-                    $this->existing_file_content_hashes = [];
-
-                    return [];
-                }
-
-                $hashes_decoded = json_decode($hashes_encoded, true);
-
-                if (!is_array($hashes_decoded)) {
-                    error_log('Unexpected value ' . gettype($hashes_decoded));
-                    $this->existing_file_content_hashes = [];
-
-                    return [];
-                }
-
-                /** @var array<string, string> $hashes_decoded */
-                $this->existing_file_content_hashes = $hashes_decoded;
-            } else {
-                $this->existing_file_content_hashes = [];
+            if (!$root_cache_directory) {
+                throw new UnexpectedValueException('No cache directory defined');
             }
+
+            if (!is_readable($file_hashes_path)) {
+                // might not exist yet
+                $this->existing_file_content_hashes = [];
+                return $this->existing_file_content_hashes;
+            }
+
+            $hashes_encoded = Providers::safeFileGetContents($file_hashes_path);
+            if (!$hashes_encoded) {
+                throw new UnexpectedValueException('File content hashes should be in cache');
+            }
+
+            $hashes_decoded = json_decode($hashes_encoded, true);
+
+            if (!is_array($hashes_decoded)) {
+                throw new UnexpectedValueException('File content hashes are of invalid type ' . gettype($hashes_decoded));
+            }
+
+            /** @var array<string, string> $hashes_decoded */
+            $this->existing_file_content_hashes = $hashes_decoded;
         }
 
         return $this->existing_file_content_hashes;
@@ -220,31 +198,18 @@ class ParserCacheProvider
         array $stmts,
         bool $touch_only
     ): void {
-        $root_cache_directory = Config::getInstance()->getCacheDirectory();
-
-        if (!$root_cache_directory) {
-            return;
-        }
-
-        $file_cache_key = $this->getParserCacheKey(
-            $file_path
-        );
-
-        $parser_cache_directory = $root_cache_directory . DIRECTORY_SEPARATOR . self::PARSER_CACHE_DIRECTORY;
-
-        $cache_location = $parser_cache_directory . DIRECTORY_SEPARATOR . $file_cache_key;
+        $cache_location = $this->getCacheLocationForPath($file_path, self::PARSER_CACHE_DIRECTORY, !$touch_only);
 
         if ($touch_only) {
             touch($cache_location);
         } else {
-            $this->createCacheDirectory($parser_cache_directory);
-
-            if ($this->use_igbinary) {
+            if ($this->config->use_igbinary) {
                 file_put_contents($cache_location, igbinary_serialize($stmts), LOCK_EX);
             } else {
                 file_put_contents($cache_location, serialize($stmts), LOCK_EX);
             }
 
+            $file_cache_key = $this->getParserCacheKey($file_path);
             $this->new_file_content_hashes[$file_cache_key] = $file_content_hash;
         }
     }
@@ -268,7 +233,11 @@ class ParserCacheProvider
 
     public function saveFileContentHashes(): void
     {
-        $root_cache_directory = Config::getInstance()->getCacheDirectory();
+        if (!$this->use_file_cache) {
+            return;
+        }
+
+        $root_cache_directory = $this->config->getCacheDirectory();
 
         if (!$root_cache_directory) {
             return;
@@ -298,28 +267,17 @@ class ParserCacheProvider
             return;
         }
 
-        $root_cache_directory = Config::getInstance()->getCacheDirectory();
-
-        if (!$root_cache_directory) {
-            return;
-        }
-
-        $file_cache_key = $this->getParserCacheKey(
-            $file_path
-        );
-
-        $parser_cache_directory = $root_cache_directory . DIRECTORY_SEPARATOR . self::FILE_CONTENTS_CACHE_DIRECTORY;
-
-        $cache_location = $parser_cache_directory . DIRECTORY_SEPARATOR . $file_cache_key;
-
-        $this->createCacheDirectory($parser_cache_directory);
+        $cache_location = $this->getCacheLocationForPath($file_path, self::FILE_CONTENTS_CACHE_DIRECTORY, true);
 
         file_put_contents($cache_location, $file_contents, LOCK_EX);
     }
 
     public function deleteOldParserCaches(float $time_before): int
     {
-        $cache_directory = Config::getInstance()->getCacheDirectory();
+        $cache_directory = $this->config->getCacheDirectory();
+
+        $this->existing_file_content_hashes = null;
+        $this->new_file_content_hashes = [];
 
         if (!$cache_directory) {
             return 0;
@@ -349,22 +307,46 @@ class ParserCacheProvider
         return $removed_count;
     }
 
-    private function getParserCacheKey(string $file_name): string
+    private function getParserCacheKey(string $file_path): string
     {
-        return md5($file_name) . ($this->use_igbinary ? '-igbinary' : '') . '-r';
+        if (PHP_VERSION_ID >= 80100) {
+            $hash = hash('xxh128', $file_path);
+        } else {
+            $hash = hash('md4', $file_path);
+        }
+
+        return $hash . ($this->config->use_igbinary ? '-igbinary' : '') . '-r';
     }
 
-    private function createCacheDirectory(string $parser_cache_directory): void
+
+    private function getCacheLocationForPath(string $file_path, string $subdirectory, bool $create_directory = false): string
     {
-        if (!is_dir($parser_cache_directory)) {
+        $root_cache_directory = $this->config->getCacheDirectory();
+
+        if (!$root_cache_directory) {
+            throw new UnexpectedValueException('No cache directory defined');
+        }
+
+        $parser_cache_directory = $root_cache_directory . DIRECTORY_SEPARATOR . $subdirectory;
+
+        if ($create_directory && !is_dir($parser_cache_directory)) {
             try {
-                mkdir($parser_cache_directory, 0777, true);
+                if (mkdir($parser_cache_directory, 0777, true) === false) {
+                    // any other error than directory already exists/permissions issue
+                    throw new RuntimeException('Failed to create ' . $parser_cache_directory . ' cache directory for unknown reasons');
+                }
             } catch (RuntimeException $e) {
                 // Race condition (#4483)
                 if (!is_dir($parser_cache_directory)) {
-                    error_log('Could not create parser cache directory: ' . $parser_cache_directory);
+                    // rethrow the error with default message
+                    // it contains the reason why creation failed
+                    throw $e;
                 }
             }
         }
+
+        return $parser_cache_directory
+               . DIRECTORY_SEPARATOR
+               . $this->getParserCacheKey($file_path);
     }
 }

--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -26,6 +26,7 @@ use function array_map;
 use function array_merge;
 use function count;
 use function filemtime;
+use function hash;
 use function md5;
 use function strlen;
 use function strpos;
@@ -132,7 +133,11 @@ class StatementsProvider
 
         $config = Config::getInstance();
 
-        $file_content_hash = md5($version . $file_contents);
+        if (PHP_VERSION_ID >= 80100) {
+            $file_content_hash = hash('xxh128', $version . $file_contents);
+        } else {
+            $file_content_hash = hash('md4', $version . $file_contents);
+        }
 
         if (!$this->parser_cache_provider
             || (!$config->isInProjectDirs($file_path) && strpos($file_path, 'vendor'))
@@ -239,6 +244,7 @@ class StatementsProvider
                     array_flip($unchanged_signature_members)
                 );
 
+                // do NOT change this to hash, it will fail on Windows for whatever reason
                 $file_path_hash = md5($file_path);
 
                 $changed_members = array_map(

--- a/tests/Internal/Provider/FakeParserCacheProvider.php
+++ b/tests/Internal/Provider/FakeParserCacheProvider.php
@@ -33,6 +33,14 @@ class FakeParserCacheProvider extends ParserCacheProvider
     {
     }
 
+    public function deleteOldParserCaches(float $time_before): int
+    {
+        $this->existing_file_content_hashes = null;
+        $this->new_file_content_hashes = [];
+
+        return 0;
+    }
+
     public function saveFileContentHashes(): void
     {
     }

--- a/tests/Internal/Provider/ParserInstanceCacheProvider.php
+++ b/tests/Internal/Provider/ParserInstanceCacheProvider.php
@@ -82,6 +82,18 @@ class ParserInstanceCacheProvider extends ParserCacheProvider
         $this->file_contents_cache[$file_path] = $file_contents;
     }
 
+    public function deleteOldParserCaches(float $time_before): int
+    {
+        $this->existing_file_content_hashes = null;
+        $this->new_file_content_hashes = [];
+
+        $this->file_contents_cache = [];
+        $this->file_content_hash = [];
+        $this->statements_cache = [];
+        $this->statements_cache_time = [];
+        return 0;
+    }
+
     public function saveFileContentHashes(): void
     {
     }


### PR DESCRIPTION
Generally, psalm throws errors in cache.

However there were 2 places, where error_log was used/leftover from early versions. Changed now for consistency.