### PR TITLE
Unmark DateInterval::$invert as read-only

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -586,7 +586,6 @@ class DateInterval
     /**
      * Is 1 if the interval is inverted and 0 otherwise
      * @var int
-     * @readonly
      */
     public $invert;
 


### PR DESCRIPTION
Despite the [PHP documentation](https://www.php.net/manual/en/class.dateinterval.php) recommending that `DateInterval` properties should be considered read-only, there is no way to specify an inverted interval via the constructor. Therefore, setting this property on an existing object should not be considered an error.