### PR TITLE
Valid array access on a non-empty-string yields a non-empty-string

### DIFF
--- a/src/Psalm/Type/Atomic/TSingleLetter.php
+++ b/src/Psalm/Type/Atomic/TSingleLetter.php
@@ -7,6 +7,6 @@ namespace Psalm\Type\Atomic;
  *
  * @psalm-immutable
  */
-final class TSingleLetter extends TString
+final class TSingleLetter extends TNonEmptyString
 {
 }

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -524,6 +524,15 @@ class ArrayAccessTest extends TestCase
                         }
                     }',
             ],
+            'nonEmptyStringAccess' => [
+                'code' => '<?php
+                    /** @var non-empty-string $a */
+                    $a = "blah";
+                    $b = $a[0];',
+                'assertions' => [
+                    '$b===' => 'non-empty-string',
+                ],
+            ],
             'notEmptyStringOffset' => [
                 'code' => '<?php
                     /**


### PR DESCRIPTION
Fix for https://github.com/vimeo/psalm/issues/6482

Unsure if TSingleLetter provides more info than TNonEmptyString as it is technically a TNonEmptyString of size 1.
 TSingleLetter isn't exposed to userland (I don't think) so should be providing more information than is available currently.