### PR TITLE
Update Call Maps and Signature for get_headers

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -3699,7 +3699,7 @@ return [
 'get_defined_functions' => ['array{internal: list<callable-string>, user: list<callable-string>}', 'exclude_disabled='=>'bool'],
 'get_defined_vars' => ['array'],
 'get_extension_funcs' => ['list<callable-string>|false', 'extension'=>'string'],
-'get_headers' => ['array|false', 'url'=>'string', 'associative='=>'int', 'context='=>'resource'],
+'get_headers' => ['array|false', 'url'=>'string', 'associative='=>'bool', 'context='=>'?resource'],
 'get_html_translation_table' => ['array', 'table='=>'int', 'flags='=>'int', 'encoding='=>'string'],
 'get_include_path' => ['string'],
 'get_included_files' => ['list<string>'],

--- a/dictionaries/CallMap_71_delta.php
+++ b/dictionaries/CallMap_71_delta.php
@@ -48,7 +48,7 @@ return [
     ],
     'get_headers' => [
       'old' => ['array|false', 'url'=>'string', 'associative='=>'int'],
-      'new' => ['array|false', 'url'=>'string', 'associative='=>'int', 'context='=>'resource'],
+      'new' => ['array|false', 'url'=>'string', 'associative='=>'int', 'context='=>'?resource'],
     ],
     'getopt' => [
       'old' => ['array<string,string|false|list<string|false>>|false', 'short_options'=>'string', 'long_options='=>'array'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -673,6 +673,10 @@ return [
       'old' => ['list<string>|null', 'object_or_class'=>'mixed'],
       'new' => ['list<string>', 'object_or_class'=>'object|class-string'],
     ],
+    'get_headers' => [
+      'old' => ['array|false', 'url'=>'string', 'associative='=>'int', 'context='=>'?resource'],
+      'new' => ['array|false', 'url'=>'string', 'associative='=>'bool', 'context='=>'?resource'],
+    ],
     'get_parent_class' => [
       'old' => ['class-string|false', 'object_or_class='=>'mixed'],
       'new' => ['class-string|false', 'object_or_class='=>'object|class-string'],

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1482,11 +1482,11 @@ function bin2hex(string $string): string {}
  *
  * @param resource|null $context
  *
- * @return ($associative is false ? list<string> : array<string, string|list<string>>)|false
+ * @return ($associative is false|0 ? list<string> : array<string, string|list<string>>)|false
  *
  * @psalm-taint-sink ssrf $url
  */
-function get_headers(string $url, bool $associative = false, $context = null) : array|false {}
+function get_headers(string $url, int $associative = 0, $context = null) : array|false {}
 
 /**
  * @psalm-pure

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1482,11 +1482,11 @@ function bin2hex(string $string): string {}
  *
  * @param resource|null $context
  *
- * @return ($associative is 0 ? list<string> : array<string, string|list<string>>)|false
+ * @return ($associative is false ? list<string> : array<string, string|list<string>>)|false
  *
  * @psalm-taint-sink ssrf $url
  */
-function get_headers(string $url, int $associative = 0, $context = null) : array|false {}
+function get_headers(string $url, bool $associative = false, $context = null) : array|false {}
 
 /**
  * @psalm-pure

--- a/stubs/Php80.phpstub
+++ b/stubs/Php80.phpstub
@@ -221,3 +221,14 @@ class DatePeriod implements IteratorAggregate
     /** @psalm-return (Start is string ? (Traversable<int, DateTime>&Iterator) : (Traversable<int, Start>&Iterator)) */
     public function getIterator(): Iterator {}
 }
+
+/**
+ * @psalm-pure
+ *
+ * @param resource|null $context
+ *
+ * @return ($associative is false|0 ? list<string> : array<string, string|list<string>>)|false
+ *
+ * @psalm-taint-sink ssrf $url
+ */
+function get_headers(string $url, bool $associative = false, $context = null) : array|false {}

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -2044,6 +2044,7 @@ class FunctionCallTest extends TestCase
                         }
                     }
                 ',
+            ],
             'getHeadersAssociativeIn8x' => [
                 'code' => '<?php
                     $a = get_headers("https://psalm.dev", true);',

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -2033,6 +2033,20 @@ class FunctionCallTest extends TestCase
                     }
                 ',
             ],
+            'getHeadersAssociativeIn8x' => [
+                'code' => '<?php
+                    $a = get_headers("https://psalm.dev", true);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'getHeadersAssociativeIn7x' => [
+                'code' => '<?php
+                    $a = get_headers("https://psalm.dev", 0);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '7.0',
+            ],
         ];
     }
 

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -2048,14 +2048,18 @@ class FunctionCallTest extends TestCase
             'getHeadersAssociativeIn8x' => [
                 'code' => '<?php
                     $a = get_headers("https://psalm.dev", true);',
-                'assertions' => [],
+                'assertions' => [
+                    '$a' => 'array<string, list<string>|string>|false',
+                ],
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
             'getHeadersAssociativeIn7x' => [
                 'code' => '<?php
                     $a = get_headers("https://psalm.dev", 0);',
-                'assertions' => [],
+                'assertions' => [
+                    '$a' => 'false|list<string>',
+                ],
                 'ignored_issues' => [],
                 'php_version' => '7.0',
             ],

--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -211,7 +211,6 @@ class InternalCallMapHandlerTest extends TestCase
         'finfo::file',
         'finfo::set_flags',
         'generator::throw',
-        'get_headers',
         'globiterator::__construct',
         'globiterator::getfileinfo',
         'globiterator::getpathinfo',


### PR DESCRIPTION
Fixes #9066 

Marks the associative paramater as bool in the CallMap and CallMap_80. Also fixes context in CallMap and CallMap_71 to get ?resource.  Updates stubs/CoreGenericFunctions.phpstub to match as well. I was not sure if stub should also be updated or just callmaps. If stub change is not needed, i will be happy to adjust the PR.

Thanks