### PR TITLE
Negated is_numeric narrows scalar type

### DIFF
--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -1292,6 +1292,10 @@ class SimpleNegatedAssertionReconciler extends Reconciler
             } elseif ($type instanceof TArrayKey) {
                 $redundant = false;
                 $non_numeric_types[] = new TString();
+            } elseif ($type instanceof TScalar) {
+                $redundant = false;
+                $non_numeric_types[] = new TString();
+                $non_numeric_types[] = new TBool();
             } elseif (!$type->isNumericType()) {
                 $non_numeric_types[] = $type;
             } else {

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -203,7 +203,7 @@ class ConditionalTest extends TestCase
                      * @param scalar $v
                      * @return bool|string
                      */
-                    function toString($)
+                    function toString($v)
                     {
                         if (is_numeric($v)) {
                             return false;

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -197,6 +197,20 @@ class ConditionalTest extends TestCase
                     '$a' => 'string',
                 ],
             ],
+            'typeRefinementonWithNegatedIsNumeric' => [
+                'code' => '<?php
+                    /**
+                     * @param scalar $v
+                     * @return bool|string
+                     */
+                    function toString($)
+                    {
+                        if (is_numeric($v)) {
+                            return false;
+                        }
+                        return $v;
+                    }',
+            ],
             'typeRefinementWithStringOrTrue' => [
                 'code' => '<?php
                     $a = rand(0, 5) > 4 ? "hello" : true;


### PR DESCRIPTION
This narrows `scalar` to `string|bool` when `is_numeric` returns false. (At least, if I've done it right! It seems to work.) Fixes #8703.