### PR TITLE
Enhance error output for shepherd

### DIFF
--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -132,7 +132,7 @@ final class Shepherd implements AfterAnalysisInterface
 
             fwrite(STDERR, "Shepherd error: server responded with $response_status_code HTTP status code.\n");
             $response_content = is_string($curl_result) ? strip_tags($curl_result) : 'n/a';
-            fwrite(STDERR, 'Shepherd response:' . PHP_EOL . $response_content);
+            fwrite(STDERR, "Shepherd response: $response_content\n");
         }
     }
 


### PR DESCRIPTION
I just tested shepherd with invalid URL and found a small issue in output, probably caused by parallel writing to STDERR.

Note lines 98 and 105 - they should be one right after another

![image](https://user-images.githubusercontent.com/5278175/213270750-cb14a040-8c9a-4a24-a940-6aba76851679.png)
