### PR TITLE
Sprintf additional validations and bugfix

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/SprintfReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/SprintfReturnTypeProvider.php
@@ -63,7 +63,7 @@ class SprintfReturnTypeProvider implements FunctionReturnTypeProviderInterface
         $node_type_provider = $statements_source->getNodeTypeProvider();
         foreach ($call_args as $index => $call_arg) {
             $type = $node_type_provider->getType($call_arg->value);
-            if ($type === null && $event->getFunctionId() === 'printf') {
+            if ($type === null && $index === 0 && $event->getFunctionId() === 'printf') {
                 break;
             }
 

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/SprintfReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/SprintfReturnTypeProvider.php
@@ -82,7 +82,29 @@ class SprintfReturnTypeProvider implements FunctionReturnTypeProviderInterface
                         $statements_source->getSuppressedIssues(),
                     );
 
-                    return null;
+                    if ($event->getFunctionId() === 'printf') {
+                        return Type::getInt(false, 0);
+                    }
+
+                    return Type::getString('');
+                }
+
+                // there are probably additional formats that return an empty string, this is just a starting point
+                if (preg_match('/^%(?:\d+\$)?[-+]?0(\.0)?s$/', $type->getSingleStringLiteral()->value) === 1) {
+                    IssueBuffer::maybeAdd(
+                        new InvalidArgument(
+                            'The pattern of argument 1 of ' . $event->getFunctionId() . ' will always return an empty string',
+                            $event->getCodeLocation(),
+                            $event->getFunctionId(),
+                        ),
+                        $statements_source->getSuppressedIssues(),
+                    );
+
+                    if ($event->getFunctionId() === 'printf') {
+                        return Type::getInt(false, 0);
+                    }
+
+                    return Type::getString('');
                 }
 
                 $args_count = count($call_args) - 1;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/SprintfReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/SprintfReturnTypeProvider.php
@@ -22,6 +22,7 @@ use ValueError;
 use function array_fill;
 use function array_pop;
 use function count;
+use function preg_match;
 use function sprintf;
 
 /**
@@ -93,7 +94,8 @@ class SprintfReturnTypeProvider implements FunctionReturnTypeProviderInterface
                 if (preg_match('/^%(?:\d+\$)?[-+]?0(?:\.0)?s$/', $type->getSingleStringLiteral()->value) === 1) {
                     IssueBuffer::maybeAdd(
                         new InvalidArgument(
-                            'The pattern of argument 1 of ' . $event->getFunctionId() . ' will always return an empty string',
+                            'The pattern of argument 1 of ' . $event->getFunctionId()
+                            . ' will always return an empty string',
                             $event->getCodeLocation(),
                             $event->getFunctionId(),
                         ),
@@ -107,13 +109,17 @@ class SprintfReturnTypeProvider implements FunctionReturnTypeProviderInterface
                     return Type::getString('');
                 }
 
-                // placeholders are too complex to handle for now
-                if (preg_match('/%(?:\d+\$)?[-+]?(?:\d+|\*)(?:\.(?:\d+|\*))?[bcdouxXeEfFgGhHs]/', $type->getSingleStringLiteral()->value) === 1) {
+                // these placeholders are too complex to handle for now
+                if (preg_match(
+                    '/%(?:\d+\$)?[-+]?(?:\d+|\*)(?:\.(?:\d+|\*))?[bcdouxXeEfFgGhHs]/',
+                    $type->getSingleStringLiteral()->value,
+                ) === 1) {
                     if ($event->getFunctionId() === 'printf') {
                         return null;
                     }
 
-                    // the core stubs are wrong for these too, since these might be empty strings, e.g. sprintf(\'%0.*s\', 0, "abc")
+                    // the core stubs are wrong for these too, since these might be empty strings
+                    // e.g. sprintf(\'%0.*s\', 0, "abc")
                     return Type::getString();
                 }
 

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/SprintfReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/SprintfReturnTypeProvider.php
@@ -101,7 +101,8 @@ class SprintfReturnTypeProvider implements FunctionReturnTypeProviderInterface
                             if ($result === $type->getSingleStringLiteral()->value) {
                                 IssueBuffer::maybeAdd(
                                     new InvalidArgument(
-                                        'Argument 1 of ' . $event->getFunctionId() . ' does not contain any placeholders',
+                                        'Argument 1 of ' . $event->getFunctionId()
+                                        . ' does not contain any placeholders',
                                         $event->getCodeLocation(),
                                         $event->getFunctionId(),
                                     ),
@@ -216,12 +217,8 @@ class SprintfReturnTypeProvider implements FunctionReturnTypeProviderInterface
                     return Type::getNonEmptyString();
                 }
 
-                /**
-                 * if we didn't have a valid result, the pattern is invalid or not yet supported by the return type provider
-                 * PHP 7 can have false here
-                 *
-                 * @psalm-suppress RedundantConditionGivenDocblockType
-                 */
+                // if we didn't have a valid result
+                // the pattern is invalid or not yet supported by the return type provider
                 if ($initial_result === null || $initial_result === false) {
                     return null;
                 }

