### PR TITLE
Defer cache directory creation until it's needed

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -241,6 +241,10 @@ final class Psalm
             $options
         );
 
+        if (isset($options['no-cache'])) {
+            $config->cache_directory = null;
+        }
+
         $config->setIncludeCollector($include_collector);
 
         $in_ci = CliUtils::runningInCI();        // disable progressbar on CI

--- a/src/Psalm/Internal/Cli/Psalter.php
+++ b/src/Psalm/Internal/Cli/Psalter.php
@@ -233,6 +233,11 @@ final class Psalter
             Report::TYPE_CONSOLE,
             $first_autoloader
         );
+
+        if (isset($options['no-cache'])) {
+            $config->cache_directory = null;
+        }
+
         $config->setIncludeCollector($include_collector);
 
         if ($config->resolve_from_config_file) {


### PR DESCRIPTION
Honestly, this is a bit of a hack, as we let `Config` to generate the
cache directory name and then reset it to null from the cli entrypoint.
Yet it's easier than passing a no-cache flag through so many layers of
static calls.

`$this->cache_directory_initialized` flag is used to make sure we
attempt to create the directory only once.

Fixes vimeo/psalm#4267
