### PR TITLE
Variables should outlive namespaces

### DIFF
--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -87,16 +87,17 @@ class NamespaceAnalyzer extends SourceAnalyzer
 
         if ($leftover_stmts) {
             $statements_analyzer = new StatementsAnalyzer($this, new NodeDataProvider());
-            $context = new Context();
-            $context->is_global = true;
-            $context->defineGlobals();
-            $context->collect_exceptions = $codebase->config->check_for_throws_in_global_scope;
-            $statements_analyzer->analyze($leftover_stmts, $context, null, true);
-
             $file_context = $this->source->context;
-            if ($file_context) {
-                $file_context->mergeExceptions($context);
+
+            if ($file_context !== null) {
+                $context = $file_context;
+            } else {
+                $context = new Context();
+                $context->is_global = true;
+                $context->defineGlobals();
+                $context->collect_exceptions = $codebase->config->check_for_throws_in_global_scope;
             }
+            $statements_analyzer->analyze($leftover_stmts, $context, null, true);
         }
     }
 

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -152,7 +152,7 @@ class ConfigTest extends TestCase
         $config = $this->project_analyzer->getConfig();
 
         $this->assertTrue($config->isInProjectDirs(realpath('src/Psalm/Type.php')));
-        $this->assertFalse($config->isInProjectDirs(realpath(__DIR__.'/../../').'/does/not/exist/FileAnalyzer.php'));
+        $this->assertFalse($config->isInProjectDirs(realpath(__DIR__ . '/../../') . '/does/not/exist/FileAnalyzer.php'));
         $this->assertFalse($config->isInProjectDirs(realpath('examples/TemplateScanner.php')));
     }
 
@@ -1159,15 +1159,18 @@ class ConfigTest extends TestCase
                         ord($_GET["str"]);
                     }
 
-                    $glob1 = 0;
-                    error_reporting($glob1);
+                    $z = $glob1;
+                    $z = 0;
+                    error_reporting($z);
 
+                    $old = $_GET["str"];
                     $_GET["str"] = 0;
                     error_reporting($_GET["str"]);
+                    $_GET["str"] = $old;
 
                     function example2(): void {
-                        global $glob1, $glob2, $glob3;
-                        error_reporting($glob1);
+                        global $z, $glob2, $glob3;
+                        error_reporting($z);
                         ord($glob2["str"]);
                         $glob3->func();
                         ord($_GET["str"]);

--- a/tests/NamespaceTest.php
+++ b/tests/NamespaceTest.php
@@ -71,6 +71,24 @@ class NamespaceTest extends TestCase
                         $c = $argv;
                     }',
             ],
+            'varsAreNotScoped' => [
+                'code' => '<?php
+                    namespace A {
+                        $a = "1";
+                    }
+                    namespace B\C {
+                        $bc = "2";
+                    }
+                    namespace {
+                        echo $a . PHP_EOL;
+                        echo $bc . PHP_EOL;
+                    }
+                ',
+                'assertions' => [
+                    '$a===' => "'1'",
+                    '$bc===' => "'2'",
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
Variables in PHP are not namespaced. In other words, namespaces share the context with the file they are located in.

See https://3v4l.org/2qvrC

Fixes vimeo/psalm#8778

Depends on #8780 
