### PR TITLE
Specify array share for `stream_context_get_params` return value

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -12891,7 +12891,7 @@ return [
 'stream_context_create' => ['resource', 'options='=>'?array', 'params='=>'?array'],
 'stream_context_get_default' => ['resource', 'options='=>'?array'],
 'stream_context_get_options' => ['array', 'stream_or_context'=>'resource'],
-'stream_context_get_params' => ['array', 'context'=>'resource'],
+'stream_context_get_params' => ['array{notification:string,options:array}', 'context'=>'resource'],
 'stream_context_set_default' => ['resource', 'options'=>'array'],
 'stream_context_set_option' => ['bool', 'context'=>'', 'wrapper_or_options'=>'string', 'option_name'=>'string', 'value'=>''],
 'stream_context_set_option\'1' => ['bool', 'context'=>'', 'wrapper_or_options'=>'array'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -14311,7 +14311,7 @@ return [
     'stream_context_create' => ['resource', 'options='=>'array', 'params='=>'array'],
     'stream_context_get_default' => ['resource', 'options='=>'array'],
     'stream_context_get_options' => ['array', 'stream_or_context'=>'resource'],
-    'stream_context_get_params' => ['array', 'context'=>'resource'],
+    'stream_context_get_params' => ['array{notification:string,options:array}', 'context'=>'resource'],
     'stream_context_set_default' => ['resource', 'options'=>'array'],
     'stream_context_set_option' => ['bool', 'context'=>'', 'wrapper_or_options'=>'string', 'option_name'=>'string', 'value'=>''],
     'stream_context_set_option\'1' => ['bool', 'context'=>'', 'wrapper_or_options'=>'array'],


### PR DESCRIPTION
Based on https://www.php.net/manual/en/function.stream-context-get-params.php docs, `#[ArrayShape(["notification" => "string", "options" => "array"])]` PHPStorm's attribute