### PR TITLE
Json baseline formatter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -107,12 +107,13 @@
     ],
     "scripts": {
         "cs": "phpcs -ps",
-        "cs-fix": "phpcbf -ps",
+        "cs-fix": "phpcbf -p",
         "lint": "parallel-lint ./src ./tests",
         "phpunit": "paratest --runner=WrapperRunner",
         "phpunit-std": "phpunit",
         "verify-callmap": "phpunit tests/Internal/Codebase/InternalCallMapHandlerTest.php",
         "psalm": "@php ./psalm --find-dead-code",
+        "psalm-set-baseline": "@php ./psalm --find-dead-code --set-baseline=psalm-baseline.xml",
         "tests": [
             "@lint",
             "@cs",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@6eb37b9dc2321e4eaade9d3d2dca1aff6f2c0a8f">
+<files psalm-version="dev-master@4d0ddf6310e9c0831dffc35385086370b28fbec7">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset occurrences="2">
       <code>$comment_block-&gt;tags['variablesfrom'][0]</code>
@@ -25,13 +25,6 @@
   <file src="src/Psalm/Config/FileFilter.php">
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>explode('::', $method_id)[1]</code>
-    </PossiblyUndefinedIntArrayOffset>
-  </file>
-  <file src="src/Psalm/ErrorBaseline.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="3">
-      <code>$matches[1]</code>
-      <code>$matches[2]</code>
-      <code>$matches[3]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/ClassAnalyzer.php">
@@ -231,6 +224,18 @@
       <code>$check_type_string</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
+  <file src="src/Psalm/Internal/BaselineFormatter/BaselineFormatterFactory.php">
+    <MixedArgument occurrences="1">
+      <code>$options['set-baseline']</code>
+    </MixedArgument>
+  </file>
+  <file src="src/Psalm/Internal/BaselineFormatter/XmlBaselineFormatter.php">
+    <PossiblyUndefinedIntArrayOffset occurrences="3">
+      <code>$matches[1]</code>
+      <code>$matches[2]</code>
+      <code>$matches[3]</code>
+    </PossiblyUndefinedIntArrayOffset>
+  </file>
   <file src="src/Psalm/Internal/Cli/Refactor.php">
     <PossiblyUndefinedIntArrayOffset occurrences="1">
       <code>$identifier_name</code>
@@ -391,6 +396,9 @@
       <code>$class_strings ?: null</code>
     </InvalidArgument>
     <RedundantCondition occurrences="2">
+      <code>!$type-&gt;possibly_undefined
+                                    &amp;&amp; !$unpacking_possibly_empty
+                                    &amp;&amp; $is_replace</code>
       <code>$is_replace</code>
     </RedundantCondition>
   </file>

--- a/src/Psalm/Internal/BaselineFormatter/BaselineFormatterFactory.php
+++ b/src/Psalm/Internal/BaselineFormatter/BaselineFormatterFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\BaselineFormatter;
+
+use Exception;
+use Psalm\Config;
+
+use function is_string;
+use function pathinfo;
+
+use const PATHINFO_EXTENSION;
+
+/**
+ * @internal
+ */
+final class BaselineFormatterFactory
+{
+    public function fromKey(string $key): BaselineFormatterInterface
+    {
+        if ($key === XmlBaselineFormatter::getKey()) {
+            return new XmlBaselineFormatter();
+        } elseif ($key === JsonBaselineFormatter::getKey()) {
+            return new JsonBaselineFormatter();
+        } else {
+            throw new Exception('Unknown baseline formatter key: ' . $key);
+        }
+    }
+
+    public function fromOptionsAndConfig(array $options, Config $config): BaselineFormatterInterface
+    {
+        if (isset($options['baseline-formatter'])) {
+            if (!is_string($options['baseline-formatter'])) {
+                throw new Exception('baseline-formatter option is not a string.');
+            }
+            $key = $options['baseline-formatter'];
+        } elseif (isset($options['set-baseline'])) {
+            $extension = pathinfo($options['set-baseline'], PATHINFO_EXTENSION);
+            $key = $extension !== '' ? $extension : XmlBaselineFormatter::getKey();
+        } elseif ($config->error_baseline) {
+            $extension = pathinfo($config->error_baseline, PATHINFO_EXTENSION);
+            $key = $extension !== '' ? $extension : XmlBaselineFormatter::getKey();
+        } else {
+            $key = XmlBaselineFormatter::getKey();
+        }
+        return $this->fromKey($key);
+    }
+}

--- a/src/Psalm/Internal/BaselineFormatter/BaselineFormatterInterface.php
+++ b/src/Psalm/Internal/BaselineFormatter/BaselineFormatterInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\BaselineFormatter;
+
+use Psalm\ErrorBaseline;
+
+/**
+ * @psalm-import-type psalmFormattedBaseline from ErrorBaseline
+ * @internal
+ */
+interface BaselineFormatterInterface
+{
+    public static function getKey(): string;
+
+    /**
+     * @param psalmFormattedBaseline $grouped_issues
+     */
+    public function format(
+        array $grouped_issues,
+        bool $include_php_versions
+    ): string;
+
+    /**
+     * @return psalmFormattedBaseline
+     */
+    public function read(string $content): array;
+}

--- a/src/Psalm/Internal/BaselineFormatter/JsonBaselineFormatter.php
+++ b/src/Psalm/Internal/BaselineFormatter/JsonBaselineFormatter.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\BaselineFormatter;
+
+use function count;
+use function get_loaded_extensions;
+use function json_decode;
+use function json_encode;
+use function phpversion;
+use function sort;
+use function trim;
+use function usort;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const PHP_VERSION;
+
+/**
+ * @internal
+ */
+class JsonBaselineFormatter implements BaselineFormatterInterface
+{
+    public static function getKey(): string
+    {
+        return 'json';
+    }
+
+    public function format(array $grouped_issues, bool $include_php_versions): string
+    {
+        $data = ['psalm_version' => PSALM_VERSION];
+        if ($include_php_versions) {
+            $extensions = [...get_loaded_extensions(), ...get_loaded_extensions(true)];
+            usort($extensions, 'strnatcasecmp');
+            $php_versions = ['php' => PHP_VERSION];
+            foreach ($extensions as $extension) {
+                $php_versions[$extension] = phpversion($extension);
+            }
+            $data['php_versions'] = $php_versions;
+        }
+        foreach ($grouped_issues as $file => $issue_types) {
+            foreach ($issue_types as $issue_type => $existing_issue_type) {
+                $data['files'][$file][$issue_type] = [];
+                sort($existing_issue_type['s']);
+                foreach ($existing_issue_type['s'] as $selection) {
+                    $data['files'][$file][$issue_type][] = trim($selection);
+                }
+            }
+        }
+        return json_encode($data, JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string, array<string, array{o:int, s: list<string>}>>
+     */
+    public function read(string $content): array
+    {
+        /** @var array{files: array<string, array<string, list<string>>>} $data */
+        $data = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        $grouped_issues = [];
+        foreach ($data['files'] as $file => $issue_types) {
+            foreach ($issue_types as $issue_type => $selections) {
+                $grouped_issues[$file][$issue_type]['o'] = count($selections);
+                $grouped_issues[$file][$issue_type]['s'] = [];
+                foreach ($selections as $selection) {
+                    $grouped_issues[$file][$issue_type]['s'][] = $selection;
+                }
+            }
+        }
+        return $grouped_issues;
+    }
+}

--- a/src/Psalm/Internal/BaselineFormatter/XmlBaselineFormatter.php
+++ b/src/Psalm/Internal/BaselineFormatter/XmlBaselineFormatter.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\BaselineFormatter;
+
+use DOMDocument;
+use DOMElement;
+use Psalm\Exception\ConfigException;
+use RuntimeException;
+
+use function array_map;
+use function get_loaded_extensions;
+use function implode;
+use function phpversion;
+use function preg_replace_callback;
+use function sort;
+use function sprintf;
+use function str_replace;
+use function trim;
+use function usort;
+
+use const LIBXML_NOBLANKS;
+use const PHP_VERSION;
+
+/**
+ * @internal
+ */
+final class XmlBaselineFormatter implements BaselineFormatterInterface
+{
+    public static function getKey(): string
+    {
+        return 'xml';
+    }
+
+    public function format(array $grouped_issues, bool $include_php_versions): string
+    {
+        $baselineDoc = new DOMDocument('1.0', 'UTF-8');
+        $filesNode = $baselineDoc->createElement('files');
+        $filesNode->setAttribute('psalm-version', PSALM_VERSION);
+
+        if ($include_php_versions) {
+            $extensions = [...get_loaded_extensions(), ...get_loaded_extensions(true)];
+
+            usort($extensions, 'strnatcasecmp');
+
+            $filesNode->setAttribute('php-version', implode(';' . "\n\t", [...[
+                ('php:' . PHP_VERSION),
+            ], ...array_map(
+                static fn(string $extension): string => $extension . ':' . phpversion($extension),
+                $extensions
+            )]));
+        }
+
+        foreach ($grouped_issues as $file => $issueTypes) {
+            $fileNode = $baselineDoc->createElement('file');
+
+            $fileNode->setAttribute('src', $file);
+
+            foreach ($issueTypes as $issueType => $existingIssueType) {
+                $issueNode = $baselineDoc->createElement($issueType);
+
+                $issueNode->setAttribute('occurrences', (string)$existingIssueType['o']);
+
+                sort($existingIssueType['s']);
+
+                foreach ($existingIssueType['s'] as $selection) {
+                    $codeNode = $baselineDoc->createElement('code');
+                    $codeNode->textContent = trim($selection);
+                    $issueNode->appendChild($codeNode);
+                }
+                $fileNode->appendChild($issueNode);
+            }
+
+            $filesNode->appendChild($fileNode);
+        }
+
+        $baselineDoc->appendChild($filesNode);
+        $baselineDoc->formatOutput = true;
+
+        $xml = preg_replace_callback(
+            '/<files (psalm-version="[^"]+") php-version="(.+)"(\/?>)\n/',
+            /**
+             * @param string[] $matches
+             */
+            static fn(array $matches): string => sprintf(
+                "<files\n  %s\n  php-version=\"\n    %s\n  \"\n%s\n",
+                $matches[1],
+                str_replace('&#10;&#9;', "\n    ", $matches[2]),
+                $matches[3]
+            ),
+            $baselineDoc->saveXML()
+        );
+
+        if ($xml === null) {
+            throw new RuntimeException('Failed to reformat opening attributes!');
+        }
+
+        return $xml;
+    }
+
+    public function read(string $content): array
+    {
+        if ($content === '') {
+            throw new ConfigException('Baseline file is empty.');
+        }
+
+        $baselineDoc = new DOMDocument();
+        $baselineDoc->loadXML($content, LIBXML_NOBLANKS);
+
+        $filesElement = $baselineDoc->getElementsByTagName('files');
+
+        if ($filesElement->length === 0) {
+            throw new ConfigException('Baseline file does not contain <files>.');
+        }
+
+        $files = [];
+
+        /** @var DOMElement $filesElement */
+        $filesElement = $filesElement[0];
+
+        foreach ($filesElement->getElementsByTagName('file') as $file) {
+            $fileName = $file->getAttribute('src');
+
+            $fileName = str_replace('\\', '/', $fileName);
+
+            $files[$fileName] = [];
+
+            foreach ($file->childNodes as $issue) {
+                if (!$issue instanceof DOMElement) {
+                    continue;
+                }
+
+                $issueType = $issue->tagName;
+
+                $files[$fileName][$issueType] = [
+                    'o' => (int)$issue->getAttribute('occurrences'),
+                    's' => [],
+                ];
+                $codeSamples = $issue->getElementsByTagName('code');
+
+                foreach ($codeSamples as $codeSample) {
+                    $files[$fileName][$issueType]['s'][] = trim($codeSample->textContent);
+                }
+            }
+        }
+
+        return $files;
+    }
+}

--- a/tests/ErrorBaselineTest.php
+++ b/tests/ErrorBaselineTest.php
@@ -9,6 +9,7 @@ use Mockery\MockInterface;
 use Psalm\ErrorBaseline;
 use Psalm\Exception\ConfigException;
 use Psalm\Internal\Analyzer\IssueData;
+use Psalm\Internal\BaselineFormatter\XmlBaselineFormatter;
 use Psalm\Internal\Provider\FileProvider;
 use Psalm\Internal\RuntimeCaches;
 
@@ -63,7 +64,7 @@ class ErrorBaselineTest extends TestCase
 
         $this->assertSame(
             $expectedParsedBaseline,
-            ErrorBaseline::read($this->fileProvider, $baselineFilePath)
+            ErrorBaseline::read($this->fileProvider, $baselineFilePath, new XmlBaselineFormatter())
         );
     }
 
@@ -91,7 +92,7 @@ class ErrorBaselineTest extends TestCase
 
         $this->assertSame(
             $expectedParsedBaseline,
-            ErrorBaseline::read($this->fileProvider, $baselineFilePath)
+            ErrorBaseline::read($this->fileProvider, $baselineFilePath, new XmlBaselineFormatter())
         );
     }
 
@@ -109,7 +110,7 @@ class ErrorBaselineTest extends TestCase
             '
         );
 
-        ErrorBaseline::read($this->fileProvider, $baselineFile);
+        ErrorBaseline::read($this->fileProvider, $baselineFile, new XmlBaselineFormatter());
     }
 
     public function testLoadShouldThrowExceptionWhenBaselineFileDoesNotExist(): void
