### PR TITLE
Switch from `phpspec/prophecy` to `mockery/mockery`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,11 @@
         "dnoegel/php-xdg-base-dir": "^0.1.1",
         "felixfbecker/advanced-json-rpc": "^3.1",
         "felixfbecker/language-server-protocol": "^1.5",
+        "mockery/mockery": "^1.5",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
         "nikic/php-parser": "^4.13",
         "openlss/lib-array2xml": "^1.0",
+        "psalm/plugin-mockery": "^0.10.0",
         "sebastian/diff": "^4.0",
         "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
         "symfony/filesystem": "^5.4 || ^6.0",
@@ -47,15 +49,12 @@
         "brianium/paratest": "^4.0||^6.0",
         "nunomaduro/mock-final-classes": "^1.1",
         "php-parallel-lint/php-parallel-lint": "^1.2",
-        "phpspec/prophecy": "^1.15",
-        "phpspec/prophecy-phpunit": "^2.0",
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-phpunit": "^0.18",
         "slevomat/coding-standard": "^7.0",
         "phpstan/phpdoc-parser": "1.6.4",
         "squizlabs/php_codesniffer": "^3.6",
-        "symfony/process": "^4.3 || ^5.0 || ^6.0",
-        "weirdan/prophecy-shim": "^1.0 || ^2.0"
+        "symfony/process": "^4.3 || ^5.0 || ^6.0"
     },
     "suggest": {
         "ext-igbinary": "^2.0.5 is required, used to serialize caching data",

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
         "nikic/php-parser": "^4.13",
         "openlss/lib-array2xml": "^1.0",
-        "psalm/plugin-mockery": "^0.10.0",
+        "psalm/plugin-mockery": "^1.1",
         "sebastian/diff": "^4.0",
         "symfony/console": "^3.4.17 || ^4.1.6 || ^5.0 || ^6.0",
         "symfony/filesystem": "^5.4 || ^6.0",

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -38,6 +38,7 @@
             <file name="vendor/felixfbecker/advanced-json-rpc/lib/Dispatcher.php" />
             <directory name="vendor/netresearch/jsonmapper" />
             <directory name="vendor/phpunit" />
+            <directory name="vendor/mockery/mockery"/>
             <file name="vendor/nikic/php-parser/lib/PhpParser/Node/UnionType.php" />
         </ignoreFiles>
     </projectFiles>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -52,6 +52,7 @@
         <plugin filename="examples/plugins/FunctionCasingChecker.php"/>
         <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
         <plugin filename="examples/plugins/InternalChecker.php"/>
+        <pluginClass class="Psalm\MockeryPlugin\Plugin"/>
     </plugins>
 
     <issueHandlers>

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2176,7 +2176,7 @@ class Config
         }
 
         if (extension_loaded('random')) {
-            $ext_random_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'ext-random.phpstub';
+            $ext_random_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'extensions' . DIRECTORY_SEPARATOR . 'ext-random.phpstub';
             $this->internal_stubs[] = $ext_random_path;
         }
 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2176,7 +2176,8 @@ class Config
         }
 
         if (extension_loaded('random')) {
-            $ext_random_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'extensions' . DIRECTORY_SEPARATOR . 'ext-random.phpstub';
+            $ext_random_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR
+                . 'extensions' . DIRECTORY_SEPARATOR . 'ext-random.phpstub';
             $this->internal_stubs[] = $ext_random_path;
         }
 

--- a/src/Psalm/Type/MutableUnion.php
+++ b/src/Psalm/Type/MutableUnion.php
@@ -212,6 +212,9 @@ final class MutableUnion implements TypeNode, Stringable
      */
     public $different = false;
 
