### PR TITLE
Bump `slevomat/coding-standard`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,7 @@
         "phpunit/phpunit": "^9.5",
         "psalm/plugin-mockery": "^1.1",
         "psalm/plugin-phpunit": "^0.18",
-        "slevomat/coding-standard": "^7.2 || ^8.0",
+        "slevomat/coding-standard": "^8.4",
         "squizlabs/php_codesniffer": "^3.6",
         "symfony/process": "^4.4 || ^5.0 || ^6.0"
     },


### PR DESCRIPTION
This prevents issues with incompatible `phpstan/phpdoc-parser`.

`slevomat/coding-standard:8.3` claimed compatibility with
`phpstan/phpdoc-parser:^1.6`, but it fails with a fatal error when
`phpstan/phpdoc-parser:1.14` is installed (apparently there was a BC
break in a minor version of `phpstan/phpdoc-parser`).

Since 8.4 slevomat/coding-standard adopted a more conservative
dependency strategy, and they don't allow new untested versions of
`phpstan/phpdoc-parser`.

8.4 still allows PHP 7.2, so we should have no problems due to 7.x
  removal.
