### PR TITLE
Fix OverriddenPropertyAccess error message

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -702,7 +702,7 @@ class ClassAnalyzer extends ClassLikeAnalyzer
                             new OverriddenPropertyAccess(
                                 'Property ' . $fq_class_name . '::$' . $property_name
                                     . ' has different access level than '
-                                    . $storage->name . '::$' . $property_name,
+                                    . $guide_class_name . '::$' . $property_name,
                                 $property_storage->location,
                             ),
                         );

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -5,6 +5,8 @@ namespace Psalm\Tests;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
+use const DIRECTORY_SEPARATOR;
+
 class ClassTest extends TestCase
 {
     use InvalidCodeAnalysisTestTrait;
@@ -936,7 +938,7 @@ class ClassTest extends TestCase
                         /** @var string|null */
                         private $foo;
                     }',
-                'error_message' => 'OverriddenPropertyAccess',
+                'error_message' => 'OverriddenPropertyAccess - src'  . DIRECTORY_SEPARATOR . 'somefile.php:9:33 - Property B::$foo has different access level than A::$foo',
             ],
             'overridePublicPropertyAccessLevelToProtected' => [
                 'code' => '<?php


### PR DESCRIPTION
The message previously didn't mention the base class, which made it confusing.

Fixes #9727.