### PR TITLE
Allow using imported types in other types within the same file

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -32,6 +32,7 @@ use Psalm\Storage\MethodStorage;
 use Psalm\Type;
 use UnexpectedValueException;
 
+use function array_merge;
 use function array_pop;
 use function end;
 use function explode;
@@ -187,7 +188,7 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements FileSour
                 return PhpParser\NodeTraverser::DONT_TRAVERSE_CHILDREN;
             }
 
-            $this->type_aliases += $classlike_node_scanner->type_aliases;
+            $this->type_aliases = array_merge($this->type_aliases, $classlike_node_scanner->type_aliases);
         } elseif ($node instanceof PhpParser\Node\Stmt\TryCatch) {
             foreach ($node->catches as $catch) {
                 foreach ($catch->types as $catch_type) {

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -629,6 +629,32 @@ class TypeAnnotationTest extends TestCase
                 'assertions' => [
                     '$output' => 'string',
                 ]
+            ],
+            'importedTypeUsedInOtherType' => [
+                'code' => '<?php
+                    /** @psalm-type OpeningTypes=self::TYPE_A|self::TYPE_B */
+                    class Foo {
+                        public const TYPE_A = 1;
+                        public const TYPE_B = 2;
+                    }
+
+                    /**
+                     * @psalm-import-type OpeningTypes from Foo
+                     * @psalm-type OpeningTypeAssignment=list<OpeningTypes>
+                     */
+                    class Main {
+                        /** @return OpeningTypeAssignment */
+                        public function doStuff(): array {
+                            return [];
+                        }
+                    }
+
+                    $instance = new Main();
+                    $output = $instance->doStuff();
+                ',
+                'assertions' => [
+                    '$output===' => 'list<1|2>',
+                ]
             ]
         ];
     }


### PR DESCRIPTION
In the test case (from issue #7116) both the type definition and the import of the typed lived in the same file. This caused `OpeningTypes` to be an `InlineTypeAlias` instead of a `LinkableTypeAlias`, in turn causing an 'Invalid type alias' exception[^1]

By replacing the array union (+) with an array_merge, the import of the type overrides the initial type declaration within the `Main` class. This means type imports within one file act more like they would when in separate files.

Fixes #7116

[^1]: [src/Psalm/Type/Atomic.php:407](https://github.com/vimeo/psalm/blob/1986c8b4a8018b1819bc4b83b0f7e69c2c936792/src/Psalm/Type/Atomic.php#L407)