### PR TITLE
Do not produce invalid array-key types with array_column

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayColumnReturnTypeProvider.php
@@ -6,14 +6,29 @@ use Psalm\CodeLocation;
 use Psalm\Context;
 use Psalm\Internal\Analyzer\SourceAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\Type\TypeCombiner;
+use Psalm\Issue\ValueNotConvertibleToArrayKey;
+use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\Event\FunctionReturnTypeProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionReturnTypeProviderInterface;
 use Psalm\Type;
 use Psalm\Type\Atomic;
+use Psalm\Type\Atomic\Scalar;
 use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TArrayKey;
+use Psalm\Type\Atomic\TBool;
 use Psalm\Type\Atomic\TClassStringMap;
+use Psalm\Type\Atomic\TFloat;
+use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TMixed;
+use Psalm\Type\Atomic\TNever;
 use Psalm\Type\Atomic\TNonEmptyArray;
+use Psalm\Type\Atomic\TNull;
+use Psalm\Type\Atomic\TNumeric;
+use Psalm\Type\Atomic\TNumericString;
+use Psalm\Type\Atomic\TScalar;
+use Psalm\Type\Atomic\TString;
 use Psalm\Type\Union;
 
 use function count;
@@ -194,7 +209,7 @@ class ArrayColumnReturnTypeProvider implements FunctionReturnTypeProviderInterfa
         }
 
 
-        $result_key_type = Type::getArrayKey();
+        $result_key_type = null;
         $result_element_type = null !== $row_type && $value_column_name_is_null ? $row_type : null;
         $have_at_least_one_res = false;
         // calculate results
@@ -212,18 +227,54 @@ class ArrayColumnReturnTypeProvider implements FunctionReturnTypeProviderInterfa
             }
 
             if ((null !== $key_column_name) && isset($row_shape->properties[$key_column_name])) {
-                $result_key_type = $row_shape->properties[$key_column_name];
+                $new_types = [];
+                foreach ($row_shape->properties[$key_column_name]->getAtomicTypes() as $atomic_type) {
+                    if ($atomic_type instanceof TNull) {
+                        $new_types[] = Type::getAtomicStringFromLiteral('');
+                    } else if ($atomic_type instanceof TMixed) {
+                        $new_types[] = $atomic_type;
+                    } else if ($atomic_type instanceof Scalar) {
+                        if ($atomic_type instanceof TInt) {
+                            $new_types[] = $atomic_type;
+                        } else if ($atomic_type instanceof TString) {
+                            $new_types[] = $atomic_type;
+                        } else if ($atomic_type instanceof TArrayKey) {
+                            $new_types[] = $atomic_type;
+                        } else if ($atomic_type instanceof TFloat || $atomic_type instanceof TBool) {
+                            $new_types[] = new TInt();
+                        } else if ($atomic_type instanceof TNumeric) {
+                            $new_types[] = new TNumericString();
+                            $new_types[] = new TInt();
+                        } else if ($atomic_type instanceof TScalar) {
+                            $new_types[] = new TArrayKey();
+                        } else {
+                            assert(false, 'Unhandled scalar type');
+                        }
+                    } else {
+                        IssueBuffer::maybeAdd(
+                            new ValueNotConvertibleToArrayKey(
+                                'Type ' . $atomic_type->getKey() . ' of ' . $row_shape->properties[$key_column_name] .
+                                    ' cannot be converted to array-key',
+                                $code_location
+                            ),
+                            $statements_source->getSuppressedIssues(),
+                        );
+                    }
+                }
+                $result_key_type = $new_types ? TypeCombiner::combine($new_types) : Type::getNever();
             }
         }
 
+        $result_element_type ??= Type::getMixed();
         if ($third_arg_type && !$key_column_name_is_null) {
+            $result_key_type ??= Type::getArrayKey();
             $type = $have_at_least_one_res ?
-                new TNonEmptyArray([$result_key_type, $result_element_type ?? Type::getMixed()])
-                : new TArray([$result_key_type, $result_element_type ?? Type::getMixed()]);
+                new TNonEmptyArray([$result_key_type, $result_element_type])
+                : new TArray([$result_key_type, $result_element_type]);
         } else {
             $type = $have_at_least_one_res ?
-                Type::getNonEmptyListAtomic($result_element_type ?? Type::getMixed())
-                : Type::getListAtomic($result_element_type ?? Type::getMixed());
+                Type::getNonEmptyListAtomic($result_element_type)
+                : Type::getListAtomic($result_element_type);
         }
 
         return new Union([$type]);

--- a/src/Psalm/Issue/ValueNotConvertibleToArrayKey.php
+++ b/src/Psalm/Issue/ValueNotConvertibleToArrayKey.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+final class ValueNotConvertibleToArrayKey extends CodeIssue
+{
+    public const ERROR_LEVEL = -1;
+    public const SHORTCODE = 321;
+}

--- a/tests/ReturnTypeProvider/ArrayColumnTest.php
+++ b/tests/ReturnTypeProvider/ArrayColumnTest.php
@@ -139,6 +139,34 @@ class ArrayColumnTest extends TestCase
                 }
             ',
         ];
+
+        yield 'arrayColumnWithNonStringScalarKey' => [
+            'code' => '<?php
+                /** @return non-empty-list<list{null, null}> */
+                function makeNullList() { return [[null, null]]; }
+                /** @return non-empty-list<list{bool, null}> */
+                function makeBoolList() { return [[false, null]]; }
+                /** @return non-empty-list<list{float, null}> */
+                function makeFloatList() { return [[1.5, null]]; }
+                /** @return non-empty-list<list{1.5, null}> */
+                function makeFloatLiteralList() { return [[1.5, null]]; }
+                /** @return non-empty-list<list{string|null, null}> */
+                function makeStringNullList() { return [[null, null]]; }
+
+                $a = array_column(makeNullList(), 1, 0);
+                $b = array_column(makeBoolList(), 1, 0);
+                $c = array_column(makeFloatList(), 1, 0);
+                $d = array_column(makeFloatLiteralList(), 1, 0);
+                $e = array_column(makeStringNullList(), 1, 0);
+            ',
+            'assertions' => [
+                '$a' => 'non-empty-array<string, null>',
+                '$b' => 'non-empty-array<int, null>',
+                '$c' => 'non-empty-array<int, null>',
+                '$d' => 'non-empty-array<int, null>',
+                '$e' => 'non-empty-array<string, null>',
+            ],
+        ];
     }
 
     public function providerInvalidCodeParse(): iterable
@@ -152,6 +180,16 @@ class ArrayColumnTest extends TestCase
                 }
             ',
             'error_message' => 'MixedMethodCall',
+        ];
+
+        yield 'arrayColumnWithUnconvertableKey' => [
+            'code' => '<?php
+                /** @return non-empty-list<list{object, null}> */
+                function makeObjectList() { return [[(object) [], null]]; }
+
+                $a = array_column(makeObjectList(), 1, 0);
+            ',
+            'error_message' => 'ValueNotConvertibleToArrayKey',
         ];
     }
 }


### PR DESCRIPTION
When using the third parameter of array_column, only scalar types and null are valid, and those types need to be converted to string/int.

https://psalm.dev/r/5a2ca24ef5