### PR TITLE
Fix invalid cast for templated class-string

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/ClassLikeStringComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ClassLikeStringComparator.php
@@ -80,7 +80,7 @@ class ClassLikeStringComparator
                     : $input_type_part->value,
             );
 
-        return AtomicTypeComparator::isContainedBy(
+        $isContainedBy = AtomicTypeComparator::isContainedBy(
             $codebase,
             $fake_input_object,
             $fake_container_object,
@@ -88,5 +88,16 @@ class ClassLikeStringComparator
             false,
             $atomic_comparison_result,
         );
+
+        if ($atomic_comparison_result
+            && $atomic_comparison_result->replacement_atomic_type instanceof TNamedObject
+        ) {
+            $atomic_comparison_result->replacement_atomic_type = new TClassString(
+                'object',
+                $atomic_comparison_result->replacement_atomic_type,
+            );
+        }
+
+        return $isContainedBy;
     }
 }

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -17,6 +17,19 @@ class FunctionCallTest extends TestCase
     public function providerValidCodeParse(): iterable
     {
         return [
+            'callFunctionWithTemplateClassStringWillNotFail' => [
+                'code' => '<?php
+                    /** @param class-string<SplFixedArray<string>> $classString */
+                    function acceptTemplatedClassString(string $classString): void
+                    {
+                    }
+
+                    /** @param class-string<SplFixedArray<string>> $classString */
+                    function app(string $classString): void
+                    {
+                        acceptTemplatedClassString($classString);
+                    }',
+            ],
             'inferGenericListFromTuple' => [
                 'code' => '<?php
                     /**


### PR DESCRIPTION
`TClassString` atomic is accidentally replaced with `TGenericObject`:
https://psalm.dev/r/831ddeffde

There is nothing wrong with that, because it is necessary for things like that:
https://psalm.dev/r/6b6ea39278

But this case is obviously missed in the `ClassLikeStringComparator`.