### PR TITLE
Revert #8955

### DIFF
--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -803,7 +803,7 @@ class Methods
                     return $candidate_type;
                 }
 
-                if ($old_contained_by_new || $overridden_storage_return_type->hasTemplate()) {
+                if ($old_contained_by_new) {
                     $self_class = $appearing_fq_class_storage->name;
 
                     return $candidate_type;

--- a/tests/Template/ClassTemplateExtendsTest.php
+++ b/tests/Template/ClassTemplateExtendsTest.php
@@ -16,7 +16,7 @@ class ClassTemplateExtendsTest extends TestCase
     public function providerValidCodeParse(): iterable
     {
         return [
-            'interface' => [
+            'SKIPPED-interface' => [
                 'code' => '<?php
                     /**
                      * Singleton interface


### PR DESCRIPTION
My PR completely broke iterators in our codebase in a way that is hard to reproduce in standalone example, and I realized the approach was actually wrong, because the issue only occurs when *not* using `@return` phpdocs but only native typehints.

I'll have to dig elsewhere to fix this :)