### PR TITLE
Add `truthy-string` to reserved word list.

### DIFF
--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -41,6 +41,7 @@ class TypeTokenizer
         'non-empty-array' => true,
         'non-empty-string' => true,
         'non-falsy-string' => true,
+        'truthy-string' => true,
         'iterable' => true,
         'null' => true,
         'mixed' => true,


### PR DESCRIPTION
Was trying to analyze my project, but kept getting `Uncaught Psalm\Exception\DocblockParseException` for the docblocks using `truthy-string`, even though Psalm [already added support](https://github.com/vimeo/psalm/pull/8400) for that type alias. This PR should fix the issue.