### PR TITLE
Improve error message to be more explicit

### DIFF
--- a/src/Psalm/Config/Creator.php
+++ b/src/Psalm/Config/Creator.php
@@ -201,7 +201,7 @@ class Creator
 
             if (!$replacements) {
                 throw new ConfigCreationException(
-                    'Could not located any PSR-0 or PSR-4-compatible paths in ' . $composer_json_location
+                    'Could not locate any PSR-0 or PSR-4-compatible paths with PHP files in ' . $composer_json_location
                 );
             }
         }


### PR DESCRIPTION
The [installation guide](https://github.com/bor0/psalm/blob/4.x/docs/running_psalm/installation.md) assumes the steps are executed in an already existing project. However, if you follow the steps in an empty folder, you will get the message about empty PSR paths which doesn't make it obvious what's going on. Adding a PHP file makes the error go away.

This PR improves the error message so that it's clear that in order for Psalm to work it has to have at least one PHP file.