### PR TITLE
Allow `array` as magic method name

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -356,7 +356,12 @@ class ClassLikeDocblockParser
 
                     $method_tree = $parse_tree_creator->create();
                 } catch (TypeParseTreeException $e) {
-                    throw new DocblockParseException($method_entry . ' is not a valid method');
+                    throw new DocblockParseException(
+                        $method_entry . ' is not a valid method: '
+                        . $e->getMessage(),
+                        0,
+                        $e,
+                    );
                 }
 
                 if (!$method_tree instanceof MethodWithReturnTypeTree

--- a/src/Psalm/Internal/Type/ParseTreeCreator.php
+++ b/src/Psalm/Internal/Type/ParseTreeCreator.php
@@ -780,8 +780,7 @@ class ParseTreeCreator
                         $type_token[0],
                         $new_parent,
                     );
-                } elseif ($type_token[0] !== 'array'
-                    && $type_token[0][0] !== '\\'
+                } elseif ($type_token[0][0] !== '\\'
                     && $this->current_leaf instanceof Root
                 ) {
                     $new_leaf = new MethodTree(

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -939,6 +939,14 @@ class MagicMethodAnnotationTest extends TestCase
                     '$e' => 'B',
                 ],
             ],
+            'arrayAsMethodName' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @method static void array() */
+                    class C {}
+                    //C::array();
+                    PHP,
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes vimeo/psalm#9321
