### PR TITLE
fix: add missing constructor parameter to IteratorIterator

### DIFF
--- a/stubs/CoreGenericIterators.phpstub
+++ b/stubs/CoreGenericIterators.phpstub
@@ -114,7 +114,7 @@ class IteratorIterator implements OuterIterator {
     /**
      * @param TIterator $iterator
      */
-    public function __construct(Traversable $iterator) {}
+    public function __construct(Traversable $iterator, ?string $class = null) {}
 
     /**
      * @return TValue|null current value or null when iterator is drained


### PR DESCRIPTION
The second parameter exist since PHP 5.1 and wasn't present in the docs before. Even reflection wasn't showing this parameter until 8.0.

I was wondering about the reason for the existence of this parameter and with the help of @choult and [an old blog post](https://blog.ircmaxell.com/2011/10/iteratoriterator-php-inconsistencies.html) the reason for the `$class` parameter was made clear.