### PR TITLE
Contextual inference for first-class-callable

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -446,7 +446,7 @@ class ArgumentsAnalyzer
 
         // Has no sense to analyse 'input' function
         // when 'container' function has more arguments than 'input'
-        if (count($container_callable_atomic->params ?? []) < count($input_first_class_callable->params)) {
+        if (count($container_callable_atomic->params ?? []) < count($input_first_class_callable->params ?? [])) {
             return null;
         }
 


### PR DESCRIPTION
### What's the problem?

Psalm cannot properly infer type for `$app->run(appHandler(...))` call:
- Should be `array{param1: 42, param2: 'test'}`
- Actual type `array{param1: mixed, param2: mixed}`

https://psalm.dev/r/58fe44f776
```php
<?php

/**
 * @template T1
 * @template T2
 */
final class App
{
    /**
     * @param T1 $param1
     * @param T2 $param2
     */
    public function __construct(
        private readonly mixed $param1,
        private readonly mixed $param2,
    ) {}

    /**
     * @template T3
     * @param callable(T1, T2): T3 $callback
     * @return T3
     */
    public function run(callable $callback): mixed
    {
        return $callback($this->param1, $this->param2);
    }
}

/**
 * @template P1
 * @template P2
 * @param P1 $param1
 * @param P2 $param2
 * @return array{param1: P1, param2: P2}
 */
function appHandler(mixed $param1, mixed $param2): array
{
    return ['param1' => $param1, 'param2' => $param2];
}

$app = new App(param1: 42, param2: 'test');
$result = $app->run(appHandler(...));

/** @psalm-check-type-exact $result = array{param1: 42, param2: 'test'} */
```

It's sad that Psalm still can't properly handle first-class-callable properly.
This PR tries to solve this problem.

### How

In the code example above, we are looking at the signature of the method being called.
See that `$callback` has `callable(T1, T2): T3` type.

We pass first-class-callable `appHandler(...)` to the `run` method.
Type of `appHandler(...)` expression can be represented as `Closure(P1, P2): array{param1: P1, param2: P2}`.

We are known types for `T1` and `T2` (`42` и `test`) during arguments analysis in the `ArgumentsAnalyazer`.
It needs to somehow map `T1` and `T2` with `P1` and `P2`.

For that I create `TemplateResult` with `['P1' => 'T1', 'P2' => 'T2']` for replacement
`Closure(P1, P2): array{param1: P1, param2: P2}` to `Closure(T1, T2): array{param1: T2, param2: T2}`.

And since the types `T1` and `T2` are known, we can replace `Closure(T1, T2): array{param1: T2, param2: T2}`
to `Closure(42, 'test'): array{param1: 42, param2: 'test'}`.

### Limitations

For now, It works only for inline first-class-callable arguments:

```php
// Inferred type: array{param1: 42, param2: 'test'}
$result = (new App(param1: 42, param2: 'test'))->run(appHandler(...));
```

In the future I will try to expand the functionality and
make sure that the following code is also checked by Psalm properly:

```php
// Inferred type Closure(mixed, mixed): array{param1: mixed, param2: mixed}
$handler = appHandler(...);

// Inferred type: array{param1: mixed, param2: mixed}
$result = (new App(param1: 42, param2: 'test'))->run($handler);
```

Now Psalm for some reason erases the type parameters, which makes further type inference impossible.
I don't have enough time yet to understand why Psalm does this.
