### PR TITLE
More specific superglobals feedback update

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -774,7 +774,7 @@ class VariableFetchAnalyzer
             // by default $_FILES is an empty array
             $default_type = new TArray([Type::getNever(), Type::getNever()]);
 
-            // ideally we would have 3 separate arrays with distinct types, but that isn't possible with psalm atm
+            // ideally we would have 4 separate arrays with distinct types, but that isn't possible with psalm atm
             return TypeCombiner::combine([$default_type, $type, $named_type]);
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -646,7 +646,7 @@ class VariableFetchAnalyzer
             $request_time_float_helper = Type::getFloat();
             $request_time_float_helper->possibly_undefined = true;
 
-            $bool_string_helper = new Union([new Bool(), new TString()]);
+            $bool_string_helper = new Union([new TBool(), new TString()]);
             $bool_string_helper->possibly_undefined = true;
 
             $detailed_type = new TKeyedArray([

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -23,6 +23,7 @@ use Psalm\Issue\UndefinedVariable;
 use Psalm\IssueBuffer;
 use Psalm\Type;
 use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TBool;
 use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TIntRange;
 use Psalm\Type\Atomic\TKeyedArray;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -746,7 +746,7 @@ class VariableFetchAnalyzer
                     new TNonEmptyList(Type::getString()),
                 ]),
                 'size' => new Union([
-                    new TInt(),
+                    new TIntRange(0, null),
                     new TNonEmptyList(Type::getInt()),
                 ]),
                 'tmp_name' => new Union([
@@ -754,7 +754,7 @@ class VariableFetchAnalyzer
                     new TNonEmptyList(Type::getString()),
                 ]),
                 'error' => new Union([
-                    new TInt(),
+                    new TIntRange(0, 8),
                     new TNonEmptyList(Type::getInt()),
                 ]),
             ];

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -646,8 +646,8 @@ class VariableFetchAnalyzer
             $request_time_float_helper = Type::getFloat();
             $request_time_float_helper->possibly_undefined = true;
 
-            $bool_helper = Type::getBool();
-            $bool_helper->possibly_undefined = true;
+            $bool_string_helper = new Union([new Bool(), new TString()]);
+            $bool_string_helper->possibly_undefined = true;
 
             $detailed_type = new TKeyedArray([
                 // https://www.php.net/manual/en/reserved.variables.server.php
@@ -724,7 +724,7 @@ class VariableFetchAnalyzer
                 'HTTP_SEC_CH_UA_MOBILE'   => $non_empty_string_helper,
                 'HTTP_SEC_CH_UA'          => $non_empty_string_helper,
                 // phpunit
-                'APP_DEBUG' => $bool_helper,
+                'APP_DEBUG' => $bool_string_helper,
                 'APP_ENV'   => $string_helper,
             ]);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -645,6 +645,9 @@ class VariableFetchAnalyzer
             $request_time_float_helper = Type::getFloat();
             $request_time_float_helper->possibly_undefined = true;
 
+            $bool_helper = Type::getBool();
+            $bool_helper->possibly_undefined = true;
+
             $detailed_type = new TKeyedArray([
                 // https://www.php.net/manual/en/reserved.variables.server.php
                 'PHP_SELF'             => $non_empty_string_helper,
@@ -719,6 +722,9 @@ class VariableFetchAnalyzer
                 'HTTP_SEC_CH_UA_PLATFORM' => $non_empty_string_helper,
                 'HTTP_SEC_CH_UA_MOBILE'   => $non_empty_string_helper,
                 'HTTP_SEC_CH_UA'          => $non_empty_string_helper,
+                // phpunit
+                'APP_DEBUG' => $bool_helper,
+                'APP_ENV'   => $string_helper,
             ]);
 
             // generic case for all other elements


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/8559
Fix https://github.com/vimeo/psalm/issues/8556

I think the `$_FILES` superglobal type is correct now, but absolute crap due to https://github.com/vimeo/psalm/discussions/8516

Ideally we would have 4 distinct array types for it like:

```
array<never, never> (= array{})
|array{error: int<0, 8>, name: string, size: int<0, max>, tmp_name: string, type: string}
|array{error: non-empty-list<int<0, 8>>, name: non-empty-list<string>, size: non-empty-list<int<0, max>>, tmp_name: non-empty-list<string>, type: non-empty-list<string>}
|array<string, array{error: int<0, 8>, name: string, size: int<0, max>, tmp_name: string, type: string}>
|array<string, array{error: non-empty-list<int<0, 8>>, name: non-empty-list<string>, size: non-empty-list<int<0, max>>, tmp_name: non-empty-list<string>, type: non-empty-list<string>}>
```

Feel free to make any changes necessary before merging, I won't have time until next weekend though.