### PR TITLE
Assign TMixed when we find an irreconciliable assertion from docblock

### DIFF
--- a/src/Psalm/Type/Reconciler.php
+++ b/src/Psalm/Type/Reconciler.php
@@ -279,7 +279,14 @@ class Reconciler
                     );
 
                     if ($result_type_candidate->isUnionEmpty()) {
-                        $result_type_candidate = $result_type_candidate->getBuilder()->addType(new TNever)->freeze();
+                        $builder = $result_type_candidate->getBuilder();
+                        if ($result_type_candidate->from_docblock) {
+                            //we assume the docblock was wrong or the user wants to check impossible inputs
+                            $builder->addType(new TMixed());
+                        } else {
+                            $builder->addType(new TNever());
+                        }
+                        $result_type_candidate = $builder->freeze();
                     }
 
                     $orred_type = Type::combineUnionTypes(


### PR DESCRIPTION
This is to keep consistency with things like https://github.com/vimeo/psalm/blob/0f4db694df248fdd2064b5f6e0be0d6cd4fbbebe/src/Psalm/Internal/Type/SimpleAssertionReconciler.php#L2314

When we get to a state where an assertion removed every possible type, we should return never only if the type was from a signature. Otherwise, it could be a wrong docblock (or a user checking an impossible type given the docblock)