### PR TITLE
Fix import type intersections

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,7 +117,7 @@
             "phpunit"
         ],
         "verify-callmap": "phpunit tests/Internal/Codebase/InternalCallMapHandlerTest.php",
-        "psalm": "@php ./psalm --find-dead-code",
+        "psalm": "@php ./psalm --find-dead-code -m",
         "tests": [
             "@lint",
             "@cs",

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -379,7 +379,12 @@ class ClassLikeNodeScanner
 
                 foreach ($type_aliases as $type_alias) {
                     // finds issues, if there are any
-                    TypeParser::parseTokens($type_alias->replacement_tokens);
+                    TypeParser::parseTokens(
+                        $type_alias->replacement_tokens,
+                        null,
+                        [],
+                        $this->type_aliases,
+                    );
                 }
 
                 $this->type_aliases += $type_aliases;

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -1095,6 +1095,7 @@ class TypeParser
             $intersection_types[$name] = $atomic_type;
         }
 
+        // TODO: Handle type aliases better
         $first_type = reset($intersection_types);
         $last_type = end($intersection_types);
 

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -179,8 +179,7 @@ abstract class Atomic implements TypeNode
         string $value,
         ?int   $analysis_php_version_id = null,
         array  $template_type_map = [],
-        array  $type_aliases = [],
-        bool   $from_docblock = false
+        array  $type_aliases = []
     ): Atomic {
         switch ($value) {
             case 'int':
@@ -243,27 +242,27 @@ abstract class Atomic implements TypeNode
             case 'array':
             case 'associative-array':
                 return new TArray([
-                    new Union([new TArrayKey($from_docblock)]),
-                    new Union([new TMixed(false, $from_docblock)]),
+                    new Union([new TArrayKey(false)]),
+                    new Union([new TMixed(false, false)]),
                 ]);
 
             case 'non-empty-array':
                 return new TNonEmptyArray([
-                    new Union([new TArrayKey($from_docblock)]),
-                    new Union([new TMixed(false, $from_docblock)]),
+                    new Union([new TArrayKey(false)]),
+                    new Union([new TMixed(false, false)]),
                 ]);
 
             case 'callable-array':
                 return new TCallableArray([
-                    new Union([new TArrayKey($from_docblock)]),
-                    new Union([new TMixed(false, $from_docblock)]),
+                    new Union([new TArrayKey(false)]),
+                    new Union([new TMixed(false, false)]),
                 ]);
 
             case 'list':
-                return Type::getListAtomic(Type::getMixed(false, $from_docblock));
+                return Type::getListAtomic(Type::getMixed(false, false));
 
             case 'non-empty-list':
-                return Type::getNonEmptyListAtomic(Type::getMixed(false, $from_docblock));
+                return Type::getNonEmptyListAtomic(Type::getMixed(false, false));
 
             case 'non-empty-string':
                 return new TNonEmptyString();

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -653,6 +653,32 @@ class TypeAnnotationTest extends TestCase
                     '$output===' => 'list<1|2>',
                 ],
             ],
+            'intersection with imported type' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @psalm-type psalmA = array{a: string}
+                     */
+                    class A {}
+                    /**
+                     * @psalm-type psalmB = array{b: string}
+                     * @psalm-import-type psalmA from A
+                     * @psalm-type psalmC = psalmB&psalmA
+                     */
+                    class B {
+                        /**
+                          * @return psalmC
+                          */
+                        public static function getC(): array {
+                            return ['a' => '', 'b' => ''];
+                        }
+                    }
+                    $c = B::getC();
+                    PHP,
+                'assertions' => [
+                    '$c===' => 'array{a: string, b: string}',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
In progress...

Attempted fix for #8984

The problem seems to be that intersection types are being validated too soon. They need to wait till after the codebase is populated and then the aliases can be inlined.