### PR TITLE
fix (DateTime|DateTimeImmutable)::modify() return types

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/DateTimeModifyReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/DateTimeModifyReturnTypeProvider.php
@@ -8,7 +8,6 @@ use Psalm\Plugin\EventHandler\Event\MethodReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\MethodReturnTypeProviderInterface;
 use Psalm\Type;
 use Psalm\Type\Atomic\TLiteralString;
-use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
 
 /**
@@ -57,11 +56,7 @@ class DateTimeModifyReturnTypeProvider implements MethodReturnTypeProviderInterf
             return Type::getFalse();
         }
         if ($has_date_time && !$has_false) {
-            return Type::intersectUnionTypes(
-                Type::parseString($event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName()),
-                new Union([new TNamedObject('static')]),
-                $statements_source->getCodebase(),
-            );
+            return Type::parseString($event->getCalledFqClasslikeName() ?? $event->getFqClasslikeName());
         }
 
         return null;

--- a/tests/DateTimeTest.php
+++ b/tests/DateTimeTest.php
@@ -44,8 +44,8 @@ class DateTimeTest extends TestCase
                     $b = $dateTimeImmutable->modify(getString());
                     ',
                 'assertions' => [
-                    '$a' => 'DateTime&static',
-                    '$b' => 'DateTimeImmutable&static',
+                    '$a' => 'DateTime',
+                    '$b' => 'DateTimeImmutable',
                 ],
             ],
             'modifyWithInvalidConstant' => [
@@ -88,6 +88,18 @@ class DateTimeTest extends TestCase
                     '$b' => 'DateTimeImmutable|false',
                 ],
             ],
+            'otherMethodAfterModify' => [
+                'code' => '<?php
+                    $datetime = new DateTime();
+                    $dateTimeImmutable = new DateTimeImmutable();
+                    $a = $datetime->modify("+1 day")->setTime(0, 0);
+                    $b = $dateTimeImmutable->modify("+1 day")->setTime(0, 0);
+                    ',
+                'assertions' => [
+                    '$a' => 'DateTime|false',
+                    '$b' => 'DateTimeImmutable',
+                ],
+            ],
             'modifyStaticReturn' => [
                 'code' => '<?php
 
@@ -99,7 +111,47 @@ class DateTimeTest extends TestCase
                     $mod = $foo->modify("+7 days");
                     ',
                 'assertions' => [
-                    '$mod' => 'Subclass&static',
+                    '$mod' => 'Subclass',
+                ],
+            ],
+            'otherMethodAfterModifyStaticReturn' => [
+                'code' => '<?php
+
+                    class Subclass extends DateTimeImmutable
+                    {
+                    }
+
+                    $datetime = new Subclass();
+                    $mod = $datetime->modify("+1 day")->setTime(0, 0);
+                    ',
+                'assertions' => [
+                    '$mod' => 'Subclass',
+                ],
+            ],
+            'formatAfterModify' => [
+                'code' => '<?php
+                    $datetime = new DateTime();
+                    $dateTimeImmutable = new DateTimeImmutable();
+                    $a = $datetime->modify("+1 day")->format("Y-m-d");
+                    $b = $dateTimeImmutable->modify("+1 day")->format("Y-m-d");
+                    ',
+                'assertions' => [
+                    '$a' => 'false|string',
+                    '$b' => 'string',
+                ],
+            ],
+            'formatAfterModifyStaticReturn' => [
+                'code' => '<?php
+
+                    class Subclass extends DateTimeImmutable
+                    {
+                    }
+
+                    $datetime = new Subclass();
+                    $format = $datetime->modify("+1 day")->format("Y-m-d");
+                    ',
+                'assertions' => [
+                    '$format' => 'string',
                 ],
             ],
         ];

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -263,7 +263,7 @@ class MethodCallTest extends TestCase
                     $b = (new DateTimeImmutable())->modify("+3 hours");',
                 'assertions' => [
                     '$yesterday' => 'MyDate',
-                    '$b' => 'DateTimeImmutable&static',
+                    '$b' => 'DateTimeImmutable',
                 ],
             ],
             'magicCall' => [


### PR DESCRIPTION
vimeo#9042 caused issues to any called method on an instance of DateTime|DateTimeImmutable after calling the modify method.

This fixes vimeo#9171