### PR TITLE
Replace package-versions with Composer 2 APIs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-tokenizer": "*",
         "amphp/amp": "^2.4.2",
         "amphp/byte-stream": "^1.5",
-        "composer/package-versions-deprecated": "^1.10.0",
+        "composer-runtime-api": "^2",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "composer/xdebug-handler": "^2.0 || ^3.0",
         "dnoegel/php-xdg-base-dir": "^0.1.1",

--- a/src/Psalm/Internal/VersionUtils.php
+++ b/src/Psalm/Internal/VersionUtils.php
@@ -4,7 +4,6 @@ namespace Psalm\Internal;
 
 use Composer\InstalledVersions;
 use OutOfBoundsException;
-use PackageVersions\Versions;
 use Phar;
 
 use function class_exists;

--- a/src/Psalm/Internal/VersionUtils.php
+++ b/src/Psalm/Internal/VersionUtils.php
@@ -2,6 +2,7 @@
 
 namespace Psalm\Internal;
 
+use Composer\InstalledVersions;
 use OutOfBoundsException;
 use PackageVersions\Versions;
 use Phar;
@@ -89,11 +90,17 @@ final class VersionUtils
     {
         try {
             return [
-                self::PSALM_PACKAGE => Versions::getVersion(self::PSALM_PACKAGE),
-                self::PHP_PARSER_PACKAGE => Versions::getVersion(self::PHP_PARSER_PACKAGE),
+                self::PSALM_PACKAGE => self::getVersion(self::PSALM_PACKAGE),
+                self::PHP_PARSER_PACKAGE => self::getVersion(self::PHP_PARSER_PACKAGE),
             ];
         } catch (OutOfBoundsException $ex) {
         }
         return null;
+    }
+
+    private static function getVersion(string $packageName): string
+    {
+        return InstalledVersions::getPrettyVersion($packageName)
+            . '@' . InstalledVersions::getReference($packageName);
     }
 }


### PR DESCRIPTION
`composer/package-versions-deprecated` is currently required by Psalm. It's a fork of the original `ocramius/package-versions` package, and there's currently a circular "replace" directive between the two packages, which may create some issues for end users:
* https://github.com/Ocramius/PackageVersions/blob/fa375ea469c9d6a5b30184cc2aa1e2cb0250598d/composer.json#L24-L26
* https://github.com/composer/package-versions-deprecated/blob/b4f54f74ef3453349c24a845d22392cd31e65f1d/composer.json#L20-L22

The package itself is used only once in Psalm, and it also has a `@deprecation` notice, advising to migrate toward Composer 2 APIs: https://github.com/composer/package-versions-deprecated/blob/b4f54f74ef3453349c24a845d22392cd31e65f1d/src/PackageVersions/Versions.php#L21

This PR does exactly this, replacing the requirement for the package for a requirement against Composer 2, and using its direct APIs.