### PR TITLE
@property annotations: allow *not* implying @psalm-seal-properties

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -62,6 +62,7 @@
         <xs:attribute name="reportMixedIssues" type="xs:boolean" default="true" />
         <xs:attribute name="useDocblockTypes" type="xs:boolean" default="true" />
         <xs:attribute name="useDocblockPropertyTypes" type="xs:boolean" default="false" />
+        <xs:attribute name="docblockPropertyTypesSealProperties" type="xs:boolean" default="true" />
         <xs:attribute name="usePhpDocMethodsWithoutMagicCall" type="xs:boolean" default="false" />
         <xs:attribute name="usePhpDocPropertiesWithoutMagicCall" type="xs:boolean" default="false" />
         <xs:attribute name="skipChecksOnUnresolvableIncludes" type="xs:boolean" default="false" />

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -97,7 +97,7 @@ If not using all docblock types, you can still use docblock property types. Defa
   docblockPropertyTypesSealProperties="[bool]"
 >
 ```
-Whether using @property in class docblocks should imply @psalm-seal-properties
+Whether using @property in class docblocks should imply @psalm-seal-properties. Defaults to `true`.
 
 #### usePhpDocMethodsWithoutMagicCall
 

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -90,6 +90,15 @@ Whether or not to use types as defined in docblocks. Defaults to `true`.
 ```
 If not using all docblock types, you can still use docblock property types. Defaults to `false` (though only relevant if `useDocblockTypes` is `false`).
 
+#### docblockPropertyTypesSealProperties
+
+```xml
+<psalm
+  docblockPropertyTypesSealProperties="[bool]"
+>
+```
+Whether using @property in class docblocks should imply @psalm-seal-properties
+
 #### usePhpDocMethodsWithoutMagicCall
 
 ```xml

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -195,7 +195,7 @@ class Config
     public $use_docblock_property_types = false;
 
     /**
-     * Whether using @property in docblocks should implicitly seal properties
+     * Whether using property annotations in docblocks should implicitly seal properties
      *
      * @var bool
      */

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -195,6 +195,13 @@ class Config
     public $use_docblock_property_types = false;
 
     /**
+     * Whether using @property in docblocks should implicitly seal properties
+     *
+     * @var bool
+     */
+    public $docblock_property_types_seal_properties = true;
+
+    /**
      * Whether or not to throw an exception on first error
      *
      * @var bool
@@ -1049,6 +1056,7 @@ class Config
         $booleanAttributes = [
             'useDocblockTypes' => 'use_docblock_types',
             'useDocblockPropertyTypes' => 'use_docblock_property_types',
+            'docblockPropertyTypesSealProperties' => 'docblock_property_types_seal_properties',
             'throwExceptionOnError' => 'throw_exception',
             'hideExternalErrors' => 'hide_external_errors',
             'hideAllErrorsExceptPassedFiles' => 'hide_all_errors_except_passed_files',

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -568,7 +568,7 @@ class ClassLikeNodeScanner
                     }
                 }
 
-                if ($config->docblock_property_types_seal_properties) {
+                if ($this->config->docblock_property_types_seal_properties) {
                     $storage->sealed_properties = true;
                 }
             }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -568,7 +568,9 @@ class ClassLikeNodeScanner
                     }
                 }
 
-                $storage->sealed_properties = true;
+                if ($config->docblock_property_types_seal_properties) {
+                    $storage->sealed_properties = true;
+                }
             }
 
             foreach ($docblock_info->methods as $method) {


### PR DESCRIPTION
I was going to open an issue for something that felt like a bug, but I figured a pull request adding a config option may be better received.

---

Add a setting that allows usage of `@property` to *augment* classes that use `__get()` and `__set()`. Previously, using `@property` once would force you to exhaustively list all possible properties. This didn't use to be the case, but was changed in df33405635cbdb6d41474503ca20c8adda55d438

This was really unexpected for our team and for a while we thought it was a psalm bug until I found the above commit.

We are using `__get()` for column access on ORM objects and we want to use `@property` to explicitly document the types of some of the columns without being forced to document every column.