### PR TITLE
Allow to specify custom shepherd endpoint clean

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -236,11 +236,6 @@
       <code>$options['tcp'] ?? null</code>
     </PossiblyInvalidArgument>
   </file>
-  <file src="src/Psalm/Internal/Cli/Psalm.php">
-    <DeprecatedProperty>
-      <code>$config-&gt;shepherd_host</code>
-    </DeprecatedProperty>
-  </file>
   <file src="src/Psalm/Internal/Cli/Refactor.php">
     <PossiblyUndefinedIntArrayOffset>
       <code>$identifier_name</code>
@@ -487,11 +482,6 @@
       <code>$type_tokens[$i - 1]</code>
       <code>$type_tokens[$i - 1]</code>
     </PossiblyInvalidArrayOffset>
-  </file>
-  <file src="src/Psalm/Plugin/Shepherd.php">
-    <DeprecatedProperty>
-      <code>$codebase-&gt;config-&gt;shepherd_host</code>
-    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Plugin/Shepherd.php">
     <DeprecatedProperty>

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -236,6 +236,11 @@
       <code>$options['tcp'] ?? null</code>
     </PossiblyInvalidArgument>
   </file>
+  <file src="src/Psalm/Internal/Cli/Psalm.php">
+    <DeprecatedProperty>
+      <code>$config-&gt;shepherd_host</code>
+    </DeprecatedProperty>
+  </file>
   <file src="src/Psalm/Internal/Cli/Refactor.php">
     <PossiblyUndefinedIntArrayOffset>
       <code>$identifier_name</code>
@@ -482,6 +487,11 @@
       <code>$type_tokens[$i - 1]</code>
       <code>$type_tokens[$i - 1]</code>
     </PossiblyInvalidArrayOffset>
+  </file>
+  <file src="src/Psalm/Plugin/Shepherd.php">
+    <DeprecatedProperty>
+      <code>$codebase-&gt;config-&gt;shepherd_host</code>
+    </DeprecatedProperty>
   </file>
   <file src="src/Psalm/Storage/ClassConstantStorage.php">
     <MutableDependency>

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -548,7 +548,7 @@ class Config
      * @var string
      * @deprecated Please use {@see self::$shepherd_endpoint} instead. Property will be removed in Psalm 6.
      */
-    public $shepherd_host = 'https://shepherd.dev/hooks/psalm/';
+    public $shepherd_host = 'shepherd.dev';
 
     /**
      * @var string

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -544,8 +544,17 @@ class Config
      */
     public $include_php_versions_in_error_baseline = false;
 
-    /** @var string */
-    public $shepherd_host = 'shepherd.dev';
+    /**
+     * @var string
+     * @deprecated Please use {@see self::$shepherd_endpoint} instead. Property will be removed in Psalm 6.
+     */
+    public $shepherd_host = 'https://shepherd.dev/hooks/psalm/';
+
+    /**
+     * @var string
+     * @internal
+     */
+    public $shepherd_endpoint = 'https://shepherd.dev/hooks/psalm/';
 
     /**
      * @var array<string, string>

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -69,6 +69,7 @@ use function preg_replace;
 use function realpath;
 use function setlocale;
 use function str_repeat;
+use function str_replace;
 use function strlen;
 use function strpos;
 use function substr;

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -306,7 +306,7 @@ final class Psalm
             ? $options['find-references-to']
             : null;
 
-        self::configureShepherd($options, $plugins);
+        self::configureShepherd($config, $options, $plugins);
 
         if (isset($options['clear-cache'])) {
             self::clearCache($config);
@@ -1164,14 +1164,16 @@ final class Psalm
 
         $plugins[] = Path::canonicalize(__DIR__ . '/../../Plugin/Shepherd.php');
 
-        $custom_shepherd_endpoint = $options['shepherd'] ?? getenv('PSALM_SHEPHERD');
+        /** @psalm-suppress MixedAssignment */
+        $custom_shepherd_endpoint = ($options['shepherd'] ?? getenv('PSALM_SHEPHERD'));
         if (is_string($custom_shepherd_endpoint) && strlen($custom_shepherd_endpoint) > 2) {
             if (parse_url($custom_shepherd_endpoint, PHP_URL_SCHEME) === null) {
                 $custom_shepherd_endpoint = 'https://' . $custom_shepherd_endpoint;
             }
 
-            $config->shepherd_endpoint = $custom_shepherd_endpoint;
+            /** @psalm-suppress DeprecatedProperty */
             $config->shepherd_host = str_replace('/hooks/psalm', '', $custom_shepherd_endpoint);
+            $config->shepherd_endpoint = $custom_shepherd_endpoint;
 
             return;
         }
