### PR TITLE
create proper TClosure instead of TNamedObject with a Closure value

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -78,7 +78,6 @@ use Psalm\Type\Atomic\TCallableString;
 use Psalm\Type\Atomic\TClassConstant;
 use Psalm\Type\Atomic\TClassString;
 use Psalm\Type\Atomic\TClosedResource;
-use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Atomic\TEnumCase;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TKeyedArray;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -78,6 +78,7 @@ use Psalm\Type\Atomic\TCallableString;
 use Psalm\Type\Atomic\TClassConstant;
 use Psalm\Type\Atomic\TClassString;
 use Psalm\Type\Atomic\TClosedResource;
+use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Atomic\TEnumCase;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TKeyedArray;
@@ -1246,7 +1247,7 @@ class AssertionFinder
                     $instanceof_class = $codebase->classlikes->getUnAliasedName($instanceof_class);
                 }
 
-                return [new IsType(new TNamedObject($instanceof_class))];
+                return [new IsType(TNamedObject::createFromName($instanceof_class))];
             }
 
             if ($this_class_name

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -384,6 +384,9 @@ abstract class Atomic implements TypeNode
 
             case 'non-empty-mixed':
                 return new TNonEmptyMixed();
+
+            case 'Closure':
+                return new TClosure('Closure');
         }
 
         if (strpos($value, '-') && strpos($value, 'OCI-') !== 0) {

--- a/src/Psalm/Type/Atomic/TNamedObject.php
+++ b/src/Psalm/Type/Atomic/TNamedObject.php
@@ -255,4 +255,21 @@ class TNamedObject extends Atomic
     {
         return ['extra_types'];
     }
+
+    /**
+     * @param array<string, TNamedObject|TTemplateParam|TIterable|TObjectWithProperties> $extra_types
+     */
+    public static function createFromName(
+        string $value,
+        bool $is_static = false,
+        bool $definite_class = false,
+        array $extra_types = [],
+        bool $from_docblock = false
+    ): TNamedObject {
+        if ($value === 'Closure') {
+            return new TClosure($value, null, null, null, [], $extra_types, $from_docblock);
+        }
+
+        return new TNamedObject($value, $is_static, $definite_class, $extra_types, $from_docblock);
+    }
 }

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -914,6 +914,26 @@ class ClosureTest extends TestCase
                     /** @psalm-suppress UndefinedFunction */
                     unknown(...);',
             ],
+            'reconcileClosure' => [
+                'code' => '<?php
+                    /**
+                    * @param Closure|callable-string $callable
+                    */
+                    function use_callable($callable) : void
+                    {
+                    }
+
+                    /**
+                    * @param Closure|string $var
+                    */
+                    function test($var) : void
+                    {
+                        if (is_callable($var))
+                            use_callable($var);
+                        else
+                            echo $var;  // $var should be string, instead it\'s considered to be Closure|string.
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
fix https://github.com/vimeo/psalm/issues/7943#issuecomment-1123058145

Reconciliation looks for TClosure through isCallableType: https://github.com/vimeo/psalm/blob/fa4891ce58e02c6bf8946ff028087d14201748b5/src/Psalm/Type/Atomic.php#L467

but some Closure are created through standard TNamedObject (and some are probably still created like that...)