### PR TITLE
Preserve `non-empty-string` type when combining literal and numeric strings

### DIFF
--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -1051,19 +1051,25 @@ class TypeCombiner
             if (!isset($combination->value_types['string'])) {
                 if ($combination->strings) {
                     if ($type instanceof TNumericString) {
-                        $has_non_numeric_string = false;
+                        $has_only_numeric_strings = true;
+                        $has_only_non_empty_strings = true;
 
                         foreach ($combination->strings as $string_type) {
                             if (!is_numeric($string_type->value)) {
-                                $has_non_numeric_string = true;
-                                break;
+                                $has_only_numeric_strings = false;
+                            }
+
+                            if ($string_type->value === '') {
+                                $has_only_non_empty_strings = false;
                             }
                         }
 
-                        if ($has_non_numeric_string) {
-                            $combination->value_types['string'] = new TString();
-                        } else {
+                        if ($has_only_numeric_strings) {
                             $combination->value_types['string'] = $type;
+                        } elseif ($has_only_non_empty_strings) {
+                            $combination->value_types['string'] = new TNonEmptyString();
+                        } else {
+                            $combination->value_types['string'] = new TString();
                         }
                     } elseif ($type instanceof TLowercaseString) {
                         $has_non_lowercase_string = false;

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -2024,6 +2024,29 @@ class ArrayAssignmentTest extends TestCase
                     '$b===' => 'list{0, 1, 2}',
                 ],
             ],
+            'appendValuesToMap' => [
+                'code' => '<?php
+                    /**
+                     * @return array{foo:numeric-string}&array<non-empty-string,non-empty-string>
+                     */
+                    function defaultQueryParams(): array
+                    {
+                        return [
+                           "foo" => "123",
+                           "bar" => "baz",
+                        ];
+                    }
+
+                    /**
+                     * @return array<non-empty-string, non-empty-string>
+                     */
+                    function getQueryParams(): array
+                    {
+                        $queryParams = defaultQueryParams();
+                        $queryParams["a"] = "zzz";
+                        return $queryParams;
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #8787