### PR TITLE
Added the test to validate test environment itself

### DIFF
--- a/tests/TestEnvironmentTest.php
+++ b/tests/TestEnvironmentTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Psalm\Tests;
+
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+use function ini_get;
+
+class TestEnvironmentTest extends PHPUnitTestCase
+{
+    public function testIniSettings(): void
+    {
+        $this->assertSame(
+            '1',
+            ini_get('zend.assertions'),
+            'zend.assertions should be set to 1 to increase test strictness',
+        );
+    }
+}


### PR DESCRIPTION
We should make sure that the environment the tests are run is as strict
as possible. For example, zend.assertions should be enabled.
