### PR TITLE
Fix return type of str_split()

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -12898,7 +12898,7 @@ return [
 'str_replace' => ['string|string[]', 'search'=>'string|array', 'replace'=>'string|array', 'subject'=>'string|array', '&w_count='=>'int'],
 'str_rot13' => ['string', 'string'=>'string'],
 'str_shuffle' => ['string', 'string'=>'string'],
-'str_split' => ['list<string>', 'string'=>'string', 'length='=>'positive-int'],
+'str_split' => ['list<non-empty-string>', 'string'=>'string', 'length='=>'positive-int'],
 'str_starts_with' => ['bool', 'haystack'=>'string', 'needle'=>'string'],
 'str_word_count' => ['array<int, string>|int', 'string'=>'string', 'format='=>'int', 'characters='=>'?string'],
 'strcasecmp' => ['int', 'string1'=>'string', 'string2'=>'string'],

--- a/dictionaries/CallMap_82_delta.php
+++ b/dictionaries/CallMap_82_delta.php
@@ -51,7 +51,7 @@ return [
     ],
     'str_split' => [
        'old' => ['non-empty-list<string>', 'string'=>'string', 'length='=>'positive-int'],
-       'new' => ['list<string>', 'string'=>'string', 'length='=>'positive-int'],
+       'new' => ['list<non-empty-string>', 'string'=>'string', 'length='=>'positive-int'],
     ],
   ],
 

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -108,7 +108,6 @@ class TypeTokenizer
      * contains the string token and the second element contains its offset,
      *
      * @return list<array{0: string, 1: int}>
-     * @psalm-suppress PossiblyUndefinedIntArrayOffset
      */
     public static function tokenize(string $string_type, bool $ignore_space = true): array
     {

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1050,7 +1050,8 @@ function str_shuffle(string $string): string {}
 
 /**
  * @psalm-pure
- * @return ($length is positive-int ? list<string> : false)
+ * @param positive-int $length
+ * @return non-empty-list<string>
  *
  * @psalm-flow ($string) -> return
  */

--- a/stubs/Php82.phpstub
+++ b/stubs/Php82.phpstub
@@ -45,4 +45,13 @@ namespace {
     {
         public function __construct() {}
     }
+
+    /**
+    * @psalm-pure
+    * @param positive-int $length
+    * @return list<non-empty-string>
+    *
+    * @psalm-flow ($string) -> return
+    */
+    function str_split(string $string, int $length = 1) {}
 }


### PR DESCRIPTION
The stubs do not include the `false` return type from PHP 7. Instead, it defines the $length parameter as `positive-int`. If that parameter is not `positive-int`, then `false` would be return. It's hard to define both conditions in stubs, so aligning with the callmap.

In PHP 8.0, the false return type was dropped for a ValueError.

In PHP 8.2, the function was changed to return an empty array if the string is empty so the return type is no longer non-empty, but the strings are now non-empty.

https://3v4l.org/mHMvb

https://github.com/php/php-src/blob/PHP-8.2.0/UPGRADING#L51