### PR TITLE
Enable opcache if it is installed

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -65,7 +65,6 @@ use function is_string;
 use function json_encode;
 use function max;
 use function microtime;
-use function opcache_get_status;
 use function parse_url;
 use function preg_match;
 use function preg_replace;

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -923,11 +923,7 @@ final class Psalm
         // If Xdebug is enabled, restart without it
         $ini_handler->check();
 
-        if (!function_exists('opcache_get_status')
-            || !($opcache_status = opcache_get_status(false))
-            || !isset($opcache_status['opcache_enabled'])
-            || !$opcache_status['opcache_enabled']
-        ) {
+        if (!function_exists('opcache_get_status')) {
             $progress->write(PHP_EOL
                 . 'Install the opcache extension to make use of JIT on PHP 8.0+ for a 20%+ performance boost!'
                 . PHP_EOL . PHP_EOL);


### PR DESCRIPTION
I realized the message is a bit misleading, it asks the user to install the opcache extension, but it also has to be enabled via `opcache.enable=1` for psalm to pick it up, but `opcache.enable=1` only affects php-fpm, while Psalm is only run via cli, so it makes little sense for us to ask to change that setting.

Users can still disable opcache for Psalm by not loading the extension at all, which generally is the standard situation on dev machines anyway.