### PR TITLE
Mention --find-unused-code instead of the old option

### DIFF
--- a/docs/running_psalm/issues/PossiblyUnusedMethod.md
+++ b/docs/running_psalm/issues/PossiblyUnusedMethod.md
@@ -1,6 +1,6 @@
 # PossiblyUnusedMethod
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any calls to
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any calls to
 a public or protected method.
 
 If this method is used and part of the public API, annotate the containing class

--- a/docs/running_psalm/issues/PossiblyUnusedParam.md
+++ b/docs/running_psalm/issues/PossiblyUnusedParam.md
@@ -1,6 +1,6 @@
 # PossiblyUnusedParam
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a particular parameter in a public/protected method
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a particular parameter in a public/protected method
 
 ```php
 <?php

--- a/docs/running_psalm/issues/PossiblyUnusedProperty.md
+++ b/docs/running_psalm/issues/PossiblyUnusedProperty.md
@@ -1,6 +1,6 @@
 # PossiblyUnusedProperty
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a
 particular public/protected property.
 
 If this property is used and part of the public API, annotate the containing

--- a/docs/running_psalm/issues/PossiblyUnusedReturnValue.md
+++ b/docs/running_psalm/issues/PossiblyUnusedReturnValue.md
@@ -1,6 +1,6 @@
 # PossiblyUnusedReturnValue
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a public/protected method’s return type.
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a public/protected method’s return type.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnevaluatedCode.md
+++ b/docs/running_psalm/issues/UnevaluatedCode.md
@@ -1,6 +1,6 @@
 # UnevaluatedCode
 
-Emitted when `--find-dead-code` is turned on and Psalm encounters code that will not be evaluated
+Emitted when `--find-unused-code` is turned on and Psalm encounters code that will not be evaluated
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnnecessaryVarAnnotation.md
+++ b/docs/running_psalm/issues/UnnecessaryVarAnnotation.md
@@ -1,6 +1,6 @@
 # UnnecessaryVarAnnotation
 
-Emitted when `--find-dead-code` is turned on and you're using a `@var` annotation on an assignment that Psalm has already identified a type for.
+Emitted when `--find-unused-code` is turned on and you're using a `@var` annotation on an assignment that Psalm has already identified a type for.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedClass.md
+++ b/docs/running_psalm/issues/UnusedClass.md
@@ -1,6 +1,6 @@
 # UnusedClass
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a
 given class.
 
 If this class is used and part of the public API, annotate it with `@psalm-api`.

--- a/docs/running_psalm/issues/UnusedClosureParam.md
+++ b/docs/running_psalm/issues/UnusedClosureParam.md
@@ -1,6 +1,6 @@
 # UnusedClosureParam
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a particular parameter in a closure.
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a particular parameter in a closure.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedConstructor.md
+++ b/docs/running_psalm/issues/UnusedConstructor.md
@@ -1,6 +1,6 @@
 # UnusedConstructor
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a given private constructor or function
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a given private constructor or function
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedDocblockParam.md
+++ b/docs/running_psalm/issues/UnusedDocblockParam.md
@@ -1,6 +1,6 @@
 # UnusedDocblockParam
 
-Emitted when `--find-dead-code` is turned on and a parameter specified in docblock does not have a corresponding parameter in function / method signature.
+Emitted when `--find-unused-code` is turned on and a parameter specified in docblock does not have a corresponding parameter in function / method signature.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedForeachValue.md
+++ b/docs/running_psalm/issues/UnusedForeachValue.md
@@ -1,6 +1,6 @@
 # UnusedForeachValue
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any
 references to the foreach value
 
 ```php

--- a/docs/running_psalm/issues/UnusedFunctionCall.md
+++ b/docs/running_psalm/issues/UnusedFunctionCall.md
@@ -1,6 +1,6 @@
 # UnusedFunctionCall
 
-Emitted when `--find-dead-code` is turned on and Psalm finds a function call whose return value is not used anywhere
+Emitted when `--find-unused-code` is turned on and Psalm finds a function call whose return value is not used anywhere
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedMethod.md
+++ b/docs/running_psalm/issues/UnusedMethod.md
@@ -1,6 +1,6 @@
 # UnusedMethod
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a
 given private method or function.
 
 If this method is used and part of the public API, annotate the containing class

--- a/docs/running_psalm/issues/UnusedMethodCall.md
+++ b/docs/running_psalm/issues/UnusedMethodCall.md
@@ -1,6 +1,6 @@
 # UnusedMethodCall
 
-Emitted when `--find-dead-code` is turned on and Psalm finds a method call whose return value is not used anywhere
+Emitted when `--find-unused-code` is turned on and Psalm finds a method call whose return value is not used anywhere
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedParam.md
+++ b/docs/running_psalm/issues/UnusedParam.md
@@ -1,6 +1,6 @@
 # UnusedParam
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a particular parameter in a private method or function
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a particular parameter in a private method or function
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedProperty.md
+++ b/docs/running_psalm/issues/UnusedProperty.md
@@ -1,6 +1,6 @@
 # UnusedProperty
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a
 private property.
 
 Properties used in constructor only are considered unused. Use normal variables instead.

--- a/docs/running_psalm/issues/UnusedReturnValue.md
+++ b/docs/running_psalm/issues/UnusedReturnValue.md
@@ -1,6 +1,6 @@
 # UnusedReturnValue
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any uses of a private method’s return value.
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any uses of a private method’s return value.
 
 ```php
 <?php

--- a/docs/running_psalm/issues/UnusedVariable.md
+++ b/docs/running_psalm/issues/UnusedVariable.md
@@ -1,6 +1,6 @@
 # UnusedVariable
 
-Emitted when `--find-dead-code` is turned on and Psalm cannot find any references to a variable, once instantiated
+Emitted when `--find-unused-code` is turned on and Psalm cannot find any references to a variable, once instantiated
 
 ```php
 <?php


### PR DESCRIPTION
Let's finish what was started.

Some people don't like being remembered about death.

And `psalm --help` calls it `--find-unused-code` anyways, since a while already.