### PR TITLE
Prevent array functions from escaping taints

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -6,6 +6,7 @@
  * @param mixed $search_value
  * @param bool  $strict
  *
+ * @psalm-flow ($array) -> return
  * @return (TArray is non-empty-array ? non-empty-list<key-of<TArray>> : list<key-of<TArray>>)
  * @psalm-pure
  */
@@ -20,6 +21,7 @@ function array_keys(array $array, $search_value = null, bool $strict = false)
  * @param array<TKey, TValue> $array
  * @param array ...$arrays
  *
+ * @psalm-flow ($array) -> return
  * @return array<TKey, TValue>
  * @psalm-pure
  */
@@ -34,6 +36,7 @@ function array_intersect(array $array, array ...$arrays)
  * @param array<TKey, TValue> $array
  * @param array ...$arrays
  *
+ * @psalm-flow ($array) -> return
  * @return array<TKey, TValue>
  * @psalm-pure
  */
@@ -48,10 +51,27 @@ function array_intersect_key(array $array, array ...$arrays)
  * @param array<TKey, TValue> $array
  * @param array ...$arrays
  *
+ * @psalm-flow ($array) -> return
  * @return array<TKey, TValue>
  * @psalm-pure
  */
 function array_intersect_assoc(array $array, array ...$arrays)
+{
+}
+
+/**
+ * @psalm-flow ($array) -> return
+ * @psalm-pure
+ */
+function array_intersect_uassoc(array $array, array ...$arrays, callable $key_compare_func): array
+{
+}
+
+/**
+ * @psalm-flow ($array) -> return
+ * @psalm-pure
+ */
+function array_intersect_ukey(array $array, array ...$arrays, callable $key_compare_func): array
 {
 }
 
@@ -62,6 +82,7 @@ function array_intersect_assoc(array $array, array ...$arrays)
  * @param array<mixed, TKey> $keys
  * @param array<mixed, TValue> $values
  *
+ * @psalm-flow ($keys, $values) -> return
  * @return (
  *     PHP_MAJOR_VERSION is 8 ?
  *         ($keys is non-empty-array ? non-empty-array<TKey, TValue> : array<TKey, TValue>) :
@@ -81,6 +102,7 @@ function array_combine(array $keys, array $values)
  * @param array<TKey, TValue> $array
  * @param array ...$arrays
  *
+ * @psalm-flow ($array) -> return
  * @return array<TKey, TValue>
  * @psalm-pure
  */
@@ -95,10 +117,27 @@ function array_diff(array $array, array ...$arrays)
  * @param array<TKey, TValue> $array
  * @param array ...$arrays
  *
+ * @psalm-flow ($array) -> return
  * @return array<TKey, TValue>
  * @psalm-pure
  */
 function array_diff_key(array $array, array ...$arrays)
+{
+}
+
+/**
+ * @psalm-flow ($array) -> return
+ * @psalm-pure
+ */
+function array_diff_uassoc(array $array, array ...$arrays, callable $key_compare_func)
+{
+}
+
+/**
+ * @psalm-flow ($array) -> return
+ * @psalm-pure
+ */
+function array_diff_ukey(array $array, array ...$arrays, callable $key_compare_func)
 {
 }
 
@@ -109,6 +148,7 @@ function array_diff_key(array $array, array ...$arrays)
  * @param array<TKey, TValue> $array
  * @param array ...$arrays
  *
+ * @psalm-flow ($array) -> return
  * @return array<TKey, TValue>
  * @psalm-pure
  */
@@ -122,6 +162,7 @@ function array_diff_assoc(array $array, array ...$arrays)
  *
  * @param array<TKey, TValue> $array
  *
+ * @psalm-flow ($array) -> return
  * @return array<TValue, TKey>
  * @psalm-pure
  */
@@ -189,6 +230,7 @@ function end(&$array)
  *
  * @param TArray $array
  *
+ * @psalm-flow ($array) -> return
  * @return (TArray is array<never, never> ? null : (TArray is non-empty-array ? key-of<TArray> : key-of<TArray>|null))
  * @psalm-pure
  */
@@ -201,6 +243,7 @@ function array_key_first($array)
  *
  * @param TArray $array
  *
+ * @psalm-flow ($array) -> return
  * @return (TArray is array<never, never> ? null : (TArray is non-empty-array ? key-of<TArray> : key-of<TArray>|null))
  * @psalm-pure
  */
@@ -209,10 +252,19 @@ function array_key_last($array)
 }
 
 /**
+ * @psalm-flow ($array, $arrays) -> return
+ * @psalm-pure
+ */
+function array_map(?callable $callback, array $array, array ...$arrays): array
+{
+}
+
+/**
  * @psalm-template TArray as array
  *
  * @param TArray $array
  *
+ * @psalm-flow ($array) -> return
  * @return (TArray is non-empty-array ? non-empty-list<value-of<TArray>> : list<value-of<TArray>>)
  * @psalm-pure
  */
