### PR TITLE
Allow *bin2hex and *bin2base64 functions to keep non-empty-string type

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -335,6 +335,22 @@ function fclose(&$stream) : bool
 }
 
 /**
+ * @psalm-pure
+ * @template T as string
+ * @param T $string
+ * @return (T is non-empty-string ? non-empty-string : string)
+ */
+function sodium_bin2base64(string $string, int $id): string
+
+/**
+ * @psalm-pure
+ * @template T as string
+ * @param T $string
+ * @return (T is non-empty-string ? non-empty-string : string)
+ */
+function sodium_bin2hex(string $string): string {}
+
+/**
  * @param string $string
  * @param-out null $string
  */
@@ -1308,8 +1324,20 @@ function base64_decode(string $string, bool $strict = false) {}
  * @psalm-pure
  *
  * @psalm-flow ($string) -> return
+ * @template T as string
+ * @param T $string
+ * @return (T is non-empty-string ? non-empty-string : string)
  */
 function base64_encode(string $string) : string {}
+
+/**
+ * @psalm-pure
+ *
+ * @template T as string
+ * @param T $string
+ * @return (T is non-empty-string ? non-empty-string : string)
+ */
+function bin2hex(string $string): string {}
 
 /**
  * @psalm-pure


### PR DESCRIPTION
Those functions should not return a string when they receive a non-empty-string in input.

The following example is expected to work:
```php
<?php

/**
 * @param non-empty-string $i
 */
function takesNonEmptyString(string $i): void {
    echo $i;
}

takesNonEmptyString(bin2hex("a"));
takesNonEmptyString(base64_encode("a"));
```

https://psalm.dev/r/0d5b2b3965