### PR TITLE
Report by issues grouped by level and type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ jobs:
           keys:
             - composer-v4
 
-      - run: composer update
+      - run: COMPOSER_ROOT_VERSION=dev-master composer update
 
       - save_cache:
           key: composer-v4

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -91,8 +91,6 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
 
 ## Errors that appear at level 7 and below
 
-These issues are treated as errors at level 7 and below.
-
 - [AbstractInstantiation](issues/AbstractInstantiation.md)
 - [AssignmentToVoid](issues/AssignmentToVoid.md)
 - [CircularReference](issues/CircularReference.md)
@@ -107,8 +105,6 @@ These issues are treated as errors at level 7 and below.
 - [UninitializedProperty](issues/UninitializedProperty.md)
 
 ## Errors that appear at level 6 and below
-
-These issues are treated as errors at level 6 and below.
 
 - [InvalidArgument](issues/InvalidArgument.md)
 - [InvalidArrayAccess](issues/InvalidArrayAccess.md)
@@ -139,8 +135,6 @@ These issues are treated as errors at level 6 and below.
 
 ## Errors that appear at level 5 and below
 
-These issues are treated as errors at level 5 and below.
-
 - [ConstructorSignatureMismatch](issues/ConstructorSignatureMismatch.md)
 - [FalsableReturnStatement](issues/FalsableReturnStatement.md)
 - [InvalidNullableReturnType](issues/InvalidNullableReturnType.md)
@@ -151,8 +145,6 @@ These issues are treated as errors at level 5 and below.
 - [UndefinedThisPropertyAssignment](issues/UndefinedThisPropertyAssignment.md)
 
 ## Errors that appear at level 4 and below
-
-These issues are treated as errors at level 4 and below.
 
 - [FalseOperand](issues/FalseOperand.md)
 - [ForbiddenCode](issues/ForbiddenCode.md)
@@ -184,8 +176,6 @@ These issues are treated as errors at level 4 and below.
 - [UndefinedMagicPropertyFetch](issues/UndefinedMagicPropertyFetch.md)
 
 ## Errors that appear at level 3 and below
-
-These issues are treated as errors at level 3 and below.
 
 - [ArgumentTypeCoercion](issues/ArgumentTypeCoercion.md)
 - [LessSpecificReturnStatement](issues/LessSpecificReturnStatement.md)
@@ -226,8 +216,6 @@ These issues are treated as errors at level 3 and below.
 - [RiskyCast](issues/RiskyCast.md)
 
 ## Errors that appear at level 2 and below
-
-These issues are treated as errors at level 2 and below.
 
 - [DeprecatedClass](issues/DeprecatedClass.md)
 - [DeprecatedConstant](issues/DeprecatedConstant.md)

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -6,9 +6,9 @@ Level 1 is the most strict, level 8 is the most lenient.
 
 When no level is explicitly defined, psalm defaults to level 2.
 