--- a/tests/ReturnTypeProvider/SprintfTest.php
+++ b/tests/ReturnTypeProvider/SprintfTest.php
@@ -143,6 +143,18 @@ class SprintfTest extends TestCase
                 'InvalidArgument',
             ],
         ];
+
+        yield 'sprintfPaddedEmptyStringFormat' => [
+            'code' => '<?php
+                $val = sprintf("%0.0s", "abc");
+            ',
+            'assertions' => [
+                '$val===' => 'string',
+            ],
+            'ignored_issues' => [
+                'InvalidArgument',
+            ],
+        ];
     }
 
     public function providerInvalidCodeParse(): iterable
@@ -205,6 +217,12 @@ class SprintfTest extends TestCase
             'sprintfFormatWithoutPlaceholders' => [
                 'code' => '<?php
                     $x = sprintf("hello", "abc");
+                ',
+                'error_message' => 'InvalidArgument',
+            ],
+            'sprintfPaddedComplexEmptyStringFormat' => [
+                'code' => '<?php
+                    $x = sprintf("%1$+0.0s", "abc");
                 ',
                 'error_message' => 'InvalidArgument',
             ],

--- a/tests/ReturnTypeProvider/SprintfTest.php
+++ b/tests/ReturnTypeProvider/SprintfTest.php
@@ -137,7 +137,7 @@ class SprintfTest extends TestCase
                 $val = sprintf("", "abc");
             ',
             'assertions' => [
-                '$val===' => 'string',
+                '$val===' => '\'\'',
             ],
             'ignored_issues' => [
                 'InvalidArgument',
@@ -149,7 +149,7 @@ class SprintfTest extends TestCase
                 $val = sprintf("%0.0s", "abc");
             ',
             'assertions' => [
-                '$val===' => 'string',
+                '$val===' => '\'\'',
             ],
             'ignored_issues' => [
                 'InvalidArgument',

--- a/tests/ReturnTypeProvider/SprintfTest.php
+++ b/tests/ReturnTypeProvider/SprintfTest.php
@@ -140,7 +140,7 @@ class SprintfTest extends TestCase
                 '$val===' => 'string',
             ],
             'ignored_issues' => [
-                'InvalidArgument'
+                'InvalidArgument',
             ],
         ];
     }

--- a/tests/ReturnTypeProvider/SprintfTest.php
+++ b/tests/ReturnTypeProvider/SprintfTest.php
@@ -155,6 +155,33 @@ class SprintfTest extends TestCase
                 'InvalidArgument',
             ],
         ];
+
+        yield 'sprintfComplexPlaceholderNotYetSupported1' => [
+            'code' => '<?php
+                $val = sprintf(\'%*.0s\', 0, "abc");
+            ',
+            'assertions' => [
+                '$val===' => 'string',
+            ],
+        ];
+
+        yield 'sprintfComplexPlaceholderNotYetSupported2' => [
+            'code' => '<?php
+                $val = sprintf(\'%0.*s\', 0, "abc");
+            ',
+            'assertions' => [
+                '$val===' => 'string',
+            ],
+        ];
+
+        yield 'sprintfComplexPlaceholderNotYetSupported3' => [
+            'code' => '<?php
+                $val = sprintf(\'%*.*s\', 0, 0, "abc");
+            ',
+            'assertions' => [
+                '$val===' => 'string',
+            ],
+        ];
     }
 
     public function providerInvalidCodeParse(): iterable

--- a/tests/ReturnTypeProvider/SprintfTest.php
+++ b/tests/ReturnTypeProvider/SprintfTest.php
@@ -131,6 +131,18 @@ class SprintfTest extends TestCase
                 '$val===' => 'int<0, max>',
             ],
         ];
+
+        yield 'sprintfEmptyStringFormat' => [
+            'code' => '<?php
+                $val = sprintf("", "abc");
+            ',
+            'assertions' => [
+                '$val===' => 'string',
+            ],
+            'ignored_issues' => [
+                'InvalidArgument'
+            ],
+        ];
     }
 
     public function providerInvalidCodeParse(): iterable
@@ -181,6 +193,18 @@ class SprintfTest extends TestCase
             'printfInvalidFormat' => [
                 'code' => '<?php
                     printf(\'"%" hello\', "a");
+                ',
+                'error_message' => 'InvalidArgument',
+            ],
+            'sprintfEmptyFormat' => [
+                'code' => '<?php
+                    $x = sprintf("", "abc");
+                ',
+                'error_message' => 'InvalidArgument',
+            ],
+            'sprintfFormatWithoutPlaceholders' => [
+                'code' => '<?php
+                    $x = sprintf("hello", "abc");
                 ',
                 'error_message' => 'InvalidArgument',
             ],


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/9900
Fix https://github.com/vimeo/psalm/issues/9901
Fix original core stubs sprintf returning a wrong type too (unrelated to return type provider) for placeholders that are always empty

Add additional errors for always empty formats
Add additional error for formats without placeholders