### PR TITLE
Support int separators in docblocks

### DIFF
--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -91,6 +91,7 @@ use function stripslashes;
 use function strlen;
 use function strpos;
 use function strtolower;
+use function strtr;
 use function substr;
 
 /**
@@ -420,8 +421,8 @@ class TypeParser
             return new TLiteralFloat((float) $parse_tree->value, $from_docblock);
         }
 
-        if (preg_match('/^\-?(0|[1-9][0-9]*)$/', $parse_tree->value)) {
-            return new TLiteralInt((int) $parse_tree->value, $from_docblock);
+        if (preg_match('/^\-?(0|[1-9]([0-9_]*[0-9])?)$/', $parse_tree->value)) {
+            return new TLiteralInt((int) strtr($parse_tree->value, ['_' => '']), $from_docblock);
         }
 
         if (!preg_match('@^(\$this|\\\\?[a-zA-Z_\x7f-\xff][\\\\\-0-9a-zA-Z_\x7f-\xff]*)$@', $parse_tree->value)) {

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -1032,6 +1032,26 @@ class TypeParseTest extends TestCase
         );
     }
 
+    public function testSingleLiteralIntWithSeparators(): void
+    {
+        $this->assertSame('10', Type::parseString('1_0')->getId());
+    }
+
+    public function testIntRangeWithSeparators(): void
+    {
+        $this->assertSame('int<10, 20>', Type::parseString('int<1_0, 2_0>')->getId());
+    }
+
+    public function testLiteralIntUnionWithSeparators(): void
+    {
+        $this->assertSame('10|20', Type::parseString('1_0|2_0')->getId());
+    }
+
+    public function testIntMaskWithIntsWithSeparators(): void
+    {
+        $this->assertSame('0|10|20|30', Type::parseString('int-mask<1_0, 2_0>')->getId());
+    }
+
     public function testSingleLiteralFloat(): void
     {
         $this->assertSame(


### PR DESCRIPTION
PHP understands `1_000` to be `1000`, so there's no reason why it shouldn't be recognized in docblocks as well.

Refs #9472