### PR TITLE
Extend impure_functions list by socket functions

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -429,7 +429,8 @@ class Functions
             // stream/socket io
             'stream_context_set_option', 'socket_write', 'stream_set_blocking', 'socket_close',
             'socket_set_option', 'stream_set_write_buffer', 'stream_socket_enable_crypto', 'stream_copy_to_stream',
-            'stream_wrapper_register',
+            'stream_wrapper_register', 'socket_connect', 'socket_bind', 'socket_set_block', 'socket_set_nonblock',
+            'socket_listen',
 
             // meta calls
             'call_user_func', 'call_user_func_array', 'define', 'create_function',


### PR DESCRIPTION
This prevents UnusedFunctionCall for some socket ext functions.

Result of all of these functions is boolean and can be ignored.

Note, socket errors can be fetched by:
 - `socket_strerror`
 - `socket_last_error`



Closes #8818 