### PR TITLE
Refuse to use PHP versions we did not request

### DIFF
--- a/.github/workflows/bcc.yml
+++ b/.github/workflows/bcc.yml
@@ -12,6 +12,8 @@ jobs:
           php-version: '8.1'
           tools: composer:v2
           coverage: none
+        env:
+          fail-fast: true
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -41,6 +41,8 @@ jobs:
           php-version: '7.4'
           tools: composer:v2
           coverage: none
+        env:
+          fail-fast: true
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
           php-version: '7.4'
           tools: composer:v2
           coverage: none
+        env:
+          fail-fast: true
 
       - uses: actions/checkout@v3
 
@@ -88,6 +90,8 @@ jobs:
           tools: composer:v2
           coverage: none
           extensions: none, curl, dom, filter, intl, json, libxml, mbstring, opcache, openssl, pcre, phar, reflection, simplexml, spl, tokenizer, xml, xmlwriter
+        env:
+          fail-fast: true
 
       - uses: actions/checkout@v3
 

--- a/.github/workflows/shepherd.yml
+++ b/.github/workflows/shepherd.yml
@@ -17,6 +17,8 @@ jobs:
         ini-values: zend.assertions=1
         tools: composer:v2
         coverage: none
+      env:
+        fail-fast: true
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-suggest

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -59,6 +59,8 @@ jobs:
           tools: composer:v2
           coverage: none
           extensions: none, curl, dom, filter, intl, json, libxml, mbstring, openssl, opcache, pcre, phar, reflection, simplexml, spl, tokenizer, xml, xmlwriter
+        env:
+          fail-fast: true
 
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
There were a number of test failures caused by setup-php failing to
install the required PHP version. While we certainly should fix our
failing tests, we also need to be sure which PHP version we're using.

This PR does exactly that.
