### PR TITLE
add hideAllErrorsExceptPassedFiles config option

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -400,6 +400,14 @@ Useful in testing, this makes Psalm throw a regular-old exception when it encoun
 ```
 Whether or not to show issues in files that are used by your project files, but which are not included in `<projectFiles>`. Defaults to `false`.
 
+#### hideAllErrorsExceptPassedFiles
+```xml
+<psalm
+  hideAllErrorsExceptPassedFiles="[bool]"
+>
+```
+Whether or not to report issues only for files that were passed explicitly as arguments in CLI. This means any files that are loaded with require/include will not report either, if not set in CLI. Useful if you want to only check errors in a single or selected files. Defaults to `false`.
+
 #### cacheDirectory
 ```xml
 <psalm

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -295,6 +295,11 @@ class Config
      */
     public $hide_external_errors = false;
 
+    /**
+     * @var bool
+     */
+    public $hide_all_errors_except_passed_files = false;
+
     /** @var bool */
     public $allow_includes = true;
 
@@ -926,6 +931,7 @@ class Config
             'useDocblockPropertyTypes' => 'use_docblock_property_types',
             'throwExceptionOnError' => 'throw_exception',
             'hideExternalErrors' => 'hide_external_errors',
+            'hideAllErrorsExceptPassedFiles' => 'hide_all_errors_except_passed_files',
             'resolveFromConfigFile' => 'resolve_from_config_file',
             'allowFileIncludes' => 'allow_includes',
             'strictBinaryOperands' => 'strict_binary_operands',
@@ -1566,6 +1572,13 @@ class Config
         $dependent_files = [strtolower($file_path) => $file_path];
 
         $project_analyzer = ProjectAnalyzer::getInstance();
+
+        // if the option is set and at least one file is passed via CLI
+        if ($this->hide_all_errors_except_passed_files
+            && $project_analyzer->check_paths_files
+            && !in_array($file_path, $project_analyzer->check_paths_files, true)) {
+            return false;
+        }
 
         $codebase = $project_analyzer->getCodebase();
 

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -205,6 +205,11 @@ class ProjectAnalyzer
     public $provide_completion = false;
 
     /**
+     * @var list<string>
+     */
+    public $check_paths_files = [];
+
+    /**
      * @var array<string,string>
      */
     private $project_files = [];
@@ -1178,6 +1183,7 @@ class ProjectAnalyzer
             if (is_dir($path)) {
                 $this->checkDirWithConfig($path, $this->config, true);
             } elseif (is_file($path)) {
+                $this->check_paths_files[] = $path;
                 $this->codebase->addFilesToAnalyze([$path => $path]);
                 $this->config->hide_external_errors = $this->config->isInProjectDirs($path);
             }


### PR DESCRIPTION
for files only (not directories, since that wouldn't make practical sense)

Fix: https://github.com/vimeo/psalm/issues/5322