### PR TITLE
Fix DatePeriod tests for implementing IteratorAggregate

### DIFF
--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -86,23 +86,21 @@ class CoreStubsTest extends TestCase
             'error_levels' => [],
             'php_version' => '8.0',
         ];
-        yield 'DatePeriod implements only Traversable on PHP 7' => [
-            '<?php
-
-            $period = new DatePeriod("R4/2012-07-01T00:00:00Z/P7D");
-            if ($period instanceof IteratorAggregate) {}',
-            'assertions' => [],
-            'error_levels' => [],
-            'php_version' => '7.3',
-        ];
         yield 'DatePeriod implements IteratorAggregate on PHP 8' => [
             '<?php
-
             $period = new DatePeriod("R4/2012-07-01T00:00:00Z/P7D");
-            if ($period instanceof IteratorAggregate) {}',
-            'assertions' => [],
-            'error_levels' => ['RedundantCondition'],
+            $iterator = $period->getIterator();',
+            'assertions' => ['$iterator' => 'Traversable<int, DateTime>&Iterator'],
+            'error_levels' => [],
             'php_version' => '8.0',
         ];
+        yield 'DatePeriod implements only Traversable on PHP 7' => [
+        '<?php
+            $period = new DatePeriod("R4/2012-07-01T00:00:00Z/P7D");
+            $iterator = $period->getIterator();',
+            'assertions' => ['$iterator' => 'Traversable<empty, empty>'],
+            'error_levels' => [],
+            'php_version' => '7.3',
+         ];
     }
 }


### PR DESCRIPTION
I wrote them in a wrong way in #8312, so they are rewritten now as @AndrolGenhald advised in #8327.
But actually I'm quite surprised Psalm allows me to call `getIterator()` on a pure Traversable. It actually results in Fatal Error: https://3v4l.org/MEpb3 (But it's the only one way I've found to test it.)
Looks like PHP 8 stubs indeed leaks to PHP 7 environment somehow.