### PR TITLE
Making `json_encode()` always produce a `non-empty-string`, when successful

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -6586,7 +6586,7 @@ return [
 'join' => ['string', 'separator'=>'string', 'array'=>'array'],
 'join\'1' => ['string', 'separator'=>'array'],
 'json_decode' => ['mixed', 'json'=>'string', 'associative='=>'bool', 'depth='=>'int', 'flags='=>'int'],
-'json_encode' => ['string|false', 'value'=>'mixed', 'flags='=>'int', 'depth='=>'int'],
+'json_encode' => ['non-empty-string|false', 'value'=>'mixed', 'flags='=>'int', 'depth='=>'int'],
 'json_last_error' => ['int'],
 'json_last_error_msg' => ['string'],
 'JsonException::__clone' => ['void'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -12476,7 +12476,7 @@ return [
     'join\'1' => ['string', 'separator'=>'array'],
     'jpeg2wbmp' => ['bool', 'jpegname'=>'string', 'wbmpname'=>'string', 'dest_height'=>'int', 'dest_width'=>'int', 'threshold'=>'int'],
     'json_decode' => ['mixed', 'json'=>'string', 'associative='=>'bool', 'depth='=>'int', 'flags='=>'int'],
-    'json_encode' => ['string|false', 'value'=>'mixed', 'flags='=>'int', 'depth='=>'int'],
+    'json_encode' => ['non-empty-string|false', 'value'=>'mixed', 'flags='=>'int', 'depth='=>'int'],
     'json_last_error' => ['int'],
     'json_last_error_msg' => ['string'],
     'judy_type' => ['int', 'array'=>'judy'],

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1294,7 +1294,7 @@ function json_decode(string $json, ?bool $associative = null, int $depth = 512, 
 /**
  * @psalm-pure
  *
- * @return ($flags is 4194304 ? string : string|false)
+ * @return ($flags is 4194304 ? non-empty-string : non-empty-string|false)
  *
  * @psalm-flow ($value) -> return
  * @psalm-ignore-falsable-return


### PR DESCRIPTION
`json_encode()` never produces `''` as a value: that would be invalid JSON anyway