### PR TITLE
Fix crashes with invalid `@psalm-check-type` syntax

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="dev-master@7966fd574a1607ccb1abf69c64eb860c7b1c735b">
+<files psalm-version="dev-master@1ee0f1bcb81fa87d8b33a74ede37a6b1d8317294">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$comment_block->tags['variablesfrom'][0]]]></code>
@@ -227,9 +227,6 @@
     <PossiblyUndefinedArrayOffset>
       <code><![CDATA[$stmt->expr->getArgs()[0]]]></code>
     </PossiblyUndefinedArrayOffset>
-    <PossiblyUndefinedIntArrayOffset>
-      <code>$check_type_string</code>
-    </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Cli/LanguageServer.php">
     <PossiblyInvalidArgument>

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -656,9 +656,9 @@ class StatementsAnalyzer extends SourceAnalyzer
         }
 
         foreach ($checked_types as [$check_type_line, $is_exact]) {
-            [$checked_var, $check_type_string] = array_map('trim', explode('=', $check_type_line));
+            [$checked_var, $check_type_string] = array_map('trim', explode('=', $check_type_line, 2)) + ['', ''];
 
-            if ($check_type_string === '') {
+            if ($check_type_string === '' || $checked_var === '') {
                 IssueBuffer::maybeAdd(
                     new InvalidDocblock(
                         "Invalid format for @psalm-check-type" . ($is_exact ? "-exact" : ""),

--- a/tests/CheckTypeTest.php
+++ b/tests/CheckTypeTest.php
@@ -64,5 +64,23 @@ class CheckTypeTest extends TestCase
             ',
             'error_message' => 'Checked variable $foo? = 1 does not match $foo = 1',
         ];
+        yield 'invalidIncompleteSyntax' => [
+            'code' => '<?php
+                /** @psalm-check-type */
+            ',
+            'error_message' => 'InvalidDocblock',
+        ];
+        yield 'invalidIncompleteSyntaxNoVar' => [
+            'code' => '<?php
+                /** @psalm-check-type = 1 */
+            ',
+            'error_message' => 'InvalidDocblock',
+        ];
+        yield 'invalidIncompleteSyntaxNoType' => [
+            'code' => '<?php
+                /** @psalm-check-type $var = */
+            ',
+            'error_message' => 'InvalidDocblock',
+        ];
     }
 }


### PR DESCRIPTION
Fixes vimeo/psalm#9201
