### PR TITLE
Do not strip the last `)` bracket when parsing phpdoc type aliases.

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -1906,8 +1906,8 @@ class ClassLikeNodeScanner
 
             $type_string = str_replace("\n", '', implode('', $var_line_parts));
 
-            $type_string = preg_replace('/>[^>^\}]*$/', '>', $type_string, 1);
-            $type_string = preg_replace('/\}[^>^\}]*$/', '}', $type_string, 1);
+            // Strip any remaining characters after the last grouping character >, } or )
+            $type_string = preg_replace('/(?<=[>})])[^>})]*$/', '', $type_string, 1);
 
             try {
                 $type_tokens = TypeTokenizer::getFullyQualifiedTokens(

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -653,6 +653,14 @@ class TypeAnnotationTest extends TestCase
                     '$output===' => 'list<1|2>',
                 ],
             ],
+            'handlesTypeWhichEndsWithRoundBracket' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-type Foo=(iterable<mixed>)
+                     */
+                    class A {}
+                    ',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes https://github.com/vimeo/psalm/issues/6782

The example in the tests is a bit simplistic. The type which was causing problems for us can be found at https://github.com/webonyx/graphql-php/blob/5ad059b288f5e21e77cc9dcc45a525bb929e77bc/src/Type/SchemaConfig.php#L29.

Reworked the regex logic to not check each grouping character separately. Removed the `^` character from the character list, which was likely unintended.