### PR TITLE
Correct return type of DateTimeImmutable sub method stub

### DIFF
--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -58,8 +58,7 @@ class DateTimeImmutable implements DateTimeInterface
 
     /**
      * @psalm-mutation-free
-     * @return static|false this method can fail in case an {@see DateInterval} with relative
-     *                      week days is passed in.
+     * @return static
      *
      * @see https://github.com/php/php-src/blob/534127d3b22b193ffb9511c4447584f0d2bd4e24/ext/date/php_date.c#L3157-L3160
      */

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -59,8 +59,7 @@ class DateTimeImmutable implements DateTimeInterface
     /**
      * @psalm-mutation-free
      * @return static
-     *
-     * @see https://github.com/php/php-src/blob/534127d3b22b193ffb9511c4447584f0d2bd4e24/ext/date/php_date.c#L3157-L3160
+
      */
     public function sub(DateInterval $interval) {}
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -271,7 +271,7 @@ class MethodCallTest extends TestCase
 
                     $b = (new DateTimeImmutable())->modify("+3 hours");',
                 'assertions' => [
-                    '$yesterday' => 'MyDate|false',
+                    '$yesterday' => 'MyDate',
                     '$b' => 'DateTimeImmutable',
                 ],
             ],


### PR DESCRIPTION
Fixes #8484 

This tiny tweak corrects the return type of the DateTimeImmutable stub as it doesn't return false.

As seen [here](https://github.com/php/php-src/blob/534127d3b22b193ffb9511c4447584f0d2bd4e24/ext/date/php_date.c#L3157-L3160) sub never returns false and only a clone as mentioned by @AndrolGenhald

