### PR TITLE
Add curl stubs to prevent crashes

### DIFF
--- a/stubs/Php80.phpstub
+++ b/stubs/Php80.phpstub
@@ -239,3 +239,24 @@ class DatePeriod implements IteratorAggregate
  * @psalm-taint-sink ssrf $url
  */
 function get_headers(string $url, bool $associative = false, $context = null) : array|false {}
+
+final class CurlHandle
+{
+    private function __construct()
+    {
+    }
+}
+
+final class CurlMultiHandle
+{
+    private function __construct()
+    {
+    }
+}
+
+final class CurlShareHandle
+{
+    private function __construct()
+    {
+    }
+}


### PR DESCRIPTION
This is related to https://github.com/vimeo/psalm/issues/9258 but not the fix.