### PR TITLE
Invalidate cached methods when referenced files are deleted

### DIFF
--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -687,6 +687,16 @@ class Analyzer
             }
         }
 
+        // This could be optimized by storing method references to files
+        foreach ($file_reference_provider->getDeletedReferencedFiles() as $deleted_file) {
+            foreach ($file_reference_provider->getFilesReferencingFile($deleted_file) as $file_referencing_deleted) {
+                $methods_referencing_deleted = $this->analyzed_methods[$file_referencing_deleted] ?? [];
+                foreach ($methods_referencing_deleted as $method_referencing_deleted => $_) {
+                    $newly_invalidated_methods[$method_referencing_deleted] = true;
+                }
+            }
+        }
+
         foreach ($newly_invalidated_methods as $method_id => $_) {
             foreach ($method_references_to_class_members as $i => $_) {
                 unset($method_references_to_class_members[$i][$method_id]);

--- a/src/Psalm/Internal/Provider/FakeFileProvider.php
+++ b/src/Psalm/Internal/Provider/FakeFileProvider.php
@@ -68,6 +68,12 @@ class FakeFileProvider extends FileProvider
         $this->fake_file_times[$file_path] = (int)microtime(true);
     }
 
+    public function deleteFile(string $file_path): void
+    {
+        unset($this->fake_files[$file_path]);
+        unset($this->fake_file_times[$file_path]);
+    }
+
     /**
      * @param array<string> $file_extensions
      * @param null|callable(string):bool $filter

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -119,5 +119,41 @@ class CacheTest extends TestCase
      */
     public static function provideCacheInteractions(): iterable
     {
+        yield 'deletedFileInvalidatesReferencingMethod' => [
+            [
+                [
+                    'files' => [
+                        '/src/A.php' => <<<'PHP'
+                            <?php
+                            class A {
+                                public function do(B $b): void
+                                {
+                                    $b->do();
+                                }
+                            }
+                            PHP,
+                        '/src/B.php' => <<<'PHP'
+                            <?php
+                            class B {
+                                public function do(): void
+                                {
+                                    echo 'B';
+                                }
+                            }
+                            PHP,
+                    ],
+                ],
+                [
+                    'files' => [
+                        '/src/B.php' => null,
+                    ],
+                    'issues' => [
+                        '/src/A.php' => [
+                            'UndefinedClass: Class, interface or enum named B does not exist',
+                        ],
+                    ],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Cache;
+
+use Psalm\Config;
+use Psalm\Internal\Analyzer\IssueData;
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\Internal\IncludeCollector;
+use Psalm\Internal\Provider\FakeFileProvider;
+use Psalm\Internal\Provider\Providers;
+use Psalm\Internal\RuntimeCaches;
+use Psalm\IssueBuffer;
+use Psalm\Tests\Internal\Provider\ClassLikeStorageInstanceCacheProvider;
+use Psalm\Tests\Internal\Provider\FakeFileReferenceCacheProvider;
+use Psalm\Tests\Internal\Provider\FileStorageInstanceCacheProvider;
+use Psalm\Tests\Internal\Provider\ParserInstanceCacheProvider;
+use Psalm\Tests\Internal\Provider\ProjectCacheProvider;
+use Psalm\Tests\TestCase;
+
+use function str_replace;
+
+use const DIRECTORY_SEPARATOR;
+
+class CacheTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        RuntimeCaches::clearAll();
+    }
+
+    public function tearDown(): void
+    {
+        RuntimeCaches::clearAll();
+
+        parent::tearDown();
+    }
+
+    /**
+     * @param array<string, list<IssueData>> $issue_data
+     * @return array<string, list<string>>
+     */
+    private static function normalizeIssueData(array $issue_data): array
+    {
+        $return = [];
+        foreach ($issue_data as $issue_data_per_file) {
+            foreach ($issue_data_per_file as $one_issue_data) {
+                $file_name = str_replace(DIRECTORY_SEPARATOR, '/', $one_issue_data->file_name);
+                $return[$file_name][] = $one_issue_data->type . ': ' . $one_issue_data->message;
+            }
+        }
+
+        return $return;
+    }
+
+    /**
+     * @param list<array{
+     *     files: array<string, string|null>,
+     *     issues?: array<string, list<string>>,
+     * }> $interactions
+     * @dataProvider provideCacheInteractions
+     */
+    public function testCacheInteractions(
+        array $interactions
+    ): void {
+        $config = Config::loadFromXML(
+            __DIR__ . DIRECTORY_SEPARATOR . 'test_base_dir',
+            <<<'XML'
+                <?xml version="1.0"?>
+                <psalm>
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+                </psalm>
+                XML,
+        );
+        $config->setIncludeCollector(new IncludeCollector());
+
+        $file_provider = new FakeFileProvider();
+        $providers = new Providers(
+            $file_provider,
+            new ParserInstanceCacheProvider(),
+            new FileStorageInstanceCacheProvider(),
+            new ClassLikeStorageInstanceCacheProvider(),
+            new FakeFileReferenceCacheProvider(),
+            new ProjectCacheProvider(),
+        );
+
+        foreach ($interactions as $interaction) {
+            foreach ($interaction['files'] as $file_path => $file_contents) {
+                $file_path = $config->base_dir . str_replace('/', DIRECTORY_SEPARATOR, $file_path);
+                if ($file_contents === null) {
+                    $file_provider->deleteFile($file_path);
+                } else {
+                    $file_provider->registerFile($file_path, $file_contents);
+                }
+            }
+
+            RuntimeCaches::clearAll();
+
+            $project_analyzer = new ProjectAnalyzer($config, $providers);
+            $project_analyzer->check($config->base_dir, true);
+
+            $issues = self::normalizeIssueData(IssueBuffer::getIssuesData());
+            self::assertSame($interaction['issues'] ?? [], $issues);
+        }
+    }
+
+    /**
+     * @return iterable<string, list{
+     *     list<array{
+     *         files: array<string, string|null>,
+     *         issues?: array<string, list<string>>,
+     *     }>,
+     * }>
+     */
+    public static function provideCacheInteractions(): iterable
+    {
+    }
+}


### PR DESCRIPTION
There's currently no invalidation mechanism for methods referencing another file (e.g. by using a symbol from it),
Example:
1. File `A.php` with method `A::do()` has an argument of type `B`, which is a class defined in file `B.php`
2. Psalm runs and caches
3. File `B.php` is deleted
4. Psalm runs and doesn't report an issue