### PR TITLE
Use TString properties instead of inheritance

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@91081f77fdd47a35d12bd87b31291c95f98be8ae">
+<files psalm-version="dev-master@8b05f2ead810d535adbfba7dbc9d4fdeef18b5d6">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset>
       <code>$comment_block-&gt;tags['variablesfrom'][0]</code>
@@ -122,6 +122,11 @@
       <code>$invalid_right_messages[0]</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
+  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php">
+    <DeprecatedClass>
+      <code>new TLowercaseString()</code>
+    </DeprecatedClass>
+  </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php">
     <ComplexMethod>
       <code>verifyType</code>
@@ -163,6 +168,11 @@
       <code>$result-&gt;non_existent_interface_method_ids[0]</code>
       <code>$result-&gt;non_existent_magic_method_ids[0]</code>
     </PossiblyUndefinedIntArrayOffset>
+  </file>
+  <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/NamedFunctionCallHandler.php">
+    <DeprecatedClass>
+      <code>new TLowercaseString()</code>
+    </DeprecatedClass>
   </file>
   <file src="src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php">
     <PossiblyUndefinedIntArrayOffset>
@@ -401,6 +411,11 @@
       <code>$method_name</code>
     </PossiblyUndefinedIntArrayOffset>
   </file>
+  <file src="src/Psalm/Internal/Provider/ReturnTypeProvider/ExplodeReturnTypeProvider.php">
+    <DeprecatedClass>
+      <code>new TLowercaseString()</code>
+    </DeprecatedClass>
+  </file>
   <file src="src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php">
     <ComplexMethod>
       <code>isContainedBy</code>
@@ -484,11 +499,17 @@
     </ImpureMethodCall>
   </file>
   <file src="src/Psalm/Type.php">
+    <DeprecatedClass>
+      <code>new TLowercaseString()</code>
+    </DeprecatedClass>
     <ImpureStaticProperty>
       <code>self::$listKey</code>
     </ImpureStaticProperty>
   </file>
   <file src="src/Psalm/Type/Atomic.php">
+    <DeprecatedClass>
+      <code>new TLowercaseString()</code>
+    </DeprecatedClass>
     <ImpureMethodCall>
       <code>classExtendsOrImplements</code>
       <code>classExtendsOrImplements</code>

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -71,7 +71,6 @@ use function array_shift;
 use function array_values;
 use function assert;
 use function count;
-use function get_class;
 use function implode;
 use function is_int;
 use function is_string;
@@ -1309,7 +1308,7 @@ class ClassLikeNodeScanner
                 && !(
                     $const->value instanceof Concat
                     && $inferred_type->isSingle()
-                    && get_class($inferred_type->getSingleAtomic()) === TString::class
+                    && TString::isPlain($inferred_type->getSingleAtomic())
                 )
             ) {
                 $exists = true;

--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -44,7 +44,6 @@ use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
-use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNonEmptyLowercaseString;
@@ -796,8 +795,10 @@ class AssertionReconciler extends Reconciler
         }
 
         // Lowercase-string and non-empty-string are compatible but none is contained into the other completely
