### PR TITLE
Fix list<T> template replacement

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -549,7 +549,6 @@
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$this->properties[0]]]></code>
       <code><![CDATA[$this->properties[0]]]></code>
-      <code><![CDATA[$this->properties[0]]]></code>
     </PossiblyUndefinedIntArrayOffset>
     <PossiblyUnusedMethod>
       <code>getList</code>

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -17,6 +17,35 @@ class FunctionCallTest extends TestCase
     public function providerValidCodeParse(): iterable
     {
         return [
+            'inferGenericListFromTuple' => [
+                'code' => '<?php
+                    /**
+                     * @template A
+                     * @param list<A> $list
+                     * @return list<A>
+                     */
+                    function testList(array $list): array { return $list; }
+                    /**
+                     * @template A
+                     * @param non-empty-list<A> $list
+                     * @return non-empty-list<A>
+                     */
+                    function testNonEmptyList(array $list): array { return $list; }
+                    /**
+                     * @template A of list<mixed>
+                     * @param A $list
+                     * @return A
+                     */
+                    function testGenericList(array $list): array { return $list; }
+                    $list = testList([1, 2, 3]);
+                    $nonEmptyList = testNonEmptyList([1, 2, 3]);
+                    $genericList = testGenericList([1, 2, 3]);',
+                'assertions' => [
+                    '$list===' => 'list<1|2|3>',
+                    '$nonEmptyList===' => 'non-empty-list<1|2|3>',
+                    '$genericList===' => 'list{1, 2, 3}',
+                ],
+            ],
             'countShapedArrays' => [
                 'code' => '<?php
                     /** @var array{a?: int} */


### PR DESCRIPTION
Currently `T` from `list<T>` incorrectly replaces from literal lists: https://psalm.dev/r/310b315ccc
Psalm infers `list<1>` instead `list<1|2|3>`. i.e. it takes first literal type and drops rest.
This PR fixes it.