### PR TITLE
Run assertions on CI

### DIFF
--- a/.github/workflows/shepherd.yml
+++ b/.github/workflows/shepherd.yml
@@ -14,6 +14,9 @@ jobs:
     - uses: shivammathur/setup-php@v2
       with:
         php-version: '8.2'
+        ini-values: zend.assertions=1
+        tools: composer:v2
+        coverage: none
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-suggest


### PR DESCRIPTION
Reports about failed assertions. Sort of fixes #9285 (which is technically fixed on master)


test on my fork (with an invalid assertion added for testing purposes on other branch): https://github.com/lptn/psalm/actions/runs/4192830670/jobs/7268928363:
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/5278175/219336788-a69452df-0449-4023-8af5-5e389b988ad6.png">
