### PR TITLE
docblock parser minor performance gain

### DIFF
--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -259,7 +259,7 @@ class CommentAnalyzer
     public static function sanitizeDocblockType(string $docblock_type): string
     {
         $docblock_type = preg_replace('@^[ \t]*\*@m', '', $docblock_type);
-        $docblock_type = preg_replace('/,\n\s+\}/', '}', $docblock_type);
+        $docblock_type = preg_replace('/,\n\s+}/', '}', $docblock_type);
         return str_replace("\n", '', $docblock_type);
     }
 
@@ -377,7 +377,7 @@ class CommentAnalyzer
                 $remaining = trim(preg_replace('@^[ \t]*\* *@m', ' ', substr($return_block, $i + 1)));
 
                 if ($remaining) {
-                    return array_merge([rtrim($type)], preg_split('/[ \s]+/', $remaining) ?: []);
+                    return array_merge([rtrim($type)], preg_split('/\s+/', $remaining) ?: []);
                 }
 
                 return [$type];

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -87,7 +87,9 @@ class DocblockParser
             if ($first_line_padding === null) {
                 $asterisk_pos = strpos($line, '*');
 
-                if ($asterisk_pos) {
+                if ($asterisk_pos === 0 || $asterisk_pos === 1) {
+                    $first_line_padding = '';
+                } elseif ($asterisk_pos > 1) {
                     $first_line_padding = substr($line, 0, $asterisk_pos - 1);
                 }
             }
@@ -99,7 +101,7 @@ class DocblockParser
                 [$type] = $type_info;
                 [$data, $data_offset] = $data_info;
 
-                if (strpos($data, '*')) {
+                if (strpos($data, '*') !== false) {
                     $data = rtrim(preg_replace('/^ *\*\s*$/m', '', $data));
                 }
 

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -122,13 +122,20 @@ class DocblockParser
 
         // Smush the whole docblock to the left edge.
         $min_indent = 80;
+        $reached_first_non_empty_line = false;
         foreach ($lines as $k => $line) {
             $indent = strspn($line, ' ');
             if ($indent === strlen($line)) {
                 // This line consists of only spaces. Trim it completely.
+                if ($reached_first_non_empty_line === false) {
+                    // remove any leading empty lines here, to avoid a preg_replace later
+                    unset($lines[$k]);
+                    continue;
+                }
                 $lines[$k] = '';
                 continue;
             }
+            $reached_first_non_empty_line = true;
             $min_indent = min($indent, $min_indent);
         }
         if ($min_indent > 0) {
@@ -141,10 +148,6 @@ class DocblockParser
         }
         $docblock = implode("\n", $lines);
         $docblock = rtrim($docblock);
-
-        // Trim any empty lines off the front, but leave the indent level if there
-        // is one.
-        $docblock = preg_replace('/^\s*\n/', '', $docblock, 1);
 
         $parsed = new ParsedDocblock($docblock, $special, $first_line_padding ?: '');
 

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -12,6 +12,7 @@ use function count;
 use function explode;
 use function implode;
 use function is_string;
+use function ltrim;
 use function min;
 use function preg_match;
 use function preg_replace;
@@ -110,7 +111,9 @@ class DocblockParser
                 unset($lines[$k]);
             } else {
                 // Strip the leading *, if present.
-                $lines[$k] = preg_replace('/^ *\*/', '', $lines[$k], 1);
+                // technically only need to preg_replace('/^ *\*/', '', $lines[$k], 1)
+                // however it's slower and removing all spaces and * is fine
+                $lines[$k] = ltrim($lines[$k], ' *');
             }
 
             $line_offset += $original_line_length + 1;

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -62,9 +62,9 @@ class DocblockParser
 
         $last = false;
         foreach ($lines as $k => $line) {
-            if (preg_match('/^[ \t]*\*?\s*@\w/i', $line)) {
+            if (strpos($line, '@') !== false && preg_match('/^[\t ]*\*?\s*@\w/', $line)) {
                 $last = $k;
-            } elseif (preg_match('/^\s*\r?$/', $line)) {
+            } elseif (trim($line) === '') {
                 $last = false;
             } elseif ($last !== false) {
                 $old_last_line = $lines[$last];

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -54,7 +54,7 @@ class DocblockParser
         }
 
         // Normalize multi-line @specials.
-        $lines = explode("\n", $docblock);
+        $lines = explode("\n", str_replace("\t", ' ', $docblock));
 
         $special = [];
 
@@ -62,7 +62,7 @@ class DocblockParser
 
         $last = false;
         foreach ($lines as $k => $line) {
-            if (strpos($line, '@') !== false && preg_match('/^[\t ]*\*?\s*@\w/', $line)) {
+            if (strpos($line, '@') !== false && preg_match('/^ *\*?\s*@\w/', $line)) {
                 $last = $k;
             } elseif (trim($line) === '') {
                 $last = false;
@@ -78,7 +78,6 @@ class DocblockParser
 
         foreach ($lines as $k => $line) {
             $original_line_length = strlen($line);
-
             $line = str_replace("\r", '', $line);
 
             if ($first_line_padding === null) {
@@ -89,7 +88,7 @@ class DocblockParser
                 }
             }
 
-            if (preg_match('/^[ \t]*\*?\s*@([\w\-\\\:]+)[\t ]*(.*)$/sm', $line, $matches, PREG_OFFSET_CAPTURE)) {
+            if (preg_match('/^ *\*?\s*@([\w\-\\\:]+) *(.*)$/sm', $line, $matches, PREG_OFFSET_CAPTURE)) {
                 /** @var array<int, array{string, int}> $matches */
                 [, $type_info, $data_info] = $matches;
 
@@ -97,7 +96,7 @@ class DocblockParser
                 [$data, $data_offset] = $data_info;
 
                 if (strpos($data, '*')) {
-                    $data = rtrim(preg_replace('/^[ \t]*\*\s*$/m', '', $data));
+                    $data = rtrim(preg_replace('/^ *\*\s*$/m', '', $data));
                 }
 
                 if (empty($special[$type])) {
@@ -111,10 +110,7 @@ class DocblockParser
                 unset($lines[$k]);
             } else {
                 // Strip the leading *, if present.
-                $text = $lines[$k];
-                $text = str_replace("\t", ' ', $text);
-                $text = preg_replace('/^ *\*/', '', $text, 1);
-                $lines[$k] = $text;
+                $lines[$k] = preg_replace('/^ *\*/', '', $lines[$k], 1);
             }
 
             $line_offset += $original_line_length + 1;

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -56,6 +56,7 @@ class DocblockParser
 
         // Normalize multi-line @specials.
         $lines = explode("\n", str_replace("\t", ' ', $docblock));
+        $has_r = strpos($docblock, "\r") === false ? false : true;
 
         $special = [];
 
@@ -79,7 +80,9 @@ class DocblockParser
 
         foreach ($lines as $k => $line) {
             $original_line_length = strlen($line);
-            $line = str_replace("\r", '', $line);
+            if ($has_r === true) {
+                $line = str_replace("\r", '', $line);
+            }
 
             if ($first_line_padding === null) {
                 $asterisk_pos = strpos($line, '*');

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2433,7 +2433,7 @@ class ConditionalTest extends TestCase
 
                                 if ($remaining) {
                                     /** @var array<string> */
-                                    return array_merge([rtrim($type)], preg_split(\'/[ \s]+/\', $remaining));
+                                    return array_merge([rtrim($type)], preg_split(\'/\s+/\', $remaining));
                                 }
 
                                 return [$type];


### PR DESCRIPTION
Profiled psalm and reduced preg_ calls in DocblockParser to save between 0-5% runtime