### PR TITLE
Opt-in unconstrained templates widening

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -34,6 +34,7 @@
         <xs:attribute name="phpVersion" type="xs:string" />
         <xs:attribute name="serializer" type="xs:string" />
 
+        <xs:attribute name="widenUnconstrainedTemplates" type="xs:boolean" default="false" />
         <xs:attribute name="addParamDefaultToDocblockType" type="xs:boolean" default="false" />
         <xs:attribute name="allowFileIncludes" type="xs:boolean" default="true" />
         <xs:attribute name="allowStringToStandInForClass" type="xs:boolean" default="false" />

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -713,6 +713,44 @@ any explicit references to them in your code. You should mark these classes with
 class UnreferencedClass {}
 ```
 
+### `@psalm-widen-unconstrained-templates`, `@psalm-narrow-unconstrained-templates`
+
+These annotations allow to control widening/narrowing unconstrained template parameters.
+
+```php
+<?php
+/**
+ * @template T
+ * @param T $value
+ * @return T
+ * @psalm-widen-unconstrained-templates
+ */
+function widen(mixed $value): mixed
+{
+    return $value;
+}
+
+/**
+ * @template T
+ * @param T $value
+ * @return T
+ * @psalm-narrow-unconstrained-templates
+ */
+function narrow(mixed $value): mixed
+{
+    return $value;
+}
+
+$int = widen(42);
+/** @psalm-check-type-exact $int = int */
+
+$literalInt = narrow(42);
+/** @psalm-check-type-exact $literalInt = 42 */
+```
+
+How to Psalm behaves with the unconstrained template depends
+on the [widenUnconstrainedTemplates](../running_psalm/configuration.md#widenunconstrainedtemplates) config parameter.
+
 ## Type Syntax
 
 Psalm supports PHPDoc’s [type syntax](https://docs.phpdoc.org/latest/guide/guides/types.html), and also the [proposed PHPDoc PSR type syntax](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types).

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -444,6 +444,85 @@ Arrays bigger than this value (100 by default) will be transformed in a generic 
 
 Please note that changing this setting might introduce unwanted side effects and those side effects won't be considered as bugs.  
 
+#### widenUnconstrainedTemplates
+```xml
+<psalm
+  widenUnconstrainedTemplates="true"
+>
+```
+It controls the replacement of unconstrained template parameters. By default `false`.
+Normally, Psalm tries to infer most specific type from usage:
+
+```php
+/**
+ * @template T
+ * @param T $value
+ * @return T 
+ */
+function id(mixed $value): mixed
+{
+    return $value;
+}
+
+// $int type is 42
+$int = id(42);
+
+// $list type is list{1, 2, 3}
+$list = id([1, 2, 3]);
+
+// $array type is array{fst: 1, snd: 2, thr: 3}
+$array = id(['fst' => 1, 'snd' => 2, 'thr' => 3]);
+```
+
+But with enabled `widenUnconstrainedTemplates` the inference will be less specific:
+
+```php
+/**
+ * @template T
+ * @param T $value
+ * @return T 
+ */
+function id(mixed $value): mixed
+{
+    return $value;
+}
+
+// $int type is int
+$int = id(42);
+
+// $list type is non-empty-list<int>
+$list = id([1, 2, 3]);
+
+// $array type is non-empty-array<non-empty-string, int>
+$array = id(['fst' => 1, 'snd' => 2, 'thr' => 3]);
+```
+
+Regardless of the `widenUnconstrainedTemplates` Psalm continues to infer most specific type for constrained templates:
+
+```php
+/**
+ * @template T of scalar|array
+ * @param T $value
+ * @return T 
+ */
+function id(mixed $value): mixed
+{
+    return $value;
+}
+
+// $int type is int
+$int = id(42);
+
+// $list type is non-empty-list<int>
+$list = id([1, 2, 3]);
+
+// $array type is non-empty-array<non-empty-string, int>
+$array = id(['fst' => 1, 'snd' => 2, 'thr' => 3]);
+```
+
+Also, you can control inference with `@psalm-widen-unconstrained-templates`/`@psalm-narrow-unconstrained-templates` annotations.
+See more [here](../annotating_code/supported_annotations.md#psalm-widen-unconstrained-templates-psalm-narrow-unconstrained-templates)
+
 #### restrictReturnTypes
 
 ```xml

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -434,6 +434,11 @@ class Config
     /**
      * @var bool
      */