@@ -1179,14 +1181,14 @@ final class Psalm
         // Legacy part, will be removed in Psalm 6
         $custom_shepherd_host = getenv('PSALM_SHEPHERD_HOST');
 
-        $is_valid_custom_shepherd_endpoint = is_string($custom_shepherd_host);
-        if ($is_valid_custom_shepherd_endpoint) {
+        if (is_string($custom_shepherd_host)) {
             if (parse_url($custom_shepherd_host, PHP_URL_SCHEME) === null) {
                 $custom_shepherd_host = 'https://' . $custom_shepherd_host;
             }
 
-            $config->shepherd_endpoint = $custom_shepherd_host . '/hooks/psalm';
+            /** @psalm-suppress DeprecatedProperty */
             $config->shepherd_host = $custom_shepherd_host;
+            $config->shepherd_endpoint = $custom_shepherd_host . '/hooks/psalm';
         }
     }
 

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -286,10 +286,12 @@ final class Psalm
         $plugins = [];
 
         if (isset($options['plugin'])) {
-            $plugins = $options['plugin'];
+            $plugins_from_options = $options['plugin'];
 
-            if (!is_array($plugins)) {
-                $plugins = [$plugins];
+            if (is_array($plugins_from_options)) {
+                $plugins = $plugins_from_options;
+            } elseif (is_string($plugins_from_options)) {
+                $plugins = [$plugins_from_options];
             }
         }
 

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -198,10 +198,9 @@ final class Psalm
         if (array_key_exists('h', $options)) {
             echo self::getHelpText();
             /*
-            --shepherd[=host]
-                Send data to Shepherd, Psalm's GitHub integration tool.
-                `host` is the location of the Shepherd server. It defaults to shepherd.dev
-                More information is available at https://psalm.dev/shepherd
+            --shepherd[=endpoint]
+                Send analysis statistics to Shepherd server.
+                `endpoint` is the URL to the Shepherd server. It defaults to shepherd.dev
             */
 
             exit;
@@ -1343,8 +1342,8 @@ final class Psalm
             --generate-stubs=PATH
                 Generate stubs for the project and dump the file in the given path
 
-            --shepherd[=host]
-                Send data to Shepherd, Psalm’s GitHub integration tool.
+            --shepherd[=endpoint]
+                Send analysis statistics to Shepherd (shepherd.dev) or your server.
 
             --alter
                 Run Psalter

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -81,7 +81,7 @@ final class Shepherd implements AfterAnalysisInterface
             $payload = json_encode($data, JSON_THROW_ON_ERROR);
 
             // Prepare new cURL resource
-            $ch = curl_init($codebase->config->shepherd_endpoint);
+            $ch = curl_init($base_address . '/hooks/psalm');
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($ch, CURLINFO_HEADER_OUT, true);

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -19,6 +19,7 @@ use function curl_setopt;
 use function function_exists;
 use function fwrite;
 use function is_array;
+use function is_int;
 use function is_string;
 use function json_encode;
 use function parse_url;
@@ -34,6 +35,7 @@ use const CURLOPT_RETURNTRANSFER;
 use const JSON_THROW_ON_ERROR;
 use const PHP_EOL;
 use const PHP_URL_HOST;
+use const PHP_URL_SCHEME;
 use const STDERR;
 use const STDOUT;
 

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -128,9 +128,31 @@ final class Shepherd implements AfterAnalysisInterface
     }
 
     /**
+     * @param mixed $ch
+     * @psalm-pure
+     * @deprecated Will be removed in Psalm 6
+     */
+    public static function getCurlErrorMessage($ch): string
+    {
+        /**
+         * @psalm-suppress MixedArgument
+         * @var array
+         */
+        $curl_info = curl_getinfo($ch);
+
+        /** @psalm-suppress MixedAssignment */
+        $ssl_verify_result = $curl_info['ssl_verify_result'] ?? null;
+        if (is_int($ssl_verify_result) && $ssl_verify_result > 1) {
+            return self::getCurlSslErrorMessage($ssl_verify_result);
+        }
+
+        return '';
+    }
+
+    /**
      * @psalm-pure
      */
-    public static function getCurlSslErrorMessage(int $ssl_verify_result): string
+    private static function getCurlSslErrorMessage(int $ssl_verify_result): string
     {
         switch ($ssl_verify_result) {
             case 1:

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -80,6 +80,13 @@ final class Shepherd implements AfterAnalysisInterface
 
             $payload = json_encode($data, JSON_THROW_ON_ERROR);
 
+            /** @psalm-suppress DeprecatedProperty */
+            $base_address = $codebase->config->shepherd_host;
+
+            if (parse_url($base_address, PHP_URL_SCHEME) === null) {
+                $base_address = 'https://' . $base_address;
+            }
+
             // Prepare new cURL resource
             $ch = curl_init($base_address . '/hooks/psalm');
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -20,7 +20,6 @@ use function fwrite;
 use function is_array;
 use function json_encode;
 use function parse_url;
-use function str_replace;
 use function strlen;
 use function var_export;
 
@@ -31,7 +30,7 @@ use const CURLOPT_POSTFIELDS;
 use const CURLOPT_RETURNTRANSFER;
 use const JSON_THROW_ON_ERROR;
 use const PHP_EOL;
-use const PHP_URL_SCHEME;
+use const PHP_URL_HOST;
 use const STDERR;
 
 final class Shepherd implements AfterAnalysisInterface
@@ -77,14 +76,8 @@ final class Shepherd implements AfterAnalysisInterface
 
             $payload = json_encode($data, JSON_THROW_ON_ERROR);
 
-            $base_address = $codebase->config->shepherd_host;
-
-            if (parse_url($base_address, PHP_URL_SCHEME) === null) {
-                $base_address = 'https://' . $base_address;
-            }
-
             // Prepare new cURL resource
-            $ch = curl_init($base_address . '/hooks/psalm');
+            $ch = curl_init($codebase->config->shepherd_endpoint);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLINFO_HEADER_OUT, true);
             curl_setopt($ch, CURLOPT_POST, true);
@@ -118,9 +111,9 @@ final class Shepherd implements AfterAnalysisInterface
                         . PHP_EOL;
                 }
             } else {
-                $short_address = str_replace('https://', '', $base_address);
+                $shepherd_host = parse_url($codebase->config->shepherd_endpoint, PHP_URL_HOST);
 
-                fwrite(STDERR, "🐑 results sent to $short_address 🐑" . PHP_EOL);
+                fwrite(STDERR, "🐑 results sent to $shepherd_host 🐑" . PHP_EOL);
             }
 
             // Close cURL session handle

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -2,6 +2,7 @@
 
 namespace Psalm\Plugin;
 
