### PR TITLE
fix `I::cases()` where `interface I extends BackedEnum`

### DIFF
--- a/stubs/Php81.phpstub
+++ b/stubs/Php81.phpstub
@@ -26,6 +26,12 @@ namespace {
          * @psalm-pure
          */
         public static function tryFrom(string|int $value): ?static;
+
+        /**
+         * @psalm-pure
+         * @return list<static>
+         */
+        public static function cases(): array;
     }
 
     class ReflectionClass implements Reflector {

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -453,6 +453,22 @@ class EnumTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'methodInheritanceByInterfaces' => [
+                'code' => '<?php
+                    interface I extends BackedEnum {}
+                    /** @var I $i */
+                    $a = $i::cases();
+                    $b = $i::from(1);
+                    $c = $i::tryFrom(2);
+                ',
+                'assertions' => [
+                    '$a===' => 'list<I>',
+                    '$b===' => 'I',
+                    '$c===' => 'I|null',
+                ],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes vimeo/psalm#9065

Inheritance in stubs seems to be broken
