### PR TITLE
Do not invalidate cache during suppression

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -421,9 +421,7 @@ final class Psalm
 
     private static function initIsDiff(array $options): bool
     {
-        return !isset($options['no-diff'])
-            && !isset($options['set-baseline'])
-            && !isset($options['update-baseline']);
+        return !isset($options['no-diff']);
     }
 
     /**


### PR DESCRIPTION
see #9918 for background

im not aware of psalm internals, but i tried this change first and it reduces runtime practically **100%** for us when running `psalm --set-baseline=psalm-baseline.xml` _with_ cache

I also cannot spot any side-effects still this may cause, eg. expected issues are still being written to, and removed from the baseline :flushed: 

Im curious what tests do here with this change, hence a PR.

cc @orklah i must be missing something :smile: 
