### PR TITLE
fix `didChange` event in LSP

### DIFF
--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -103,6 +103,7 @@ class TextDocument
     /**
      * The document change notification is sent from the client to the server to signal changes to a text document.
      *
+     * @param VersionedTextDocumentIdentifier $textDocument the document that was changed
      * @param TextDocumentContentChangeEvent[] $contentChanges
      */
     public function didChange(VersionedTextDocumentIdentifier $textDocument, array $contentChanges): void


### PR DESCRIPTION
`advanced-json-rpc` need docblock to mapping request, see: https://github.com/felixfbecker/php-advanced-json-rpc/blob/b5f37dbff9a8ad360ca341f3240dc1c168b45447/lib/Dispatcher.php#L99

This commit accidentally deleted it https://github.com/vimeo/psalm/commit/36fa162d6d158e64a15cdc6a064dfb9bd388be3e