### PR TITLE
Fix mixed type hole when sending Foo<string> to Foo<mixed>

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.16",
         "slevomat/coding-standard": "^7.0",
+        "phpstan/phpdoc-parser": "1.6.4",
         "squizlabs/php_codesniffer": "^3.6",
         "symfony/process": "^4.3 || ^5.0 || ^6.0"
     },

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -38,6 +38,7 @@
             <file name="vendor/felixfbecker/advanced-json-rpc/lib/Dispatcher.php" />
             <directory name="vendor/netresearch/jsonmapper" />
             <directory name="vendor/phpunit" />
+            <file name="vendor/nikic/php-parser/lib/PhpParser/Node/UnionType.php" />
         </ignoreFiles>
     </projectFiles>
 

--- a/src/Psalm/Internal/LanguageServer/Client/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Client/TextDocument.php
@@ -57,6 +57,8 @@ class TextDocument
      * @param TextDocumentIdentifier $textDocument The document to get the content for
      *
      * @return Promise<TextDocumentItem> The document's current content
+     *
+     * @psalm-suppress MixedReturnTypeCoercion due to Psalm bug
      */
     public function xcontent(TextDocumentIdentifier $textDocument): Promise
     {

--- a/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
@@ -167,13 +167,7 @@ class GenericTypeComparator
                             ) {
                                 // do nothing
                             } else {
-                                if ($container_param->hasMixed() || $container_param->isArrayKey()) {
-                                    if ($atomic_comparison_result) {
-                                        $atomic_comparison_result->type_coerced_from_mixed = true;
-                                    }
-                                } else {
-                                    $all_types_contain = false;
-                                }
+                                $all_types_contain = false;
 
                                 if ($atomic_comparison_result) {
                                     $atomic_comparison_result->type_coerced = false;

--- a/tests/IfThisIsTest.php
+++ b/tests/IfThisIsTest.php
@@ -219,7 +219,7 @@ class IfThisIsTest extends TestCase
             'ifThisIsResolveTemplateParams' => [
                 'code' => '<?php
                     /**
-                     * @template T
+                     * @template-covariant T
                      */
                     final class Option
                     {
@@ -228,8 +228,8 @@ class IfThisIsTest extends TestCase
                     }
 
                     /**
-                     * @template L
-                     * @template R
+                     * @template-covariant L
+                     * @template-covariant R
                      */
                     final class Either
                     {

--- a/tests/Template/ClassTemplateExtendsTest.php
+++ b/tests/Template/ClassTemplateExtendsTest.php
@@ -987,15 +987,16 @@ class ClassTemplateExtendsTest extends TestCase
                         }
                     }
 
-                    /** @var SplObjectStorage<\stdClass, string> */
+                    /** @var SplObjectStorage<\stdClass, mixed> */
                     $storage = new SplObjectStorage();
                     new SomeService($storage);
 
                     $c = new \stdClass();
                     $storage[$c] = "hello";
+                    /** @psalm-suppress MixedAssignment */
                     $b = $storage->offsetGet($c);',
                 'assertions' => [
-                    '$b' => 'string',
+                    '$b' => 'mixed',
                 ],
             ],
             'extendsArrayIterator' => [

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -4600,6 +4600,23 @@ class ClassTemplateTest extends TestCase
                     final class Three {}',
                 'error_message' => 'InvalidReturnStatement - src' . DIRECTORY_SEPARATOR . 'somefile.php:12:40 - The inferred type \'T:A as One|Two\' ',
             ],
+            'preventMixedNestedCoercion' => [
+                'code' => '<?php
+                    /** @template T */
+                    class MyCollection {
+                        /** @param array<T> $members */
+                        public function __construct(public array $members) {}
+                    }
+
+                    /**
+                     * @param MyCollection<string> $c
+                     * @return MyCollection<mixed>
+                     */
+                    function getMixedCollection(MyCollection $c): MyCollection {
+                        return $c;
+                    }',
+                'error_message' => 'InvalidReturnStatement',
+            ],
         ];
     }
 }


### PR DESCRIPTION
This fixes a minor type hole that allowed `mixed` and `array-key` to bypass variance checks.