### PR TITLE
Invalidate cached methods when referenced class property types change

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1098,6 +1098,15 @@ class ProjectAnalyzer
         }
     }
 
+    public function finish(float $start_time, string $psalm_version): void
+    {
+        $this->codebase->file_reference_provider->removeDeletedFilesFromReferences();
+
+        if ($this->project_cache_provider) {
+            $this->project_cache_provider->processSuccessfulRun($start_time, $psalm_version);
+        }
+    }
+
     public function getConfig(): Config
     {
         return $this->config;

--- a/src/Psalm/Internal/Diff/ClassStatementsDiffer.php
+++ b/src/Psalm/Internal/Diff/ClassStatementsDiffer.php
@@ -158,6 +158,22 @@ class ClassStatementsDiffer extends AstDiffer
                         return false;
                     }
 
+                    if ($a->type xor $b->type) {
+                        return false;
+                    }
+
+                    if ($a->type && $b->type) {
+                        $a_type_start = (int) $a->type->getAttribute('startFilePos');
+                        $a_type_end = (int) $a->type->getAttribute('endFilePos');
+                        $b_type_start = (int) $b->type->getAttribute('startFilePos');
+                        $b_type_end = (int) $b->type->getAttribute('endFilePos');
+                        if (substr($a_code, $a_type_start, $a_type_end - $a_type_start + 1)
+                            !== substr($b_code, $b_type_start, $b_type_end - $b_type_start + 1)
+                        ) {
+                            return false;
+                        }
+                    }
+
                     $body_change = substr($a_code, $a_comments_end, $a_end - $a_comments_end)
                         !== substr($b_code, $b_comments_end, $b_end - $b_comments_end);
                 } else {

--- a/src/Psalm/Internal/LanguageServer/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/LanguageServer/Provider/FileStorageCacheProvider.php
@@ -19,21 +19,12 @@ class FileStorageCacheProvider extends InternalFileStorageCacheProvider
     {
     }
 
-    public function writeToCache(FileStorage $storage, string $file_contents): void
+    /**
+     * @param lowercase-string $file_path
+     */
+    protected function storeInCache(string $file_path, FileStorage $storage): void
     {
-        $file_path = strtolower($storage->file_path);
         $this->cache[$file_path] = $storage;
-    }
-
-    public function getLatestFromCache(string $file_path, string $file_contents): ?FileStorage
-    {
-        $cached_value = $this->loadFromCache(strtolower($file_path));
-
-        if (!$cached_value) {
-            return null;
-        }
-
-        return $cached_value;
     }
 
     public function removeCacheForFile(string $file_path): void
@@ -41,8 +32,11 @@ class FileStorageCacheProvider extends InternalFileStorageCacheProvider
         unset($this->cache[strtolower($file_path)]);
     }
 
-    private function loadFromCache(string $file_path): ?FileStorage
+    /**
+     * @param lowercase-string $file_path
+     */
+    protected function loadFromCache(string $file_path): ?FileStorage
     {
-        return $this->cache[strtolower($file_path)] ?? null;
+        return $this->cache[$file_path] ?? null;
     }
 }

--- a/src/Psalm/Internal/Provider/FileReferenceProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceProvider.php
@@ -14,7 +14,6 @@ use function array_keys;
 use function array_merge;
 use function array_unique;
 use function explode;
-use function file_exists;
 
 /**
  * Used to determine which files reference other files, necessary for using the --diff
@@ -164,10 +163,12 @@ class FileReferenceProvider
      */
     private static array $method_param_uses = [];
 
+    private FileProvider $file_provider;
     public ?FileReferenceCacheProvider $cache = null;
 
-    public function __construct(?FileReferenceCacheProvider $cache = null)
+    public function __construct(FileProvider $file_provider, ?FileReferenceCacheProvider $cache = null)
     {
+        $this->file_provider = $file_provider;
         $this->cache = $cache;
     }
 
@@ -179,7 +180,7 @@ class FileReferenceProvider
         if (self::$deleted_files === null) {
             self::$deleted_files = array_filter(
                 array_keys(self::$file_references),
-                static fn(string $file_name): bool => !file_exists($file_name)
+                fn(string $file_name): bool => !$this->file_provider->fileExists($file_name)
             );
         }
 

