### PR TITLE
Fix inference high order function when closure param is omitted

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -268,7 +268,12 @@ class ArgumentsAnalyzer
 
             $inferred_arg_type = $statements_analyzer->node_data->getType($arg->value);
 
-            if (null !== $inferred_arg_type && null !== $template_result && null !== $param && null !== $param->type) {
+            if (null !== $inferred_arg_type
+                && null !== $template_result
+                && null !== $param
+                && null !== $param->type
+                && !$arg->unpack
+            ) {
                 $codebase = $statements_analyzer->getCodebase();
 
                 TemplateStandinTypeReplacer::fillTemplateResult(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -235,7 +235,10 @@ class FunctionCallAnalyzer extends CallAnalyzer
             $function_call_info->function_id,
         );
 
-        $template_result->lower_bounds += $already_inferred_lower_bounds;
+        $template_result->lower_bounds = array_merge(
+            $template_result->lower_bounds,
+            $already_inferred_lower_bounds,
+        );
 
         if ($function_name instanceof PhpParser\Node\Name && $function_call_info->function_id) {
             $stmt_type = FunctionCallReturnTypeFetcher::fetch(

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -963,6 +963,48 @@ class CallableTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'inferTypeWhenClosureParamIsOmitted' => [
+                'code' => '<?php
+                    /**
+                     * @template A
+                     * @template B
+                     * @param A $a
+                     * @param callable(A): B $ab
+                     * @return B
+                     */
+                    function pipe(mixed $a, callable $ab): mixed
+                    {
+                        return $ab($a);
+                    }
+                    /**
+                     * @template A
+                     * @param callable(A): void $callback
+                     * @return Closure(list<A>): list<A>
+                     */
+                    function iterate(callable $callback): Closure
+                    {
+                        return function(array $list) use ($callback) {
+                            foreach ($list as $item) {
+                                $callback($item);
+                            }
+                            return $list;
+                        };
+                    }
+                    $result1 = pipe(
+                        [1, 2, 3],
+                        iterate(fn($i) => print_r($i)),
+                    );
+                    $result2 = pipe(
+                        [1, 2, 3],
+                        iterate(fn() => print_r("noop")),
+                    );',
+                'assertions' => [
+                    '$result1===' => 'list<1|2|3>',
+                    '$result2===' => 'list<1|2|3>',
+                ],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
             'varReturnType' => [
                 'code' => '<?php
                     $add_one = function(int $a) : int {


### PR DESCRIPTION
$result1 and $result2 must have the same type: https://psalm.dev/r/efac7ef1f4