+    /** @psalm-suppress PossiblyUnusedProperty */
+    public bool $propagate_parent_nodes = false;
+
     /**
      * @psalm-external-mutation-free
      * @param non-empty-array<Atomic>  $types

--- a/tests/PsalmPluginTest.php
+++ b/tests/PsalmPluginTest.php
@@ -3,9 +3,8 @@
 namespace Psalm\Tests;
 
 use InvalidArgumentException;
-use Prophecy\Argument;
-use Prophecy\PhpUnit\ProphecyTrait;
-use Prophecy\Prophecy\ObjectProphecy;
+use Mockery;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Psalm\Internal\PluginManager\Command\DisableCommand;
 use Psalm\Internal\PluginManager\Command\EnableCommand;
 use Psalm\Internal\PluginManager\Command\ShowCommand;
@@ -15,18 +14,19 @@ use Psalm\Internal\RuntimeCaches;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Tester\CommandTester;
+use Mockery\MockInterface;
 
 use function preg_quote;
 
 /** @group PluginManager */
 class PsalmPluginTest extends TestCase
 {
-    use ProphecyTrait;
+    use MockeryPHPUnitIntegration;
 
-    /** @var ObjectProphecy */
+    /** @var PluginList&MockInterface */
     private $plugin_list;
 
-    /** @var ObjectProphecy */
+    /** @var PluginListFactory&MockInterface */
     private $plugin_list_factory;
 
     /** @var Application */
@@ -35,15 +35,18 @@ class PsalmPluginTest extends TestCase
     public function setUp(): void
     {
         RuntimeCaches::clearAll();
-        $this->plugin_list = $this->prophesize(PluginList::class);
-        $this->plugin_list_factory = $this->prophesize(PluginListFactory::class);
-        $this->plugin_list_factory->__invoke(Argument::any(), Argument::any())->willReturn($this->plugin_list->reveal());
+        $this->plugin_list = Mockery::mock(PluginList::class);
+        $this->plugin_list_factory = Mockery::mock(PluginListFactory::class);
+        $this->plugin_list_factory
+            ->allows()->__invoke(Mockery::andAnyOtherArgs())
+            ->andReturns($this->plugin_list)
+            ->byDefault();
 
         $this->app = new Application('psalm-plugin', '0.1');
         $this->app->addCommands([
-            new ShowCommand($this->plugin_list_factory->reveal()),
-            new EnableCommand($this->plugin_list_factory->reveal()),
-            new DisableCommand($this->plugin_list_factory->reveal()),
+            new ShowCommand($this->plugin_list_factory),
+            new EnableCommand($this->plugin_list_factory),
+            new DisableCommand($this->plugin_list_factory),
         ]);
 
         $this->app->getDefinition()->addOption(
@@ -52,8 +55,8 @@ class PsalmPluginTest extends TestCase
 
         $this->app->setDefaultCommand('show');
 
-        $this->plugin_list->getEnabled()->willReturn([]);
-        $this->plugin_list->getAvailable()->willReturn([]);
+        $this->plugin_list->allows()->getEnabled()->andReturns([])->byDefault();
+        $this->plugin_list->allows()->getAvailable()->andReturns([])->byDefault();
     }
 
     /**
@@ -74,7 +77,7 @@ class PsalmPluginTest extends TestCase
      */
     public function showsEnabledPlugins(): void
     {
-        $this->plugin_list->getEnabled()->willReturn(['a\b\c' => 'vendor/package']);
+        $this->plugin_list->expects()->getEnabled()->andReturns(['a\b\c' => 'vendor/package']);
 
         $show_command = new CommandTester($this->app->find('show'));
         $show_command->execute([]);
@@ -89,7 +92,7 @@ class PsalmPluginTest extends TestCase
      */
     public function showsAvailablePlugins(): void
     {
-        $this->plugin_list->getAvailable()->willReturn(['a\b\c' => 'vendor/package']);
+        $this->plugin_list->expects()->getAvailable()->andReturns(['a\b\c' => 'vendor/package']);
 
         $show_command = new CommandTester($this->app->find('show'));
         $show_command->execute([]);
@@ -104,7 +107,7 @@ class PsalmPluginTest extends TestCase
      */
     public function passesExplicitConfigToPluginListFactory(): void
     {
-        $this->plugin_list_factory->__invoke(Argument::any(), '/a/b/c')->willReturn($this->plugin_list->reveal());
+        $this->plugin_list_factory->expects()->__invoke(Mockery::any(), '/a/b/c')->andReturns($this->plugin_list);
 
         $show_command = new CommandTester($this->app->find('show'));
         $show_command->execute([
@@ -117,8 +120,9 @@ class PsalmPluginTest extends TestCase
      */
     public function showsColumnHeaders(): void
     {
-        $this->plugin_list->getAvailable()->willReturn(['a\b\c' => 'vendor/package']);
-        $this->plugin_list->getAvailable()->willReturn(['c\d\e' => 'another-vendor/package']);
+        $this->plugin_list
+            ->shouldReceive('getAvailable')->andReturn(['a\b\c' => 'vendor/package'])
+            ->shouldReceive('getAvailable')->andReturn(['c\d\e' => 'another-vendor/package']);
 
         $show_command = new CommandTester($this->app->find('show'));
         $show_command->execute([]);
@@ -168,7 +172,7 @@ class PsalmPluginTest extends TestCase
      */
     public function enableComplainsWhenPassedUnresolvablePlugin(): void
     {
-        $this->plugin_list->resolvePluginClass(Argument::any())->willThrow(new InvalidArgumentException);
+        $this->plugin_list->expects()->resolvePluginClass(Mockery::any())->andThrows(new InvalidArgumentException());
 
         $enable_command = new CommandTester($this->app->find('enable'));
         $enable_command->execute(['pluginName' => 'vendor/package']);
@@ -185,13 +189,9 @@ class PsalmPluginTest extends TestCase
      */
     public function enableComplainsWhenPassedAlreadyEnabledPlugin(): void
     {
-        $this->plugin_list->resolvePluginClass('vendor/package')->will(
-            function (array $_args, ObjectProphecy $plugin_list): string {
-                        $plugin_list->isEnabled('Vendor\Package\PluginClass')->willReturn(true);
-
-                return 'Vendor\Package\PluginClass';
-            }
-        );
+        $plugin_class = 'Vendor\Package\PluginClass';
+        $this->plugin_list->expects()->resolvePluginClass('vendor/package')->andReturns($plugin_class);
+        $this->plugin_list->expects()->isEnabled($plugin_class)->andReturns(true);
 
         $enable_command = new CommandTester($this->app->find('enable'));
         $enable_command->execute(['pluginName' => 'vendor/package']);
@@ -206,15 +206,10 @@ class PsalmPluginTest extends TestCase
      */
     public function enableReportsSuccessWhenItEnablesPlugin(): void
     {
-        $this->plugin_list->resolvePluginClass('vendor/package')->will(
-            function (array $_args, ObjectProphecy $plugin_list): string {
-                $plugin_class = 'Vendor\Package\PluginClass';
-                        $plugin_list->isEnabled($plugin_class)->willReturn(false);
-                        $plugin_list->enable($plugin_class)->shouldBeCalled();
-
-                return $plugin_class;
-            }
-        );
+        $plugin_class = 'Vendor\Package\PluginClass';
+        $this->plugin_list->expects()->resolvePluginClass('vendor/package')->andReturns($plugin_class);
+        $this->plugin_list->expects()->isEnabled($plugin_class)->andReturns(false);
+        $this->plugin_list->expects()->enable($plugin_class);
 
         $enable_command = new CommandTester($this->app->find('enable'));
         $enable_command->execute(['pluginName' => 'vendor/package']);
@@ -239,7 +234,7 @@ class PsalmPluginTest extends TestCase
      */
     public function disableComplainsWhenPassedUnresolvablePlugin(): void
     {
-        $this->plugin_list->resolvePluginClass(Argument::any())->willThrow(new InvalidArgumentException);
+        $this->plugin_list->expects()->resolvePluginClass(Mockery::any())->andThrows(new InvalidArgumentException);
 
         $disable_command = new CommandTester($this->app->find('disable'));
         $disable_command->execute(['pluginName' => 'vendor/package']);
@@ -256,13 +251,9 @@ class PsalmPluginTest extends TestCase
      */
     public function disableComplainsWhenPassedNotEnabledPlugin(): void
     {
-        $this->plugin_list->resolvePluginClass('vendor/package')->will(
-            function (array $_args, ObjectProphecy $plugin_list): string {
-                        $plugin_list->isEnabled('Vendor\Package\PluginClass')->willReturn(false);
-
-                return 'Vendor\Package\PluginClass';
-            }
-        );
+        $plugin_class = 'Vendor\Package\PluginClass';
+        $this->plugin_list->expects()->resolvePluginClass('vendor/package')->andReturns($plugin_class);
+        $this->plugin_list->expects()->isEnabled($plugin_class)->andReturns(false);
 
         $disable_command = new CommandTester($this->app->find('disable'));
         $disable_command->execute(['pluginName' => 'vendor/package']);
@@ -277,15 +268,10 @@ class PsalmPluginTest extends TestCase
      */
     public function disableReportsSuccessWhenItDisablesPlugin(): void
     {
-        $this->plugin_list->resolvePluginClass('vendor/package')->will(
-            function (array $_args, ObjectProphecy $plugin_list): string {
-                $plugin_class = 'Vendor\Package\PluginClass';
-                        $plugin_list->isEnabled($plugin_class)->willReturn(true);
-                        $plugin_list->disable($plugin_class)->shouldBeCalled();
-
-                return $plugin_class;
-            }
-        );
+        $plugin_class = 'Vendor\Package\PluginClass';
+        $this->plugin_list->expects()->resolvePluginClass('vendor/package')->andReturns($plugin_class);
+        $this->plugin_list->expects()->isEnabled($plugin_class)->andReturns(true);
+        $this->plugin_list->expects()->disable($plugin_class);
 
         $disable_command = new CommandTester($this->app->find('disable'));
         $disable_command->execute(['pluginName' => 'vendor/package']);

--- a/tests/PsalmPluginTest.php
+++ b/tests/PsalmPluginTest.php
@@ -5,6 +5,7 @@ namespace Psalm\Tests;
 use InvalidArgumentException;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use Mockery\MockInterface;
 use Psalm\Internal\PluginManager\Command\DisableCommand;
 use Psalm\Internal\PluginManager\Command\EnableCommand;
 use Psalm\Internal\PluginManager\Command\ShowCommand;
@@ -14,7 +15,6 @@ use Psalm\Internal\RuntimeCaches;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Tester\CommandTester;
-use Mockery\MockInterface;
 
 use function preg_quote;
 

--- a/tests/PsalmPluginTest.php
+++ b/tests/PsalmPluginTest.php
@@ -234,7 +234,7 @@ class PsalmPluginTest extends TestCase
      */
     public function disableComplainsWhenPassedUnresolvablePlugin(): void
     {
-        $this->plugin_list->expects()->resolvePluginClass(Mockery::any())->andThrows(new InvalidArgumentException);
+        $this->plugin_list->expects()->resolvePluginClass(Mockery::any())->andThrows(new InvalidArgumentException());
 
         $disable_command = new CommandTester($this->app->find('disable'));
         $disable_command->execute(['pluginName' => 'vendor/package']);


### PR DESCRIPTION
It provides similar functionality, but is a bit more alive and does not prevent installation with PHP 8.2

Refs #8752 