-Some issues are [always treated as errors](#always-treated-as-errors). These are issues with a very low probability of false-positives.
+Some issues are always treated as errors. These are issues with a very low probability of false-positives.
 
-At [level 1](#errors-that-only-appear-at-level-1) all issues (except those emitted for opt-in features) that Psalm can find are treated as errors. Those issues include any situation where Psalm cannot infer the type of a given expression.
+At level 1 all issues (except those emitted for opt-in features) that Psalm can find are treated as errors. Those issues include any situation where Psalm cannot infer the type of a given expression.
 
 At level 2 Psalm ignores those `Mixed*` issues, but treats most other issues as errors.
 
@@ -89,6 +89,173 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
  - [UnusedFunctionCall](issues/UnusedFunctionCall.md)
  - [UnusedMethodCall](issues/UnusedMethodCall.md)
 
+## Errors that appear at level 7 and below
+
+These issues are treated as errors at level 7 and below.
+
+- [AbstractInstantiation](issues/AbstractInstantiation.md)
+- [AssignmentToVoid](issues/AssignmentToVoid.md)
+- [CircularReference](issues/CircularReference.md)
+- [ConflictingReferenceConstraint](issues/ConflictingReferenceConstraint.md)
+- [ContinueOutsideLoop](issues/ContinueOutsideLoop.md)
+- [InvalidTypeImport](issues/InvalidTypeImport.md)
+- [MethodSignatureMismatch](issues/MethodSignatureMismatch.md)
+- [OverriddenMethodAccess](issues/OverriddenMethodAccess.md)
+- [ParamNameMismatch](issues/ParamNameMismatch.md)
+- [ReservedWord](issues/ReservedWord.md)
+- [UnhandledMatchCondition](issues/UnhandledMatchCondition.md)
+- [UninitializedProperty](issues/UninitializedProperty.md)
+
+## Errors that appear at level 6 and below
+
+These issues are treated as errors at level 6 and below.
+
+- [InvalidArgument](issues/InvalidArgument.md)
+- [InvalidArrayAccess](issues/InvalidArrayAccess.md)
+- [InvalidArrayAssignment](issues/InvalidArrayAssignment.md)
+- [InvalidArrayOffset](issues/InvalidArrayOffset.md)
+- [InvalidCast](issues/InvalidCast.md)
+- [InvalidCatch](issues/InvalidCatch.md)
+- [InvalidClass](issues/InvalidClass.md)
+- [InvalidClone](issues/InvalidClone.md)
+- [InvalidFunctionCall](issues/InvalidFunctionCall.md)
+- [InvalidIterator](issues/InvalidIterator.md)
+- [InvalidMethodCall](issues/InvalidMethodCall.md)
+- [InvalidNamedArgument](issues/InvalidNamedArgument.md)
+- [InvalidPropertyAssignment](issues/InvalidPropertyAssignment.md)
+- [InvalidPropertyAssignmentValue](issues/InvalidPropertyAssignmentValue.md)
+- [InvalidPropertyFetch](issues/InvalidPropertyFetch.md)
+- [InvalidReturnStatement](issues/InvalidReturnStatement.md)
+- [InvalidReturnType](issues/InvalidReturnType.md)
+- [InvalidTemplateParam](issues/InvalidTemplateParam.md)
+- [NullArgument](issues/NullArgument.md)
+- [NullArrayOffset](issues/NullArrayOffset.md)
+- [TooManyTemplateParams](issues/TooManyTemplateParams.md)
+- [TraitMethodSignatureMismatch](issues/TraitMethodSignatureMismatch.md)
+- [UndefinedMethod](issues/UndefinedMethod.md)
+- [UndefinedPropertyAssignment](issues/UndefinedPropertyAssignment.md)
+- [UndefinedPropertyFetch](issues/UndefinedPropertyFetch.md)
+- [UndefinedThisPropertyFetch](issues/UndefinedThisPropertyFetch.md)
+
+## Errors that appear at level 5 and below
+
+These issues are treated as errors at level 5 and below.
+
+- [ConstructorSignatureMismatch](issues/ConstructorSignatureMismatch.md)
+- [FalsableReturnStatement](issues/FalsableReturnStatement.md)
+- [InvalidNullableReturnType](issues/InvalidNullableReturnType.md)
+- [LessSpecificImplementedReturnType](issues/LessSpecificImplementedReturnType.md)
+- [MoreSpecificImplementedParamType](issues/MoreSpecificImplementedParamType.md)
+- [NullableReturnStatement](issues/NullableReturnStatement.md)
+- [UndefinedInterfaceMethod](issues/UndefinedInterfaceMethod.md)
+- [UndefinedThisPropertyAssignment](issues/UndefinedThisPropertyAssignment.md)
+
+## Errors that appear at level 4 and below
+
+These issues are treated as errors at level 4 and below.
+
+- [FalseOperand](issues/FalseOperand.md)
+- [ForbiddenCode](issues/ForbiddenCode.md)
+- [ImplementedParamTypeMismatch](issues/ImplementedParamTypeMismatch.md)
+- [ImplementedReturnTypeMismatch](issues/ImplementedReturnTypeMismatch.md)
+- [ImplicitToStringCast](issues/ImplicitToStringCast.md)
+- [InternalClass](issues/InternalClass.md)
+- [InternalMethod](issues/InternalMethod.md)
+- [InternalProperty](issues/InternalProperty.md)
+- [InvalidDocblock](issues/InvalidDocblock.md)
+- [InvalidLiteralArgument](issues/InvalidLiteralArgument.md)
+- [InvalidOperand](issues/InvalidOperand.md)
+- [InvalidScalarArgument](issues/InvalidScalarArgument.md)
+- [InvalidToString](issues/InvalidToString.md)
+- [MismatchingDocblockParamType](issues/MismatchingDocblockParamType.md)
+- [MismatchingDocblockReturnType](issues/MismatchingDocblockReturnType.md)
+- [MissingDocblockType](issues/MissingDocblockType.md)
+- [NoInterfaceProperties](issues/NoInterfaceProperties.md)
+- [PossibleRawObjectIteration](issues/PossibleRawObjectIteration.md)
+- [RedundantCondition](issues/RedundantCondition.md)
+- [RedundantFunctionCall](issues/RedundantFunctionCall.md)
+- [RedundantPropertyInitializationCheck](issues/RedundantPropertyInitializationCheck.md)
+- [StringIncrement](issues/StringIncrement.md)
+- [TooManyArguments](issues/TooManyArguments.md)
+- [TypeDoesNotContainNull](issues/TypeDoesNotContainNull.md)
+- [TypeDoesNotContainType](issues/TypeDoesNotContainType.md)
+- [UndefinedMagicMethod](issues/UndefinedMagicMethod.md)
+- [UndefinedMagicPropertyAssignment](issues/UndefinedMagicPropertyAssignment.md)
+- [UndefinedMagicPropertyFetch](issues/UndefinedMagicPropertyFetch.md)
+
+## Errors that appear at level 3 and below
+
+These issues are treated as errors at level 3 and below.
+
+- [ArgumentTypeCoercion](issues/ArgumentTypeCoercion.md)
+- [LessSpecificReturnStatement](issues/LessSpecificReturnStatement.md)
+- [MoreSpecificReturnType](issues/MoreSpecificReturnType.md)
+- [PossiblyFalseArgument](issues/PossiblyFalseArgument.md)
+- [PossiblyFalseIterator](issues/PossiblyFalseIterator.md)
+- [PossiblyFalseOperand](issues/PossiblyFalseOperand.md)
+- [PossiblyFalsePropertyAssignmentValue](issues/PossiblyFalsePropertyAssignmentValue.md)
+- [PossiblyFalseReference](issues/PossiblyFalseReference.md)
+- [PossiblyInvalidArgument](issues/PossiblyInvalidArgument.md)
+- [PossiblyInvalidArrayAccess](issues/PossiblyInvalidArrayAccess.md)
+- [PossiblyInvalidArrayAssignment](issues/PossiblyInvalidArrayAssignment.md)
+- [PossiblyInvalidArrayOffset](issues/PossiblyInvalidArrayOffset.md)
+- [PossiblyInvalidCast](issues/PossiblyInvalidCast.md)
+- [PossiblyInvalidClone](issues/PossiblyInvalidClone.md)
+- [PossiblyInvalidFunctionCall](issues/PossiblyInvalidFunctionCall.md)
+- [PossiblyInvalidIterator](issues/PossiblyInvalidIterator.md)
+- [PossiblyInvalidMethodCall](issues/PossiblyInvalidMethodCall.md)
+- [PossiblyInvalidOperand](issues/PossiblyInvalidOperand.md)
+- [PossiblyInvalidPropertyAssignment](issues/PossiblyInvalidPropertyAssignment.md)
+- [PossiblyInvalidPropertyAssignmentValue](issues/PossiblyInvalidPropertyAssignmentValue.md)
+- [PossiblyInvalidPropertyFetch](issues/PossiblyInvalidPropertyFetch.md)
+- [PossiblyNullArgument](issues/PossiblyNullArgument.md)
+- [PossiblyNullArrayAccess](issues/PossiblyNullArrayAccess.md)
+- [PossiblyNullArrayAssignment](issues/PossiblyNullArrayAssignment.md)
+- [PossiblyNullArrayOffset](issues/PossiblyNullArrayOffset.md)
+- [PossiblyNullFunctionCall](issues/PossiblyNullFunctionCall.md)
+- [PossiblyNullIterator](issues/PossiblyNullIterator.md)
+- [PossiblyNullPropertyAssignment](issues/PossiblyNullPropertyAssignment.md)
+- [PossiblyNullPropertyAssignmentValue](issues/PossiblyNullPropertyAssignmentValue.md)
+- [PossiblyNullPropertyFetch](issues/PossiblyNullPropertyFetch.md)
+- [PossiblyNullReference](issues/PossiblyNullReference.md)
+- [PossiblyUndefinedArrayOffset](issues/PossiblyUndefinedArrayOffset.md)
+- [PossiblyUndefinedGlobalVariable](issues/PossiblyUndefinedGlobalVariable.md)
+- [PossiblyUndefinedMethod](issues/PossiblyUndefinedMethod.md)
+- [PossiblyUndefinedVariable](issues/PossiblyUndefinedVariable.md)
+- [PropertyTypeCoercion](issues/PropertyTypeCoercion.md)
+- [RiskyCast](issues/RiskyCast.md)
+
+## Errors that appear at level 2 and below
+
+These issues are treated as errors at level 2 and below.
+
+- [DeprecatedClass](issues/DeprecatedClass.md)
+- [DeprecatedConstant](issues/DeprecatedConstant.md)
+- [DeprecatedFunction](issues/DeprecatedFunction.md)
+- [DeprecatedInterface](issues/DeprecatedInterface.md)
+- [DeprecatedMethod](issues/DeprecatedMethod.md)
+- [DeprecatedProperty](issues/DeprecatedProperty.md)
+- [DeprecatedTrait](issues/DeprecatedTrait.md)
+- [DocblockTypeContradiction](issues/DocblockTypeContradiction.md)
+- [InvalidDocblockParamName](issues/InvalidDocblockParamName.md)
+- [InvalidFalsableReturnType](issues/InvalidFalsableReturnType.md)
+- [InvalidStringClass](issues/InvalidStringClass.md)
+- [MissingClosureParamType](issues/MissingClosureParamType.md)
+- [MissingClosureReturnType](issues/MissingClosureReturnType.md)
+- [MissingConstructor](issues/MissingConstructor.md)
+- [MissingParamType](issues/MissingParamType.md)
+- [MissingPropertyType](issues/MissingPropertyType.md)
+- [MissingReturnType](issues/MissingReturnType.md)
+- [NullOperand](issues/NullOperand.md)
+- [PropertyNotSetInConstructor](issues/PropertyNotSetInConstructor.md)
+- [RawObjectIteration](issues/RawObjectIteration.md)
+- [RedundantConditionGivenDocblockType](issues/RedundantConditionGivenDocblockType.md)
+- [RedundantFunctionCallGivenDocblockType](issues/RedundantFunctionCallGivenDocblockType.md)
+- [ReferenceConstraintViolation](issues/ReferenceConstraintViolation.md)
+- [UndefinedTrace](issues/UndefinedTrace.md)
+- [UnresolvableInclude](issues/UnresolvableInclude.md)
+- [UnsafeInstantiation](issues/UnsafeInstantiation.md)
+
 ## Errors that only appear at level 1
 
  - [LessSpecificReturnType](issues/LessSpecificReturnType.md)
@@ -114,174 +281,6 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
  - [PossiblyNullOperand](issues/PossiblyNullOperand.md)
  - [RedundantIdentityWithTrue](issues/RedundantIdentityWithTrue.md)
  - [Trace](issues/Trace.md)
-
-## Errors ignored at level 3 and higher
-
-These issues are treated as errors at level 2 and below.
-
- - [DeprecatedClass](issues/DeprecatedClass.md)
- - [DeprecatedConstant](issues/DeprecatedConstant.md)
- - [DeprecatedFunction](issues/DeprecatedFunction.md)
- - [DeprecatedInterface](issues/DeprecatedInterface.md)
- - [DeprecatedMethod](issues/DeprecatedMethod.md)
- - [DeprecatedProperty](issues/DeprecatedProperty.md)
- - [DeprecatedTrait](issues/DeprecatedTrait.md)
- - [DocblockTypeContradiction](issues/DocblockTypeContradiction.md)
- - [InvalidDocblockParamName](issues/InvalidDocblockParamName.md)
- - [InvalidFalsableReturnType](issues/InvalidFalsableReturnType.md)
- - [InvalidStringClass](issues/InvalidStringClass.md)
- - [MissingClosureParamType](issues/MissingClosureParamType.md)
- - [MissingClosureReturnType](issues/MissingClosureReturnType.md)
- - [MissingConstructor](issues/MissingConstructor.md)
- - [MissingParamType](issues/MissingParamType.md)
- - [MissingPropertyType](issues/MissingPropertyType.md)
- - [MissingReturnType](issues/MissingReturnType.md)
- - [NullOperand](issues/NullOperand.md)
- - [PropertyNotSetInConstructor](issues/PropertyNotSetInConstructor.md)
- - [RawObjectIteration](issues/RawObjectIteration.md)
- - [RedundantConditionGivenDocblockType](issues/RedundantConditionGivenDocblockType.md)
- - [RedundantFunctionCallGivenDocblockType](issues/RedundantFunctionCallGivenDocblockType.md)
- - [ReferenceConstraintViolation](issues/ReferenceConstraintViolation.md)
- - [UndefinedTrace](issues/UndefinedTrace.md)
- - [UnresolvableInclude](issues/UnresolvableInclude.md)
- - [UnsafeInstantiation](issues/UnsafeInstantiation.md)
-
-## Errors ignored at level 4 and higher
-
-These issues are treated as errors at level 3 and below.
-
- - [ArgumentTypeCoercion](issues/ArgumentTypeCoercion.md)
- - [LessSpecificReturnStatement](issues/LessSpecificReturnStatement.md)
- - [MoreSpecificReturnType](issues/MoreSpecificReturnType.md)
- - [PossiblyFalseArgument](issues/PossiblyFalseArgument.md)
- - [PossiblyFalseIterator](issues/PossiblyFalseIterator.md)
- - [PossiblyFalseOperand](issues/PossiblyFalseOperand.md)
- - [PossiblyFalsePropertyAssignmentValue](issues/PossiblyFalsePropertyAssignmentValue.md)
- - [PossiblyFalseReference](issues/PossiblyFalseReference.md)
- - [PossiblyInvalidArgument](issues/PossiblyInvalidArgument.md)
- - [PossiblyInvalidArrayAccess](issues/PossiblyInvalidArrayAccess.md)
- - [PossiblyInvalidArrayAssignment](issues/PossiblyInvalidArrayAssignment.md)
- - [PossiblyInvalidArrayOffset](issues/PossiblyInvalidArrayOffset.md)
- - [PossiblyInvalidCast](issues/PossiblyInvalidCast.md)
- - [PossiblyInvalidClone](issues/PossiblyInvalidClone.md)
- - [PossiblyInvalidFunctionCall](issues/PossiblyInvalidFunctionCall.md)
- - [PossiblyInvalidIterator](issues/PossiblyInvalidIterator.md)
- - [PossiblyInvalidMethodCall](issues/PossiblyInvalidMethodCall.md)
- - [PossiblyInvalidOperand](issues/PossiblyInvalidOperand.md)
- - [PossiblyInvalidPropertyAssignment](issues/PossiblyInvalidPropertyAssignment.md)
- - [PossiblyInvalidPropertyAssignmentValue](issues/PossiblyInvalidPropertyAssignmentValue.md)
- - [PossiblyInvalidPropertyFetch](issues/PossiblyInvalidPropertyFetch.md)
- - [PossiblyNullArgument](issues/PossiblyNullArgument.md)
- - [PossiblyNullArrayAccess](issues/PossiblyNullArrayAccess.md)
- - [PossiblyNullArrayAssignment](issues/PossiblyNullArrayAssignment.md)
- - [PossiblyNullArrayOffset](issues/PossiblyNullArrayOffset.md)
- - [PossiblyNullFunctionCall](issues/PossiblyNullFunctionCall.md)
- - [PossiblyNullIterator](issues/PossiblyNullIterator.md)
- - [PossiblyNullPropertyAssignment](issues/PossiblyNullPropertyAssignment.md)
- - [PossiblyNullPropertyAssignmentValue](issues/PossiblyNullPropertyAssignmentValue.md)
- - [PossiblyNullPropertyFetch](issues/PossiblyNullPropertyFetch.md)
- - [PossiblyNullReference](issues/PossiblyNullReference.md)
- - [PossiblyUndefinedArrayOffset](issues/PossiblyUndefinedArrayOffset.md)
- - [PossiblyUndefinedGlobalVariable](issues/PossiblyUndefinedGlobalVariable.md)
- - [PossiblyUndefinedMethod](issues/PossiblyUndefinedMethod.md)
- - [PossiblyUndefinedVariable](issues/PossiblyUndefinedVariable.md)
- - [PropertyTypeCoercion](issues/PropertyTypeCoercion.md)
- - [RiskyCast](issues/RiskyCast.md)
-
-## Errors ignored at level 5 and higher
-
-These issues are treated as errors at level 4 and below.
-
- - [FalseOperand](issues/FalseOperand.md)
- - [ForbiddenCode](issues/ForbiddenCode.md)
- - [ImplementedParamTypeMismatch](issues/ImplementedParamTypeMismatch.md)
- - [ImplementedReturnTypeMismatch](issues/ImplementedReturnTypeMismatch.md)
- - [ImplicitToStringCast](issues/ImplicitToStringCast.md)
- - [InternalClass](issues/InternalClass.md)
- - [InternalMethod](issues/InternalMethod.md)
- - [InternalProperty](issues/InternalProperty.md)
- - [InvalidDocblock](issues/InvalidDocblock.md)
- - [InvalidLiteralArgument](issues/InvalidLiteralArgument.md)
- - [InvalidOperand](issues/InvalidOperand.md)
- - [InvalidScalarArgument](issues/InvalidScalarArgument.md)
- - [InvalidToString](issues/InvalidToString.md)
- - [MismatchingDocblockParamType](issues/MismatchingDocblockParamType.md)
- - [MismatchingDocblockReturnType](issues/MismatchingDocblockReturnType.md)
- - [MissingDocblockType](issues/MissingDocblockType.md)
- - [NoInterfaceProperties](issues/NoInterfaceProperties.md)
- - [PossibleRawObjectIteration](issues/PossibleRawObjectIteration.md)
- - [RedundantCondition](issues/RedundantCondition.md)
- - [RedundantFunctionCall](issues/RedundantFunctionCall.md)
- - [RedundantPropertyInitializationCheck](issues/RedundantPropertyInitializationCheck.md)
- - [StringIncrement](issues/StringIncrement.md)
- - [TooManyArguments](issues/TooManyArguments.md)
- - [TypeDoesNotContainNull](issues/TypeDoesNotContainNull.md)
- - [TypeDoesNotContainType](issues/TypeDoesNotContainType.md)
- - [UndefinedMagicMethod](issues/UndefinedMagicMethod.md)
- - [UndefinedMagicPropertyAssignment](issues/UndefinedMagicPropertyAssignment.md)
- - [UndefinedMagicPropertyFetch](issues/UndefinedMagicPropertyFetch.md)
-
-## Errors ignored at level 6 and higher
-
-These issues are treated as errors at level 5 and below.
-
- - [ConstructorSignatureMismatch](issues/ConstructorSignatureMismatch.md)
- - [FalsableReturnStatement](issues/FalsableReturnStatement.md)
- - [InvalidNullableReturnType](issues/InvalidNullableReturnType.md)
- - [LessSpecificImplementedReturnType](issues/LessSpecificImplementedReturnType.md)
- - [MoreSpecificImplementedParamType](issues/MoreSpecificImplementedParamType.md)
- - [NullableReturnStatement](issues/NullableReturnStatement.md)
- - [UndefinedInterfaceMethod](issues/UndefinedInterfaceMethod.md)
- - [UndefinedThisPropertyAssignment](issues/UndefinedThisPropertyAssignment.md)
-
-## Errors ignored at level 7 and higher
-
-These issues are treated as errors at level 6 and below.
-
- - [InvalidArgument](issues/InvalidArgument.md)
- - [InvalidArrayAccess](issues/InvalidArrayAccess.md)
- - [InvalidArrayAssignment](issues/InvalidArrayAssignment.md)
- - [InvalidArrayOffset](issues/InvalidArrayOffset.md)
- - [InvalidCast](issues/InvalidCast.md)
- - [InvalidCatch](issues/InvalidCatch.md)
- - [InvalidClass](issues/InvalidClass.md)
- - [InvalidClone](issues/InvalidClone.md)
- - [InvalidFunctionCall](issues/InvalidFunctionCall.md)
- - [InvalidIterator](issues/InvalidIterator.md)
- - [InvalidMethodCall](issues/InvalidMethodCall.md)
- - [InvalidNamedArgument](issues/InvalidNamedArgument.md)
- - [InvalidPropertyAssignment](issues/InvalidPropertyAssignment.md)
- - [InvalidPropertyAssignmentValue](issues/InvalidPropertyAssignmentValue.md)
- - [InvalidPropertyFetch](issues/InvalidPropertyFetch.md)
- - [InvalidReturnStatement](issues/InvalidReturnStatement.md)
- - [InvalidReturnType](issues/InvalidReturnType.md)
- - [InvalidTemplateParam](issues/InvalidTemplateParam.md)
- - [NullArgument](issues/NullArgument.md)
- - [NullArrayOffset](issues/NullArrayOffset.md)
- - [TooManyTemplateParams](issues/TooManyTemplateParams.md)
- - [TraitMethodSignatureMismatch](issues/TraitMethodSignatureMismatch.md)
- - [UndefinedMethod](issues/UndefinedMethod.md)
- - [UndefinedPropertyAssignment](issues/UndefinedPropertyAssignment.md)
- - [UndefinedPropertyFetch](issues/UndefinedPropertyFetch.md)
- - [UndefinedThisPropertyFetch](issues/UndefinedThisPropertyFetch.md)
-
-## Errors ignored at level 8
-
-These issues are treated as errors at level 7 and below.
-
- - [AbstractInstantiation](issues/AbstractInstantiation.md)
- - [AssignmentToVoid](issues/AssignmentToVoid.md)
- - [CircularReference](issues/CircularReference.md)
- - [ConflictingReferenceConstraint](issues/ConflictingReferenceConstraint.md)
- - [ContinueOutsideLoop](issues/ContinueOutsideLoop.md)
- - [InvalidTypeImport](issues/InvalidTypeImport.md)
- - [MethodSignatureMismatch](issues/MethodSignatureMismatch.md)
- - [OverriddenMethodAccess](issues/OverriddenMethodAccess.md)
- - [ParamNameMismatch](issues/ParamNameMismatch.md)
- - [ReservedWord](issues/ReservedWord.md)
- - [UnhandledMatchCondition](issues/UnhandledMatchCondition.md)
- - [UninitializedProperty](issues/UninitializedProperty.md)
-
 
 ## Feature-specific errors
 

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -1262,7 +1262,7 @@ final class Psalm
             --output-format=console
                 Changes the output format.
                 Available formats: compact, console, text, emacs, json, pylint, xml, checkstyle, junit, sonarqube,
-                                   github, phpstorm, codeclimate
+                                   github, phpstorm, codeclimate, by-issue-level
 
             --no-progress
                 Disable the progress indicator

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -17,6 +17,7 @@ use Psalm\Issue\TaintedInput;
 use Psalm\Issue\UnusedPsalmSuppress;
 use Psalm\Plugin\EventHandler\Event\AfterAnalysisEvent;
 use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
+use Psalm\Report\ByIssueSeverityReport;
 use Psalm\Report\CheckstyleReport;
 use Psalm\Report\CodeClimateReport;
 use Psalm\Report\CompactReport;
@@ -852,6 +853,10 @@ final class IssueBuffer
 
             case Report::TYPE_JSON:
                 $output = new JsonReport($normalized_data, self::$fixable_issue_counts, $report_options);
+                break;
+
+            case Report::TYPE_BY_ISSUE_SEVERITY:
+                $output = new ByIssueSeverityReport($normalized_data, self::$fixable_issue_counts, $report_options);
                 break;
 
             case Report::TYPE_JSON_SUMMARY:

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -17,7 +17,7 @@ use Psalm\Issue\TaintedInput;
 use Psalm\Issue\UnusedPsalmSuppress;
 use Psalm\Plugin\EventHandler\Event\AfterAnalysisEvent;
 use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;
-use Psalm\Report\ByIssueSeverityReport;
+use Psalm\Report\ByIssueLevelAndTypeReport;
 use Psalm\Report\CheckstyleReport;
 use Psalm\Report\CodeClimateReport;
 use Psalm\Report\CompactReport;
@@ -855,8 +855,8 @@ final class IssueBuffer
                 $output = new JsonReport($normalized_data, self::$fixable_issue_counts, $report_options);
                 break;
 
-            case Report::TYPE_BY_ISSUE_SEVERITY:
-                $output = new ByIssueSeverityReport($normalized_data, self::$fixable_issue_counts, $report_options);
+            case Report::TYPE_BY_ISSUE_LEVEL:
+                $output = new ByIssueLevelAndTypeReport($normalized_data, self::$fixable_issue_counts, $report_options);
                 break;
 
             case Report::TYPE_JSON_SUMMARY:

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -29,7 +29,7 @@ abstract class Report
     public const TYPE_SARIF = 'sarif';
     public const TYPE_CODECLIMATE = 'codeclimate';
     public const TYPE_COUNT = 'count';
-    const TYPE_BY_ISSUE_SEVERITY = 'by-issue-severity';
+    public const TYPE_BY_ISSUE_SEVERITY = 'by-issue-severity';
 
     /**
      * @var array<int, IssueData>

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -29,7 +29,7 @@ abstract class Report
     public const TYPE_SARIF = 'sarif';
     public const TYPE_CODECLIMATE = 'codeclimate';
     public const TYPE_COUNT = 'count';
-    public const TYPE_BY_ISSUE_SEVERITY = 'by-issue-severity';
+    public const TYPE_BY_ISSUE_LEVEL = 'by-issue-level';
 
     /**
      * @var array<int, IssueData>

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -29,6 +29,7 @@ abstract class Report
     public const TYPE_SARIF = 'sarif';
     public const TYPE_CODECLIMATE = 'codeclimate';
     public const TYPE_COUNT = 'count';
+    const TYPE_BY_ISSUE_SEVERITY = 'by-issue-severity';
 
     /**
      * @var array<int, IssueData>

--- a/src/Psalm/Report/ByIssueLevelAndTypeReport.php
+++ b/src/Psalm/Report/ByIssueLevelAndTypeReport.php
@@ -180,8 +180,11 @@ HEADING;
     {
         usort($this->issues_data, function (IssueData $left, IssueData $right): int {
             // negative error levels go to the top, followed by large positive levels, with level 1 at the bottom.
-            return [$left->error_level > 0, -$left->error_level, $left->type, $left->file_path, $left->file_name, $left->line_from] <=>
-                [$right->error_level > 0, -$right->error_level, $right->type, $right->file_path, $right->file_name, $right->line_from];
+            return [$left->error_level > 0, -$left->error_level, $left->type,
+                    $left->file_path, $left->file_name, $left->line_from]
+                <=>
+                [$right->error_level > 0, -$right->error_level, $right->type,
+                    $right->file_path, $right->file_name, $right->line_from];
         });
     }
 }

--- a/src/Psalm/Report/ByIssueLevelAndTypeReport.php
+++ b/src/Psalm/Report/ByIssueLevelAndTypeReport.php
@@ -44,8 +44,6 @@ final class ByIssueLevelAndTypeReport extends Report
 
 HEADING;
 
-        ;
-
         foreach ($this->issues_data as $issue_data) {
             $output .= $this->format($issue_data) . "\n" . "\n";
         }
@@ -54,7 +52,7 @@ HEADING;
     }
 
     /**
-     * Copied from ConsoleReport with only very minor changes. Todo consider reducing code duplication
+     * Copied from ConsoleReport with only very minor changes.
      */
     private function format(IssueData $issue_data): string
     {
@@ -106,7 +104,7 @@ HEADING;
     }
 
     /**
-     * Copied from ConsoleReport unchanged. Todo consider reducing code duplication
+     * Copied from ConsoleReport unchanged. We could consider moving to another class to reduce duplication.
      * @param non-empty-list<DataFlowNodeData|array{label: string, entry_path_type: string}> $taint_trace
      */
     private function getTaintSnippets(array $taint_trace): string
@@ -141,6 +139,7 @@ HEADING;
     }
 
     /**
+     * Copied from ConsoleReport unchanged. We could consider moving to another class to reduce duplication.
      * @param IssueData|DataFlowNodeData $data
      */
     private function getFileReference($data): string
@@ -180,7 +179,7 @@ HEADING;
     private function sortIssuesByLevelAndType(): void
     {
         usort($this->issues_data, function (IssueData $left, IssueData $right): int {
-
+            // negative error levels go to the top, followed by large positive levels, with level 1 at the bottom.
             return [$left->error_level > 0, -$left->error_level, $left->type] <=>
                 [$right->error_level > 0, -$right->error_level, $right->type];
         });

--- a/src/Psalm/Report/ByIssueLevelAndTypeReport.php
+++ b/src/Psalm/Report/ByIssueLevelAndTypeReport.php
@@ -34,7 +34,7 @@ final class ByIssueLevelAndTypeReport extends Report
 |                                                                                        |
 |    The level at which issue is reported as an error is given in brackets - e.g.        |
 |    `ERROR (2): MissingReturnType` indicates that MissingReturnType is only reported    |
-|    as an error when Psalm's level is set to 4 or below.                                |
+|    as an error when Psalm's level is set to 2 or below.                                |
 |                                                                                        |
 |    Issues are shown or hidden in this report according to current settings. For        |
 |    the most complete report set Psalm's error level to 0 or use --show-info=true       |

--- a/src/Psalm/Report/ByIssueLevelAndTypeReport.php
+++ b/src/Psalm/Report/ByIssueLevelAndTypeReport.php
@@ -25,21 +25,23 @@ final class ByIssueLevelAndTypeReport extends Report
         $this->sortIssuesByLevelAndType();
 
         $output = <<<HEADING
-        |----------------------------------------------------------------------------------------|
-        |    Issues have been sorted by level and type. Feature-specific issues and the          |
-        |    most serious issues that will always be reported are listed first, with             |
-        |    remaining issues in level order. Issues near the top are usually the most serious.  |
-        |    Reducing the errorLevel in psalm.xml will suppress output of issues further down    |
-        |    this report.                                                                        |
-        |                                                                                        |
-        |    The level at which issue is reported as an error is given in brackets - e.g.        |
-        |    `ERROR (2): MissingReturnType` indicates that MissingReturnType is only reported    |
-        |    as an error when Psalm's level is set to 4 or below.                                |
-        |                                                                                        |
-        |    Issues are shown or hidden in this report according to current settings. For        |
-        |    the most complete report set Psalm's error level to 0 or use --show-info=true       |
-        |    See https://psalm.dev/docs/running_psalm/error_levels/                              |
-        |----------------------------------------------------------------------------------------|
+|----------------------------------------------------------------------------------------|
+|    Issues have been sorted by level and type. Feature-specific issues and the          |
+|    most serious issues that will always be reported are listed first, with             |
+|    remaining issues in level order. Issues near the top are usually the most serious.  |
+|    Reducing the errorLevel in psalm.xml will suppress output of issues further down    |
+|    this report.                                                                        |
+|                                                                                        |
+|    The level at which issue is reported as an error is given in brackets - e.g.        |
+|    `ERROR (2): MissingReturnType` indicates that MissingReturnType is only reported    |
+|    as an error when Psalm's level is set to 4 or below.                                |
+|                                                                                        |
+|    Issues are shown or hidden in this report according to current settings. For        |
+|    the most complete report set Psalm's error level to 0 or use --show-info=true       |
+|    See https://psalm.dev/docs/running_psalm/error_levels/                              |
+|----------------------------------------------------------------------------------------|
+
+
 HEADING;
 
         ;

--- a/src/Psalm/Report/ByIssueLevelAndTypeReport.php
+++ b/src/Psalm/Report/ByIssueLevelAndTypeReport.php
@@ -180,8 +180,8 @@ HEADING;
     {
         usort($this->issues_data, function (IssueData $left, IssueData $right): int {
             // negative error levels go to the top, followed by large positive levels, with level 1 at the bottom.
-            return [$left->error_level > 0, -$left->error_level, $left->type] <=>
-                [$right->error_level > 0, -$right->error_level, $right->type];
+            return [$left->error_level > 0, -$left->error_level, $left->type, $left->file_path, $left->file_name, $left->line_from] <=>
+                [$right->error_level > 0, -$right->error_level, $right->type, $right->file_path, $right->file_name, $right->line_from];
         });
     }
 }

--- a/src/Psalm/Report/ByIssueLevelAndTypeReport.php
+++ b/src/Psalm/Report/ByIssueLevelAndTypeReport.php
@@ -15,7 +15,7 @@ use function strtr;
 use function substr;
 use function usort;
 
-final class ByIssueSeverityReport extends Report
+final class ByIssueLevelAndTypeReport extends Report
 {
     /** @var string|null */
     private $link_format;

--- a/src/Psalm/Report/ByIssueSeverityReport.php
+++ b/src/Psalm/Report/ByIssueSeverityReport.php
@@ -1,0 +1,192 @@
+<?php
+
+namespace Psalm\Report;
+
+use Psalm\Config;
+use Psalm\Internal\Analyzer\DataFlowNodeData;
+use Psalm\Internal\Analyzer\IssueData;
+use Psalm\Report;
+
+use function basename;
+use function get_cfg_var;
+use function ini_get;
+use function strlen;
+use function strtr;
+use function substr;
+use function usort;
+
+final class ByIssueSeverityReport extends Report
+{
+    /** @var string|null */
+    private $link_format;
+
+    public function create(): string
+    {
+        $this->sortIssuesByLevelAndType();
+
+        $output = '';
+
+        foreach ($this->issues_data as $issue_data) {
+            $output .= $this->format($issue_data) . "\n" . "\n";
+        }
+
+        return $output;
+    }
+
+    private function format(IssueData $issue_data): string
+    {
+        $issue_string = '';
+
+        $is_error = $issue_data->severity === Config::REPORT_ERROR;
+
+        if ($is_error) {
+            $issue_string .= ($this->use_color ? "\e[0;31mERROR\e[0m" : 'ERROR');
+        } else {
+            $issue_string .= 'INFO';
+        }
+
+        $issue_reference = $issue_data->link ? ' (see ' . $issue_data->link . ')' : '';
+
+        $issue_string .= " ($issue_data->error_level): "
+            . $issue_data->type
+            . ' - ' . $this->getFileReference($issue_data)
+            . ' - ' . $issue_data->message . $issue_reference . "\n";
+
+
+        if ($issue_data->taint_trace) {
+            $issue_string .= $this->getTaintSnippets($issue_data->taint_trace);
+        } elseif ($this->show_snippet) {
+            $snippet = $issue_data->snippet;
+
+            if (!$this->use_color) {
+                $issue_string .= $snippet;
+            } else {
+                $selection_start = $issue_data->from - $issue_data->snippet_from;
+                $selection_length = $issue_data->to - $issue_data->from;
+
+                $issue_string .= substr($snippet, 0, $selection_start)
+                    . ($is_error ? "\e[97;41m" : "\e[30;47m") . substr($snippet, $selection_start, $selection_length)
+                    . "\e[0m" . substr($snippet, $selection_length + $selection_start) . "\n";
+            }
+        }
+
+        if ($issue_data->other_references) {
+            if ($this->show_snippet) {
+                $issue_string .= "\n";
+            }
+
+            $issue_string .= $this->getTaintSnippets($issue_data->other_references);
+        }
+
+        return $issue_string;
+    }
+
+    /**
+     * @param non-empty-list<DataFlowNodeData|array{label: string, entry_path_type: string}> $taint_trace
+     */
+    private function getTaintSnippets(array $taint_trace): string
+    {
+        $snippets = '';
+
+        foreach ($taint_trace as $node_data) {
+            if ($node_data instanceof DataFlowNodeData) {
+                $snippets .= '  ' . $node_data->label . ' - ' . $this->getFileReference($node_data) . "\n";
+
+                if ($this->show_snippet) {
+                    $snippet = $node_data->snippet;
+
+                    if (!$this->use_color) {
+                        $snippets .= $snippet . "\n\n";
+                    } else {
+                        $selection_start = $node_data->from - $node_data->snippet_from;
+                        $selection_length = $node_data->to - $node_data->from;
+
+                        $snippets .= substr($snippet, 0, $selection_start)
+                            . "\e[30;47m" . substr($snippet, $selection_start, $selection_length)
+                            . "\e[0m" . substr($snippet, $selection_length + $selection_start) . "\n\n";
+                    }
+                }
+            } else {
+                $snippets .= '  ' . $node_data['label'] . "\n";
+                $snippets .= '    <no known location>' . "\n\n";
+            }
+        }
+
+        return $snippets;
+    }
+
+    /**
+     * @param IssueData|DataFlowNodeData $data
+     */
+    private function getFileReference($data): string
+    {
+        $reference = $data->file_name . ':' . $data->line_from . ':' . $data->column_from;
+
+        if (!$this->use_color) {
+            return $reference;
+        }
+
+        $file_basename = basename($data->file_name);
+        $file_path = substr($data->file_name, 0, -strlen($file_basename));
+
+        $reference = $file_path
+            . "\033[1;31m"
+            . $file_basename . ':' . $data->line_from . ':' . $data->column_from
+            . "\033[0m"
+        ;
+
+        if ($this->in_ci) {
+            return $reference;
+        }
+
+        if (null === $this->link_format) {
+            // if xdebug is not enabled, use `get_cfg_var` to get the value directly from php.ini
+            $this->link_format = ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')
+                ?: 'file://%f#L%l';
+        }
+
+        $link = strtr($this->link_format, ['%f' => $data->file_path, '%l' => $data->line_from]);
+        // $reference = $data->file_name . ':' . $data->line_from . ':' . $data->column_from;
+
+
+        return "\033]8;;" . $link . "\033\\" . $reference . "\033]8;;\033\\";
+    }
+
+    /**
+     * @param $severity
+     */
+    public function errorLevelMessage(int $severity): string
+    {
+        if ($severity < -1) {
+            return "Issues reported based on feature-specific config:";
+        }
+
+        if ($severity < 0) {
+            return "Issues always reported:";
+        }
+
+        return "Issues reported at error level $severity" .
+        ($severity === 1) ? ":" : " or less:";
+    }
+    public function sortIssuesByLevelAndType(): void
+    {
+        usort($this->issues_data, function (IssueData $left, IssueData $right): int {
+            $leftLevel = $left->error_level;
+            $rightLevel = $right->error_level;
+
+            if ($leftLevel != $rightLevel) {
+                if ($rightLevel > 0 && $leftLevel > 0) {
+                    return $rightLevel <=> $leftLevel;
+                }
+
+                if ($rightLevel > 0) {
+                    return -1;
+                }
+
+                return $leftLevel <=> $rightLevel;
+            }
+
+            return $left->type <=> $right->type;
+        });
+    }
+}

--- a/src/Psalm/Report/ByIssueSeverityReport.php
+++ b/src/Psalm/Report/ByIssueSeverityReport.php
@@ -33,6 +33,9 @@ final class ByIssueSeverityReport extends Report
         return $output;
     }
 
+    /**
+     * Copied from ConsoleReport with only very minor changes. Todo consider reducing code duplication
+     */
     private function format(IssueData $issue_data): string
     {
         $issue_string = '';
@@ -82,6 +85,7 @@ final class ByIssueSeverityReport extends Report
     }
 
     /**
+     * Copied from ConsoleReport unchanged. Todo consider reducing code duplication
      * @param non-empty-list<DataFlowNodeData|array{label: string, entry_path_type: string}> $taint_trace
      */
     private function getTaintSnippets(array $taint_trace): string

--- a/src/Psalm/Report/ByIssueSeverityReport.php
+++ b/src/Psalm/Report/ByIssueSeverityReport.php
@@ -152,22 +152,6 @@ final class ByIssueSeverityReport extends Report
         return "\033]8;;" . $link . "\033\\" . $reference . "\033]8;;\033\\";
     }
 
