### PR TITLE
Add a support for multilevel glob wildcards

### DIFF
--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -452,7 +452,13 @@ class FileFilter
             if ($onlyDir) {
                 return array_map('realpath', glob($parts[0], GLOB_ONLYDIR | GLOB_NOSORT));
             } else {
-                return array_map('realpath', glob($parts[0], GLOB_NOSORT));
+                return array_map(
+                    'realpath',
+                    array_filter(
+                        glob($parts[0], GLOB_NOSORT),
+                        'file_exists',
+                    ),
+                );
             }
         }
         $firstDir = self::slashify($parts[0]);

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -20,6 +20,7 @@ use function is_dir;
 use function is_iterable;
 use function preg_match;
 use function preg_replace;
+use function preg_split;
 use function readlink;
 use function realpath;
 use function restore_error_handler;
@@ -133,12 +134,11 @@ class FileFilter
                 }
 
                 if (strpos($prospective_directory_path, '*') !== false) {
-                    // Strip meaningless finishing recursive wildcard like "path/**/" or "path/**"
+                    // Strip meaningless trailing recursive wildcard like "path/**/" or "path/**"
                     $prospective_directory_path = preg_replace('#(\/\*\*)+\/?$#', '/', $prospective_directory_path);
-                    // Strip meaningless duplicated wildcards like "path/**/**/path"
-                    $prospective_directory_path = preg_replace('#(\*\*\/)+#', '**/', $prospective_directory_path);
+                    // Split by /**/, allow duplicated wildcards like "path/**/**/path" and any leading dir separator.
                     /** @var non-empty-list<non-empty-string> $path_parts */
-                    $path_parts = explode('/**/', $prospective_directory_path);
+                    $path_parts = preg_split('#(\/|\\\)(\*\*\/)+#', $prospective_directory_path);
                     $globs = self::recursiveGlob($path_parts, true);
 
                     if (empty($globs)) {
@@ -253,10 +253,9 @@ class FileFilter
                 }
 
                 if (strpos($prospective_file_path, '*') !== false) {
-                    // Strip meaningless duplicated wildcards like "path/**/**/path"
-                    $prospective_file_path = preg_replace('#(\*\*\/)+#', '**/', $prospective_file_path);
+                    // Split by /**/, allow duplicated wildcards like "path/**/**/path" and any leading dir separator.
                     /** @var non-empty-list<non-empty-string> $path_parts */
-                    $path_parts = explode('/**/', $prospective_file_path);
+                    $path_parts = preg_split('#(\/|\\\)(\*\*\/)+#', $prospective_file_path);
                     $globs = self::recursiveGlob($path_parts, false);
 
                     if (empty($globs)) {


### PR DESCRIPTION
This can work like `glob.glob` in Python with `**` in the path, e.g. `src/**/BinaryOp*` would match
- src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
- src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp
- src/Psalm/Node/Expr/BinaryOp

If there are no `/**/` in the path then it works as before.

There is some backward incompatibility: PHP's `glob` treats `path/**/path` and `path/*/path` and even `path/***/path` as the same pattern, so if someone used `/**/` in their config file, they need to adjust it to avoid an excessively wide match.

Closes https://github.com/vimeo/psalm/issues/5721