### PR TITLE
Prevent DB escaping functions from affecting non-sql taints

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -514,6 +514,17 @@ class mysqli
     function real_escape_string($string) {}
 }
 
+class SQLite3
+{
+    /**
+     * @psalm-pure
+     *
+     * @psalm-taint-escape sql
+     * @psalm-flow ($string) -> return
+     */
+    static function escapeString($string) {}
+}
+
 
 #[Attribute(Attribute::TARGET_METHOD)]
 final class ReturnTypeWillChange

--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -495,6 +495,25 @@ final class WeakMap implements ArrayAccess, Countable, IteratorAggregate, Traver
     public function offsetUnset($offset) {}
 }
 
+class mysqli
+{
+    /**
+     * @psalm-pure
+     *
+     * @psalm-taint-escape sql
+     * @psalm-flow ($string) -> return
+     */
+    function escape_string($string) {}
+
+    /**
+     * @psalm-pure
+     *
+     * @psalm-taint-escape sql
+     * @psalm-flow ($string) -> return
+     */
+    function real_escape_string($string) {}
+}
+
 
 #[Attribute(Attribute::TARGET_METHOD)]
 final class ReturnTypeWillChange

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1492,3 +1492,19 @@ function mb_convert_encoding(array|string $string, string $to_encoding, array|st
  * @psalm-suppress ReferenceConstraintViolation
  */
 function stream_select(null|array &$read, null|array &$write, null|array &$except, null|int $seconds, null|int $microseconds = null) : bool|int {}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-taint-escape sql
+ * @psalm-flow ($string) -> return
+ */
+function mysqli_escape_string($string) {}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-taint-escape sql
+ * @psalm-flow ($string) -> return
+ */
+function mysqli_real_escape_string($string) {}

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1508,3 +1508,51 @@ function mysqli_escape_string($string) {}
  * @psalm-flow ($string) -> return
  */
 function mysqli_real_escape_string($string) {}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-taint-escape sql
+ * @psalm-flow ($string) -> return
+ */
+function db2_escape_string($string) {}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-taint-escape sql
+ * @psalm-flow ($string) -> return
+ */
+function cubrid_real_escape_string($string) {}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-taint-escape sql
+ * @psalm-flow ($string1, $string2) -> return
+ */
+function pg_escape_bytea($string1, $string2 = null) {}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-taint-escape sql
+ * @psalm-flow ($string1, $string2) -> return
+ */
+function pg_escape_identifier($string1, $string2 = null) {}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-taint-escape sql
+ * @psalm-flow ($string1, $string2) -> return
+ */
+function pg_escape_literal($string1, $string2 = null) {}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-taint-escape sql
+ * @psalm-flow ($string1, $string2) -> return
+ */
+function pg_escape_string($string1, $string2 = null) {}

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -727,6 +727,17 @@ class TaintTest extends TestCase
                     echo urlencode($_GET["bad"]);
                 ',
             ],
+            'mysqliEscapeFunctions' => [
+                'code' => '<?php
+                    $mysqli = new mysqli();
+
+                    $a = $mysqli->escape_string($_GET["a"]);
+                    $b = mysqli_escape_string($_GET["b"]);
+                    $c = $mysqli->real_escape_string($_GET["c"]);
+                    $d = mysqli_real_escape_string($_GET["d"]);
+
+                    $mysqli->query("$a$b$c$d");',
+            ],
         ];
     }
 
@@ -2388,6 +2399,28 @@ class TaintTest extends TestCase
                     system(urlencode($_GET["bad"]));
                 ',
                 'error_message' => 'TaintedShell',
+            ],
+            'assertMysqliOnlyEscapesSqlTaints1' => [
+                'code' => '<?php
+                    $mysqli = new mysqli();
+                    echo $mysqli->escape_string($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertMysqliOnlyEscapesSqlTaints2' => [
+                'code' => '<?php
+                    $mysqli = new mysqli();
+                    echo $mysqli->real_escape_string($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertMysqliOnlyEscapesSqlTaints3' => [
+                'code' => '<?php
+                    echo mysqli_escape_string($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertMysqliOnlyEscapesSqlTaints4' => [
+                'code' => '<?php
+                    echo mysqli_real_escape_string($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
             ],
         ];
     }

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -2422,6 +2422,61 @@ class TaintTest extends TestCase
                     echo mysqli_real_escape_string($_GET["a"]);',
                 'error_message' => 'TaintedHtml',
             ],
+            'assertDb2OnlyEscapesSqlTaints' => [
+                'code' => '<?php
+                    echo db2_escape_string($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertCubridOnlyEscapesSqlTaints' => [
+                'code' => '<?php
+                    echo cubrid_real_escape_string($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertSQLiteOnlyEscapesSqlTaints' => [
+                'code' => '<?php
+                    echo SQLite3::escapeString($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertPGOnlyEscapesSqlTaints1' => [
+                'code' => '<?php
+                    echo pg_escape_bytea($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertPGOnlyEscapesSqlTaints2' => [
+                'code' => '<?php
+                    echo pg_escape_bytea($conn, $_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertPGOnlyEscapesSqlTaints3' => [
+                'code' => '<?php
+                    echo pg_escape_identifier($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertPGOnlyEscapesSqlTaints4' => [
+                'code' => '<?php
+                    echo pg_escape_identifier($conn, $_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertPGOnlyEscapesSqlTaints5' => [
+                'code' => '<?php
+                    echo pg_escape_literal($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertPGOnlyEscapesSqlTaints6' => [
+                'code' => '<?php
+                    echo pg_escape_literal($conn, $_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertPGOnlyEscapesSqlTaints7' => [
+                'code' => '<?php
+                    echo pg_escape_string($_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
+            'assertPGOnlyEscapesSqlTaints8' => [
+                'code' => '<?php
+                    echo pg_escape_string($conn, $_GET["a"]);',
+                'error_message' => 'TaintedHtml',
+            ],
         ];
     }
 


### PR DESCRIPTION
I found a developer who was using `mysql_escape_string()` to prevent Psalm from reporting non-sql taint types.  This PR aims to prevent any DB escape method from being misused in this way.  I'm happy to do anything a different way if you'd prefer.