### PR TITLE
Add option to skip callmap test

### DIFF
--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -44,6 +44,7 @@ use const PHP_MAJOR_VERSION;
 use const PHP_MINOR_VERSION;
 use const PHP_VERSION;
 
+/** @group callmap */
 class InternalCallMapHandlerTest extends TestCase
 {
     /**


### PR DESCRIPTION
With this change, callmap tests can be skipped with
`--exclude-group=callmap`:

```console
$ php-noxdebug vendor/bin/paratest --passthru-php="-dmemory_limit=-1" --exclude-group=callmap
```
