### PR TITLE
Fix MissingThrowsDocblock when documented interface is extended by thrown exception interface

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -721,7 +721,10 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 if ($expected_exception === $possibly_thrown_exception
                     || (
                         $codebase->classOrInterfaceExists($possibly_thrown_exception)
-                        && $codebase->classExtendsOrImplements($possibly_thrown_exception, $expected_exception)
+                        && (
+                            $codebase->interfaceExtends($possibly_thrown_exception, $expected_exception)
+                            || $codebase->classExtendsOrImplements($possibly_thrown_exception, $expected_exception)
+                        )
                     )
                 ) {
                     $is_expected = true;

--- a/tests/ThrowsAnnotationTest.php
+++ b/tests/ThrowsAnnotationTest.php
@@ -659,4 +659,41 @@ class ThrowsAnnotationTest extends TestCase
 
         $this->analyzeFile('somefile.php', $context);
     }
+
+    public function testDocumentedThrowInterfaceWithFunctionCallWithImplementedExceptionThrow(): void
+    {
+        Config::getInstance()->check_for_throws_docblock = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                interface TestExceptionInterface extends Throwable
+                {
+                }
+
+                class TestException extends Exception implements TestExceptionInterface
+                {
+                }
+
+                class Example
+                {
+                    /**
+                     * @throws Throwable
+                     */
+                    private function methodOne(): void {
+                        $this->methodTwo();
+                    }
+
+                    /**
+                     * @throws TestExceptionInterface
+                     */
+                    private function methodTwo(): void {}
+                }
+            ',
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
 }


### PR DESCRIPTION
When an interface exception is documented via the `@throws` tag and a called method has a documented interface exception which extends the parent's one Psalm reports a `MissingThrowsDocblock`.

Example: https://psalm.dev/r/db257bfea4

With this PR I'm adding a check that ensures a better validation for interfaces extensions.