### PR TITLE
`json_encode()` returns a non-empty-string with `JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE`

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1467,7 +1467,11 @@ function json_decode(string $json, ?bool $associative = null, int $depth = 512, 
 /**
  * @psalm-pure
  *
- * @return ($flags is 4194304 ? non-empty-string : non-empty-string|false)
+ * @return (
+ *      $flags is 4194304
+ *          ? non-empty-string
+ *          : ($flags is 4194560 ? non-empty-string : non-empty-string|false)
+ *  )
  *
  * @psalm-flow ($value) -> return
  * @psalm-ignore-falsable-return

--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -123,5 +123,13 @@ class CoreStubsTest extends TestCase
                 '$a===' => 'string',
             ],
         ];
+        yield 'json_encode returns a non-empty-string provided JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE' => [
+            'code' => '<?php
+                /** @return non-empty-string */
+                function foo(): string {
+                    return json_encode([], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
+                }
+            ',
+        ];
     }
 }

--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -125,11 +125,11 @@ class CoreStubsTest extends TestCase
         ];
         yield 'json_encode returns a non-empty-string provided JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE' => [
             'code' => '<?php
-                /** @return non-empty-string */
-                function foo(): string {
-                    return json_encode([], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
-                }
+                $a = json_encode([], JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR);
             ',
+            'assertions' => [
+                '$a===' => 'non-empty-string',
+            ],
         ];
     }
 }


### PR DESCRIPTION
It's a common use case in our codebase, and I encounter it often in the wild when there's a lot of non-ASCII data is encoded.