### PR TITLE
Fix crash when using phantom methods as first-class callable

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -685,18 +685,22 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                     }
                 }
 
-                if (ArgumentsAnalyzer::analyze(
-                    $statements_analyzer,
-                    $stmt->getArgs(),
-                    null,
-                    null,
-                    true,
-                    $context
-                ) === false) {
-                    return;
-                }
+                if ($stmt->isFirstClassCallable()) {
+                    $result->return_type = Type::getClosure();
+                } else {
+                    if (ArgumentsAnalyzer::analyze(
+                        $statements_analyzer,
+                        $stmt->getArgs(),
+                        null,
+                        null,
+                        true,
+                        $context
+                    ) === false) {
+                        return;
+                    }
 
-                $result->return_type = Type::getMixed();
+                    $result->return_type = Type::getMixed();
+                }
                 return;
 
             default:

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -872,6 +872,21 @@ class ClosureTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'FirstClassCallable:Method:Asserted' => [
+                'code' => '<?php
+                    $r = false;
+                    /** @var object $o */;
+                    /** @var string $m */;
+                    if (method_exists($o, $m)) {
+                        $r = $o->$m(...);
+                    }
+                ',
+                'assertions' => [
+                    '$r===' => 'Closure|false',
+                ],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
             'arrowFunctionReturnsNeverImplictly' => [
                 'code' => '<?php
                     $bar = ["foo", "bar"];


### PR DESCRIPTION
Fixes vimeo/psalm#8377
