### PR TITLE
improve cache flush debug info and code if cache disabled

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -64,6 +64,7 @@ use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_shift;
+use function clearstatcache;
 use function cli_set_process_title;
 use function count;
 use function defined;

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -348,15 +348,22 @@ class ProjectAnalyzer
 
     private function clearCacheDirectoryIfConfigOrComposerLockfileChanged(): void
     {
+        $cache_directory = $this->config->getCacheDirectory();
+        if ($cache_directory === null) {
+            return;
+        }
+
         if ($this->project_cache_provider
             && $this->project_cache_provider->hasLockfileChanged()
         ) {
-            $this->progress->debug(
-                'Composer lockfile change detected, clearing cache' . "\n"
-            );
+            // we only clear the cache if it actually exists
+            // if it's not populated yet, we don't clear anything but populate the cache instead
+            clearstatcache(true, $cache_directory);
+            if (is_dir($cache_directory)) {
+                $this->progress->debug(
+                    'Composer lockfile change detected, clearing cache directory ' . $cache_directory . "\n"
+                );
 
-            $cache_directory = $this->config->getCacheDirectory();
-            if ($cache_directory !== null) {
                 Config::removeCacheDirectory($cache_directory);
             }
 
@@ -368,12 +375,12 @@ class ProjectAnalyzer
         } elseif ($this->file_reference_provider->cache
             && $this->file_reference_provider->cache->hasConfigChanged()
         ) {
-            $this->progress->debug(
-                'Config change detected, clearing cache' . "\n"
-            );
+            clearstatcache(true, $cache_directory);
+            if (is_dir($cache_directory)) {
+                $this->progress->debug(
+                    'Config change detected, clearing cache directory ' . $cache_directory . "\n"
+                );
 
-            $cache_directory = $this->config->getCacheDirectory();
-            if ($cache_directory !== null) {
                 Config::removeCacheDirectory($cache_directory);
             }
 


### PR DESCRIPTION
When debugging the message didn't make sense when no cache directory exists yet, wasting time debugging why a config file changed (even though it didn't change, the cache just wasn't populated yet)

Also remove some duplicate code and bail earlier if cache directory is null, since all subsequent calls need it to not be null