### PR TITLE
Make template constraints examples in docs consistent

### DIFF
--- a/docs/annotating_code/templated_annotations.md
+++ b/docs/annotating_code/templated_annotations.md
@@ -229,7 +229,7 @@ Templated types aren't limited to key-value pairs, and you can re-use templates 
 ```php
 <?php
 /**
- * @template T0 as array-key
+ * @template T0 of array-key
  *
  * @template-implements IteratorAggregate<T0, int>
  */

--- a/docs/annotating_code/type_syntax/conditional_types.md
+++ b/docs/annotating_code/type_syntax/conditional_types.md
@@ -18,7 +18,7 @@ Let's suppose we want to make a userland implementation of PHP's numeric additio
 <?php
 
 /**
- * @template T as int|float
+ * @template T of int|float
  * @param T $a
  * @param T $b
  * @return int|float
@@ -57,7 +57,7 @@ class A {
     const TYPE_INT = 1;
 
     /**
-     * @template T as int
+     * @template T of int
      * @param T $i
      * @psalm-return (
      *     T is self::TYPE_STRING

--- a/docs/running_psalm/issues/InvalidTemplateParam.md
+++ b/docs/running_psalm/issues/InvalidTemplateParam.md
@@ -6,7 +6,7 @@ Emitted when using the `@extends`/`@implements` annotation to extend a class tha
 <?php
 
 /**
- * @template T as object
+ * @template T of object
  */
 class Base {}
 

--- a/docs/running_psalm/issues/NonInvariantDocblockPropertyType.md
+++ b/docs/running_psalm/issues/NonInvariantDocblockPropertyType.md
@@ -42,7 +42,7 @@ You can either broaden the type or you could, in certain situations, use templat
 <?php
 
 /**
- * @template T as string|null
+ * @template T of string|null
  */
 abstract class A {
     /** @var T */


### PR DESCRIPTION
Currently the examples in the documentation for template constraints vary between two syntaxes, the `as <type>` & the `of <type>`. Even though both syntaxes are valid & do the same thing, only the `of <type>` [one is documented](https://github.com/vimeo/psalm/blob/9ed9c4b64ca91654e39a2f00bd61002d5e7a506b/docs/annotating_code/templated_annotations.md?plain=1#L208) (and probably the preferred syntax), which can be very confusing for newcomers who are using psalm for the first time.

This PR aims to remove those inconsistencies by using only the `of <type>` syntax in the docs.