### PR TITLE
Disable JIT-incompatible extensions to prevent warnings

### DIFF
--- a/src/Psalm/Internal/Cli/LanguageServer.php
+++ b/src/Psalm/Internal/Cli/LanguageServer.php
@@ -237,7 +237,13 @@ final class LanguageServer
 
         $ini_handler = new PsalmRestarter('PSALM');
 
-        $ini_handler->disableExtension('grpc');
+        $ini_handler->disableExtensions([
+            'grpc',
+            'uopz',
+            // extensions bellow are incompatible with JIT
+            'pcov',
+            'blackfire',
+        ]);
 
         // If Xdebug is enabled, restart without it
         $ini_handler->check();

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -903,7 +903,12 @@ final class Psalm
             $ini_handler->disableExtension('grpc');
         }
 
-        $ini_handler->disableExtension('uopz');
+        $ini_handler->disableExtensions([
+            'uopz',
+            // extesions that are incompatible with JIT (they are also usually make Psalm slow)
+            'pcov',
+            'blackfire',
+        ]);
 
         // If Xdebug is enabled, restart without it
         $ini_handler->check();

--- a/src/Psalm/Internal/Cli/Psalter.php
+++ b/src/Psalm/Internal/Cli/Psalter.php
@@ -3,13 +3,13 @@
 namespace Psalm\Internal\Cli;
 
 use AssertionError;
-use Composer\XdebugHandler\XdebugHandler;
 use Psalm\Config;
 use Psalm\Exception\UnsupportedIssueToFixException;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\CliUtils;
 use Psalm\Internal\Composer;
 use Psalm\Internal\ErrorHandler;
+use Psalm\Internal\Fork\PsalmRestarter;
 use Psalm\Internal\IncludeCollector;
 use Psalm\Internal\Provider\ClassLikeStorageCacheProvider;
 use Psalm\Internal\Provider\FileProvider;
@@ -218,10 +218,16 @@ final class Psalter
             static fn(): ?\Composer\Autoload\ClassLoader =>
                 CliUtils::requireAutoloaders($current_dir, isset($options['r']), $vendor_dir)
         );
-
+        $ini_handler = new PsalmRestarter('PSALTER');
+        $ini_handler->disableExtensions([
+            'grpc',
+            'uopz',
+            'pcov',
+            'blackfire',
+        ]);
 
         // If Xdebug is enabled, restart without it
-        (new XdebugHandler('PSALTER'))->check();
+        $ini_handler->check();
 
         $paths_to_check = CliUtils::getPathsToCheck($options['f'] ?? null);
 


### PR DESCRIPTION
This also enables JIT for `psalter` and syncs the list of disabled
extensions between `psalm`, `psalter` and `psalm-language-server`

/cc: @danog
