### PR TITLE
Replace `@template T as X` with `@template T of X` in documentation

### DIFF
--- a/docs/annotating_code/type_syntax/atomic_types.md
+++ b/docs/annotating_code/type_syntax/atomic_types.md
@@ -46,7 +46,7 @@ Atomic types are the basic building block of all type information used in Psalm.
     * [`key-of<T>`](utility_types.md#key-oft)
     * [`value-of<T>`](utility_types.md#value-oft)
     * [`properties-of<T>`](utility_types.md#properties-oft)
-    * [`class-string-map<T as Foo, T>`](utility_types.md#class-string-mapt-as-foo-t)
+    * [`class-string-map<T of Foo, T>`](utility_types.md#class-string-mapt-as-foo-t)
     * [`T[K]`](utility_types.md#tk)
     * [Type aliases](utility_types.md#type-aliases)
     * [Variable templates](utility_types.md#variable-templates)

--- a/docs/annotating_code/type_syntax/utility_types.md
+++ b/docs/annotating_code/type_syntax/utility_types.md
@@ -148,7 +148,7 @@ $b = asArray(new B);
 /** @psalm-trace $b */; // array{foo: string, bar: int, baz: float}
 ```
 
-## class-string-map&lt;T as Foo, T&gt;
+## class-string-map&lt;T of Foo, T&gt;
 
 Used to indicate an array where each value is equal an instance of the class string contained in the key:
 
@@ -166,11 +166,11 @@ class Foo {}
 class Bar extends Foo {}
 
 class A {
-  /** @var class-string-map<T as Foo, T> */
+  /** @var class-string-map<T of Foo, T> */
   private static array $map = [];
 
   /**
-   * @template U as Foo
+   * @template U of Foo
    * @param class-string<U> $class
    * @return U
    */
@@ -191,7 +191,7 @@ $bar = A::get(Bar::class);
 /** @psalm-trace $bar */; // Bar
 ```
 
-If we had used an `array<class-string<Foo>, Foo>` instead of a `class-string-map<T as Foo, T>` in the above example, we would've gotten some false positive `InvalidReturnStatement` issues, caused by the lack of a type assertion inside the `isset`.  
+If we had used an `array<class-string<Foo>, Foo>` instead of a `class-string-map<T of Foo, T>` in the above example, we would've gotten some false positive `InvalidReturnStatement` issues, caused by the lack of a type assertion inside the `isset`.  
 On the other hand, when using `class-string-map`, Psalm assumes that the value obtained by using a key `class-string<T>` is always equal to `T`.  
 
 Unbounded templates can also be used for unrelated classes:
@@ -250,8 +250,8 @@ Used to get the value corresponding to the specified key:
 <?php
 
 /**
- * @template T as array
- * @template TKey as string
+ * @template T of array
+ * @template TKey of string
  * @param T $arr
  * @param TKey $k
  * @return T[TKey]
@@ -325,9 +325,9 @@ Variable templates allow directly using variables instead of template types, for
 <?php
 
 /**
- * @template TA as string
- * @template TB as string
- * @template TChoose as bool
+ * @template TA of string
+ * @template TB of string
+ * @template TChoose of bool
  * @param TA $a
  * @param TB $b
  * @param TChoose $choose


### PR DESCRIPTION
According to https://github.com/vimeo/psalm/commit/1986c8b4a8018b1819bc4b83b0f7e69c2c936792#r108961921, `as` is an alias to `of`. However, only `of` is documented (in docs/annotating_code/templated_annotations.md). That caused me confusion reading this.

I think as long as the alias is not documented, it's better to not use it in the docs. Even if it was documented, it would probably be better to not use aliases to avoid confusion.