### PR TITLE
Fix UnevaluatedCode false positive at declare(strict_types=1)

### DIFF
--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -496,6 +496,7 @@ class StatementsAnalyzer extends SourceAnalyzer
             && !($stmt instanceof PhpParser\Node\Stmt\Interface_)
             && !($stmt instanceof PhpParser\Node\Stmt\Trait_)
             && !($stmt instanceof PhpParser\Node\Stmt\HaltCompiler)
+            && !($stmt instanceof PhpParser\Node\Stmt\Declare_)
         ) {
             if ($codebase->find_unused_variables) {
                 IssueBuffer::maybeAdd(


### PR DESCRIPTION
I can't reproduce it at psalm.dev and can't write useful test. But locally I see `UnevaluatedCode` on namespaced files without classes:

![image](https://user-images.githubusercontent.com/34217190/234980343-f6016d94-fec4-4ee2-b553-885b9f01b9d3.png)

https://psalm.dev/r/59e04972a3 (no errors, but actually there is)