### PR TITLE
Resolve class constants within PhpStorm metadata

### DIFF
--- a/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
+++ b/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
@@ -76,7 +76,7 @@ class PhpStormMetaScanner
                     $constant_type = $codebase->classlikes->getClassConstantType(
                         $resolved_name,
                         $array_item->key->name->name,
-                        ReflectionProperty::IS_PUBLIC,
+                        ReflectionProperty::IS_PRIVATE,
                     );
 
                     if (!$constant_type instanceof Union || !$constant_type->isSingleStringLiteral()) {

--- a/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
+++ b/src/Psalm/Internal/Scanner/PhpStormMetaScanner.php
@@ -12,6 +12,7 @@ use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Union;
+use ReflectionProperty;
 
 use function count;
 use function implode;
@@ -62,6 +63,38 @@ class PhpStormMetaScanner
                         ]);
                     } elseif ($array_item->value instanceof PhpParser\Node\Scalar\String_) {
                         $map[$array_item->key->value] = $array_item->value->value;
+                    }
+                } elseif ($array_item->key instanceof PhpParser\Node\Expr\ClassConstFetch
+                    && $array_item->key->class instanceof PhpParser\Node\Name\FullyQualified
+                    && $array_item->key->name instanceof PhpParser\Node\Identifier
+                ) {
+                    $resolved_name =  $array_item->key->class->getAttribute('resolvedName');
+                    if (!$resolved_name) {
+                        continue;
+                    }
+
+                    $constant_type = $codebase->classlikes->getClassConstantType(
+                        $resolved_name,
+                        $array_item->key->name->name,
+                        ReflectionProperty::IS_PUBLIC,
+                    );
+
+                    if (!$constant_type instanceof Union || !$constant_type->isSingleStringLiteral()) {
+                        continue;
+                    }
+
+                    $meta_key = $constant_type->getSingleStringLiteral()->value;
+
+                    if ($array_item->value instanceof PhpParser\Node\Expr\ClassConstFetch
+                        && $array_item->value->class instanceof PhpParser\Node\Name\FullyQualified
+                        && $array_item->value->name instanceof PhpParser\Node\Identifier
+                        && strtolower($array_item->value->name->name)
+                    ) {
+                        $map[$meta_key] = new Union([
+                            new TNamedObject(implode('\\', $array_item->value->class->parts)),
+                        ]);
+                    } elseif ($array_item->value instanceof PhpParser\Node\Scalar\String_) {
+                        $map[$meta_key] = $array_item->value->value;
                     }
                 }
             }

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -319,7 +319,7 @@ class StubTest extends TestCase
                     class MyClass {
                     
                         public const OBJECT = "object";
-                        public const EXCEPTION = "exception";
+                        private const EXCEPTION = "exception";
                         
                         /**
                          * @return mixed

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -317,6 +317,10 @@ class StubTest extends TestCase
             '<?php
                 namespace Ns {
                     class MyClass {
+                    
+                        public const OBJECT = "object";
+                        public const EXCEPTION = "exception";
+                        
                         /**
                          * @return mixed
                          * @psalm-suppress InvalidReturnType
@@ -328,6 +332,12 @@ class StubTest extends TestCase
                          * @psalm-suppress InvalidReturnType
                          */
                         public function create2(string $s) {}
+                        
+                        /**
+                         * @return mixed
+                         * @psalm-suppress InvalidReturnType
+                         */
+                        public function create3(string $s) {}
 
                         /**
                          * @param mixed $s
@@ -374,6 +384,9 @@ class StubTest extends TestCase
 
                     $y1 = (new \Ns\MyClass)->creAte2("object");
                     $y2 = (new \Ns\MyClass)->creaTe2("exception");
+                    
+                    $const1 = (new \Ns\MyClass)->creAte3(\Ns\MyClass::OBJECT);
+                    $const2 = (new \Ns\MyClass)->creaTe3("exception");
 
                     $b1 = \Create("object");
                     $b2 = \cReate("exception");
@@ -403,6 +416,9 @@ class StubTest extends TestCase
 
                 '$y1===' => 'stdClass',
                 '$y2===' => 'Exception',
+
+                '$const1===' => 'stdClass',
+                '$const2===' => 'Exception',
 
                 '$b1===' => 'stdClass',
                 '$b2===' => 'Exception',

--- a/tests/fixtures/stubs/phpstorm.meta.php
+++ b/tests/fixtures/stubs/phpstorm.meta.php
@@ -25,6 +25,13 @@ namespace PHPSTORM_META {
         'object' => \stdClass::class,
     ]));
 
+    // tests with class constant as key
+    override(\Ns\MyClass::crEate3(), map([
+        '' => '@',
+        \Ns\MyClass::EXCEPTION => \Exception::class,
+        \Ns\MyClass::OBJECT => \stdClass::class,
+    ]));
+
     override(\Ns\MyClass::foO(0), type(0));
     override(\Ns\MyClass::Bar(0), elementType(0));
     override(\foo(0), type(0));


### PR DESCRIPTION
The PHPStorm allows using class constants for the `override` method - https://www.jetbrains.com/help/phpstorm/ide-advanced-metadata.html#passing-a-class-constant. The Psalm supports only strings for now.

The current PR replicates PHPStorm functionality. i.e. for PHPStorm metadata
```php
namespace PHPSTORM_META {
    override(
        \Psr\Container\ContainerInterface::get(0),
        map([
            \Ns\MyClass::PROPERTIES => \Ns\MyClass\Properties::class,
            '' => '@',
        ])
    );
}
```

the following code will be parsed and analyzed correctly
```php
$properties = $container->get(\Ns\MyClass::PROPERTIES); // $properties instance of  \Ns\MyClass\Properties::class
```

In my tests, the PHPStorm functionality is a bit broken because the IDE doesn't recognize ` $container->get(self::PROPERTIES);` or `$container->get('properties');`, FQCN only (or vice versa if the `override` definition made with a string literal the PHPStorm expects exactly string literal). But I think it should be considered a bug so the current PR resolves every class constant to string so every combination works.