+    public $widen_unconstrained_templates = false;
+
+    /**
+     * @var bool
+     */
     public $ensure_array_string_offsets_exist = false;
 
     /**
@@ -1054,6 +1059,7 @@ class Config
         $config_xml = simplexml_import_dom($dom_document);
 
         $booleanAttributes = [
+            'widenUnconstrainedTemplates' => 'widen_unconstrained_templates',
             'useDocblockTypes' => 'use_docblock_types',
             'useDocblockPropertyTypes' => 'use_docblock_property_types',
             'docblockPropertyTypesSealProperties' => 'docblock_property_types_seal_properties',

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -33,7 +33,7 @@ final class DocComment
         'taint-unescape', 'self-out', 'consistent-constructor', 'stub-override',
         'require-extends', 'require-implements', 'param-out', 'ignore-var',
         'consistent-templates', 'if-this-is', 'this-out', 'check-type', 'check-type-exact',
-        'api',
+        'api', 'widen-unconstrained-templates', 'narrow-unconstrained-templates',
     ];
 
     /**

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -270,6 +270,14 @@ class ClassLikeDocblockParser
             $info->override_method_visibility = true;
         }
 
+        if (isset($parsed_docblock->tags['psalm-widen-unconstrained-templates'])) {
+            $info->widen_unconstrained_templates = 'widen';
+        }
+
+        if (isset($parsed_docblock->tags['psalm-narrow-unconstrained-templates'])) {
+            $info->widen_unconstrained_templates = 'narrow';
+        }
+
         if (isset($parsed_docblock->tags['psalm-suppress'])) {
             foreach ($parsed_docblock->tags['psalm-suppress'] as $offset => $suppress_entry) {
                 foreach (DocComment::parseSuppressList($suppress_entry) as $issue_offset => $suppressed_issue) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -692,6 +692,8 @@ class ClassLikeNodeScanner
             $storage->override_property_visibility = $docblock_info->override_property_visibility;
             $storage->override_method_visibility = $docblock_info->override_method_visibility;
 
+            $storage->widen_unconstrained_templates = $docblock_info->widen_unconstrained_templates;
+
             $storage->suppressed_issues = $docblock_info->suppressed_issues;
 
             if ($docblock_info->description) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -555,6 +555,14 @@ class FunctionLikeDocblockParser
             $info->description = $parsed_docblock->description;
         }
 
+        if (isset($parsed_docblock->tags['psalm-widen-unconstrained-templates'])) {
+            $info->widen_unconstrained_templates = 'widen';
+        }
+
+        if (isset($parsed_docblock->tags['psalm-narrow-unconstrained-templates'])) {
+            $info->widen_unconstrained_templates = 'narrow';
+        }
+
         $info->public_api = isset($parsed_docblock->tags['psalm-api']) || isset($parsed_docblock->tags['api']);
 
         return $info;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -171,6 +171,8 @@ class FunctionLikeDocblockScanner
             );
         }
 
+        $storage->widen_unconstrained_templates = $docblock_info->widen_unconstrained_templates;
+
         $storage->suppressed_issues = $docblock_info->suppressed_issues;
 
         foreach ($docblock_info->throws as [$throw, $offset, $line]) {

--- a/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
@@ -103,4 +103,7 @@ class ClassLikeDocblockComment
     public ?string $description = null;
 
     public bool $public_api = false;
+
+    /** @var 'widen'|'narrow'|null */
+    public ?string $widen_unconstrained_templates = null;
 }

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -176,4 +176,7 @@ class FunctionDocblockComment
     public array $unexpected_tags = [];
 
     public bool $public_api = false;
+
+    /** @var 'widen'|'narrow'|null */
+    public ?string $widen_unconstrained_templates = null;
 }

--- a/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
@@ -136,36 +136,33 @@ class GenericTypeComparator
                 && !$container_type_part instanceof TIterable
                 && !$container_param->hasTemplate()
                 && !$input_param->hasTemplate()
