### PR TITLE
Don't throw UnnecesseryVarAnnotation when hinting a mixed template var

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/ForeachAnalyzer.php
@@ -191,7 +191,7 @@ class ForeachAnalyzer
                     && $type_location
                     && isset($context->vars_in_scope[$var_comment->var_id])
                     && $context->vars_in_scope[$var_comment->var_id]->getId() === $comment_type->getId()
-                    && !$comment_type->isMixed()
+                    && !$comment_type->isMixed(true)
                 ) {
                     $project_analyzer = $statements_analyzer->getProjectAnalyzer();
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -270,7 +270,7 @@ class AssignmentAnalyzer
                 && $extended_var_id
                 && (!$not_ignored_docblock_var_ids || isset($not_ignored_docblock_var_ids[$extended_var_id]))
                 && $temp_assign_value_type->getId() === $comment_type->getId()
-                && !$comment_type->isMixed()
+                && !$comment_type->isMixed(true)
             ) {
                 if ($codebase->alter_code
                     && isset($statements_analyzer->getProjectAnalyzer()->getIssuesToFix()['UnnecessaryVarAnnotation'])

--- a/src/Psalm/Type/UnionTrait.php
+++ b/src/Psalm/Type/UnionTrait.php
@@ -52,6 +52,8 @@ use function reset;
 use function sort;
 use function strpos;
 
+use const ARRAY_FILTER_USE_BOTH;
+
 /**
  * @psalm-immutable
  * @psalm-import-type TProperties from Union
@@ -800,11 +802,13 @@ trait UnionTrait
         return count(
             array_filter(
                 $this->types,
-                static fn($type): bool => $type instanceof TMixed
+                static fn($type, $key): bool => $key === 'mixed'
+                    || $type instanceof TMixed
                     || ($check_templates
                         && $type instanceof TTemplateParam
                         && $type->as->isMixed()
-                    )
+                    ),
+                ARRAY_FILTER_USE_BOTH,
             ),
         ) === count($this->types);
     }

--- a/src/Psalm/Type/UnionTrait.php
+++ b/src/Psalm/Type/UnionTrait.php
@@ -795,9 +795,18 @@ trait UnionTrait
     /**
      * @psalm-mutation-free
      */
-    public function isMixed(): bool
+    public function isMixed(bool $check_templates = false): bool
     {
-        return isset($this->types['mixed']) && count($this->types) === 1;
+        return count(
+            array_filter(
+                $this->types,
+                static fn($type): bool => $type instanceof TMixed
+                    || ($check_templates
+                        && $type instanceof TTemplateParam
+                        && $type->as->isMixed()
+                    )
+            ),
+        ) === count($this->types);
     }
 
     /**

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -4112,6 +4112,32 @@ class ClassTemplateTest extends TestCase
                     '$t===' => '\'\'',
                 ],
             ],
+            'mixedAssignment' => [
+                'code' => '<?php
+                    /** @template T */
+                    abstract class Foo {
+                        /** @psalm-var T */
+                        protected $value;
+
+                        /** @psalm-param T $value */
+                        public function __construct($value)
+                        {
+                            /** @var T */
+                            $value = $this->normalize($value);
+                            $this->value = $value;
+                        }
+
+                        /**
+                         * @psalm-param T $value
+                         * @psalm-return T
+                         */
+                        protected function normalize($value)
+                        {
+                            return $value;
+                        }
+                    }
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fix for #6752, the snippet https://psalm.dev/r/8b76b19f48 no longer throws a warning.

Feels wrong to require the annotation but I guess there is no way of specifying `@tempate T of not-mixed` 