### PR TITLE
Doc/psalm api on methods

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -642,7 +642,7 @@ function (): Generator {
 ```
 This annotation supports only generic types, meaning that e.g. `@psalm-yield string` would be ignored.
 
-### `@psalm-api`
+### `@api`, `@psalm-api`
 
 Used to tell Psalm that a class or method is used, even if no references to it can be
 found. Unused issues will be suppressed.

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -644,7 +644,7 @@ This annotation supports only generic types, meaning that e.g. `@psalm-yield str
 
 ### `@psalm-api`
 
-Used to tell Psalm that a class is used, even if no references to it can be
+Used to tell Psalm that a class or method is used, even if no references to it can be
 found. Unused issues will be suppressed.
 
 For example, in frameworks, controllers are often invoked "magically" without

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1277,6 +1277,23 @@ class UnusedCodeTest extends TestCase
                     new A;
                     PHP,
             ],
+            'api with unused class' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @api */
+                    class A {}
+                    PHP,
+            ],
+            'api on unused public method' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class A {
+                        /** @api */
+                        public function b(): void {}
+                    }
+                    new A;
+                    PHP,
+            ],
         ];
     }
 


### PR DESCRIPTION
Added to documentation that `@psalm-api` can be used on methods (See #9383 and [Comment](https://github.com/vimeo/psalm/issues/9531#issuecomment-1473970471)).
Added to documentation and test that `@api` can be used where `@psalm-api` can be used.