### PR TITLE
Include setrawcookie as an impure function

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -425,7 +425,7 @@ class Functions
             'call_user_func', 'call_user_func_array', 'define', 'create_function',
 
             // http
-            'header', 'header_remove', 'http_response_code', 'setcookie',
+            'header', 'header_remove', 'http_response_code', 'setcookie', 'setrawcookie',
 
             // output buffer
             'ob_start', 'ob_end_clean', 'ob_get_clean', 'readfile', 'printf', 'var_dump', 'phpinfo',

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -666,6 +666,13 @@ class UnusedCodeTest extends TestCase
                         return $c;
                     }',
             ],
+            'setRawCookieImpure' => [
+                'code' => '<?php
+                    setrawcookie(
+                        "name",
+                        "value",
+                    );',
+            ],
             'usedUsort' => [
                 'code' => '<?php
                     /** @param string[] $arr */


### PR DESCRIPTION
Without this, a call to `setrawcookie` when the return value isn't used causes an `UnusedFunctionCall` error.

https://psalm.dev/r/7764222d83