### PR TITLE
Preserve case-sensitive class name in method issues

### DIFF
--- a/src/Psalm/Issue/MethodIssue.php
+++ b/src/Psalm/Issue/MethodIssue.php
@@ -10,7 +10,10 @@ abstract class MethodIssue extends CodeIssue
 {
     /**
      * @var string
+     * @psalm-suppress PossiblyUnusedProperty Allows plugins to autoload the class.
      */
+    public string $fq_class_name;
+    /** @var lowercase-string */
     public $method_id;
 
     public function __construct(
@@ -19,6 +22,7 @@ abstract class MethodIssue extends CodeIssue
         string $method_id
     ) {
         parent::__construct($message, $code_location);
+        [$this->fq_class_name] = \explode('::', $method_id);
         $this->method_id = strtolower($method_id);
     }
 }


### PR DESCRIPTION
Currently, a plugin like this is impossible in a PSR-4 environment because autoloading is case-sensitive:
```php
<?php

declare(strict_types=1);

namespace App\Psalm\Hook;

use App\Controller\AbstractLegacyController;
use Psalm\Issue\PossiblyUnusedMethod;
use Psalm\Plugin\EventHandler\BeforeAddIssueInterface;
use Psalm\Plugin\EventHandler\Event\BeforeAddIssueEvent;

class ZendControllerActionSuppressUnusedHook implements BeforeAddIssueInterface
{
    public static function beforeAddIssue(BeforeAddIssueEvent $event): ?bool
    {
        $codeIssue = $event->getIssue();
        if ($codeIssue instanceof PossiblyUnusedMethod) {
            [$class, $method] = \explode('::', $codeIssue->method_id);
            if (
                \is_subclass_of($class, AbstractLegacyController::class)
                && \str_ends_with($method, 'action')
            ) {
                return false;
            }
        }
        return null;
    }
}
```
`\is_subclass_of($class, AbstractLegacyController::class)` is returning false.