### PR TITLE
Make `stringable-object` equivalent to `Stringable`

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -190,7 +190,7 @@ class ArrayAnalyzer
                     && !$atomic_key_type instanceof TTemplateParam
                     && !(
                         $atomic_key_type instanceof TObjectWithProperties
-                        && isset($atomic_key_type->methods['__toString'])
+                        && isset($atomic_key_type->methods['__tostring'])
                     )
                 ) {
                     IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -632,9 +632,9 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
 
                 if ($lhs_type_part instanceof TObjectWithProperties
                     && $stmt->name instanceof PhpParser\Node\Identifier
-                    && isset($lhs_type_part->methods[$stmt->name->name])
+                    && isset($lhs_type_part->methods[strtolower($stmt->name->name)])
                 ) {
-                    $result->existent_method_ids[] = $lhs_type_part->methods[$stmt->name->name];
+                    $result->existent_method_ids[] = $lhs_type_part->methods[strtolower($stmt->name->name)];
                 } elseif (!$is_intersection) {
                     if ($stmt->name instanceof PhpParser\Node\Identifier) {
                         $codebase->analyzer->addMixedMemberName(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -808,7 +808,7 @@ class CastAnalyzer
                     }
 
                     if ($intersection_type instanceof TObjectWithProperties
-                        && isset($intersection_type->methods['__toString'])
+                        && isset($intersection_type->methods['__tostring'])
                     ) {
                         $castable_types[] = new TString();
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -832,7 +832,7 @@ class ArrayFetchAnalyzer
                             && !$atomic_key_type instanceof TTemplateParam
                             && !(
                                 $atomic_key_type instanceof TObjectWithProperties
-                                && isset($atomic_key_type->methods['__toString'])
+                                && isset($atomic_key_type->methods['__tostring'])
                             )
                         ) {
                             $bad_types[] = $atomic_key_type;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/MbInternalEncodingReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/MbInternalEncodingReturnTypeProvider.php
@@ -66,7 +66,7 @@ class MbInternalEncodingReturnTypeProvider implements FunctionReturnTypeProvider
             }
 
             if ($atomic_type instanceof Type\Atomic\TObjectWithProperties
-                && isset($atomic_type->methods['__toString'])
+                && isset($atomic_type->methods['__tostring'])
             ) {
                 $has_tostring = true;
                 continue;

--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -615,7 +615,7 @@ class AtomicTypeComparator
                     return true;
                 }
             } elseif ($input_type_part instanceof TObjectWithProperties
-                && isset($input_type_part->methods['__toString'])
+                && isset($input_type_part->methods['__tostring'])
             ) {
                 if ($atomic_comparison_result) {
                     $atomic_comparison_result->to_string_cast = true;

--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -215,6 +215,28 @@ class AtomicTypeComparator
             return true;
         }
 
+        if ($container_type_part instanceof TObjectWithProperties
+            && $container_type_part->is_stringable_object_only
+        ) {
+            if (($input_type_part instanceof TObjectWithProperties
+                    && $input_type_part->is_stringable_object_only)
+                || ($input_type_part instanceof TNamedObject
+                    && $codebase->methodExists(new MethodIdentifier($input_type_part->value, '__tostring')))
+            ) {
+                return true;
+            }
+            return false;
+        }
+
+        if ($container_type_part instanceof TNamedObject
+            && $container_type_part->value === 'Stringable'
+            && $codebase->analysis_php_version_id >= 8_00_00
+            && $input_type_part instanceof TObjectWithProperties
+            && $input_type_part->is_stringable_object_only
+        ) {
+            return true;
+        }
+
         if (($container_type_part instanceof TKeyedArray
                 && $input_type_part instanceof TKeyedArray)
             || ($container_type_part instanceof TObjectWithProperties

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -82,6 +82,7 @@ use function explode;
 use function get_class;
 use function min;
 use function strpos;
+use function strtolower;
 
 /**
  * This class receives a known type and an assertion (probably coming from AssertionFinder). The goal is to refine
@@ -802,10 +803,10 @@ class SimpleAssertionReconciler extends Reconciler
                         } elseif ($extra_type instanceof TObjectWithProperties) {
                             $match_found = true;
 
-                            if (!isset($extra_type->methods[$method_name])) {
+                            if (!isset($extra_type->methods[strtolower($method_name)])) {
                                 unset($extra_types[$k]);
                                 $extra_type = $extra_type->setMethods(array_merge($extra_type->methods, [
-                                    $method_name => 'object::' . $method_name
+                                    strtolower($method_name) => 'object::' . $method_name
                                 ]));
                                 $extra_types[$extra_type->getKey()] = $extra_type;
                                 $did_remove_type = true;
@@ -816,7 +817,7 @@ class SimpleAssertionReconciler extends Reconciler
                     if (!$match_found) {
                         $extra_type = new TObjectWithProperties(
                             [],
-                            [$method_name => $type->value . '::' . $method_name]
+                            [strtolower($method_name) => $type->value . '::' . $method_name]
                         );
                         $extra_types[$extra_type->getKey()] = $extra_type;
                         $did_remove_type = true;
@@ -826,9 +827,9 @@ class SimpleAssertionReconciler extends Reconciler
                 }
                 $object_types[] = $type;
             } elseif ($type instanceof TObjectWithProperties) {
-                if (!isset($type->methods[$method_name])) {
+                if (!isset($type->methods[strtolower($method_name)])) {
                     $type = $type->setMethods(array_merge($type->methods, [
-                        $method_name => 'object::' . $method_name
+                        strtolower($method_name) => 'object::' . $method_name
                     ]));
                     $did_remove_type = true;
                 }
@@ -836,7 +837,7 @@ class SimpleAssertionReconciler extends Reconciler
             } elseif ($type instanceof TObject || $type instanceof TMixed) {
                 $object_types[] = new TObjectWithProperties(
                     [],
-                    [$method_name =>  'object::' . $method_name]
+                    [strtolower($method_name) =>  'object::' . $method_name]
                 );
                 $did_remove_type = true;
             } elseif ($type instanceof TString) {

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -33,6 +33,9 @@ final class TObjectWithProperties extends TObject
      */
     public $methods;
 
+    /** @var bool */
+    public $is_stringable_object_only = false;
+
     /**
      * Constructs a new instance of a generic type
      *
@@ -50,6 +53,9 @@ final class TObjectWithProperties extends TObject
         $this->methods = $methods;
         $this->extra_types = $extra_types;
         $this->from_docblock = $from_docblock;
+
+        $this->is_stringable_object_only =
+            $this->properties === [] && $this->methods === ['__tostring' => 'string'];
     }
 
     /**
@@ -62,6 +68,10 @@ final class TObjectWithProperties extends TObject
         }
         $cloned = clone $this;
         $cloned->properties = $properties;
+
+        $cloned->is_stringable_object_only =
+            $cloned->properties === [] && $cloned->methods === ['__tostring' => 'string'];
+
         return $cloned;
     }
 
@@ -75,6 +85,10 @@ final class TObjectWithProperties extends TObject
         }
         $cloned = clone $this;
         $cloned->methods = $methods;
+
+        $cloned->is_stringable_object_only =
+            $cloned->properties === [] && $cloned->methods === ['__tostring' => 'string'];
+
         return $cloned;
     }
 

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -29,7 +29,7 @@ final class TObjectWithProperties extends TObject
     public $properties;
 
     /**
-     * @var array<string, string>
+     * @var array<lowercase-string, string>
      */
     public $methods;
 
@@ -37,7 +37,7 @@ final class TObjectWithProperties extends TObject
      * Constructs a new instance of a generic type
      *
      * @param array<string|int, Union> $properties
-     * @param array<string, string> $methods
+     * @param array<lowercase-string, string> $methods
      * @param array<string, TNamedObject|TTemplateParam|TIterable|TObjectWithProperties> $extra_types
      */
     public function __construct(
@@ -66,7 +66,7 @@ final class TObjectWithProperties extends TObject
     }
 
     /**
-     * @param array<string, string> $methods
+     * @param array<lowercase-string, string> $methods
      */
     public function setMethods(array $methods): self
     {

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -2536,6 +2536,12 @@ class ArrayFunctionCallTest extends TestCase
                 ',
                 'error_message' => 'RawObjectIteration',
             ],
+            'implodeWithNonStringableArgs' => [
+                'code' => '<?php
+                    implode(",", [new stdClass]);
+                ',
+                'error_message' => 'InvalidArgument',
+            ],
         ];
     }
 }

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1907,6 +1907,56 @@ class FunctionCallTest extends TestCase
                     '$b===' => 'lowercase-string',
                 ],
             ],
