### PR TITLE
Use PHPStorm output format by default on JetBrains terminals

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -403,7 +403,20 @@ final class Psalm
     {
         return isset($options['output-format']) && is_string($options['output-format'])
             ? $options['output-format']
-            : Report::TYPE_CONSOLE;
+            : self::findDefaultOutputFormat();
+    }
+
+    /**
+     * @return Report::TYPE_*
+     */
+    private static function findDefaultOutputFormat(): string
+    {
+        $emulator = getenv('TERMINAL_EMULATOR');
+        if (is_string($emulator) && substr($emulator, 0, 9) === 'JetBrains') {
+            return Report::TYPE_PHP_STORM;
+        }
+
+        return Report::TYPE_CONSOLE;
     }
 
     private static function initShowInfo(array $options): bool


### PR DESCRIPTION
Goal: improve developer experience by using better defaults.

about `TERMINAL_EMULATOR` env var - it's tested on macOS and Ubuntu PHPStorm versions - works as expected.


We can also auto-detect other output formats, but firstly I would like to check this idea on this PR