### PR TITLE
Enforce literal string length limit

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ArrayAnalyzer.php
@@ -33,7 +33,6 @@ use Psalm\Type\Atomic\TList;
 use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
-use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNonEmptyArray;
 use Psalm\Type\Atomic\TObjectWithProperties;
@@ -536,7 +535,7 @@ class ArrayAnalyzer
                             continue 2;
                         }
                         $new_offset = $key;
-                        $array_creation_info->item_key_atomic_types[] = new TLiteralString($new_offset);
+                        $array_creation_info->item_key_atomic_types[] = Type::getAtomicStringFromLiteral($new_offset);
                         $array_creation_info->all_list = false;
                     } else {
                         $new_offset = $array_creation_info->int_offset++;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -170,7 +170,10 @@ class ArrayAssignmentAnalyzer
         $key_values = [];
 
         if ($current_dim instanceof PhpParser\Node\Scalar\String_) {
-            $key_values[] = new TLiteralString($current_dim->value);
+            $value_type = Type::getAtomicStringFromLiteral($current_dim->value);
+            if ($value_type instanceof TLiteralString) {
+                $key_values[] = $value_type;
+            }
         } elseif ($current_dim instanceof PhpParser\Node\Scalar\LNumber && !$root_is_string) {
             $key_values[] = new TLiteralInt($current_dim->value);
         } elseif ($current_dim
@@ -330,7 +333,7 @@ class ArrayAssignmentAnalyzer
                                 $v = $type->value;
                                 $v[0] = $new_char;
                                 $changed = true;
-                                $type = new TLiteralString($v);
+                                $type = Type::getAtomicStringFromLiteral($v);
                                 break;
                             }
                         }
@@ -1036,7 +1039,10 @@ class ArrayAssignmentAnalyzer
         $key_values = [];
 
         if ($dim instanceof PhpParser\Node\Scalar\String_) {
-            $key_values[] = new TLiteralString($dim->value);
+            $value_type = Type::getAtomicStringFromLiteral($dim->value);
+            if ($value_type instanceof TLiteralString) {
+                $key_values[] = $value_type;
+            }
         } elseif ($dim instanceof PhpParser\Node\Scalar\LNumber) {
             $key_values[] = new TLiteralInt($dim->value);
         } else {
@@ -1077,7 +1083,10 @@ class ArrayAssignmentAnalyzer
                 && $child_stmt_dim_type->isSingleStringLiteral())
         ) {
             if ($child_stmt->dim instanceof PhpParser\Node\Scalar\String_) {
-                $offset_type = new TLiteralString($child_stmt->dim->value);
+                $offset_type = Type::getAtomicStringFromLiteral($child_stmt->dim->value);
+                if (!$offset_type instanceof TLiteralString) {
+                    return [null, '[string]', false];
+                }
             } else {
                 $offset_type = $child_stmt_dim_type->getSingleStringLiteral();
             }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -29,7 +29,6 @@ use Psalm\Type;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;
-use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNonEmptyNonspecificLiteralString;
@@ -173,7 +172,7 @@ class ConcatAnalyzer
                                 break 2;
                             }
 
-                            $result_type_parts[] = new TLiteralString($literal);
+                            $result_type_parts[] = Type::getAtomicStringFromLiteral($literal);
                         }
                     }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BitwiseNotAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BitwiseNotAnalyzer.php
@@ -50,7 +50,7 @@ class BitwiseNotAnalyzer
                     if ($type_part instanceof TLiteralInt) {
                         $type_part = new TLiteralInt(~$type_part->value);
                     } elseif ($type_part instanceof TLiteralString) {
-                        $type_part = new TLiteralString(~$type_part->value);
+                        $type_part = Type::getAtomicStringFromLiteral(~$type_part->value);
                     }
 
                     $acceptable_types[] = $type_part;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -35,7 +35,6 @@ use Psalm\Type\Atomic\TIntRange;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TList;
 use Psalm\Type\Atomic\TLiteralInt;
-use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNonEmptyArray;
 use Psalm\Type\Atomic\TNull;
