### PR TITLE
Improve json_encode/json_decode functions signatures

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1468,11 +1468,7 @@ function json_decode(string $json, ?bool $associative = null, int $depth = 512, 
 /**
  * @psalm-pure
  *
- * @return (
- *      $flags is 4194304
- *          ? non-empty-string
- *          : ($flags is 4194560 ? non-empty-string : non-empty-string|false)
- *  )
+ * @return ($flags is int<4194304, 8388607> ? non-empty-string : non-empty-string|false)
  *
  * @psalm-flow ($value) -> return
  * @psalm-ignore-falsable-return

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1460,6 +1460,7 @@ function ldap_escape(string $value, string $ignore = "", int $flags = 0) : strin
 /**
  * @psalm-pure
  *
+ * @param int<1, 2147483647> $depth
  * @return mixed
  * @psalm-flow ($json) -> return
  */
@@ -1468,6 +1469,7 @@ function json_decode(string $json, ?bool $associative = null, int $depth = 512, 
 /**
  * @psalm-pure
  *
+ * @param int<1, 2147483647> $depth
  * @return ($flags is int<4194304, 8388607> ? non-empty-string : non-empty-string|false)
  *
  * @psalm-flow ($value) -> return

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1467,6 +1467,8 @@ function ldap_escape(string $value, string $ignore = "", int $flags = 0) : strin
 function json_decode(string $json, ?bool $associative = null, int $depth = 512, int $flags = 0) {}
 
 /**
+ * The conditional return type below relies on the fact that JSON_THROW_ON_ERROR is 
+ * the highest-valued of JSON constants
  * @psalm-pure
  *
  * @param int<1, 2147483647> $depth

--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -139,12 +139,16 @@ class CoreStubsTest extends TestCase
                 $b = json_encode([], JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE);
                 $c = json_encode([], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
                 $d = json_encode([], JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
+                $e = json_encode([], JSON_PRESERVE_ZERO_FRACTION);
+                $f = json_encode([], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
             ',
             'assertions' => [
                 '$a===' => 'non-empty-string',
                 '$b===' => 'non-empty-string',
                 '$c===' => 'non-empty-string',
                 '$d===' => 'non-empty-string',
+                '$e===' => 'false|non-empty-string',
+                '$f===' => 'false|non-empty-string',
             ],
         ];
     }

--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -2,11 +2,13 @@
 
 namespace Psalm\Tests;
 
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
 class CoreStubsTest extends TestCase
 {
     use ValidCodeAnalysisTestTrait;
+    use InvalidCodeAnalysisTestTrait;
 
     public function providerValidCodeParse(): iterable
     {
@@ -144,6 +146,22 @@ class CoreStubsTest extends TestCase
                 '$c===' => 'non-empty-string',
                 '$d===' => 'non-empty-string',
             ],
+        ];
+    }
+
+    public function providerInvalidCodeParse(): iterable
+    {
+        yield 'json_decode invalid depth' => [
+            'code' => '<?php
+                json_decode("true", depth: -1);
+            ',
+            'error_message' => 'InvalidArgument',
+        ];
+        yield 'json_encode invalid depth' => [
+            'code' => '<?php
+                json_encode([], depth: 439877348953739);
+            ',
+            'error_message' => 'InvalidArgument',
         ];
     }
 }

--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -131,5 +131,19 @@ class CoreStubsTest extends TestCase
                 '$a===' => 'non-empty-string',
             ],
         ];
+        yield 'json_encode returns a non-empty-string with JSON_THROW_ON_ERROR' => [
+            'code' => '<?php
+                $a = json_encode([], JSON_THROW_ON_ERROR | JSON_HEX_TAG);
+                $b = json_encode([], JSON_THROW_ON_ERROR | JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP | JSON_UNESCAPED_UNICODE);
+                $c = json_encode([], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+                $d = json_encode([], JSON_THROW_ON_ERROR | JSON_PRESERVE_ZERO_FRACTION);
+            ',
+            'assertions' => [
+                '$a===' => 'non-empty-string',
+                '$b===' => 'non-empty-string',
+                '$c===' => 'non-empty-string',
+                '$d===' => 'non-empty-string',
+            ],
+        ];
     }
 }


### PR DESCRIPTION
I just realized there's an easy way to add support for every flags combination with JSON_THROW_ON_ERROR.
Also it adds a constrant for `$depth` according to [specs](https://www.php.net/manual/en/function.json-decode.php#:~:text=The%20value%20must%20be%20greater%20than%200%2C%20and%20less%20than%20or%20equal%20to%202147483647).