### PR TITLE
Forbid most magic methods on enums

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -264,6 +264,7 @@
             <xs:element name="InvalidDocblockParamName" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidEnumBackingType" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidEnumCaseValue" type="ClassIssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidEnumMethod" type="MethodIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidExtendClass" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidFalsableReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidFunctionCall" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -45,6 +45,7 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
  - [InaccessibleProperty](issues/InaccessibleProperty.md)
  - [InterfaceInstantiation](issues/InterfaceInstantiation.md)
  - [InvalidAttribute](issues/InvalidAttribute.md)
+ - [InvalidEnumMethod](issues/InvalidEnumMethod.md)
  - [InvalidExtendClass](issues/InvalidExtendClass.md)
  - [InvalidGlobal](issues/InvalidGlobal.md)
  - [InvalidParamDefault](issues/InvalidParamDefault.md)

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -69,6 +69,7 @@
  - [InvalidDocblockParamName](issues/InvalidDocblockParamName.md)
  - [InvalidEnumBackingType](issues/InvalidEnumBackingType.md)
  - [InvalidEnumCaseValue](issues/InvalidEnumCaseValue.md)
+ - [InvalidEnumMethod](issues/InvalidEnumMethod.md)
  - [InvalidExtendClass](issues/InvalidExtendClass.md)
  - [InvalidFalsableReturnType](issues/InvalidFalsableReturnType.md)
  - [InvalidFunctionCall](issues/InvalidFunctionCall.md)

--- a/docs/running_psalm/issues/InvalidEnumMethod.md
+++ b/docs/running_psalm/issues/InvalidEnumMethod.md
@@ -1,0 +1,15 @@
+# InvalidEnumMethod
+
+Enums may not define most of the magic methods like `__get`, `__toString`, etc.
+
+```php
+<?php
+enum Status: string {
+    case Open = 'open';
+    case Closed = 'closed';
+
+    public function __toString(): string {
+        return "SomeStatus";
+    }
+}
+```

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -2020,6 +2020,10 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
 
             MethodAnalyzer::checkMethodSignatureMustOmitReturnType($storage, $codeLocation);
 
+            if ($appearing_class_storage->is_enum) {
+                MethodAnalyzer::checkForbiddenEnumMethod($storage);
+            }
+
             if (!$context->calling_method_id || !$context->collect_initializations) {
                 $context->calling_method_id = strtolower((string)$method_id);
             }

--- a/src/Psalm/Issue/InvalidEnumMethod.php
+++ b/src/Psalm/Issue/InvalidEnumMethod.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+final class InvalidEnumMethod extends MethodIssue
+{
+    public const ERROR_LEVEL = -1;
+    public const SHORTCODE = 314;
+}

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -310,6 +310,7 @@ class DocumentationTest extends TestCase
                 case 'DuplicateEnumCaseValue':
                 case 'InvalidEnumBackingType':
                 case 'InvalidEnumCaseValue':
+                case 'InvalidEnumMethod':
                 case 'NoEnumProperties':
                 case 'OverriddenFinalConstant':
                     $php_version = '8.1';
@@ -436,7 +437,7 @@ class DocumentationTest extends TestCase
             throw new UnexpectedValueException("Issues index not found");
         }
 
-        $issues_index_contents = file($issues_index, FILE_IGNORE_NEW_LINES|FILE_SKIP_EMPTY_LINES);
+        $issues_index_contents = file($issues_index, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
         if ($issues_index_contents === false) {
             throw new UnexpectedValueException("Issues index returned false");
         }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -686,6 +686,17 @@ class EnumTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'forbiddenMethod' => [
+                'code' => '<?php
+                    enum Foo {
+                        case A;
+                        public function __get() {}
+                    }
+                ',
+                'error_message' => 'InvalidEnumMethod',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes vimeo/psalm#8889

Additionally this fixes case-sensitivity of
MethodSignatureMustOmitReturnType issue

Fixes vimeo/psalm#8888
