### PR TITLE
Argument 1 of curl_unescape

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1696,7 +1696,7 @@ return [
 'curl_share_strerror' => ['?string', 'error_code'=>'int'],
 'curl_strerror' => ['?string', 'error_code'=>'int'],
 'curl_upkeep' => ['bool', 'handle'=>'CurlHandle'],
-'curl_unescape' => ['string|false', 'handle'=>'CurlShareHandle', 'string'=>'string'],
+'curl_unescape' => ['string|false', 'handle'=>'CurlHandle', 'string'=>'string'],
 'curl_version' => ['array', 'version='=>'int'],
 'CURLFile::__construct' => ['void', 'filename'=>'string', 'mimetype='=>'string', 'postfilename='=>'string'],
 'CURLFile::__wakeup' => ['void'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -347,7 +347,7 @@ return [
     ],
     'curl_unescape' => [
       'old' => ['string|false', 'ch'=>'resource', 'string'=>'string'],
-      'new' => ['string|false', 'handle'=>'CurlShareHandle', 'string'=>'string'],
+      'new' => ['string|false', 'handle'=>'CurlHandle', 'string'=>'string'],
     ],
     'date' => [
       'old' => ['string', 'format'=>'string', 'timestamp='=>'int'],


### PR DESCRIPTION
Fixes error:

> Argument 1 of curl_unescape expects CurlShareHandle, but CurlHandle|false provided

https://www.php.net/manual/en/function.curl-unescape.php