@@ -120,7 +121,7 @@ class ErrorBaselineTest extends TestCase
 
         $this->fileProvider->expects()->fileExists($baselineFile)->andReturns(false);
 
-        ErrorBaseline::read($this->fileProvider, $baselineFile);
+        ErrorBaseline::read($this->fileProvider, $baselineFile, new XmlBaselineFormatter());
     }
 
     public function testCountTotalIssuesShouldReturnCorrectNumber(): void
@@ -292,7 +293,8 @@ class ErrorBaselineTest extends TestCase
                     ),
                 ],
             ],
-            false
+            false,
+            new XmlBaselineFormatter(),
         );
 
         $this->fileProvider->shouldHaveReceived()
@@ -521,7 +523,7 @@ class ErrorBaselineTest extends TestCase
 
         $this->assertSame(
             $expectedParsedBaseline,
-            ErrorBaseline::read($this->fileProvider, $baselineFilePath)
+            ErrorBaseline::read($this->fileProvider, $baselineFilePath, new XmlBaselineFormatter())
         );
     }
 }

--- a/tests/Internal/BaselineFormatter/BaselineFormatterFactoryTest.php
+++ b/tests/Internal/BaselineFormatter/BaselineFormatterFactoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Internal\BaselineFormatter;
+
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Psalm\Config;
+use Psalm\Internal\BaselineFormatter\BaselineFormatterFactory;
+use Psalm\Internal\BaselineFormatter\JsonBaselineFormatter;
+use Psalm\Internal\BaselineFormatter\XmlBaselineFormatter;
+
+class BaselineFormatterFactoryTest extends TestCase
+{
+    /**
+     * @dataProvider provideForTestFromKey
+     * @param class-string|null $expectedClass
+     */
+    public function testFromKey(string $key, ?string $expectedClass): void
+    {
+        $sut = new BaselineFormatterFactory();
+        if ($expectedClass === null) {
+            $this->expectException(Exception::class);
+            $sut->fromKey($key);
+        } else {
+            $this->assertInstanceOf($expectedClass, $sut->fromKey($key));
+        }
+    }
+
+    /**
+     * @return iterable<int, list{string, class-string|null}>
+     */
+    public function provideForTestFromKey(): iterable
+    {
+        yield ['xml', XmlBaselineFormatter::class];
+        yield ['json', JsonBaselineFormatter::class];
+        yield ['bogus', null];
+    }
+
+    /**
+     * @dataProvider provideForTestFromOptionsAndConfig
+     * @param class-string $expectedClass
+     */
+    public function testFromOptionsAndConfig(array $options, Config $config, string $expectedClass): void
+    {
+        $sut = new BaselineFormatterFactory();
+        $this->assertInstanceOf($expectedClass, $sut->fromOptionsAndConfig($options, $config));
+    }
+
+    /**
+     * @return iterable<int, list{array, Config, class-string}>
+     */
+    public function provideForTestFromOptionsAndConfig(): iterable
+    {
+        yield [
+            ['baseline-formatter' => 'json'],
+            Config::loadFromXML(__DIR__, '<?xml version="1.0"?><psalm/>'),
+            JsonBaselineFormatter::class,
+        ];
+        yield [
+            ['baseline-formatter' => 'xml'],
+            Config::loadFromXML(__DIR__, '<?xml version="1.0"?><psalm/>'),
+            XmlBaselineFormatter::class,
+        ];
+        yield [
+            ['set-baseline' => 'psalm-baseline.json'],
+            Config::loadFromXML(__DIR__, '<?xml version="1.0"?><psalm/>'),
+            JsonBaselineFormatter::class,
+        ];
+        yield [
+            ['set-baseline' => 'psalm-baseline.xml'],
+            Config::loadFromXML(__DIR__, '<?xml version="1.0"?><psalm/>'),
+            XmlBaselineFormatter::class,
+        ];
+        yield [
+            [],
+            Config::loadFromXML(__DIR__, '<?xml version="1.0"?><psalm errorBaseline="psalm-baseline.json"/>'),
+            JsonBaselineFormatter::class,
+        ];
+        yield [
+            [],
+            Config::loadFromXML(__DIR__, '<?xml version="1.0"?><psalm errorBaseline="psalm-baseline.xml"/>'),
+            XmlBaselineFormatter::class,
+        ];
+        yield [
+            [],
+            Config::loadFromXML(__DIR__, '<?xml version="1.0"?><psalm/>'),
+            XmlBaselineFormatter::class,
+        ];
+    }
+}

