### PR TITLE
Replace all references to static variables when moving class

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
@@ -369,6 +369,8 @@ class StaticPropertyFetchAnalyzer
                     }
                 }
             }
+
+            return true;
         }
 
         if ($var_id) {

--- a/tests/FileManipulation/ClassMoveTest.php
+++ b/tests/FileManipulation/ClassMoveTest.php
@@ -749,6 +749,29 @@ class ClassMoveTest extends TestCase
                     'Foo\Hello' => 'Foo\Bar\Hello',
                 ],
             ],
+            'renamesAllStaticPropReferences' => [
+                'input' => '<?php
+                    namespace Foo;
+
+                    class Bar {
+                        public static $props = [1, 2, 3];
+                    }
+                    echo Bar::$props[1];
+                    echo Bar::$props[2];
+                ',
+                'output' => '<?php
+                    namespace Zoo;
+
+                    class Baz {
+                        public static $props = [1, 2, 3];
+                    }
+                    echo \Zoo\Baz::$props[1];
+                    echo \Zoo\Baz::$props[2];
+                ',
+                'migrations' => [
+                    'Foo\Bar' => 'Zoo\Baz',
+                ],
+            ],
         ];
     }
 }


### PR DESCRIPTION
Previously `psalter` would only replace the first occurrence of the property access. Now it replaces all occurrences (by keeping the old name unknown in the context).
