### PR TITLE
Add a stub file for Attributes defined by PHP

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2236,6 +2236,8 @@ class Config
         ];
 
         if ($codebase->analysis_php_version_id >= 8_00_00) {
+            $stringable_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'CoreGenericAttributes.phpstub';
+            $this->internal_stubs[] = $stringable_path;
             $stringable_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'Php80.phpstub';
             $this->internal_stubs[] = $stringable_path;
         }

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2226,30 +2226,27 @@ class Config
         $codebase->register_stub_files = true;
 
         $dir_lvl_2 = dirname(__DIR__, 2);
+        $stubsDir = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR;
         $this->internal_stubs = [
-            $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'CoreGenericFunctions.phpstub',
-            $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'CoreGenericClasses.phpstub',
-            $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'CoreGenericIterators.phpstub',
-            $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'CoreImmutableClasses.phpstub',
-            $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'Reflection.phpstub',
-            $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'SPL.phpstub',
+            $stubsDir . 'CoreGenericFunctions.phpstub',
+            $stubsDir . 'CoreGenericClasses.phpstub',
+            $stubsDir . 'CoreGenericIterators.phpstub',
+            $stubsDir . 'CoreImmutableClasses.phpstub',
+            $stubsDir . 'Reflection.phpstub',
+            $stubsDir . 'SPL.phpstub',
         ];
 
         if ($codebase->analysis_php_version_id >= 8_00_00) {
-            $stringable_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'CoreGenericAttributes.phpstub';
-            $this->internal_stubs[] = $stringable_path;
-            $stringable_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'Php80.phpstub';
-            $this->internal_stubs[] = $stringable_path;
+            $this->internal_stubs[] = $stubsDir . 'CoreGenericAttributes.phpstub';
+            $this->internal_stubs[] = $stubsDir . 'Php80.phpstub';
         }
 
         if ($codebase->analysis_php_version_id >= 8_01_00) {
-            $stringable_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'Php81.phpstub';
-            $this->internal_stubs[] = $stringable_path;
+            $this->internal_stubs[] = $stubsDir . 'Php81.phpstub';
         }
 
         if ($codebase->analysis_php_version_id >= 8_02_00) {
-            $stringable_path = $dir_lvl_2 . DIRECTORY_SEPARATOR . 'stubs' . DIRECTORY_SEPARATOR . 'Php82.phpstub';
-            $this->internal_stubs[] = $stringable_path;
+            $this->internal_stubs[] = $stubsDir . 'Php82.phpstub';
             $this->php_extensions['random'] = true; // random is a part of the PHP core starting from PHP 8.2
         }
 

--- a/stubs/CoreGenericAttributes.phpstub
+++ b/stubs/CoreGenericAttributes.phpstub
@@ -1,0 +1,13 @@
+<?php
+
+#[Attribute(Attribute::TARGET_CLASS)]
+final class AllowDynamicProperties
+{
+    public function __construct() {}
+}
+
+#[Attribute(Attribute::TARGET_PARAMETER)]
+final class SensitiveParameter
+{
+    public function __construct() {}
+}

--- a/stubs/Php82.phpstub
+++ b/stubs/Php82.phpstub
@@ -34,18 +34,6 @@ namespace {
         public function getIterator(): Iterator {}
     }
 
-    #[Attribute(Attribute::TARGET_PARAMETER)]
-    final class SensitiveParameter
-    {
-        public function __construct() {}
-    }
-
-    #[Attribute(Attribute::TARGET_CLASS)]
-    final class AllowDynamicProperties
-    {
-        public function __construct() {}
-    }
-
     /**
     * @psalm-pure
     * @param positive-int $length


### PR DESCRIPTION
Adding a stub so that running Psalm in a PHP environment that doesn't support a built-in Attribute eg 8.0 with #[AllowDynamicProperties]

Should be fine until php-src introduces a new attribute the conflicts with a userland class...