### PR TITLE
Contextual inference for const callable

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -758,7 +758,7 @@ class ArgumentsAnalyzer
                                 IssueBuffer::maybeAdd(
                                     new InvalidNamedArgument(
                                         'Parameter $' . $key_type->value . ' does not exist on function '
-                                        . ($cased_method_id ?: $method_id),
+                                            . ($cased_method_id ?: $method_id),
                                         new CodeLocation($statements_analyzer, $arg),
                                         (string)$method_id,
                                     ),
@@ -778,7 +778,7 @@ class ArgumentsAnalyzer
                                 IssueBuffer::maybeAdd(
                                     new InvalidNamedArgument(
                                         'Parameter $' . $arg->name->name . ' has already been used in '
-                                        . ($cased_method_id ?: $method_id),
+                                            . ($cased_method_id ?: $method_id),
                                         new CodeLocation($statements_analyzer, $arg->name),
                                         (string) $method_id,
                                     ),
@@ -990,7 +990,7 @@ class ArgumentsAnalyzer
             || $arg->value instanceof PhpParser\Node\Expr\Ternary
             || (
                 (
-                    $arg->value instanceof PhpParser\Node\Expr\ConstFetch
+                $arg->value instanceof PhpParser\Node\Expr\ConstFetch
                     || $arg->value instanceof PhpParser\Node\Expr\FuncCall
                     || $arg->value instanceof PhpParser\Node\Expr\MethodCall
                     || $arg->value instanceof PhpParser\Node\Expr\StaticCall
@@ -1188,7 +1188,7 @@ class ArgumentsAnalyzer
                     IssueBuffer::maybeAdd(
                         new PossiblyUndefinedVariable(
                             'Variable ' . $var_id
-                            . ' must be defined prior to use within an unknown function or method',
+                                . ' must be defined prior to use within an unknown function or method',
                             new CodeLocation($statements_analyzer->getSource(), $arg->value),
                         ),
                         $statements_analyzer->getSuppressedIssues(),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -243,8 +243,9 @@ class ArgumentsAnalyzer
 
             $context->inside_call = $was_inside_call;
 
-            if ($high_order_callable_info) {
+            if ($high_order_callable_info && $high_order_template_result) {
                 HighOrderFunctionArgHandler::enhanceCallableArgType(
+                    $context,
                     $arg->value,
                     $statements_analyzer,
                     $high_order_callable_info,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -196,11 +196,9 @@ class ArgumentsAnalyzer
             }
 
             $high_order_template_result = null;
-            $high_order_callable_info = HighOrderFunctionArgHandler::getCallableArgInfo(
-                $context,
-                $arg->value,
-                $statements_analyzer,
-            );
+            $high_order_callable_info = $param
+                ? HighOrderFunctionArgHandler::getCallableArgInfo($context, $arg->value, $statements_analyzer, $param)
+                : null;
 
             if ($param && $high_order_callable_info) {
                 $high_order_template_result = HighOrderFunctionArgHandler::remapLowerBounds(
@@ -245,22 +243,13 @@ class ArgumentsAnalyzer
 
             $context->inside_call = $was_inside_call;
 
-            if ($high_order_callable_info && $high_order_callable_info->isFirstClassCallable()) {
-                $inferred_first_class_callable_type = TemplateInferredTypeReplacer::replace(
-                    $high_order_callable_info->asFirstClassCallable(),
-                    $high_order_template_result ?? new TemplateResult([], []),
-                    $statements_analyzer->getCodebase(),
+            if ($high_order_callable_info) {
+                HighOrderFunctionArgHandler::enhanceCallableArgType(
+                    $arg->value,
+                    $statements_analyzer,
+                    $high_order_callable_info,
+                    $high_order_template_result,
                 );
-
-                $statements_analyzer->node_data->setType($arg->value, $inferred_first_class_callable_type);
-            } elseif ($high_order_callable_info && $high_order_callable_info->isInvokableClassCallable()) {
-                $inferred_invokable_class_callable_type = TemplateInferredTypeReplacer::replace(
-                    $high_order_callable_info->asInvokableClassCallable(),
-                    $high_order_template_result ?? new TemplateResult([], []),
-                    $statements_analyzer->getCodebase(),
-                );
-
-                $statements_analyzer->node_data->setType($arg->value, $inferred_invokable_class_callable_type);
             }
 
             if (($argument_offset === 0 && $method_id === 'array_filter' && count($args) === 2)

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -20,7 +20,6 @@ use Psalm\Internal\Codebase\TaintFlowGraph;
 use Psalm\Internal\DataFlow\TaintSink;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Stubs\Generator\StubsGenerator;
-use Psalm\Internal\Type\Comparator\CallableTypeComparator;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Type\TemplateInferredTypeReplacer;
 use Psalm\Internal\Type\TemplateResult;
@@ -197,34 +196,19 @@ class ArgumentsAnalyzer
             }
 
             $high_order_template_result = null;
-            $inferred_first_class_callable_type = null;
+            $high_order_callable_info = HighOrderFunctionArgHandler::getCallableArgInfo(
+                $context,
+                $arg->value,
+                $statements_analyzer,
+            );
 
-            if (($arg->value instanceof PhpParser\Node\Expr\FuncCall
-                    || $arg->value instanceof PhpParser\Node\Expr\MethodCall
-                    || $arg->value instanceof PhpParser\Node\Expr\StaticCall)
-                && $param
-                && $function_storage = self::getHighOrderFuncStorage($context, $statements_analyzer, $arg->value)
-            ) {
-                if (!$arg->value->isFirstClassCallable()) {
-                    $high_order_template_result = self::handleHighOrderFuncCallArg(
-                        $statements_analyzer,
-                        $template_result ?? new TemplateResult([], []),
-                        $function_storage,
-                        $param,
-                    );
-                } else {
-                    $inferred_first_class_callable_type = self::handleFirstClassCallableCallArg(
-                        $statements_analyzer->getCodebase(),
-                        $template_result ?? new TemplateResult([], []),
-                        new TClosure(
-                            'Closure',
-                            $function_storage->params,
-                            $function_storage->return_type,
-                            $function_storage->pure,
-                        ),
-                        $param,
-                    );
-                }
+            if ($param && $high_order_callable_info) {
+                $high_order_template_result = HighOrderFunctionArgHandler::remapLowerBounds(
+                    $statements_analyzer,
+                    $template_result ?? new TemplateResult([], []),
+                    $high_order_callable_info,
+                    $param->type ?? Type::getMixed(),
+                );
             } elseif (($arg->value instanceof PhpParser\Node\Expr\Closure
                     || $arg->value instanceof PhpParser\Node\Expr\ArrowFunction)
                 && $param
@@ -243,12 +227,9 @@ class ArgumentsAnalyzer
             }
 
             $was_inside_call = $context->inside_call;
-
             $context->inside_call = true;
 
-            if ($inferred_first_class_callable_type) {
-                $statements_analyzer->node_data->setType($arg->value, $inferred_first_class_callable_type);
-            } elseif (ExpressionAnalyzer::analyze(
+            if (ExpressionAnalyzer::analyze(
                 $statements_analyzer,
                 $arg->value,
                 $context,
@@ -263,6 +244,24 @@ class ArgumentsAnalyzer
             }
 
             $context->inside_call = $was_inside_call;
+
+            if ($high_order_callable_info && $high_order_callable_info->isFirstClassCallable()) {
+                $inferred_first_class_callable_type = TemplateInferredTypeReplacer::replace(
+                    $high_order_callable_info->asFirstClassCallable(),
+                    $high_order_template_result ?? new TemplateResult([], []),
+                    $statements_analyzer->getCodebase(),
+                );
+
+                $statements_analyzer->node_data->setType($arg->value, $inferred_first_class_callable_type);
+            } elseif ($high_order_callable_info && $high_order_callable_info->isInvokableClassCallable()) {
+                $inferred_invokable_class_callable_type = TemplateInferredTypeReplacer::replace(
+                    $high_order_callable_info->asInvokableClassCallable(),
+                    $high_order_template_result ?? new TemplateResult([], []),
+                    $statements_analyzer->getCodebase(),
+                );
+
+                $statements_analyzer->node_data->setType($arg->value, $inferred_invokable_class_callable_type);
+            }
 
             if (($argument_offset === 0 && $method_id === 'array_filter' && count($args) === 2)
                 || ($argument_offset > 0 && $method_id === 'array_map' && count($args) >= 2)
@@ -360,264 +359,6 @@ class ArgumentsAnalyzer
 
             $template_result->lower_bounds += $replace_template_result->lower_bounds;
         }
-    }
-
-    private static function getHighOrderFuncStorage(
-        Context $context,
-        StatementsAnalyzer $statements_analyzer,
-        PhpParser\Node\Expr\CallLike $function_like_call
-    ): ?FunctionLikeStorage {
-        $codebase = $statements_analyzer->getCodebase();
-
-        try {
-            if ($function_like_call instanceof PhpParser\Node\Expr\FuncCall) {
-                $function_id = strtolower((string) $function_like_call->name->getAttribute('resolvedName'));
-
-                if (empty($function_id)) {
-                    return null;
-                }
-
-                if ($codebase->functions->dynamic_storage_provider->has($function_id)) {
-                    return $codebase->functions->dynamic_storage_provider->getFunctionStorage(
-                        $function_like_call,
-                        $statements_analyzer,
-                        $function_id,
-                        $context,
-                        new CodeLocation($statements_analyzer, $function_like_call),
-                    );
-                }
-
-                return $codebase->functions->getStorage($statements_analyzer, $function_id);
-            }
-
-            if ($function_like_call instanceof PhpParser\Node\Expr\MethodCall &&
-                $function_like_call->var instanceof PhpParser\Node\Expr\Variable &&
-                $function_like_call->name instanceof PhpParser\Node\Identifier &&
-                is_string($function_like_call->var->name) &&
-                isset($context->vars_in_scope['$' . $function_like_call->var->name])
-            ) {
-                $lhs_type = $context->vars_in_scope['$' . $function_like_call->var->name]->getSingleAtomic();
-
-                if (!$lhs_type instanceof Type\Atomic\TNamedObject) {
-                    return null;
-                }
-
-                $method_id = new MethodIdentifier(
-                    $lhs_type->value,
-                    strtolower((string)$function_like_call->name),
-                );
-
-                return $codebase->methods->getStorage($method_id);
-            }
-
-            if ($function_like_call instanceof PhpParser\Node\Expr\StaticCall &&
-                $function_like_call->name instanceof PhpParser\Node\Identifier
-            ) {
-                $method_id = new MethodIdentifier(
-                    (string)$function_like_call->class->getAttribute('resolvedName'),
-                    strtolower($function_like_call->name->name),
-                );
-
-                return $codebase->methods->getStorage($method_id);
-            }
-        } catch (UnexpectedValueException $e) {
-            return null;
-        }
-
-        return null;
-    }
-
-    /**
-     * Infers type for first-class-callable call.
-     */
-    private static function handleFirstClassCallableCallArg(
-        Codebase $codebase,
-        TemplateResult $inferred_template_result,
-        TClosure $input_first_class_callable,
-        FunctionLikeParameter $container_callable_param
-    ): ?Union {
-        $container_callable_atomic = $container_callable_param->type && $container_callable_param->type->isSingle()
-            ? $container_callable_param->type->getSingleAtomic()
-            : null;
-
-        if (!$container_callable_atomic instanceof TClosure && !$container_callable_atomic instanceof TCallable) {
-            return null;
-        }
-
-        // Has no sense to analyse 'input' function
-        // when 'container' function has more arguments than 'input'
-        if (count($container_callable_atomic->params ?? []) < count($input_first_class_callable->params ?? [])) {
-            return null;
-        }
-
-        $remapped_lower_bounds = [];
-
-        // Traverse side by side 'container' params and 'input' params.
-        // This maps 'input' templates to 'container' templates.
-        //
-        // Example:
-        // 'input'     => Closure(C:Bar, D:Bar): array{C:Bar, D:Bar}
-        // 'container' => Closure(A:Foo, B:Foo): array{A:Foo, B:Foo}
-        //
-        // $remapped_lower_bounds will be: [
-        //     'C' => ['Bar' => ['A:Foo']],
-        //     'D' => ['Bar' => ['B:Foo']]
-        // ].
-        foreach ($container_callable_atomic->params ?? [] as $offset => $container_param) {
-            if (!isset($input_first_class_callable->params[$offset])) {
-                continue;
-            }
-
-            $input_param_type = $input_first_class_callable->params[$offset]->type ?? Type::getMixed();
-            $container_param_type = $container_param->type ?? Type::getMixed();
-
-            foreach ($input_param_type->getTemplateTypes() as $input_atomic) {
-                foreach ($container_param_type->getTemplateTypes() as $container_atomic) {
-                    $inferred_lower_bounds = $inferred_template_result->lower_bounds
-                        [$container_atomic->param_name]
-                        [$container_atomic->defining_class] ?? [];
-
-                    foreach ($inferred_lower_bounds as $lower_bound) {
-                        // Check template constraint of input first-class-callable.
-                        // Correct type cannot be inferred if constraint check failed.
-                        if (!$codebase->isTypeContainedByType($lower_bound->type, $input_atomic->as)) {
-                            return null;
-                        }
-                    }
-
-                    $remapped_lower_bounds
-                        [$input_atomic->param_name]
-                        [$input_atomic->defining_class] = new Union([$container_atomic]);
-                }
-            }
-        }
-
-        // Turns Closure(C:Bar, D:Bar): array{C:Bar, D:Bar}
-        //    to Closure(A:Foo, B:Foo): array{A:Foo, B:Foo}
-        $remapped_first_class_callable = TemplateInferredTypeReplacer::replace(
-            new Union([$input_first_class_callable]),
-            new TemplateResult($inferred_template_result->template_types, $remapped_lower_bounds),
-            $codebase,
-        );
-
-        // Turns Closure(A:Foo, B:Foo): array{A:Foo, B:Foo}
-        // to fully inferred Closure (thanks to $inferred_template_result)
-        return TemplateInferredTypeReplacer::replace(
-            $remapped_first_class_callable,
-            $inferred_template_result,
-            $codebase,
-        );
-    }
-
-    /**
-     * Compiles TemplateResult for high-order functions ($func_call)
-     * by previous template args ($inferred_template_result).
-     *
-     * It's need for proper template replacement:
-     *
-     * ```
-     * * template T
-     * * return Closure(T): T
-     * function id(): Closure { ... }
-     *
-     * * template A
-     * * template B
-     * *
-     * * param list<A> $_items
-     * * param callable(A): B $_ab
-     * * return list<B>
-     * function map(array $items, callable $ab): array { ... }
-     *
-     * // list<int>
-     * $numbers = [1, 2, 3];
-     *
-     * $result = map($numbers, id());
-     * // $result is list<int> because template T of id() was inferred by previous arg.
-     * ```
-     */
-    private static function handleHighOrderFuncCallArg(
-        StatementsAnalyzer $statements_analyzer,
-        TemplateResult $inferred_template_result,
-        FunctionLikeStorage $storage,
-        FunctionLikeParameter $actual_func_param
-    ): ?TemplateResult {
-        $codebase = $statements_analyzer->getCodebase();
-
-        $input_hof_atomic = $storage->return_type && $storage->return_type->isSingle()
-            ? $storage->return_type->getSingleAtomic()
-            : null;
-
-        // Try upcast invokable to callable type.
-        if ($input_hof_atomic instanceof Type\Atomic\TNamedObject &&
-            $input_hof_atomic->value !== 'Closure' &&
-            $codebase->classExists($input_hof_atomic->value)
-        ) {
-            $callable_from_invokable = CallableTypeComparator::getCallableFromAtomic(
-                $codebase,
-                $input_hof_atomic,
-            );
-
-            if ($callable_from_invokable) {
-                $invoke_id = new MethodIdentifier($input_hof_atomic->value, '__invoke');
-                $declaring_invoke_id = $codebase->methods->getDeclaringMethodId($invoke_id);
-
-                $storage = $codebase->methods->getStorage($declaring_invoke_id ?? $invoke_id);
-                $input_hof_atomic = $callable_from_invokable;
-            }
-        }
-
-        if (!$input_hof_atomic instanceof TClosure && !$input_hof_atomic instanceof TCallable) {
-            return null;
-        }
-
-        $container_hof_atomic = $actual_func_param->type && $actual_func_param->type->isSingle()
-            ? $actual_func_param->type->getSingleAtomic()
-            : null;
-
-        if (!$container_hof_atomic instanceof TClosure && !$container_hof_atomic instanceof TCallable) {
-            return null;
-        }
-
-        $replaced_container_hof_atomic = new Union([$container_hof_atomic]);
-
-        // Replaces all input args in container function.
-        //
-        // For example:
-        // The map function expects callable(A):B as second param
-        // We know that previous arg type is list<int> where the int is the A template.
-        // Then we can replace callable(A): B to callable(int):B using $inferred_template_result.
-        $replaced_container_hof_atomic = TemplateInferredTypeReplacer::replace(
-            $replaced_container_hof_atomic,
-            $inferred_template_result,
-            $codebase,
-        );
-
-        /** @var TClosure|TCallable $container_hof_atomic */
-        $container_hof_atomic = $replaced_container_hof_atomic->getSingleAtomic();
-        $high_order_template_result = new TemplateResult($storage->template_types ?: [], []);
-
-        // We can replace each templated param for the input function.
-        // Example:
-        // map($numbers, id());
-        // We know that map expects callable(int):B because the $numbers is list<int>.
-        // We know that id() returns callable(T):T.
-        // Then we can replace templated params sequentially using the expected callable(int):B.
-        foreach ($input_hof_atomic->params ?? [] as $offset => $actual_func_param) {
-            if ($actual_func_param->type &&
-                $actual_func_param->type->getTemplateTypes() &&
-                isset($container_hof_atomic->params[$offset])
-            ) {
-                TemplateStandinTypeReplacer::fillTemplateResult(
-                    $actual_func_param->type,
-                    $high_order_template_result,
-                    $codebase,
-                    null,
-                    $container_hof_atomic->params[$offset]->type,
-                );
-            }
-        }
-
-        return $high_order_template_result;
     }
 
     /**
@@ -1047,7 +788,7 @@ class ArgumentsAnalyzer
                                 IssueBuffer::maybeAdd(
                                     new InvalidNamedArgument(
                                         'Parameter $' . $arg->name->name . ' has already been used in '
-                                            . ($cased_method_id ?: $method_id),
+                                        . ($cased_method_id ?: $method_id),
                                         new CodeLocation($statements_analyzer, $arg->name),
                                         (string) $method_id,
                                     ),
@@ -1067,7 +808,7 @@ class ArgumentsAnalyzer
                     IssueBuffer::maybeAdd(
                         new InvalidNamedArgument(
                             'Parameter $' . $arg->name->name . ' does not exist on function '
-                                . ($cased_method_id ?: $method_id),
+                            . ($cased_method_id ?: $method_id),
                             new CodeLocation($statements_analyzer, $arg->name),
                             (string) $method_id,
                         ),
@@ -1259,7 +1000,7 @@ class ArgumentsAnalyzer
             || $arg->value instanceof PhpParser\Node\Expr\Ternary
             || (
                 (
-                $arg->value instanceof PhpParser\Node\Expr\ConstFetch
+                    $arg->value instanceof PhpParser\Node\Expr\ConstFetch
                     || $arg->value instanceof PhpParser\Node\Expr\FuncCall
                     || $arg->value instanceof PhpParser\Node\Expr\MethodCall
                     || $arg->value instanceof PhpParser\Node\Expr\StaticCall
@@ -1457,7 +1198,7 @@ class ArgumentsAnalyzer
                     IssueBuffer::maybeAdd(
                         new PossiblyUndefinedVariable(
                             'Variable ' . $var_id
-                                . ' must be defined prior to use within an unknown function or method',
+                            . ' must be defined prior to use within an unknown function or method',
                             new CodeLocation($statements_analyzer->getSource(), $arg->value),
                         ),
                         $statements_analyzer->getSuppressedIssues(),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgHandler.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
+
+use PhpParser;
+use Psalm\CodeLocation;
+use Psalm\Context;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\TemplateInferredTypeReplacer;
+use Psalm\Internal\Type\TemplateResult;
+use Psalm\Internal\Type\TemplateStandinTypeReplacer;
+use Psalm\Type;
+use Psalm\Type\Atomic\TCallable;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Union;
+use UnexpectedValueException;
+
+use function is_string;
+use function strpos;
+use function strtolower;
+
+/**
+ * @internal
+ */
+final class HighOrderFunctionArgHandler
+{
+    public static function remapLowerBounds(
+        StatementsAnalyzer $statements_analyzer,
+        TemplateResult $inferred_template_result,
+        HighOrderFunctionArgInfo $input_function,
+        Union $container_function_type
+    ): TemplateResult {
+        $container_type = TemplateInferredTypeReplacer::replace(
+            $container_function_type,
+            $inferred_template_result,
+            $statements_analyzer->getCodebase(),
+        );
+
+        $input_function_type = $input_function->getFunctionType();
+        $input_function_template_result = $input_function->getTemplates();
+
+        foreach ($input_function_type->getAtomicTypes() as $input_atomic) {
+            if (!$input_atomic instanceof TClosure && !$input_atomic instanceof TCallable) {
+                continue;
+            }
+
+            foreach ($container_type->getAtomicTypes() as $container_atomic) {
+                if (!$container_atomic instanceof TClosure && !$container_atomic instanceof TCallable) {
+                    continue;
+                }
+
+                foreach ($input_atomic->params ?? [] as $offset => $input_param) {
+                    if (!isset($container_atomic->params[$offset])) {
+                        continue;
+                    }
+
+                    TemplateStandinTypeReplacer::fillTemplateResult(
+                        $input_param->type ?? Type::getMixed(),
+                        $input_function_template_result,
+                        $statements_analyzer->getCodebase(),
+                        $statements_analyzer,
+                        $container_atomic->params[$offset]->type,
+                    );
+                }
+            }
+        }
+
+        return $input_function_template_result;
+    }
+
+    public static function getCallableArgInfo(
+        Context $context,
+        PhpParser\Node\Expr $expr,
+        StatementsAnalyzer $statements_analyzer
+    ): ?HighOrderFunctionArgInfo {
+        $codebase = $statements_analyzer->getCodebase();
+
+        try {
+            if ($expr instanceof PhpParser\Node\Expr\FuncCall) {
+                $function_id = strtolower((string) $expr->name->getAttribute('resolvedName'));
+
+                if (empty($function_id)) {
+                    return null;
+                }
+
+                $dynamic_storage = !$expr->isFirstClassCallable()
+                    ? $codebase->functions->dynamic_storage_provider->getFunctionStorage(
+                        $expr,
+                        $statements_analyzer,
+                        $function_id,
+                        $context,
+                        new CodeLocation($statements_analyzer, $expr),
+                    )
+                    : null;
+
+                return new HighOrderFunctionArgInfo(
+                    $expr->isFirstClassCallable(),
+                    $dynamic_storage ?? $codebase->functions->getStorage($statements_analyzer, $function_id),
+                );
+            }
+
+            if ($expr instanceof PhpParser\Node\Expr\MethodCall &&
+                $expr->var instanceof PhpParser\Node\Expr\Variable &&
+                $expr->name instanceof PhpParser\Node\Identifier &&
+                is_string($expr->var->name) &&
+                isset($context->vars_in_scope['$' . $expr->var->name])
+            ) {
+                $lhs_type = $context->vars_in_scope['$' . $expr->var->name]->getSingleAtomic();
+
+                if (!$lhs_type instanceof Type\Atomic\TNamedObject) {
+                    return null;
+                }
+
+                $method_id = new MethodIdentifier(
+                    $lhs_type->value,
+                    strtolower((string)$expr->name),
+                );
+
+                return new HighOrderFunctionArgInfo(
+                    $expr->isFirstClassCallable(),
+                    $codebase->methods->getStorage($method_id),
+                );
+            }
+
+            if ($expr instanceof PhpParser\Node\Expr\StaticCall &&
+                $expr->name instanceof PhpParser\Node\Identifier
+            ) {
+                $method_id = new MethodIdentifier(
+                    (string)$expr->class->getAttribute('resolvedName'),
+                    strtolower($expr->name->name),
+                );
+
+                return new HighOrderFunctionArgInfo(
+                    $expr->isFirstClassCallable(),
+                    $codebase->methods->getStorage($method_id),
+                );
+            }
+
+            if ($expr instanceof PhpParser\Node\Expr\ConstFetch) {
+                $constant = $context->constants[$expr->name->toString()] ?? null;
+
+                $literal = $constant && $constant->isSingle()
+                    ? $constant->getSingleAtomic()
+                    : null;
+
+                if (!$literal instanceof Type\Atomic\TLiteralString || empty($literal->value)) {
+                    return null;
+                }
+
+                return new HighOrderFunctionArgInfo(
+                    true,
+                    strpos($literal->value, '::') !== false
+                        ? $codebase->methods->getStorage(MethodIdentifier::wrap($literal->value))
+                        : $codebase->functions->getStorage($statements_analyzer, strtolower($literal->value)),
+                );
+            }
+
+            if ($expr instanceof PhpParser\Node\Expr\ClassConstFetch &&
+                $expr->name instanceof PhpParser\Node\Identifier
+            ) {
+                $method_id = new MethodIdentifier(
+                    (string)$expr->class->getAttribute('resolvedName'),
+                    strtolower($expr->name->name),
+                );
+
+                return new HighOrderFunctionArgInfo(
+                    true,
+                    $codebase->methods->getStorage($method_id),
+                );
+            }
+
+            if ($expr instanceof PhpParser\Node\Expr\New_ &&
+                $expr->class instanceof PhpParser\Node\Name
+            ) {
+                $class_storage = $codebase->classlikes
+                    ->getStorageFor((string) $expr->class->getAttribute('resolvedName'));
+
+                $invoke_storage = $class_storage && isset($class_storage->methods['__invoke'])
+                    ? $class_storage->methods['__invoke']
+                    : null;
+
+                if (!$invoke_storage) {
+                    return null;
+                }
+
+                return new HighOrderFunctionArgInfo(false, $invoke_storage, $class_storage);
+            }
+        } catch (UnexpectedValueException $e) {
+            return null;
+        }
+
+        return null;
+    }
+}

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgHandler.php
@@ -78,6 +78,10 @@ final class HighOrderFunctionArgHandler
         HighOrderFunctionArgInfo $high_order_callable_info,
         ?TemplateResult $high_order_template_result
     ): void {
+        if ($high_order_callable_info->getType() === HighOrderFunctionArgInfo::TYPE_CALLABLE) {
+            return;
+        }
+
         $statements_analyzer->node_data->setType($arg_expr, TemplateInferredTypeReplacer::replace(
             $high_order_callable_info->getFunctionType(),
             $high_order_template_result ?? new TemplateResult([], []),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgHandler.php
@@ -154,7 +154,7 @@ final class HighOrderFunctionArgHandler
         StatementsAnalyzer $statements_analyzer,
         FunctionLikeParameter $container_param
     ): ?HighOrderFunctionArgInfo {
-        if (!$container_param->type || !$container_param->type->hasCallableType()) {
+        if (!self::isSupported($container_param)) {
             return null;
         }
 
@@ -279,6 +279,28 @@ final class HighOrderFunctionArgHandler
         }
 
         return null;
+    }
+
+    private static function isSupported(FunctionLikeParameter $container_param): bool
+    {
+        if (!$container_param->type || !$container_param->type->hasCallableType()) {
+            return false;
+        }
+
+        foreach ($container_param->type->getAtomicTypes() as $a) {
+            if (($a instanceof TClosure || $a instanceof TCallable) && !$a->params) {
+                return false;
+            }
+
+            if ($a instanceof Type\Atomic\TCallableArray ||
+                $a instanceof Type\Atomic\TCallableString ||
+                $a instanceof Type\Atomic\TCallableKeyedArray
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static function fromLiteralString(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgInfo.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgInfo.php
@@ -54,6 +54,11 @@ final class HighOrderFunctionArgInfo
         return new TemplateResult($templates, []);
     }
 
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
     public function getFunctionType(): Union
     {
         switch ($this->type) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgInfo.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgInfo.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Analyzer\Statements\Expression\Call;
+
+use Psalm\Internal\Type\TemplateResult;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\FunctionLikeStorage;
+use Psalm\Type;
+use Psalm\Type\Atomic\TCallable;
+use Psalm\Type\Atomic\TClosure;
+use Psalm\Type\Union;
+
+use function array_merge;
+
+/**
+ * @internal
+ */
+final class HighOrderFunctionArgInfo
+{
+    private bool $first_class_callable;
+    private FunctionLikeStorage $function_storage;
+    private ?ClassLikeStorage $class_storage;
+
+    public function __construct(
+        bool $first_class_callable,
+        FunctionLikeStorage $function_storage,
+        ClassLikeStorage $class_storage = null
+    ) {
+        $this->first_class_callable = $first_class_callable;
+        $this->function_storage = $function_storage;
+        $this->class_storage = $class_storage;
+    }
+
+    public function getTemplates(): TemplateResult
+    {
+        $templates = $this->class_storage
+            ? array_merge(
+                $this->function_storage->template_types ?? [],
+                $this->class_storage->template_types ?? [],
+            )
+            : $this->function_storage->template_types ?? [];
+
+        return new TemplateResult($templates, []);
+    }
+
+    public function isInvokableClassCallable(): bool
+    {
+        return null !== $this->class_storage;
+    }
+
+    public function isFirstClassCallable(): bool
+    {
+        return $this->first_class_callable;
+    }
+
+    public function getFunctionType(): Union
+    {
+        if ($this->isFirstClassCallable()) {
+            return $this->asFirstClassCallable();
+        }
+
+        if ($this->isInvokableClassCallable()) {
+            return $this->asInvokableClassCallable();
+        }
+
+        return $this->asHighOrderFunction();
+    }
+
+    public function asFirstClassCallable(): Union
+    {
+        return new Union([
+            new TClosure(
+                'Closure',
+                $this->function_storage->params,
+                $this->function_storage->return_type,
+                $this->function_storage->pure,
+            ),
+        ]);
+    }
+
+    public function asInvokableClassCallable(): Union
+    {
+        return new Union([
+            new TCallable(
+                'callable',
+                $this->function_storage->params,
+                $this->function_storage->return_type,
+                $this->function_storage->pure,
+            ),
+        ]);
+    }
+
+    public function asHighOrderFunction(): Union
+    {
+        return $this->function_storage->return_type ?? Type::getMixed();
+    }
+}

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -74,7 +74,8 @@ class NewAnalyzer extends CallAnalyzer
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\New_ $stmt,
-        Context $context
+        Context $context,
+        TemplateResult $template_result = null
     ): bool {
         $fq_class_name = null;
 
@@ -256,6 +257,7 @@ class NewAnalyzer extends CallAnalyzer
                     $fq_class_name,
                     $from_static,
                     $can_extend,
+                    $template_result,
                 );
             } else {
                 ArgumentsAnalyzer::analyze(
@@ -291,7 +293,8 @@ class NewAnalyzer extends CallAnalyzer
         Context $context,
         string $fq_class_name,
         bool $from_static,
-        bool $can_extend
+        bool $can_extend,
+        TemplateResult $template_result = null
     ): void {
         $storage = $codebase->classlike_storage_provider->get($fq_class_name);
 
@@ -392,7 +395,7 @@ class NewAnalyzer extends CallAnalyzer
                 );
             }
 
-            $template_result = new TemplateResult([], []);
+            $template_result ??= new TemplateResult([], []);
 
             if (self::checkMethodArgs(
                 $method_id,

--- a/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ExpressionAnalyzer.php
@@ -280,7 +280,7 @@ class ExpressionAnalyzer
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\New_) {
-            return NewAnalyzer::analyze($statements_analyzer, $stmt, $context);
+            return NewAnalyzer::analyze($statements_analyzer, $stmt, $context, $template_result);
         }
 
         if ($stmt instanceof PhpParser\Node\Expr\Array_) {

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -364,69 +364,163 @@ class CallableTest extends TestCase
                     '$result' => 'list<int>',
                 ],
             ],
-            'PipeTest' => [
+            'inferInvokableClassCallable' => [
                 'code' => '<?php
-                     /**
-                      * @template A
-                      * @template B
-                      */
-                     final class MapOperator
-                     {
-                         /**
-                          * @param Closure(A): B $ab
-                          */
-                         public function __construct(private Closure $ab) { }
+                    /**
+                     * @template A
+                     * @template B
+                     */
+                    final class MapOperator
+                    {
+                        /** @var Closure(A): B */
+                        private Closure $ab;
 
-                         /**
-                          * @param list<A> $a
-                          * @return list<B>
-                          */
-                         public function __invoke($a): array
-                         {
-                             $b = [];
+                        /**
+                         * @param callable(A): B $ab
+                         */
+                        public function __construct(callable $ab)
+                        {
+                            $this->ab = Closure::fromCallable($ab);
+                        }
 
-                             foreach ($a as $item) {
-                                 $b[] = ($this->ab)($item);
-                             }
+                        /**
+                         * @template K
+                         * @param array<K, A> $a
+                         * @return array<K, B>
+                         */
+                        public function __invoke(array $a): array
+                        {
+                            $b = [];
 
-                             return $b;
-                         }
-                     }
-                     /**
-                      * @template A
-                      * @template B
-                      *
-                      * @param Closure(A): B $ab
-                      * @return MapOperator<A, B>
-                      */
-                     function map(Closure $ab): MapOperator
-                     {
-                         return new MapOperator($ab);
-                     }
-                     /**
-                      * @template A
-                      * @template B
-                      *
-                      * @param A $_a
-                      * @param callable(A): B $_ab
-                      * @return B
-                      */
-                     function pipe(array $_a, callable $_ab): array
-                     {
-                         throw new RuntimeException("???");
-                     }
-                     $result1 = pipe(
-                         ["1", "2", "3"],
-                         map(fn ($i) => (int) $i)
-                     );
-                     $result2 = pipe(
-                         ["1", "2", "3"],
-                         new MapOperator(fn ($i) => (int) $i)
-                     );
-                 ',
+                            foreach ($a as $k => $v) {
+                                $b[$k] = ($this->ab)($v);
+                            }
+
+                            return $b;
+                        }
+                    }
+                    /**
+                     * @template A
+                     * @template B
+                     * @param A $a
+                     * @param callable(A): B $ab
+                     * @return B
+                     */
+                    function pipe(mixed $a, callable $ab): mixed
+                    {
+                        return $ab($a);
+                    }
+                    /**
+                     * @return array<string, int>
+                     */
+                    function getDict(): array
+                    {
+                        return ["fst" => 1, "snd" => 2, "thr" => 3];
+                    }
+                    $result = pipe(getDict(), new MapOperator(fn($i) => ["num" => $i]));
+                ',
                 'assertions' => [
-                    '$result1' => 'list<int>',
-                    '$result2' => 'list<int>',
+                    '$result' => 'array<string, array{num: int}>',
+                ],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'inferConstCallableLikeFirstClassCallable' => [
+                'code' => '<?php
+                    namespace Functions {
+                        use Closure;
+
+                        final class Module
+                        {
+                            const id = "Functions\Module::id";
+                            /**
+                             * @template A
+                             * @param A $value
+                             * @return A
+                             */
+                            public static function id(mixed $value): mixed
+                            {
+                                return $value;
+                            }
+                        }
+                        const classId = Module::id;
+                        const id = "Functions\id";
+                        /**
+                         * @template A
+                         * @param A $value
+                         * @return A
+                         */
+                        function id(mixed $value): mixed
+                        {
+                            return $value;
+                        }
+                        /**
+                         * @template A
+                         * @template B
+                         * @param callable(A): B $callback
+                         * @return Closure(list<A>): list<B>
+                         */
+                        function map(callable $callback): Closure
+                        {
+                            return fn(array $list) => array_map($callback, $list);
+                        }
+                        /**
+                         * @template A
+                         * @template B
+                         * @param A $a
+                         * @param callable(A): B $ab
+                         * @return B
+                         */
+                        function pipe1(mixed $a, callable $ab): mixed
+                        {
+                            return $ab($a);
+                        }
+                        /**
+                         * @template A
+                         * @template B
+                         * @template C
+                         * @param A $a
+                         * @param callable(A): B $ab
+                         * @param callable(B): C $bc
+                         * @return C
+                         */
+                        function pipe2(mixed $a, callable $ab, callable $bc): mixed
+                        {
+                            return $bc($ab($a));
+                        }
+                    }
+
+                    namespace App {
+                        use Functions\Module;
+                        use function Functions\map;
+                        use function Functions\pipe1;
+                        use function Functions\pipe2;
+                        use const Functions\classId;
+                        use const Functions\id;
+
+                        $class_const_id = pipe1([42], Module::id);
+                        $class_const_composition = pipe1([42], map(Module::id));
+                        $class_const_sequential = pipe2([42], map(fn($i) => ["num" => $i]), Module::id);
+
+                        $class_const_alias_id = pipe1([42], classId);
+                        $class_const_alias_composition = pipe1([42], map(classId));
+                        $class_const_alias_sequential = pipe2([42], map(fn($i) => ["num" => $i]), classId);
+
+                        $const_id = pipe1([42], id);
+                        $const_composition = pipe1([42], map(id));
+                        $const_sequential = pipe2([42], map(fn($i) => ["num" => $i]), id);
+                    }
+                ',
+                'assertions' => [
+                    '$class_const_id===' => 'list{42}',
+                    '$class_const_composition===' => 'list<42>',
+                    '$class_const_sequential===' => 'list<array{num: 42}>',
+                    '$class_const_alias_id===' => 'list{42}',
+                    '$class_const_alias_composition===' => 'list<42>',
+                    '$class_const_alias_sequential===' => 'list<array{num: 42}>',
+                    '$const_id===' => 'list{42}',
+                    '$const_composition===' => 'list<42>',
+                    '$const_sequential===' => 'list<array{num: 42}>',
                 ],
                 'ignored_issues' => [],
                 'php_version' => '8.0',
@@ -593,6 +687,50 @@ class CallableTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'inferFirstClassCallableWithGenericObject' => [
+                'code' => '<?php
+                    /**
+                     * @template A
+                     * @template B
+                     * @param A $a
+                     * @param callable(A): B $ab
+                     * @return B
+                     */
+                    function pipe($a, callable $ab)
+                    {
+                        return $ab($a);
+                    }
+                    /**
+                     * @template A
+                     * @psalm-immutable
+                     */
+                    final class Container
+                    {
+                        /** @param A $value */
+                        public function __construct(
+                            public readonly mixed $value,
+                        ) {}
+                    }
+                    /**
+                     * @template A
+                     * @param Container<A> $container
+                     * @return A
+                     */
+                    function unwrap(Container $container)
+                    {
+                        return $container->value;
+                    }
+                    $result = pipe(
+                        new Container(42),
+                        unwrap(...),
+                    );
+                ',
+                'assertions' => [
+                    '$result===' => '42',
+                ],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
             'inferFirstClassCallableOnMethodCall' => [
                 'code' => '<?php
                     /**
@@ -734,7 +872,7 @@ class CallableTest extends TestCase
                             private readonly mixed $param2,
                         ) {
                         }
-                    
+
                         /**
                          * @template T3
                          * @param callable(T1, T2): T3 $callback
@@ -745,7 +883,7 @@ class CallableTest extends TestCase
                             return $callback($this->param1, $this->param2);
                         }
                     }
-                    
+
                     /**
                      * @template T of int|float
                      * @param T $param2
@@ -755,7 +893,7 @@ class CallableTest extends TestCase
                     {
                         return ["param1" => $param1, "param2" => $param2];
                     }
-                    
+
                     /**
                      * @template T of int|float
                      * @param T $param1
@@ -765,7 +903,7 @@ class CallableTest extends TestCase
                     {
                         return ["param1" => $param1, "param2" => $param2];
                     }
-                    
+
                     /**
                      * @return array{param1: int, param2: int}
                      */
@@ -773,9 +911,9 @@ class CallableTest extends TestCase
                     {
                         return ["param1" => $param1, "param2" => $param2];
                     }
-                    
+
                     $app = new App(param1: 42, param2: 42);
-                    
+
                     $result1 = $app->run(appHandler1(...));
                     $result2 = $app->run(appHandler2(...));
                     $result3 = $app->run(appHandler3(...));

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -509,6 +509,14 @@ class CallableTest extends TestCase
                         $const_id = pipe1([42], id);
                         $const_composition = pipe1([42], map(id));
                         $const_sequential = pipe2([42], map(fn($i) => ["num" => $i]), id);
+
+                        $string_id = pipe1([42], "Functions\id");
+                        $string_composition = pipe1([42], map("Functions\id"));
+                        $string_sequential = pipe2([42], map(fn($i) => ["num" => $i]), "Functions\id");
+
+                        $class_string_id = pipe1([42], "Functions\Module::id");
+                        $class_string_composition = pipe1([42], map("Functions\Module::id"));
+                        $class_string_sequential = pipe2([42], map(fn($i) => ["num" => $i]), "Functions\Module::id");
                     }
                 ',
                 'assertions' => [
@@ -521,6 +529,12 @@ class CallableTest extends TestCase
                     '$const_id===' => 'list{42}',
                     '$const_composition===' => 'list<42>',
                     '$const_sequential===' => 'list<array{num: 42}>',
+                    '$string_id===' => 'list{42}',
+                    '$string_composition===' => 'list<42>',
+                    '$string_sequential===' => 'list<array{num: 42}>',
+                    '$class_string_id===' => 'list{42}',
+                    '$class_string_composition===' => 'list<42>',
+                    '$class_string_sequential===' => 'list<array{num: 42}>',
                 ],
                 'ignored_issues' => [],
                 'php_version' => '8.0',

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -2357,7 +2357,7 @@ class ClassTemplateTest extends TestCase
                         }
                     }
 
-                    /** @param ArrayCollection<int> $ints */
+                    /** @param ArrayCollection<int<0, max>> $ints */
                     function takesInts(ArrayCollection $ints) :void {}
 
                     /** @param ArrayCollection<int|string> $ints */

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -2363,7 +2363,10 @@ class ClassTemplateTest extends TestCase
                     /** @param ArrayCollection<int|string> $ints */
                     function takesIntsOrStrings(ArrayCollection $ints) :void {}
 
-                    takesInts((new ArrayCollection([ "a", "bc" ]))->map("strlen"));
+                    /** @return list<string> */
+                    function getList() :array {return [];}
+
+                    takesInts((new ArrayCollection(getList()))->map("strlen"));
 
                     /** @return ($s is "string" ? string : int) */
                     function foo(string $s) {
@@ -2373,7 +2376,7 @@ class ClassTemplateTest extends TestCase
                         return 5;
                     }
 
-                    takesIntsOrStrings((new ArrayCollection([ "a", "bc" ]))->map("foo"));
+                    takesIntsOrStrings((new ArrayCollection(getList()))->map("foo"));
 
                     /**
                      * @template T


### PR DESCRIPTION
Same as #9570 but for `const`.
Also I've extracted previously added functionality to separate class.