### PR TITLE
improve cache code consistency and race conditions

### DIFF
--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -5,6 +5,7 @@ namespace Psalm\Internal\Provider;
 use Psalm\Config;
 use Psalm\Internal\Provider\Providers;
 use Psalm\Storage\ClassLikeStorage;
+use RuntimeException;
 use UnexpectedValueException;
 
 use function array_merge;
@@ -168,7 +169,16 @@ class ClassLikeStorageCacheProvider
         $parser_cache_directory = $root_cache_directory . DIRECTORY_SEPARATOR . self::CLASS_CACHE_DIRECTORY;
 
         if ($create_directory && !is_dir($parser_cache_directory)) {
-            mkdir($parser_cache_directory, 0777, true);
+            try {
+                mkdir($parser_cache_directory, 0777, true);
+            } catch (RuntimeException $e) {
+                // Race condition (#4483)
+                if (!is_dir($parser_cache_directory)) {
+                    // rethrow the error with default message
+                    // it contains the reason why creation failed
+                    throw $e;
+                }
+            }
         }
 
         $data = $file_path ? strtolower($file_path) . ' ' : '';

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -5,6 +5,7 @@ namespace Psalm\Internal\Provider;
 use Psalm\Config;
 use Psalm\Internal\Codebase\Analyzer;
 use Psalm\Internal\Provider\Providers;
+use RuntimeException;
 use UnexpectedValueException;
 
 use function file_exists;
@@ -12,6 +13,7 @@ use function file_put_contents;
 use function igbinary_serialize;
 use function igbinary_unserialize;
 use function is_array;
+use function is_dir;
 use function is_readable;
 use function mkdir;
 use function serialize;
@@ -992,18 +994,29 @@ class FileReferenceCacheProvider
     {
         $cache_directory = Config::getInstance()->getCacheDirectory();
 
-        if ($cache_directory) {
-            if (!file_exists($cache_directory)) {
-                mkdir($cache_directory, 0777, true);
-            }
-
-            $config_hash_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CONFIG_HASH_CACHE_NAME;
-
-            file_put_contents(
-                $config_hash_cache_location,
-                $hash,
-                LOCK_EX
-            );
+        if (!$cache_directory) {
+            return;
         }
+
+        if (!is_dir($cache_directory)) {
+            try {
+                mkdir($cache_directory, 0777, true);
+            } catch (RuntimeException $e) {
+                // Race condition (#4483)
+                if (!is_dir($cache_directory)) {
+                    // rethrow the error with default message
+                    // it contains the reason why creation failed
+                    throw $e;
+                }
+            }
+        }
+
+        $config_hash_cache_location = $cache_directory . DIRECTORY_SEPARATOR . self::CONFIG_HASH_CACHE_NAME;
+
+        file_put_contents(
+            $config_hash_cache_location,
+            $hash,
+            LOCK_EX
+        );
     }
 }

--- a/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
@@ -5,6 +5,7 @@ namespace Psalm\Internal\Provider;
 use Psalm\Config;
 use Psalm\Internal\Provider\Providers;
 use Psalm\Storage\FileStorage;
+use RuntimeException;
 use UnexpectedValueException;
 
 use function array_merge;
@@ -168,7 +169,16 @@ class FileStorageCacheProvider
         $parser_cache_directory = $root_cache_directory . DIRECTORY_SEPARATOR . self::FILE_STORAGE_CACHE_DIRECTORY;
 
         if ($create_directory && !is_dir($parser_cache_directory)) {
-            mkdir($parser_cache_directory, 0777, true);
+            try {
+                mkdir($parser_cache_directory, 0777, true);
+            } catch (RuntimeException $e) {
+                // Race condition (#4483)
+                if (!is_dir($parser_cache_directory)) {
+                    // rethrow the error with default message
+                    // it contains the reason why creation failed
+                    throw $e;
+                }
+            }
         }
 
         if (PHP_VERSION_ID >= 80100) {

--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -26,7 +26,7 @@ use function array_map;
 use function array_merge;
 use function count;
 use function filemtime;
-use function md5;
+use function hash;
 use function strlen;
 use function strpos;
 
@@ -132,7 +132,11 @@ class StatementsProvider
 
         $config = Config::getInstance();
 
-        $file_content_hash = md5($version . $file_contents);
+        if (PHP_VERSION_ID >= 80100) {
+            $file_content_hash = hash('xxh128', $version . $file_contents);
+        } else {
+            $file_content_hash = hash('md4', $version . $file_contents);
+        }
 
         if (!$this->parser_cache_provider
             || (!$config->isInProjectDirs($file_path) && strpos($file_path, 'vendor'))
@@ -239,7 +243,11 @@ class StatementsProvider
                     array_flip($unchanged_signature_members)
                 );
 
-                $file_path_hash = md5($file_path);
+                if (PHP_VERSION_ID >= 80100) {
+                    $file_path_hash = hash('xxh128', $file_path);
+                } else {
+                    $file_path_hash = hash('md4', $file_path);
+                }
 
                 $changed_members = array_map(
                     function (string $key) use ($file_path_hash): string {

--- a/tests/Internal/Provider/ParserInstanceCacheProvider.php
+++ b/tests/Internal/Provider/ParserInstanceCacheProvider.php
@@ -82,6 +82,15 @@ class ParserInstanceCacheProvider extends ParserCacheProvider
         $this->file_contents_cache[$file_path] = $file_contents;
     }
 
+    public function deleteOldParserCaches(float $time_before): int
+    {
+        $this->file_contents_cache = [];
+        $this->file_content_hash = [];
+        $this->statements_cache = [];
+        $this->statements_cache_time = [];
+        return 0;
+    }
+
     public function saveFileContentHashes(): void
     {
     }


### PR DESCRIPTION
* use consistent race condition dir creation code in all places in cache
* fix rare race condition on file cache unlink
* update leftover md5 in provider to commonly used hash
* use exceptions instead of error_log for ParserCacheProvider like all other cache providers do