### PR TITLE
PHP 8.2 attributes moved to 8.2 stub

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -531,14 +531,3 @@ final class ReturnTypeWillChange
     public function __construct() {}
 }
 
-#[Attribute(Attribute::TARGET_PARAMETER)]
-final class SensitiveParameter
-{
-    public function __construct() {}
-}
-
-#[Attribute(Attribute::TARGET_CLASS)]
-final class AllowDynamicProperties
-{
-    public function __construct() {}
-}

--- a/stubs/Php82.phpstub
+++ b/stubs/Php82.phpstub
@@ -33,4 +33,16 @@ namespace {
         /** @psalm-return (Start is string ? Iterator<int, DateTime> : Iterator<int, Start>) */
         public function getIterator(): Iterator {}
     }
+
+    #[Attribute(Attribute::TARGET_PARAMETER)]
+    final class SensitiveParameter
+    {
+        public function __construct() {}
+    }
+
+    #[Attribute(Attribute::TARGET_CLASS)]
+    final class AllowDynamicProperties
+    {
+        public function __construct() {}
+    }
 }

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -263,6 +263,9 @@ class AttributeTest extends TestCase
                     class Foo
                     {}
                 ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.2',
             ],
             'sensitiveParameter' => [
                 'code' => '<?php
@@ -277,6 +280,9 @@ class AttributeTest extends TestCase
                         ) {}
                     }
                 ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.2',
             ],
             'createObjectAsAttributeArg' => [
                 'code' => '<?php
@@ -801,6 +807,8 @@ class AttributeTest extends TestCase
                     }
                 ',
                 'error_message' => 'Attribute SensitiveParameter cannot be used on a method',
+                'ignored_issues' => [],
+                'php_version' => '8.2',
             ],
         ];
     }

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -2,7 +2,6 @@
 
 namespace Psalm\Tests;
 
-use Psalm\Issue\ConstantDeclarationInTrait;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
@@ -1233,7 +1232,7 @@ class TraitTest extends TestCase
                     <?php
                     trait A { const B = 0; }
                     PHP,
-                'error_message' => ConstantDeclarationInTrait::getIssueType(),
+                'error_message' => 'ConstantDeclarationInTrait',
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],


### PR DESCRIPTION
Previously Psalm thought they were available in earlier versions, e.g. https://psalm.dev/r/94083038ab?php=8.0