### PR TITLE
Fix keyed array generalization

### DIFF
--- a/src/Psalm/Internal/TypeVisitor/ContainsLiteralVisitor.php
+++ b/src/Psalm/Internal/TypeVisitor/ContainsLiteralVisitor.php
@@ -4,6 +4,7 @@ namespace Psalm\Internal\TypeVisitor;
 
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
@@ -26,6 +27,11 @@ class ContainsLiteralVisitor extends TypeVisitor
             || $type instanceof TTrue
             || $type instanceof TFalse
         ) {
+            $this->contains_literal = true;
+            return self::STOP_TRAVERSAL;
+        }
+
+        if ($type instanceof TKeyedArray && !$type->isGenericList()) {
             $this->contains_literal = true;
             return self::STOP_TRAVERSAL;
         }

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -3571,6 +3571,33 @@ class ClassTemplateTest extends TestCase
 
                     if ($me->data["name"] === "David") {}',
             ],
+            'generaliseTemplatedTuple' => [
+                'code' => '<?php
+                    /** @template T */
+                    final class Container
+                    {
+                        /** @var T */
+                        private $data;
+
+                        /** @param T $value */
+                        public function __construct($value) {
+                            $this->data = $value;
+                        }
+                    }
+
+                    /**
+                     * @param Container<non-empty-list<DateTimeImmutable>> $_values
+                     */
+                    function test(Container $_values): void {}
+
+                    $container = new Container([
+                        new DateTimeImmutable(),
+                    ]);
+                    /** @psalm-check-type-exact $container = Container<list{DateTimeImmutable}> */;
+
+                    test($container);
+                    /** @psalm-check-type-exact $container = Container<non-empty-list<DateTimeImmutable>> */;',
+            ],
             'allowCovariantBoundsMismatchSameContainers' => [
                 'code' => '<?php
                     /**


### PR DESCRIPTION
`$container` should be generalized after `test` call https://psalm.dev/r/6239d321f0 like https://psalm.dev/r/23e5380fa9 isn't it?