### PR TITLE
getopt() return type fix

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -3730,7 +3730,7 @@ return [
 'getmyinode' => ['int|false'],
 'getmypid' => ['int|false'],
 'getmyuid' => ['int|false'],
-'getopt' => ['array<string,string>|array<string,false>|array<string,list<mixed>>|false', 'short_options'=>'string', 'long_options='=>'array', '&w_rest_index='=>'int'],
+'getopt' => ['array<string,string|false|list<string|false>>|false', 'short_options'=>'string', 'long_options='=>'array', '&w_rest_index='=>'int'],
 'getprotobyname' => ['int|false', 'protocol'=>'string'],
 'getprotobynumber' => ['string', 'protocol'=>'int'],
 'getrandmax' => ['int'],

--- a/dictionaries/CallMap_71_delta.php
+++ b/dictionaries/CallMap_71_delta.php
@@ -51,8 +51,8 @@ return [
       'new' => ['array|false', 'url'=>'string', 'associative='=>'int', 'context='=>'resource'],
     ],
     'getopt' => [
-      'old' => ['array<string,string>|array<string,false>|array<string,list<mixed>>|false', 'short_options'=>'string', 'long_options='=>'array'],
-      'new' => ['array<string,string>|array<string,false>|array<string,list<mixed>>|false', 'short_options'=>'string', 'long_options='=>'array', '&w_rest_index='=>'int'],
+      'old' => ['array<string,string|false|list<string|false>>|false', 'short_options'=>'string', 'long_options='=>'array'],
+      'new' => ['array<string,string|false|list<string|false>>|false', 'short_options'=>'string', 'long_options='=>'array', '&w_rest_index='=>'int'],
     ],
     'pg_fetch_all' => [
       'old' => ['array<array>', 'result'=>'resource'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -11157,7 +11157,7 @@ return [
     'getmyinode' => ['int|false'],
     'getmypid' => ['int|false'],
     'getmyuid' => ['int|false'],
-    'getopt' => ['array<string,string>|array<string,false>|array<string,list<mixed>>|false', 'short_options'=>'string', 'long_options='=>'array'],
+    'getopt' => ['array<string,string|false|list<string|false>>|false', 'short_options'=>'string', 'long_options='=>'array'],
     'getprotobyname' => ['int|false', 'protocol'=>'string'],
     'getprotobynumber' => ['string', 'protocol'=>'int'],
     'getrandmax' => ['int'],


### PR DESCRIPTION
You can have false, string, and array values (with false and string values) at the same time:

`% php tester.php -a -b=value -c -c -c -c -c=value`
```php
<?php
var_export(getopt('ab:c::'));
```
```txt
array (
  'a' => false,
  'b' => 'value',
  'c' => 
  array (
    0 => false,
    1 => false,
    2 => false,
    3 => false,
    4 => 'value',
  ),
)
```