### PR TITLE
Add additional checks for concat of non-empty strings to return non-falsy

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -199,9 +199,6 @@ class ConcatAnalyzer
                     $numeric_type
                 );
 
-                $numeric_type = Type::getNumericString();
-                $numeric_type->addType(new TInt());
-                $numeric_type->addType(new TFloat());
                 $right_is_numeric = UnionTypeComparator::isContainedBy(
                     $codebase,
                     $right_type,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -199,6 +199,17 @@ class ConcatAnalyzer
                     $numeric_type
                 );
 
+                $numeric_type = Type::getNumericString();
+                $numeric_type->addType(new TInt());
+                $numeric_type->addType(new TFloat());
+                $right_is_numeric = UnionTypeComparator::isContainedBy(
+                    $codebase,
+                    $right_type,
+                    $numeric_type
+                );
+
+                $has_numeric_type = $left_is_numeric || $right_is_numeric;
+
                 if ($left_is_numeric) {
                     $right_uint = Type::getPositiveInt();
                     $right_uint->addType(new TLiteralInt(0));
@@ -230,15 +241,22 @@ class ConcatAnalyzer
                 $non_empty_string = clone $numeric_type;
                 $non_empty_string->addType(new TNonEmptyString());
 
-                $has_non_empty = UnionTypeComparator::isContainedBy(
+                $left_non_empty = UnionTypeComparator::isContainedBy(
                     $codebase,
                     $left_type,
                     $non_empty_string
-                ) || UnionTypeComparator::isContainedBy(
+                );
+
+                $right_non_empty = UnionTypeComparator::isContainedBy(
                     $codebase,
                     $right_type,
                     $non_empty_string
                 );
+
+                $has_non_empty = $left_non_empty || $right_non_empty;
+                $all_non_empty = $left_non_empty && $right_non_empty;
+
+                $has_numeric_and_non_empty = $has_numeric_type && $has_non_empty;
 
                 $all_literals = $left_type->allLiterals() && $right_type->allLiterals();
 
@@ -248,7 +266,8 @@ class ConcatAnalyzer
                     } elseif ($all_lowercase) {
                         $result_type = Type::getNonEmptyLowercaseString();
                     } else {
-                        $result_type = Type::getNonEmptyString();
+                        $result_type = $all_non_empty || $has_numeric_and_non_empty ?
+                            Type::getNonFalsyString() : Type::getNonEmptyString();
                     }
                 } else {
                     if ($all_literals) {

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -34,6 +34,7 @@ use Psalm\Type\Atomic\TNever;
 use Psalm\Type\Atomic\TNonEmptyList;
 use Psalm\Type\Atomic\TNonEmptyLowercaseString;
 use Psalm\Type\Atomic\TNonEmptyString;
+use Psalm\Type\Atomic\TNonFalsyString;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TNumeric;
 use Psalm\Type\Atomic\TNumericString;
@@ -215,6 +216,13 @@ abstract class Type
     public static function getNonEmptyString(): Union
     {
         $type = new TNonEmptyString();
+
+        return new Union([$type]);
+    }
+
+    public static function getNonFalsyString(): Union
+    {
+        $type = new TNonFalsyString();
 
         return new Union([$type]);
     }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -830,6 +830,32 @@ class BinaryOperationTest extends TestCase
                         return ($foo instanceof FooInterface ? $foo->toString() : null) ?? "Not a stringable foo";
                     }',
             ],
+            'concatNonEmptyReturnNonFalsyString' => [
+                '<?php
+                    /** @var  non-empty-string $s1 */
+                    $s1 = "0";
+                    /** @var  non-empty-string $s1 */
+                    $s2 = "0";
+
+                    $a = $s1.$s2;',
+                'assertions' => [
+                    '$a===' => 'non-falsy-string',
+                ],
+            ],
+            'concatNumericWithNonEmptyReturnNonFalsyString' => [
+                '<?php
+                    /** @var  numeric-string $s1 */
+                    $s1 = "1";
+                    /** @var  non-empty-string $s2 */
+                    $s2 = "0";
+
+                    $a = $s1.$s2;
+                    $b = $s2.$s1;',
+                'assertions' => [
+                    '$a===' => 'non-falsy-string',
+                    '$b===' => 'non-falsy-string',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #8315 

This change adds some additional checks so:

- Concat of two non-empty-string types returns a non-falsy-string
- Concat of a non-empty-string and a numeric-string returns a non-falsy-string