### PR TITLE
Make Psalter add `@throws` annotation with properly namespaced exception

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -720,7 +720,14 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             }
 
             if (!$is_expected) {
-                $missingThrowsDocblockErrors[] = $possibly_thrown_exception;
+                $missing_docblock_exception = new TNamedObject($possibly_thrown_exception);
+                $missingThrowsDocblockErrors[] = $missing_docblock_exception->toNamespacedString(
+                    $this->source->getNamespace(),
+                    $this->source->getAliasedClassesFlipped(),
+                    $this->source->getFQCLN(),
+                    true
+                );
+
                 foreach ($codelocations as $codelocation) {
                     // issues are suppressed in ThrowAnalyzer, CallAnalyzer, etc.
                     IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -405,6 +405,7 @@ class FunctionDocblockManipulator
             $inferredThrowsClause = array_reduce(
                 $this->throwsExceptions,
                 function (string $throwsClause, string $exception) {
+                    $exception = '\\' . $exception;
                     return $throwsClause === '' ? $exception : $throwsClause.'|'.$exception;
                 },
                 ''

--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -405,7 +405,6 @@ class FunctionDocblockManipulator
             $inferredThrowsClause = array_reduce(
                 $this->throwsExceptions,
                 function (string $throwsClause, string $exception) {
-                    $exception = '\\' . $exception;
                     return $throwsClause === '' ? $exception : $throwsClause.'|'.$exception;
                 },
                 ''

--- a/tests/FileManipulation/ThrowsBlockAdditionTest.php
+++ b/tests/FileManipulation/ThrowsBlockAdditionTest.php
@@ -118,6 +118,30 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                 ['MissingThrowsDocblock'],
                 true,
             ],
+            'addThrowsAnnotationToFunctionInNamespace' => [
+                '<?php
+                    namespace Foo;
+                    function foo(string $s): string {
+                        if("" === $s) {
+                            throw new \InvalidArgumentException();
+                        }
+                        return $s;
+                    }',
+                '<?php
+                    namespace Foo;
+                    /**
+                     * @throws \InvalidArgumentException
+                     */
+                    function foo(string $s): string {
+                        if("" === $s) {
+                            throw new \InvalidArgumentException();
+                        }
+                        return $s;
+                    }',
+                '7.4',
+                ['MissingThrowsDocblock'],
+                true,
+            ],
         ];
     }
 }

--- a/tests/FileManipulation/ThrowsBlockAdditionTest.php
+++ b/tests/FileManipulation/ThrowsBlockAdditionTest.php
@@ -180,6 +180,46 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                 ['MissingThrowsDocblock'],
                 true,
             ],
+            'addThrowsAnnotationAccountsForUseStatements' => [
+                '<?php
+                    namespace Foo {
+                        use Bar\BarException;
+                        function foo(): void {
+                            bar();
+                        }
+                        /**
+                         * @throws BarException
+                         */
+                        function bar(): void {
+                            throw new BarException();
+                        }
+                    }
+                    namespace Bar {
+                        class BarException extends \DomainException {}
+                    }',
+                '<?php
+                    namespace Foo {
+                        use Bar\BarException;
+                        /**
+                         * @throws BarException
+                         */
+                        function foo(): void {
+                            bar();
+                        }
+                        /**
+                         * @throws BarException
+                         */
+                        function bar(): void {
+                            throw new BarException();
+                        }
+                    }
+                    namespace Bar {
+                        class BarException extends \DomainException {}
+                    }',
+                '7.4',
+                ['MissingThrowsDocblock'],
+                true,
+            ],
         ];
     }
 }

--- a/tests/FileManipulation/ThrowsBlockAdditionTest.php
+++ b/tests/FileManipulation/ThrowsBlockAdditionTest.php
@@ -142,6 +142,44 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                 ['MissingThrowsDocblock'],
                 true,
             ],
+            'addThrowsAnnotationToFunctionFromFunctionFromOtherNamespace' => [
+                '<?php
+                    namespace Foo {
+                        function foo(): void {
+                            \Bar\bar();
+                        }
+                    }
+                    namespace Bar {
+                        class BarException extends \DomainException {}
+                        /**
+                         * @throws BarException
+                         */
+                        function bar(): void {
+                            throw new BarException();
+                        }
+                    }',
+                '<?php
+                    namespace Foo {
+                        /**
+                         * @throws \Bar\BarException
+                         */
+                        function foo(): void {
+                            \Bar\bar();
+                        }
+                    }
+                    namespace Bar {
+                        class BarException extends \DomainException {}
+                        /**
+                         * @throws BarException
+                         */
+                        function bar(): void {
+                            throw new BarException();
+                        }
+                    }',
+                '7.4',
+                ['MissingThrowsDocblock'],
+                true,
+            ],
         ];
     }
 }

--- a/tests/FileManipulation/ThrowsBlockAdditionTest.php
+++ b/tests/FileManipulation/ThrowsBlockAdditionTest.php
@@ -20,7 +20,7 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                     }',
                 '<?php
                     /**
-                     * @throws \InvalidArgumentException
+                     * @throws InvalidArgumentException
                      */
                     function foo(string $s): string {
                         if("" === $s) {
@@ -45,7 +45,7 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                     }',
                 '<?php
                     /**
-                     * @throws \InvalidArgumentException|\DomainException
+                     * @throws InvalidArgumentException|DomainException
                      */
                     function foo(string $s): string {
                         if("" === $s) {
@@ -74,7 +74,7 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @throws InvalidArgumentException|DomainException
-                     * @throws \Exception
+                     * @throws Exception
                      */
                     function foo(string $s): string {
                         if("" === $s) {
@@ -103,7 +103,7 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @throws InvalidArgumentException
-                     * @throws \DomainException
+                     * @throws DomainException
                      */
                     function foo(string $s): string {
                         if("" === $s) {

--- a/tests/FileManipulation/ThrowsBlockAdditionTest.php
+++ b/tests/FileManipulation/ThrowsBlockAdditionTest.php
@@ -20,7 +20,7 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                     }',
                 '<?php
                     /**
-                     * @throws InvalidArgumentException
+                     * @throws \InvalidArgumentException
                      */
                     function foo(string $s): string {
                         if("" === $s) {
@@ -45,7 +45,7 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                     }',
                 '<?php
                     /**
-                     * @throws InvalidArgumentException|DomainException
+                     * @throws \InvalidArgumentException|\DomainException
                      */
                     function foo(string $s): string {
                         if("" === $s) {
@@ -74,7 +74,7 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @throws InvalidArgumentException|DomainException
-                     * @throws Exception
+                     * @throws \Exception
                      */
                     function foo(string $s): string {
                         if("" === $s) {
@@ -103,7 +103,7 @@ class ThrowsBlockAdditionTest extends FileManipulationTestCase
                 '<?php
                     /**
                      * @throws InvalidArgumentException
-                     * @throws DomainException
+                     * @throws \DomainException
                      */
                     function foo(string $s): string {
                         if("" === $s) {


### PR DESCRIPTION
Fixes  #8467.

I've added the test provided in #8467, fixed that by prefixing the classname with a backslash and updated other tests.

I'm not certain if the fix for the exception class is now in the right place, and if there are possibly utilities to solve this. If there are, I'd be happy to apply them.

Running `$ composer tests` failed because of the same reasons for which the current main branch fails.

