### PR TITLE
Allow sebastian/diff 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "fidry/cpu-core-counter": "^0.4.0",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
         "nikic/php-parser": "^4.13",
-        "sebastian/diff": "^4.0",
+        "sebastian/diff": "^4.0 || ^5.0",
         "spatie/array-to-xml": "^2.17.0",
         "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
         "symfony/filesystem": "^5.4 || ^6.0"


### PR DESCRIPTION
This is the same as #8109 but targeting Psalm 5.x as requested:

> I'm opening this (draft) PR because I need to use Psalm while testing against PHPUnit 10 in [facile-it/paraunit#162](https://github.com/facile-it/paraunit/pull/172) and following PRs
> 
> There is only one breaking change (for now?) in this new major of `diff`, and it doesn't impact us: https://github.com/sebastianbergmann/diff/blob/e363869ae7ee88060e691cb080f4651bf2adbdcb/ChangeLog.md?plain=1#L5-L13
> 
> > * Passing a `DiffOutputBuilderInterface` instance to `Differ::__construct()` is no longer optional
> 
> We're not impacted since Psalm doesn't use `DiffOutputBuilderInterface`. We should wait for the tag on `diff`'s side before merging this though.

