### PR TITLE
Mark inferred mutation-free constructor as such

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -811,6 +811,7 @@ class FunctionLikeNodeScanner
         }
 
         $storage->external_mutation_free = true;
+        $storage->mutation_free_inferred = true;
 
         foreach ($assigned_properties as $property_name => $property_type) {
             $classlike_storage->properties[$property_name]->type = $property_type;

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -372,6 +372,32 @@ class ClassTest extends TestCase
                         }
                     }',
             ],
+            'markInferredMutationFreeDuringPropertyTypeInferenceAsActuallyInferred' => [
+                'code' => '<?php
+                    class A {}
+
+                    /**
+                     * @psalm-consistent-constructor
+                     */
+                    abstract class AbstractClass
+                    {
+                        protected $renderer;
+
+                        public function __construct(A $r)
+                        {
+                            $this->renderer = $r;
+                        }
+                    }
+
+                    class ConcreteClass extends AbstractClass
+                    {
+                        public function __construct(A $r)
+                        {
+                            parent::__construct($r);
+                        }
+                    }
+                ',
+            ],
             'interfaceExistsCreatesClassString' => [
                 'code' => '<?php
                     function funB(string $className) : ?ReflectionClass {


### PR DESCRIPTION
Previously Psalm treated those constructors as explicitly mutation-free,
and thus required descendant constructors to be explicitly marked too.

Fixes vimeo/psalm#8602
