### PR TITLE
Require `<?php` tag in tests

### DIFF
--- a/tests/Traits/InvalidCodeAnalysisTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisTestTrait.php
@@ -51,6 +51,11 @@ trait InvalidCodeAnalysisTestTrait
             $this->markTestSkipped('Skipped due to a bug.');
         }
 
+        // sanity check - do we have a PHP tag?
+        if (strpos($code, '<?php') === false) {
+            $this->fail('Test case must have a <?php tag');
+        }
+
         if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
             $code = str_replace("\n", "\r\n", $code);
         }

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -55,6 +55,11 @@ trait ValidCodeAnalysisTestTrait
             $this->markTestSkipped('Skipped due to a bug.');
         }
 
+        // sanity check - do we have a PHP tag?
+        if (strpos($code, '<?php') === false) {
+            $this->fail('Test case must have a <?php tag');
+        }
+
         foreach ($ignored_issues as $issue_name) {
             Config::getInstance()->setCustomErrorLevel($issue_name, Config::REPORT_SUPPRESS);
         }


### PR DESCRIPTION
This had me puzzled for some time on several occasions
