### PR TITLE
Remove always-empty ClassAnalyzer leftover_stmts array

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -362,16 +362,6 @@ class ClassAnalyzer extends ClassLikeAnalyzer
             return;
         }
 
-        if ($this->leftover_stmts) {
-            (new StatementsAnalyzer(
-                $this,
-                new NodeDataProvider(),
-            ))->analyze(
-                $this->leftover_stmts,
-                $class_context,
-            );
-        }
-
         if (!$storage->abstract) {
             foreach ($storage->declaring_method_ids as $declaring_method_id) {
                 $method_storage = $codebase->methods->getStorage($declaring_method_id);

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -92,11 +92,6 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
      */
     protected ?string $parent_fq_class_name = null;
 
-    /**
-     * @var PhpParser\Node\Stmt[]
-     */
-    protected array $leftover_stmts = [];
-
     protected ClassLikeStorage $storage;
 
     public function __construct(PhpParser\Node\Stmt\ClassLike $class, SourceAnalyzer $source, string $fq_class_name)


### PR DESCRIPTION
Happened to notice this as I was reading through the code.