@@ -80,7 +79,7 @@ class FunctionCallReturnTypeFetcher
         if ($stmt->isFirstClassCallable()) {
             $candidate_callable = CallableTypeComparator::getCallableFromAtomic(
                 $codebase,
-                new TLiteralString($function_id),
+                Type::getAtomicStringFromLiteral($function_id),
                 null,
                 $statements_analyzer,
                 true,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NamedFunctionCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NamedFunctionCallHandler.php
@@ -35,7 +35,6 @@ use Psalm\Type\Atomic\TDependentGetDebugType;
 use Psalm\Type\Atomic\TDependentGetType;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;
-use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
@@ -625,17 +624,17 @@ class NamedFunctionCallHandler
                         $class_string_types[] = new TClassString();
                     } else {
                         if ($class_type instanceof TInt) {
-                            $class_string_types[] = new TLiteralString('int');
+                            $class_string_types[] = Type::getAtomicStringFromLiteral('int');
                         } elseif ($class_type instanceof TString) {
-                            $class_string_types[] = new TLiteralString('string');
+                            $class_string_types[] = Type::getAtomicStringFromLiteral('string');
                         } elseif ($class_type instanceof TFloat) {
-                            $class_string_types[] = new TLiteralString('float');
+                            $class_string_types[] = Type::getAtomicStringFromLiteral('float');
                         } elseif ($class_type instanceof TBool) {
-                            $class_string_types[] = new TLiteralString('bool');
+                            $class_string_types[] = Type::getAtomicStringFromLiteral('bool');
                         } elseif ($class_type instanceof TClosedResource) {
-                            $class_string_types[] = new TLiteralString('resource (closed)');
+                            $class_string_types[] = Type::getAtomicStringFromLiteral('resource (closed)');
                         } elseif ($class_type instanceof TNull) {
-                            $class_string_types[] = new TLiteralString('null');
+                            $class_string_types[] = Type::getAtomicStringFromLiteral('null');
                         } else {
                             $class_string_types[] = new TString();
                         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -721,7 +721,7 @@ class CastAnalyzer
                 || $atomic_type instanceof TNumeric
             ) {
                 if ($atomic_type instanceof TLiteralInt || $atomic_type instanceof TLiteralFloat) {
-                    $castable_types[] = new TLiteralString((string) $atomic_type->value);
+                    $castable_types[] = Type::getAtomicStringFromLiteral((string) $atomic_type->value);
                 } elseif ($atomic_type instanceof TNonspecificLiteralInt) {
                     $castable_types[] = new TNonspecificLiteralString();
                 } else {
@@ -740,20 +740,20 @@ class CastAnalyzer
             if ($atomic_type instanceof TNull
                 || $atomic_type instanceof TFalse
             ) {
-                $valid_strings[] = new TLiteralString('');
+                $valid_strings[] = Type::getAtomicStringFromLiteral('');
                 continue;
             }
 
             if ($atomic_type instanceof TTrue
             ) {
-                $valid_strings[] = new TLiteralString('1');
+                $valid_strings[] = Type::getAtomicStringFromLiteral('1');
                 continue;
             }
 
             if ($atomic_type instanceof TBool
             ) {
-                $valid_strings[] = new TLiteralString('1');
-                $valid_strings[] = new TLiteralString('');
+                $valid_strings[] = Type::getAtomicStringFromLiteral('1');
+                $valid_strings[] = Type::getAtomicStringFromLiteral('');
                 continue;
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
@@ -10,6 +10,7 @@ use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
+use Psalm\Type;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
@@ -123,7 +124,7 @@ class EncapsulatedStringAnalyzer
         if ($non_empty) {
             if ($literal_string !== null) {
                 $stmt_type = new Union(
-                    [new TLiteralString($literal_string)],
+                    [Type::getAtomicStringFromLiteral($literal_string)],
                     ['parent_nodes' => $parent_nodes],
                 );
             } elseif ($all_literals) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -481,7 +481,10 @@ class ArrayFetchAnalyzer
         $key_values = [];
 
         if ($stmt->dim instanceof PhpParser\Node\Scalar\String_) {
-            $key_values[] = new TLiteralString($stmt->dim->value);
+            $value_type = Type::getAtomicStringFromLiteral($stmt->dim->value);
+            if ($value_type instanceof TLiteralString) {
+                $key_values[] = $value_type;
+            }
         } elseif ($stmt->dim instanceof PhpParser\Node\Scalar\LNumber) {
             $key_values[] = new TLiteralInt($stmt->dim->value);
         } elseif ($stmt->dim && ($stmt_dim_type = $statements_analyzer->node_data->getType($stmt->dim))) {
@@ -514,7 +517,7 @@ class ArrayFetchAnalyzer
 
             if ($in_assignment) {
                 $offset_type->removeType('null');
-                $offset_type->addType(new TLiteralString(''));
+                $offset_type->addType(Type::getAtomicStringFromLiteral(''));
             }
         }
 
@@ -534,7 +537,7 @@ class ArrayFetchAnalyzer
                 $offset_type->removeType('null');
 
                 if (!$offset_type->ignore_nullable_issues) {
-                    $offset_type->addType(new TLiteralString(''));
+                    $offset_type->addType(Type::getAtomicStringFromLiteral(''));
                 }
             }
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -52,7 +52,6 @@ use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TLiteralInt;
-use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNull;
@@ -935,7 +934,7 @@ class AtomicPropertyFetchAnalyzer
         if ($lhs_type_part instanceof TEnumCase) {
             $statements_analyzer->node_data->setType(
                 $stmt,
-                new Union([new TLiteralString($lhs_type_part->case_name)]),
+                new Union([Type::getAtomicStringFromLiteral($lhs_type_part->case_name)]),
             );
         } else {
             $statements_analyzer->node_data->setType($stmt, Type::getNonEmptyString());
@@ -971,7 +970,7 @@ class AtomicPropertyFetchAnalyzer
 
         foreach ($enum_cases as $enum_case) {
             if (is_string($enum_case->value)) {
-                $case_values[] = new TLiteralString($enum_case->value);
+                $case_values[] = Type::getAtomicStringFromLiteral($enum_case->value);
             } elseif (is_int($enum_case->value)) {
                 $case_values[] = new TLiteralInt($enum_case->value);
             } else {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -758,7 +758,7 @@ class SimpleTypeInferer
                 foreach ($unpacked_atomic_type->properties as $key => $property_value) {
                     if (is_string($key)) {
                         $new_offset = $key;
-                        $array_creation_info->item_key_atomic_types[] = new TLiteralString($new_offset);
+                        $array_creation_info->item_key_atomic_types[] = Type::getAtomicStringFromLiteral($new_offset);
                     } else {
                         $new_offset = $array_creation_info->int_offset++;
                         $array_creation_info->item_key_atomic_types[] = new TLiteralInt($new_offset);

--- a/src/Psalm/Internal/Codebase/ConstantTypeResolver.php
+++ b/src/Psalm/Internal/Codebase/ConstantTypeResolver.php
@@ -94,7 +94,7 @@ class ConstantTypeResolver
                         || $right instanceof TLiteralFloat
                         || $right instanceof TLiteralInt)
                 ) {
-                    return new TLiteralString($left->value . $right->value);
+                    return Type::getAtomicStringFromLiteral($left->value . $right->value);
                 }
 
                 return new TString();
@@ -355,7 +355,7 @@ class ConstantTypeResolver
         }
 
         if (is_string($value)) {
-            return new TLiteralString($value);
+            return Type::getAtomicStringFromLiteral($value);
         }
 
         if (is_int($value)) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -704,10 +704,10 @@ class ClassLikeNodeScanner
             $name_types = [];
             $values_types = [];
             foreach ($storage->enum_cases as $name => $enumCaseStorage) {
-                $name_types[] = new Type\Atomic\TLiteralString($name);
+                $name_types[] = Type::getAtomicStringFromLiteral($name);
                 if ($storage->enum_type !== null) {
                     if (is_string($enumCaseStorage->value)) {
-                        $values_types[] = new Type\Atomic\TLiteralString($enumCaseStorage->value);
+                        $values_types[] = Type::getAtomicStringFromLiteral($enumCaseStorage->value);
                     } elseif (is_int($enumCaseStorage->value)) {
                         $values_types[] = new Type\Atomic\TLiteralInt($enumCaseStorage->value);
                     }

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/GetObjectVarsReturnTypeProvider.php
@@ -56,7 +56,7 @@ class GetObjectVarsReturnTypeProvider implements FunctionReturnTypeProviderInter
             $object_type = reset($atomics);
 
             if ($object_type instanceof Atomic\TEnumCase) {
-                $properties = ['name' => new Union([new Atomic\TLiteralString($object_type->case_name)])];
+                $properties = ['name' => new Union([Type::getAtomicStringFromLiteral($object_type->case_name)])];
                 $codebase = $statements_source->getCodebase();
                 $enum_classlike_storage = $codebase->classlike_storage_provider->get($object_type->value);
                 if ($enum_classlike_storage->enum_type === null) {
@@ -66,7 +66,7 @@ class GetObjectVarsReturnTypeProvider implements FunctionReturnTypeProviderInter
                 if (is_int($enum_case_storage->value)) {
                     $properties['value'] = new Union([new Atomic\TLiteralInt($enum_case_storage->value)]);
                 } elseif (is_string($enum_case_storage->value)) {
-                    $properties['value'] = new Union([new Atomic\TLiteralString($enum_case_storage->value)]);
+                    $properties['value'] = new Union([Type::getAtomicStringFromLiteral($enum_case_storage->value)]);
                 }
                 return new TKeyedArray($properties);
             }

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/VersionCompareReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/VersionCompareReturnTypeProvider.php
@@ -9,7 +9,6 @@ use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
 use Psalm\Type\Atomic\TBool;
 use Psalm\Type\Atomic\TLiteralInt;
-use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Union;
 
@@ -42,20 +41,20 @@ class VersionCompareReturnTypeProvider implements FunctionReturnTypeProviderInte
             if ($operator_type) {
                 if (!$operator_type->hasMixed()) {
                     $acceptable_operator_type = new Union([
-                        new TLiteralString('<'),
-                        new TLiteralString('lt'),
-                        new TLiteralString('<='),
-                        new TLiteralString('le'),
-                        new TLiteralString('>'),
-                        new TLiteralString('gt'),
-                        new TLiteralString('>='),
-                        new TLiteralString('ge'),
-                        new TLiteralString('=='),
-                        new TLiteralString('='),
-                        new TLiteralString('eq'),
-                        new TLiteralString('!='),
-                        new TLiteralString('<>'),
-                        new TLiteralString('ne'),
+                        Type::getAtomicStringFromLiteral('<'),
+                        Type::getAtomicStringFromLiteral('lt'),
+                        Type::getAtomicStringFromLiteral('<='),
+                        Type::getAtomicStringFromLiteral('le'),
+                        Type::getAtomicStringFromLiteral('>'),
+                        Type::getAtomicStringFromLiteral('gt'),
+                        Type::getAtomicStringFromLiteral('>='),
+                        Type::getAtomicStringFromLiteral('ge'),
+                        Type::getAtomicStringFromLiteral('=='),
+                        Type::getAtomicStringFromLiteral('='),
+                        Type::getAtomicStringFromLiteral('eq'),
+                        Type::getAtomicStringFromLiteral('!='),
+                        Type::getAtomicStringFromLiteral('<>'),
+                        Type::getAtomicStringFromLiteral('ne'),
                     ]);
 
                     $codebase = $statements_source->getCodebase();

--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -987,17 +987,17 @@ class SimpleNegatedAssertionReconciler extends Reconciler
 
             if (get_class($string_atomic_type) === TString::class) {
                 $existing_var_type->removeType('string');
-                $existing_var_type->addType(new TLiteralString(''));
-                $existing_var_type->addType(new TLiteralString('0'));
+                $existing_var_type->addType(Type::getAtomicStringFromLiteral(''));
+                $existing_var_type->addType(Type::getAtomicStringFromLiteral('0'));
             } elseif (get_class($string_atomic_type) === TNonEmptyString::class) {
                 $existing_var_type->removeType('string');
-                $existing_var_type->addType(new TLiteralString('0'));
+                $existing_var_type->addType(Type::getAtomicStringFromLiteral('0'));
             } elseif (get_class($string_atomic_type) === TNonEmptyLowercaseString::class) {
                 $existing_var_type->removeType('string');
-                $existing_var_type->addType(new TLiteralString('0'));
+                $existing_var_type->addType(Type::getAtomicStringFromLiteral('0'));
             } elseif (get_class($string_atomic_type) === TNonEmptyNonspecificLiteralString::class) {
                 $existing_var_type->removeType('string');
-                $existing_var_type->addType(new TLiteralString('0'));
+                $existing_var_type->addType(Type::getAtomicStringFromLiteral('0'));
             }
         }
 

--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -1473,7 +1473,7 @@ class TypeCombiner
                 } elseif ($type instanceof TKeyedArray && isset($type->class_strings[$property_name])) {
                     $objectlike_keys[$property_name] = new TLiteralClassString($property_name, $from_docblock);
                 } else {
-                    $objectlike_keys[$property_name] = new TLiteralString($property_name, $from_docblock);
+                    $objectlike_keys[$property_name] = Type::getAtomicStringFromLiteral($property_name, $from_docblock);
                 }
             }
 

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -47,7 +47,6 @@ use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
-use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNonEmptyArray;
@@ -393,7 +392,7 @@ class TypeParser
         }
 
         if ($parse_tree->value[0] === '"' || $parse_tree->value[0] === '\'') {
-            return new TLiteralString(substr($parse_tree->value, 1, -1), $from_docblock);
+            return Type::getAtomicStringFromLiteral(substr($parse_tree->value, 1, -1), $from_docblock);
         }
 
         if (strpos($parse_tree->value, '::')) {

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -251,29 +251,27 @@ abstract class Type
 
     public static function getString(?string $value = null): Union
     {
-        $type = null;
+        return new Union([$value === null ? new TString() : self::getAtomicStringFromLiteral($value)]);
+    }
 
-        if ($value !== null) {
-            $config = Config::getInstance();
+    /** @return TLiteralString|TNonEmptyString */
+    public static function getAtomicStringFromLiteral(string $value, bool $from_docblock = false): TString
+    {
+        $config = Config::getInstance();
 
-            $event = new StringInterpreterEvent($value, ProjectAnalyzer::getInstance()->getCodebase());
+        $event = new StringInterpreterEvent($value, ProjectAnalyzer::getInstance()->getCodebase());
 
-            $type = $config->eventDispatcher->dispatchStringInterpreter($event);
+        $type = $config->eventDispatcher->dispatchStringInterpreter($event);
 
-            if (!$type) {
-                if (strlen($value) < $config->max_string_length) {
-                    $type = new TLiteralString($value);
-                } else {
-                    $type = new TNonEmptyString();
-                }
+        if (!$type) {
+            if (strlen($value) < $config->max_string_length) {
+                $type = new TLiteralString($value, $from_docblock);
+            } else {
+                $type = new TNonEmptyString($from_docblock);
             }
         }
 
-        if (!$type) {
-            $type = new TString();
-        }
-
-        return new Union([$type]);
+        return $type;
     }
 
     /**

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -13,7 +13,6 @@ use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralInt;
-use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNonEmptyArray;
 use Psalm\Type\Union;
 use UnexpectedValueException;
@@ -309,7 +308,8 @@ class TKeyedArray extends Atomic
             } elseif (isset($this->class_strings[$key])) {
                 $key_types[] = new TLiteralClassString($key);
             } else {
-                $key_types[] = new TLiteralString($key);
+                /** @psalm-suppress ImpureMethodCall let's assume string interpreters are pure */
+                $key_types[] = Type::getAtomicStringFromLiteral($key);
             }
         }
 
@@ -362,7 +362,8 @@ class TKeyedArray extends Atomic
             } elseif (isset($this->class_strings[$key])) {
                 $key_types[] = new TLiteralClassString($key);
             } else {
-                $key_types[] = new TLiteralString($key);
+                /** @psalm-suppress ImpureMethodCall let's assume string interpreters are pure */
+                $key_types[] = Type::getAtomicStringFromLiteral($key);
             }
 
             $value_type = Type::combineUnionTypes($property, $value_type);

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -1521,6 +1521,24 @@ class ConstantTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'constantTypeRespectsLiteralStringLimit' => [
+                'code' => <<<'PHP'
+                    <?php
+
+                    class A {
+                        const T = 'TEXT';
+                    }
+
+                    class B
+                    {
+                        const ARRAY = [
+                            'a' => A::T,
+                            'b' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                        ];
+                    }
+                    $z = B::ARRAY['b'];
+                    PHP,
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes vimeo/psalm#9376

Ensures:
* that we never have a literal string exceeding the length limit
* that we call string interpreter for all literal strings
