### PR TITLE
Add imap_is_open() to PHP 8.2 dictionary

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -6018,6 +6018,7 @@ return [
 'imap_header' => ['stdClass|false', 'stream_id'=>'resource', 'msg_no'=>'int', 'from_length='=>'int', 'subject_length='=>'int', 'default_host='=>'string'],
 'imap_headerinfo' => ['stdClass|false', 'imap'=>'IMAP\Connection', 'message_num'=>'int', 'from_length='=>'int', 'subject_length='=>'int'],
 'imap_headers' => ['array|false', 'imap'=>'IMAP\Connection'],
+'imap_is_open' => ['bool', 'imap'=>'IMAP\Connection'],
 'imap_last_error' => ['string|false'],
 'imap_list' => ['array|false', 'imap'=>'IMAP\Connection', 'reference'=>'string', 'pattern'=>'string'],
 'imap_listmailbox' => ['array|false', 'imap'=>'IMAP\Connection', 'reference'=>'string', 'pattern'=>'string'],

--- a/dictionaries/CallMap_82_delta.php
+++ b/dictionaries/CallMap_82_delta.php
@@ -20,6 +20,7 @@ return [
     'mysqli::execute_query' => ['mysqli_result|bool', 'query'=>'non-empty-string', 'params='=>'list<mixed>|null'],
     'openssl_cipher_key_length' => ['positive-int|false', 'cipher_algo'=>'non-empty-string'],
     'curl_upkeep' => ['bool', 'handle'=>'CurlHandle'],
+    'imap_is_open' => ['bool', 'imap'=>'IMAP\Connection'],
     'ini_parse_quantity' => ['int', 'shorthand'=>'non-empty-string'],
     'libxml_get_external_entity_loader' => ['(callable(string,string,array{directory:?string,intSubName:?string,extSubURI:?string,extSubSystem:?string}):(resource|string|null))|null'],
     'memory_reset_peak_usage' => ['void'],


### PR DESCRIPTION
New function added to PHP 8.2.1: https://github.com/php/php-src/pull/10094

Also, it can be potentially added to PHP 8.1.15 (I'll update dictionaries in this case)