### PR TITLE
Throw MismatchingDocblockReturnType when types are narrowed

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -981,13 +981,12 @@ class ReturnTypeAnalyzer
 
         if (!UnionTypeComparator::isContainedBy(
             $codebase,
-            $fleshed_out_return_type,
             $fleshed_out_signature_type,
+            $fleshed_out_return_type,
             false,
             false,
             $union_comparison_result,
-        ) && !$union_comparison_result->type_coerced_from_mixed
-        ) {
+        )) {
             if ($codebase->alter_code
                 && isset($project_analyzer->getIssuesToFix()['MismatchingDocblockReturnType'])
             ) {

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1398,6 +1398,18 @@ class AnnotationTest extends TestCase
                     }',
                 'error_message' => 'MismatchingDocblockReturnType',
             ],
+            'invalidDocblockNullableReturn' => [
+                'code' => '<?php
+                    /**
+                     * @param ?string[] $in
+                     * @return string[]
+                     */
+                    function A(?array $in): ?array
+                    {
+                        return $in;
+                    }',
+                'error_message' => 'MismatchingDocblockReturnType',
+            ],
             'intParamTypeDefinedInParent' => [
                 'code' => '<?php
                     class A {


### PR DESCRIPTION
Fix for https://github.com/vimeo/psalm/issues/9699