### PR TITLE
fix DateTime::modify() and DateTimeImmutable::modify() return types

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/DateTimeModifyReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/DateTimeModifyReturnTypeProvider.php
@@ -8,6 +8,7 @@ use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
 use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
 /**
@@ -56,7 +57,11 @@ class DateTimeModifyReturnTypeProvider implements MethodReturnTypeProviderInterf
             return Type::getFalse();
         }
         if ($has_date_time && !$has_false) {
-            return Type::parseString($event->getFqClasslikeName());
+            return Type::intersectUnionTypes(
+                Type::parseString($event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName()),
+                new Union([new TNamedObject('static')]),
+                $statements_source->getCodebase(),
+            );
         }
 
         return null;

--- a/tests/DateTimeTest.php
+++ b/tests/DateTimeTest.php
@@ -44,8 +44,8 @@ class DateTimeTest extends TestCase
                     $b = $dateTimeImmutable->modify(getString());
                     ',
                 'assertions' => [
-                    '$a' => 'DateTime',
-                    '$b' => 'DateTimeImmutable',
+                    '$a' => 'DateTime&static',
+                    '$b' => 'DateTimeImmutable&static',
                 ],
             ],
             'modifyWithInvalidConstant' => [
@@ -86,6 +86,20 @@ class DateTimeTest extends TestCase
                 'assertions' => [
                     '$a' => 'DateTime|false',
                     '$b' => 'DateTimeImmutable|false',
+                ],
+            ],
+            'modifyStaticReturn' => [
+                'code' => '<?php
+
+                    class Subclass extends DateTimeImmutable
+                    {
+                    }
+
+                    $foo = new Subclass("2023-01-01 12:12:13");
+                    $mod = $foo->modify("+7 days");
+                    ',
+                'assertions' => [
+                    '$mod' => 'Subclass&static',
                 ],
             ],
         ];

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -263,7 +263,7 @@ class MethodCallTest extends TestCase
                     $b = (new DateTimeImmutable())->modify("+3 hours");',
                 'assertions' => [
                     '$yesterday' => 'MyDate',
-                    '$b' => 'DateTimeImmutable',
+                    '$b' => 'DateTimeImmutable&static',
                 ],
             ],
             'magicCall' => [


### PR DESCRIPTION
even though the two methods return types are documented as returning their respective types, in PHP they are in-fact returning `static` internally in all versions of PHP currently supported by psalm.

This fixes #9042