### PR TITLE
Add @psalm-api annotation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
             "phpunit"
         ],
         "verify-callmap": "phpunit tests/Internal/Codebase/InternalCallMapHandlerTest.php",
-        "psalm": "@php ./psalm --find-dead-code",
+        "psalm": "@php ./psalm",
         "tests": [
             "@lint",
             "@cs",

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -630,7 +630,7 @@ class Success implements Promise {
  * @return Promise<string>
  */
 function fetch(): Promise {
-	return new Success('{"data":[]}');
+    return new Success('{"data":[]}');
 }
 
 function (): Generator {
@@ -641,6 +641,21 @@ function (): Generator {
 };
 ```
 This annotation supports only generic types, meaning that e.g. `@psalm-yield string` would be ignored.
+
+### `@psalm-api`
+
+Used to tell Psalm that a class is used, even if no references to it can be
+found. Unused issues will be suppressed.
+
+For example, in frameworks, controllers are often invoked "magically" without
+any explicit references to them in your code. You should mark these classes with
+`@psalm-api`.
+```php
+/**
+ * @psalm-api
+ */
+class UnreferencedClass {}
+```
 
 ## Type Syntax
 

--- a/docs/running_psalm/issues/PossiblyUnusedMethod.md
+++ b/docs/running_psalm/issues/PossiblyUnusedMethod.md
@@ -1,6 +1,10 @@
 # PossiblyUnusedMethod
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any calls to a public or protected method.
+Emitted when `--find-dead-code` is turned on and Psalm cannot find any calls to
+a public or protected method.
+
+If this method is used and part of the public API, annotate the containing class
+with `@psalm-api`.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/PossiblyUnusedProperty.md
+++ b/docs/running_psalm/issues/PossiblyUnusedProperty.md
@@ -1,6 +1,10 @@
 # PossiblyUnusedProperty
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a particular public/protected property
+Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a
+particular public/protected property.
+
+If this property is used and part of the public API, annotate the containing
+class with `@psalm-api`.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedClass.md
+++ b/docs/running_psalm/issues/UnusedClass.md
@@ -1,6 +1,9 @@
 # UnusedClass
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a given class
+Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a
+given class.
+
+If this class is used and part of the public API, annotate it with `@psalm-api`.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedMethod.md
+++ b/docs/running_psalm/issues/UnusedMethod.md
@@ -1,6 +1,10 @@
 # UnusedMethod
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a given private method or function
+Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a
+given private method or function.
+
+If this method is used and part of the public API, annotate the containing class
+with `@psalm-api`.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedProperty.md
+++ b/docs/running_psalm/issues/UnusedProperty.md
@@ -1,6 +1,10 @@
 # UnusedProperty
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a private property
+Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a
+private property.
+
+If this property is used and part of the public API, annotate the containing
+class with `@psalm-api`.
 
 ```php
 <?php

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -48,4 +48,8 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <const name="__IS_TEST_ENV__" value="1" />
+    </php>
 </phpunit>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@91081f77fdd47a35d12bd87b31291c95f98be8ae">
+<files psalm-version="dev-master@6fc9e50b9765d573db796e81522af759bc6987a5">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset>
       <code>$comment_block-&gt;tags['variablesfrom'][0]</code>
@@ -307,6 +307,13 @@
       <code>$type &lt; 1 || $type &gt; 4</code>
       <code>$type &gt; 4</code>
     </DocblockTypeContradiction>
+  </file>
+  <file src="src/Psalm/Internal/LanguageServer/LanguageServer.php">
+    <PossiblyUnusedParam>
+      <code>$capabilities</code>
+      <code>$processId</code>
+      <code>$rootPath</code>
+    </PossiblyUnusedParam>
   </file>
   <file src="src/Psalm/Internal/LanguageServer/Message.php">
     <PossiblyUndefinedIntArrayOffset>

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -60,6 +60,7 @@ use function chdir;
 use function class_exists;
 use function clearstatcache;
 use function count;
+use function defined;
 use function dirname;
 use function explode;
 use function extension_loaded;
@@ -69,6 +70,7 @@ use function file_get_contents;
 use function filetype;
 use function flock;
 use function fopen;
+use function fwrite;
 use function get_class;
 use function get_defined_constants;
 use function get_defined_functions;
@@ -122,6 +124,7 @@ use const PHP_EOL;
 use const PHP_VERSION_ID;
 use const PSALM_VERSION;
 use const SCANDIR_SORT_NONE;
+use const STDERR;
 
 /**
  * @psalm-suppress PropertyNotSetInConstructor
@@ -441,6 +444,8 @@ class Config
     public $forbidden_functions = [];
 
     /**
+     * TODO: Psalm 6: Update default to be true and remove warning.
+     *
      * @var bool
      */
     public $find_unused_code = false;
@@ -1090,6 +1095,9 @@ class Config
             $attribute_text = (string) $config_xml['findUnusedCode'];
             $config->find_unused_code = $attribute_text === 'true' || $attribute_text === '1';
             $config->find_unused_variables = $config->find_unused_code;
+        } elseif (!defined('__IS_TEST_ENV__')) {
+            fwrite(STDERR, 'Warning: "findUnusedCode" will be defaulted to "true" in Psalm 6. You should explicitly'
+                . ' enable or disable this setting.' . PHP_EOL);
         }
 
         if (isset($config_xml['findUnusedVariablesAndParams'])) {

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -33,6 +33,7 @@ final class DocComment
         'taint-unescape', 'self-out', 'consistent-constructor', 'stub-override',
         'require-extends', 'require-implements', 'param-out', 'ignore-var',
         'consistent-templates', 'if-this-is', 'this-out', 'check-type', 'check-type-exact',
+        'api',
     ];
 
     /**

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -474,6 +474,8 @@ class ClassLikeDocblockParser
             $info->description = $parsed_docblock->description;
         }
 
+        $info->public_api = isset($parsed_docblock->tags['psalm-api']) || isset($parsed_docblock->tags['api']);
+
         self::addMagicPropertyToInfo($comment, $info, $parsed_docblock->tags, 'property');
         self::addMagicPropertyToInfo($comment, $info, $parsed_docblock->tags, 'psalm-property');
         self::addMagicPropertyToInfo($comment, $info, $parsed_docblock->tags, 'property-read');

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -681,6 +681,8 @@ class ClassLikeNodeScanner
             if ($docblock_info->description) {
                 $storage->description = $docblock_info->description;
             }
+
+            $storage->public_api = $docblock_info->public_api;
         }
 
         foreach ($node->stmts as $node_stmt) {

--- a/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
@@ -101,4 +101,6 @@ class ClassLikeDocblockComment
     public array $implementation_requirements = [];
 
     public ?string $description = null;
+
+    public bool $public_api = false;
 }

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -462,6 +462,8 @@ final class ClassLikeStorage implements HasAttributesInterface
      */
     public $description;
 
+    public bool $public_api = false;
+
     public function __construct(string $name)
     {
         $this->name = $name;

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1229,6 +1229,33 @@ class UnusedCodeTest extends TestCase
                     $a->bar[$a->foo] = "bar";
                     print_r($a->bar);',
             ],
+            'psalm-api with unused class' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @psalm-api */
+                    class A {}
+                    PHP,
+            ],
+            'psalm-api with unused public and protected property' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @psalm-api */
+                    class A {
+                        public int $b = 0;
+                        protected int $c = 0;
+                    }
+                    PHP,
+            ],
+            'psalm-api with unused public and protected method' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @psalm-api */
+                    class A {
+                        public function b(): void {}
+                        protected function c(): void {}
+                    }
+                    PHP,
+            ],
         ];
     }
 
