### PR TITLE
Don't crash on empty `jit_buffer_size`

### DIFF
--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -87,6 +87,10 @@ class PsalmRestarter extends XdebugHandler
 
     private static function toBytes(string $value): int
     {
+        if (strlen($value) === 0) {
+            return 0;
+        }
+
         $unit = strtolower($value[strlen($value) - 1]);
 
         if (in_array($unit, ['g', 'm', 'k'], true)) {


### PR DESCRIPTION
Fixes vimeo/psalm#9396