-        if (($type_2_atomic instanceof TLowercaseString && $type_1_atomic instanceof TNonEmptyString) ||
-            ($type_2_atomic instanceof TNonEmptyString && $type_1_atomic instanceof TLowercaseString)
+        if ($type_1_atomic instanceof TString
+            && $type_2_atomic instanceof TString
+            && (($type_2_atomic->lowercase === true && $type_1_atomic instanceof TNonEmptyString)
+                || ($type_2_atomic instanceof TNonEmptyString && $type_1_atomic->lowercase === true))
         ) {
             $matching_atomic_type = new TNonEmptyLowercaseString();
         }

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -20,7 +20,6 @@ use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
-use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNonEmptyLowercaseString;
 use Psalm\Type\Atomic\TNonEmptyNonspecificLiteralString;
@@ -55,7 +54,7 @@ class ScalarTypeComparator
         bool $allow_float_int_equality = true,
         ?TypeComparisonResult $atomic_comparison_result = null
     ): bool {
-        if (get_class($container_type_part) === TString::class
+        if (TString::isPlain($container_type_part)
             && $input_type_part instanceof TString
         ) {
             return true;
@@ -74,7 +73,7 @@ class ScalarTypeComparator
         }
 
         if ($container_type_part instanceof TNonEmptyString
-            && get_class($input_type_part) === TString::class
+            && TString::isPlain($input_type_part)
         ) {
             if ($atomic_comparison_result) {
                 $atomic_comparison_result->type_coerced = true;
@@ -117,20 +116,21 @@ class ScalarTypeComparator
         }
 
         if ($input_type_part instanceof TCallableString
+            && $container_type_part instanceof TString
             && (get_class($container_type_part) === TSingleLetter::class
                 || get_class($container_type_part) === TNonEmptyString::class
                 || get_class($container_type_part) === TNonFalsyString::class
-                || get_class($container_type_part) === TLowercaseString::class)
+                || $container_type_part->lowercase === true)
         ) {
             return true;
         }
 
-        if (($container_type_part instanceof TLowercaseString
-                || $container_type_part instanceof TNonEmptyLowercaseString)
+        if ($container_type_part instanceof TString
+            && ($container_type_part->lowercase === true || $container_type_part instanceof TNonEmptyLowercaseString)
             && $input_type_part instanceof TString
         ) {
-            if (($input_type_part instanceof TLowercaseString
-                    && $container_type_part instanceof TLowercaseString)
+            if (($input_type_part->lowercase === true
+                    && $container_type_part->lowercase === true)
                 || ($input_type_part instanceof TNonEmptyLowercaseString
                     && $container_type_part instanceof TNonEmptyLowercaseString)
             ) {
@@ -138,12 +138,12 @@ class ScalarTypeComparator
             }
 
             if ($input_type_part instanceof TNonEmptyLowercaseString
-                && $container_type_part instanceof TLowercaseString
+                && $container_type_part->lowercase === true
             ) {
                 return true;
             }
 
-            if ($input_type_part instanceof TLowercaseString
+            if ($input_type_part->lowercase === true
                 && $container_type_part instanceof TNonEmptyLowercaseString
             ) {
                 if ($atomic_comparison_result) {
@@ -155,7 +155,7 @@ class ScalarTypeComparator
 
             if ($input_type_part instanceof TLiteralString) {
                 if (strtolower($input_type_part->value) === $input_type_part->value) {
-                    return $input_type_part->value || $container_type_part instanceof TLowercaseString;
+                    return $input_type_part->value || $container_type_part->lowercase === true;
                 }
 
                 return false;
@@ -375,7 +375,7 @@ class ScalarTypeComparator
             return false;
         }
 
-        if ((get_class($input_type_part) === TString::class
+        if ((TString::isPlain($input_type_part)
                 || get_class($input_type_part) === TSingleLetter::class
                 || $input_type_part instanceof TNonEmptyString
                 || $input_type_part instanceof TNonspecificLiteralString)
@@ -389,8 +389,8 @@ class ScalarTypeComparator
             return false;
         }
 
-        if (($input_type_part instanceof TLowercaseString
-                || $input_type_part instanceof TNonEmptyLowercaseString)
+        if ($input_type_part instanceof TString
+            && ($input_type_part->lowercase === true || $input_type_part instanceof TNonEmptyLowercaseString)
             && $container_type_part instanceof TLiteralString
             && strtolower($container_type_part->value) === $container_type_part->value
         ) {
@@ -421,7 +421,7 @@ class ScalarTypeComparator
         }
 
         if ($container_type_part instanceof TTraitString
-            && (get_class($input_type_part) === TString::class
+            && (TString::isPlain($input_type_part)
                 || $input_type_part instanceof TNonEmptyString
                 || $input_type_part instanceof TNonEmptyNonspecificLiteralString)
         ) {
@@ -500,7 +500,8 @@ class ScalarTypeComparator
             return true;
         }
 
-        if ($input_type_part instanceof TLowercaseString
+        if ($input_type_part instanceof TString
+            && $input_type_part->lowercase === true
             && get_class($container_type_part) === TNonEmptyString::class) {
             return false;
         }

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -50,7 +50,6 @@ use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TList;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
-use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNever;
@@ -462,7 +461,7 @@ class SimpleAssertionReconciler extends Reconciler
             );
         }
 
-        if ($assertion_type && get_class($assertion_type) === TString::class) {
+        if ($assertion_type && TString::isPlain($assertion_type)) {
             return self::reconcileString(
                 $assertion,
                 $existing_var_type,
@@ -996,7 +995,7 @@ class SimpleAssertionReconciler extends Reconciler
 
         foreach ($existing_var_atomic_types as $type) {
             if ($type instanceof TString) {
-                if (get_class($type) === TString::class) {
+                if (TString::isPlain($type)) {
                     $type = $type->setFromDocblock(false);
                 }
                 $string_types[] = $type;
@@ -2596,7 +2595,7 @@ class SimpleAssertionReconciler extends Reconciler
                 && $codebase->methodExists($type->value . '::__invoke')
             ) {
                 $callable_types[] = $type;
-            } elseif (get_class($type) === TString::class
+            } elseif (TString::isPlain($type)
                 || get_class($type) === TNonEmptyString::class
                 || get_class($type) === TNonFalsyString::class
             ) {
@@ -2792,10 +2791,10 @@ class SimpleAssertionReconciler extends Reconciler
         if (isset($types['string'])) {
             $string_atomic_type = $types['string'];
 
-            if (get_class($string_atomic_type) === TString::class) {
+            if (TString::isPlain($string_atomic_type)) {
                 unset($types['string']);
                 $types []= new TNonFalsyString();
-            } elseif (get_class($string_atomic_type) === TLowercaseString::class) {
+            } elseif ($string_atomic_type instanceof TString && $string_atomic_type->lowercase === true) {
                 unset($types['string']);
                 $types []= new TNonEmptyLowercaseString();
             } elseif (get_class($string_atomic_type) === TNonspecificLiteralString::class) {

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -344,7 +344,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
             );
         }
 
-        if ($assertion_type && get_class($assertion_type) === TString::class && !$existing_var_type->hasMixed()) {
+        if ($assertion_type && TString::isPlain($assertion_type) && !$existing_var_type->hasMixed()) {
             return self::reconcileString(
                 $assertion,
                 $existing_var_type,
@@ -979,7 +979,7 @@ class SimpleNegatedAssertionReconciler extends Reconciler
         if ($existing_var_type->hasType('string')) {
             $string_atomic_type = $existing_var_type->getAtomicTypes()['string'];
 
-            if (get_class($string_atomic_type) === TString::class) {
+            if (TString::isPlain($string_atomic_type)) {
                 $existing_var_type->removeType('string');
                 $existing_var_type->addType(new TLiteralString(''));
                 $existing_var_type->addType(new TLiteralString('0'));

--- a/src/Psalm/Type/Atomic/TLowercaseString.php
+++ b/src/Psalm/Type/Atomic/TLowercaseString.php
@@ -3,17 +3,13 @@
 namespace Psalm\Type\Atomic;
 
 /**
+ * @deprecated Use {@see TString} with {@see TString::$lowercase} set to true.
  * @psalm-immutable
  */
 final class TLowercaseString extends TString
 {
-    public function getId(bool $exact = true, bool $nested = false): string
+    public function __construct(bool $from_docblock = false)
     {
-        return 'lowercase-string';
-    }
-
-    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
-    {
-        return false;
+        parent::__construct($from_docblock, true);
     }
 }

--- a/src/Psalm/Type/Atomic/TString.php
+++ b/src/Psalm/Type/Atomic/TString.php
@@ -2,6 +2,10 @@
 
 namespace Psalm\Type\Atomic;
 
+use Psalm\Type\Atomic;
+
+use function get_class;
+
 /**
  * Denotes the `string` type, where the exact value is unknown.
  *
@@ -9,6 +13,23 @@ namespace Psalm\Type\Atomic;
  */
 class TString extends Scalar
 {
+    public ?bool $lowercase = null;
+
+    public function __construct(bool $from_docblock = false, ?bool $lowercase = null)
+    {
+        parent::__construct($from_docblock);
+        $this->lowercase = $lowercase;
+    }
+
+    /**
+     * @psalm-pure
+     */
+    public static function isPlain(Atomic $atomic): bool
+    {
+        return get_class($atomic) === self::class
+            && $atomic->lowercase === null;
+    }
+
     /**
      * @param  array<lowercase-string, string> $aliased_classes
      */
@@ -24,5 +45,21 @@ class TString extends Scalar
     public function getKey(bool $include_extra = true): string
     {
         return 'string';
+    }
+
+    public function getId(bool $exact = true, bool $nested = false): string
+    {
+        if ($this->lowercase !== null) {
+            return $this->lowercase ? 'lowercase-string' : 'non-lowercase-string';
+        }
+        return parent::getId();
+    }
+
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
+    {
+        if ($this->lowercase !== null) {
+            return false;
+        }
+        return parent::canBeFullyExpressedInPhp($analysis_php_version_id);
     }
 }

--- a/src/Psalm/Type/UnionTrait.php
+++ b/src/Psalm/Type/UnionTrait.php
@@ -29,7 +29,6 @@ use Psalm\Type\Atomic\TList;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
-use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNever;
@@ -260,7 +259,7 @@ trait UnionTrait
             } elseif ($type instanceof TLiteralString) {
                 $literal_strings[] = $type_string;
             } else {
-                if (get_class($type) === TString::class) {
+                if (TString::isPlain($type)) {
                     $has_non_literal_string = true;
                 } elseif (get_class($type) === TInt::class) {
                     $has_non_literal_int = true;
@@ -660,7 +659,8 @@ trait UnionTrait
     public function hasLowercaseString(): bool
     {
         return isset($this->types['string'])
-            && ($this->types['string'] instanceof TLowercaseString
+            && $this->types['string'] instanceof TString
+            && ($this->types['string']->lowercase === true
                 || $this->types['string'] instanceof TNonEmptyLowercaseString);
     }
 


### PR DESCRIPTION
Goals:
- Use properties instead of inheritance to more strictly define `TString`
  - Once fully implemented, I believe this will simplify working with string types
- Allow intersection types between strings
- Easily allow the negation of any property

TODO (in this PR):
- [ ] Update `TNonEmptyLowercaseString` to use `TString::$lowercase`
- [ ] Support `TString::$lowercase = false` (non-lowercase-string)

Future scope:
- Deprecate all `TString` child classes and convert to use a property