### PR TITLE
Allow parameter types to be contained by a class template type 

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -1096,10 +1096,6 @@ class CallAnalyzer
                                         $statements_analyzer->getCodebase(),
                                         $lower_bound->type,
                                         $bound_with_equality->type
-                                    ) && UnionTypeComparator::isContainedBy(
-                                        $statements_analyzer->getCodebase(),
-                                        $bound_with_equality->type,
-                                        $lower_bound->type
                                     )) {
                                         continue 2;
                                     }

--- a/tests/Template/FunctionTemplateTest.php
+++ b/tests/Template/FunctionTemplateTest.php
@@ -1658,6 +1658,8 @@ class FunctionTemplateTest extends TestCase
                     }
 
                     normalizeField("foo", new StringNorm());',
+                'assertions' => [],
+                'ignored_issues' => [],
                 'php_version' => '8.0'
             ]
         ];

--- a/tests/Template/FunctionTemplateTest.php
+++ b/tests/Template/FunctionTemplateTest.php
@@ -1657,7 +1657,8 @@ class FunctionTemplateTest extends TestCase
                         $n->normalize($value);
                     }
 
-                    normalizeField("foo", new StringNorm());'
+                    normalizeField("foo", new StringNorm());',
+                'php_version' => '8.0'
             ]
         ];
     }

--- a/tests/Template/FunctionTemplateTest.php
+++ b/tests/Template/FunctionTemplateTest.php
@@ -1621,6 +1621,44 @@ class FunctionTemplateTest extends TestCase
                         return $p - 1;
                     }'
             ],
+            'literalIsAlwaysContainedInString' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     */
+                    interface Norm
+                    {
+                        /**
+                         * @param T $input
+                         * @return T
+                         */
+                        public function normalize(mixed $input): mixed;
+                    }
+
+                    /**
+                     * @implements Norm<string>
+                     */
+                    class StringNorm implements Norm
+                    {
+                        public function normalize(mixed $input): mixed
+                        {
+                            return strtolower($input);
+                        }
+                    }
+
+                    /**
+                     * @template TNorm
+                     *
+                     * @param TNorm $value
+                     * @param Norm<TNorm> $n
+                     */
+                    function normalizeField(mixed $value, Norm $n): void
+                    {
+                        $n->normalize($value);
+                    }
+
+                    normalizeField("foo", new StringNorm());'
+            ]
         ];
     }
 


### PR DESCRIPTION
... in template function calls.

Not sure why the original logic checked for equality (in a weird way by actually checking A⊆B and B⊆A, not by actually running B==A with equals).

Fixes https://github.com/vimeo/psalm/issues/8732