### PR TITLE
Handle different line endings from baseline.

### DIFF
--- a/src/Psalm/ErrorBaseline.php
+++ b/src/Psalm/ErrorBaseline.php
@@ -118,7 +118,7 @@ final class ErrorBaseline
 
                 foreach ($codeSamples as $codeSample) {
                     $files[$fileName][$issueType]['o'] += 1;
-                    $files[$fileName][$issueType]['s'][] = trim($codeSample->textContent);
+                    $files[$fileName][$issueType]['s'][] = str_replace("\r\n", "\n", trim($codeSample->textContent));
                 }
 
                 // TODO: Remove in Psalm 6

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -782,7 +782,7 @@ class LanguageServer extends Dispatcher
                             if ($issue_baseline[$file][$type]['o'] === count($issue_baseline[$file][$type]['s'])) {
                                 /** @psalm-suppress MixedArrayAccess, MixedAssignment */
                                 $position = array_search(
-                                    trim($issue_data->selected_text),
+                                    str_replace("\r\n", "\n", trim($issue_data->selected_text)),
                                     $issue_baseline[$file][$type]['s'],
                                     true,
                                 );

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -592,7 +592,7 @@ final class IssueBuffer
                         if (isset($issue_baseline[$file][$type]) && $issue_baseline[$file][$type]['o'] > 0) {
                             if ($issue_baseline[$file][$type]['o'] === count($issue_baseline[$file][$type]['s'])) {
                                 $position = array_search(
-                                    trim($issue_data->selected_text),
+                                    str_replace("\r\n", "\n", trim($issue_data->selected_text)),
                                     $issue_baseline[$file][$type]['s'],
                                     true,
                                 );

--- a/tests/ErrorBaselineTest.php
+++ b/tests/ErrorBaselineTest.php
@@ -98,6 +98,37 @@ class ErrorBaselineTest extends TestCase
         );
     }
 
+    public function testShouldIgnoreCarriageReturnInMultilineSnippets(): void
+    {
+        $baselineFilePath = 'baseline.xml';
+
+        $this->fileProvider->allows()->fileExists($baselineFilePath)->andReturns(true);
+        $this->fileProvider->allows()->getContents($baselineFilePath)->andReturns(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+            <files>
+              <file src=\"sample/sample-file.php\">
+                <MixedAssignment>
+                  <code>
+foo&#13;
+bar&#13;
+                  </code>
+                </MixedAssignment>
+              </file>
+            </files>",
+        );
+
+        $expectedParsedBaseline = [
+            'sample/sample-file.php' => [
+                'MixedAssignment' => ['o' => 1, 's' => ["foo\nbar"]],
+            ],
+        ];
+
+        $this->assertSame(
+            $expectedParsedBaseline,
+            ErrorBaseline::read($this->fileProvider, $baselineFilePath),
+        );
+    }
+
     public function testLoadShouldThrowExceptionWhenFilesAreNotDefinedInBaselineFile(): void
     {
         $this->expectException(ConfigException::class);

--- a/tests/IssueBufferTest.php
+++ b/tests/IssueBufferTest.php
@@ -79,11 +79,31 @@ class IssueBufferTest extends TestCase
                     0,
                 ),
             ],
+            '/path/four.php' => [
+                new IssueData(
+                    "error",
+                    0,
+                    0,
+                    "MissingPropertyType",
+                    'Message',
+                    "four.php",
+                    "/path/four.php",
+                    "snippet-4-multiline\r\nwith-carriage-return\r",
+                    "snippet-4-multiline\r\nwith-carriage-return\r",
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                ),
+            ],
         ]);
         $baseline = [
             'one.php' => ['MissingPropertyType' => ['o' => 1, 's' => ['snippet-1']] ],
             'two.php' => ['MissingPropertyType' => ['o' => 1, 's' => ['snippet-2']] ],
             'three.php' => ['MissingPropertyType' => ['o' => 1, 's' => ['snippet-3-has-carriage-return']] ],
+            'four.php' => ['MissingPropertyType' => ['o' => 1, 's' => ["snippet-4-multiline\nwith-carriage-return"]] ],
         ];
 
         $analyzer = $this->createMock(Analyzer::class);


### PR DESCRIPTION
This change allows to have different file encoding in baseline and PHP file. This is issue when working in multi-platform team, generating baseline on Linux, and trying to run code analysis on Windows.

Fixes #9239 