### PR TITLE
Fix missing global class type when scanning cached files

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -238,6 +238,12 @@ class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements FileSour
                             $var_id = '$' . $var->name;
 
                             $functionlike_node_scanner->storage->global_variables[$var_id] = true;
+
+                            if (isset($this->codebase->config->globals[$var_id])) {
+                                $var_type = Type::parseString($this->codebase->config->globals[$var_id]);
+                                /** @psalm-suppress UnusedMethodCall */
+                                $var_type->queueClassLikesForScanning($this->codebase, $this->file_storage);
+                            }
                         }
                     }
                 }

--- a/tests/Internal/Scanner/FileScannerTest.php
+++ b/tests/Internal/Scanner/FileScannerTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Psalm\Tests\Internal\Scanner;
+
+use Psalm\Aliases;
+use Psalm\Codebase;
+use Psalm\Config;
+use Psalm\Internal\Provider\FakeFileProvider;
+use Psalm\Internal\Provider\Providers;
+use Psalm\Internal\Scanner\FileScanner;
+use Psalm\Storage\FileStorage;
+use Psalm\Storage\FunctionStorage;
+use Psalm\Tests\TestCase;
+use Psalm\Tests\TestConfig;
+
+class FileScannerTest extends TestCase
+{
+    /**
+     * @dataProvider providerScan
+     */
+    public function testScan(
+        Config $config,
+        string $file_contents,
+        FileStorage $expected_file_storage
+    ): void {
+        $file_provider = new FakeFileProvider();
+        $codebase = new Codebase(
+            $config,
+            new Providers($file_provider),
+        );
+
+        $file_provider->registerFile('/dir/file.php', $file_contents);
+
+        $file_scanner = new FileScanner('/dir/file.php', 'file.php', true);
+        $file_storage = new FileStorage('/dir/file.php');
+        $file_scanner->scan(
+            $codebase,
+            $file_storage,
+        );
+
+        // Reset properties that are difficult to mock
+        foreach ($file_storage->functions as $function_storage) {
+            $function_storage->location = null;
+            $function_storage->stmt_location = null;
+        }
+
+        self::assertEquals($expected_file_storage, $file_storage);
+    }
+
+    /**
+     * @return iterable<string, list{Config, string, FileStorage}>
+     */
+    public static function providerScan(): iterable
+    {
+        $config = new TestConfig();
+        $config->globals['$global'] = 'GlobalClass';
+
+        $function_storage_some_function = new FunctionStorage();
+        $function_storage_some_function->cased_name = 'some_function';
+        $function_storage_some_function->required_param_count = 0;
+        $function_storage_some_function->global_variables = [
+            '$global' => true,
+        ];
+
+        $file_storage = new FileStorage('/dir/file.php');
+        $file_storage->deep_scan = true;
+        $file_storage->aliases = new Aliases();
+        $file_storage->functions = [
+            'some_function' => $function_storage_some_function,
+        ];
+        $file_storage->declaring_function_ids = [
+            'some_function' => '/dir/file.php',
+        ];
+        $file_storage->referenced_classlikes = [
+            'globalclass' => 'GlobalClass',
+        ];
+        yield 'referenceConfiguredGlobalClass' => [
+            $config,
+            <<<'PHP'
+            <?php
+
+            function some_function()
+            {
+                global $global;
+            }
+            PHP,
+            $file_storage,
+        ];
+    }
+}


### PR DESCRIPTION
Once the project files are cached, `ProjectAnalyzer` will no longer scan them again if they haven't changed.
This means that a global class type defined in the configuration ([`globals`](https://psalm.dev/docs/running_psalm/configuration/#globals)) must be scanned in another way. Otherwise analyzing a file using such a global would raise an "UndefinedClass" issue.

To me it seems to be the best solution to consider the configured global types for scanning in `ReflectorVistor`, similar to the way an `@var` annotation would be handled.

I haven't found any tests for file scanning and wasn't sure if a more involved end-to-end test case would be desired, so I just created a test case for `FileScanner`.