-    /**
-     * @param $severity
-     */
-    public function errorLevelMessage(int $severity): string
-    {
-        if ($severity < -1) {
-            return "Issues reported based on feature-specific config:";
-        }
-
-        if ($severity < 0) {
-            return "Issues always reported:";
-        }
-
-        return "Issues reported at error level $severity" .
-        ($severity === 1) ? ":" : " or less:";
-    }
     public function sortIssuesByLevelAndType(): void
     {
         usort($this->issues_data, function (IssueData $left, IssueData $right): int {

--- a/src/Psalm/Report/ByIssueSeverityReport.php
+++ b/src/Psalm/Report/ByIssueSeverityReport.php
@@ -156,7 +156,7 @@ final class ByIssueSeverityReport extends Report
         return "\033]8;;" . $link . "\033\\" . $reference . "\033]8;;\033\\";
     }
 
-    public function sortIssuesByLevelAndType(): void
+    private function sortIssuesByLevelAndType(): void
     {
         usort($this->issues_data, function (IssueData $left, IssueData $right): int {
             $leftLevel = $left->error_level;

--- a/tests/ByIssueLevelAndTypeReportTest.php
+++ b/tests/ByIssueLevelAndTypeReportTest.php
@@ -37,7 +37,7 @@ class ByIssueLevelAndTypeReportTest extends TestCase
         |                                                                                        |
         |    The level at which issue is reported as an error is given in brackets - e.g.        |
         |    `ERROR (2): MissingReturnType` indicates that MissingReturnType is only reported    |
-        |    as an error when Psalm's level is set to 4 or below.                                |
+        |    as an error when Psalm's level is set to 2 or below.                                |
         |                                                                                        |
         |    Issues are shown or hidden in this report according to current settings. For        |
         |    the most complete report set Psalm's error level to 0 or use --show-info=true       |

--- a/tests/ByIssueLevelAndTypeReportTest.php
+++ b/tests/ByIssueLevelAndTypeReportTest.php
@@ -72,7 +72,7 @@ class ByIssueLevelAndTypeReportTest extends TestCase
         EXPECTED, $report->create());
     }
 
-    public function issueData(int $errorLevel, string $type): IssueData
+    private function issueData(int $errorLevel, string $type): IssueData
     {
         return new IssueData(
             'error',

--- a/tests/ByIssueLevelAndTypeReportTest.php
+++ b/tests/ByIssueLevelAndTypeReportTest.php
@@ -28,48 +28,48 @@ class ByIssueLevelAndTypeReportTest extends TestCase
         $report = new ByIssueLevelAndTypeReport($issuesData, [], $reportOptions);
 
         $this->assertSame(<<<EXPECTED
-|----------------------------------------------------------------------------------------|
-|    Issues have been sorted by level and type. Feature-specific issues and the          |
-|    most serious issues that will always be reported are listed first, with             |
-|    remaining issues in level order. Issues near the top are usually the most serious.  |
-|    Reducing the errorLevel in psalm.xml will suppress output of issues further down    |
-|    this report.                                                                        |
-|                                                                                        |
-|    The level at which issue is reported as an error is given in brackets - e.g.        |
-|    `ERROR (2): MissingReturnType` indicates that MissingReturnType is only reported    |
-|    as an error when Psalm's level is set to 4 or below.                                |
-|                                                                                        |
-|    Issues are shown or hidden in this report according to current settings. For        |
-|    the most complete report set Psalm's error level to 0 or use --show-info=true       |
-|    See https://psalm.dev/docs/running_psalm/error_levels/                              |
-|----------------------------------------------------------------------------------------|
+        |----------------------------------------------------------------------------------------|
+        |    Issues have been sorted by level and type. Feature-specific issues and the          |
+        |    most serious issues that will always be reported are listed first, with             |
+        |    remaining issues in level order. Issues near the top are usually the most serious.  |
+        |    Reducing the errorLevel in psalm.xml will suppress output of issues further down    |
+        |    this report.                                                                        |
+        |                                                                                        |
+        |    The level at which issue is reported as an error is given in brackets - e.g.        |
+        |    `ERROR (2): MissingReturnType` indicates that MissingReturnType is only reported    |
+        |    as an error when Psalm's level is set to 4 or below.                                |
+        |                                                                                        |
+        |    Issues are shown or hidden in this report according to current settings. For        |
+        |    the most complete report set Psalm's error level to 0 or use --show-info=true       |
+        |    See https://psalm.dev/docs/running_psalm/error_levels/                              |
+        |----------------------------------------------------------------------------------------|
 
-ERROR: SomeAlwaysReportedIssueType - file.php:1:1 - message
-
-
-ERROR: SomeFeatureSpecificIssueType - file.php:1:1 - message
+        ERROR: SomeAlwaysReportedIssueType - file.php:1:1 - message
 
 
-ERROR (7): SomeLevel7IssueType - file.php:1:1 - message
+        ERROR: SomeFeatureSpecificIssueType - file.php:1:1 - message
 
 
-ERROR (4): AnotherLevel4IssueType - file.php:1:1 - message
+        ERROR (7): SomeLevel7IssueType - file.php:1:1 - message
 
 
-ERROR (4): SomeLevel4IssueType - file.php:1:1 - message
+        ERROR (4): AnotherLevel4IssueType - file.php:1:1 - message
 
 
-ERROR (4): SomeLevel4IssueType - file.php:1:1 - message
+        ERROR (4): SomeLevel4IssueType - file.php:1:1 - message
 
 
-ERROR (2): SomeLevel2IssueType - file.php:1:1 - message
+        ERROR (4): SomeLevel4IssueType - file.php:1:1 - message
 
 
-ERROR (1): SomeIssueType - file.php:1:1 - message
+        ERROR (2): SomeLevel2IssueType - file.php:1:1 - message
+
+
+        ERROR (1): SomeIssueType - file.php:1:1 - message
 
 
 
-EXPECTED, $report->create());
+        EXPECTED,$report->create());
     }
 
     public function issueData(int $errorLevel, string $type): IssueData

--- a/tests/ByIssueLevelAndTypeReportTest.php
+++ b/tests/ByIssueLevelAndTypeReportTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Psalm\Tests;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\Internal\Analyzer\IssueData;
+use Psalm\Report\ByIssueLevelAndTypeReport;
+use Psalm\Report\ReportOptions;
+
+class ByIssueLevelAndTypeReportTest extends TestCase
+{
+    public function testItGeneratesReport(): void
+    {
+        $issuesData = [
+            $this->issueData(2, 'SomeLevel2IssueType'),
+            $this->issueData(-1, 'SomeAlwaysReportedIssueType'),
+            $this->issueData(4, 'SomeLevel4IssueType'),
+            $this->issueData(7, 'SomeLevel7IssueType'),
+            $this->issueData(4, 'AnotherLevel4IssueType'),
+            $this->issueData(4, 'SomeLevel4IssueType'), // same issue type as above, will be sorted together
+            $this->issueData(1, 'SomeIssueType'),
+            $this->issueData(-2, 'SomeFeatureSpecificIssueType'),
+        ];
+
+        $reportOptions = new ReportOptions();
+        $reportOptions->use_color = false;
+
+        $report = new ByIssueLevelAndTypeReport($issuesData, [], $reportOptions);
+
+        $this->assertSame(<<<EXPECTED
+|----------------------------------------------------------------------------------------|
+|    Issues have been sorted by level and type. Feature-specific issues and the          |
+|    most serious issues that will always be reported are listed first, with             |
+|    remaining issues in level order. Issues near the top are usually the most serious.  |
+|    Reducing the errorLevel in psalm.xml will suppress output of issues further down    |
+|    this report.                                                                        |
+|                                                                                        |
+|    The level at which issue is reported as an error is given in brackets - e.g.        |
+|    `ERROR (2): MissingReturnType` indicates that MissingReturnType is only reported    |
+|    as an error when Psalm's level is set to 4 or below.                                |
+|                                                                                        |
+|    Issues are shown or hidden in this report according to current settings. For        |
+|    the most complete report set Psalm's error level to 0 or use --show-info=true       |
+|    See https://psalm.dev/docs/running_psalm/error_levels/                              |
+|----------------------------------------------------------------------------------------|
+
+ERROR: SomeAlwaysReportedIssueType - file.php:1:1 - message
+
+
+ERROR: SomeFeatureSpecificIssueType - file.php:1:1 - message
+
+
+ERROR (7): SomeLevel7IssueType - file.php:1:1 - message
+
+
+ERROR (4): AnotherLevel4IssueType - file.php:1:1 - message
+
+
+ERROR (4): SomeLevel4IssueType - file.php:1:1 - message
+
+
+ERROR (4): SomeLevel4IssueType - file.php:1:1 - message
+
+
+ERROR (2): SomeLevel2IssueType - file.php:1:1 - message
+
+
+ERROR (1): SomeIssueType - file.php:1:1 - message
+
+
+
+EXPECTED, $report->create());
+    }
+
+    public function issueData(int $errorLevel, string $type): IssueData
+    {
+        return new IssueData(
+            'error',
+            1,
+            1,
+            $type,
+            'message',
+            'file.php',
+            '/',
+            '',
+            '',
+            1,
+            1,
+            1,
+            1,
+            1,
+            1,
+            0,
+            $errorLevel
+        );
+    }
+}

--- a/tests/ByIssueLevelAndTypeReportTest.php
+++ b/tests/ByIssueLevelAndTypeReportTest.php
@@ -69,7 +69,7 @@ class ByIssueLevelAndTypeReportTest extends TestCase
 
 
 
-        EXPECTED,$report->create());
+        EXPECTED, $report->create());
     }
 
     public function issueData(int $errorLevel, string $type): IssueData


### PR DESCRIPTION
#8746 

This adds a new output format, `--output-format=by-issue-level`, which is almost exactly the same as the default console output, except that:

- Issues are sorted by error level then issue type, rather than by file and position in file
- Error level number is included in output, e.g. `ERROR (3): PossiblyNullArgument `

This is intended to be useful for getting an overview of a project, particularly when onboarding Psalm to a new codebase, and for choosing what error level to set in psalm config. The most severe errors (plus any reported due to feature specific config) appear first in the output, with the issues that would only be reported at error level 1 appearing at the end.

I wasn't sure where to document this, so for now I've made the report include a block of explanation as a heading. Happy to move that text to a more appropriate place.