+use BadMethodCallException;
 use Psalm\Config;
 use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Plugin\EventHandler\AfterAnalysisInterface;
@@ -18,12 +19,14 @@ use function curl_setopt;
 use function function_exists;
 use function fwrite;
 use function is_array;
+use function is_string;
 use function json_encode;
 use function parse_url;
+use function strip_tags;
 use function strlen;
-use function var_export;
 
 use const CURLINFO_HEADER_OUT;
+use const CURLOPT_FOLLOWLOCATION;
 use const CURLOPT_HTTPHEADER;
 use const CURLOPT_POST;
 use const CURLOPT_POSTFIELDS;
@@ -32,6 +35,7 @@ use const JSON_THROW_ON_ERROR;
 use const PHP_EOL;
 use const PHP_URL_HOST;
 use const STDERR;
+use const STDOUT;
 
 final class Shepherd implements AfterAnalysisInterface
 {
@@ -130,7 +134,7 @@ final class Shepherd implements AfterAnalysisInterface
     {
         switch ($ssl_verify_result) {
             case 1:
-                throw new \BadMethodCallException('code 1 means a successful SSL response, there is no error to parse');
+                throw new BadMethodCallException('code 1 means a successful SSL response, there is no error to parse');
             case 2:
                 return 'unable to get issuer certificate';
             case 3:

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -79,6 +79,7 @@ final class Shepherd implements AfterAnalysisInterface
             // Prepare new cURL resource
             $ch = curl_init($codebase->config->shepherd_endpoint);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+            curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
             curl_setopt($ch, CURLINFO_HEADER_OUT, true);
             curl_setopt($ch, CURLOPT_POST, true);
             curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);


### PR DESCRIPTION
Currently it's possible to specify only a custom domain, so you have to use `hooks/psalm/` route. In this PR I made it more flexible, so a user can specify any URL.

Before this PR, it's possible to specify shepherd host using 2 ways (by priority):
 1. `--shepherd` cli option. Without value it just a flag to send report to http://shepherd.dev. It's also possible to use it with value: `--shepherd=custom.domain`
 2. Using a combination of 2 env vars: `PSALM_SHEPHERD` and `PSALM_SHEPHERD_HOST`. Where `PSALM_SHEPHERD` is a flag, using `PSALM_SHEPHERD_HOST` you can specify a domain (introduced by https://github.com/vimeo/psalm/pull/5512, shipped within [4.9.0](https://github.com/vimeo/psalm/releases/tag/4.9.0))


I think it will be nice to use a single env variable instead 2, as we do for cli option (for consistency). Also, any van names that includes "host" are not valid anymore as we can specify full URL/endpoint. 