### PR TITLE
fix: treat includes starting with '.' and '..' correct

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -395,11 +395,9 @@ class IncludeAnalyzer
             return $file_name;
         }
 
-        if (
-            (substr($file_name, 0, 2) === '.' . DIRECTORY_SEPARATOR)
+        if ((substr($file_name, 0, 2) === '.' . DIRECTORY_SEPARATOR)
             || (substr($file_name, 0, 3) === '..' . DIRECTORY_SEPARATOR)
         ) {
-
             $file = $current_directory . DIRECTORY_SEPARATOR . $file_name;
 
             if (file_exists($file)) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -395,6 +395,20 @@ class IncludeAnalyzer
             return $file_name;
         }
 
+        if (
+            (substr($file_name, 0, 2) === '.' . DIRECTORY_SEPARATOR)
+            || (substr($file_name, 0, 3) === '..' . DIRECTORY_SEPARATOR)
+        ) {
+
+            $file = $current_directory . DIRECTORY_SEPARATOR . $file_name;
+
+            if (file_exists($file)) {
+                return $file;
+            }
+
+            return null;
+        }
+
         $paths = PATH_SEPARATOR === ':'
             ? preg_split('#(?<!phar):#', get_include_path())
             : explode(PATH_SEPARATOR, get_include_path());

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -2,7 +2,6 @@
 
 namespace Psalm\Tests;
 
-use PHP_CodeSniffer\Tokenizers\PHP;
 use Psalm\Config;
 use Psalm\Exception\CodeException;
 use Psalm\Internal\Analyzer\FileAnalyzer;
@@ -13,7 +12,8 @@ use function strpos;
 
 use const DIRECTORY_SEPARATOR;
 
-class IncludeTest extends TestCase {
+class IncludeTest extends TestCase
+{
     /**
      * @dataProvider providerTestValidIncludes
      * @param array<int, string> $files_to_check
@@ -96,7 +96,8 @@ class IncludeTest extends TestCase {
     /**
      * @return array<string,array{files:array<string,string>,files_to_check:array<int,string>,hoist_constants?:bool,ignored_issues?:list<string>}>
      */
-    public function providerTestValidIncludes(): array {
+    public function providerTestValidIncludes(): array
+    {
         return [
             'basicRequire' => [
                 'files' => [
@@ -651,7 +652,8 @@ class IncludeTest extends TestCase {
     /**
      * @return array<string,array{files:array<string,string>,files_to_check:array<int,string>,error_message:string}>
      */
-    public function providerTestInvalidIncludes(): array {
+    public function providerTestInvalidIncludes(): array
+    {
         return [
             'undefinedMethodInRequire' => [
                 'files' => [
@@ -907,7 +909,7 @@ class IncludeTest extends TestCase {
                     getcwd() . DIRECTORY_SEPARATOR . 'test_1.php',
                     getcwd() . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'test_2.php',
                 ],
-                'error_message' => 'MissingFile'
+                'error_message' => 'MissingFile',
             ],
         ];
     }


### PR DESCRIPTION
this fixes #9605 for includes with non compound strings, eg.:
```php
include './path/to/file.php';
```

but it does not work for compound expressions, eg: 
```php
include '.' . '/path/to/file.php';
```

Compound expressions are evaluated within `IncludeAnalyzer::getPathTo(...)` and are directly returned as absolute path, so there is no chance to detect the need of this special treatment.

The function is used in several different places, and I am not familar enough with this code to do the refactoring, sorry.
