### PR TITLE
Allow omitting argument offsets for map-type overrides in phpstorm.meta

### DIFF
--- a/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
+++ b/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
@@ -89,15 +89,22 @@ class PhpStormMetaScanner
         if ($identifier instanceof PhpParser\Node\Expr\StaticCall
             && $identifier->class instanceof PhpParser\Node\Name\FullyQualified
             && $identifier->name instanceof PhpParser\Node\Identifier
-            && $identifier->getArgs()
-            && $identifier->getArgs()[0]->value instanceof PhpParser\Node\Scalar\LNumber
+            && (
+                $identifier->getArgs() === []
+                || $identifier->getArgs()[0]->value instanceof PhpParser\Node\Scalar\LNumber
+            )
         ) {
             $meta_fq_classlike_name = implode('\\', $identifier->class->parts);
 
             $meta_method_name = strtolower($identifier->name->name);
 
             if ($map) {
-                $offset = $identifier->getArgs()[0]->value->value;
+                $offset = 0;
+                if ($identifier->getArgs()
+                    && $identifier->getArgs()[0]->value instanceof PhpParser\Node\Scalar\LNumber
+                ) {
+                    $offset = $identifier->getArgs()[0]->value->value;
+                }
 
                 $codebase->methods->return_type_provider->registerClosure(
                     $meta_fq_classlike_name,
@@ -248,13 +255,20 @@ class PhpStormMetaScanner
 
         if ($identifier instanceof PhpParser\Node\Expr\FuncCall
             && $identifier->name instanceof PhpParser\Node\Name\FullyQualified
-            && $identifier->getArgs()
-            && $identifier->getArgs()[0]->value instanceof PhpParser\Node\Scalar\LNumber
+            && (
+                $identifier->getArgs() === []
+                || $identifier->getArgs()[0]->value instanceof PhpParser\Node\Scalar\LNumber
+            )
         ) {
             $function_id = strtolower(implode('\\', $identifier->name->parts));
 
             if ($map) {
-                $offset = $identifier->getArgs()[0]->value->value;
+                $offset = 0;
+                if ($identifier->getArgs()
+                    && $identifier->getArgs()[0]->value instanceof PhpParser\Node\Scalar\LNumber
+                ) {
+                    $offset = $identifier->getArgs()[0]->value->value;
+                }
 
                 $codebase->functions->return_type_provider->registerClosure(
                     $function_id,

--- a/tests/fixtures/stubs/phpstorm.meta.php
+++ b/tests/fixtures/stubs/phpstorm.meta.php
@@ -1,12 +1,25 @@
 <?php
 namespace PHPSTORM_META {
 
+    // tests with argument offset (0)
     override(\Ns\MyClass::crEate(0), map([
         '' => '@',
         'exception' => \Exception::class,
         'object' => \stdClass::class,
     ]));
     override(\create(0), map([
+        '' => '@',
+        'exception' => \Exception::class,
+        'object' => \stdClass::class,
+    ]));
+
+    // tests without argument offset (0 by default)
+    override(\Ns\MyClass::crEate2(), map([
+        '' => '@',
+        'exception' => \Exception::class,
+        'object' => \stdClass::class,
+    ]));
+    override(\create2(), map([
         '' => '@',
         'exception' => \Exception::class,
         'object' => \stdClass::class,


### PR DESCRIPTION
Fixes vimeo/psalm#8758

Depends on #8779
