### PR TITLE
Prevent duplicate (Possibly)UnusedMethod/(Possibly)UnusedProperty

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -2144,7 +2144,8 @@ class ClassLikes
                             'Cannot find ' . ($has_variable_calls ? 'explicit' : 'any')
                                 . ' references to property ' . $property_id
                                 . ($has_variable_calls ? ' (but did find some potential references)' : ''),
-                            $property_storage->location
+                            $property_storage->location,
+                            $property_id
                         );
 
                         if ($codebase->alter_code) {
@@ -2173,7 +2174,8 @@ class ClassLikes
                         'Cannot find ' . ($has_variable_calls ? 'explicit' : 'any')
                             . ' references to private property ' . $property_id
                             . ($has_variable_calls ? ' (but did find some potential references)' : ''),
-                        $property_storage->location
+                        $property_storage->location,
+                        $property_id
                     );
 
                     if ($codebase->alter_code) {

--- a/src/Psalm/Issue/PossiblyUnusedMethod.php
+++ b/src/Psalm/Issue/PossiblyUnusedMethod.php
@@ -2,8 +2,21 @@
 
 namespace Psalm\Issue;
 
+use Psalm\CodeLocation;
+
+use function strtolower;
+
 final class PossiblyUnusedMethod extends MethodIssue
 {
     public const ERROR_LEVEL = -2;
     public const SHORTCODE = 87;
+
+    public function __construct(
+        string $message,
+        CodeLocation $code_location,
+        string $method_id
+    ) {
+        parent::__construct($message, $code_location, $method_id);
+        $this->dupe_key = strtolower($method_id);
+    }
 }

--- a/src/Psalm/Issue/PossiblyUnusedProperty.php
+++ b/src/Psalm/Issue/PossiblyUnusedProperty.php
@@ -2,8 +2,19 @@
 
 namespace Psalm\Issue;
 
-final class PossiblyUnusedProperty extends CodeIssue
+use Psalm\CodeLocation;
+
+final class PossiblyUnusedProperty extends PropertyIssue
 {
     public const ERROR_LEVEL = -2;
     public const SHORTCODE = 149;
+
+    public function __construct(
+        string $message,
+        CodeLocation $code_location,
+        string $property_id
+    ) {
+        parent::__construct($message, $code_location, $property_id);
+        $this->dupe_key = $property_id;
+    }
 }

--- a/src/Psalm/Issue/UnusedMethod.php
+++ b/src/Psalm/Issue/UnusedMethod.php
@@ -2,8 +2,21 @@
 
 namespace Psalm\Issue;
 
+use Psalm\CodeLocation;
+
+use function strtolower;
+
 final class UnusedMethod extends MethodIssue
 {
     public const ERROR_LEVEL = -2;
     public const SHORTCODE = 76;
+
+    public function __construct(
+        string $message,
+        CodeLocation $code_location,
+        string $method_id
+    ) {
+        parent::__construct($message, $code_location, $method_id);
+        $this->dupe_key = strtolower($method_id);
+    }
 }

--- a/src/Psalm/Issue/UnusedProperty.php
+++ b/src/Psalm/Issue/UnusedProperty.php
@@ -2,8 +2,19 @@
 
 namespace Psalm\Issue;
 
-final class UnusedProperty extends CodeIssue
+use Psalm\CodeLocation;
+
+final class UnusedProperty extends PropertyIssue
 {
     public const ERROR_LEVEL = -2;
     public const SHORTCODE = 150;
+
+    public function __construct(
+        string $message,
+        CodeLocation $code_location,
+        string $property_id
+    ) {
+        parent::__construct($message, $code_location, $property_id);
+        $this->dupe_key = $property_id;
+    }
 }


### PR DESCRIPTION
This also allows (Possibly)UnusedProperty to be suppressed with
`referencedProperty` attribute in psalm.xml

Fixes vimeo/psalm#8874
