### PR TITLE
include CLI args in PHP errors to more quickly identify run issues in CI

### DIFF
--- a/src/Psalm/Internal/Cli/LanguageServer.php
+++ b/src/Psalm/Internal/Cli/LanguageServer.php
@@ -62,7 +62,7 @@ final class LanguageServer
     public static function run(array $argv): void
     {
         gc_disable();
-        ErrorHandler::install();
+        ErrorHandler::install($argv);
         $valid_short_options = [
             'h',
             'v',

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -168,7 +168,7 @@ final class Psalm
         gc_collect_cycles();
         gc_disable();
 
-        ErrorHandler::install();
+        ErrorHandler::install($argv);
 
         $args = array_slice($argv, 1);
 
@@ -190,7 +190,6 @@ final class Psalm
             fwrite(STDERR, 'Too many config files provided' . PHP_EOL);
             exit(1);
         }
-
 
         if (array_key_exists('h', $options)) {
             echo self::getHelpText();

--- a/src/Psalm/Internal/Cli/Psalter.php
+++ b/src/Psalm/Internal/Cli/Psalter.php
@@ -97,7 +97,7 @@ final class Psalter
         gc_collect_cycles();
         gc_disable();
 
-        ErrorHandler::install();
+        ErrorHandler::install($argv);
 
         self::setMemoryLimit();
 

--- a/src/Psalm/Internal/Cli/Refactor.php
+++ b/src/Psalm/Internal/Cli/Refactor.php
@@ -72,7 +72,7 @@ final class Refactor
         gc_collect_cycles();
         gc_disable();
 
-        ErrorHandler::install();
+        ErrorHandler::install($argv);
 
         $args = array_slice($argv, 1);
 

--- a/src/Psalm/Internal/ErrorHandler.php
+++ b/src/Psalm/Internal/ErrorHandler.php
@@ -8,6 +8,7 @@ use Throwable;
 use function defined;
 use function error_reporting;
 use function fwrite;
+use function implode;
 use function ini_set;
 use function set_error_handler;
 use function set_exception_handler;
@@ -24,8 +25,15 @@ final class ErrorHandler
     /** @var bool */
     private static $exceptions_enabled = true;
 
-    public static function install(): void
+    /** @var string */
+    private static $args = '';
+
+    /**
+     * @param array<int,string> $argv
+     */
+    public static function install(array $argv = array()): void
     {
+        self::$args = implode(' ', $argv);
         self::setErrorReporting();
         self::installErrorHandler();
         self::installExceptionHandler();
@@ -67,7 +75,9 @@ final class ErrorHandler
         ): bool {
             if (ErrorHandler::$exceptions_enabled && ($error_code & error_reporting())) {
                 throw new RuntimeException(
-                    'PHP Error: ' . $error_message . ' in ' . $error_filename . ':' . $error_line,
+                    'PHP Error: ' . $error_message
+                    . ' in ' . $error_filename . ':' . $error_line
+                    . ' for command with CLI args "' . ErrorHandler::$args . '"',
                     $error_code
                 );
             }


### PR DESCRIPTION
When errors are collected in a general log, identifying the origin Psalm command requires multiple additional steps if Psalm encounters an PHP error. Including the CLI args in the error makes this much quicker.