### PR TITLE
Make `$http_response_header` a non-empty-list

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -612,7 +612,12 @@ class VariableFetchAnalyzer
         }
 
         if ($var_id === '$http_response_header') {
-            return Type::getNonEmptyList(Type::getNonFalsyString());
+            // $http_response_header exists only in the local scope after a successful network request
+            return new Union([
+                Type::getNonEmptyList(Type::getNonFalsyString())
+            ], [
+                'possibly_undefined' => true,
+            ]);
         }
 
         if ($var_id === '$GLOBALS') {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -614,7 +614,7 @@ class VariableFetchAnalyzer
         if ($var_id === '$http_response_header') {
             // $http_response_header exists only in the local scope after a successful network request
             return new Union([
-                Type::getNonEmptyList(Type::getNonFalsyString())
+                Type::getNonEmptyListAtomic(Type::getNonFalsyString())
             ], [
                 'possibly_undefined' => true,
             ]);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -612,7 +612,7 @@ class VariableFetchAnalyzer
         }
 
         if ($var_id === '$http_response_header') {
-            return Type::getList(Type::getNonEmptyString());
+            return Type::getNonEmptyList(Type::getNonFalsyString());
         }
 
         if ($var_id === '$GLOBALS') {

--- a/tests/SuperGlobalsTest.php
+++ b/tests/SuperGlobalsTest.php
@@ -12,7 +12,7 @@ class SuperGlobalsTest extends TestCase
     {
         yield 'http_response_headerIsList' => [
             'code' => '<?php
-                /** @return list<string> */
+                /** @return non-empty-list<non-falsy-string> */
                 function returnsList(): array {
                     return $http_response_header;
                 }

--- a/tests/SuperGlobalsTest.php
+++ b/tests/SuperGlobalsTest.php
@@ -2,11 +2,13 @@
 
 namespace Psalm\Tests;
 
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
 class SuperGlobalsTest extends TestCase
 {
     use ValidCodeAnalysisTestTrait;
+    use InvalidCodeAnalysisTestTrait;
 
     public function providerValidCodeParse(): iterable
     {
@@ -30,6 +32,19 @@ class SuperGlobalsTest extends TestCase
                     return $_ENV;
                 }
             '
+        ];
+    }
+
+    public function providerInvalidCodeParse(): iterable
+    {
+        yield 'undefined http_response_header' => [
+            'code' => '<?php
+                /** @return non-empty-list<non-falsy-string> */
+                function returnsList(): array {
+                    return $http_response_header;
+                }
+            ',
+            'error_message' => 'InvalidReturnStatement',
         ];
     }
 }

--- a/tests/SuperGlobalsTest.php
+++ b/tests/SuperGlobalsTest.php
@@ -14,6 +14,9 @@ class SuperGlobalsTest extends TestCase
             'code' => '<?php
                 /** @return non-empty-list<non-falsy-string> */
                 function returnsList(): array {
+                    if (!isset($http_response_header)) {
+                        throw new \RuntimeException();
+                    }
                     return $http_response_header;
                 }
             ',


### PR DESCRIPTION
This list always contains at least one element: http status code. So I think it's safe to assume it's a non-empty-list.
https://www.php.net/manual/en/reserved.variables.httpresponseheader.php
