### PR TITLE
Load opcache extension if it is loadable

### DIFF
--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -63,7 +63,7 @@ class PsalmRestarter extends XdebugHandler
         }
         $cmd = [PHP_BINARY, '-n', '-dzend_extension=opcache', '-r', 'var_dump(function_exists("opcache_get_status"));'];
 
-        if (PHP_VERSION_ID >= 70400) {
+        if (PHP_VERSION_ID >= 7_04_00) {
             $cmd = $cmd;
         } else {
             $cmd = Process::escapeShellCommand($cmd);

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -2,19 +2,28 @@
 
 namespace Psalm\Internal\Fork;
 
+use Composer\XdebugHandler\Process;
 use Composer\XdebugHandler\XdebugHandler;
 
 use function array_filter;
 use function array_merge;
 use function array_splice;
+use function defined;
 use function extension_loaded;
+use function fgets;
 use function file_get_contents;
 use function file_put_contents;
+use function function_exists;
 use function implode;
 use function in_array;
 use function ini_get;
+use function is_resource;
 use function preg_replace;
+use function proc_close;
+use function proc_open;
+use function trim;
 
+use const PHP_BINARY;
 use const PHP_VERSION_ID;
 
 /**
@@ -23,6 +32,7 @@ use const PHP_VERSION_ID;
 class PsalmRestarter extends XdebugHandler
 {
     private bool $required = false;
+    private ?bool $needOPcache = null;
 
     /**
      * @var string[]
@@ -41,6 +51,41 @@ class PsalmRestarter extends XdebugHandler
     }
 
     /**
+     * Returns true if the opcache extension is not currently loaded and *can* be loaded.
+     */
+    private function canAndNeedToLoadOpcache(): bool
+    {
+        if (function_exists('opcache_get_status')) {
+            return false;
+        }
+        if ($this->needOPcache !== null) {
+            return $this->needOPcache;
+        }
+        $cmd = [PHP_BINARY, '-n', '-dzend_extension=opcache', '-r', 'var_dump(function_exists("opcache_get_status"));'];
+
+        if (PHP_VERSION_ID >= 70400) {
+            $cmd = $cmd;
+        } else {
+            $cmd = Process::escapeShellCommand($cmd);
+            if (defined('PHP_WINDOWS_VERSION_BUILD')) {
+                // Outer quotes required on cmd string below PHP 8
+                $cmd = '"'.$cmd.'"';
+            }
+        }
+
+        $process = proc_open($cmd, [['pipe', 'r'], ['pipe', 'w'], ['pipe', 'w']], $pipes);
+        $this->needOPcache =
+            isset($pipes[1])
+            && trim(fgets($pipes[1]) ?: '') === 'bool(true)';
+
+        if (is_resource($process)) {
+            proc_close($process);
+        }
+
+        return $this->needOPcache;
+    }
+
+    /**
      * No type hint to allow xdebug-handler v1 and v2 usage
      *
      * @param bool $default
@@ -53,23 +98,25 @@ class PsalmRestarter extends XdebugHandler
             static fn(string $extension): bool => extension_loaded($extension)
         );
 
-        if (PHP_VERSION_ID >= 8_00_00 && (extension_loaded('opcache') || extension_loaded('Zend OPcache'))) {
-            // restart to enable JIT if it's not configured in the optimal way
-            if (!in_array(ini_get('opcache.enable_cli'), ['1', 'true', true, 1])) {
-                return true;
-            }
+        if ($this->canAndNeedToLoadOpcache()) {
+            return true;
+        }
 
-            if (((int) ini_get('opcache.jit')) !== 1205) {
-                return true;
-            }
+        // restart to enable JIT if it's not configured in the optimal way
+        if (!in_array(ini_get('opcache.enable_cli'), ['1', 'true', true, 1])) {
+            return true;
+        }
 
-            if (((int) ini_get('opcache.jit')) === 0) {
-                return true;
-            }
+        if (((int) ini_get('opcache.jit')) !== 1205) {
+            return true;
+        }
 
-            if (ini_get('opcache.optimization_level') !== '0x7FFEBFFF') {
-                return true;
-            }
+        if (((int) ini_get('opcache.jit')) === 0) {
+            return true;
+        }
+
+        if (ini_get('opcache.optimization_level') !== '0x7FFEBFFF') {
+            return true;
         }
 
         return $default || $this->required;
@@ -92,27 +139,26 @@ class PsalmRestarter extends XdebugHandler
             file_put_contents($this->tmpIni, $content);
         }
 
-        $additional_options = [];
-
-        // executed in the parent process (before restart)
-        // if it wasn't loaded then we apparently don't have opcache installed and there's no point trying
-        // to tweak it
-        // If we're running on 7.4 there's no JIT available
-        if (PHP_VERSION_ID >= 8_00_00 && (extension_loaded('opcache') || extension_loaded('Zend OPcache'))) {
-            $additional_options = [
-                '-dopcache.enable_cli=true',
-                '-dopcache.jit_buffer_size=512M',
-                '-dopcache.jit=1205',
-                '-dopcache.optimization_level=0x7FFEBFFF',
-            ];
-        }
-
         array_splice(
             $command,
             1,
             0,
-            $additional_options,
+            [
+                '-dopcache.enable_cli=true',
+                '-dopcache.jit_buffer_size=512M',
+                '-dopcache.jit=1205',
+                '-dopcache.optimization_level=0x7FFEBFFF',
+            ],
         );
+
+        if ($this->canAndNeedToLoadOpcache()) {
+            array_splice(
+                $command,
+                1,
+                0,
+                ['-dzend_extension=opcache'],
+            );
+        }
 
         parent::restart($command);
     }


### PR DESCRIPTION
This avoids warnings if the opcache extension isn't installed at all, and loads it if it isn't already loaded.
I've removed some PHP 7.4 exclusion code, IMO it doesn't hurt to load opcache on PHP 7.4, it's bound to yield at least some performance improvements even without JIT, at least due to opcode optimizations.