### PR TITLE
Infer getDefaultValueConstantName() type when isDefaultValueConstant() is true

### DIFF
--- a/stubs/Reflection.phpstub
+++ b/stubs/Reflection.phpstub
@@ -642,6 +642,13 @@ class ReflectionParameter implements Reflector {
     * @since 8.0
     */
     public function isPromoted(): bool {}
+
+    /**
+     * @psalm-assert-if-true string $this->getDefaultValueConstantName()
+     */
+    public function isDefaultValueConstant(): bool {}
+
+    public function getDefaultValueConstantName(): ?string {}
 }
 
 /** @psalm-immutable */


### PR DESCRIPTION
Fixes the following false positive: https://psalm.dev/r/2f72f1d245

```php
function someFunction(int $a = PDO::FETCH_ASSOC): int {
    return $a;
}

function printConstantName(string $constantName): void {
    echo $constantName;
}

$reflectionFunction = new ReflectionFunction(someFunction(...));

foreach ($reflectionFunction->getParameters() as $reflectionParameter) {
    if ($reflectionParameter->isDefaultValueAvailable()) {
        if ($reflectionParameter->isDefaultValueConstant()) {
            printConstantName($reflectionParameter->getDefaultValueConstantName());
        }
    }
}
```

> ERROR: PossiblyNullArgument - 16:31 - Argument 1 of printConstantName cannot be null, possibly null value provided