### PR TITLE
Fix `ReflectionClass` stub

### DIFF
--- a/stubs/Reflection.phpstub
+++ b/stubs/Reflection.phpstub
@@ -67,8 +67,6 @@ class ReflectionClass implements Reflector {
     public function hasMethod(string $name): bool {}
 
     /**
-     * @param non-empty-string $name
-     *
      * @psalm-pure
      * @throws ReflectionException
      */
@@ -82,16 +80,12 @@ class ReflectionClass implements Reflector {
     public function getMethods(?int $filter = null): array {}
 
     /**
-     * @param non-empty-string $name
-     *
      * @psalm-pure
      * @throws ReflectionException
      */
     public function hasProperty(string $name): bool {}
 
     /**
-     * @param non-empty-string $name
-     *
      * @psalm-pure
      * @throws ReflectionException
      */
@@ -106,14 +100,11 @@ class ReflectionClass implements Reflector {
     public function getProperties(?int $filter = null): array {}
 
     /**
-     * @param non-empty-string $name
-     *
      * @psalm-pure
      */
     public function hasConstant(string $name): bool {}
 
     /**
-     * @param non-empty-string $name
      * @return mixed
      *
      * @psalm-pure
@@ -122,7 +113,6 @@ class ReflectionClass implements Reflector {
     public function getConstant(string $name) {}
 
     /**
-     * @param non-empty-string $name
      * @return ReflectionClassConstant|false
      *
      * @psalm-pure


### PR DESCRIPTION
https://3v4l.org/rWS0L - empty names are strange but valid in native Reflection

Currently I'm getting a lot of errors when trying to upgrade Psalm in https://github.com/Roave/BetterReflection/
I can suppress them but I think the errors are not right here.

```
better-reflection\src\Reflection\Adapter\ReflectionClass.php:99:16:error - RedundantCondition: '' can never contain non-empty-string
better-reflection\src\Reflection\Adapter\ReflectionClass.php:139:38:error - MethodSignatureMismatch: Argument 1 of Roave\BetterReflection\Reflection\Adapter\ReflectionClass::getMethod has wrong type 'string', expecting 'string' as defined by ReflectionClass::getMethod
better-reflection\src\Reflection\Adapter\ReflectionClass.php:141:19:error - RedundantCondition: '' can never contain non-empty-string
better-reflection\src\Reflection\Adapter\ReflectionClass.php:163:40:error - MethodSignatureMismatch: Argument 1 of Roave\BetterReflection\Reflection\Adapter\ReflectionClass::hasProperty has wrong type 'string', expecting 'string' as defined by ReflectionClass::hasProperty
better-reflection\src\Reflection\Adapter\ReflectionClass.php:165:13:error - TypeDoesNotContainType: '' cannot be identical to non-empty-string
better-reflection\src\Reflection\Adapter\ReflectionClass.php:172:40:error - MethodSignatureMismatch: Argument 1 of Roave\BetterReflection\Reflection\Adapter\ReflectionClass::getProperty has wrong type 'string', expecting 'string' as defined by ReflectionClass::getProperty
better-reflection\src\Reflection\Adapter\ReflectionClass.php:174:37:error - RedundantCondition: '' can never contain non-empty-string
better-reflection\src\Reflection\Adapter\ReflectionClass.php:196:40:error - MethodSignatureMismatch: Argument 1 of Roave\BetterReflection\Reflection\Adapter\ReflectionClass::hasConstant has wrong type 'string', expecting 'string' as defined by ReflectionClass::hasConstant
better-reflection\src\Reflection\Adapter\ReflectionClass.php:198:13:error - TypeDoesNotContainType: '' cannot be identical to non-empty-string
better-reflection\src\Reflection\Adapter\ReflectionClass.php:222:40:error - MethodSignatureMismatch: Argument 1 of Roave\BetterReflection\Reflection\Adapter\ReflectionClass::getConstant has wrong type 'string', expecting 'string' as defined by ReflectionClass::getConstant
better-reflection\src\Reflection\Adapter\ReflectionClass.php:224:13:error - TypeDoesNotContainType: '' cannot be identical to non-empty-string
better-reflection\src\Reflection\Adapter\ReflectionClass.php:252:50:error - MethodSignatureMismatch: Argument 1 of Roave\BetterReflection\Reflection\Adapter\ReflectionClass::getReflectionConstant has wrong type 'string', expecting 'string' as defined by ReflectionClass::getReflectionConstant
```