### PR TITLE
make stubbed constant types configurable with comment

### DIFF
--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -696,6 +696,48 @@ class StubTest extends TestCase
     /**
      * @runInSeparateProcess
      */
+    public function testStubbedConstantVarCommentType(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/constant_var_comment.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $file_path = getcwd() . '/src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                /**
+                 * @param non-empty-string $arg
+                 * @return void
+                 */
+                function hello($arg) {
+                    echo $arg;
+                }
+
+                hello(FOO_BAR);',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
     public function testClassAlias(): void
     {
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(

--- a/tests/fixtures/stubs/constant_var_comment.phpstub
+++ b/tests/fixtures/stubs/constant_var_comment.phpstub
@@ -1,0 +1,3 @@
+<?php
+
+define('FOO_BAR', /** @var non-empty-string */ 'world');


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/4024

With a simplified, more straightforward syntax compared to the example in the issue (which never really worked apparently and only set the type to mixed):

```
define('DEBUG', /** @var bool */ false);
```
