### PR TITLE
Passing class template params to MethodParamsProviderEvent

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -237,7 +237,8 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             $template_result,
             $context,
             new CodeLocation($source, $stmt_name),
-            $statements_analyzer
+            $statements_analyzer,
+            $lhs_type_part
         ) === false) {
             return Type::getMixed();
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -278,7 +278,8 @@ class CallAnalyzer
         ?TemplateResult $class_template_result,
         Context $context,
         CodeLocation $code_location,
-        StatementsAnalyzer $statements_analyzer
+        StatementsAnalyzer $statements_analyzer,
+        ?Type\Atomic $lhs_type_part = null
     ): bool {
         $codebase = $statements_analyzer->getCodebase();
 
@@ -294,7 +295,15 @@ class CallAnalyzer
             ) !== false;
         }
 
-        $method_params = $codebase->methods->getMethodParams($method_id, $statements_analyzer, $args, $context);
+        $method_params = $codebase->methods->getMethodParams(
+            $method_id,
+            $statements_analyzer,
+            $args,
+            $context,
+            $lhs_type_part instanceof Type\Atomic\TGenericObject
+                ? $lhs_type_part->type_params
+                : null,
+        );
 
         $fq_class_name = $method_id->fq_class_name;
         $method_name = $method_id->method_name;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -302,7 +302,7 @@ class CallAnalyzer
             $context,
             $lhs_type_part instanceof Type\Atomic\TGenericObject
                 ? $lhs_type_part->type_params
-                : null,
+                : null
         );
 
         $fq_class_name = $method_id->fq_class_name;

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -359,7 +359,8 @@ class Methods
     }
 
     /**
-     * @param  list<PhpParser\Node\Arg> $args
+     * @param list<PhpParser\Node\Arg> $args
+     * @param ?list<Union> $templates
      *
      * @return list<FunctionLikeParameter>
      */
@@ -367,7 +368,8 @@ class Methods
         MethodIdentifier $method_id,
         ?StatementsSource $source = null,
         ?array $args = null,
-        ?Context $context = null
+        ?Context $context = null,
+        ?array $templates = null
     ): array {
         $fq_class_name = $method_id->fq_class_name;
         $method_name = $method_id->method_name;
@@ -378,7 +380,9 @@ class Methods
                 $method_name,
                 $args,
                 $source,
-                $context
+                $context,
+                null,
+                $templates
             );
 
             if ($method_params !== null) {

--- a/src/Psalm/Internal/Provider/MethodParamsProvider.php
+++ b/src/Psalm/Internal/Provider/MethodParamsProvider.php
@@ -12,6 +12,7 @@ use Psalm\Plugin\EventHandler\MethodParamsProviderInterface;
 use Psalm\Plugin\Hook\MethodParamsProviderInterface as LegacyMethodParamsProviderInterface;
 use Psalm\StatementsSource;
 use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type\Union;
 
 use function array_values;
 use function is_subclass_of;
@@ -100,9 +101,10 @@ class MethodParamsProvider
     }
 
     /**
-     * @param ?list<Arg>  $call_args
+     * @param ?list<Arg> $call_args
+     * @param ?list<Union> $templates
      *
-     * @return  ?list<FunctionLikeParameter>
+     * @return ?list<FunctionLikeParameter>
      */
     public function getMethodParams(
         string $fq_classlike_name,
@@ -110,7 +112,8 @@ class MethodParamsProvider
         ?array $call_args = null,
         ?StatementsSource $statements_source = null,
         ?Context $context = null,
-        ?CodeLocation $code_location = null
+        ?CodeLocation $code_location = null,
+        ?array $templates = null
     ): ?array {
         foreach (self::$legacy_handlers[strtolower($fq_classlike_name)] ?? [] as $class_handler) {
             $result = $class_handler(
@@ -134,7 +137,8 @@ class MethodParamsProvider
                 $call_args,
                 $statements_source,
                 $context,
-                $code_location
+                $code_location,
+                $templates
             );
             $result = $class_handler($event);
 

--- a/src/Psalm/Plugin/EventHandler/Event/MethodParamsProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/MethodParamsProviderEvent.php
@@ -6,6 +6,7 @@ use PhpParser;
 use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\StatementsSource;
+use Psalm\Type\Union;
 
 class MethodParamsProviderEvent
 {
@@ -34,8 +35,12 @@ class MethodParamsProviderEvent
      */
     private $code_location;
 
+    /** @var ?list<Union> */
+    private $templates;
+
     /**
-     * @param  list<PhpParser\Node\Arg>    $call_args
+     * @param list<PhpParser\Node\Arg> $call_args
+     * @param ?list<Union> $templates
      */
     public function __construct(
         string $fq_classlike_name,
@@ -43,7 +48,8 @@ class MethodParamsProviderEvent
         ?array $call_args = null,
         ?StatementsSource $statements_source = null,
         ?Context $context = null,
-        ?CodeLocation $code_location = null
+        ?CodeLocation $code_location = null,
+        ?array $templates = null
     ) {
         $this->fq_classlike_name = $fq_classlike_name;
         $this->method_name_lowercase = $method_name_lowercase;
@@ -51,6 +57,15 @@ class MethodParamsProviderEvent
         $this->statements_source = $statements_source;
         $this->context = $context;
         $this->code_location = $code_location;
+        $this->templates = $templates;
+    }
+
+    /**
+     * @return ?list<Union>
+     */
+    public function getTemplates(): ?array
+    {
+        return $this->templates;
     }
 
     public function getFqClasslikeName(): string

--- a/src/Psalm/Plugin/EventHandler/Event/MethodParamsProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/MethodParamsProviderEvent.php
@@ -63,7 +63,7 @@ class MethodParamsProviderEvent
     /**
      * @return ?list<Union>
      */
-    public function getTemplates(): ?array
+    public function getTemplateTypeParameters(): ?array
     {
         return $this->templates;
     }


### PR DESCRIPTION
Without templates in the `MethodParamsProvider` is difficult to do something helpful.

For example I want to support `mapN`, `flatMapN` and `etcN` methods in `Option` data class.
It's like `map`, `flatMap` but deconstruct input tuple.

```php
/** @var Option<array{int, int}> */
$option = ...;
$option->mapN(fn($a, $b) => $a + $b);
```

Without knowledge of `array{int, int}` inside `MethodParamsProvider` hook I can't do this.