### PR TITLE
Introduce and use `IssueData` constants for severity levels

### DIFF
--- a/src/Psalm/Internal/Analyzer/IssueData.php
+++ b/src/Psalm/Internal/Analyzer/IssueData.php
@@ -11,6 +11,12 @@ use const STR_PAD_LEFT;
  */
 class IssueData
 {
+    public const SEVERITY_INFO = 'info';
+    public const SEVERITY_ERROR = 'error';
+
+    /**
+     * @var self::SEVERITY_*
+     */
     public string $severity;
 
     public int $line_from;
@@ -93,6 +99,7 @@ class IssueData
     public ?string $dupe_key = null;
 
     /**
+     * @param self::SEVERITY_* $severity
      * @param ?list<DataFlowNodeData|array{label: string, entry_path_type: string}> $taint_trace
      * @param ?list<DataFlowNodeData> $other_references
      */

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -1552,12 +1552,12 @@ class Analyzer
         $has_info = false;
 
         foreach ($issues as $issue) {
-            if ($issue->severity === 'error') {
+            if ($issue->severity === IssueData::SEVERITY_ERROR) {
                 $has_error = true;
                 break;
             }
 
-            if ($issue->severity === 'info') {
+            if ($issue->severity === IssueData::SEVERITY_INFO) {
                 $has_info = true;
             }
         }

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -1552,13 +1552,13 @@ class Analyzer
         $has_info = false;
 
         foreach ($issues as $issue) {
-            if ($issue->severity === IssueData::SEVERITY_ERROR) {
-                $has_error = true;
-                break;
-            }
-
-            if ($issue->severity === IssueData::SEVERITY_INFO) {
-                $has_info = true;
+            switch ($issue->severity) {
+                case IssueData::SEVERITY_INFO:
+                    $has_info = true;
+                    break;
+                default:
+                    $has_error = true;
+                    break;
             }
         }
 

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -728,10 +728,10 @@ class LanguageServer extends Dispatcher
                         new Position($end_line - 1, $end_column - 1),
                     );
                     switch ($severity) {
-                        case Config::REPORT_INFO:
+                        case IssueData::SEVERITY_INFO:
                             $diagnostic_severity = DiagnosticSeverity::WARNING;
                             break;
-                        case Config::REPORT_ERROR:
+                        case IssueData::SEVERITY_ERROR:
                         default:
                             $diagnostic_severity = DiagnosticSeverity::ERROR;
                             break;
@@ -788,7 +788,7 @@ class LanguageServer extends Dispatcher
                                 );
 
                                 if ($position !== false) {
-                                    $issue_data->severity = Config::REPORT_INFO;
+                                    $issue_data->severity = IssueData::SEVERITY_INFO;
                                     /** @psalm-suppress MixedArgument */
                                     array_splice($issue_baseline[$file][$type]['s'], $position, 1);
                                     /** @psalm-suppress MixedArrayAssignment, MixedOperand, MixedAssignment */
@@ -797,7 +797,7 @@ class LanguageServer extends Dispatcher
                             } else {
                                 /** @psalm-suppress MixedArrayAssignment */
                                 $issue_baseline[$file][$type]['s'] = [];
-                                $issue_data->severity = Config::REPORT_INFO;
+                                $issue_data->severity = IssueData::SEVERITY_INFO;
                                 /** @psalm-suppress MixedArrayAssignment, MixedOperand, MixedAssignment */
                                 $issue_baseline[$file][$type]['o']--;
                             }
@@ -806,7 +806,7 @@ class LanguageServer extends Dispatcher
                     }, $data[$file_path] ?? []),
                     function (IssueData $issue_data) {
                         //Hide Warnings
-                        if ($issue_data->severity === Config::REPORT_INFO &&
+                        if ($issue_data->severity === IssueData::SEVERITY_INFO &&
                             $this->client->clientConfiguration->hideWarnings
                         ) {
                             return false;

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -731,7 +731,6 @@ class LanguageServer extends Dispatcher
                         case IssueData::SEVERITY_INFO:
                             $diagnostic_severity = DiagnosticSeverity::WARNING;
                             break;
-                        case IssueData::SEVERITY_ERROR:
                         default:
                             $diagnostic_severity = DiagnosticSeverity::ERROR;
                             break;

--- a/src/Psalm/Issue/CodeIssue.php
+++ b/src/Psalm/Issue/CodeIssue.php
@@ -68,6 +68,9 @@ abstract class CodeIssue
         return array_pop($fqcn_parts);
     }
 
+    /**
+     * @param IssueData::SEVERITY_* $severity
+     */
     public function toIssueData(string $severity): IssueData
     {
         $location = $this->code_location;

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -302,7 +302,7 @@ final class IssueBuffer
 
         if ($reporting_level === Config::REPORT_INFO) {
             if ($is_tainted || !self::alreadyEmitted($emitted_key)) {
-                self::$issues_data[$e->getFilePath()][] = $e->toIssueData(Config::REPORT_INFO);
+                self::$issues_data[$e->getFilePath()][] = $e->toIssueData(IssueData::SEVERITY_INFO);
 
                 if ($is_fixable) {
                     self::addFixableIssue($issue_type);
@@ -331,7 +331,7 @@ final class IssueBuffer
 
         if ($is_tainted || !self::alreadyEmitted($emitted_key)) {
             ++self::$error_count;
-            self::$issues_data[$e->getFilePath()][] = $e->toIssueData(Config::REPORT_ERROR);
+            self::$issues_data[$e->getFilePath()][] = $e->toIssueData(IssueData::SEVERITY_ERROR);
 
             if ($is_fixable) {
                 self::addFixableIssue($issue_type);
@@ -618,7 +618,7 @@ final class IssueBuffer
                         foreach ($issues as $issue_name => $issue) {
                             if ($issue['o'] !== 0) {
                                 $issues_data[$file_path][] = new IssueData(
-                                    Config::REPORT_ERROR,
+                                    IssueData::SEVERITY_ERROR,
                                     0,
                                     0,
                                     UnusedBaselineEntry::getIssueType(),

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -598,13 +598,13 @@ final class IssueBuffer
                                 );
 
                                 if ($position !== false) {
-                                    $issue_data->severity = Config::REPORT_INFO;
+                                    $issue_data->severity = IssueData::SEVERITY_INFO;
                                     array_splice($issue_baseline[$file][$type]['s'], $position, 1);
                                     $issue_baseline[$file][$type]['o']--;
                                 }
                             } else {
                                 $issue_baseline[$file][$type]['s'] = [];
-                                $issue_data->severity = Config::REPORT_INFO;
+                                $issue_data->severity = IssueData::SEVERITY_INFO;
                                 $issue_baseline[$file][$type]['o']--;
                             }
                         }

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -123,7 +123,7 @@ final class Shepherd implements AfterAnalysisInterface
         $issues = $event->getIssues();
         $normalized_data = $issues === [] ? [] : array_filter(
             array_merge(...array_values($issues)),
-            static fn(IssueData $i): bool => $i->severity === 'error',
+            static fn(IssueData $i): bool => $i->severity === IssueData::SEVERITY_ERROR,
         );
 
         $codebase = $event->getCodebase();

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -74,7 +74,7 @@ abstract class Report
         if (!$report_options->show_info) {
             $this->issues_data = array_filter(
                 $issues_data,
-                static fn(IssueData $issue_data): bool => $issue_data->severity !== Config::REPORT_INFO,
+                static fn(IssueData $issue_data): bool => $issue_data->severity !== IssueData::SEVERITY_INFO,
             );
         } else {
             $this->issues_data = $issues_data;

--- a/src/Psalm/Report/CompactReport.php
+++ b/src/Psalm/Report/CompactReport.php
@@ -3,6 +3,7 @@
 namespace Psalm\Report;
 
 use Psalm\Config;
+use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -31,7 +32,7 @@ final class CompactReport extends Report
 
         $output = [];
         foreach ($this->issues_data as $i => $issue_data) {
-            if (!$this->show_info && $issue_data->severity === Config::REPORT_INFO) {
+            if (!$this->show_info && $issue_data->severity === IssueData::SEVERITY_INFO) {
                 continue;
             }
 

--- a/src/Psalm/Report/EmacsReport.php
+++ b/src/Psalm/Report/EmacsReport.php
@@ -2,7 +2,7 @@
 
 namespace Psalm\Report;
 
-use Psalm\Config;
+use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
 
 use function sprintf;
@@ -18,7 +18,7 @@ final class EmacsReport extends Report
                 $issue_data->file_path,
                 $issue_data->line_from,
                 $issue_data->column_from,
-                ($issue_data->severity === Config::REPORT_ERROR ? 'error' : 'warning'),
+                ($issue_data->severity === IssueData::SEVERITY_ERROR ? 'error' : 'warning'),
                 $issue_data->type,
                 $issue_data->message,
                 $issue_data->link,

--- a/src/Psalm/Report/GithubActionsReport.php
+++ b/src/Psalm/Report/GithubActionsReport.php
@@ -2,7 +2,7 @@
 
 namespace Psalm\Report;
 
-use Psalm\Config;
+use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
 
 use function sprintf;
@@ -34,7 +34,7 @@ final class GithubActionsReport extends Report
 
             $output .= sprintf(
                 '::%1$s %2$s::%3$s',
-                ($issue_data->severity === Config::REPORT_ERROR ? 'error' : 'warning'),
+                ($issue_data->severity === IssueData::SEVERITY_ERROR ? 'error' : 'warning'),
                 $properties,
                 $data,
             ) . "\n";

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -27,8 +27,8 @@ final class JunitReport extends Report
         $ndata = [];
 
         foreach ($this->issues_data as $error) {
-            $is_error = $error->severity === Config::REPORT_ERROR;
-            $is_warning = $error->severity === Config::REPORT_INFO;
+            $is_error = $error->severity === IssueData::SEVERITY_ERROR;
+            $is_warning = $error->severity === IssueData::SEVERITY_INFO;
 
             if (!$is_error && !$is_warning) {
                 continue;

--- a/src/Psalm/Report/TextReport.php
+++ b/src/Psalm/Report/TextReport.php
@@ -2,7 +2,7 @@
 
 namespace Psalm\Report;
 
-use Psalm\Config;
+use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
 
 use function sprintf;
@@ -18,7 +18,7 @@ final class TextReport extends Report
                 $issue_data->file_path,
                 $issue_data->line_from,
                 $issue_data->column_from,
-                ($issue_data->severity === Config::REPORT_ERROR ? 'error' : 'warning'),
+                ($issue_data->severity === IssueData::SEVERITY_ERROR ? 'error' : 'warning'),
                 $issue_data->type,
                 $issue_data->message,
             ) . "\n";

--- a/tests/ByIssueLevelAndTypeReportTest.php
+++ b/tests/ByIssueLevelAndTypeReportTest.php
@@ -75,7 +75,7 @@ class ByIssueLevelAndTypeReportTest extends TestCase
     private function issueData(int $errorLevel, string $type): IssueData
     {
         return new IssueData(
-            'error',
+            IssueData::SEVERITY_ERROR,
             1,
             1,
             $type,

--- a/tests/ErrorBaselineTest.php
+++ b/tests/ErrorBaselineTest.php
@@ -187,7 +187,7 @@ bar&#13;
             [
                 'sample/sample-file.php' => [
                     new IssueData(
-                        'error',
+                        IssueData::SEVERITY_ERROR,
                         0,
                         0,
                         'MixedAssignment',
@@ -204,7 +204,7 @@ bar&#13;
                         0,
                     ),
                     new IssueData(
-                        'error',
+                        IssueData::SEVERITY_ERROR,
                         0,
                         0,
                         'MixedAssignment',
@@ -221,7 +221,7 @@ bar&#13;
                         0,
                     ),
                     new IssueData(
-                        'error',
+                        IssueData::SEVERITY_ERROR,
                         0,
                         0,
                         'MixedAssignment',
@@ -238,7 +238,7 @@ bar&#13;
                         0,
                     ),
                     new IssueData(
-                        'error',
+                        IssueData::SEVERITY_ERROR,
                         0,
                         0,
                         'MixedOperand',
@@ -274,7 +274,7 @@ bar&#13;
                 ],
                 'sample/sample-file2.php' => [
                     new IssueData(
-                        'error',
+                        IssueData::SEVERITY_ERROR,
                         0,
                         0,
                         'MixedAssignment',
@@ -291,7 +291,7 @@ bar&#13;
                         0,
                     ),
                     new IssueData(
-                        'error',
+                        IssueData::SEVERITY_ERROR,
                         0,
                         0,
                         'MixedAssignment',
@@ -308,7 +308,7 @@ bar&#13;
                         0,
                     ),
                     new IssueData(
-                        'error',
+                        IssueData::SEVERITY_ERROR,
                         0,
                         0,
                         'TypeCoercion',
@@ -410,7 +410,7 @@ bar&#13;
         $newIssues = [
             'sample/sample-file.php' => [
                 new IssueData(
-                    'error',
+                    IssueData::SEVERITY_ERROR,
                     0,
                     0,
                     'MixedAssignment',
@@ -427,7 +427,7 @@ bar&#13;
                     0,
                 ),
                 new IssueData(
-                    'error',
+                    IssueData::SEVERITY_ERROR,
                     0,
                     0,
                     'MixedAssignment',
@@ -444,7 +444,7 @@ bar&#13;
                     0,
                 ),
                 new IssueData(
-                    'error',
+                    IssueData::SEVERITY_ERROR,
                     0,
                     0,
                     'MixedOperand',
@@ -461,7 +461,7 @@ bar&#13;
                     0,
                 ),
                 new IssueData(
-                    'error',
+                    IssueData::SEVERITY_ERROR,
                     0,
                     0,
                     'MixedOperand',
@@ -480,7 +480,7 @@ bar&#13;
             ],
             'sample/sample-file2.php' => [
                 new IssueData(
-                    'error',
+                    IssueData::SEVERITY_ERROR,
                     0,
                     0,
                     'TypeCoercion',

--- a/tests/IssueBufferTest.php
+++ b/tests/IssueBufferTest.php
@@ -24,7 +24,7 @@ class IssueBufferTest extends TestCase
         IssueBuffer::addIssues([
             '/path/one.php' => [
                 new IssueData(
-                    "error",
+                    IssueData::SEVERITY_ERROR,
                     0,
                     0,
                     "MissingPropertyType",
@@ -43,7 +43,7 @@ class IssueBufferTest extends TestCase
             ],
             '/path/two.php' => [
                 new IssueData(
-                    "error",
+                    IssueData::SEVERITY_ERROR,
                     0,
                     0,
                     "MissingPropertyType",
@@ -62,7 +62,7 @@ class IssueBufferTest extends TestCase
             ],
             '/path/three.php' => [
                 new IssueData(
-                    "error",
+                    IssueData::SEVERITY_ERROR,
                     0,
                     0,
                     "MissingPropertyType",
@@ -81,7 +81,7 @@ class IssueBufferTest extends TestCase
             ],
             '/path/four.php' => [
                 new IssueData(
-                    "error",
+                    IssueData::SEVERITY_ERROR,
                     0,
                     0,
                     "MissingPropertyType",

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -833,7 +833,7 @@ class ReportOutputTest extends TestCase
     {
         $issues_data = [
             22 => new IssueData(
-                'info',
+                IssueData::SEVERITY_INFO,
                 15,
                 15,
                 'PossiblyUndefinedGlobalVariable',


### PR DESCRIPTION
Introduce and use IssueData constants for severity: they are not the same as Config::REPORT_* constants.
