### PR TITLE
An attempt to fix #4460

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -514,11 +514,8 @@ class ArrayAssignmentAnalyzer
                 $array_atomic_key_type = Type::getArrayKey();
             }
 
-            if ($offset_already_existed
-                && $parent_var_id
-                && ($parent_type = $context->vars_in_scope[$parent_var_id] ?? null)
-            ) {
-                if ($parent_type->hasList() && strpos($parent_var_id, '[') === false) {
+            if ($parent_var_id && ($parent_type = $context->vars_in_scope[$parent_var_id] ?? null)) {
+                if ($offset_already_existed && $parent_type->hasList() && strpos($parent_var_id, '[') === false) {
                     $array_atomic_type_list = $value_type;
                 } elseif ($parent_type->hasClassStringMap()
                     && $key_type

--- a/tests/Template/ClassStringMapTest.php
+++ b/tests/Template/ClassStringMapTest.php
@@ -105,6 +105,22 @@ class ClassStringMapTest extends TestCase
                         }
                     }',
             ],
+            'simpleSetter' => [
+                'code' => '<?php
+                    class Container {
+                        /** @var class-string-map<T, T> */
+                        public array $map = [];
+                        /**
+                         * @template U of object
+                         * @param class-string<U> $key
+                         * @param U $obj
+                         */
+                        public function set(string $key, object $obj): void {
+                            $this->map[$key] = $obj;
+                        }
+                    }'
+                    ,
+            ],
         ];
     }
 


### PR DESCRIPTION
A quick fix made just using my intuition. I guess, the ``$offset_already_existed`` should only be applied to list, to avoid introducing discontinuities in lists. This is not the case for class-string-map however, where only the type of key and value matters.