### PR TITLE
Map special RPC paths

### DIFF
--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -997,4 +997,19 @@ class LanguageServer extends Dispatcher
 
         return $filepath;
     }
+
+    // the methods below forward special paths
+    // like `$/cancelRequest` to `$this->cancelRequest()`
+    // and `$/a/b/c` to `$this->a->b->c()`
+
+    public function __isset(string $prop_name): bool
+    {
+        return $prop_name === '$';
+    }
+
+    /** @return static */
+    public function __get(string $prop_name): self
+    {
+        return $this;
+    }
 }

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -1008,7 +1008,7 @@ class LanguageServer extends Dispatcher
     }
 
     /** @return static */
-    public function __get(string $prop_name): self
+    public function __get(string $_prop_name): self
     {
         return $this;
     }


### PR DESCRIPTION
Now `$/cancelRequest` will be resolved to `$server->cancelRequest()`
and `$/textDocument/whatever` to `$server->textDocument->whatever()`

/cc: @tm1000

Refs: https://github.com/vimeo/psalm/issues/10035#issuecomment-1648526809
