### PR TITLE
Allow space before array shape opening brace and added unit tests

### DIFF
--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -346,6 +346,11 @@ class CommentAnalyzer
                     continue;
                 }
 
+                if ($next_char === '{') {
+                    $type .= ' ';
+                    continue;
+                }
+
                 if ($next_char === '|' || $next_char === '&') {
                     $nexter_char = $i < $l - 2 ? $return_block[$i + 2] : null;
 

--- a/tests/CommentAnalyzerTest.php
+++ b/tests/CommentAnalyzerTest.php
@@ -75,4 +75,69 @@ class CommentAnalyzerTest extends BaseTestCase
         $comment_docblock = CommentAnalyzer::getTypeFromComment($php_parser_doc, new FileScanner('somefile.php', 'somefile.php', false), new Aliases);
         $this->assertSame('Use a string', $comment_docblock[0]->description);
     }
+
+    /**
+     * @dataProvider providerSplitDocLine
+     * @param string $doc_line
+     * @param string[] $expected
+     */
+    public function testSplitDocLine(string $doc_line, array $expected): void
+    {
+        $this->assertSame($expected, CommentAnalyzer::splitDocLine($doc_line));
+    }
+
+    public function providerSplitDocLine(): iterable
+    {
+        return [
+            'typeWithVar' => [
+                'doc_line' =>
+                    'TArray $array',
+                'expected' => [
+                    'TArray',
+                    '$array',
+                ],
+            ],
+            'arrayShape' => [
+                'doc_line' =>
+                    'array{
+                     *     a: int,
+                     *     b: string,
+                     * }',
+                'expected' => [
+                    'array{
+                     *     a: int,
+                     *     b: string,
+                     * }',
+                ]
+            ],
+            'arrayShapeWithSpace' => [
+                'doc_line' =>
+                    'array {
+                     *     a: int,
+                     *     b: string,
+                     * }',
+                'expected' => [
+                    'array {
+                     *     a: int,
+                     *     b: string,
+                     * }',
+                ]
+            ],
+            'func_num_args' => [
+                'doc_line' =>
+                    '(
+                     *     func_num_args() is 1
+                     *     ? array{dirname: string, basename: string, extension?: string, filename: string}
+                     *     : string
+                     * )',
+                'expected' => [
+                    '(
+                     *     func_num_args() is 1
+                     *     ? array{dirname: string, basename: string, extension?: string, filename: string}
+                     *     : string
+                     * )'
+                ]
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
Currently when defining an array shape it is possible to include a space before the opening brace on the nested level, but not on the "top" level, e.g.

```php
/**
 * @param array { // <- does not work
 *     key: array { // <- does work
 *         a: int
 *     }
 * } $arr
 * @return int
 */
function foo($arr) {
    /** @psalm-trace $a */
    $a  = $arr['key']['a'];
    return $a;
}
```
Psalm examples:
Works: https://psalm.dev/r/bf0dc1c5dc
Does not work: https://psalm.dev/r/ac1064b93d

This PR allows the space before array shape opening brace and adds unit tests for `\Psalm\Internal\Analyzer\CommentAnalyzer::splitDocLine()`