### PR TITLE
Handle included directory paths without crashing

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1139,6 +1139,11 @@ class ProjectAnalyzer
         return $this->file_provider->fileExists($file_path);
     }
 
+    public function isDirectory(string $file_path): bool
+    {
+        return $this->file_provider->isDirectory($file_path);
+    }
+
     public function alterCodeAfterCompletion(
         bool $dry_run = false,
         bool $safe_types = false

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -158,7 +158,8 @@ class IncludeAnalyzer
 
             $current_file_analyzer = $statements_analyzer->getFileAnalyzer();
 
-            if ($current_file_analyzer->project_analyzer->fileExists($path_to_file)) {
+            if ($current_file_analyzer->project_analyzer->fileExists($path_to_file)
+                && !$current_file_analyzer->project_analyzer->isDirectory($path_to_file)) {
                 if ($statements_analyzer->hasParentFilePath($path_to_file)
                     || !$codebase->file_storage_provider->has($path_to_file)
                     || ($statements_analyzer->hasAlreadyRequiredFilePath($path_to_file)

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -291,6 +291,7 @@ class Scanner
     private function shouldScan(string $file_path): bool
     {
         return $this->file_provider->fileExists($file_path)
+            && !$this->file_provider->isDirectory($file_path)
             && (!isset($this->scanned_files[$file_path])
                 || (isset($this->files_to_deep_scan[$file_path]) && !$this->scanned_files[$file_path]));
     }

--- a/src/Psalm/Internal/Provider/FakeFileProvider.php
+++ b/src/Psalm/Internal/Provider/FakeFileProvider.php
@@ -20,9 +20,19 @@ class FakeFileProvider extends FileProvider
      */
     public array $fake_file_times = [];
 
+    /**
+     * @var array<string, true>
+     */
+    public array $fake_directories = [];
+
     public function fileExists(string $file_path): bool
     {
         return isset($this->fake_files[$file_path]) || parent::fileExists($file_path);
+    }
+
+    public function isDirectory(string $file_path): bool
+    {
+        return isset($this->fake_directories[$file_path]) || parent::isDirectory($file_path);
     }
 
     /** @psalm-external-mutation-free */

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -145,6 +145,11 @@ class FileProvider
         return file_exists($file_path);
     }
 
+    public function isDirectory(string $file_path): bool
+    {
+        return is_dir($file_path);
+    }
+
     /**
      * @param array<string> $file_extensions
      * @param null|callable(string):bool $filter

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -58,11 +58,13 @@ class IncludeTest extends TestCase
      * @dataProvider providerTestInvalidIncludes
      * @param array<int, string> $files_to_check
      * @param array<string, string> $files
+     * @param list<string> $directories
      */
     public function testInvalidInclude(
         array $files,
         array $files_to_check,
-        string $error_message
+        string $error_message,
+        array $directories = []
     ): void {
         if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
@@ -77,6 +79,10 @@ class IncludeTest extends TestCase
 
         foreach ($files_to_check as $file_path) {
             $codebase->addFilesToAnalyze([$file_path => $file_path]);
+        }
+
+        foreach ($directories as $directory) {
+            $this->file_provider->fake_directories[$directory] = true;
         }
 
         $config = $codebase->config;
@@ -650,7 +656,12 @@ class IncludeTest extends TestCase
     }
 
     /**
-     * @return array<string,array{files:array<string,string>,files_to_check:array<int,string>,error_message:string}>
+     * @return array<string,array{
+     *     files: array<string,string>,
+     *     files_to_check: array<int,string>,
+     *     error_message: string,
+     *     directories?: list<string>
+     * }>
      */
     public function providerTestInvalidIncludes(): array
     {
@@ -910,6 +921,17 @@ class IncludeTest extends TestCase
                     getcwd() . DIRECTORY_SEPARATOR . 'a' . DIRECTORY_SEPARATOR . 'test_2.php',
                 ],
                 'error_message' => 'MissingFile',
+            ],
+            'directoryPath' => [
+                'files' => [
+                    getcwd() . DIRECTORY_SEPARATOR . 'test.php' => '<?php
+                        // empty require resolves to a directory
+                        require "";
+                        ',
+                ],
+                'files_to_check' => [getcwd() . DIRECTORY_SEPARATOR . 'test.php'],
+                'error_message' => 'MissingFile',
+                'directories' => [getcwd() . DIRECTORY_SEPARATOR],
             ],
         ];
     }


### PR DESCRIPTION
If an include or require resolves to a directory, we now raise a `MissingFile` error rather than throwing an unhandled `UnexpectedValueException`.

Fixes #9639.