### PR TITLE
Fix #9549 (Improve pcre functions return type based on valid/invalid regex patterns)

### DIFF
--- a/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionReturnTypeProvider.php
@@ -36,6 +36,7 @@ use Psalm\Internal\Provider\ReturnTypeProvider\MbInternalEncodingReturnTypeProvi
 use Psalm\Internal\Provider\ReturnTypeProvider\MinMaxReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\MktimeReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\ParseUrlReturnTypeProvider;
+use Psalm\Internal\Provider\ReturnTypeProvider\PcrePatternFunctionsReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\RandReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\RoundReturnTypeProvider;
 use Psalm\Internal\Provider\ReturnTypeProvider\StrReplaceReturnTypeProvider;
@@ -87,6 +88,7 @@ class FunctionReturnTypeProvider
         $this->registerClass(FilterVarReturnTypeProvider::class);
         $this->registerClass(IteratorToArrayReturnTypeProvider::class);
         $this->registerClass(ParseUrlReturnTypeProvider::class);
+        $this->registerClass(PcrePatternFunctionsReturnTypeProvider::class);
         $this->registerClass(StrReplaceReturnTypeProvider::class);
         $this->registerClass(StrTrReturnTypeProvider::class);
         $this->registerClass(VersionCompareReturnTypeProvider::class);

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PcrePatternFunctionsReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PcrePatternFunctionsReturnTypeProvider.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Provider\ReturnTypeProvider;
+
+use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
+use Psalm\Type;
+use Psalm\Type\Atomic;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\MutableUnion;
+use Psalm\Type\Union;
+use Throwable;
+
+use function array_map;
+use function count;
+use function preg_match;
+
+/**
+ * @internal
+ */
+class PcrePatternFunctionsReturnTypeProvider implements FunctionReturnTypeProviderInterface
+{
+
+    public static function getFunctionIds(): array
+    {
+        return ['preg_grep', 'preg_match', 'preg_match_all'];
+    }
+
+    public static function getFunctionReturnType(FunctionReturnTypeProviderEvent $event): ?Union
+    {
+        $args = $event->getCallArgs();
+        $function_id = $event->getFunctionId();
+        if ($function_id === 'preg_grep') {
+            if (count($args) >= 2) {
+                $pattern_type = $event->getStatementsSource()->getNodeTypeProvider()->getType($args[0]->value);
+                $array_type = $event->getStatementsSource()->getNodeTypeProvider()->getType($args[1]->value);
+                return static::getPregGrepReturnType($pattern_type, $array_type);
+            }
+        } elseif ($function_id === 'preg_match') {
+            if (count($args) >= 1) {
+                $pattern_type = $event->getStatementsSource()->getNodeTypeProvider()->getType($args[0]->value);
+                return static::getPregMatchReturnType($pattern_type);
+            }
+        } elseif ($function_id === 'preg_match_all') {
+            if (count($args) >= 1) {
+                $pattern_type = $event->getStatementsSource()->getNodeTypeProvider()->getType($args[0]->value);
+                return static::getPregMatchAllReturnType($pattern_type);
+            }
+        }
+        return null;
+    }
+
+    private static function getPregMatchReturnType(?Union $pattern_type): Union
+    {
+        return static::computeReturnTypeFromPattern(
+            $pattern_type,
+            new MutableUnion([
+                Type::getInt(false, 0)->getSingleAtomic(),
+                Type::getInt(false, 1)->getSingleAtomic(),
+            ]),
+            Type::getFalse()->getSingleAtomic(),
+        );
+    }
+
+    private static function getPregMatchAllReturnType(?Union $pattern_type): Union
+    {
+        return static::computeReturnTypeFromPattern(
+            $pattern_type,
+            new MutableUnion([
+                new Atomic\TIntRange(0, null),
+            ]),
+            Type::getFalse()->getSingleAtomic(),
+        );
+    }
+
+    private static function getPregGrepReturnType(?Union $pattern_type, ?Union $array_arg_type): ?Union
+    {
+        $return_type_builder = null;
+        $array_arg_atomic = $array_arg_type
+            && $array_arg_type->hasType('array')
+            && ($array_atomic_type = $array_arg_type->getArray())
+            && ($array_atomic_type instanceof TArray
+                || $array_atomic_type instanceof TKeyedArray)
+                ? $array_atomic_type
+                : null;
+
+        if ($array_arg_atomic instanceof TArray) {
+            if ($array_arg_atomic instanceof Type\Atomic\TNonEmptyArray) {
+                $return_type_builder = new Type\MutableUnion([new TArray($array_arg_atomic->type_params)]);
+            } else {
+                $return_type_builder = new Type\MutableUnion([$array_arg_atomic]);
+            }
+        } elseif ($array_arg_atomic instanceof TKeyedArray) {
+            $properties = array_map(
+                static fn(Union $type): Union => $type->setPossiblyUndefined(true),
+                $array_arg_atomic->properties,
+            );
+            if ($array_arg_atomic->is_list) {
+                $return_type_builder = new MutableUnion([
+                    $array_arg_atomic->setProperties($properties)->getGenericArrayType(),
+                ]);
+            } else {
+                $return_type_builder = new MutableUnion([$array_arg_atomic->setProperties($properties)]);
+            }
+        }
+
+        if ($return_type_builder === null) {
+            return null;
+        }
+
+        return static::computeReturnTypeFromPattern(
+            $pattern_type,
+            $return_type_builder,
+            Type::getFalse()->getSingleAtomic(),
+        );
+    }
+
+    private static function computeReturnTypeFromPattern(
+        ?Union $pattern_type,
+        MutableUnion $return_type_candidate,
+        Atomic $invalid_pattern_return_type,
+        Atomic $possibly_invalid_pattern_return_type = null
+    ): Union {
+        if (!$possibly_invalid_pattern_return_type) {
+            $possibly_invalid_pattern_return_type = $invalid_pattern_return_type;
+        }
+        if ($pattern_type
+            && !$pattern_type->isUnionEmpty()
+            && $pattern_type->allStringLiterals()
+        ) {
+            ['all_valid' => $all_valid, 'any_valid' => $any_valid]
+                = static::checkRegexPatterns($pattern_type->getLiteralStrings());
+            if ($any_valid) {
+                if (!$all_valid) {
+                    static::addFailingReturnType($return_type_candidate, $possibly_invalid_pattern_return_type);
+                }
+            } else {
+                $return_type_candidate = new MutableUnion([$invalid_pattern_return_type]);
+            }
+        } else {
+            static::addFailingReturnType($return_type_candidate, $possibly_invalid_pattern_return_type);
+        }
+        return $return_type_candidate->freeze();
+    }
+
+    private static function addFailingReturnType(MutableUnion $type_builder, Atomic $failing_type): void
+    {
+        $type_builder->addType($failing_type);
+        if ($failing_type instanceof Atomic\TNull) {
+            $type_builder->ignore_nullable_issues = true;
+        } elseif ($failing_type instanceof Atomic\TFalse) {
+            $type_builder->ignore_falsable_issues = true;
+        }
+        //return $type_builder;
+    }
+
+    /**
+     * @param Type\Atomic\TLiteralString[] $patterns
+     * @return array{'all_valid': bool, 'any_valid': bool}
+     */
+    private static function checkRegexPatterns(array $patterns): array
+    {
+        $all_valid = true;
+        $any_valid = false;
+        foreach ($patterns as $pattern) {
+            $current_valid = static::isValidRegexPattern($pattern->value);
+            $all_valid = $all_valid && $current_valid;
+            $any_valid = $any_valid || $current_valid;
+        }
+        return ['all_valid' => $all_valid, 'any_valid' => $any_valid];
+    }
+
+    private static function isValidRegexPattern(string $pattern): bool
+    {
+        try {
+            return @preg_match($pattern, '') !== false;
+        } catch (Throwable $_) {
+            return false;
+        }
+    }
+}

