### PR TITLE
Consider new HTML entity en/decode function defaults since PHP 8.1

### DIFF
--- a/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
+++ b/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
@@ -10,7 +10,6 @@ use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
 
 use function count;
 use function strtolower;
-use function version_compare;
 
 use const ENT_QUOTES;
 

--- a/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
+++ b/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
@@ -47,8 +47,7 @@ class HtmlFunctionTainter implements AddTaintsInterface, RemoveTaintsInterface
             $second_arg = $item->getArgs()[1]->value ?? null;
 
             if ($second_arg === null) {
-                $php_version = $statements_analyzer->getCodebase()->config->getPhpVersion();
-                if ($php_version !== null && version_compare($php_version, '8.1', '>=')) {
+                if ($statements_analyzer->getCodebase()->analysis_php_version_id >= 8_01_00) {
                     return ['html', 'has_quotes'];
                 }
                 return ['html'];
@@ -100,8 +99,7 @@ class HtmlFunctionTainter implements AddTaintsInterface, RemoveTaintsInterface
             $second_arg = $item->getArgs()[1]->value ?? null;
 
             if ($second_arg === null) {
-                $php_version = $statements_analyzer->getCodebase()->config->getPhpVersion();
-                if ($php_version !== null && version_compare($php_version, '8.1', '>=')) {
+                if ($statements_analyzer->getCodebase()->analysis_php_version_id >= 8_01_00) {
                     return ['html', 'has_quotes'];
                 }
                 return ['html'];

--- a/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
+++ b/src/Psalm/Internal/Provider/AddRemoveTaints/HtmlFunctionTainter.php
@@ -10,6 +10,7 @@ use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
 
 use function count;
 use function strtolower;
+use function version_compare;
 
 use const ENT_QUOTES;
 
@@ -46,6 +47,10 @@ class HtmlFunctionTainter implements AddTaintsInterface, RemoveTaintsInterface
             $second_arg = $item->getArgs()[1]->value ?? null;
 
             if ($second_arg === null) {
+                $php_version = $statements_analyzer->getCodebase()->config->getPhpVersion();
+                if ($php_version !== null && version_compare($php_version, '8.1', '>=')) {
+                    return ['html', 'has_quotes'];
+                }
                 return ['html'];
             }
 
@@ -95,6 +100,10 @@ class HtmlFunctionTainter implements AddTaintsInterface, RemoveTaintsInterface
             $second_arg = $item->getArgs()[1]->value ?? null;
 
             if ($second_arg === null) {
+                $php_version = $statements_analyzer->getCodebase()->config->getPhpVersion();
+                if ($php_version !== null && version_compare($php_version, '8.1', '>=')) {
+                    return ['html', 'has_quotes'];
+                }
                 return ['html'];
             }
 


### PR DESCRIPTION
Sine PHP 8.1, ENT_QUOTES is the default value for `htmlspecialchars()` and related functions.

This removes TaintedTextWithQuotes false positives when using `--taint-analysis` on projects using PHP 8.1 or greater.