@@ -227,6 +279,7 @@ function array_values($array)
  * @param array<T, mixed> $haystack
  * @param bool            $strict
  *
+ * @psalm-flow ($haystack) -> return
  * @return T|false
  * @psalm-pure
  */
@@ -313,9 +366,28 @@ function uksort(array &$array, callable $callback): bool
  *
  * @param array<K,T> $array
  *
+ * @psalm-flow ($array) -> return
  * @return array<K,T>
  */
 function array_change_key_case(array $array, int $case = CASE_LOWER)
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_chunk(array $array, int $length)
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_column(array $array, int|string|null $column_key)
 {
 }
 
@@ -343,9 +415,165 @@ function array_key_exists($key, array $array) : bool
  *
  * @param array<TKey, TValue> ...$arrays
  *
+ * @psalm-flow ($arrays) -> return
  * @return array<TKey, TValue>
  */
 function array_merge_recursive(array ...$arrays)
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array, $value) -> return
+ */
+function array_pad(array $array, int $length, mixed $value): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_rand(array $array, int $num = 1): int|string|array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array, $initial) -> return
+ */
+function array_reduce(array $array, callable $callback, mixed $initial = null): mixed
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array, $replacements) -> return
+ */
+function array_replace(array $array, array ...$replacements): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array, $replacements) -> return
+ */
+function array_replace_recursive(array $array, array ...$replacements): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_reverse(array $array, bool $preserve_keys = false): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_slice(
+    array $array,
+    int $offset,
+    ?int $length = null,
+    bool $preserve_keys = false
+): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array, $replacement) -> return
+ */
+function array_splice(
+    array &$array,
+    int $offset,
+    ?int $length = null,
+    mixed $replacement = []
+): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_udiff(array $array, array ...$arrays, callable $value_compare_func): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_udiff_assoc(array $array, array ...$arrays, callable $value_compare_func): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_udiff_uassoc(
+    array $array,
+    array ...$arrays,
+    callable $value_compare_func,
+    callable $key_compare_func
+): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_uintersect(array $array, array ...$arrays, callable $value_compare_func): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_uintersect_assoc(array $array, array ...$arrays, callable $value_compare_func): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array1) -> return
+ */
+function array_uintersect_uassoc(
+    array $array1,
+    array ...$arrays,
+    callable $value_compare_func,
+    callable $key_compare_func
+): array
+{
+}
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-flow ($array) -> return
+ */
+function array_unique(array $array, int $flags = SORT_STRING): array
 {
 }
 
@@ -359,9 +587,18 @@ function array_merge_recursive(array ...$arrays)
  *
  * @param array<TKey, TValue> ...$arrays
  *
+ * @psalm-flow ($arrays) -> return
  * @return array<TKey, TValue>
  */
 function array_merge(array ...$arrays)
+{
+}
+
+/**
+ * @psalm-pure
+ * @psalm-flow ($value) -> return
+ */
+function array_fill(int $start_index, int $count, mixed $value): array
 {
 }
 
@@ -374,9 +611,18 @@ function array_merge(array ...$arrays)
  * @param array<TKey> $keys
  * @param TValue $value
  *