--- a/tests/ReturnTypeProvider/PcreFunctionsTest.php
+++ b/tests/ReturnTypeProvider/PcreFunctionsTest.php
@@ -1,0 +1,428 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\ReturnTypeProvider;
+
+use Psalm\Tests\TestCase;
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+class PcreFunctionsTest extends TestCase
+{
+    use InvalidCodeAnalysisTestTrait;
+    use ValidCodeAnalysisTestTrait;
+
+    public function providerValidCodeParse(): iterable
+    {
+        yield 'preg_grep with string pattern' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var array<string, string> $arr */
+                $arr = [];
+                /** @var string $pattern */
+                $pattern = '';
+                $result = preg_grep($pattern, $arr);
+
+                PHP,
+        ];
+        yield 'preg_grep with valid literal pattern' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var array<string, string> $arr */
+                $arr = [];
+                $result = preg_grep('/valid/', $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'array<string, string>',
+            ],
+        ];
+        yield 'preg_grep with invalid literal pattern' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var array<string, string> $arr */
+                $arr = [];
+                $result = preg_grep('///', $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'false',
+            ],
+        ];
+        yield 'preg_grep with valid literal pattern union' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var array<string, string> $arr */
+                $arr = [];
+                /** @var '/foo/'|'/bar/'|'/baz/' $pattern */
+                $pattern = '';
+                $result = preg_grep($pattern, $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'array<string, string>',
+            ],
+        ];
+        yield 'preg_grep with valid and invalid literal pattern union' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var array<string, string> $arr */
+                $arr = [];
+                /** @var '/foo/'|'///'|'/baz/' $pattern */
+                $pattern = '';
+                $result = preg_grep($pattern, $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'array<string, string>|false',
+            ],
+        ];
+        yield 'preg_grep with invalid literal pattern union' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var array<string, string> $arr */
+                $arr = [];
+                /** @var '///'|'////'|'/////' $pattern */
+                $pattern = '';
+                $result = preg_grep($pattern, $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'false',
+            ],
+        ];
+        yield 'preg_grep with valid and invalid literal pattern union ignores false' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @param array<string, string> $arr */
+                function takesArray(array $arr): void {}
+                /** @var array<string, string> $arr */
+                $arr = [];
+                /** @var '/foo/'|'///'|'/baz/' $pattern */
+                $pattern = '';
+                takesArray(preg_grep($pattern, $arr));
+
+                PHP,
+        ];
+        yield 'preg_grep with string pattern ignores false' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @param array<string, string> $arr */
+                function takesArray(array $arr): void {}
+                /** @var array<string, string> $arr */
+                $arr = [];
+                /** @var string $pattern */
+                $pattern = '';
+                takesArray(preg_grep($pattern, $arr));
+
+                PHP,
+        ];
+        yield 'preg_grep with non-empty-array returns array' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var non-empty-array<string, string> $arr */
+                $arr = [];
+                $result = preg_grep('/valid/', $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'array<string, string>',
+            ],
+        ];
+        yield 'preg_grep with list returns array' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var list<string, string> $arr */
+                $arr = [];
+                $result = preg_grep('/valid/', $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'array<int<0, max>, string>',
+            ],
+        ];
+        yield 'preg_grep with non-empty-list returns array' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var non-empty-list<string, string> $arr */
+                $arr = [];
+                $result = preg_grep('/valid/', $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'array<int<0, max>, string>',
+            ],
+        ];
+        yield 'preg_grep with sealed shape array returns sealed shape array' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var array{bar: 'baz', buzz: 'fizz', foo: 'foo'} string $arr */
+                $arr = [];
+                $result = preg_grep('/valid/', $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'array{bar?: \'baz\', buzz?: \'fizz\', foo?: \'foo\'}',
+            ],
+        ];
+        yield 'preg_grep with unsealed shape array returns unsealed shape array' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var array{bar: 'baz', buzz: 'fizz', foo: 'foo'}&array<string, string> string $arr */
+                $arr = [];
+                $result = preg_grep('/valid/', $arr);
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'array{bar?: \'baz\', buzz?: \'fizz\', foo?: \'foo\', ...<string, string>}',
+            ],
+        ];
+        yield 'preg_match with string pattern' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var string $pattern */
+                $pattern = '';
+                $result = preg_match($pattern, 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => '0|1|false',
+            ],
+        ];
+        yield 'preg_match with valid literal pattern' => [
+            'code' => <<<'PHP'
+                <?php
+                $result = preg_match('/valid/', 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => '0|1',
+            ],
+        ];
+        yield 'preg_match with invalid literal pattern' => [
+            'code' => <<<'PHP'
+                <?php
+                $result = preg_match('///', 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'false',
+            ],
+        ];
+        yield 'preg_match with valid literal pattern union' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var '/foo/'|'/bar/'|'/baz/' $pattern */
+                $pattern = '';
+                $result = preg_match($pattern, 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => '0|1',
+            ],
+        ];
+        yield 'preg_match with valid and invalid literal pattern union' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var '/foo/'|'///'|'/baz/' $pattern */
+                $pattern = '';
+                $result = preg_match($pattern, 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => '0|1|false',
+            ],
+        ];
+        yield 'preg_match with invalid literal pattern union' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var '///'|'////'|'/////' $pattern */
+                $pattern = '';
+                $result = preg_match($pattern, 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'false',
+            ],
+        ];
+        yield 'preg_match with valid and invalid literal pattern union ignores false' => [
+            'code' => <<<'PHP'
+                <?php
+                function takesInt(int $i): void {}
+                /** @var '/foo/'|'///'|'/baz/' $pattern */
+                $pattern = '';
+                takesInt(preg_match($pattern, 'subject'));
+
+                PHP,
+        ];
+        yield 'preg_match with string pattern ignores false' => [
+            'code' => <<<'PHP'
+                <?php
+                function takesInt(int $i): void {}
+                /** @var string $pattern */
+                $pattern = '';
+                takesInt(preg_match($pattern, 'subject'));
+
+                PHP,
+        ];
+        yield 'preg_match_all with string pattern' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var string $pattern */
+                $pattern = '';
+                $result = preg_match_all($pattern, 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'false|int<0, max>',
+            ],
+        ];
+        yield 'preg_match_all with valid literal pattern' => [
+            'code' => <<<'PHP'
+                <?php
+                $result = preg_match_all('/valid/', 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'int<0, max>',
+            ],
+        ];
+        yield 'preg_match_all with invalid literal pattern' => [
+            'code' => <<<'PHP'
+                <?php
+                $result = preg_match_all('///', 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'false',
+            ],
+        ];
+        yield 'preg_match_all with valid literal pattern union' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var '/foo/'|'/bar/'|'/baz/' $pattern */
+                $pattern = '';
+                $result = preg_match_all($pattern, 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'int<0, max>',
+            ],
+        ];
+        yield 'preg_match_all with valid and invalid literal pattern union' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var '/foo/'|'///'|'/baz/' $pattern */
+                $pattern = '';
+                $result = preg_match_all($pattern, 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'false|int<0, max>',
+            ],
+        ];
+        yield 'preg_match_all with invalid literal pattern union' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @var '///'|'////'|'/////' $pattern */
+                $pattern = '';
+                $result = preg_match_all($pattern, 'subject');
+
+                PHP,
+            'assertions' => [
+                '$result===' => 'false',
+            ],
+        ];
+        yield 'preg_match_all with valid and invalid literal pattern union ignores false' => [
+            'code' => <<<'PHP'
+                <?php
+                function takesInt(int $i): void {}
+                /** @var '/foo/'|'///'|'/baz/' $pattern */
+                $pattern = '';
+                takesInt(preg_match_all($pattern, 'subject'));
+
+                PHP,
+        ];
+        yield 'preg_match_all with string pattern ignores false' => [
+            'code' => <<<'PHP'
+                <?php
+                function takesInt(int $i): void {}
+                /** @var string $pattern */
+                $pattern = '';
+                takesInt(preg_match_all($pattern, 'subject'));
+
+                PHP,
+        ];
+    }
+
+    public function providerInvalidCodeParse(): iterable
+    {
+        yield 'preg_grep with invalid literal pattern does not ignore false' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @param array<string, string> $arr */
+                function takesArray(array $arr): void {}
+                /** @var array<string, string> $arr */
+                $arr = [];
+                takesArray(preg_grep('///', $arr));
+
+                PHP,
+            'error_message' => 'Argument 1 of takesArray cannot be false',
+        ];
+        yield 'preg_grep with invalid literal pattern union does not ignore false' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @param array<string, string> $arr */
+                function takesArray(array $arr): void {}
+                /** @var array<string, string> $arr */
+                $arr = [];
+                /** @var '///'|'////'|'/////' $pattern */
+                $pattern = '';
+                takesArray(preg_grep($pattern, $arr));
+
+                PHP,
+            'error_message' => 'Argument 1 of takesArray cannot be false',
+        ];
+        yield 'preg_match with invalid literal pattern does not ignore false' => [
+            'code' => <<<'PHP'
+                <?php
+                function takesInt(int $i): void {}
+                takesInt(preg_match('///', 'subject'));
+
+                PHP,
+            'error_message' => 'Argument 1 of takesInt cannot be false',
+        ];
+        yield 'preg_match with invalid literal pattern union does not ignore false' => [
+            'code' => <<<'PHP'
+                <?php
+                function takesInt(int $i): void {}
+                /** @var '///'|'////'|'/////' $pattern */
+                $pattern = '';
+                takesInt(preg_match($pattern, 'subject'));
+
+                PHP,
+            'error_message' => 'Argument 1 of takesInt cannot be false',
+        ];
+        yield 'preg_match_all with invalid literal pattern does not ignore false' => [
+            'code' => <<<'PHP'
+                <?php
+                function takesInt(int $i): void {}
+                takesInt(preg_match_all('///', 'subject'));
+
+                PHP,
+            'error_message' => 'Argument 1 of takesInt cannot be false',
+        ];
+        yield 'preg_match_all with invalid literal pattern union does not ignore false' => [
+            'code' => <<<'PHP'
+                <?php
+                function takesInt(int $i): void {}
+                /** @var '///'|'////'|'/////' $pattern */
+                $pattern = '';
+                takesInt(preg_match_all($pattern, 'subject'));
+
+                PHP,
+            'error_message' => 'Argument 1 of takesInt cannot be false',
+        ];
+    }
+}


### PR DESCRIPTION
Added return type provider for preg-grep, preg_match and preg_match_all