### PR TITLE
Shepherd: send a list of issues (instead of array with int keys)

### DIFF
--- a/src/Psalm/Plugin/EventHandler/Event/AfterAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterAnalysisEvent.php
@@ -10,7 +10,7 @@ final class AfterAnalysisEvent
 {
     private Codebase $codebase;
     /**
-     * @var IssueData[][]
+     * @var array<string, list<IssueData>> where string key is a filepath
      */
     private array $issues;
     private array $build_info;
@@ -19,7 +19,7 @@ final class AfterAnalysisEvent
     /**
      * Called after analysis is complete
      *
-     * @param array<string, list<IssueData>> $issues
+     * @param array<string, list<IssueData>> $issues where string key is a filepath
      * @internal
      */
     public function __construct(
@@ -40,7 +40,7 @@ final class AfterAnalysisEvent
     }
 
     /**
-     * @return IssueData[][]
+     * @return array<string, list<IssueData>> where string key is a filepath
      */
     public function getIssues(): array
     {

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -120,9 +120,9 @@ final class Shepherd implements AfterAnalysisInterface
             return null;
         }
 
-        $issues = $event->getIssues();
-        $normalized_data = $issues === [] ? [] : array_values(array_filter(
-            array_merge(...array_values($issues)), // flatten an array
+        $issues_grouped_by_filename = $event->getIssues();
+        $normalized_data = $issues_grouped_by_filename === [] ? [] : array_values(array_filter(
+            array_merge(...array_values($issues_grouped_by_filename)), // flatten an array
             static fn(IssueData $i): bool => $i->severity === IssueData::SEVERITY_ERROR,
         ));
 

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -121,10 +121,10 @@ final class Shepherd implements AfterAnalysisInterface
         }
 
         $issues = $event->getIssues();
-        $normalized_data = $issues === [] ? [] : array_filter(
-            array_merge(...array_values($issues)),
+        $normalized_data = $issues === [] ? [] : array_values(array_filter(
+            array_merge(...array_values($issues)), // flatten an array
             static fn(IssueData $i): bool => $i->severity === 'error',
-        );
+        ));
 
         $codebase = $event->getCodebase();
 


### PR DESCRIPTION
As result Shepherd will send an array is issues instead of object with "random" numeric keys

Right now shepherd sends cURL request with payload like:
```json
    "issues": {
        "1558": {
            "severity": "error",
            "line_from": 43,
            "line_to": 46,
            "type": "PossiblyUndefinedIntArrayOffset",
           ...
```

There is no sense of keeping these numeric keys like "1558". So, it should be like:


```json
    "issues": [
        {
            "severity": "error",
            "line_from": 43,
            "line_to": 46,
            "type": "PossiblyUndefinedIntArrayOffset",
           ...
```
