### PR TITLE
Compare list generic params

### DIFF
--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -15,6 +15,7 @@ use UnexpectedValueException;
 use function assert;
 use function count;
 use function implode;
+use function is_string;
 use function preg_replace;
 use function strpos;
 use function strtolower;
@@ -244,7 +245,7 @@ class NamespaceAnalyzer extends SourceAnalyzer
         while (($pos = strpos($identifier, "\\")) !== false) {
             if ($pos > 0) {
                 $part = substr($identifier, 0, $pos);
-                assert($part !== "");
+                assert(is_string($part) && $part !== "");
                 $parts[] = $part;
             }
             $parts[] = "\\";
@@ -253,13 +254,13 @@ class NamespaceAnalyzer extends SourceAnalyzer
         if (($pos = strpos($identifier, "::")) !== false) {
             if ($pos > 0) {
                 $part = substr($identifier, 0, $pos);
-                assert($part !== "");
+                assert(is_string($part) && $part !== "");
                 $parts[] = $part;
             }
             $parts[] = "::";
             $identifier = substr($identifier, $pos + 2);
         }
-        if ($identifier !== "") {
+        if ($identifier !== "" && $identifier !== false) {
             $parts[] = $identifier;
         }
 

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1721,6 +1721,18 @@ class ReturnTypeTest extends TestCase
                     }',
                 'error_message' => 'InvalidClass',
             ],
+            'listItems' => [
+                'code' => <<<'PHP'
+                    <?php
+
+                    /** @return list<int> */
+                    function f(): array
+                    {
+                        return[ 1, new stdClass, "zzz"];
+                    }
+                    PHP,
+                'error_message' => 'InvalidReturnStatement',
+            ],
         ];
     }
 }

--- a/tests/TypeComparatorTest.php
+++ b/tests/TypeComparatorTest.php
@@ -94,7 +94,7 @@ class TypeComparatorTest extends TestCase
     }
 
     /**
-     * @dataProvider getAllowedChildTypes
+     * @dataProvider getSuccessfulComparisons
      */
     public function testTypeAcceptsType(string $parent_type_string, string $child_type_string): void
     {
@@ -107,13 +107,32 @@ class TypeComparatorTest extends TestCase
                 $child_type,
                 $parent_type,
             ),
+            'Type ' . $parent_type_string . ' should contain ' . $child_type_string,
+        );
+    }
+
+    /**
+     * @dataProvider getUnsuccessfulComparisons
+     */
+    public function testTypeDoesNotAcceptType(string $parent_type_string, string $child_type_string): void
+    {
+        $parent_type = Type::parseString($parent_type_string);
+        $child_type = Type::parseString($child_type_string);
+
+        $this->assertFalse(
+            UnionTypeComparator::isContainedBy(
+                $this->project_analyzer->getCodebase(),
+                $child_type,
+                $parent_type,
+            ),
+            'Type ' . $parent_type_string . ' should not contain ' . $child_type_string,
         );
     }
 
     /**
      * @return array<array{string, string}>
      */
-    public function getAllowedChildTypes(): array
+    public function getSuccessfulComparisons(): array
     {
         return [
             'iterableAcceptsArray' => [
@@ -140,6 +159,19 @@ class TypeComparatorTest extends TestCase
                 'lowercase-string',
                 'callable-string',
             ],
+        ];
+    }
+
+    /** @return iterable<string, list{string,string}> */
+    public function getUnsuccessfulComparisons(): iterable
+    {
+        yield 'genericListDoesNotAcceptListTupleWithMismatchedTypes' => [
+            'list<int>',
+            'list{int, string}',
+        ];
+        yield 'genericListDoesNotAcceptArrayTupleWithMismatchedTypes' => [
+            'list<int>',
+            'array{int, string}',
         ];
     }
 }


### PR DESCRIPTION
So that `list<int>` does not accept `[1, new stdClass]`

Fixes vimeo/psalm#9485
