### PR TITLE
make superglobals more specific

### DIFF
--- a/docs/running_psalm/issues/MixedArgument.md
+++ b/docs/running_psalm/issues/MixedArgument.md
@@ -6,5 +6,5 @@ Emitted when Psalm cannot determine the type of an argument
 <?php
 
 function takesInt(int $i) : void {}
-takesInt($_GET['foo']);
+takesInt($GLOBALS['foo']);
 ```

--- a/docs/running_psalm/issues/MixedArrayAccess.md
+++ b/docs/running_psalm/issues/MixedArrayAccess.md
@@ -5,5 +5,5 @@ Emitted when trying to access an array offset on a value whose type Psalm cannot
 ```php
 <?php
 
-echo $_GET['foo'][0];
+echo $GLOBALS['foo'][0];
 ```

--- a/docs/running_psalm/issues/MixedArrayAssignment.md
+++ b/docs/running_psalm/issues/MixedArrayAssignment.md
@@ -5,5 +5,5 @@ Emitted when trying to assign a value to an array offset on a value whose type P
 ```php
 <?php
 
-$_GET['foo'][0] = "5";
+$GLOBALS['foo'][0] = "5";
 ```

--- a/docs/running_psalm/issues/MixedArrayOffset.md
+++ b/docs/running_psalm/issues/MixedArrayOffset.md
@@ -5,5 +5,5 @@ Emitted when attempting to access an array offset where Psalm cannot determine t
 ```php
 <?php
 
-echo [1, 2, 3][$_GET['foo']];
+echo [1, 2, 3][$GLOBALS['foo']];
 ```

--- a/docs/running_psalm/issues/MixedAssignment.md
+++ b/docs/running_psalm/issues/MixedAssignment.md
@@ -6,7 +6,7 @@ cannot infer a type more specific than `mixed`.
 ```php
 <?php
 
-$a = $_GET['foo'];
+$a = $GLOBALS['foo'];
 ```
 
 ## How to fix
@@ -16,7 +16,7 @@ The above example can be fixed in a few ways – by adding an `assert` call:
 ```php
 <?php
 
-$a = $_GET['foo'];
+$a = $GLOBALS['foo'];
 assert(is_string($a));
 ```
 
@@ -25,7 +25,7 @@ or by adding an explicit cast:
 ```php
 <?php
 
-$a = (string) $_GET['foo'];
+$a = (string) $GLOBALS['foo'];
 ```
 
 or by adding a docblock
@@ -34,5 +34,5 @@ or by adding a docblock
 <?php
 
 /** @var string */
-$a = $_GET['foo'];
+$a = $GLOBALS['foo'];
 ```

--- a/docs/running_psalm/issues/MixedClone.md
+++ b/docs/running_psalm/issues/MixedClone.md
@@ -5,5 +5,5 @@ Emitted when trying to clone a value whose type is not known
 ```php
 <?php
 
-$a = clone $_GET["a"];
+$a = clone $GLOBALS["a"];
 ```

--- a/docs/running_psalm/issues/MixedFunctionCall.md
+++ b/docs/running_psalm/issues/MixedFunctionCall.md
@@ -6,6 +6,6 @@ Emitted when calling a function on a value whose type Psalm cannot infer.
 <?php
 
 /** @var mixed */
-$a = $_GET['foo'];
+$a = $GLOBALS['foo'];
 $a();
 ```

--- a/docs/running_psalm/issues/MixedInferredReturnType.md
+++ b/docs/running_psalm/issues/MixedInferredReturnType.md
@@ -6,6 +6,6 @@ Emitted when Psalm cannot determine a function's return type
 <?php
 
 function foo() : int {
-    return $_GET['foo'];
+    return $GLOBALS['foo'];
 }
 ```

--- a/docs/running_psalm/issues/MixedOperand.md
+++ b/docs/running_psalm/issues/MixedOperand.md
@@ -5,7 +5,7 @@ Emitted when Psalm cannot infer a type for an operand in any calculated expressi
 ```php
 <?php
 
-echo $_GET['foo'] + "hello";
+echo $GLOBALS['foo'] + "hello";
 ```
 
 ## Why it’s bad

--- a/docs/running_psalm/issues/MixedReturnStatement.md
+++ b/docs/running_psalm/issues/MixedReturnStatement.md
@@ -6,6 +6,6 @@ Emitted when Psalm cannot determine the type of a given return statement
 <?php
 
 function foo() : int {
-    return $_GET['foo']; // emitted here
+    return $GLOBALS['foo']; // emitted here
 }
 ```

--- a/docs/running_psalm/issues/MixedStringOffsetAssignment.md
+++ b/docs/running_psalm/issues/MixedStringOffsetAssignment.md
@@ -5,5 +5,5 @@ Emitted when assigning a value on a string using a value for which Psalm cannot 
 ```php
 <?php
 
