### PR TITLE
Add DatePeriod::INCLUDE_END_DATE option

### DIFF
--- a/stubs/Php80.phpstub
+++ b/stubs/Php80.phpstub
@@ -220,12 +220,12 @@ class DatePeriod implements IteratorAggregate
     /**
      * @param Start $start
      * @param (Start is string ? 0|self::EXCLUDE_START_DATE : DateInterval) $interval
-     * @param (Start is string ? never : DateTimeInterface|positive-int) $end
+     * @param (Start is string ? never : (DateTimeInterface|positive-int)) $end
      * @param (Start is string ? never : 0|self::EXCLUDE_START_DATE) $options
      */
     public function __construct($start, $interval = 0, $end = 1, $options = 0) {}
 
-    /** @psalm-return (Start is string ? (Traversable<int, DateTime>&Iterator) : (Traversable<int, Start>&Iterator)) */
+    /** @psalm-return (Start is string ? Iterator<int, DateTime> : Iterator<int, Start>) */
     public function getIterator(): Iterator {}
 }
 

--- a/stubs/Php82.phpstub
+++ b/stubs/Php82.phpstub
@@ -10,4 +10,27 @@ namespace {
         /** @return non-empty-list<ReflectionNamedType|ReflectionIntersectionType> */
         public function getTypes(): array {}
     }
+
+    /**
+    * @psalm-immutable
+    *
+    * @template-covariant Start of string|DateTimeInterface
+    * @implements IteratorAggregate<int, DateTimeInterface>
+    */
+    class DatePeriod implements IteratorAggregate
+    {
+        const EXCLUDE_START_DATE = 1;
+        const INCLUDE_END_DATE = 2;
+
+        /**
+        * @param Start $start
+        * @param (Start is string ? int-mask<self::EXCLUDE_START_DATE, self::INCLUDE_END_DATE> : DateInterval) $interval
+        * @param (Start is string ? never : (DateTimeInterface|positive-int)) $end
+        * @param (Start is string ? never : int-mask<self::EXCLUDE_START_DATE, self::INCLUDE_END_DATE>) $options
+        */
+        public function __construct($start, $interval = 0, $end = 1, $options = 0) {}
+
+        /** @psalm-return (Start is string ? Iterator<int, DateTime> : Iterator<int, Start>) */
+        public function getIterator(): Iterator {}
+    }
 }


### PR DESCRIPTION
closes https://github.com/vimeo/psalm/issues/9147

I'm not sure how the anonymous namespace in php82 stubs works, but added DatePeriod to match other classes.