### PR TITLE
Emit `DeprecatedInterface` when interface is referenced in a generic

### DIFF
--- a/src/Psalm/Internal/TypeVisitor/TypeChecker.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeChecker.php
@@ -11,6 +11,7 @@ use Psalm\Internal\Analyzer\MethodAnalyzer;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\DeprecatedClass;
+use Psalm\Issue\DeprecatedInterface;
 use Psalm\Issue\InvalidTemplateParam;
 use Psalm\Issue\MissingTemplateParam;
 use Psalm\Issue\ReservedWord;
@@ -192,14 +193,25 @@ class TypeChecker extends TypeVisitor
             $class_storage = $codebase->classlike_storage_provider->get($fq_class_name_lc);
 
             if ($class_storage->deprecated) {
-                IssueBuffer::maybeAdd(
-                    new DeprecatedClass(
-                        'Class ' . $atomic->value . ' is marked as deprecated',
-                        $this->code_location,
-                        $atomic->value
-                    ),
-                    $this->source->getSuppressedIssues() + $this->suppressed_issues
-                );
+                if ($class_storage->is_interface) {
+                    IssueBuffer::maybeAdd(
+                        new DeprecatedInterface(
+                            'Interface ' . $atomic->value . ' is marked as deprecated',
+                            $this->code_location,
+                            $atomic->value
+                        ),
+                        $this->source->getSuppressedIssues() + $this->suppressed_issues
+                    );
+                } else {
+                    IssueBuffer::maybeAdd(
+                        new DeprecatedClass(
+                            'Class ' . $atomic->value . ' is marked as deprecated',
+                            $this->code_location,
+                            $atomic->value
+                        ),
+                        $this->source->getSuppressedIssues() + $this->suppressed_issues
+                    );
+                }
             }
         }
 

--- a/tests/DeprecatedAnnotationTest.php
+++ b/tests/DeprecatedAnnotationTest.php
@@ -289,7 +289,28 @@ class DeprecatedAnnotationTest extends TestCase
                 'error_message' => 'DeprecatedConstant',
                 'ignored_issues' => [],
                 'php_version' => '8.1',
-            ]
+            ],
+            'deprecatedInterfaceInGenerics' => [
+                'code' => '<?php
+                    /** @deprecated */
+                    interface MyInterface {}
+
+                    /** @extends ArrayObject<array-key, MyInterface> */
+                    class MyClass extends ArrayObject {}
+                ',
+                'error_message' => 'DeprecatedInterface',
+            ],
+            'deprecatedTrait' => [
+                'code' => '<?php
+                    /** @deprecated */
+                    trait T {}
+
+                    class C {
+                        use T;
+                    }
+                ',
+                'error_message' => 'DeprecatedTrait',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes vimeo/psalm#8617
