### PR TITLE
Fix is_object assertions on final classes

### DIFF
--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1609,11 +1609,7 @@ class SimpleAssertionReconciler extends Reconciler
                 && self::areIntersectionTypesAllowed($codebase, $type)
             ) {
                 $object_types[] = $type->addIntersectionType($assertion_type);
-                $redundant = false;
-            } elseif ($type instanceof TNamedObject
-                && $codebase->classlike_storage_provider->has($type->value)
-                && $codebase->classlike_storage_provider->get($type->value)->final
-            ) {
+                // This is wrong, a proper check for redundant object shape assertions should be added
                 $redundant = false;
             } elseif ($type->isObjectType()) {
                 $object_types[] = $type;

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1604,15 +1604,21 @@ class SimpleAssertionReconciler extends Reconciler
         $object_types = [];
         $redundant = true;
 
+        $assertion_type_is_intersectable_type = Type::isIntersectionType($assertion_type);
         foreach ($existing_var_atomic_types as $type) {
-            if (Type::isIntersectionType($assertion_type)
+            if ($assertion_type_is_intersectable_type
                 && self::areIntersectionTypesAllowed($codebase, $type)
             ) {
                 $object_types[] = $type->addIntersectionType($assertion_type);
-                // This is wrong, a proper check for redundant object shape assertions should be added
                 $redundant = false;
             } elseif ($type->isObjectType()) {
-                $object_types[] = $type;
+                if ($assertion_type_is_intersectable_type
+                    && !self::areIntersectionTypesAllowed($codebase, $type)
+                ) {
+                    $redundant = false;
+                } else {
+                    $object_types[] = $type;
+                }
             } elseif ($type instanceof TCallable) {
                 $callable_object = new TCallableObject($type->from_docblock, $type);
                 $object_types[] = $callable_object;

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1609,6 +1609,7 @@ class SimpleAssertionReconciler extends Reconciler
             if ($assertion_type_is_intersectable_type
                 && self::areIntersectionTypesAllowed($codebase, $type)
             ) {
+                /** @var TNamedObject|TTemplateParam|TIterable|TObjectWithProperties|TCallableObject $assertion_type */
                 $object_types[] = $type->addIntersectionType($assertion_type);
                 $redundant = false;
             } elseif ($type->isObjectType()) {

--- a/tests/TypeReconciliation/TypeTest.php
+++ b/tests/TypeReconciliation/TypeTest.php
@@ -1334,6 +1334,16 @@ class TypeTest extends TestCase
                     /** @param non-empty-array $a */
                     function expectNonEmptyArray(array $a): array { return $a; }',
             ],
+            'isObjectMakesObject' => [
+                'code' => '<?php
+
+                    final class test {}
+
+                    /** @var array|int|float|test|null */
+                    $a = null;
+                    if (\is_object($a)) {
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
They were broken by https://github.com/vimeo/psalm/pull/9656/files, this should fix them.

Even with this fix, not too sure the type reconciliation logic added in #9656 is entirely correct...