### PR TITLE
Add getAtomicType to IsNotAClass for proper negation Reconciliation

### DIFF
--- a/src/Psalm/Storage/Assertion/IsAClass.php
+++ b/src/Psalm/Storage/Assertion/IsAClass.php
@@ -26,7 +26,7 @@ final class IsAClass extends Assertion
         return new IsNotAClass($this->type, $this->allow_string);
     }
 
-    public function getAtomicType(): ?Atomic
+    public function getAtomicType(): Atomic
     {
         return $this->type;
     }

--- a/src/Psalm/Storage/Assertion/IsNotAClass.php
+++ b/src/Psalm/Storage/Assertion/IsNotAClass.php
@@ -31,6 +31,11 @@ final class IsNotAClass extends Assertion
         return new IsAClass($this->type, $this->allow_string);
     }
 
+    public function getAtomicType(): Atomic
+    {
+        return $this->type;
+    }
+
     public function __toString(): string
     {
         return 'isa-' . ($this->allow_string ? 'string-' : '') . $this->type;

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -175,6 +175,7 @@ class ReconcilerTest extends TestCase
             'SimpleXMLIteratorNotAlwaysTruthy' => ['SimpleXMLIterator', new Truthy(), 'SimpleXMLIterator'],
             'SimpleXMLIteratorNotAlwaysTruthy2' => ['SimpleXMLIterator', new Falsy(), 'SimpleXMLIterator'],
             'stringWithAny' => ['string', new Any(), 'string'],
+            'IsNotAClassReconciliation' => ['int', new Assertion\IsNotAClass(new TNamedObject('IDObject'), true), 'int|IDObject'],
         ];
     }
 


### PR DESCRIPTION
fix https://github.com/vimeo/psalm/issues/7926

If someone is interested, the issue was here: https://github.com/vimeo/psalm/blob/1c19260cddea29803cba2ef31c3a49189bcdeb0c/src/Psalm/Internal/Type/NegatedAssertionReconciler.php#L214

IsNotAClass was not returning an Atomic so it couldn't be removed from the Union