### PR TITLE
Allow `true` in native types

### DIFF
--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -303,7 +303,10 @@ abstract class Atomic implements TypeNode
                 return $analysis_php_version_id !== null ? new TNamedObject($value) : new TNumeric();
 
             case 'true':
-                return $analysis_php_version_id !== null ? new TNamedObject($value) : new TTrue();
+                if ($analysis_php_version_id === null || $analysis_php_version_id >= 8_02_00) {
+                    return new TTrue();
+                }
+                return new TNamedObject($value);
 
             case 'false':
                 if ($analysis_php_version_id === null || $analysis_php_version_id >= 8_00_00) {

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1154,6 +1154,31 @@ class ReturnTypeTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'newReturnTypesInPhp82' => [
+                'code' => '<?php
+                    function alwaysTrue(): true {
+                        return true;
+                    }
+
+                    function alwaysFalse(): false {
+                        return false;
+                    }
+
+                    function alwaysNull(): null {
+                        return null;
+                    }
+                    $true = alwaysTrue();
+                    $false = alwaysFalse();
+                    $null = alwaysNull();
+                ',
+                'assertions' => [
+                    '$true===' => 'true',
+                    '$false===' => 'false',
+                    '$null===' => 'null',
+                ],
+                'ignored_issues' => [],
+                'php_version' => '8.2',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes vimeo/psalm#8872

For `null` and `false`, we already allowed them even as standalone
types, even though PHP before 8.2 only allowed them as part of a union.