@@ -1748,6 +1775,66 @@ class UnusedCodeTest extends TestCase
                     }
                 ',
                 'error_message' => 'InaccessibleProperty',
+            ],
+            'psalm-api with unused private property' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @psalm-api */
+                    class A {
+                        private int $b = 0;
+                    }
+                    PHP,
+                'error_message' => 'UnusedProperty',
+            ],
+            'psalm-api with final class and unused protected property' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @psalm-api */
+                    final class A {
+                        protected int $b = 0;
+                    }
+                    PHP,
+                'error_message' => 'PossiblyUnusedProperty',
+            ],
+            'psalm-api with unused private method' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @psalm-api */
+                    class A {
+                        private function b(): void {}
+                    }
+                    PHP,
+                'error_message' => 'UnusedMethod',
+            ],
+            'psalm-api with final class and unused protected method' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @psalm-api */
+                    final class A {
+                        protected function b(): void {}
+                    }
+                    PHP,
+                'error_message' => 'PossiblyUnusedMethod',
+            ],
+            'psalm-api with unused class and unused param' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @psalm-api */
+                    class A {
+                        public function b(int $c): void {}
+                    }
+                    PHP,
+                'error_message' => 'PossiblyUnusedParam',
+            ],
+            'unused param' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @psalm-suppress UnusedClass */
+                    class A {
+                        public function b(int $c): void {}
+                    }
+                    PHP,
+                'error_message' => 'PossiblyUnusedParam',
             ],
         ];
     }


### PR DESCRIPTION
- Added new `@psalm-api`
  - Added documentation
- Method param usages are checked regardless of if the class or method has references