### PR TITLE
Allow any attribute for complex types in schema

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -130,6 +130,7 @@
         <xs:attribute name="disableSuppressAll" type="xs:boolean" default="false" />
         <xs:attribute name="triggerErrorExits" type="TriggerErrorExitsType" default="default" />
         <xs:attribute name="threads" type="xs:integer" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="ProjectFilesType">
@@ -138,24 +139,25 @@
             <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
             <xs:element name="ignoreFiles" minOccurs="0" maxOccurs="1" type="IgnoreFilesType" />
         </xs:choice>
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="TaintAnalysisType">
         <xs:choice maxOccurs="unbounded">
             <xs:element name="ignoreFiles" minOccurs="0" maxOccurs="1" type="IgnoreFilesType" />
         </xs:choice>
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="NameAttributeType">
         <xs:attribute name="name" type="xs:string" use="required" />
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="StubsAttributeType">
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="preloadClasses" type="xs:boolean" default="false" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="IgnoreFilesType">
@@ -165,14 +167,14 @@
         </xs:choice>
 
         <xs:attribute name="allowMissingFiles" type="xs:string" />
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="ProjectDirectoryAttributeType">
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="ignoreTypeStats" type="xs:string" />
         <xs:attribute name="useStrictTypes" type="xs:string" />
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="FileExtensionsType">
@@ -185,21 +187,21 @@
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="MockClassesType">
         <xs:sequence>
             <xs:element name="class" maxOccurs="unbounded" type="NameAttributeType" />
         </xs:sequence>
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="UniversalObjectCratesType">
         <xs:sequence>
             <xs:element name="class" maxOccurs="unbounded" type="NameAttributeType" />
         </xs:sequence>
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="ExceptionsType">
@@ -207,21 +209,21 @@
             <xs:element name="class" minOccurs="0" maxOccurs="unbounded" type="ExceptionType" />
             <xs:element name="classAndDescendants" minOccurs="0" maxOccurs="unbounded" type="ExceptionType" />
         </xs:sequence>
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="StubsType">
         <xs:sequence>
             <xs:element name="file" maxOccurs="unbounded" type="StubsAttributeType" />
         </xs:sequence>
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="ExitFunctionsType">
         <xs:sequence>
             <xs:element name="function" maxOccurs="unbounded" type="NameAttributeType" />
         </xs:sequence>
-        <xs:anyAttribute processContents="skip"/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="PluginsType">
@@ -229,6 +231,7 @@
             <xs:element name="plugin">
                 <xs:complexType>
                     <xs:attribute name="filename" type="xs:string" use="required" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
             <xs:element name="pluginClass">
@@ -237,10 +240,11 @@
                         <xs:any minOccurs="0" maxOccurs="unbounded" processContents="skip"/>
                     </xs:sequence>
                     <xs:attribute name="class" type="xs:string" use="required" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
         </xs:choice>
-        <xs:anyAttribute/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="IssueHandlersType">
@@ -527,7 +531,7 @@
             <xs:element name="UnusedReturnValue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="UnusedVariable" type="IssueHandlerType" minOccurs="0" />
         </xs:choice>
-        <xs:anyAttribute/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="IssueHandlerType">
@@ -540,11 +544,13 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
         <xs:attribute name="errorLevel" type="ErrorLevelType" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="PluginIssueHandlerType">
@@ -557,12 +563,14 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:anyAttribute processContents="skip"/>
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
         <xs:attribute name="errorLevel" type="ErrorLevelType" />
         <xs:attribute name="name" type="xs:string" use="required" />
+        <xs:anyAttribute processContents="skip"/>
     </xs:complexType>
 
     <xs:complexType name="MethodIssueHandlerType">
@@ -576,11 +584,13 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
         <xs:attribute name="errorLevel" type="ErrorLevelType" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="FunctionIssueHandlerType">
@@ -594,11 +604,13 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
         <xs:attribute name="errorLevel" type="ErrorLevelType" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="ArgumentIssueHandlerType">
@@ -612,11 +624,13 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
         <xs:attribute name="errorLevel" type="ErrorLevelType" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="ClassIssueHandlerType">
@@ -630,11 +644,13 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
         <xs:attribute name="errorLevel" type="ErrorLevelType" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="PropertyIssueHandlerType">
@@ -648,11 +664,13 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
         <xs:attribute name="errorLevel" type="ErrorLevelType" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="VariableIssueHandlerType">
@@ -666,28 +684,32 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
 
         <xs:attribute name="errorLevel" type="ErrorLevelType" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="GlobalsType">
         <xs:sequence>
             <xs:element name="var" maxOccurs="unbounded" type="IdentifierType" />
         </xs:sequence>
-        <xs:anyAttribute/>
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="IdentifierType">
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="type" type="xs:string" use="required" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:complexType name="ExceptionType">
         <xs:attribute name="name" type="xs:string" use="required" />
         <xs:attribute name="onlyGlobalScope" type="xs:string" />
+        <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
     <xs:simpleType name="ErrorLevelType">


### PR DESCRIPTION
I think we can use full power of [XInclude](https://www.w3.org/TR/xinclude/) and allow any attribute with `lax` or `skip` value in `processContents` attribute. This gives more flexibility of building dynamic configs.

For example, with current schema i can't use XInclude for issueHandlers configuration, because it has "anyAttribute" configuration, but without `processContents="lax"` or `processContents="skip"` attribute. This PR solves this problem and other problems like this