### PR TITLE
Only disable grpc extension if it is not properly configured

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -44,6 +44,7 @@ use function array_sum;
 use function array_values;
 use function chdir;
 use function count;
+use function extension_loaded;
 use function file_exists;
 use function file_put_contents;
 use function function_exists;
@@ -899,8 +900,17 @@ final class Psalm
             }
         }
 
-        if ($threads > 1) {
+        if ($threads > 1
+            && extension_loaded('grpc')
+            && (ini_get('grpc.enable_fork_support') === '1' && ini_get('grpc.poll_strategy') === 'epoll1') === false
+        ) {
             $ini_handler->disableExtension('grpc');
+
+            $progress->warning(PHP_EOL
+                . 'grpc extension has been disabled. '
+                . 'Set grpc.enable_fork_support = 1 and grpc.poll_strategy = epoll1 in php.ini to enable it. '
+                . 'See https://github.com/grpc/grpc/issues/20250#issuecomment-531321945 for more information.'
+                . PHP_EOL . PHP_EOL);
         }
 
         $ini_handler->disableExtensions([


### PR DESCRIPTION
Related to #6796, but I'm not sure if it fixes it.

I ran into a conflict between my composer platform requirements and hardcoded disabling of this extension in psalm after installing `grpc` extension as a requirement of a google library.

This PR combines muglug's and weirdan's suggestions from the issue, to disable the extension only if it is not configured correctly (see https://github.com/grpc/grpc/issues/20250#issuecomment-531321945). It now also displays a warning message, instead of silently disabling it.

> I added this code because of https://github.com/grpc/grpc/issues/13412 (the same was true I think of the APC extension). Since that issue has been fixed for a few years, and users can selectively disable extensions anyway, it should be good to remove this exception.

> So I suspect we would still have to have some special treatment for grpc ext, e.g. check if the environment var is set and warn + downgrade to single thread otherwise.

I'd be happy to add tests, however I don't know if/what makes sense for something like this.
