### PR TITLE
Fix type widening when `Any` assertion is used

### DIFF
--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -293,6 +293,10 @@ class AssertionReconciler extends Reconciler
 
         $old_var_type_string = $existing_var_type->getId();
 
+        if ($new_type_part instanceof TMixed) {
+            return $existing_var_type;
+        }
+
         $new_type_has_interface = false;
 
         if ($new_type_part->isObjectType()) {

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -105,7 +105,7 @@ class SimpleAssertionReconciler extends Reconciler
         int &$failed_reconciliation = Reconciler::RECONCILIATION_OK,
         bool $inside_loop = false
     ): ?Union {
-        if ($assertion instanceof Any && $existing_var_type->hasMixed()) {
+        if ($assertion instanceof Any) {
             return $existing_var_type;
         }
 

--- a/tests/TypeReconciliation/IssetTest.php
+++ b/tests/TypeReconciliation/IssetTest.php
@@ -188,6 +188,24 @@ class IssetTest extends TestCase
                         return $arr[$b];
                     }',
             ],
+            'issetWithCalculatedKeyAndEqualComparison' => [
+                'code' => '<?php
+                    /** @var array<string, string> $array */
+                    $array = [];
+
+                    function sameString(string $string): string {
+                        return $string;
+                    }
+
+                    if (isset($array[sameString("key")]) === false) {
+                        throw new \LogicException("No such key");
+                    }
+                    $value = $array[sameString("key")];
+                    ',
+                'assertions' => [
+                    '$value' => 'string',
+                ],
+            ],
             'issetArrayOffsetConditionalCreationWithInt' => [
                 'code' => '<?php
                     /** @param array<int, string> $arr */

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -9,6 +9,7 @@ use Psalm\Internal\Provider\NodeDataProvider;
 use Psalm\Internal\Type\AssertionReconciler;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Storage\Assertion;
+use Psalm\Storage\Assertion\Any;
 use Psalm\Storage\Assertion\Falsy;
 use Psalm\Storage\Assertion\IsIdentical;
 use Psalm\Storage\Assertion\IsLooselyEqual;
@@ -179,6 +180,7 @@ class ReconcilerTest extends TestCase
             'SimpleXMLElementNotAlwaysTruthy2' => ['SimpleXMLElement', new Falsy(), 'SimpleXMLElement'],
             'SimpleXMLIteratorNotAlwaysTruthy' => ['SimpleXMLIterator', new Truthy(), 'SimpleXMLIterator'],
             'SimpleXMLIteratorNotAlwaysTruthy2' => ['SimpleXMLIterator', new Falsy(), 'SimpleXMLIterator'],
+            'stringWithAny' => ['string', new Any(), 'string'],
         ];
     }
 


### PR DESCRIPTION
Fixes #8084

Also contains a related change to the reconcilers fast path where I believe an existing check is unnecessary.

PR targets the master branch. I have been unable to backport this to 4.x, the work done in the master branch makes this issue a lot easier to resolve.