### PR TITLE
Add support for callable in array_reduce

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php
@@ -100,7 +100,7 @@ class ArrayReduceReturnTypeProvider implements FunctionReturnTypeProviderInterfa
 
         $initial_type = $reduce_return_type;
 
-        if ($closure_types = $function_call_arg_type->getClosureTypes()) {
+        if ($closure_types = $function_call_arg_type->getClosureTypes() ?: $function_call_arg_type->getCallableTypes()) {
             $closure_atomic_type = reset($closure_types);
 
             $closure_return_type = $closure_atomic_type->return_type ?: Type::getMixed();

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -565,6 +565,22 @@ class ClosureTest extends TestCase
                     '$result' => 'array{stdClass}'
                 ],
             ],
+            'CallableWithArrayReduce' => [
+                '<?php
+                    /**
+                     * @return callable(int, int): int
+                     */
+                    function maker() {
+                       return function(int $sum, int $e) {
+                          return $sum + $e;
+                       };
+                    }
+                    $maker = maker();
+                    $result = array_reduce([1, 2, 3], $maker, 0);',
+                'assertions' => [
+                    '$result' => 'int'
+                ],
+            ],
             'FirstClassCallable:NamedFunction:is_int' => [
                 '<?php
                     $closure = is_int(...);


### PR DESCRIPTION
Hi @orklah,

I applied the same fix than https://github.com/vimeo/psalm/pull/5373 but for array_reduce.

I assume another fix should be done to array_filter too.