+                && !($container_type_params_covariant[$i] ?? false)
             ) {
-                if ($input_param->containsAnyLiteral()) {
+                if ($input_param->containsAnyLiteral() || $input_param->containsAnyNonEmptiness()) {
                     if ($atomic_comparison_result_type_params !== null) {
                         $atomic_comparison_result_type_params[$i] = $container_param;
                     }
-                } else {
-                    if (!($container_type_params_covariant[$i] ?? false)
-                        && !$container_param->had_template
+                } elseif (!$container_param->had_template) {
+                    // Make sure types are basically the same
+                    if (!UnionTypeComparator::isContainedBy(
+                        $codebase,
+                        $container_param,
+                        $input_param,
+                        $container_param->ignore_nullable_issues,
+                        $container_param->ignore_falsable_issues,
+                        $param_comparison_result,
+                        $allow_interface_equality,
+                    ) || $param_comparison_result->type_coerced
                     ) {
-                        // Make sure types are basically the same
-                        if (!UnionTypeComparator::isContainedBy(
-                            $codebase,
-                            $container_param,
-                            $input_param,
-                            $container_param->ignore_nullable_issues,
-                            $container_param->ignore_falsable_issues,
-                            $param_comparison_result,
-                            $allow_interface_equality,
-                        ) || $param_comparison_result->type_coerced
+                        if ($container_param->hasStaticObject()
+                            && $input_param->isStaticObject()
                         ) {
-                            if ($container_param->hasStaticObject()
-                                && $input_param->isStaticObject()
-                            ) {
-                                // do nothing
-                            } else {
-                                $all_types_contain = false;
+                            // do nothing
+                        } else {
+                            $all_types_contain = false;
 
-                                if ($atomic_comparison_result) {
-                                    $atomic_comparison_result->type_coerced = false;
-                                }
+                            if ($atomic_comparison_result) {
+                                $atomic_comparison_result->type_coerced = false;
                             }
                         }
                     }

--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -24,6 +24,7 @@ use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNonEmptyLowercaseString;
 use Psalm\Type\Atomic\TNonEmptyNonspecificLiteralString;
+use Psalm\Type\Atomic\TNonEmptyScalar;
 use Psalm\Type\Atomic\TNonEmptyString;
 use Psalm\Type\Atomic\TNonFalsyString;
 use Psalm\Type\Atomic\TNonspecificLiteralInt;
@@ -272,6 +273,10 @@ class ScalarTypeComparator
                 $atomic_comparison_result->scalar_type_match_found = !$container_type_part->from_docblock;
             }
 
+            return false;
+        }
+
+        if ($container_type_part instanceof TNonEmptyScalar && $input_type_part instanceof Scalar) {
             return false;
         }
 

--- a/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
@@ -890,7 +890,12 @@ class TemplateStandinTypeReplacer
                             [$param_name_key]
                             [$atomic_type->defining_class]
                             [] = new TemplateBound(
-                                $generic_param,
+                                TypeWidener::widenIfTemplateUnconstrained(
+                                    $atomic_type,
+                                    $generic_param,
+                                    $codebase,
+                                    $statements_analyzer,
+                                ),
                                 $depth,
                                 $input_arg_offset,
                                 $bound_equality_classlike,
@@ -899,7 +904,12 @@ class TemplateStandinTypeReplacer
                 } else {
                     $template_result->lower_bounds[$param_name_key][$atomic_type->defining_class] = [
                         new TemplateBound(
-                            $generic_param,
+                            TypeWidener::widenIfTemplateUnconstrained(
+                                $atomic_type,
+                                $generic_param,
+                                $codebase,
+                                $statements_analyzer,
+                            ),
                             $depth,
                             $input_arg_offset,
                             $bound_equality_classlike,

--- a/src/Psalm/Internal/Type/TypeWidener.php
+++ b/src/Psalm/Internal/Type/TypeWidener.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Type;
+
+use Psalm\Codebase;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\MethodIdentifier;
+use Psalm\Type;
+use Psalm\Type\Atomic;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TBool;
+use Psalm\Type\Atomic\TCallableObject;
+use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TFloat;
+use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TIntRange;
+use Psalm\Type\Atomic\TIterable;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TLiteralFloat;
+use Psalm\Type\Atomic\TLiteralInt;
+use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNonEmptyArray;
+use Psalm\Type\Atomic\TNonEmptyString;
+use Psalm\Type\Atomic\TObjectWithProperties;
+use Psalm\Type\Atomic\TString;
+use Psalm\Type\Atomic\TTemplateParam;
+use Psalm\Type\Atomic\TTrue;
+use Psalm\Type\Union;
+use Throwable;
+
+use function array_map;
+use function strlen;
+use function strpos;
+use function strtolower;
+use function substr;
+
+/**
+ * @internal
+ */
+final class TypeWidener
+{
+    public static function widenIfTemplateUnconstrained(
+        TTemplateParam $template,
+        Union $type,
+        Codebase $codebase,
+        ?StatementsAnalyzer $statements_analyzer
+    ): Union {
+        return $template->as->isMixed() && self::shouldWidenTemplate($template, $codebase, $statements_analyzer)
+            ? self::widenUnion($type)
+            : $type;
+    }
+
+    public static function widenUnion(Union $type): Union
+    {
+        $without_literals = array_map(
+            fn(Atomic $atomic) => self::widenAtomic($atomic),
+            $type->getAtomicTypes(),
+        );
+
+        return $type->setTypes($without_literals);
+    }
+
+    public static function widenAtomic(Atomic $atomic): Atomic
+    {
+        if ($atomic instanceof TTrue || $atomic instanceof TFalse) {
+            return new TBool($atomic->from_docblock);
+        }
+
+        if ($atomic instanceof TLiteralInt || $atomic instanceof TIntRange) {
+            return new TInt($atomic->from_docblock);
+        }
+
+        if ($atomic instanceof TLiteralString) {
+            return $atomic->value === ''
+                ? new TString($atomic->from_docblock)
+                : new TNonEmptyString($atomic->from_docblock);
+        }
+
+        if ($atomic instanceof TLiteralFloat) {
+            return new TFloat($atomic->from_docblock);
+        }
+
+        if ($atomic instanceof TKeyedArray) {
+            if ($atomic->is_list) {
+                $value_type = self::widenUnion($atomic->getGenericValueType());
+
+                return $atomic->isNonEmpty()
+                    ? Type::getNonEmptyListAtomic($value_type, $atomic->from_docblock)
+                    : Type::getListAtomic($value_type, $atomic->from_docblock);
+            }
+
+            $type_params = self::widenTypeParams([
+                $atomic->getGenericKeyType(),
+                $atomic->getGenericValueType(),
+            ]);
+
+            if ($atomic->isNonEmpty()) {
+                return new TNonEmptyArray(
+                    $type_params,
+                    null,
+                    null,
+                    'non-empty-array',
+                    $atomic->from_docblock,
+                );
+            }
+
+            return new TArray($type_params, $atomic->from_docblock);
+        }
+
+        if ($atomic instanceof TGenericObject) {
+            return new TGenericObject(
+                $atomic->value,
+                self::widenTypeParams($atomic->type_params),
+                $atomic->remapped_params,
+                $atomic->is_static,
+                self::widenExtraTypes($atomic->extra_types),
+                $atomic->from_docblock,
+            );
+        }
+
+        if ($atomic instanceof TNamedObject) {
+            return new TNamedObject(
+                $atomic->value,
+                $atomic->is_static,
+                $atomic->definite_class,
+                self::widenExtraTypes($atomic->extra_types),
+                $atomic->from_docblock,
+            );
+        }
+
+        if ($atomic instanceof TObjectWithProperties) {
+            return new TObjectWithProperties(
+                self::widenTypeParams($atomic->properties),
+                $atomic->methods,
+                self::widenExtraTypes($atomic->extra_types),
+            );
+        }
+
+        if ($atomic instanceof TIterable) {
+            return new TIterable(
+                self::widenTypeParams($atomic->type_params),
+                self::widenExtraTypes($atomic->extra_types),
+                $atomic->from_docblock,
+            );
+        }
+
+        if ($atomic instanceof TNonEmptyArray) {
+            return new TNonEmptyArray(
+                self::widenTypeParams($atomic->type_params),
+                $atomic->count,
+                $atomic->min_count,
+                'non-empty-array',
+                $atomic->from_docblock,
+            );
+        }
+
+        if ($atomic instanceof TArray) {
+            return new TArray(
+                self::widenTypeParams($atomic->type_params),
+                $atomic->from_docblock,
+            );
+        }
+
+        return $atomic;
+    }
+
+    private static function shouldWidenTemplate(
+        TTemplateParam $template,
+        Codebase $codebase,
+        ?StatementsAnalyzer $statements_analyzer
+    ): bool {
+        $should_widen = static function (?string $type = null) use ($codebase): bool {
+            switch ($type) {
+                case 'widen':
+                    return true;
+                case 'narrow':
+                    return false;
+                default:
+                    return $codebase->config->widen_unconstrained_templates;
+            }
+        };
+
+        try {
+            if (strpos($template->defining_class, 'fn-') === 0) {
+                /** @var non-empty-string */
+                $function_like_id = substr($template->defining_class, strlen('fn-'));
+
+                if (MethodIdentifier::isValidMethodIdReference($function_like_id)) {
+                    $method_id = MethodIdentifier::wrap($function_like_id);
+                    $declaring_method_id = $codebase->methods->getDeclaringMethodId($method_id);
+
+                    return $should_widen(
+                        $codebase->methods
+                            ->getStorage($declaring_method_id ?? $method_id)
+                            ->widen_unconstrained_templates,
+                    );
+                }
+
+                return $should_widen(
+                    $codebase->functions
+                        ->getStorage($statements_analyzer, strtolower($function_like_id))
+                        ->widen_unconstrained_templates,
+                );
+            }
+
+            return $should_widen(
+                $codebase->classlike_storage_provider
+                    ->get($template->defining_class)
+                    ->widen_unconstrained_templates,
+            );
+        } catch (Throwable $e) {
+            return $should_widen();
+        }
+    }
+
+    /**
+     * @param array<string, TNamedObject|TTemplateParam|TIterable|TObjectWithProperties|TCallableObject> $extra_types
+     * @return array<string, TNamedObject|TTemplateParam|TIterable|TObjectWithProperties|TCallableObject>
+     */
+    private static function widenExtraTypes(array $extra_types): array
+    {
+        /** @var array<string, TNamedObject|TTemplateParam|TIterable|TObjectWithProperties|TCallableObject> */
+        return array_map(
+            fn(Atomic $intersection) => self::widenAtomic($intersection),
+            $extra_types,
+        );
+    }
+
+    /**
+     * @template TTypeParams of Union[]
+     * @param TTypeParams $type_params
+     * @return TTypeParams
+     */
+    private static function widenTypeParams(array $type_params): array
+    {
+        /** @var TTypeParams */
+        return array_map(
+            fn(Union $type_param) => self::widenUnion($type_param),
+            $type_params,
+        );
+    }
+}

--- a/src/Psalm/Internal/TypeVisitor/ContainsLiteralVisitor.php
+++ b/src/Psalm/Internal/TypeVisitor/ContainsLiteralVisitor.php
@@ -4,6 +4,7 @@ namespace Psalm\Internal\TypeVisitor;
 
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
@@ -26,6 +27,11 @@ class ContainsLiteralVisitor extends TypeVisitor
             || $type instanceof TTrue
             || $type instanceof TFalse
         ) {
+            $this->contains_literal = true;
+            return self::STOP_TRAVERSAL;
+        }
+
+        if ($type instanceof TKeyedArray && !$type->isGenericList()) {
             $this->contains_literal = true;
             return self::STOP_TRAVERSAL;
         }

--- a/src/Psalm/Internal/TypeVisitor/ContainsNonEmptinessVisitor.php
+++ b/src/Psalm/Internal/TypeVisitor/ContainsNonEmptinessVisitor.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\TypeVisitor;
+
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TNonEmptyArray;
+use Psalm\Type\Atomic\TNonEmptyScalar;
+use Psalm\Type\Atomic\TNonEmptyString;
+use Psalm\Type\TypeNode;
+use Psalm\Type\TypeVisitor;
+
+/**
+ * @internal
+ */
+final class ContainsNonEmptinessVisitor extends TypeVisitor
+{
+    private bool $contains_non_emptiness = false;
+
+    protected function enterNode(TypeNode $type): ?int
+    {
+        if ($type instanceof TNonEmptyString
+            || $type instanceof TNonEmptyScalar
+            || $type instanceof TNonEmptyArray
+        ) {
+            $this->contains_non_emptiness = true;
+            return self::STOP_TRAVERSAL;
+        }
+
+        if ($type instanceof TKeyedArray && $type->isNonEmpty()) {
+            $this->contains_non_emptiness = true;
+            return self::STOP_TRAVERSAL;
+        }
+
+        return null;
+    }
+
+    public function matches(): bool
+    {
+        return $this->contains_non_emptiness;
+    }
+}

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -86,6 +86,11 @@ final class ClassLikeStorage implements HasAttributesInterface
     public $override_method_visibility = false;
 
     /**
+     * @var 'widen'|'narrow'|null
+     */
+    public $widen_unconstrained_templates = null;
+
+    /**
      * @var array<int, string>
      */
     public $suppressed_issues = [];

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -65,6 +65,11 @@ abstract class FunctionLikeStorage implements HasAttributesInterface
     public $cased_name;
 
     /**
+     * @var 'widen'|'narrow'|null
+     */
+    public $widen_unconstrained_templates = null;
+
+    /**
      * @var array<int, string>
      */
     public $suppressed_issues = [];

--- a/src/Psalm/Type/UnionTrait.php
+++ b/src/Psalm/Type/UnionTrait.php
@@ -9,6 +9,7 @@ use Psalm\Internal\TypeVisitor\CanContainObjectTypeVisitor;
 use Psalm\Internal\TypeVisitor\ClasslikeReplacer;
 use Psalm\Internal\TypeVisitor\ContainsClassLikeVisitor;
 use Psalm\Internal\TypeVisitor\ContainsLiteralVisitor;
+use Psalm\Internal\TypeVisitor\ContainsNonEmptinessVisitor;
 use Psalm\Internal\TypeVisitor\TemplateTypeCollector;
 use Psalm\Internal\TypeVisitor\TypeChecker;
 use Psalm\Internal\TypeVisitor\TypeScanner;
@@ -1360,6 +1361,17 @@ trait UnionTrait
         $literal_visitor->traverseArray($this->types);
 
         return $literal_visitor->matches();
+    }
+
+    /** @psalm-mutation-free */
+    public function containsAnyNonEmptiness(): bool
+    {
+        $non_emptiness_visitor = new ContainsNonEmptinessVisitor();
+
+        /** @psalm-suppress ImpureMethodCall Actually mutation-free */
+        $non_emptiness_visitor->traverseArray($this->types);
+
+        return $non_emptiness_visitor->matches();
     }
 
     /**

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -3523,7 +3523,7 @@ class ClassTemplateTest extends TestCase
                     '$b===' => '1|2',
                 ],
             ],
-            'generaliseTemplatedString' => [
+            'generaliseTemplatedStringLiteral' => [
                 'code' => '<?php
                     /** @template TData */
                     class Container {
@@ -3547,7 +3547,7 @@ class ClassTemplateTest extends TestCase
 
                     if ($me->data === "David") {}',
             ],
-            'generaliseTemplatedArray' => [
+            'generaliseTemplatedArrayShape' => [
                 'code' => '<?php
                     /** @template TData */
                     class Container {
@@ -3570,6 +3570,60 @@ class ClassTemplateTest extends TestCase
                     takesContainer($me);
 
                     if ($me->data["name"] === "David") {}',
+            ],
+            'generaliseTemplatedList' => [
+                'code' => '<?php
+                    /** @template T */
+                    class Container {
+                        /** @param T $_value */
+                        public function __construct($_value) {}
+                    }
+
+                    /** @param Container<list<int>> $_box */
+                    function takesContainer(Container $_box): void {}
+
+                    /** @var Container<non-empty-list<int>> */
+                    $container = new Container([42]);
+                    /** @psalm-check-type-exact $container = Container<non-empty-list<int>> */;
+
+                    takesContainer($container);
+                    /** @psalm-check-type-exact $container = Container<list<int>> */;',
+            ],
+            'generaliseTemplatedArray' => [
+                'code' => '<?php
+                    /** @template T */
+                    class Container {
+                        /** @param T $_value */
+                        public function __construct($_value) {}
+                    }
+
+                    /** @param Container<array<string, int>> $_box */
+                    function takesContainer(Container $_box): void {}
+
+                    /** @var Container<non-empty-array<string, int>> */
+                    $container = new Container(["fst" => 42]);
+                    /** @psalm-check-type-exact $container = Container<non-empty-array<string, int>> */;
+
+                    takesContainer($container);
+                    /** @psalm-check-type-exact $container = Container<array<string, int>> */;',
+            ],
+            'generaliseTemplatedNonEmptyString' => [
+                'code' => '<?php
+                    /** @template T */
+                    class Container {
+                        /** @param T $_value */
+                        public function __construct($_value) {}
+                    }
+
+                    /** @param Container<list<string>> $_box */
+                    function takesContainer(Container $_box): void {}
+
+                    /** @var Container<list<non-empty-string>> */
+                    $container = new Container(["str"]);
+                    /** @psalm-check-type-exact $container = Container<list<non-empty-string>> */;
+
+                    takesContainer($container);
+                    /** @psalm-check-type-exact $container = Container<list<string>> */;',
             ],
             'allowCovariantBoundsMismatchSameContainers' => [
                 'code' => '<?php

--- a/tests/WidenUnconstrainedTemplatesTest.php
+++ b/tests/WidenUnconstrainedTemplatesTest.php
@@ -1,0 +1,339 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests;
+
+use Psalm\Config;
+use Psalm\Context;
+
+final class WidenUnconstrainedTemplatesTest extends TestCase
+{
+    public function testLiteralWillBeWidenIfTemplateHasNoConstraints(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /** @template T */
+              final class Container {
+                  /** @param T $value */
+                  public function __construct($value) {}
+              }
+
+              /** @var list<1|2|3> */
+              $list = [];
+              /** @var array<1|2|3, 4|5|6> */
+              $array = [];
+              /** @var non-empty-array<1|2|3, 4|5|6> */
+              $nonEmptyArray = [1 => 5];
+              /** @var ArrayObject<"fst", 1> */
+              $arrayObject = new ArrayObject(["fst" => 1]);
+              /** @var Countable&iterable<"snd", 2> */
+              $countableAndIterable = new ArrayObject(["snd" => 2]);
+              $objectWithProperties = (object)["a" => 42];
+
+              $containerInt = new Container(42);
+              /** @psalm-check-type-exact $containerInt = Container<int> */
+
+              $containerFloat = new Container(42.00);
+              /** @psalm-check-type-exact $containerFloat = Container<float> */
+
+              $containerBool = new Container(true);
+              /** @psalm-check-type-exact $containerBool = Container<bool> */
+
+              $containerString = new Container("");
+              /** @psalm-check-type-exact $containerString = Container<string> */
+
+              $containerNonEmptyString = new Container("str");
+              /** @psalm-check-type-exact $containerNonEmptyString = Container<non-empty-string> */
+
+              $containerArrayIntInt = new Container($array);
+              /** @psalm-check-type-exact $containerArrayIntInt = Container<array<int, int>> */
+
+              $containerNonEmptyArrayIntInt = new Container($nonEmptyArray);
+              /** @psalm-check-type-exact $containerNonEmptyArrayIntInt = Container<non-empty-array<int, int>> */
+
+              $containerListInt = new Container($list);
+              /** @psalm-check-type-exact $containerListInt = Container<list<int>> */
+
+              $containerNonEmptyListInt = new Container([1, 2, 3]);
+              /** @psalm-check-type-exact $containerNonEmptyListInt = Container<non-empty-list<int>> */
+
+              $containerArrayObject = new Container($arrayObject);
+              /** @psalm-check-type-exact $containerArrayObject = Container<ArrayObject<non-empty-string, int>> */
+
+              $containerCountableAndIterable = new Container($countableAndIterable);
+              /** @psalm-check-type-exact $containerCountableAndIterable = Container<Countable&iterable<non-empty-string, int>> */
+
+              $containerObjectWithProperties = new Container($objectWithProperties);
+              /** @psalm-check-type-exact $containerObjectWithProperties = Container<object{a: int}> */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testLiteralWillBeNarrowedIfTemplateHasAnyConstraints(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /** @template T of mixed|null */
+              final class Container {
+                  /** @param T $value */
+                  public function __construct($value) {}
+              }
+
+              /** @var list<1|2|3> */
+              $list = [];
+              /** @var array<1|2|3, 4|5|6> */
+              $array = [];
+              /** @var non-empty-array<1|2|3, 4|5|6> */
+              $nonEmptyArray = [1 => 5];
+              /** @var ArrayObject<"fst", 1> */
+              $arrayObject = new ArrayObject(["fst" => 1]);
+              /** @var Countable&iterable<"snd", 2> */
+              $countableAndIterable = new ArrayObject(["snd" => 2]);
+              $objectWithProperties = (object)["a" => 42];
+
+              $containerInt = new Container(42);
+              /** @psalm-check-type-exact $containerInt = Container<42> */
+
+              $containerFloat = new Container(42.00);
+              /** @psalm-check-type-exact $containerFloat = Container<42.00> */
+
+              $containerBool = new Container(true);
+              /** @psalm-check-type-exact $containerBool = Container<true> */
+
+              $containerString = new Container("");
+              /** @psalm-check-type-exact $containerString = Container<\'\'> */
+
+              $containerNonEmptyString = new Container("str");
+              /** @psalm-check-type-exact $containerNonEmptyString = Container<\'str\'> */
+
+              $containerArrayIntInt = new Container($array);
+              /** @psalm-check-type-exact $containerArrayIntInt = Container<array<1|2|3, 4|5|6>> */
+
+              $containerNonEmptyArrayIntInt = new Container($nonEmptyArray);
+              /** @psalm-check-type-exact $containerNonEmptyArrayIntInt = Container<non-empty-array<1|2|3, 4|5|6>> */
+
+              $containerListInt = new Container($list);
+              /** @psalm-check-type-exact $containerListInt = Container<list<1|2|3>> */
+
+              $containerNonEmptyListInt = new Container([1, 2, 3]);
+              /** @psalm-check-type-exact $containerNonEmptyListInt = Container<list{1, 2, 3}> */
+
+              $containerArrayObject = new Container($arrayObject);
+              /** @psalm-check-type-exact $containerArrayObject = Container<ArrayObject<"fst", 1>> */
+
+              $containerCountableAndIterable = new Container($countableAndIterable);
+              /** @psalm-check-type-exact $containerCountableAndIterable = Container<Countable&iterable<"snd", 2>> */
+
+              $containerObjectWithProperties = new Container($objectWithProperties);
+              /** @psalm-check-type-exact $containerObjectWithProperties = Container<object{a: 42}> */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testLiteralWillBeNarrowedWithExplicitAnnotationAtClass(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /**
+               * @template T
+               * @psalm-narrow-unconstrained-templates
+               */
+              final class Container {
+                  /** @param T $value */
+                  public function __construct($value) {}
+              }
+
+              $containerInt = new Container(42);
+              /** @psalm-check-type-exact $containerInt = Container<42> */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testLiteralWillBeNarrowedWithExplicitAnnotationAtFunction(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /**
+               * @template T
+               * @psalm-narrow-unconstrained-templates
+               * @param T $value
+               * @return T
+               */
+              function id($value) {
+                  return $value;
+              }
+
+              $containerInt = id([42]);
+              /** @psalm-check-type-exact $containerInt = list{42} */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testLiteralWillBeNarrowedWithExplicitAnnotationAtMethod(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              final class Container {
+                  /**
+                   * @template T
+                   * @psalm-narrow-unconstrained-templates
+                   * @param T $value
+                   * @return T
+                   */
+                  public function id($value) {
+                      return $value;
+                  }
+              }
+
+              $containerInt = (new Container())->id([42]);
+              /** @psalm-check-type-exact $containerInt = list{42} */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testLiteralWillBeNarrowedWithExplicitAnnotationAtStaticMethod(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              final class Container {
+                  /**
+                   * @template T
+                   * @psalm-narrow-unconstrained-templates
+                   * @param T $value
+                   * @return T
+                   */
+                  public static function id($value) {
+                      return $value;
+                  }
+              }
+
+              $containerInt = Container::id([42]);
+              /** @psalm-check-type-exact $containerInt = list{42} */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testLiteralWillBeWidenWithExplicitAnnotationAtClass(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /**
+               * @template T
+               * @psalm-widen-unconstrained-templates
+               */
+              final class Container {
+                  /** @param T $value */
+                  public function __construct($value) {}
+              }
+
+              $containerInt = new Container(42);
+              /** @psalm-check-type-exact $containerInt = Container<int> */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testLiteralWillBeWidenWithExplicitAnnotationAtFunction(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              /**
+               * @template T
+               * @psalm-widen-unconstrained-templates
+               * @param T $value
+               * @return T
+               */
+              function id($value) {
+                  return $value;
+              }
+
+              $containerInt = id([42]);
+              /** @psalm-check-type-exact $containerInt = non-empty-list<int> */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testLiteralWillBeWidenWithExplicitAnnotationAtMethod(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              final class Container {
+                  /**
+                   * @template T
+                   * @psalm-widen-unconstrained-templates
+                   * @param T $value
+                   * @return T
+                   */
+                  public function id($value) {
+                      return $value;
+                  }
+              }
+
+              $containerInt = (new Container())->id([42]);
+              /** @psalm-check-type-exact $containerInt = non-empty-list<int> */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testLiteralWillBeWidenWithExplicitAnnotationAtStaticMethod(): void
+    {
+        Config::getInstance()->widen_unconstrained_templates = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+              final class Container {
+                  /**
+                   * @template T
+                   * @psalm-widen-unconstrained-templates
+                   * @param T $value
+                   * @return T
+                   */
+                  public static function id($value) {
+                      return $value;
+                  }
+              }
+
+              $containerInt = Container::id([42]);
+              /** @psalm-check-type-exact $containerInt = non-empty-list<int> */',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+}


### PR DESCRIPTION
Closes #4564

1) I prefer leave old behavior by default.
Even It aligns Psalm with PHPStan It still is BC change.

2) Widening/narrowing is controllable both with config and annotations. 

3) I relly don't know how to widen string and array/list.
Should `'some-literal'` widens to `non-empty-string` or `string`?
Should `[1, 2, 3]` widens to `non-empty-list<int>` or `list<int>`?

I chose non-empty side, but it can't fix original snippet from #4564.
```php
<?php

/**
 * @template A
 * @param A $a
 * @return Closure(A): bool
 */
function eq($a): Closure
{
    return fn($b) => $a === $b;
}

function isEqTo123(string $value): bool
{
    $equals = eq('123');

    // ERROR: ArgumentTypeCoercion
    // Argument 1 expects non-empty-string, but parent type string provided
    return $equals($value);
}
```

It seems to PHPStan widens non-empty: https://phpstan.org/r/707c06d9-e28b-4209-a9af-9c5602190d27
Should we do the same?
