### PR TITLE
Add support for @psalm-no-seal-properties and @psalm-no-seal-methods

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -157,9 +157,10 @@ takesFoo(getFoo());
 
 This provides the same, but for `false`. Psalm uses this internally for functions like `preg_replace`, which can return false if the given input has encoding errors, but where 99.9% of the time the function operates as expected.
 
-### `@psalm-seal-properties`
+### `@psalm-seal-properties`, `@psalm-no-seal-properties`
 
 If you have a magic property getter/setter, you can use `@psalm-seal-properties` to instruct Psalm to disallow getting and setting any properties not contained in a list of `@property` (or `@property-read`/`@property-write`) annotations.
+This is automatically enabled with the configuration option `sealAllProperties` and can be disabled for a class with `@psalm-no-seal-properties`
 
 ```php
 <?php
@@ -179,6 +180,29 @@ class A {
 
 $a = new A();
 $a->bar = 5; // this call fails
+```
+
+### `@psalm-seal-methods`, `@psalm-no-seal-methods`
+
+If you have a magic method caller, you can use `@psalm-seal-methods` to instruct Psalm to disallow calling any methods not contained in a list of `@method` annotations.
+This is automatically enabled with the configuration option `sealAllMethods` and can be disabled for a class with `@psalm-no-seal-methods`
+
+```php
+<?php
+/**
+ * @method foo(): string
+ * @psalm-seal-methods
+ */
+class A {
+     public function __call(string $name, array $args) {
+          if ($name === "foo") {
+               return "hello";
+          }
+     }
+ }
+
+$a = new A();
+$b = $a->bar(); // this call fails
 ```
 
 ### `@psalm-internal`

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -24,6 +24,7 @@ final class DocComment
         'assert', 'assert-if-true', 'assert-if-false', 'suppress',
         'ignore-nullable-return', 'override-property-visibility',
         'override-method-visibility', 'seal-properties', 'seal-methods',
+        'no-seal-properties', 'no-seal-methods',
         'ignore-falsable-return', 'variadic', 'pure',
         'ignore-variable-method', 'ignore-variable-property', 'internal',
         'taint-sink', 'taint-source', 'assert-untainted', 'scope-this',

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -1087,7 +1087,7 @@ class InstancePropertyAssignmentAnalyzer
              * If we have an explicit list of all allowed magic properties on the class, and we're
              * not in that list, fall through
              */
