### PR TITLE
Allowed taints to pass through urlencode()

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -840,6 +840,15 @@ function htmlspecialchars_decode(string $string, ?int $flags = null) : string {}
 /**
  * @psalm-pure
  *
+ * @psalm-taint-escape html
+ * @psalm-taint-escape has_quotes
+ * @psalm-flow ($string) -> return
+ */
+function urlencode(string $string) : string {}
+
+/**
+ * @psalm-pure
+ *
  * @psalm-return (
  *     $string is ''
  *     ? 0

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -722,6 +722,11 @@ class TaintTest extends TestCase
                         }
                     }'
             ],
+            'urlencode' => [
+                'code' => '<?php
+                    echo urlencode($_GET["bad"]);
+                '
+            ],
         ];
     }
 
@@ -2373,6 +2378,17 @@ class TaintTest extends TestCase
                     new $a($b);',
                 'error_message' => 'TaintedCallable',
             ],
+            'urlencode' => [
+                /**
+                 * urlencode() should only prevent html & has_quotes taints
+                 * All other taint types should be unaffected.
+                 * We arbitrarily chose system() to test this.
+                 */
+                'code' => '<?php
+                    system(urlencode($_GET["bad"]));
+                ',
+                'error_message' => 'TaintedShell'
+            ]
         ];
     }
 


### PR DESCRIPTION
The `urlencode()` function currently escapes all taints.  I suspect it should only escape html & has_quotes taints.  Here's an example where a taint should likely be reported, but is not:

https://psalm.dev/r/4c72d132a4

This PR attempts to fix this.  Don't hesitate to let me know if I'm missing anything, or if you have any concerns.