### PR TITLE
Fix dictionary for strip_tags

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -13907,7 +13907,7 @@ return [
 'streamWrapper::unlink' => ['bool', 'path'=>'string'],
 'streamWrapper::url_stat' => ['array', 'path'=>'string', 'flags'=>'int'],
 'strftime' => ['string|false', 'format'=>'string', 'timestamp='=>'?int'],
-'strip_tags' => ['string', 'string'=>'string', 'allowed_tags='=>'string'],
+'strip_tags' => ['string', 'string'=>'string', 'allowed_tags='=>'string|list<non-empty-string>|null'],
 'stripcslashes' => ['string', 'string'=>'string'],
 'stripos' => ['int|false', 'haystack'=>'string', 'needle'=>'string', 'offset='=>'int'],
 'stripslashes' => ['string', 'string'=>'string'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -13907,7 +13907,7 @@ return [
 'streamWrapper::unlink' => ['bool', 'path'=>'string'],
 'streamWrapper::url_stat' => ['array', 'path'=>'string', 'flags'=>'int'],
 'strftime' => ['string|false', 'format'=>'string', 'timestamp='=>'?int'],
-'strip_tags' => ['string', 'string'=>'string', 'allowed_tags='=>'string'],
+'strip_tags' => ['string', 'string'=>'string', 'allowed_tags='=>'?string'],
 'stripcslashes' => ['string', 'string'=>'string'],
 'stripos' => ['int|false', 'haystack'=>'string', 'needle'=>'string', 'offset='=>'int'],
 'stripslashes' => ['string', 'string'=>'string'],

--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -13907,7 +13907,7 @@ return [
 'streamWrapper::unlink' => ['bool', 'path'=>'string'],
 'streamWrapper::url_stat' => ['array', 'path'=>'string', 'flags'=>'int'],
 'strftime' => ['string|false', 'format'=>'string', 'timestamp='=>'?int'],
-'strip_tags' => ['string', 'string'=>'string', 'allowed_tags='=>'?string'],
+'strip_tags' => ['string', 'string'=>'string', 'allowed_tags='=>'string'],
 'stripcslashes' => ['string', 'string'=>'string'],
 'stripos' => ['int|false', 'haystack'=>'string', 'needle'=>'string', 'offset='=>'int'],
 'stripslashes' => ['string', 'string'=>'string'],

--- a/dictionaries/CallMap_74_delta.php
+++ b/dictionaries/CallMap_74_delta.php
@@ -45,6 +45,10 @@ return [
       'old' => ['resource|false', 'command'=>'string', 'descriptor_spec'=>'array', '&pipes'=>'resource[]', 'cwd='=>'?string', 'env_vars='=>'?array', 'options='=>'?array'],
       'new' => ['resource|false', 'command'=>'string|array', 'descriptor_spec'=>'array', '&pipes'=>'resource[]', 'cwd='=>'?string', 'env_vars='=>'?array', 'options='=>'?array'],
     ],
+    'strip_tags' => [
+      'old' => ['string', 'string'=>'string', 'allowed_tags='=>'?string'],
+      'new' => ['string', 'string'=>'string', 'allowed_tags='=>'string|null|list<non-empty-string>'],
+    ],
   ],
   'removed' => [
   ],

--- a/dictionaries/CallMap_74_delta.php
+++ b/dictionaries/CallMap_74_delta.php
@@ -46,8 +46,8 @@ return [
       'new' => ['resource|false', 'command'=>'string|array', 'descriptor_spec'=>'array', '&pipes'=>'resource[]', 'cwd='=>'?string', 'env_vars='=>'?array', 'options='=>'?array'],
     ],
     'strip_tags' => [
-      'old' => ['string', 'string'=>'string', 'allowed_tags='=>'?string'],
-      'new' => ['string', 'string'=>'string', 'allowed_tags='=>'string|null|list<non-empty-string>'],
+      'old' => ['string', 'string'=>'string', 'allowed_tags='=>'string'],
+      'new' => ['string', 'string'=>'string', 'allowed_tags='=>'string|list<non-empty-string>'],
     ],
   ],
   'removed' => [

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -1381,6 +1381,10 @@ return [
       'old' => ['string|false', 'format'=>'string', 'timestamp='=>'int'],
       'new' => ['string|false', 'format'=>'string', 'timestamp='=>'?int'],
     ],
+    'strip_tags' => [
+      'old' => ['string', 'string'=>'string', 'allowed_tags='=>'string|list<non-empty-string>'],
+      'new' => ['string', 'string'=>'string', 'allowed_tags='=>'string|list<non-empty-string>|null'],
+    ],
     'stripos' => [
       'old' => ['int|false', 'haystack'=>'string', 'needle'=>'string|int', 'offset='=>'int'],
       'new' => ['int|false', 'haystack'=>'string', 'needle'=>'string', 'offset='=>'int'],


### PR DESCRIPTION
Changes:
 - allow null for 2nd parameter `$allowed_tags` from PHP 8.0 (see [docs](https://www.php.net/manual/en/function.strip-tags.php#refsect1-function.strip-tags-changelog))
 - allow array for 2nd parameter `$allowed_tags` from PHP 7.4 (see [docs](https://www.php.net/manual/en/function.strip-tags.php#refsect1-function.strip-tags-changelog))

Proofs:
 - https://3v4l.org/VjbXO
 - https://3v4l.org/VWsPr