--- a/tests/Internal/BaselineFormatter/JsonBaselineFormatterTest.php
+++ b/tests/Internal/BaselineFormatter/JsonBaselineFormatterTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Internal\BaselineFormatter;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\ErrorBaseline;
+use Psalm\Internal\BaselineFormatter\JsonBaselineFormatter;
+
+use function define;
+use function defined;
+
+/**
+ * @psalm-import-type psalmFormattedBaseline from ErrorBaseline
+ */
+class JsonBaselineFormatterTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('PSALM_VERSION')) {
+            define('PSALM_VERSION', '0.0.0');
+        }
+    }
+
+    /**
+     * @dataProvider provideForTestRead
+     */
+    public function testRead(string $content, array $expectedResult): void
+    {
+        $sut = new JsonBaselineFormatter();
+        $this->assertSame($expectedResult, $sut->read($content));
+    }
+
+    /**
+     * @return iterable<int, list{string, array}>
+     */
+    public function provideForTestRead(): iterable
+    {
+        yield [
+            <<<'JSON'
+                {
+                    "files": {
+                        "sample/sample-file.php": {
+                            "MixedAssignment": [
+                                "foo",
+                                "bar"
+                            ],
+                            "InvalidReturnStatement": [
+                                "foo"
+                            ]
+                        },
+                        "sample/sample-file2.php": {
+                            "PossiblyUnusedMethod": [
+                                "foo",
+                                "bar"
+                            ]
+                        }
+                    }
+                }
+                JSON,
+            [
+                'sample/sample-file.php' => [
+                    'MixedAssignment' => ['o' => 2, 's' => ['foo', 'bar']],
+                    'InvalidReturnStatement' => ['o' => 1, 's' => ['foo']],
+                ],
+                'sample/sample-file2.php' => [
+                    'PossiblyUnusedMethod' => ['o' => 2, 's' => ['foo', 'bar']],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideForTestFormat
+     * @param psalmFormattedBaseline $grouped_issues
+     */
+    public function testFormat(array $grouped_issues, string $expectedResult): void
+    {
+        $sut = new JsonBaselineFormatter();
+        $this->assertSame($expectedResult, $sut->format($grouped_issues, false));
+    }
+
+    /**
+     * @return iterable<int, list{psalmFormattedBaseline, string}>
+     */
+    public function provideForTestFormat(): iterable
+    {
+        yield [
+            [],
+            <<<'JSON'
+                {
+                    "psalm_version": "0.0.0"
+                }
+                JSON,
+        ];
+        yield [
+            [
+                'sample/sample-file.php' => [
+                    'MixedAssignment' => ['o' => 2, 's' => ['foo', 'bar']],
+                    'InvalidReturnStatement' => ['o' => 1, 's' => []],
+                ],
+                'sample/sample-file2.php' => [
+                    'PossiblyUnusedMethod' => ['o' => 2, 's' => ['foo', 'bar']],
+                ],
+            ],
+            <<<'JSON'
+                {
+                    "psalm_version": "0.0.0",
+                    "files": {
+                        "sample\/sample-file.php": {
+                            "MixedAssignment": [
+                                "bar",
+                                "foo"
+                            ],
+                            "InvalidReturnStatement": []
+                        },
+                        "sample\/sample-file2.php": {
+                            "PossiblyUnusedMethod": [
+                                "bar",
+                                "foo"
+                            ]
+                        }
+                    }
+                }
+                JSON,
+        ];
+    }
+}

--- a/tests/Internal/BaselineFormatter/XmlBaselineFormatterTest.php
+++ b/tests/Internal/BaselineFormatter/XmlBaselineFormatterTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Internal\BaselineFormatter;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\ErrorBaseline;
+use Psalm\Exception\ConfigException;
+use Psalm\Internal\BaselineFormatter\XmlBaselineFormatter;
+
+use function define;
+use function defined;
+
+/**
+ * @psalm-import-type psalmFormattedBaseline from ErrorBaseline
+ */
+class XmlBaselineFormatterTest extends TestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('PSALM_VERSION')) {
+            define('PSALM_VERSION', '0.0.0');
+        }
+    }
+
+    /**
+     * @dataProvider provideForTestRead
+     */
+    public function testRead(string $content, array $expectedResult): void
+    {
+        $sut = new XmlBaselineFormatter();
+        $this->assertSame($expectedResult, $sut->read($content));
+    }
+
+    /**
+     * @return iterable<int, list{string, array}>
+     */
+    public function provideForTestRead(): iterable
+    {
+        yield [
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <files>
+                  <file src="sample/sample-file.php">
+                    <MixedAssignment occurrences="2">
+                      <code>foo</code>
+                      <code>bar</code>
+                    </MixedAssignment>
+                    <InvalidReturnStatement occurrences="1"/>
+                  </file>
+                  <file src="sample\sample-file2.php">
+                    <PossiblyUnusedMethod occurrences="2">
+                      <code>foo</code>
+                      <code>bar</code>
+                    </PossiblyUnusedMethod>
+                  </file>
+                </files>
+                XML,
+            [
+                'sample/sample-file.php' => [
+                    'MixedAssignment' => ['o' => 2, 's' => ['foo', 'bar']],
+                    'InvalidReturnStatement' => ['o' => 1, 's' => []],
+                ],
+                'sample/sample-file2.php' => [
+                    'PossiblyUnusedMethod' => ['o' => 2, 's' => ['foo', 'bar']],
+                ],
+            ],
+        ];
+    }
+
+    public function testExceptionOnEmptyContent(): void
+    {
+        $sut = new XmlBaselineFormatter();
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Baseline file is empty.');
+        $sut->read('');
+    }
+
+    public function testExceptionOnNoFilesElement(): void
+    {
+        $sut = new XmlBaselineFormatter();
+        $this->expectException(ConfigException::class);
+        $this->expectExceptionMessage('Baseline file does not contain <files>.');
+        $sut->read('<?xml version="1.0" encoding="UTF-8"?><bogus/>');
+    }
+
+    /**
+     * @dataProvider provideForTestFormat
+     * @param psalmFormattedBaseline $grouped_issues
+     */
+    public function testFormat(array $grouped_issues, string $expectedResult): void
+    {
+        $sut = new XmlBaselineFormatter();
+        $this->assertSame($expectedResult, $sut->format($grouped_issues, false));
+    }
+
+    /**
+     * @return iterable<int, list{psalmFormattedBaseline, string}>
+     */
+    public function provideForTestFormat(): iterable
+    {
+        yield [
+            [],
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <files psalm-version="0.0.0"/>
+
+                XML,
+        ];
+        yield [
+            [
+                'sample/sample-file.php' => [
+                    'MixedAssignment' => ['o' => 2, 's' => ['foo', 'bar']],
+                    'InvalidReturnStatement' => ['o' => 1, 's' => []],
+                ],
+                'sample/sample-file2.php' => [
+                    'PossiblyUnusedMethod' => ['o' => 2, 's' => ['foo', 'bar']],
+                ],
+            ],
+            <<<'XML'
+                <?xml version="1.0" encoding="UTF-8"?>
+                <files psalm-version="0.0.0">
+                  <file src="sample/sample-file.php">
+                    <MixedAssignment occurrences="2">
+                      <code>bar</code>
+                      <code>foo</code>
+                    </MixedAssignment>
+                    <InvalidReturnStatement occurrences="1"/>
+                  </file>
+                  <file src="sample/sample-file2.php">
+                    <PossiblyUnusedMethod occurrences="2">
+                      <code>bar</code>
+                      <code>foo</code>
+                    </PossiblyUnusedMethod>
+                  </file>
+                </files>
+
+                XML,
+        ];
+    }
+}


### PR DESCRIPTION
I just think JSON is much easier to read and work with.
And not including `occurrences` will lead to smaller diffs, which is important for my team, as our baseline is constantly being updated.


TODO: document new cli option