--- a/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
@@ -64,9 +64,17 @@ class FileStorageCacheProvider
     public function writeToCache(FileStorage $storage, string $file_contents): void
     {
         $file_path = strtolower($storage->file_path);
-        $cache_location = $this->getCacheLocationForPath($file_path, true);
         $storage->hash = $this->getCacheHash($file_path, $file_contents);
 
+        $this->storeInCache($file_path, $storage);
+    }
+
+    /**
+     * @param lowercase-string $file_path
+     */
+    protected function storeInCache(string $file_path, FileStorage  $storage): void
+    {
+        $cache_location = $this->getCacheLocationForPath($file_path, true);
         $this->cache->saveItem($cache_location, $storage);
     }
 
@@ -107,7 +115,10 @@ class FileStorageCacheProvider
         return PHP_VERSION_ID >= 8_01_00 ? hash('xxh128', $data) : hash('md4', $data);
     }
 
-    private function loadFromCache(string $file_path): ?FileStorage
+    /**
+     * @param lowercase-string $file_path
+     */
+    protected function loadFromCache(string $file_path): ?FileStorage
     {
         $storage = $this->cache->getItem($this->getCacheLocationForPath($file_path));
         if ($storage instanceof FileStorage) {

--- a/src/Psalm/Internal/Provider/Providers.php
+++ b/src/Psalm/Internal/Provider/Providers.php
@@ -51,7 +51,7 @@ class Providers
             $parser_cache_provider,
             $file_storage_cache_provider,
         );
-        $this->file_reference_provider = new FileReferenceProvider($file_reference_cache_provider);
+        $this->file_reference_provider = new FileReferenceProvider($file_provider, $file_reference_cache_provider);
     }
 
     public static function safeFileGetContents(string $path): string

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -792,11 +792,7 @@ final class IssueBuffer
         }
 
         if ($is_full && $start_time) {
-            $codebase->file_reference_provider->removeDeletedFilesFromReferences();
-
-            if ($project_analyzer->project_cache_provider) {
-                $project_analyzer->project_cache_provider->processSuccessfulRun($start_time, PSALM_VERSION);
-            }
+            $project_analyzer->finish($start_time, PSALM_VERSION);
         }
 
         if ($error_count

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -19,6 +19,7 @@ use Psalm\Tests\Internal\Provider\ParserInstanceCacheProvider;
 use Psalm\Tests\Internal\Provider\ProjectCacheProvider;
 use Psalm\Tests\TestCase;
 
+use function microtime;
 use function str_replace;
 
 use const DIRECTORY_SEPARATOR;
@@ -101,8 +102,10 @@ class CacheTest extends TestCase
 
             RuntimeCaches::clearAll();
 
+            $start_time = microtime(true);
             $project_analyzer = new ProjectAnalyzer($config, $providers);
             $project_analyzer->check($config->base_dir, true);
+            $project_analyzer->finish($start_time, PSALM_VERSION);
 
             $issues = self::normalizeIssueData(IssueBuffer::getIssuesData());
             self::assertSame($interaction['issues'] ?? [], $issues);

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -158,5 +158,46 @@ class CacheTest extends TestCase
                 ],
             ],
         ];
+
+        yield 'classPropertyTypeChangeInvalidatesReferencingMethod' => [
+            [
+                [
+                    'files' => [
+                        '/src/A.php' => <<<'PHP'
+                            <?php
+                            class A {
+                                public function foo(B $b): int
+                                {
+                                    return $b->value;
+                                }
+                            }
+                            PHP,
+                        '/src/B.php' => <<<'PHP'
+                            <?php
+                            class B {
+                                public ?int $value = 0;
+                            }
+                            PHP,
+                    ],
+                    'issues' => [
+                        '/src/A.php' => [
+                            "NullableReturnStatement: The declared return type 'int' for A::foo is not nullable, but the function returns 'int|null'",
+                            "InvalidNullableReturnType: The declared return type 'int' for A::foo is not nullable, but 'int|null' contains null",
+                        ],
+                    ],
+                ],
+                [
+                    'files' => [
+                        '/src/B.php' => <<<'PHP'
+                            <?php
+                            class B {
+                                public int $value = 0;
+                            }
+                            PHP,
+                    ],
+                    'issues' => [],
+                ],
+            ],
+        ];
     }
 }

--- a/tests/FileDiffTest.php
+++ b/tests/FileDiffTest.php
@@ -544,6 +544,63 @@ class FileDiffTest extends TestCase
                 [],
                 [[84, 133]],
             ],