+            'passingStringableObjectToStringableParam' => [
+                'code' => '<?php
+                    function acceptsStringable(Stringable $_p): void {}
+                    /** @param stringable-object $p */
+                    function f(object $p): void
+                    {
+                        f($p);
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'passingStringableToStringableObjectParam' => [
+                'code' => '<?php
+                    /** @param stringable-object $_o */
+                    function acceptsStringableObject(object $_o): void {}
+
+                    function f(Stringable $o): void
+                    {
+                        acceptsStringableObject($o);
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'passingImplicitStringableObjectToStringableObjectParam' => [
+                'code' => '<?php
+                    /** @param stringable-object $o */
+                    function acceptsStringableObject(object $o): void {}
+
+                    class C { public function __toString(): string { return __CLASS__; }}
+
+                    acceptsStringableObject(new C);
+                ',
+            ],
+            'passingExplicitStringableObjectToStringableObjectParam' => [
+                'code' => '<?php
+                    /** @param stringable-object $o */
+                    function acceptsStringableObject(object $o): void {}
+
+                    class C implements Stringable { public function __toString(): string { return __CLASS__; }}
+
+                    acceptsStringableObject(new C);
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
         ];
     }
 
@@ -2457,7 +2507,35 @@ class FunctionCallTest extends TestCase
                 'error_message' => 'TypeDoesNotContainType',
                 'ignored_issues' => [],
                 'php_version' => '8.1',
-            ]
+            ],
+            'passingObjectToStringableObjectParam' => [
+                'code' => '<?php
+                    /** @param stringable-object $o */
+                    function acceptsStringableObject(object $o): void {}
+
+                    acceptsStringableObject((object)[]);
+                ',
+                'error_message' => 'InvalidArgument',
+            ],
+            'passingNonStringableObjectToStringableObjectParam' => [
+                'code' => '<?php
+                    /** @param stringable-object $o */
+                    function acceptsStringableObject(object $o): void {}
+
+                    class C {}
+                    acceptsStringableObject(new C);
+                ',
+                'error_message' => 'InvalidArgument',
+            ],
+            'passingStdClassToStringableObjectParam' => [
+                'code' => '<?php
+                    /** @param stringable-object $o */
+                    function acceptsStringableObject(object $o): void {}
+
+                    acceptsStringableObject(new stdClass);
+                ',
+                'error_message' => 'InvalidArgument',
+            ],
         ];
     }
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -454,7 +454,7 @@ class MethodCallTest extends TestCase
                     function foo(ReturnsString $user, $a): string {
                         strlen($user->getId());
 
-                        (is_object($a) && method_exists($a, "getS")) ? (string)$a->getS() : "";
+                        (is_object($a) && method_exists($a, "getS")) ? (string)$a->GETS() : "";
 
                         return $user->getId();
                     }',

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1118,6 +1118,42 @@ class ReturnTypeTest extends TestCase
                     }
                 ',
             ],
+            'returningExplicitStringableForStringableObjectReturnType' => [
+                'code' => '<?php
+                    class C implements Stringable { public function __toString(): string { return __CLASS__; } }
+
+                    /** @return stringable-object */
+                    function f(): object {
+                        return new C;
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'returningImplicitStringableForStringableObjectReturnType' => [
+                'code' => '<?php
+                    class C { public function __toString(): string { return __CLASS__; } }
+
+                    /** @return stringable-object */
+                    function f(): object {
+                        return new C;
+                    }
+                ',
+            ],
+            'returningStringableObjectForStringableReturnType' => [
+                'code' => '<?php
+                    class C implements Stringable { public function __toString(): string { return __CLASS__; } }
+
+                    /** @param stringable-object $p */
+                    function f(object $p): Stringable {
+                        return $p;
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes vimeo/psalm#8575
Supersedes vimeo/psalm#8595


There were a number of problems with `stringable-object` (`object{__tostring()}`) type used by `implode`/`join` stubs:

1. `stringable-object` type is repesented internally as `object{__tostring()}` (lowercase), but checks in various places were using `__toString` casing (note the capital `S`).
2. There was no support for checking sub/supertypes involving `stringable-object` and `Stringable` interface.
