### PR TITLE
Update workflows to use non-deprecated method of setting step output

### DIFF
--- a/.github/workflows/bcc.yml
+++ b/.github/workflows/bcc.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Get Composer Cache Directories
         id: composer-cache
         run: |
-          echo "::set-output name=files_cache::$(composer config cache-files-dir)"
-          echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+          echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer cache
         uses: actions/cache@v3

--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -49,8 +49,8 @@ jobs:
       - name: Get Composer Cache Directories
         id: composer-cache
         run: |
-          echo "::set-output name=files_cache::$(composer config cache-files-dir)"
-          echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+          echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
       - name: Get Composer Cache Directories
         id: composer-cache
         run: |
-          echo "::set-output name=files_cache::$(composer config cache-files-dir)"
-          echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+          echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer cache
         uses: actions/cache@v3
@@ -58,8 +58,8 @@ jobs:
       - id: chunk-matrix
         name: Generates the Chunk Matrix
         run: |
-          echo "::set-output name=count::$(php -r 'echo json_encode([ ${{ env.CHUNK_COUNT }} ]);')"
-          echo "::set-output name=chunks::$(php -r 'echo json_encode(range(1, ${{ env.CHUNK_COUNT }} ));')"
+          echo "count=$(php -r 'echo json_encode([ ${{ env.CHUNK_COUNT }} ]);')" >> $GITHUB_OUTPUT
+          echo "chunks=$(php -r 'echo json_encode(range(1, ${{ env.CHUNK_COUNT }} ));')" >> $GITHUB_OUTPUT
 
   tests:
     name: "Unit Tests - ${{ matrix.chunk }}"
@@ -94,8 +94,8 @@ jobs:
       - name: Get Composer Cache Directories
         id: composer-cache
         run: |
-          echo "::set-output name=files_cache::$(composer config cache-files-dir)"
-          echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+          echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer cache
         uses: actions/cache@v3

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -23,8 +23,8 @@ jobs:
       - id: chunk-matrix
         name: Generates the Chunk Matrix
         run: |
-          echo "::set-output name=count::$(php -r 'echo json_encode([ ${{ env.CHUNK_COUNT }} ]);')"
-          echo "::set-output name=chunks::$(php -r 'echo json_encode(range(1, ${{ env.CHUNK_COUNT }} ));')"
+          echo "count=$(php -r 'echo json_encode([ ${{ env.CHUNK_COUNT }} ]);')" >> $GITHUB_OUTPUT
+          echo "chunks=$(php -r 'echo json_encode(range(1, ${{ env.CHUNK_COUNT }} ));')" >> $GITHUB_OUTPUT
 
   tests:
     name: "Unit Tests - ${{ matrix.chunk }}"
@@ -64,8 +64,8 @@ jobs:
       - name: Get Composer Cache Directories
         id: composer-cache
         run: |
-          echo "::set-output name=files_cache::$(composer config cache-files-dir)"
-          echo "::set-output name=vcs_cache::$(composer config cache-vcs-dir)"
+          echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer cache
         uses: actions/cache@v3

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -64,8 +64,8 @@ jobs:
       - name: Get Composer Cache Directories
         id: composer-cache
         run: |
-          echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-          echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
+          echo "files_cache=""$(composer config cache-files-dir)""" >> $GITHUB_OUTPUT
+          echo "vcs_cache=""$(composer config cache-vcs-dir)""" >> $GITHUB_OUTPUT
 
       - name: Cache composer cache
         uses: actions/cache@v3

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           echo "count=$(php -r 'echo json_encode([ ${{ env.CHUNK_COUNT }} ]);')" >> $GITHUB_OUTPUT
           echo "chunks=$(php -r 'echo json_encode(range(1, ${{ env.CHUNK_COUNT }} ));')" >> $GITHUB_OUTPUT
+        shell: bash
 
   tests:
     name: "Unit Tests - ${{ matrix.chunk }}"
@@ -64,8 +65,9 @@ jobs:
       - name: Get Composer Cache Directories
         id: composer-cache
         run: |
-          echo "files_cache=""$(composer config cache-files-dir)""" >> $GITHUB_OUTPUT
-          echo "vcs_cache=""$(composer config cache-vcs-dir)""" >> $GITHUB_OUTPUT
+          echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+          echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
+        shell: bash
 
       - name: Cache composer cache
         uses: actions/cache@v3


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Before:
 
![image](https://user-images.githubusercontent.com/57403/217909820-d64ef2ab-b771-47ce-a69b-008d4dfd70ce.png)

After:

![image](https://user-images.githubusercontent.com/57403/217910026-2390c40b-dad8-4e71-b462-7764d1752df5.png)
