### PR TITLE
Fix language server first-class callable crashes

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -471,6 +471,7 @@ class FunctionCallAnalyzer extends CallAnalyzer
             = $function_call_info->is_stubbed || $function_call_info->in_call_map || $namespaced_function_exists;
 
         if ($function_call_info->function_exists
+            && !$stmt->isFirstClassCallable()
             && $codebase->store_node_types
             && !$context->collect_initializations
             && !$context->collect_mutations

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -95,6 +95,7 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
         }
 
         if ($codebase->store_node_types
+            && !$stmt->isFirstClassCallable()
             && !$context->collect_initializations
             && !$context->collect_mutations
         ) {
@@ -226,6 +227,7 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
         }
 
         if ($codebase->store_node_types
+            && !$stmt->isFirstClassCallable()
             && !$context->collect_initializations
             && !$context->collect_mutations
         ) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -322,6 +322,7 @@ class AtomicStaticCallAnalyzer
         $cased_method_id = $fq_class_name . '::' . $stmt_name->name;
 
         if ($codebase->store_node_types
+            && !$stmt->isFirstClassCallable()
             && !$context->collect_initializations
             && !$context->collect_mutations
         ) {

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -2,7 +2,6 @@
 
 namespace Psalm\Tests;
 
-use Psalm\Context;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
@@ -12,36 +11,6 @@ class ClosureTest extends TestCase
 {
     use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
-
-    public function testLanguageServerFirstClassCallable(): void
-    {
-        $code = '<?php
-            function foo(): void {}
-
-            class A {
-                public static function publicStatic(): void {}
-
-                public function publicMethod(): void {}
-            }
-
-            foo(...);
-            A::publicStatic(...);
-            (new A())->publicMethod(...);
-        ';
-
-        $context = new Context();
-
-        $this->project_analyzer->setPhpVersion('8.1.0', 'tests');
-
-        $codebase = $this->project_analyzer->getCodebase();
-        $codebase->enterServerMode();
-        $codebase->config->visitPreloadedStubFiles($codebase);
-
-        $file_path = self::$src_dir_path . 'somefile.php';
-
-        $this->addFile($file_path, $code);
-        $this->analyzeFile($file_path, $context);
-    }
 
     public function providerValidCodeParse(): iterable
     {

--- a/tests/Traits/InvalidCodeAnalysisTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisTestTrait.php
@@ -73,6 +73,7 @@ trait InvalidCodeAnalysisTestTrait
         $this->expectExceptionMessageMatches('/\b' . preg_quote($error_message, '/') . '\b/');
 
         $codebase = $this->project_analyzer->getCodebase();
+        $codebase->enterServerMode();
         $codebase->config->visitPreloadedStubFiles($codebase);
 
         $this->addFile($file_path, $code);

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -68,6 +68,7 @@ trait ValidCodeAnalysisTestTrait
         $this->project_analyzer->setPhpVersion($php_version, 'tests');
 
         $codebase = $this->project_analyzer->getCodebase();
+        $codebase->enterServerMode();
         $codebase->config->visitPreloadedStubFiles($codebase);
 
         $file_path = self::$src_dir_path . 'somefile.php';


### PR DESCRIPTION
The language server crashes whenever it encounters any kind of first-class callable construct. This fixes the problem for functions, method, and static methods. (`new` looks like it requires some more work; see #9335.)

I'm unfamiliar with this code base, so am not sure if this is a _good_ fix, or if I've written the test in the best way. Very open to suggestions!