### PR TITLE
Mark hash_update functions as impure

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -524,6 +524,9 @@ class Functions
 
             //gettext
             'bindtextdomain',
+            
+            // hash
+            'hash_update', 'hash_update_file', 'hash_update_stream',
         ];
 
         if (in_array(strtolower($function_id), $impure_functions, true)) {


### PR DESCRIPTION
This prevents Psalm from marking calls to them as UnusedFunctionCall.