### PR TITLE
Document the object with properties syntax

### DIFF
--- a/docs/annotating_code/type_syntax/atomic_types.md
+++ b/docs/annotating_code/type_syntax/atomic_types.md
@@ -21,6 +21,7 @@ Atomic types are the basic building block of all type information used in Psalm.
 ## [Object types](object_types.md)
 
 - [object](object_types.md)
+- [object{foo: string}](object_types.md)
 - [Exception, Foo\MyClass and Foo\MyClass<Bar>](object_types.md)
 - [Generator](object_types.md)
 

--- a/docs/annotating_code/type_syntax/object_types.md
+++ b/docs/annotating_code/type_syntax/object_types.md
@@ -2,6 +2,25 @@
 
 `object`, `stdClass`, `Foo`, `Bar\Baz` etc. are examples of object types. These types are also valid types in PHP.
 
+#### Object properties
+
+Psalm supports specifying the properties of an object and their expected types, e.g.:
+
+```php
+/** @param object{foo: string} $obj */
+function takesObject(object $obj) : string {
+    return $obj->foo;
+}
+
+takesObject((object) ["foo" => "hello"]);
+```
+
+Optional properties can be denoted by a trailing `?`, e.g.:
+
+```php
+/** @param object{optional?: string} */
+```
+
 #### Generic object types
 
 Psalm supports using generic object types like `ArrayObject<int, string>`. Any generic object should be typehinted with appropriate [`@template` tags](../templated_annotations.md).


### PR DESCRIPTION
Currently the object with properties syntax is not documented anywhere.