### PR TITLE
Don't update types of the outer scope when in an elseif conditional

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseIfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseIfAnalyzer.php
@@ -358,16 +358,6 @@ class ElseIfAnalyzer
                         $elseif_context->inside_loop,
                         new CodeLocation($statements_analyzer->getSource(), $elseif, $outer_context->include_location),
                     );
-
-                $updated_vars = [];
-
-                $outer_context->update(
-                    $elseif_context,
-                    $implied_outer_context,
-                    false,
-                    array_keys($negated_elseif_types),
-                    $updated_vars,
-                );
             }
         }
 

--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -313,7 +313,7 @@ class InternalCallMapHandlerTest extends TestCase
     }
 
     /**
-     * @return iterable<string, array{0: callable-string, 1: array<int|string, string>}>
+     * @return iterable<string, array{string, array<int|string, string>}>
      */
     public function callMapEntryProvider(): iterable
     {
@@ -404,7 +404,7 @@ class InternalCallMapHandlerTest extends TestCase
      * @depends testGetcallmapReturnsAValidCallmap
      * @dataProvider callMapEntryProvider
      * @coversNothing
-     * @psalm-param callable-string $functionName
+     * @psalm-param string $functionName
      * @param array<int|string, string> $callMapEntry
      */
     public function testIgnoredFunctionsStillFail(string $functionName, array $callMapEntry): void
@@ -462,7 +462,7 @@ class InternalCallMapHandlerTest extends TestCase
      * @depends testGetcallmapReturnsAValidCallmap
      * @depends testIgnoresAreSortedAndUnique
      * @dataProvider callMapEntryProvider
-     * @psalm-param callable-string $functionName
+     * @psalm-param string $functionName
      * @param array<int|string, string> $callMapEntry
      */
     public function testCallMapCompliesWithReflection(string $functionName, array $callMapEntry): void

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -3052,6 +3052,23 @@ class ConditionalTest extends TestCase
                     '$int' => 'int<97, 122>',
                 ],
             ],
+            'short_circuited_conditional_test' => [
+                'code' => '<?php
+                    /** @var ?stdClass $existing */
+                    $existing = null;
+
+                    /** @var bool $foo */
+                    $foo = true;
+
+                    if ($foo) {
+                    } elseif ($existing === null) {
+                        throw new \RuntimeException();
+                    }
+                    ',
+                'assertions' => [
+                    '$existing' => 'null|stdClass',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This feels extreme for https://github.com/vimeo/psalm/issues/9894 but I'm struggling to come up with a situation where the condition in an elseif can safely modify the outer scope unless the `elseif` could actually just be an `if` (the if branch was an early return). 