+ * @psalm-flow ($value) -> return
  * @return array<TKey, TValue>
  */
 function array_fill_keys(array $keys, $value): array
+{
+}
+
+/**
+ * @psalm-pure
+ * @psalm-flow ($array) -> return
+ */
+function array_filter(array $array, ?callable $callback = null, int $mode = 0): array
 {
 }
 
@@ -1264,6 +1510,7 @@ function str_getcsv(string $string, string $separator = ',', string $enclosure =
  *
  * @param TArray $array
  *
+ * @psalm-flow ($array) -> return
  * @return (TArray is non-empty-array ? non-empty-array<TKey, positive-int> : array<TKey, positive-int>)
  *
  * @psalm-pure

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -741,12 +741,132 @@ class TaintTest extends TestCase
         ];
     }
 
+    private function getLastFunctionName($lines){
+        $i = count($lines);
+        do{
+            $i--;
+            $parts = explode('(', $lines[$i]);
+        }while(count($parts) === 1);
+
+        $functionName = trim(str_replace('return ', '', $parts[0]));
+        if(empty($functionName)){
+            throw new \Exception("Function name detection failed for code: " . implode("\n", $lines));
+        }
+
+        return $functionName;
+    }
+
+    public function buildDataSets($dataSetNamePrefix, $taintType, $codeBlocks)
+    {
+        $dataSets = [];
+
+        foreach($codeBlocks as $code){
+            $lines = explode("\n", $code);
+            if(count($lines) > 1){
+                $code = "(function(){{$code}})()";
+            }
+
+            $functionName = $this->getLastFunctionName($lines);
+            $dataSetNumber = 0;
+            do{
+                $dataSetNumber++;
+                $dataSetName = "$dataSetNamePrefix-$functionName-$dataSetNumber";
+            }while(isset($items[$dataSetName]));
+
+            $dataSets[$dataSetName] = [
+                'code' => "<?php var_dump($code);",
+                'error_message' => $taintType,
+            ];
+        };
+
+        return $dataSets;
+    }
+
     /**
      * @return array<string, array{code: string, error_message: string}>
      */
     public function providerInvalidCodeParse(): array
     {
-        return [
+        $arrayFunctionTaintFlowDataSets = $this->buildDataSets('taintFlow', 'TaintedHtml', [
+            'array_change_key_case([$_GET["a"]])',
+            'array_chunk([$_GET["a"]], 1)',
+            'array_column([[$_GET["a"]]], 0)',
+            'array_combine([0], [$_GET["a"]])',
+            'array_combine([$_GET["a"]], [0])',
+            'array_count_values([$_GET["a"]])',
+            'array_diff([$_GET["a"]], [])',
+            'array_diff_assoc([$_GET["a"] => 0], [])',
+            'array_diff_key([$_GET["a"] => 0], [])',
+            'array_diff_uassoc([$_GET["a"]], [], function(){return false;})',
+            'array_diff_ukey([$_GET["a"]], [], function(){return false;})',
+            'array_fill(0, 1, $_GET["a"])',
+            'array_fill_keys([0], $_GET["a"])',
+            'array_filter([$_GET["a"]])',
+            'array_flip([$_GET["a"]])',
+            'array_intersect([$_GET["a"]], [$_GET["a"]])',
+            'array_intersect_assoc([$_GET["a"]], [$_GET["a"]])',
+            'array_intersect_key([$_GET["a"]], [0])',
+            'array_intersect_uassoc([0 => $_GET["a"]], [1 => $_GET["a"]], function(){return 0;})',
+            'array_intersect_ukey([0 => $_GET["a"]], [1 => 2], function(){return 0;})',
+            'array_keys([$_GET["a"] => 0])',
+            'array_key_first([$_GET["a"] => 0])',
+            'array_key_last([$_GET["a"] => 0])',
+            'array_map(function($a){return $a;}, [$_GET["a"]])',
+            'array_map(function($a, $b){return $b;}, [0], [$_GET["a"]])',
+            'array_merge([$_GET["a"]])',
+            'array_merge_recursive(["b" => ["c" => $_GET["a"]]], ["b" => ["c" => "d"]])',
+            'array_pad([$_GET["a"]], 2, 1)',
+            'array_pad([], 1, $_GET["a"])',
+            '
+                $a = [$_GET["a"]];
+                return array_pop($a);
+            ',
+            '
+                $a = [];
+                array_push($a, $_GET["a"]);
+                return $a;
+            ',
+            'array_rand([$_GET["a"] => 0])',
+            'array_reduce([$_GET["a"]], function($carry, $item){return $item;})',
+            'array_reduce([], function(){}, $_GET["a"])',
+            'array_replace([$_GET["a"]], [])',
+            'array_replace([], [$_GET["a"]])',
+            'array_replace_recursive([$_GET["a"]], [])',
+            'array_replace_recursive([], [$_GET["a"]])',
+            'array_reverse([$_GET["a"]])',
+            'array_search(0, [$_GET["a"] => 0])',
+            '
+                $a = [$_GET["a"]];
+                return array_shift($a);
+            ',
+            'array_slice([$_GET["a"]], 0)',
+            '
+                $a = [$_GET["a"]];
+                return array_splice($a, 0);
+            ',
+            // This dataset is currently broken, but mmcev106 plans to fix it in an upcoming PR.
+            // '
+            //     $a = [];
+            //     array_splice($a, 0, 0, [$_GET["a"]]);
+            //     return $a;
+            // ',
+            'array_udiff([$_GET["a"]], [], function(){return false;})',
+            'array_udiff_assoc([$_GET["a"]], [], function(){return false;})',
+            'array_udiff_uassoc([$_GET["a"]], [], function(){return false;}, function(){return false;})',
+            'array_uintersect([$_GET["a"]], [$_GET["a"]], function(){return 0;})',
+            'array_uintersect_assoc([$_GET["a"]], [$_GET["a"]], function(){return 0;})',
+            'array_uintersect_uassoc([$_GET["a"]], [$_GET["a"]], function(){return 0;}, function(){return 0;})',
+            'array_unique([$_GET["a"]])',
+            // This dataset is currently broken, but mmcev106 plans to fix it in an upcoming PR.
+            // '
+            //     $a = [];
+            //     array_unshift($a, $_GET["a"]);
+            //     return $a;
+            // ',
+            'array_values([$_GET["a"]])',
+        ]);
+
+        return array_merge($arrayFunctionTaintFlowDataSets, [
             'taintedInputFromMethodReturnTypeSimple' => [
                 'code' => '<?php
                     class A {
@@ -2477,7 +2597,7 @@ class TaintTest extends TestCase
                     echo pg_escape_string($conn, $_GET["a"]);',
                 'error_message' => 'TaintedHtml',
             ],
-        ];
+        ]);
     }
 
     /**

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -741,7 +741,8 @@ class TaintTest extends TestCase
         ];
     }
 
-    private function getLastFunctionName($lines){
+    private function getLastFunctionName($lines)
+    {
         $i = count($lines);
         do{
             $i--;
@@ -866,7 +867,7 @@ class TaintTest extends TestCase
             'array_values([$_GET["a"]])',
         ]);
 
-        return array_merge($arrayFunctionTaintFlowDataSets, [
+        return array_merge([
             'taintedInputFromMethodReturnTypeSimple' => [
                 'code' => '<?php
                     class A {
@@ -2597,7 +2598,7 @@ class TaintTest extends TestCase
                     echo pg_escape_string($conn, $_GET["a"]);',
                 'error_message' => 'TaintedHtml',
             ],
-        ]);
+        ], $arrayFunctionTaintFlowDataSets);
     }
 
     /**


### PR DESCRIPTION
These changes allow tainted array function arguments to flow through to return values.  Don't hesitate to speak up if there are any concerns or requests.  I'm hoping you'll appreciate `buildDataSets()` as it significantly reduces boilerplate.  Once approved & merged, I plan to create similar PRs for other core functions.