### PR TITLE
Remove occurrences from error baseline

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -251,7 +251,7 @@
     </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.PropertyTypeHint">
         <exclude name="SlevomatCodingStandard.TypeHints.PropertyTypeHint.MissingTraversableTypeHintSpecification"/>
-        <!-- TODO: Remove these include-patterns in Psalm v6.0.0 -->
+        <!-- TODO: Remove in Psalm 6 -->
         <include-pattern>bin/*</include-pattern>
         <include-pattern>src/Psalm/Internal/*</include-pattern>
         <include-pattern>tests/*</include-pattern>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@d90a9a28a53176b4eb329d4c062d37516d3227f3">
+<files psalm-version="dev-master@91081f77fdd47a35d12bd87b31291c95f98be8ae">
   <file src="examples/TemplateChecker.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="2">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$comment_block-&gt;tags['variablesfrom'][0]</code>
       <code>$matches[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="examples/TemplateScanner.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="2">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$comment_block-&gt;tags['variablesfrom'][0]</code>
       <code>$matches[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Codebase.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="6">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$const_name</code>
       <code>$const_name</code>
       <code>$matches[0]</code>
@@ -23,19 +23,19 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Config/FileFilter.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>explode('::', $method_id)[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/ErrorBaseline.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="3">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$matches[1]</code>
       <code>$matches[2]</code>
       <code>$matches[3]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/ClassAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="4">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$comments[0]</code>
       <code>$property_name</code>
       <code>$stmt-&gt;props[0]</code>
@@ -43,12 +43,12 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$property_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/ProjectAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="5">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$destination_parts[1]</code>
       <code>$destination_parts[1]</code>
       <code>$destination_parts[1]</code>
@@ -57,30 +57,30 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Block/ForAnalyzer.php">
-    <ArgumentTypeCoercion occurrences="1">
+    <ArgumentTypeCoercion>
       <code>$stmt-&gt;cond</code>
     </ArgumentTypeCoercion>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php">
-    <ConflictingReferenceConstraint occurrences="2">
+    <ConflictingReferenceConstraint>
       <code>if (AtomicTypeComparator::isContainedBy(</code>
       <code>if (AtomicTypeComparator::isContainedBy(</code>
     </ConflictingReferenceConstraint>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Block/SwitchAnalyzer.php">
-    <InvalidPropertyAssignmentValue occurrences="1">
+    <InvalidPropertyAssignmentValue>
       <code>$context-&gt;assigned_var_ids += $switch_scope-&gt;new_assigned_var_ids</code>
     </InvalidPropertyAssignmentValue>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Block/SwitchCaseAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="3">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$new_case_equality_expr-&gt;getArgs()[1]</code>
       <code>$switch_scope-&gt;leftover_statements[0]</code>
       <code>$traverser-&gt;traverse([$switch_condition])[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="28">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$assertion-&gt;rule[0]</code>
       <code>$assertion-&gt;rule[0]</code>
       <code>$assertion-&gt;rule[0]</code>
@@ -112,28 +112,28 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/StaticPropertyAssignmentAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$new_property_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="2">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$invalid_left_messages[0]</code>
       <code>$invalid_right_messages[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php">
-    <ComplexMethod occurrences="1">
+    <ComplexMethod>
       <code>verifyType</code>
     </ComplexMethod>
-    <PossiblyUndefinedIntArrayOffset occurrences="3">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$method_name</code>
       <code>$parts[1]</code>
       <code>explode('::', $cased_method_id)[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArrayFunctionArgumentsAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="5">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$args[0]</code>
       <code>$args[0]</code>
       <code>$args[1]</code>
@@ -142,20 +142,20 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php">
-    <PossiblyUndefinedArrayOffset occurrences="1">
+    <PossiblyUndefinedArrayOffset>
       <code>$stmt-&gt;getArgs()[0]</code>
     </PossiblyUndefinedArrayOffset>
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$parts[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$method</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="6">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$result-&gt;invalid_method_call_types[0]</code>
       <code>$result-&gt;non_existent_class_method_ids[0]</code>
       <code>$result-&gt;non_existent_class_method_ids[0]</code>
@@ -165,59 +165,56 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$new_method_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="2">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$callable_arg-&gt;items[0]</code>
       <code>$callable_arg-&gt;items[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="2">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$new_const_name</code>
       <code>$new_const_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
-      <code>$properties[0]</code>
-    </PossiblyUndefinedIntArrayOffset>
-    <ReferenceConstraintViolation occurrences="3">
+    <ReferenceConstraintViolation>
       <code>$stmt_type</code>
       <code>$stmt_type</code>
       <code>$stmt_type</code>
     </ReferenceConstraintViolation>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php">
-    <ReferenceConstraintViolation occurrences="1">
+    <ReferenceConstraintViolation>
       <code>$stmt_type</code>
     </ReferenceConstraintViolation>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$invalid_fetch_types[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$new_property_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/YieldAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$atomic_return_type-&gt;type_params[2]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$method_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="6">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$token_list[$iter]</code>
       <code>$token_list[$iter]</code>
       <code>$token_list[$iter]</code>
@@ -227,30 +224,30 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Analyzer/StatementsAnalyzer.php">
-    <PossiblyUndefinedArrayOffset occurrences="1">
+    <PossiblyUndefinedArrayOffset>
       <code>$stmt-&gt;expr-&gt;getArgs()[0]</code>
     </PossiblyUndefinedArrayOffset>
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$check_type_string</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Cli/LanguageServer.php">
-    <PossiblyInvalidArgument occurrences="1">
+    <PossiblyInvalidArgument>
       <code>$options['tcp'] ?? null</code>
     </PossiblyInvalidArgument>
   </file>
   <file src="src/Psalm/Internal/Cli/Refactor.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$identifier_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Codebase/Analyzer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$trait</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Codebase/ClassLikes.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="5">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$destination_name</code>
       <code>$destination_name</code>
       <code>$destination_name</code>
@@ -259,23 +256,23 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Codebase/Functions.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$stub</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Codebase/InternalCallMapHandler.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="2">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$callables[0]</code>
       <code>$callables[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Codebase/Methods.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$function_callables[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Codebase/Properties.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="6">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$property_name</code>
       <code>$property_name</code>
       <code>$property_name</code>
@@ -285,7 +282,7 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Diff/ClassStatementsDiffer.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="6">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$a-&gt;props[0]</code>
       <code>$a-&gt;stmts[0]</code>
       <code>$a_stmt_comments[0]</code>
@@ -295,44 +292,44 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Diff/FileDiffer.php">
-    <InvalidArrayOffset occurrences="1">
+    <InvalidArrayOffset>
       <code>$b[$y]</code>
     </InvalidArrayOffset>
   </file>
   <file src="src/Psalm/Internal/FileManipulation/PropertyDocblockManipulator.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$stmt-&gt;props[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/LanguageServer/LanguageClient.php">
-    <DocblockTypeContradiction occurrences="3">
+    <DocblockTypeContradiction>
       <code>$type &lt; 1</code>
       <code>$type &lt; 1 || $type &gt; 4</code>
       <code>$type &gt; 4</code>
     </DocblockTypeContradiction>
   </file>
   <file src="src/Psalm/Internal/LanguageServer/Message.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$pair[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/LanguageServer/ProtocolStreamReader.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$parts[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/LanguageServer/Server/TextDocument.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$contentChanges[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/MethodIdentifier.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$method_id_parts[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="8">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$cs[0]</code>
       <code>$match[0]</code>
       <code>$match[1]</code>
@@ -344,7 +341,7 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="4">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$doc_line_parts[1]</code>
       <code>$matches[0]</code>
       <code>$method_tree-&gt;children[0]</code>
@@ -352,77 +349,77 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="2">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$l[4]</code>
       <code>$r[4]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/ExpressionScanner.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="2">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$node-&gt;getArgs()[0]</code>
       <code>$node-&gt;getArgs()[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$since_parts[1]</code>
     </PossiblyUndefinedIntArrayOffset>
-    <RedundantCondition occurrences="1">
+    <RedundantCondition>
       <code>count($line_parts) &gt; 0</code>
     </RedundantCondition>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php">
-    <PossiblyInvalidArrayOffset occurrences="1">
+    <PossiblyInvalidArrayOffset>
       <code>$fixed_type_tokens[$i - 1]</code>
     </PossiblyInvalidArrayOffset>
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$source_param_string</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$stmt-&gt;stmts[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/PhpVisitor/SimpleNameResolver.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$cs[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMapReturnTypeProvider.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$callable_method_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayMergeReturnTypeProvider.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$class_strings ?: null</code>
     </InvalidArgument>
   </file>
   <file src="src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReduceReturnTypeProvider.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$method_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php">
-    <ComplexMethod occurrences="1">
+    <ComplexMethod>
       <code>isContainedBy</code>
     </ComplexMethod>
-    <PossiblyUndefinedIntArrayOffset occurrences="2">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$array-&gt;properties[0]</code>
       <code>$array-&gt;properties[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php">
-    <LessSpecificReturnStatement occurrences="1">
+    <LessSpecificReturnStatement>
       <code>$callable</code>
     </LessSpecificReturnStatement>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>TCallable|TClosure|null</code>
     </MoreSpecificReturnType>
   </file>
   <file src="src/Psalm/Internal/Type/SimpleAssertionReconciler.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="4">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$array_atomic_type-&gt;properties[0]</code>
       <code>$properties[0]</code>
       <code>$properties[0]</code>
@@ -430,13 +427,13 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php">
-    <ImpureMethodCall occurrences="2">
+    <ImpureMethodCall>
       <code>getClassTemplateTypes</code>
       <code>has</code>
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Internal/Type/TypeCombiner.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="7">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$combination-&gt;array_type_params[1]</code>
       <code>$combination-&gt;array_type_params[1]</code>
       <code>$combination-&gt;array_type_params[1]</code>
@@ -447,12 +444,12 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Type/TypeExpander.php">
-    <InvalidArgument occurrences="1">
+    <InvalidArgument>
       <code>$fallback_params</code>
     </InvalidArgument>
   </file>
   <file src="src/Psalm/Internal/Type/TypeParser.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="10">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$const_name</code>
       <code>$const_name</code>
       <code>$intersection_types[0]</code>
@@ -466,7 +463,7 @@
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Type/TypeTokenizer.php">
-    <PossiblyInvalidArrayOffset occurrences="4">
+    <PossiblyInvalidArrayOffset>
       <code>$type_tokens[$i - 1]</code>
       <code>$type_tokens[$i - 1]</code>
       <code>$type_tokens[$i - 1]</code>
@@ -474,12 +471,12 @@
     </PossiblyInvalidArrayOffset>
   </file>
   <file src="src/Psalm/Storage/ClassConstantStorage.php">
-    <MutableDependency occurrences="1">
+    <MutableDependency>
       <code>CustomMetadataTrait</code>
     </MutableDependency>
   </file>
   <file src="src/Psalm/Storage/FunctionLikeParameter.php">
-    <ImpureMethodCall occurrences="4">
+    <ImpureMethodCall>
       <code>traverse</code>
       <code>traverse</code>
       <code>traverse</code>
@@ -487,12 +484,12 @@
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type.php">
-    <ImpureStaticProperty occurrences="1">
+    <ImpureStaticProperty>
       <code>self::$listKey</code>
     </ImpureStaticProperty>
   </file>
   <file src="src/Psalm/Type/Atomic.php">
-    <ImpureMethodCall occurrences="12">
+    <ImpureMethodCall>
       <code>classExtendsOrImplements</code>
       <code>classExtendsOrImplements</code>
       <code>classExtendsOrImplements</code>
@@ -506,15 +503,15 @@
       <code>traverse</code>
       <code>traverse</code>
     </ImpureMethodCall>
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>array_keys($template_type_map[$value])[0]</code>
     </PossiblyUndefinedIntArrayOffset>
-    <ReferenceConstraintViolation occurrences="1">
+    <ReferenceConstraintViolation>
       <code>$value</code>
     </ReferenceConstraintViolation>
   </file>
   <file src="src/Psalm/Type/Atomic/CallableTrait.php">
-    <ImpureMethodCall occurrences="4">
+    <ImpureMethodCall>
       <code>replace</code>
       <code>replace</code>
       <code>replace</code>
@@ -522,62 +519,62 @@
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type/Atomic/GenericTrait.php">
-    <ImpureMethodCall occurrences="3">
+    <ImpureMethodCall>
       <code>getMappedGenericTypeParams</code>
       <code>replace</code>
       <code>replace</code>
     </ImpureMethodCall>
-    <InvalidReturnType occurrences="2">
+    <InvalidReturnType>
       <code>TTypeParams|null</code>
       <code>TTypeParams|null</code>
     </InvalidReturnType>
-    <PossiblyUndefinedIntArrayOffset occurrences="1">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$this-&gt;type_params[1]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Type/Atomic/HasIntersectionTrait.php">
-    <ImpureMethodCall occurrences="1">
+    <ImpureMethodCall>
       <code>getMostSpecificTypeFromBounds</code>
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type/Atomic/TCallableList.php">
-    <DeprecatedClass occurrences="1">
+    <DeprecatedClass>
       <code>TNonEmptyList</code>
     </DeprecatedClass>
   </file>
   <file src="src/Psalm/Type/Atomic/TClassString.php">
-    <ImpureMethodCall occurrences="1">
+    <ImpureMethodCall>
       <code>replace</code>
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type/Atomic/TClassStringMap.php">
-    <ImpureMethodCall occurrences="4">
+    <ImpureMethodCall>
       <code>getString</code>
       <code>getString</code>
       <code>replace</code>
       <code>replace</code>
     </ImpureMethodCall>
-    <ImpurePropertyAssignment occurrences="1">
+    <ImpurePropertyAssignment>
       <code>$cloned-&gt;value_param</code>
     </ImpurePropertyAssignment>
   </file>
   <file src="src/Psalm/Type/Atomic/TConditional.php">
-    <ImpureMethodCall occurrences="1">
+    <ImpureMethodCall>
       <code>replace</code>
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type/Atomic/TDependentListKey.php">
-    <PossiblyUnusedMethod occurrences="1">
+    <PossiblyUnusedMethod>
       <code>__construct</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Psalm/Type/Atomic/TKeyedArray.php">
-    <DeprecatedClass occurrences="3">
+    <DeprecatedClass>
       <code>TList</code>
       <code>new TList($this-&gt;getGenericValueType())</code>
       <code>new TNonEmptyList($this-&gt;getGenericValueType())</code>
     </DeprecatedClass>
-    <ImpureMethodCall occurrences="13">
+    <ImpureMethodCall>
       <code>combine</code>
       <code>combine</code>
       <code>combineUnionTypes</code>
@@ -592,58 +589,58 @@
       <code>replace</code>
       <code>replace</code>
     </ImpureMethodCall>
-    <ImpurePropertyAssignment occurrences="1">
+    <ImpurePropertyAssignment>
       <code>$key_type-&gt;possibly_undefined</code>
     </ImpurePropertyAssignment>
-    <PossiblyUndefinedIntArrayOffset occurrences="3">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$this-&gt;properties[0]</code>
       <code>$this-&gt;properties[0]</code>
       <code>$this-&gt;properties[0]</code>
     </PossiblyUndefinedIntArrayOffset>
-    <PossiblyUnusedMethod occurrences="1">
+    <PossiblyUnusedMethod>
       <code>getList</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Psalm/Type/Atomic/TList.php">
-    <ImpureMethodCall occurrences="2">
+    <ImpureMethodCall>
       <code>replace</code>
       <code>replace</code>
     </ImpureMethodCall>
-    <ImpurePropertyAssignment occurrences="1">
+    <ImpurePropertyAssignment>
       <code>$cloned-&gt;type_param</code>
     </ImpurePropertyAssignment>
   </file>
   <file src="src/Psalm/Type/Atomic/TNonEmptyList.php">
-    <DeprecatedClass occurrences="1">
+    <DeprecatedClass>
       <code>TList</code>
     </DeprecatedClass>
-    <PossiblyUnusedMethod occurrences="1">
+    <PossiblyUnusedMethod>
       <code>setCount</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="src/Psalm/Type/Atomic/TObjectWithProperties.php">
-    <ImpureMethodCall occurrences="2">
+    <ImpureMethodCall>
       <code>replace</code>
       <code>replace</code>
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type/Atomic/TTemplateKeyOf.php">
-    <ImpureMethodCall occurrences="1">
+    <ImpureMethodCall>
       <code>replace</code>
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type/Atomic/TTemplatePropertiesOf.php">
-    <ImpureMethodCall occurrences="1">
+    <ImpureMethodCall>
       <code>replace</code>
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type/Atomic/TTemplateValueOf.php">
-    <ImpureMethodCall occurrences="1">
+    <ImpureMethodCall>
       <code>replace</code>
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type/MutableUnion.php">
-    <PossiblyUnusedProperty occurrences="7">
+    <PossiblyUnusedProperty>
       <code>$allow_mutations</code>
       <code>$by_ref</code>
       <code>$failed_reconciliation</code>
@@ -654,52 +651,52 @@
     </PossiblyUnusedProperty>
   </file>
   <file src="src/Psalm/Type/Reconciler.php">
-    <PossiblyUndefinedIntArrayOffset occurrences="3">
+    <PossiblyUndefinedIntArrayOffset>
       <code>$const_name</code>
       <code>$type[0]</code>
       <code>$type[0][0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Type/TypeNode.php">
-    <ReferenceConstraintViolation occurrences="1">
+    <ReferenceConstraintViolation>
       <code>$node</code>
     </ReferenceConstraintViolation>
   </file>
   <file src="src/Psalm/Type/TypeVisitor.php">
-    <ImpureMethodCall occurrences="1">
+    <ImpureMethodCall>
       <code>visit</code>
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type/Union.php">
-    <PossiblyUnusedProperty occurrences="1">
+    <PossiblyUnusedProperty>
       <code>$ignore_isset</code>
     </PossiblyUnusedProperty>
   </file>
   <file src="src/Psalm/Type/UnionTrait.php">
-    <ImpureMethodCall occurrences="4">
+    <ImpureMethodCall>
       <code>traverse</code>
       <code>traverse</code>
       <code>traverseArray</code>
       <code>traverseArray</code>
     </ImpureMethodCall>
-    <MoreSpecificReturnType occurrences="1">
+    <MoreSpecificReturnType>
       <code>TArray|TKeyedArray|TClassStringMap</code>
     </MoreSpecificReturnType>
-    <PossiblyUndefinedStringArrayOffset occurrences="1">
+    <PossiblyUndefinedStringArrayOffset>
       <code>$this-&gt;types['array']</code>
     </PossiblyUndefinedStringArrayOffset>
-    <PossiblyUnusedMethod occurrences="2">
+    <PossiblyUnusedMethod>
       <code>allFloatLiterals</code>
       <code>allFloatLiterals</code>
     </PossiblyUnusedMethod>
   </file>
   <file src="tests/Internal/Codebase/InternalCallMapHandlerTest.php">
-    <UnusedPsalmSuppress occurrences="1">
+    <UnusedPsalmSuppress>
       <code>UndefinedMethod</code>
     </UnusedPsalmSuppress>
   </file>
   <file src="vendor/nikic/php-parser/lib/PhpParser/Node/Expr/ArrowFunction.php">
-    <PossiblyUndefinedStringArrayOffset occurrences="1">
+    <PossiblyUndefinedStringArrayOffset>
       <code>$subNodes['expr']</code>
     </PossiblyUndefinedStringArrayOffset>
   </file>

--- a/tests/ErrorBaselineTest.php
+++ b/tests/ErrorBaselineTest.php
@@ -3,6 +3,7 @@
 namespace Psalm\Tests;
 
 use DOMDocument;
+use DOMElement;
 use Mockery;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Mockery\MockInterface;
@@ -11,6 +12,8 @@ use Psalm\Exception\ConfigException;
 use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Internal\Provider\FileProvider;
 use Psalm\Internal\RuntimeCaches;
+
+use function count;
 
 use const LIBXML_NOBLANKS;
 
@@ -36,14 +39,14 @@ class ErrorBaselineTest extends TestCase
             '<?xml version="1.0" encoding="UTF-8"?>
             <files>
               <file src="sample/sample-file.php">
-                <MixedAssignment occurrences="2">
+                <MixedAssignment>
                   <code>foo</code>
                   <code>bar</code>
                 </MixedAssignment>
                 <InvalidReturnStatement occurrences="1"/>
               </file>
               <file src="sample\sample-file2.php">
-                <PossiblyUnusedMethod occurrences="2">
+                <PossiblyUnusedMethod>
                   <code>foo</code>
                   <code>bar</code>
                 </PossiblyUnusedMethod>
@@ -76,7 +79,7 @@ class ErrorBaselineTest extends TestCase
             "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
             <files>
               <file src=\"sample/sample-file.php\">
-                <MixedAssignment occurrences=\"1\">
+                <MixedAssignment>
                   <code>foo\r</code>
                 </MixedAssignment>
               </file>
@@ -317,27 +320,27 @@ class ErrorBaselineTest extends TestCase
 
                     $this->assertSame('MixedAssignment', $file1Issues[0]->tagName);
                     $this->assertSame(
-                        '3',
-                        $file1Issues[0]->getAttribute('occurrences'),
+                        3,
+                        count($file1Issues[0]->getElementsByTagName('code')),
                         'MixedAssignment should have occured 3 times',
                     );
                     $this->assertSame('MixedOperand', $file1Issues[1]->tagName);
                     $this->assertSame(
-                        '1',
-                        $file1Issues[1]->getAttribute('occurrences'),
+                        1,
+                        count($file1Issues[1]->getElementsByTagName('code')),
                         'MixedOperand should have occured 1 time',
                     );
 
                     $this->assertSame('MixedAssignment', $file2Issues[0]->tagName);
                     $this->assertSame(
-                        '2',
-                        $file2Issues[0]->getAttribute('occurrences'),
+                        2,
+                        count($file2Issues[0]->getElementsByTagName('code')),
                         'MixedAssignment should have occured 2 times',
                     );
                     $this->assertSame('TypeCoercion', $file2Issues[1]->tagName);
                     $this->assertSame(
-                        '1',
-                        $file2Issues[1]->getAttribute('occurrences'),
+                        1,
+                        count($file2Issues[1]->getElementsByTagName('code')),
                         'TypeCoercion should have occured 1 time',
                     );
 
@@ -493,7 +496,7 @@ class ErrorBaselineTest extends TestCase
             <files>
               <file src="sample/sample-file.php">
                 <!-- here is a comment ! //-->
-                <MixedAssignment occurrences="2">
+                <MixedAssignment>
                   <code>foo</code>
                   <code>bar</code>
                 </MixedAssignment>
@@ -501,7 +504,7 @@ class ErrorBaselineTest extends TestCase
               </file>
               <!-- And another one ! //-->
               <file src="sample\sample-file2.php">
-                <PossiblyUnusedMethod occurrences="2">
+                <PossiblyUnusedMethod>
                   <code>foo</code>
                   <code>bar</code>
                 </PossiblyUnusedMethod>


### PR DESCRIPTION
Occurrences are redundant information in the baseline and are noise in diffs.

The only time (as far as I can tell) that a code snippet was not included is if it had a "\n". I just removed this restriction. Not 100% the reason for it in the first place.