### PR TITLE
forbidden function bug and better get_defined_functions() signature

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -3697,7 +3697,7 @@ return [
 'get_declared_interfaces' => ['list<class-string>'],
 'get_declared_traits' => ['list<class-string>|null'],
 'get_defined_constants' => ['array<string,int|string|float|bool|null|array|resource>', 'categorize='=>'bool'],
-'get_defined_functions' => ['array<string,list<callable-string>>', 'exclude_disabled='=>'bool'],
+'get_defined_functions' => ['array{internal: list<callable-string>, user: list<callable-string>}', 'exclude_disabled='=>'bool'],
 'get_defined_vars' => ['array'],
 'get_extension_funcs' => ['list<callable-string>|false', 'extension'=>'string'],
 'get_headers' => ['array|false', 'url'=>'string', 'associative='=>'int', 'context='=>'resource'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -11124,7 +11124,7 @@ return [
     'get_declared_interfaces' => ['list<class-string>'],
     'get_declared_traits' => ['list<class-string>|null'],
     'get_defined_constants' => ['array<string,int|string|float|bool|null|array|resource>', 'categorize='=>'bool'],
-    'get_defined_functions' => ['array<string,list<callable-string>>', 'exclude_disabled='=>'bool'],
+    'get_defined_functions' => ['array{internal: list<callable-string>, user: list<callable-string>}', 'exclude_disabled='=>'bool'],
     'get_defined_vars' => ['array'],
     'get_extension_funcs' => ['list<callable-string>|false', 'extension'=>'string'],
     'get_headers' => ['array|false', 'url'=>'string', 'associative='=>'int'],

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2257,17 +2257,11 @@ class Config
     public function collectPredefinedFunctions(): void
     {
         $defined_functions = get_defined_functions();
-
-        if (isset($defined_functions['user'])) {
-            foreach ($defined_functions['user'] as $function_name) {
-                $this->predefined_functions[$function_name] = true;
-            }
+        foreach ($defined_functions['user'] as $function_name) {
+            $this->predefined_functions[$function_name] = true;
         }
-
-        if (isset($defined_functions['internal'])) {
-            foreach ($defined_functions['internal'] as $function_name) {
-                $this->predefined_functions[$function_name] = true;
-            }
+        foreach ($defined_functions['internal'] as $function_name) {
+            $this->predefined_functions[$function_name] = true;
         }
     }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NamedFunctionCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NamedFunctionCallHandler.php
@@ -48,7 +48,6 @@ use Psalm\Type\Union;
 
 use function array_map;
 use function extension_loaded;
-use function implode;
 use function in_array;
 use function is_string;
 use function strpos;
@@ -60,7 +59,7 @@ use function strtolower;
 class NamedFunctionCallHandler
 {
     /**
-     * @param  lowercase-string  $function_id
+     * @param lowercase-string $function_id
      */
     public static function handle(
         StatementsAnalyzer $statements_analyzer,
@@ -68,7 +67,7 @@ class NamedFunctionCallHandler
         PhpParser\Node\Expr\FuncCall $stmt,
         PhpParser\Node\Expr\FuncCall $real_stmt,
         PhpParser\Node\Name $function_name,
-        ?string $function_id,
+        string $function_id,
         Context $context
     ): void {
         if ($function_id === 'get_class'
@@ -298,17 +297,17 @@ class NamedFunctionCallHandler
         ) {
             IssueBuffer::maybeAdd(
                 new ForbiddenCode(
-                    'Unsafe ' . implode('', $function_name->parts),
+                    'Unsafe ' . $function_id,
                     new CodeLocation($statements_analyzer->getSource(), $stmt),
                 ),
                 $statements_analyzer->getSuppressedIssues(),
             );
         }
 
-        if (isset($codebase->config->forbidden_functions[strtolower((string) $function_name)])) {
+        if (isset($codebase->config->forbidden_functions[$function_id])) {
             IssueBuffer::maybeAdd(
                 new ForbiddenCode(
-                    'You have forbidden the use of ' . $function_name,
+                    'You have forbidden the use of ' . $function_id,
                     new CodeLocation($statements_analyzer->getSource(), $stmt),
                 ),
                 $statements_analyzer->getSuppressedIssues(),

--- a/tests/ForbiddenCodeTest.php
+++ b/tests/ForbiddenCodeTest.php
@@ -216,6 +216,40 @@ class ForbiddenCodeTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
+    public function testNoExceptionWithMatchingNameButDifferentNamespace(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__, 2),
+                <<<'XML'
+                    <?xml version="1.0"?>
+                    <psalm>
+                        <forbiddenFunctions>
+                            <function name="strlen"/>
+                        </forbiddenFunctions>
+                    </psalm>
+                    XML,
+            ),
+        );
+        $file_path = getcwd() . '/src/somefile.php';
+        $this->addFile(
+            $file_path,
+            <<<'PHP'
+                <?php
+                namespace Foo {
+                    function strlen(): int {
+                        return 0;
+                    }
+                }
+                namespace {
+                    use function Foo\strlen;
+                    strlen();
+                }
+                PHP,
+        );
+        $this->analyzeFile($file_path, new Context());
+    }
+
     public function testForbiddenEmptyFunction(): void
     {
         $this->expectExceptionMessage('ForbiddenCode');


### PR DESCRIPTION
* The full namespace of the used function was not being considered when checking if it is forbidden.
  * I am surprised that names are not fully qualified before analysis
* Gave `get_defined_functions()` its proper array shape.
  * Sad I can't do `callable-string&lowercase-string`