### PR TITLE
Correct `Clause::$hash` type

### DIFF
--- a/src/Psalm/Internal/Clause.php
+++ b/src/Psalm/Internal/Clause.php
@@ -81,7 +81,7 @@ class Clause
     /** @var array<string, bool> */
     public $redefined_vars = [];
 
-    /** @var string|int */
+    /** @var string */
     public $hash;
 
     /**


### PR DESCRIPTION
Fixes vimeo/psalm#7706
