### PR TITLE
fix sealed combination

### DIFF
--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -1507,6 +1507,7 @@ class TypeCombiner
             || ($combination->array_sometimes_filled && $overwrite_empty_array)
             || ($combination->objectlike_entries
                 && $combination->objectlike_sealed
+                && ($combination->array_min_counts[0] ?? false) !== true
                 && $overwrite_empty_array)
         ) {
             if ($combination->all_arrays_lists) {

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -2290,6 +2290,27 @@ class ArrayFunctionCallTest extends TestCase
                     }
                     ',
             ],
+            'mergeBetweenSealedArrayWithPossiblyUndefinedAndMixedArrayIsMixedArray' => [
+                'code' => '<?php
+
+                    function findit(Closure $x): void
+                    {
+                        $closure = new ReflectionFunction($x);
+
+                        $statics = [];
+
+                        if (rand(0, 1)) {
+                            $statics = ["this" => "a"];
+                        }
+                        $b = $statics + $closure->getStaticVariables();
+                        /** @psalm-check-type $b = array<array-key, mixed> */
+
+                        $_a = count($b);
+
+                        /** @psalm-check-type $_a = int<0, max> */
+                    }
+                    ',
+            ],
         ];
     }
 


### PR DESCRIPTION
This will fix #8719

We were creating an non-empty-array based on the fact that there were sealed properties without actually checking if they could be undefined

@danog could you review that? Not sure if it was the best move here