### PR TITLE
Make ctype_digit and ctype_lower work as assertions

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -103,6 +103,8 @@ class AssertionFinder
         'is_scalar' => ['scalar', [Type::class, 'getScalar']],
         'is_iterable' => ['iterable'],
         'is_countable' => ['countable'],
+        'ctype_digit' => ['numeric-string', [Type::class, 'getNumericString']],
+        'ctype_lower' => ['non-empty-lowercase-string', [Type::class, 'getNonEmptyLowercaseString']],
     ];
 
     /**

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2848,6 +2848,58 @@ class ConditionalTest extends TestCase
                         return true;
                     }'
             ],
+            'ctypeDigitMakesStringNumeric' => [
+                '<?php
+                    /** @param numeric-string $num */
+                    function foo(string $num): void {}
+
+                    /** @param mixed $m */
+                    function bar(mixed $m): void
+                    {
+                        if (is_string($m) && ctype_digit($m)) {
+                            foo($m);
+                        }
+                    }
+                    ',
+            ],
+            'SKIPPED-ctypeDigitNarrowsIntToARange' => [
+                '<?php
+                    $int = rand(-1000, 1000);
+
+                    if (!ctype_digit($int)) {
+                        die;
+                    }
+                    ',
+                'assertions' => [
+                    '$int' => 'int<48, 57>|int<256, 1000>'
+                ]
+            ],
+            'ctypeLowerMakesStringLowercase' => [
+                '<?php
+                    /** @param non-empty-lowercase-string $num */
+                    function foo(string $num): void {}
+
+                    /** @param mixed $m */
+                    function bar($m): void
+                    {
+                        if (is_string($m) && ctype_lower($m)) {
+                            foo($m);
+                        }
+                    }
+                    ',
+            ],
+            'SKIPPED-ctypeLowerNarrowsIntToARange' => [
+                '<?php
+                    $int = rand(-1000, 1000);
+
+                    if (!ctype_lower($int)) {
+                        die;
+                    }
+                    ',
+                'assertions' => [
+                    '$int' => 'int<97, 122>'
+                ]
+            ],
         ];
     }
 


### PR DESCRIPTION
Make `ctype_digit` assert for `numeric-string`, and `ctype_lower` for `non-empty-lowercase-string`.
I've implemented it as @orklah advised it [here](https://github.com/vimeo/psalm/issues/8419#issuecomment-1218358112), but I've added two skipped tests that would fail with this naive implementation. It can be ignored though, because passing `int`s to `ctype_*` functions was deprecated in PHP 8.1.