+            'propertyTypeAddition' => [
+                '<?php
+                namespace Foo;
+
+                class A {
+                    public $a;
+                }',
+                '<?php
+                namespace Foo;
+
+                class A {
+                    public string $a;
+                }',
+                [],
+                [],
+                ['foo\a::$a', 'foo\a::$a'],
+                [],
+                [[84, 93]],
+            ],
+            'propertyTypeRemoval' => [
+                '<?php
+                namespace Foo;
+
+                class A {
+                    public string $a;
+                }',
+                '<?php
+                namespace Foo;
+
+                class A {
+                    public $a;
+                }',
+                [],
+                [],
+                ['foo\a::$a', 'foo\a::$a'],
+                [],
+                [[84, 100]],
+            ],
+            'propertyTypeChange' => [
+                '<?php
+                namespace Foo;
+
+                class A {
+                    public string $a;
+                }',
+                '<?php
+                namespace Foo;
+
+                class A {
+                    public ?string $a;
+                }',
+                [],
+                [],
+                ['foo\a::$a', 'foo\a::$a'],
+                [],
+                [[84, 100]],
+            ],
             'addDocblockToFirst' => [
                 '<?php
                 namespace Foo;

--- a/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
+++ b/tests/Internal/Provider/FakeFileReferenceCacheProvider.php
@@ -58,6 +58,9 @@ class FakeFileReferenceCacheProvider extends FileReferenceCacheProvider
      */
     private array $cached_file_maps = [];
 
+    /** @var array<string, array{int, int}> */
+    private array $cached_type_coverage = [];
+
     public function __construct()
     {
         parent::__construct(Config::getInstance());
@@ -270,9 +273,18 @@ class FakeFileReferenceCacheProvider extends FileReferenceCacheProvider
     }
 
     /**
+     * @return array<string, array{int, int}>
+     */
+    public function getTypeCoverage(): array
+    {
+        return $this->cached_type_coverage;
+    }
+
+    /**
      * @param array<string, array{int, int}> $mixed_counts
      */
     public function setTypeCoverage(array $mixed_counts): void
     {
+        $this->cached_type_coverage = $mixed_counts;
     }
 }

--- a/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
+++ b/tests/Internal/Provider/FileStorageInstanceCacheProvider.php
@@ -16,21 +16,12 @@ class FileStorageInstanceCacheProvider extends FileStorageCacheProvider
     {
     }
 
-    public function writeToCache(FileStorage $storage, string $file_contents): void
+    /**
+     * @param lowercase-string $file_path
+     */
+    protected function storeInCache(string $file_path, FileStorage $storage): void
     {
-        $file_path = strtolower($storage->file_path);
         $this->cache[$file_path] = $storage;
-    }
-
-    public function getLatestFromCache(string $file_path, string $file_contents): ?FileStorage
-    {
-        $cached_value = $this->loadFromCache(strtolower($file_path));
-
-        if (!$cached_value) {
-            return null;
-        }
-
-        return $cached_value;
     }
 
     public function removeCacheForFile(string $file_path): void
@@ -38,8 +29,11 @@ class FileStorageInstanceCacheProvider extends FileStorageCacheProvider
         unset($this->cache[strtolower($file_path)]);
     }
 
-    private function loadFromCache(string $file_path): ?FileStorage
+    /**
+     * @param lowercase-string $file_path
+     */
+    protected function loadFromCache(string $file_path): ?FileStorage
     {
-        return $this->cache[strtolower($file_path)] ?? null;
+        return $this->cache[$file_path] ?? null;
     }
 }

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -188,7 +188,7 @@ class ProjectCheckerTest extends TestCase
         $this->assertSame(0, IssueBuffer::getErrorCount());
 
         $this->assertSame(
-            'Psalm was able to infer types for 100% of the codebase',
+            "No files analyzed\nPsalm was able to infer types for 100% of the codebase",
             $this->project_analyzer->getCodebase()->analyzer->getTypeInferenceSummary(
                 $this->project_analyzer->getCodebase(),
             ),


### PR DESCRIPTION
When the property type changes in a class referenced by a method, that method is currently not invalidated.
Example:
1. File `A.php` with method `A::foo()` has an argument of type `B`, which is a class defined in file `B.php`
   It uses `B::$value` incorrectly, raising an issue.
2. Psalm runs and caches
3. The type of `B::$value` changes to fix the issue
4. Psalm runs and still reports the same issue