### PR TITLE
Recognize casts from object-with-properties to array

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -259,6 +259,15 @@ class CastAnalyzer
                         || $type instanceof TKeyedArray
                     ) {
                         $permissible_atomic_types[] = $type;
+                    } elseif ($type instanceof TObjectWithProperties) {
+                        $array_type = $type->properties === []
+                            ? new TArray([Type::getArrayKey(), Type::getMixed()])
+                            : new TKeyedArray(
+                                $type->properties,
+                                null,
+                                [Type::getArrayKey(), Type::getMixed()]
+                            );
+                        $permissible_atomic_types[] = $array_type;
                     } else {
                         $all_permissible = false;
                         break;

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -40,5 +40,14 @@ class CastTest extends TestCase
                 '$int===' => '0|1|int<10, 20>',
             ],
         ];
+        yield 'castObjectWithPropertiesToArray' => [
+            'code' => '<?php
+                /** @var object{a:int,b:string} $o */
+                $a = (array) $o;
+            ',
+            'assertions' => [
+                '$a===' => 'array{a: int, b: string, ...<array-key, mixed>}',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Previously `(array)(object)['a' => 1, 'b' => 'foo']` would result in
`array<array-key, mixed>`. Now it would be inferred as
`array{a:1,b:foo,...<array-key,mixed>}`
