### PR TITLE
Fix `ReflectionFunctionAbstract::getExtensionName()` stub

### DIFF
--- a/stubs/Php80.phpstub
+++ b/stubs/Php80.phpstub
@@ -152,6 +152,13 @@ abstract class ReflectionFunctionAbstract implements Reflector
      * @psalm-pure
      */
     public function getFileName(): string|false {}
+
+    /**
+     * @return non-empty-string|false
+     *
+     * @psalm-pure
+     */
+    public function getExtensionName(): string|false {}
 }
 
 /** @psalm-immutable */

--- a/stubs/Reflection.phpstub
+++ b/stubs/Reflection.phpstub
@@ -346,11 +346,11 @@ abstract class ReflectionFunctionAbstract implements Reflector
     public function getExtension(): ?ReflectionExtension {}
 
     /**
-     * @return non-empty-string
+     * @return non-empty-string|false
      *
      * @psalm-pure
      */
-    public function getExtensionName(): string {}
+    public function getExtensionName() {}
 
     /**
      * @return non-empty-string|false


### PR DESCRIPTION
https://3v4l.org/XaplB

I'm not able to find a situation when the extension name can be empty string.