### PR TITLE
Allow suppressing `MissingThrowsDocblock` for individual exceptions

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -318,7 +318,7 @@
             <xs:element name="MissingPropertyType" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="MissingReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MissingTemplateParam" type="IssueHandlerType" minOccurs="0" />
-            <xs:element name="MissingThrowsDocblock" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MissingThrowsDocblock" type="ClassIssueHandlerType" minOccurs="0" />
             <xs:element name="MixedArgument" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="MixedArgumentTypeCoercion" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="MixedArrayAccess" type="IssueHandlerType" minOccurs="0" />

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -736,6 +736,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                             $possibly_thrown_exception . ' is thrown but not caught - please either catch'
                                 . ' or add a @throws annotation',
                             $codelocation,
+                            $possibly_thrown_exception,
                         ),
                     );
                 }

--- a/src/Psalm/Issue/MissingThrowsDocblock.php
+++ b/src/Psalm/Issue/MissingThrowsDocblock.php
@@ -2,7 +2,7 @@
 
 namespace Psalm\Issue;
 
-final class MissingThrowsDocblock extends CodeIssue
+final class MissingThrowsDocblock extends ClassIssue
 {
     public const SHORTCODE = 169;
 }


### PR DESCRIPTION
Fixes vimeo/psalm#8638
