### PR TITLE
Re-enable platform-check

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -68,7 +68,7 @@
         },
         "optimize-autoloader": true,
         "sort-packages": true,
-        "platform-check": false
+        "platform-check": true
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This makes sure that we output sensible error (not very pretty, but useful) when required extensions are missing.

Fixes vimeo/psalm#7560

Note: according to Github stats, this was the most-visited issue:

![image](https://user-images.githubusercontent.com/57403/204078929-c47538b2-c26a-4992-bba0-875698d49321.png)
