### PR TITLE
Optimize composer caching

### DIFF
--- a/.github/workflows/bcc.yml
+++ b/.github/workflows/bcc.yml
@@ -23,6 +23,10 @@ jobs:
           echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
           echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
+      - name: Generate composer.lock
+        run: |
+          composer update --no-install
+
       - name: Cache composer cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-phar.yml
+++ b/.github/workflows/build-phar.yml
@@ -52,6 +52,10 @@ jobs:
           echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
           echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
+      - name: Generate composer.lock
+        run: |
+          composer update --no-install
+
       - name: Cache composer cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,10 @@ jobs:
           echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
           echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
 
+      - name: Generate composer.lock
+        run: |
+          composer update --no-install
+
       - name: Cache composer cache
         uses: actions/cache@v3
         with:
@@ -96,6 +100,10 @@ jobs:
         run: |
           echo "files_cache=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
           echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
+
+      - name: Generate composer.lock
+        run: |
+          composer update --no-install
 
       - name: Cache composer cache
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Generate composer.lock
         run: |
           composer update --no-install
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
 
       - name: Cache composer cache
         uses: actions/cache@v3
@@ -104,6 +106,8 @@ jobs:
       - name: Generate composer.lock
         run: |
           composer update --no-install
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
 
       - name: Cache composer cache
         uses: actions/cache@v3

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -72,6 +72,8 @@ jobs:
       - name: Generate composer.lock
         run: |
           composer update --no-install
+        env:
+          COMPOSER_ROOT_VERSION: dev-master
 
       - name: Cache composer cache
         uses: actions/cache@v3

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -69,6 +69,10 @@ jobs:
           echo "vcs_cache=$(composer config cache-vcs-dir)" >> $GITHUB_OUTPUT
         shell: bash
 
+      - name: Generate composer.lock
+        run: |
+          composer update --no-install
+
       - name: Cache composer cache
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
Previously our composer package cache would not be updated because we had no `composer.lock` (which hash is used as part of the cache key).

Generating `composer.lock` (but not installing packages) before we check the cache fixes this.