### PR TITLE
Indent docblocks in DocComment test

### DIFF
--- a/tests/DocCommentTest.php
+++ b/tests/DocCommentTest.php
@@ -36,17 +36,19 @@ class DocCommentTest extends BaseTestCase
             ],
         );
 
-        $expectedDoc = '/**
- * some desc
- *
- * @param string $bli
- * @param int $bla
- *
- * @throws \Exception
- *
- * @return bool
- */
-';
+        $expectedDoc = <<<'PHP'
+            /**
+             * some desc
+             *
+             * @param string $bli
+             * @param int $bla
+             *
+             * @throws \Exception
+             *
+             * @return bool
+             */
+
+            PHP;
 
         $this->assertSame($expectedDoc, $docComment->render(''));
     }
@@ -74,15 +76,17 @@ class DocCommentTest extends BaseTestCase
             ],
         );
 
-        $expectedDoc = '/**
- * some desc
- *
- * @param string $bli
- * @param int $bla
- * @throws \Exception
- * @return bool
- */
-';
+        $expectedDoc = <<<'PHP'
+            /**
+             * some desc
+             *
+             * @param string $bli
+             * @param int $bla
+             * @throws \Exception
+             * @return bool
+             */
+
+            PHP;
 
         $this->assertSame($expectedDoc, $docComment->render(''));
     }
@@ -110,17 +114,19 @@ class DocCommentTest extends BaseTestCase
             ],
         );
 
-        $expectedDoc = '/**
- * some desc
- *
- * @param string $bli
- * @param int $bla
- *
- * @throws \Exception
- *
- * @return bool
- */
-';
+        $expectedDoc = <<<'PHP'
+            /**
+             * some desc
+             *
+             * @param string $bli
+             * @param int $bla
+             *
+             * @throws \Exception
+             *
+             * @return bool
+             */
+
+            PHP;
 
         $this->assertSame($expectedDoc, $docComment->render(''));
     }
@@ -129,17 +135,19 @@ class DocCommentTest extends BaseTestCase
     {
         ParsedDocblock::addNewLineBetweenAnnotations(true);
 
-        $expectedDoc = '/**
- * some desc
- *
- * @param string $bli
- * @param int $bla
- *
- * @throws \Exception
- *
- * @return bool
- */
-';
+        $expectedDoc = <<<'PHP'
+            /**
+             * some desc
+             *
+             * @param string $bli
+             * @param int $bla
+             *
+             * @throws \Exception
+             *
+             * @return bool
+             */
+
+            PHP;
         $docComment = DocComment::parsePreservingLength(
             new Doc($expectedDoc),
         );
@@ -151,17 +159,21 @@ class DocCommentTest extends BaseTestCase
     {
         ParsedDocblock::addNewLineBetweenAnnotations(true);
 
-        $expectedDoc = '/**
-     * some desc
-     *
-     * @param string $bli
-     * @param int $bla
-     *
-     * @throws \Exception
-     *
-     * @return bool
-     */
-    ';
+        $expectedDoc = <<<'PHP'
+            /**
+                 * some desc
+                 *
+                 * @param string $bli
+                 * @param int $bla
+                 *
+                 * @throws \Exception
+                 *
+                 * @return bool
+                 */
+
+            PHP
+            . "    ";
+
         $docComment = DocComment::parsePreservingLength(
             new Doc($expectedDoc),
         );
@@ -173,19 +185,21 @@ class DocCommentTest extends BaseTestCase
     {
         ParsedDocblock::addNewLineBetweenAnnotations(true);
 
-        $expectedDoc = '/**
- * some self-referential desc with " * @return bool
- * " as part of it.
- *
- * @param string $bli
- * @param string $bli_this_suffix_is_kept
- * @param int $bla
- *
- * @throws \Exception
- *
- * @return bool
- */
-';
+        $expectedDoc = <<<'PHP'
+            /**
+             * some self-referential desc with " * @return bool
+             * " as part of it.
+             *
+             * @param string $bli
+             * @param string $bli_this_suffix_is_kept
+             * @param int $bla
+             *
+             * @throws \Exception
+             *
+             * @return bool
+             */
+
+            PHP;
         $docComment = DocComment::parsePreservingLength(
             new Doc($expectedDoc),
         );


### PR DESCRIPTION
Since heredocs in PHP 7.3+ automatically strip leading whitespace we can
fix the formatting for this test.
