### PR TITLE
always combine the result of expansions

### DIFF
--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -77,8 +77,6 @@ class TypeExpander
     ): Union {
         $new_return_type_parts = [];
 
-        $had_split_values = false;
-
         foreach ($return_type->getAtomicTypes() as $return_type_part) {
             $parts = self::expandAtomic(
                 $codebase,
@@ -94,21 +92,13 @@ class TypeExpander
                 $throw_on_unresolvable_constant,
             );
 
-            if ($return_type_part instanceof TTypeAlias || count($parts) > 1) {
-                $had_split_values = true;
-            }
-
             $new_return_type_parts = [...$new_return_type_parts, ...$parts];
         }
 
-        if ($had_split_values) {
-            $fleshed_out_type = TypeCombiner::combine(
-                $new_return_type_parts,
-                $codebase,
-            );
-        } else {
-            $fleshed_out_type = new Union($new_return_type_parts);
-        }
+        $fleshed_out_type = TypeCombiner::combine(
+            $new_return_type_parts,
+            $codebase,
+        );
 
         $fleshed_out_type->from_docblock = $return_type->from_docblock;
         $fleshed_out_type->ignore_nullable_issues = $return_type->ignore_nullable_issues;

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -771,6 +771,38 @@ class TypeAnnotationTest extends TestCase
                     '$output===' => 'array{phone: string}',
                 ],
             ],
+            'combineAliasOfArrayAndArrayCorrectly' => [
+                'code' => '<?php
+
+                    /**
+                     * @psalm-type C = array{c: string}
+                     */
+                    class A {}
+
+                    /**
+                     * @template F
+                     */
+                    class D {
+                        /**
+                         * @param F $data
+                         */
+                        public function __construct(public $data) {}
+                    }
+
+
+                    /**
+                     * @psalm-import-type C from A
+                     */
+                    class G {
+
+                        /**
+                         * @param D<array{b: bool}>|D<C> $_doesNotWork
+                         */
+                        public function doesNotWork($_doesNotWork): void {
+                            /** @psalm-check-type-exact $_doesNotWork = D<array{b?: bool, c?: string}> */;
+                        }
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This fixes https://github.com/vimeo/psalm/issues/9305

What happened is that we had two array types in $new_return_type_parts at the end of the loop. However, an Union can only take a single array type without having to combine them

There was a specific handling for `split_values` but I couldn't get why Psalm thinks TTypeAlias or a single type that is extended into two need to be combined but two types would not need to be combined.

This may result in cases where performance are degraded but I'm not sure how to check the need to make a combination without reimplementing half the checks made in TypeCombiner...