### PR TITLE
trim(), ltrim(), rtrim() now keep lowercase string attribute

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -566,6 +566,12 @@ function strpos($haystack, $needle, int $offset = 0) : int {}
 /**
  * @psalm-pure
  *
+ * @return (
+ *      $string is class-string
+ *          ? ($characters is '\\' ? class-string : string)
+ *          : ($string is lowercase-string ? lowercase-string : string)
+ * )
+ *
  * @psalm-flow ($string) -> return
  */
 function trim(string $string, string $characters = " \t\n\r\0\x0B") : string {}
@@ -573,7 +579,11 @@ function trim(string $string, string $characters = " \t\n\r\0\x0B") : string {}
 /**
  * @psalm-pure
  *
- * @return ($string is class-string ? ($characters is '\\' ? class-string : string) : string)
+ * @return (
+ *      $string is class-string
+ *          ? ($characters is '\\' ? class-string : string)
+ *          : ($string is lowercase-string ? lowercase-string : string)
+ * )
  *
  * @psalm-flow ($string) -> return
  */
@@ -581,6 +591,8 @@ function ltrim(string $string, string $characters = " \t\n\r\0\x0B") : string {}
 
 /**
  * @psalm-pure
+ *
+ * @return ($string is lowercase-string ? lowercase-string : string)
  *
  * @psalm-flow ($string) -> return
  */

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1785,6 +1785,33 @@ class FunctionCallTest extends TestCase
                 [],
                 '8.0',
             ],
+            'trimSavesLowercaseAttribute' => [
+                '<?php
+                    $a = random_bytes(2);
+                    $b = trim(strtolower($a));
+                ',
+                'assertions' => [
+                    '$b===' => 'lowercase-string',
+                ],
+            ],
+            'ltrimSavesLowercaseAttribute' => [
+                '<?php
+                    $a = random_bytes(2);
+                    $b = ltrim(strtolower($a));
+                ',
+                'assertions' => [
+                    '$b===' => 'lowercase-string',
+                ],
+            ],
+            'rtrimSavesLowercaseAttribute' => [
+                '<?php
+                    $a = random_bytes(2);
+                    $b = rtrim(strtolower($a));
+                ',
+                'assertions' => [
+                    '$b===' => 'lowercase-string',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #8439 