-            if (!$var_id || !$class_storage->sealed_properties) {
+            if (!$var_id || !$class_storage->hasSealedProperties($codebase->config)) {
                 if (!$context->collect_initializations && !$context->collect_mutations) {
                     self::taintProperty(
                         $statements_analyzer,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -546,7 +546,7 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             case '__set':
                 // If `@psalm-seal-properties` is set, the property must be defined with
                 // a `@property` annotation
-                if (($class_storage->sealed_properties || $codebase->config->seal_all_properties)
+                if (($class_storage->hasSealedProperties($codebase->config))
                     && !isset($class_storage->pseudo_property_set_types['$' . $prop_name])
                 ) {
                     IssueBuffer::maybeAdd(
@@ -644,7 +644,7 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
             case '__get':
                 // If `@psalm-seal-properties` is set, the property must be defined with
                 // a `@property` annotation
-                if (($class_storage->sealed_properties || $codebase->config->seal_all_properties)
+                if (($class_storage->hasSealedProperties($codebase->config))
                     && !isset($class_storage->pseudo_property_get_types['$' . $prop_name])
                 ) {
                     IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -190,7 +190,7 @@ class MissingMethodCallHandler
                 $context,
             );
 
-            if ($class_storage->sealed_methods || $config->seal_all_methods) {
+            if ($class_storage->hasSealedMethods($config)) {
                 $result->non_existent_magic_method_ids[] = $method_id->__toString();
 
                 return null;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -702,7 +702,7 @@ class AtomicPropertyFetchAnalyzer
              * If we have an explicit list of all allowed magic properties on the class, and we're
              * not in that list, fall through
              */
-            if (!($class_storage->sealed_properties || $codebase->config->seal_all_properties)
+            if (!($class_storage->hasSealedProperties($codebase->config))
                 && !$override_property_visibility
             ) {
                 return false;

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -920,8 +920,8 @@ class Populator
         $fq_class_name = $storage->name;
         $fq_class_name_lc = strtolower($fq_class_name);
 
-        if ($parent_storage->sealed_methods) {
-            $storage->sealed_methods = true;
+        if ($parent_storage->sealed_methods !== null) {
+            $storage->sealed_methods = $parent_storage->sealed_methods;
         }
 
         // register where they appear (can never be in a trait)
@@ -1032,8 +1032,8 @@ class Populator
         ClassLikeStorage $storage,
         ClassLikeStorage $parent_storage
     ): void {
-        if ($parent_storage->sealed_properties) {
-            $storage->sealed_properties = true;
+        if ($parent_storage->sealed_properties !== null) {
+            $storage->sealed_properties = $parent_storage->sealed_properties;
         }
 
         // register where they appear (can never be in a trait)

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -241,9 +241,15 @@ class ClassLikeDocblockParser
         if (isset($parsed_docblock->tags['psalm-seal-properties'])) {
             $info->sealed_properties = true;
         }
+        if (isset($parsed_docblock->tags['psalm-no-seal-properties'])) {
+            $info->sealed_properties = false;
+        }
 
         if (isset($parsed_docblock->tags['psalm-seal-methods'])) {
             $info->sealed_methods = true;
+        }
+        if (isset($parsed_docblock->tags['psalm-no-seal-methods'])) {
+            $info->sealed_methods = false;
         }
 
         if (isset($parsed_docblock->tags['psalm-immutable'])
@@ -296,6 +302,9 @@ class ClassLikeDocblockParser
         }
 
         if (isset($parsed_docblock->combined_tags['method'])) {
+            if ($info->sealed_methods === null) {
+                $info->sealed_methods = true;
+            }
             foreach ($parsed_docblock->combined_tags['method'] as $offset => $method_entry) {
                 $method_entry = preg_replace('/[ \t]+/', ' ', trim($method_entry));
 
@@ -480,6 +489,13 @@ class ClassLikeDocblockParser
         }
 
         $info->public_api = isset($parsed_docblock->tags['psalm-api']) || isset($parsed_docblock->tags['api']);
+
+        if (isset($parsed_docblock->tags['property'])
+            && $codebase->config->docblock_property_types_seal_properties
+            && $info->sealed_properties === null
+        ) {
+            $info->sealed_properties = true;
+        }
 
         self::addMagicPropertyToInfo($comment, $info, $parsed_docblock->tags, 'property');
         self::addMagicPropertyToInfo($comment, $info, $parsed_docblock->tags, 'psalm-property');

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -577,10 +577,6 @@ class ClassLikeNodeScanner
                         );
                     }
                 }
-
-                if ($this->config->docblock_property_types_seal_properties) {
-                    $storage->sealed_properties = true;
-                }
             }
 
             foreach ($docblock_info->methods as $method) {
@@ -607,8 +603,6 @@ class ClassLikeNodeScanner
                         $lc_method_name,
                     );
                 }
-
-                $storage->sealed_methods = true;
             }
 
 

--- a/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
@@ -63,9 +63,9 @@ class ClassLikeDocblockComment
      */
     public array $methods = [];
 
-    public bool $sealed_properties = false;
+    public ?bool $sealed_properties = null;
 
-    public bool $sealed_methods = false;
+    public ?bool $sealed_methods = null;
 
     public bool $override_property_visibility = false;
 

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -4,6 +4,7 @@ namespace Psalm\Storage;
 
 use Psalm\Aliases;
 use Psalm\CodeLocation;
+use Psalm\Config;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\TypeAlias\ClassTypeAlias;
@@ -66,14 +67,14 @@ final class ClassLikeStorage implements HasAttributesInterface
     public $mixin_declaring_fqcln;
 
     /**
-     * @var bool
+     * @var ?bool
      */
-    public $sealed_properties = false;
+    public $sealed_properties = null;
 
     /**
-     * @var bool
+     * @var ?bool
      */
-    public $sealed_methods = false;
+    public $sealed_methods = null;
 
     /**
      * @var bool
@@ -499,5 +500,15 @@ final class ClassLikeStorage implements HasAttributesInterface
         }
 
         return $type_params;
+    }
+
+    public function hasSealedProperties(Config $config): bool
+    {
+        return $this->sealed_properties ?? $config->seal_all_properties;
+    }
+
+    public function hasSealedMethods(Config $config): bool
+    {
+        return $this->sealed_methods ?? $config->seal_all_methods;
     }
 }

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -1174,6 +1174,31 @@ class MagicMethodAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
+    public function testNoSealAllMethods(): void
+    {
+        Config::getInstance()->seal_all_methods = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /** @psalm-no-seal-properties */
+              class A {
+                public function __call(string $method, array $args) {}
+              }
+
+              class B extends A {}
+
+              $b = new B();
+              $b->foo();
+              ',
+        );
+
+        $error_message = 'UndefinedMagicMethod';
+        $this->expectException(CodeException::class);
+        $this->expectExceptionMessage($error_message);
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
     public function testSealAllMethodsWithFoo(): void
     {
         Config::getInstance()->seal_all_methods = true;

--- a/tests/MagicPropertyTest.php
+++ b/tests/MagicPropertyTest.php
@@ -1213,4 +1213,28 @@ class MagicPropertyTest extends TestCase
         $this->expectExceptionMessage($error_message);
         $this->analyzeFile('somefile.php', new Context());
     }
+
+    public function testNoSealAllProperties(): void
+    {
+        Config::getInstance()->seal_all_properties = true;
+        Config::getInstance()->seal_all_methods = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /** @psalm-no-seal-properties */
+              class A {
+                public function __get(string $name) {}
+              }
+
+              class B extends A {}
+
+              $b = new B();
+              /** @var string $result */
+              $result = $b->foo;
+              ',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
 }


### PR DESCRIPTION
Implements #2588, 

I don't like using `public ?bool $sealed_properties = null;` where

- `true` is explicitly or inherited @seal-properties
- `false` is explicitly or inherited @no-seal-properties
- `null` is unspecified so use the configuration setting

Also unsure what the best practice is for accessing `Config::getInstance()`