### PR TITLE
Add stubs for ext-random (PHP 8.2)

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2169,6 +2169,11 @@ class Config
             $this->internal_stubs[] = $ext_apcu_path;
         }
 
+        if (extension_loaded('random')) {
+            $ext_random_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'ext-random.phpstub';
+            $this->internal_stubs[] = $ext_random_path;
+        }
+
         foreach ($this->internal_stubs as $stub_path) {
             if (!file_exists($stub_path)) {
                 throw new UnexpectedValueException('Cannot locate ' . $stub_path);

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1299,7 +1299,7 @@ class ProjectAnalyzer
      */
     public function setPhpVersion(string $version, string $source): void
     {
-        if (!preg_match('/^(5\.[456]|7\.[01234]|8\.[01])(\..*)?$/', $version)) {
+        if (!preg_match('/^(5\.[456]|7\.[01234]|8\.[012])(\..*)?$/', $version)) {
             throw new UnexpectedValueException('Expecting a version number in the format x.y');
         }
 

--- a/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
+++ b/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
@@ -37,7 +37,7 @@ use function version_compare;
 class InternalCallMapHandler
 {
     private const PHP_MAJOR_VERSION = 8;
-    private const PHP_MINOR_VERSION = 1;
+    private const PHP_MINOR_VERSION = 2;
     private const LOWEST_AVAILABLE_DELTA = 71;
 
     /**

--- a/stubs/extensions/ext-random.phpstub
+++ b/stubs/extensions/ext-random.phpstub
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ * PHP 8.2 introduces a new PHP extension named "random".
+ * @see https://github.com/php/php-src/blob/master/ext/random/random.stub.php
+ * @see https://php.watch/versions/8.2/ext-random
+ */
+
+namespace Random\Engine
+{
+    final class Mt19937 implements \Random\Engine
+    {
+        public function __construct(int|null $seed = null, int $mode = MT_RAND_MT19937) {}
+
+        /** @return non-empty-string */
+        public function generate(): string {}
+
+        public function __serialize(): array {}
+
+        public function __unserialize(array $data): void {}
+
+        public function __debugInfo(): array {}
+    }
+
+    final class PcgOneseq128XslRr64 implements \Random\Engine
+    {
+        public function __construct(string|int|null $seed = null) {}
+
+        public function generate(): string {}
+
+        public function jump(int $advance): void {}
+
+        public function __serialize(): array {}
+
+        public function __unserialize(array $data): void {}
+
+        public function __debugInfo(): array {}
+    }
+
+    final class Xoshiro256StarStar implements \Random\Engine
+    {
+        public function __construct(string|int|null $seed = null) {}
+
+        public function generate(): string {}
+
+        public function jump(): void {}
+
+        public function jumpLong(): void {}
+
+        public function __serialize(): array {}
+
+        public function __unserialize(array $data): void {}
+
+        public function __debugInfo(): array {}
+    }
+
+    final class Secure implements \Random\CryptoSafeEngine
+    {
+        public function generate(): string {}
+    }
+}
+
+namespace Random
+{
+    interface Engine
+    {
+        public function generate(): string;
+    }
+
+    interface CryptoSafeEngine extends Engine
+    {
+    }
+
+    final class Randomizer
+    {
+        public readonly Engine $engine;
+
+        public function __construct(?Engine $engine = null) {}
+
+        public function nextInt(): int {}
+
+        public function getInt(int $min, int $max): int {}
+
+        /**
+         * @param positive-int $length
+         * @return non-empty-string
+         */
+        public function getBytes(int $length): string {}
+
+        public function shuffleArray(array $array): array {}
+
+        public function shuffleBytes(string $bytes): string {}
+
+        public function pickArrayKeys(array $array, int $num): array {}
+
+        public function __serialize(): array {}
+
+        public function __unserialize(array $data): void {}
+    }
+
+    class RandomError extends \Error
+    {
+    }
+
+    class BrokenRandomEngineError extends RandomError
+    {
+    }
+
+    class RandomException extends \Exception
+    {
+    }
+}


### PR DESCRIPTION
Replaces another PR: https://github.com/vimeo/psalm/pull/8633 (this one uses `master` as base branch)
____
First, simple version of functionality introduced or moved to `ext-random`.

I'm new to make this sort of changes to Psalm and open for any suggestions (but prefer to spit changes into few PRs if it's possible).

At the first iteration it's almost a cope of https://github.com/php/php-src/blob/master/ext/random/random.stub.php