### PR TITLE
Modernize LSP progress reporting

### DIFF
--- a/src/Psalm/Internal/LanguageServer/Client/Progress/LegacyProgress.php
+++ b/src/Psalm/Internal/LanguageServer/Client/Progress/LegacyProgress.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Psalm\Internal\LanguageServer\Client\Progress;
+
+use LanguageServerProtocol\LogMessage;
+use LanguageServerProtocol\MessageType;
+use LogicException;
+use Psalm\Internal\LanguageServer\ClientHandler;
+
+/** @internal */
+final class LegacyProgress implements ProgressInterface
+{
+    private ClientHandler $handler;
+    private ?string $title = null;
+
+    public function __construct(ClientHandler $handler)
+    {
+        $this->handler = $handler;
+    }
+
+    public function begin(string $title, ?string $message = null, ?int $percentage = null): void
+    {
+        if ($this->title !== null) {
+            throw new LogicException('Progress has already been started');
+        }
+
+        $this->title = $title;
+
+        $this->notify($message);
+    }
+
+    public function update(?string $message = null, ?int $percentage = null): void
+    {
+        if ($this->title === null) {
+            throw new LogicException('The progress has not been started yet');
+        }
+
+        $this->notify($message);
+    }
+
+    public function end(?string $message = null): void
+    {
+        if ($this->title === null) {
+            throw new LogicException('The progress has not been started yet');
+        }
+
+        $this->notify($message);
+    }
+
+    private function notify(?string $message): void
+    {
+        $this->handler->notify(
+            'telemetry/event',
+            new LogMessage(
+                MessageType::INFO,
+                $this->title . (empty($message) ? '' : (': ' . $message)),
+            ),
+        );
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/Client/Progress/Progress.php
+++ b/src/Psalm/Internal/LanguageServer/Client/Progress/Progress.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Psalm\Internal\LanguageServer\Client\Progress;
+
+use LogicException;
+use Psalm\Internal\LanguageServer\ClientHandler;
+
+/** @internal */
+final class Progress implements ProgressInterface
+{
+    private ClientHandler $handler;
+    private string $token;
+    private bool $withPercentage = false;
+    private bool $finished = false;
+
+    public function __construct(ClientHandler $handler, string $token)
+    {
+        $this->handler = $handler;
+        $this->token = $token;
+    }
+
+    public function begin(
+        string $title,
+        ?string $message = null,
+        ?int $percentage = null
+    ): void {
+        if ($this->finished) {
+            throw new LogicException('Progress has already been finished');
+        }
+
+        $notification = [
+            'token' => $this->token,
+            'value' => [
+                'kind' => 'begin',
+                'title' => $title,
+            ],
+        ];
+
+        if ($message !== null) {
+            $notification['value']['message'] = $message;
+        }
+
+        if ($percentage !== null) {
+            $notification['value']['percentage'] = $percentage;
+            $this->withPercentage = true;
+        }
+
+        $this->handler->notify('$/progress', $notification);
+    }
+
+    public function end(?string $message = null): void
+    {
+        if ($this->finished) {
+            throw new LogicException('Progress has already been finished');
+        }
+
+        $notification = [
+            'token' => $this->token,
+            'value' => [
+                'kind' => 'end',
+            ],
+        ];
+
+        if ($message !== null) {
+            $notification['value']['message'] = $message;
+        }
+
+        $this->handler->notify('$/progress', $notification);
+
+        $this->finished = true;
+    }
+
+    public function update(?string $message = null, ?int $percentage = null): void
+    {
+        if ($this->finished) {
+            throw new LogicException('Progress has already been finished');
+        }
+
+        $notification = [
+            'token' => $this->token,
+            'value' => [
+                'kind' => 'report',
+            ],
+        ];
+
+        if ($message !== null) {
+            $notification['value']['message'] = $message;
+        }
+
+        if ($percentage !== null) {
+            if (!$this->withPercentage) {
+                throw new LogicException(
+                    'Cannot update percentage for progress '
+                    . 'that was started without percentage',
+                );
+            }
+            $notification['value']['percentage'] = $percentage;
+        }
+
+        $this->handler->notify('$/progress', $notification);
+    }
+}

--- a/src/Psalm/Internal/LanguageServer/Client/Progress/ProgressInterface.php
+++ b/src/Psalm/Internal/LanguageServer/Client/Progress/ProgressInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Psalm\Internal\LanguageServer\Client\Progress;
+
+/** @internal */
+interface ProgressInterface
+{
+    public function begin(
+        string $title,
+        ?string $message = null,
+        ?int $percentage = null
+    ): void;
+
+    public function update(?string $message = null, ?int $percentage = null): void;
+    public function end(?string $message = null): void;
+}

--- a/src/Psalm/Internal/LanguageServer/LanguageClient.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageClient.php
@@ -7,6 +7,9 @@ namespace Psalm\Internal\LanguageServer;
 use JsonMapper;
 use LanguageServerProtocol\LogMessage;
 use LanguageServerProtocol\LogTrace;
+use Psalm\Internal\LanguageServer\Client\Progress\LegacyProgress;
+use Psalm\Internal\LanguageServer\Client\Progress\Progress;
+use Psalm\Internal\LanguageServer\Client\Progress\ProgressInterface;
 use Psalm\Internal\LanguageServer\Client\TextDocument as ClientTextDocument;
 use Psalm\Internal\LanguageServer\Client\Workspace as ClientWorkspace;
 
@@ -129,6 +132,15 @@ class LanguageClient
             'telemetry/event',
             $logMessage,
         );
+    }
+
+    public function makeProgress(string $token): ProgressInterface
+    {
+        if ($this->server->clientCapabilities->window->workDoneProgress ?? false) {
+            return new Progress($this->handler, $token);
+        } else {
+            return new LegacyProgress($this->handler);
+        }
     }
 
     /**

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -378,31 +378,19 @@ class LanguageServer extends Dispatcher
      * The initialize request is sent as the first request from the client to the server.
      *
      * @param ClientCapabilities $capabilities The capabilities provided by the client (editor)
-     * @param int|null $processId The process Id of the parent process that started the server.
      * Is null if the process has not been started by another process. If the parent process is
      * not alive then the server should exit (see exit notification) its process.
      * @param ClientInfo|null $clientInfo Information about the client
-     * @param string|null $locale  The locale the client is currently showing the user interface
-     * in. This must not necessarily be the locale of the operating
-     * system.
-     * @param string|null $rootPath The rootPath of the workspace. Is null if no folder is open.
-     * @param mixed $initializationOptions
      * @param string|null $trace The initial trace setting. If omitted trace is disabled ('off').
      * @param string|null $workDoneToken The token to be used to report progress during init.
      * @psalm-return Promise<InitializeResult>
-     * @psalm-suppress PossiblyUnusedParam
      */
     public function initialize(
         ClientCapabilities $capabilities,
-        ?int $processId = null,
         ?ClientInfo $clientInfo = null,
-        ?string $locale = null,
-        ?string $rootPath = null,
         ?string $rootUri = null,
-        $initializationOptions = null,
         ?string $trace = null,
         ?string $workDoneToken = null
-        //?array $workspaceFolders = null //error in json-dispatcher
     ): Promise {
         $this->clientInfo = $clientInfo;
         $this->clientCapabilities = $capabilities;

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -419,7 +419,7 @@ class LanguageServer extends Dispatcher
                 $progress = $this->client->makeProgress($workDoneToken ?? uniqid('tkn', true));
 
                 $this->logInfo("Initializing...");
-                $progress->begin('Initialization', 'Starting');
+                $progress->begin('Psalm', 'initializing');
 
                 // Eventually, this might block on something. Leave it as a generator.
                 /** @psalm-suppress TypeDoesNotContainType */
@@ -430,14 +430,14 @@ class LanguageServer extends Dispatcher
                 $this->project_analyzer->serverMode($this);
 
                 $this->logInfo("Initializing: Getting code base...");
-                $progress->update('Getting code base');
+                $progress->update('getting code base');
 
                 $this->logInfo("Initializing: Scanning files ({$this->project_analyzer->threads} Threads)...");
-                $progress->update('Scanning files');
+                $progress->update('scanning files');
                 $this->codebase->scanFiles($this->project_analyzer->threads);
 
                 $this->logInfo("Initializing: Registering stub files...");
-                $progress->update('Registering stub files');
+                $progress->update('registering stub files');
                 $this->codebase->config->visitStubFiles($this->codebase, $this->project_analyzer->progress);
 
                 if ($this->textDocument === null) {
@@ -577,7 +577,7 @@ class LanguageServer extends Dispatcher
                 }
 
                 $this->logInfo("Initializing: Complete.");
-                $progress->end('Initialized');
+                $progress->end('initialized');
 
                 /**
                  * Information about the server.

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -388,6 +388,7 @@ class LanguageServer extends Dispatcher
      * @param string|null $rootPath The rootPath of the workspace. Is null if no folder is open.
      * @param mixed $initializationOptions
      * @param string|null $trace The initial trace setting. If omitted trace is disabled ('off').
+     * @param string|null $workDoneToken The token to be used to report progress during init.
      * @psalm-return Promise<InitializeResult>
      * @psalm-suppress PossiblyUnusedParam
      */
@@ -400,7 +401,7 @@ class LanguageServer extends Dispatcher
         ?string $rootUri = null,
         $initializationOptions = null,
         ?string $trace = null,
-        ?string $workdDoneToken = null
+        ?string $workDoneToken = null
         //?array $workspaceFolders = null //error in json-dispatcher
     ): Promise {
         $this->clientInfo = $clientInfo;
@@ -414,8 +415,8 @@ class LanguageServer extends Dispatcher
 
         return call(
             /** @return Generator<int, true, mixed, InitializeResult> */
-            function () use ($workdDoneToken) {
-                $progress = $this->client->makeProgress($workdDoneToken ?? uniqid('tkn', true));
+            function () use ($workDoneToken) {
+                $progress = $this->client->makeProgress($workDoneToken ?? uniqid('tkn', true));
 
                 $this->logInfo("Initializing...");
                 $progress->begin('Initialization', 'Starting');

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -398,10 +398,8 @@ class TextDocument
      * The code action request is sent from the client to the server to compute commands
      * for a given text document and range. These commands are typically code fixes to
      * either fix problems or to beautify/refactor code.
-     *
-     * @psalm-suppress PossiblyUnusedParam
      */
-    public function codeAction(TextDocumentIdentifier $textDocument, Range $range, CodeActionContext $context): Promise
+    public function codeAction(TextDocumentIdentifier $textDocument, CodeActionContext $context): Promise
     {
         if (!$this->server->client->clientConfiguration->provideCodeActions) {
             return new Success(null);

--- a/src/Psalm/Internal/LanguageServer/Server/Workspace.php
+++ b/src/Psalm/Internal/LanguageServer/Server/Workspace.php
@@ -108,10 +108,9 @@ class Workspace
     /**
      * A notification sent from the client to the server to signal the change of configuration settings.
      *
-     * @param mixed $settings
-     * @psalm-suppress PossiblyUnusedMethod, PossiblyUnusedParam
+     * @psalm-suppress PossiblyUnusedMethod
      */
-    public function didChangeConfiguration($settings): void
+    public function didChangeConfiguration(): void
     {
         $this->server->logDebug(
             'workspace/didChangeConfiguration',

--- a/tests/LanguageServer/DiagnosticTest.php
+++ b/tests/LanguageServer/DiagnosticTest.php
@@ -91,10 +91,21 @@ class DiagnosticTest extends AsyncTestCase
         );
 
         $write->on('message', function (Message $message) use ($deferred, $server): void {
-            /** @psalm-suppress PossiblyNullPropertyFetch,UndefinedPropertyFetch,MixedPropertyFetch */
-            if ($message->body->method === 'telemetry/event' && $message->body->params->message === 'initialized') {
+            /** @psalm-suppress NullPropertyFetch,PossiblyNullPropertyFetch,UndefinedPropertyFetch */
+            if ($message->body->method === 'telemetry/event' && ($message->body->params->message ?? null) === 'initialized') {
                 $this->assertFalse($server->clientCapabilities->textDocument->completion->completionItem->snippetSupport);
                 $deferred->resolve(null);
+                return;
+            }
+
+            /** @psalm-suppress NullPropertyFetch,PossiblyNullPropertyFetch */
+            if ($message->body->method === '$/progress'
+                && ($message->body->params->value->kind ?? null) === 'end'
+                && ($message->body->params->value->message ?? null) === 'initialized'
+            ) {
+                $this->assertFalse($server->clientCapabilities->textDocument->completion->completionItem->snippetSupport);
+                $deferred->resolve(null);
+                return;
             }
         });
 


### PR DESCRIPTION
This will use `$/progress` when available and fall back to old
telemetry-based reporting otherwise

Refs #10035 