### PR TITLE
Fix added null type after if

### DIFF
--- a/src/Psalm/Internal/Type/AssertionReconciler.php
+++ b/src/Psalm/Internal/Type/AssertionReconciler.php
@@ -47,6 +47,7 @@ use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNever;
 use Psalm\Type\Atomic\TNonEmptyLowercaseString;
 use Psalm\Type\Atomic\TNonEmptyString;
 use Psalm\Type\Atomic\TNull;
@@ -508,6 +509,8 @@ class AssertionReconciler extends Reconciler
 
             if ($intersection_type) {
                 $new_type = $intersection_type;
+            } elseif ($key !== '$this') {
+                $new_type = new Union([new TNever()]);
             }
         }
 

--- a/tests/TypeReconciliation/TypeTest.php
+++ b/tests/TypeReconciliation/TypeTest.php
@@ -16,6 +16,17 @@ class TypeTest extends TestCase
     public function providerValidCodeParse(): iterable
     {
         return [
+            'strictNotNullCheck' => [
+                'code' => '<?php
+                    $a = 1;
+
+                    /** @psalm-suppress RedundantCondition */
+                    if ($a !== null) {
+                    }',
+                'assertions' => [
+                    '$a===' => '1',
+                ],
+            ],
             'sealArray' => [
                 'code' => '<?php
                     /** @var array */


### PR DESCRIPTION
Fixes #9395, but *not* #9348

Maybe the condition needs to be refined according to this:
https://github.com/vimeo/psalm/blob/222887acfefe72f8cc212392ebef2b58f23f5d9e/src/Psalm/Internal/Type/AssertionReconciler.php#L478-L481

With a simple `else` instead of `elseif ($key !== '$this')` these three tests started to fail:
- ClassTemplateExtendsTest => inferPropertyTypeOnThisInstanceofExtended
- TraitTest => staticClassTraitUser
- TraitTest => getClassTraitUser

Some helpful comments for debugging: https://github.com/vimeo/psalm/commit/6638deb2536ee3f53397e8fcc717dba3e7b15c6d

As noted above, I'm very unsure about the correct condition needed here, but this seems to work with the current test base.