### PR TITLE
Allow conditions inside loops to preserve or narrow int range

### DIFF
--- a/src/Psalm/Internal/Diff/FileDiffer.php
+++ b/src/Psalm/Internal/Diff/FileDiffer.php
@@ -77,8 +77,6 @@ class FileDiffer
     {
         $result = [];
         for ($d = count($trace) - 1; $d >= 0; --$d) {
-            // Todo: fix integer ranges in fors
-            /** @var int<0, max> $d */
             $v = $trace[$d];
             $k = $x - $y;
 

--- a/src/Psalm/Internal/Type/Comparator/ArrayTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ArrayTypeComparator.php
@@ -123,10 +123,6 @@ class ArrayTypeComparator
         }
 
         foreach ($input_type_part->type_params as $i => $input_param) {
-            if ($i > 1) {
-                break;
-            }
-
             $container_param = $container_type_part->type_params[$i];
 
             if ($i === 0

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1962,10 +1962,6 @@ class SimpleAssertionReconciler extends Reconciler
         }
 
         foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
-            if ($inside_loop) {
-                continue;
-            }
-
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
                     // if the range contains the assertion, the range must be adapted
@@ -2075,10 +2071,6 @@ class SimpleAssertionReconciler extends Reconciler
         }
 
         foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
-            if ($inside_loop) {
-                continue;
-            }
-
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
                     // if the range contains the assertion, the range must be adapted

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -1840,10 +1840,6 @@ class SimpleNegatedAssertionReconciler extends Reconciler
         }
 
         foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
-            if ($inside_loop) {
-                continue;
-            }
-
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
                     // if the range contains the assertion, the range must be adapted
@@ -1951,10 +1947,6 @@ class SimpleNegatedAssertionReconciler extends Reconciler
         }
 
         foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
-            if ($inside_loop) {
-                continue;
-            }
-
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
                     // if the range contains the assertion, the range must be adapted

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -443,9 +443,8 @@ class IntRangeTest extends TestCase
                     '$remainder===' => 'int<min, 1>',
                 ],
             ],
-            'SKIPPED-IntRangeRestrictWhenUntouched' => [
+            'IntRangeRestrictWhenUntouched' => [
                 'code' => '<?php
-                    //skipped, int range in loops not supported yet
                     foreach ([1, 2, 3] as $i) {
                         if ($i > 1) {
                             takesInt($i);
@@ -457,33 +456,54 @@ class IntRangeTest extends TestCase
                         return;
                     }',
             ],
-            'SKIPPED-wrongLoopAssertion' => [
+            'intRangeExpandedByLoop' => [
                 'code' => '<?php
-                    //skipped, int range in loops not supported yet
+                    for ($i = 0; $i < 10; $i++) {
+                        takesInt($i);
+                    }
+                    for (; $i < 20; $i++) {
+                        takesInt($i);
+                    }
+
+                    /** @psalm-param int<0, 20> $i */
+                    function takesInt(int $i): void{
+                        return;
+                    }',
+            ],
+            'statementsInLoopPreserveNonNegativeIntRange' => [
+                'code' => '<?php
+                    $sum = 0;
+                    foreach ([-6, 0, 2] as $i) {
+                        if ($i > 0) {
+                            $sum += $i;
+                        }
+                    }
+                    takesNonNegativeInt($sum);
+
+                    /** @psalm-param int<0, max> $i */
+                    function takesNonNegativeInt(int $i): void{
+                        return;
+                    }',
+            ],
+            'wrongLoopAssertion' => [
+                'code' => '<?php
                     function a(): array {
                         $type_tokens = getArray();
 
                         for ($i = 0, $l = rand(0,100); $i < $l; ++$i) {
-
-                            /** @psalm-trace $i */;
                             if ($i > 0 && rand(0,1)) {
                                 continue;
                             }
-                            /** @psalm-trace $i  */;
-
 
                             $type_tokens[$i] = "";
 
-                            /** @psalm-trace $type_tokens */;
-
-                            if($i > 1){
+                            if ($i > 1) {
                                 $type_tokens[$i - 2];
                             }
                         }
 
                         return [];
                     }
-
 
                     /** @return array<int, string> */
                     function getArray(): array {


### PR DESCRIPTION
Fixes #7555, fixes #8020, fixes #8865

I lack familiarity with the assertion reconciler code, so I'm not sure if there is something the continue if `$inside_loop` checks were necessary for. But at least the current tests still seem to pass without them, and this fixes issues where conditions inside a loop failed to preserve or narrow the range of an int as expected.