### PR TITLE
Improve types for range()

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -9625,7 +9625,7 @@ return [
 'rand\'1' => ['int'],
 'random_bytes' => ['non-empty-string', 'length'=>'positive-int'],
 'random_int' => ['int', 'min'=>'int', 'max'=>'int'],
-'range' => ['array', 'start'=>'mixed', 'end'=>'mixed', 'step='=>'int|float'],
+'range' => ['non-empty-array', 'start'=>'string|int|float', 'end'=>'string|int|float', 'step='=>'int<1, max>|float'],
 'RangeException::__clone' => ['void'],
 'RangeException::__construct' => ['void', 'message='=>'string', 'code='=>'int', 'previous='=>'?Throwable'],
 'RangeException::__toString' => ['string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -13731,7 +13731,7 @@ return [
     'rand\'1' => ['int'],
     'random_bytes' => ['non-empty-string', 'length'=>'positive-int'],
     'random_int' => ['int', 'min'=>'int', 'max'=>'int'],
-    'range' => ['array', 'start'=>'mixed', 'end'=>'mixed', 'step='=>'int|float'],
+    'range' => ['non-empty-array', 'start'=>'string|int|float', 'end'=>'string|int|float', 'step='=>'int<1, max>|float'],
     'rar_allow_broken_set' => ['bool', 'rarfile'=>'RarArchive', 'allow_broken'=>'bool'],
     'rar_broken_is' => ['bool', 'rarfile'=>'rararchive'],
     'rar_close' => ['bool', 'rarfile'=>'rararchive'],


### PR DESCRIPTION
This is based on the new RFC https://wiki.php.net/rfc/proper-range-semantics 
While the RFC is only in discussion phase, SA should already pick up these issues. Regardless of the final status of RFC, there should be no negative or 0 step values, and start/end should be string|float|int. While resources, arrays and objects are accepted, this is NOT the documented functionality. Using it is currently relying on implementation detail and is undefined behaviour. We can also promise that the return value is non-empty-array because the end is inclusive. This means that `range(1, 1)` will return `[1]`, and an empty array will only be returned if we use exotic values that break the algorithm, e.g. NAN. 