-"hello"[0] = $_GET['foo'];
+"hello"[0] = $GLOBALS['foo'];
 ```

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1088,7 +1088,7 @@ class Codebase
             }
 
             if (strpos($symbol, '$') === 0) {
-                $type = VariableFetchAnalyzer::getGlobalType($symbol);
+                $type = VariableFetchAnalyzer::getGlobalType($symbol, $this->analysis_php_version_id);
                 if (!$type->isMixed()) {
                     return ['type' => '<?php ' . $type];
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -541,18 +541,28 @@ class VariableFetchAnalyzer
 
         if ($var_id === '$argv') {
             // only in CLI, null otherwise
-            return new Union([
+            $argv_nullable = new Union([
                 new TNonEmptyList(Type::getString()),
                 new TNull()
             ]);
+            // use TNull explicitly instead of this
+            // as it will cause weird errors due to ignore_nullable_issues true
+            // e.g. InvalidPropertyAssignmentValue
+            // $this->argv 'list<string>' cannot be assigned type 'non-empty-list<string>'
+            // $argv_nullable->possibly_undefined = true;
+            $argv_nullable->ignore_nullable_issues = true;
+            return $argv_nullable;
         }
 
         if ($var_id === '$argc') {
             // only in CLI, null otherwise
-            return new Union([
+            $argc_nullable = new Union([
                 new TIntRange(1, null),
                 new TNull()
             ]);
+            // $argc_nullable->possibly_undefined = true;
+            $argc_nullable->ignore_nullable_issues = true;
+            return $argc_nullable;
         }
 
         if (!self::isSuperGlobal($var_id)) {

--- a/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
@@ -33,6 +33,7 @@ class GlobalAnalyzer
             );
         }
 
+        $codebase = $statements_analyzer->getCodebase();
         $source = $statements_analyzer->getSource();
         $function_storage = $source instanceof FunctionLikeAnalyzer
             ? $source->getFunctionLikeStorage($statements_analyzer)
@@ -44,7 +45,8 @@ class GlobalAnalyzer
                     $var_id = '$' . $var->name;
 
                     if ($var->name === 'argv' || $var->name === 'argc') {
-                        $context->vars_in_scope[$var_id] = VariableFetchAnalyzer::getGlobalType($var_id);
+                        $context->vars_in_scope[$var_id] =
+                            VariableFetchAnalyzer::getGlobalType($var_id, $codebase->analysis_php_version_id);
                     } elseif (isset($function_storage->global_types[$var_id])) {
                         $context->vars_in_scope[$var_id] = clone $function_storage->global_types[$var_id];
                         $context->vars_possibly_in_scope[$var_id] = true;
@@ -52,7 +54,7 @@ class GlobalAnalyzer
                         $context->vars_in_scope[$var_id] =
                             $global_context && $global_context->hasVariable($var_id)
                                 ? clone $global_context->vars_in_scope[$var_id]
-                                : VariableFetchAnalyzer::getGlobalType($var_id);
+                                : VariableFetchAnalyzer::getGlobalType($var_id, $codebase->analysis_php_version_id);
 
                         $context->vars_possibly_in_scope[$var_id] = true;
 

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -117,7 +117,7 @@ class AssertionReconciler extends Reconciler
             && is_string($key)
             && VariableFetchAnalyzer::isSuperGlobal($key)
         ) {
-            $existing_var_type = VariableFetchAnalyzer::getGlobalType($key);
+            $existing_var_type = VariableFetchAnalyzer::getGlobalType($key, $codebase->analysis_php_version_id);
         }
 
         if ($existing_var_type === null) {

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -724,7 +724,7 @@ class ArrayAssignmentTest extends TestCase
             'mixedSwallowsArrayAssignment' => [
                 '<?php
                     /** @psalm-suppress MixedAssignment */
-                    $a = $_GET["foo"];
+                    $a = $GLOBALS["foo"];
 
                     /** @psalm-suppress MixedArrayAssignment */
                     $a["bar"] = "cool";

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1512,7 +1512,7 @@ class ArrayFunctionCallTest extends TestCase
                     $direct_closure_result = array_reduce(
                         $arr,
                         function (int $carry, int $item) {
-                            return $_GET["boo"];
+                            return $GLOBALS["boo"];
                         },
                         1
                     );',
@@ -2212,7 +2212,7 @@ class ArrayFunctionCallTest extends TestCase
                     $e = array_filter(
                         ["a" => 5, "b" => 12, "c" => null],
                         function(?int $i) {
-                            return $_GET["a"];
+                            return $GLOBALS["a"];
                         }
                     );',
                 'error_message' => 'MixedArgumentTypeCoercion',

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -513,7 +513,7 @@ class AssertAnnotationTest extends TestCase
                     }
 
                     /** @psalm-suppress MixedAssignment */
-                    $a = $_GET["a"];
+                    $a = $GLOBALS["a"];
 
                     assertIntOrFoo($a);
 

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -375,7 +375,7 @@ class AssertAnnotationTest extends TestCase
                         echo "Ma chaine " . $myString;
                     }',
             ],
-            'assertServerVar' => [
+            'assertSessionVar' => [
                 '<?php
                     namespace Bar;
 
@@ -388,8 +388,8 @@ class AssertAnnotationTest extends TestCase
                         return is_string($a);
                     }
 
-                    if (my_is_string($_SERVER["abc"])) {
-                        $i = substr($_SERVER["abc"], 1, 2);
+                    if (my_is_string($_SESSION["abc"])) {
+                        $i = substr($_SESSION["abc"], 1, 2);
                     }',
             ],
             'dontBleedBadAssertVarIntoContext' => [

--- a/tests/FileUpdates/TemporaryUpdateTest.php
+++ b/tests/FileUpdates/TemporaryUpdateTest.php
@@ -217,7 +217,7 @@ class TemporaryUpdateTest extends TestCase
                                 }
 
                                 public function bar() {
-                                    $a = $_GET["foo"];
+                                    $a = $GLOBALS["foo"];
                                     return $this->foo();
                                 }
                             }',
@@ -232,7 +232,7 @@ class TemporaryUpdateTest extends TestCase
                                 }
 
                                 public function bar() {
-                                    $a = $_GET["foo"];
+                                    $a = $GLOBALS["foo"];
                                     return $this->foo();
                                 }
                             }',
@@ -247,7 +247,7 @@ class TemporaryUpdateTest extends TestCase
                                 }
 
                                 public function bar() : int {
-                                    $a = $_GET["foo"];
+                                    $a = $GLOBALS["foo"];
                                     return $this->foo();
                                 }
                             }',
@@ -268,7 +268,7 @@ class TemporaryUpdateTest extends TestCase
                                 }
 
                                 public function bar() : int {
-                                    $a = $_GET["foo"];
+                                    $a = $GLOBALS["foo"];
                                     return $this->foo();
                                 }
                             }',
@@ -285,7 +285,7 @@ class TemporaryUpdateTest extends TestCase
                                 }
 
                                 public function bar() : int {
-                                    $a = $_GET["foo"];
+                                    $a = $GLOBALS["foo"];
                                     return $this->foo();
                                 }
                             }',
@@ -303,7 +303,7 @@ class TemporaryUpdateTest extends TestCase
                                 }
 
                                 public function bar() : int {
-                                    $a = $_GET["foo"];
+                                    $a = $GLOBALS["foo"];
                                     return $this->foo();
                                 }
                             }',

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -128,7 +128,7 @@ class FunctionCallTest extends TestCase
             'noRedundantConditionAfterMixedOrEmptyArrayCountCheck' => [
                 '<?php
                     function foo(string $s) : void {
-                        $a = $_GET["s"] ?: [];
+                        $a = $GLOBALS["s"] ?: [];
                         if (count($a)) {}
                         if (!count($a)) {}
                     }',
@@ -1037,7 +1037,7 @@ class FunctionCallTest extends TestCase
                     /** @psalm-suppress InvalidScalarArgument */
                     $a = mktime("foo");
                     /** @psalm-suppress MixedArgument */
-                    $b = mktime($_GET["foo"]);
+                    $b = mktime($GLOBALS["foo"]);
                     $c = mktime(1, 2, 3);',
                 'assertions' => [
                     '$a' => 'false|int',
@@ -1481,7 +1481,7 @@ class FunctionCallTest extends TestCase
                     $y2 = date("Y", 10000);
                     $F2 = date("F", 10000);
                     /** @psalm-suppress MixedArgument */
-                    $F3 = date("F", $_GET["F3"]);',
+                    $F3 = date("F", $GLOBALS["F3"]);',
                 [
                     '$y' => 'numeric-string',
                     '$m' => 'numeric-string',

--- a/tests/Internal/CliUtilsTest.php
+++ b/tests/Internal/CliUtilsTest.php
@@ -19,7 +19,7 @@ class CliUtilsTest extends TestCase
     protected function setUp(): void
     {
         global $argv;
-        $this->argv = $argv;
+        $this->argv = $argv ?? [];
     }
 
     protected function tearDown(): void

--- a/tests/Internal/CliUtilsTest.php
+++ b/tests/Internal/CliUtilsTest.php
@@ -12,14 +12,14 @@ use const DIRECTORY_SEPARATOR;
 class CliUtilsTest extends TestCase
 {
     /**
-     * @var array<int, string>
+     * @var list<string>
      */
     private $argv = [];
 
     protected function setUp(): void
     {
         global $argv;
-        $this->argv = $argv ?? [];
+        $this->argv = $argv;
     }
 
     protected function tearDown(): void

--- a/tests/JsonOutputTest.php
+++ b/tests/JsonOutputTest.php
@@ -123,11 +123,11 @@ class JsonOutputTest extends TestCase
             'assertCancelsMixedAssignment' => [
                 '<?php
                     $a = $_GET["hello"];
-                    assert(is_int($a));
-                    if (is_int($a)) {}',
-                'message' => 'Docblock-defined type int for $a is always int',
+                    assert(is_string($a));
+                    if (is_string($a)) {}',
+                'message' => 'Docblock-defined type string for $a is always string',
                 'line' => 4,
-                'error' => 'is_int($a)',
+                'error' => 'is_string($a)',
             ],
         ];
     }

--- a/tests/LanguageServer/SymbolLookupTest.php
+++ b/tests/LanguageServer/SymbolLookupTest.php
@@ -78,7 +78,7 @@ class SymbolLookupTest extends TestCase
                     return $a + $b;
                 }
 
-                $_SERVER;'
+                $_SESSION;'
         );
 
         new FileAnalyzer($this->project_analyzer, 'somefile.php', 'somefile.php');
@@ -111,9 +111,9 @@ class SymbolLookupTest extends TestCase
         $this->assertNotNull($information);
         $this->assertSame("<?php function B\qux(\n    int \$a,\n    int \$b\n) : int", $information['type']);
 
-        $information = $codebase->getSymbolInformation('somefile.php', '$_SERVER');
+        $information = $codebase->getSymbolInformation('somefile.php', '$_SESSION');
         $this->assertNotNull($information);
-        $this->assertSame("<?php array<array-key, mixed>", $information['type']);
+        $this->assertSame("<?php array<string, mixed>", $information['type']);
 
         $information = $codebase->getSymbolInformation('somefile.php', '$my_global');
         $this->assertNotNull($information);

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1213,7 +1213,7 @@ class ReturnTypeTest extends TestCase
                      * @psalm-suppress UndefinedClass
                      */
                     function fooFoo(): A {
-                        return $_GET["a"];
+                        return $GLOBALS["a"];
                     }
 
                     fooFoo()->bar();',

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -458,13 +458,6 @@ class TaintTest extends TestCase
 
                     echo $a[0]["b"];',
             ],
-            'intUntainted' => [
-                '<?php
-                    $input = $_GET[\'input\'];
-                    if (is_int($input)) {
-                        echo "$input";
-                    }',
-            ],
             'dontTaintSpecializedInstanceProperty' => [
                 '<?php
                     /** @psalm-taint-specialize */
@@ -672,7 +665,7 @@ class TaintTest extends TestCase
             ],
             'resultOfPlusIsNotTainted' => [
                 '<?php
-                    $input = $_GET["foo"];
+                    $input = is_numeric( $_GET["foo"] ) ? $_GET["foo"] : "";
                     $var = $input + 1;
                     var_dump($var);'
             ],
@@ -1611,7 +1604,15 @@ class TaintTest extends TestCase
                     function test(...$args) {
                         echo $args[0];
                     }
-                    test(...$_GET["other"]);',
+
+                    /**
+                     * @psalm-taint-source input
+                     */
+                    function getQueryParam() {}
+
+                    // cannot use $_GET, see #8477
+                    $foo = getQueryParam();
+                    test(...$foo);',
                 'error_message' => 'TaintedHtml',
             ],
             'foreachArg' => [

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -1425,7 +1425,7 @@ class ClassTemplateTest extends TestCase
                     }
 
                     /** @psalm-suppress MixedArgument */
-                    $c = new ArrayCollection($_GET["a"]);',
+                    $c = new ArrayCollection($GLOBALS["a"]);',
                 [
                     '$c' => 'ArrayCollection<array-key, mixed>',
                 ],

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -40,7 +40,7 @@ class ConditionalReturnTypeTest extends TestCase
                     $a = (new A)->getAttribute("colour", "red"); // typed as string
                     $b = (new A)->getAttribute(null); // typed as array<string, string>
                     /** @psalm-suppress MixedArgument */
-                    $c = (new A)->getAttribute($_GET["foo"]); // typed as string|array<string, string>',
+                    $c = (new A)->getAttribute($GLOBALS["foo"]); // typed as string|array<string, string>',
                 [
                     '$a' => 'string',
                     '$b' => 'array<string, string>',

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -768,10 +768,10 @@ class ConditionalTest extends TestCase
                         }
                     }',
             ],
-            'isStringServerVar' => [
+            'isStringSessionVar' => [
                 '<?php
-                    if (is_string($_SERVER["abc"])) {
-                        echo substr($_SERVER["abc"], 1, 2);
+                    if (is_string($_SESSION["abc"])) {
+                        echo substr($_SESSION["abc"], 1, 2);
                     }',
             ],
             'notObject' => [

--- a/tests/TypeReconciliation/EmptyTest.php
+++ b/tests/TypeReconciliation/EmptyTest.php
@@ -200,7 +200,7 @@ class EmptyTest extends TestCase
                 '<?php
                     function foo($t) : void {
                         if (empty($t)) {
-                            foreach ($_GET["u"] as $a) {
+                            foreach ($GLOBALS["u"] as $a) {
                                 if (empty($t)) {
                                     $t = $a;
                                 }

--- a/tests/fixtures/DummyProjectWithErrors/src/FileWithErrors.php
+++ b/tests/fixtures/DummyProjectWithErrors/src/FileWithErrors.php
@@ -24,5 +24,10 @@ function bang(string $s) : string {
 
 function boom(): void
 {
-    echo (string) ($_GET['abc'] ?? 'z');
+    echo (string) ($GLOBALS['abc'] ?? 'z');
+}
+
+function booom(): void
+{
+    echo isset($_GET['abc']) && is_string($_GET['abc']) ? $_GET['abc'] : 'z';
 }

--- a/tests/fixtures/expected_taint_graph.dot
+++ b/tests/fixtures/expected_taint_graph.dot
@@ -1,6 +1,9 @@
 digraph Taints {
-	"$_GET:src/FileWithErrors.php:345" -> "$_GET['abc']-src/FileWithErrors.php:345-349"
-	"$_GET['abc']-src/FileWithErrors.php:345-349" -> "coalesce-src/FileWithErrors.php:345-363"
+	"$_GET:src/FileWithErrors.php:413" -> "$_GET['abc']-src/FileWithErrors.php:413-417"
+	"$_GET:src/FileWithErrors.php:440" -> "$_GET['abc']-src/FileWithErrors.php:440-444"
+	"$_GET:src/FileWithErrors.php:456" -> "$_GET['abc']-src/FileWithErrors.php:456-460"
+	"$_GET['abc']-src/FileWithErrors.php:440-444" -> "call to is_string-src/FileWithErrors.php:440-451"
+	"$_GET['abc']-src/FileWithErrors.php:456-460" -> "call to echo-src/FileWithErrors.php:407-473"
 	"$s-src/FileWithErrors.php:109-110" -> "variable-use" -> "acme\sampleproject\bar"
 	"$s-src/FileWithErrors.php:162-163" -> "variable-use" -> "acme\sampleproject\baz"
 	"$s-src/FileWithErrors.php:215-216" -> "variable-use" -> "acme\sampleproject\bat"
@@ -10,6 +13,8 @@ digraph Taints {
 	"acme\sampleproject\bat#1" -> "$s-src/FileWithErrors.php:215-216"
 	"acme\sampleproject\baz#1" -> "$s-src/FileWithErrors.php:162-163"
 	"acme\sampleproject\foo#1" -> "$s-src/FileWithErrors.php:57-58"
-	"call to echo-src/FileWithErrors.php:335-364" -> "echo#1-src/filewitherrors.php:330"
-	"coalesce-src/FileWithErrors.php:345-363" -> "call to echo-src/FileWithErrors.php:335-364"
+	"call to echo-src/FileWithErrors.php:335-367" -> "echo#1-src/filewitherrors.php:330"
+	"call to echo-src/FileWithErrors.php:407-473" -> "echo#1-src/filewitherrors.php:402"
+	"call to is_string-src/FileWithErrors.php:440-451" -> "is_string#1-src/filewitherrors.php:430"
+	"coalesce-src/FileWithErrors.php:345-366" -> "call to echo-src/FileWithErrors.php:335-367"
 }


### PR DESCRIPTION
Make the types of superglobals like $_GET, $_POST,... more specific than "Mixed" to allow for simpler and stricter conditions and more effective psalm checks in many cases.