### PR TITLE
Precise count range

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -1543,7 +1543,7 @@ return [
 'Couchbase\WildcardSearchQuery::jsonSerialize' => ['array'],
 'Couchbase\zlibCompress' => ['string', 'data'=>'string'],
 'Couchbase\zlibDecompress' => ['string', 'data'=>'string'],
-'count' => ['int', 'value'=>'Countable|array', 'mode='=>'int'],
+'count' => ['int<0, max>', 'value'=>'Countable|array', 'mode='=>'int'],
 'count_chars' => ['array<int,int>', 'input'=>'string', 'mode='=>'0|1|2'],
 'count_chars\'1' => ['string', 'input'=>'string', 'mode='=>'3|4'],
 'Countable::count' => ['int'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -290,8 +290,8 @@ return [
       'new' => ['bool', 'typelib_name'=>'string', 'case_insensitive='=>'true'],
     ],
     'count' => [
-        'old' => ['int', 'value'=>'Countable|array|SimpleXMLElement', 'mode='=>'int'],
-        'new' => ['int', 'value'=>'Countable|array', 'mode='=>'int'],
+        'old' => ['int<0, max>', 'value'=>'Countable|array|SimpleXMLElement', 'mode='=>'int'],
+        'new' => ['int<0, max>', 'value'=>'Countable|array', 'mode='=>'int'],
     ],
     'count_chars' => [
       'old' => ['array<int,int>|false', 'input'=>'string', 'mode='=>'0|1|2'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -10084,7 +10084,7 @@ return [
     'copy' => ['bool', 'from'=>'string', 'to'=>'string', 'context='=>'resource'],
     'cos' => ['float', 'num'=>'float'],
     'cosh' => ['float', 'num'=>'float'],
-    'count' => ['int', 'value'=>'Countable|array|SimpleXMLElement', 'mode='=>'int'],
+    'count' => ['int<0, max>', 'value'=>'Countable|array|SimpleXMLElement', 'mode='=>'int'],
     'count_chars' => ['array<int,int>|false', 'input'=>'string', 'mode='=>'0|1|2'],
     'count_chars\'1' => ['string|false', 'input'=>'string', 'mode='=>'3|4'],
     'crack_check' => ['bool', 'dictionary'=>'', 'password'=>'string'],

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1220,6 +1220,13 @@ class FunctionCallTest extends TestCase
                         return count($x);
                     }',
             ],
+            'countOnObjectShouldBePositive' => [
+                'code' => '<?php
+                    /** @return positive-int|0 */
+                    function example(\Countable $x) : int {
+                        return count($x);
+                    }',
+            ],
             'countOnPureObjectIsPure' => [
                 'code' => '<?php
                     class PureCountable implements \Countable {
@@ -2354,14 +2361,6 @@ class FunctionCallTest extends TestCase
                         }
                     }',
                 'error_message' => 'TypeDoesNotContainType',
-            ],
-            'countOnObjectCannotBePositive' => [
-                'code' => '<?php
-                    /** @return positive-int|0 */
-                    function example(\Countable $x) : int {
-                        return count($x);
-                    }',
-                'error_message' => 'LessSpecificReturnStatement',
             ],
             'countOnUnknownObjectCannotBePure' => [
                 'code' => '<?php


### PR DESCRIPTION
According to https://github.com/JetBrains/phpstorm-stubs/blob/ccff41f1a6b40ff4ecfaa4964fa5007fa78f6225/Core/Core_c.php#L701

Countable should return int<0, max>. cc @orklah 