### PR TITLE
Add type detection for PDOStatement::fetchAll(PDO::FETCH_CLASS, SomeClass::class)

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
@@ -116,6 +116,13 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
             case 6: // PDO::FETCH_BOUND - bool
                 return Type::getBool();
 
+            case 7: // PDO::FETCH_COLUMN - scalar|null|false
+                return new Union([
+                    new TScalar(),
+                    new TNull(),
+                    new TFalse(),
+                ]);
+
             case 8: // PDO::FETCH_CLASS - object|false
                 return new Union([
                     $fetch_class_name ? new TNamedObject($fetch_class_name) : new TObject(),
@@ -130,16 +137,33 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                     new TFalse(),
                 ]);
 
-            case 11: // PDO::FETCH_NAMED - array<string, scalar|list<scalar>>|false
+            case 11: // PDO::FETCH_NAMED - array<string, scalar|null|list<scalar|null>>|false
                 return new Union([
                     new TArray([
                         Type::getString(),
                         new Union([
                             new TScalar(),
-                            Type::getListAtomic(Type::getScalar()),
+                            new TNull(),
+                            Type::getListAtomic(
+                                new Union([
+                                    new TScalar(),
+                                    new TNull(),
+                                ])
+                            ),
                         ]),
                     ]),
                     new TFalse(),
+                ]);
+
+            case 12: // PDO::FETCH_KEY_PAIR - array<array-key,scalar|null>
+                return new Union([
+                    new TArray([
+                        Type::getArrayKey(),
+                        new Union([
+                            new TScalar(),
+                            new TNull(),
+                        ]),
+                    ]),
                 ]);
 
             case 3: // PDO::FETCH_NUM - list<scalar|null>|false
@@ -199,7 +223,7 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                                     new TNull(),
                                 ]),
                             ]),
-                        ]),
+                        ])
                     ),
                 ]);
 
@@ -214,7 +238,7 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                                     new TNull(),
                                 ]),
                             ]),
-                        ]),
+                        ])
                     ),
                 ]);
 
@@ -225,27 +249,27 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                     ),
                 ]);
 
+            case 7: // PDO::FETCH_COLUMN - scalar|null|false
+                return new Union([
+                    Type::getListAtomic(
+                        new Union([
+                            new TScalar(),
+                            new TNull(),
+                            new TFalse(),
+                        ])
+                    ),
+                ]);
+
             case 8: // PDO::FETCH_CLASS - list<object>
                 return new Union([
                     Type::getListAtomic(
                         new Union([
                             $fetch_class_name ? new TNamedObject($fetch_class_name) : new TObject()
-                        ]),
+                        ])
                     ),
                 ]);
 
-            case 1: // PDO::FETCH_LAZY - list<object>
-                // This actually returns a PDORow object, but that class is
-                // undocumented, and its attributes are all dynamic anyway
-                return new Union([
-                    Type::getListAtomic(
-                        new Union([
-                            new TObject()
-                        ]),
-                    ),
-                ]);
-
-            case 11: // PDO::FETCH_NAMED - list<array<string, scalar|list<scalar>>>
+            case 11: // PDO::FETCH_NAMED - list<array<string, scalar|null|list<scalar|null>>>
                 return new Union([
                     Type::getListAtomic(
                         new Union([
@@ -253,11 +277,28 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                                 Type::getString(),
                                 new Union([
                                     new TScalar(),
-                                    Type::getListAtomic(Type::getScalar()),
+                                    new TNull(),
+                                    Type::getListAtomic(
+                                        new Union([
+                                            new TScalar(),
+                                            new TNull(),
+                                        ])
+                                    ),
                                 ]),
                             ]),
-                        ]),
+                        ])
                     ),
+                ]);
+
+            case 12: // PDO::FETCH_KEY_PAIR - array<array-key,scalar|null>
+                return new Union([
+                    new TArray([
+                        Type::getArrayKey(),
+                        new Union([
+                            new TScalar(),
+                            new TNull(),
+                        ]),
+                    ]),
                 ]);
 
             case 3: // PDO::FETCH_NUM - list<list<scalar|null>>
@@ -268,9 +309,9 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                                 new Union([
                                     new TScalar(),
                                     new TNull(),
-                                ]),
+                                ])
                             ),
-                        ]),
+                        ])
                     ),
                 ]);
 
@@ -279,7 +320,7 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                     Type::getListAtomic(
                         new Union([
                             new TNamedObject('stdClass')
-                        ]),
+                        ])
                     ),
                 ]);
         }

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
@@ -27,88 +27,261 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
     public static function getMethodReturnType(MethodReturnTypeProviderEvent $event): ?Union
     {
         $config = Config::getInstance();
+        $method_name_lowercase = $event->getMethodNameLowercase();
+
+        if (!$config->php_extensions["pdo"]) {
+            return null;
+        }
+
+        if ($method_name_lowercase === 'setfetchmode') {
+            return self::handleSetFetchMode($event);
+        }
+
+        if ($method_name_lowercase === 'fetch') {
+            return self::handleFetch($event);
+        }
+
+        if ($method_name_lowercase === 'fetchall') {
+            return self::handleFetchAll($event);
+        }
+
+        return null;
+    }
+
+    private static function handleSetFetchMode(MethodReturnTypeProviderEvent $event)
+    {
         $source = $event->getSource();
         $call_args = $event->getCallArgs();
-        $method_name_lowercase = $event->getMethodNameLowercase();
-        if ($method_name_lowercase === 'fetch'
-            && $config->php_extensions["pdo"]
-            && isset($call_args[0])
+        $context = $event->getContext();
+
+        if (isset($call_args[0])
+            && ($first_arg_type = $source->getNodeTypeProvider()->getType($call_args[0]->value))
+            && $first_arg_type->isSingleIntLiteral()
+        ) {
+            $context->references_in_scope['fetch_mode'] = $first_arg_type->getSingleIntLiteral()->value;
+        }
+
+        if (isset($call_args[1])
+            && ($second_arg_type = $source->getNodeTypeProvider()->getType($call_args[1]->value))
+            && $second_arg_type->isSingleStringLiteral()
+        ) {
+            $context->references_in_scope['fetch_class'] = $second_arg_type->getSingleStringLiteral()->value;
+        }
+
+        return null;
+    }
+
+    private static function handleFetch(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $source = $event->getSource();
+        $call_args = $event->getCallArgs();
+        $context = $event->getContext();
+
+        $fetch_mode = $context->references_in_scope['fetch_mode'] ?? null;
+
+        if (isset($call_args[0])
             && ($first_arg_type = $source->getNodeTypeProvider()->getType($call_args[0]->value))
             && $first_arg_type->isSingleIntLiteral()
         ) {
             $fetch_mode = $first_arg_type->getSingleIntLiteral()->value;
+        }
 
-            switch ($fetch_mode) {
-                case 2: // PDO::FETCH_ASSOC - array<string,scalar|null>|false
-                    return new Union([
-                        new TArray([
-                            Type::getString(),
-                            new Union([
-                                new TScalar(),
-                                new TNull(),
+        $fetch_class_name = $context->references_in_scope['fetch_class'] ?? null;
+
+        switch ($fetch_mode) {
+            case 2: // PDO::FETCH_ASSOC - array<string,scalar|null>|false
+                return new Union([
+                    new TArray([
+                        Type::getString(),
+                        new Union([
+                            new TScalar(),
+                            new TNull(),
+                        ]),
+                    ]),
+                    new TFalse(),
+                ]);
+
+            case 4: // PDO::FETCH_BOTH - array<array-key,scalar|null>|false
+                return new Union([
+                    new TArray([
+                        Type::getArrayKey(),
+                        new Union([
+                            new TScalar(),
+                            new TNull(),
+                        ]),
+                    ]),
+                    new TFalse(),
+                ]);
+
+            case 6: // PDO::FETCH_BOUND - bool
+                return Type::getBool();
+
+            case 8: // PDO::FETCH_CLASS - object|false
+                return new Union([
+                    $fetch_class_name ? new TNamedObject($fetch_class_name) : new TObject(),
+                    new TFalse(),
+                ]);
+
+            case 1: // PDO::FETCH_LAZY - object|false
+                // This actually returns a PDORow object, but that class is
+                // undocumented, and its attributes are all dynamic anyway
+                return new Union([
+                    new TObject(),
+                    new TFalse(),
+                ]);
+
+            case 11: // PDO::FETCH_NAMED - array<string, scalar|list<scalar>>|false
+                return new Union([
+                    new TArray([
+                        Type::getString(),
+                        new Union([
+                            new TScalar(),
+                            Type::getListAtomic(Type::getScalar()),
+                        ]),
+                    ]),
+                    new TFalse(),
+                ]);
+
+            case 3: // PDO::FETCH_NUM - list<scalar|null>|false
+                return new Union([
+                    Type::getListAtomic(
+                        new Union([
+                            new TScalar(),
+                            new TNull(),
+                        ]),
+                    ),
+                    new TFalse(),
+                ]);
+
+            case 5: // PDO::FETCH_OBJ - stdClass|false
+                return new Union([
+                    new TNamedObject('stdClass'),
+                    new TFalse(),
+                ]);
+        }
+
+        return null;
+    }
+
+    private static function handleFetchAll(MethodReturnTypeProviderEvent $event): ?Union
+    {
+        $source = $event->getSource();
+        $call_args = $event->getCallArgs();
+        $context = $event->getContext();
+
+        $fetch_mode = $context->references_in_scope['fetch_mode'] ?? null;
+
+        if (isset($call_args[0])
+            && ($first_arg_type = $source->getNodeTypeProvider()->getType($call_args[0]->value))
+            && $first_arg_type->isSingleIntLiteral()
+        ) {
+            $fetch_mode = $first_arg_type->getSingleIntLiteral()->value;
+        }
+
+        $fetch_class_name = $context->references_in_scope['fetch_class'] ?? null;
+
+        if (isset($call_args[1])
+            && ($second_arg_type = $source->getNodeTypeProvider()->getType($call_args[1]->value))
+            && $second_arg_type->isSingleStringLiteral()
+        ) {
+            $fetch_class_name = $second_arg_type->getSingleStringLiteral()->value;
+        }
+
+        switch ($fetch_mode) {
+            case 2: // PDO::FETCH_ASSOC - list<array<string,scalar|null>>
+                return new Union([
+                    Type::getListAtomic(
+                        new Union([
+                            new TArray([
+                                Type::getString(),
+                                new Union([
+                                    new TScalar(),
+                                    new TNull(),
+                                ]),
                             ]),
                         ]),
-                        new TFalse(),
-                    ]);
+                    ),
+                ]);
 
-                case 4: // PDO::FETCH_BOTH - array<array-key,scalar|null>|false
-                    return new Union([
-                        new TArray([
-                            Type::getArrayKey(),
-                            new Union([
-                                new TScalar(),
-                                new TNull(),
+            case 4: // PDO::FETCH_BOTH - list<array<array-key,scalar|null>>
+                return new Union([
+                    Type::getListAtomic(
+                        new Union([
+                            new TArray([
+                                Type::getArrayKey(),
+                                new Union([
+                                    new TScalar(),
+                                    new TNull(),
+                                ]),
                             ]),
                         ]),
-                        new TFalse(),
-                    ]);
+                    ),
+                ]);
 
-                case 6: // PDO::FETCH_BOUND - bool
-                    return Type::getBool();
+            case 6: // PDO::FETCH_BOUND - list<bool>
+                return new Union([
+                    Type::getListAtomic(
+                        Type::getBool()
+                    ),
+                ]);
 
-                case 8: // PDO::FETCH_CLASS - object|false
-                    return new Union([
-                        new TObject(),
-                        new TFalse(),
-                    ]);
+            case 8: // PDO::FETCH_CLASS - list<object>
+                return new Union([
+                    Type::getListAtomic(
+                        new Union([
+                            $fetch_class_name ? new TNamedObject($fetch_class_name) : new TObject()
+                        ]),
+                    ),
+                ]);
 
-                case 1: // PDO::FETCH_LAZY - object|false
-                    // This actually returns a PDORow object, but that class is
-                    // undocumented, and its attributes are all dynamic anyway
-                    return new Union([
-                        new TObject(),
-                        new TFalse(),
-                    ]);
+            case 1: // PDO::FETCH_LAZY - list<object>
+                // This actually returns a PDORow object, but that class is
+                // undocumented, and its attributes are all dynamic anyway
+                return new Union([
+                    Type::getListAtomic(
+                        new Union([
+                            new TObject()
+                        ]),
+                    ),
+                ]);
 
-                case 11: // PDO::FETCH_NAMED - array<string, scalar|list<scalar>>|false
-                    return new Union([
-                        new TArray([
-                            Type::getString(),
-                            new Union([
-                                new TScalar(),
-                                Type::getListAtomic(Type::getScalar()),
+            case 11: // PDO::FETCH_NAMED - list<array<string, scalar|list<scalar>>>
+                return new Union([
+                    Type::getListAtomic(
+                        new Union([
+                            new TArray([
+                                Type::getString(),
+                                new Union([
+                                    new TScalar(),
+                                    Type::getListAtomic(Type::getScalar()),
+                                ]),
                             ]),
                         ]),
-                        new TFalse(),
-                    ]);
+                    ),
+                ]);
 
-                case 3: // PDO::FETCH_NUM - list<scalar|null>|false
-                    return new Union([
-                        Type::getListAtomic(
-                            new Union([
-                                new TScalar(),
-                                new TNull(),
-                            ]),
-                        ),
-                        new TFalse(),
-                    ]);
+            case 3: // PDO::FETCH_NUM - list<list<scalar|null>>
+                return new Union([
+                    Type::getListAtomic(
+                        new Union([
+                            Type::getListAtomic(
+                                new Union([
+                                    new TScalar(),
+                                    new TNull(),
+                                ]),
+                            ),
+                        ]),
+                    ),
+                ]);
 
-                case 5: // PDO::FETCH_OBJ - stdClass|false
-                    return new Union([
-                        new TNamedObject('stdClass'),
-                        new TFalse(),
-                    ]);
-            }
+            case 5: // PDO::FETCH_OBJ - list<stdClass>
+                return new Union([
+                    Type::getListAtomic(
+                        new Union([
+                            new TNamedObject('stdClass')
+                        ]),
+                    ),
+                ]);
         }
 
         return null;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
@@ -216,13 +216,12 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                     ),
                 ]);
 
-            case 7: // PDO::FETCH_COLUMN - scalar|null|false
+            case 7: // PDO::FETCH_COLUMN - list<scalar|null>
                 return new Union([
                     Type::getListAtomic(
                         new Union([
                             new TScalar(),
                             new TNull(),
-                            new TFalse(),
                         ]),
                     ),
                 ]);

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
@@ -54,14 +54,14 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
         $call_args = $event->getCallArgs();
         $context = $event->getContext();
 
-        $context->references_in_scope['fetch_mode'] = null;
-        $context->references_in_scope['fetch_class'] = null;
+        unset($context->references_in_scope['fetch_mode']);
+        unset($context->references_in_scope['fetch_class']);
 
         if (isset($call_args[0])
             && ($first_arg_type = $source->getNodeTypeProvider()->getType($call_args[0]->value))
             && $first_arg_type->isSingleIntLiteral()
         ) {
-            $context->references_in_scope['fetch_mode'] = $first_arg_type->getSingleIntLiteral()->value;
+            $context->references_in_scope['fetch_mode'] = (string) $first_arg_type->getSingleIntLiteral()->value;
         }
 
         if (isset($call_args[1])

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
@@ -48,7 +48,7 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
         return null;
     }
 
-    private static function handleSetFetchMode(MethodReturnTypeProviderEvent $event)
+    private static function handleSetFetchMode(MethodReturnTypeProviderEvent $event): ?Union
     {
         $source = $event->getSource();
         $call_args = $event->getCallArgs();
@@ -148,7 +148,7 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                                 new Union([
                                     new TScalar(),
                                     new TNull(),
-                                ])
+                                ]),
                             ),
                         ]),
                     ]),
@@ -223,7 +223,7 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                                     new TNull(),
                                 ]),
                             ]),
-                        ])
+                        ]),
                     ),
                 ]);
 
@@ -238,14 +238,14 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                                     new TNull(),
                                 ]),
                             ]),
-                        ])
+                        ]),
                     ),
                 ]);
 
             case 6: // PDO::FETCH_BOUND - list<bool>
                 return new Union([
                     Type::getListAtomic(
-                        Type::getBool()
+                        Type::getBool(),
                     ),
                 ]);
 
@@ -256,7 +256,7 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                             new TScalar(),
                             new TNull(),
                             new TFalse(),
-                        ])
+                        ]),
                     ),
                 ]);
 
@@ -264,8 +264,8 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                 return new Union([
                     Type::getListAtomic(
                         new Union([
-                            $fetch_class_name ? new TNamedObject($fetch_class_name) : new TObject()
-                        ])
+                            $fetch_class_name ? new TNamedObject($fetch_class_name) : new TObject(),
+                        ]),
                     ),
                 ]);
 
@@ -282,11 +282,11 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                                         new Union([
                                             new TScalar(),
                                             new TNull(),
-                                        ])
+                                        ]),
                                     ),
                                 ]),
                             ]),
-                        ])
+                        ]),
                     ),
                 ]);
 
@@ -309,9 +309,9 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                                 new Union([
                                     new TScalar(),
                                     new TNull(),
-                                ])
+                                ]),
                             ),
-                        ])
+                        ]),
                     ),
                 ]);
 
@@ -319,8 +319,8 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
                 return new Union([
                     Type::getListAtomic(
                         new Union([
-                            new TNamedObject('stdClass')
-                        ])
+                            new TNamedObject('stdClass'),
+                        ]),
                     ),
                 ]);
         }

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/PdoStatementReturnTypeProvider.php
@@ -54,6 +54,9 @@ class PdoStatementReturnTypeProvider implements MethodReturnTypeProviderInterfac
         $call_args = $event->getCallArgs();
         $context = $event->getContext();
 
+        $context->references_in_scope['fetch_mode'] = null;
+        $context->references_in_scope['fetch_class'] = null;
+
         if (isset($call_args[0])
             && ($first_arg_type = $source->getNodeTypeProvider()->getType($call_args[0]->value))
             && $first_arg_type->isSingleIntLiteral()

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -622,6 +622,46 @@ class MethodCallTest extends TestCase
                         return $foo;
                     }',
             ],
+            'pdoStatementFetchColumn' => [
+                'code' => '<?php
+                    /** @return scalar|null|false */
+                    function fetch_column() {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_COLUMN);
+                    }',
+            ],
+            'pdoStatementFetchAllColumn' => [
+                'code' => '<?php
+                    /** @return list<scalar|null> */
+                    function fetch_column() {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_COLUMN);
+                    }',
+            ],
+            'pdoStatementFetchKeyPair' => [
+                'code' => '<?php
+                    /** @return array<array-key,scalar|null> */
+                    function fetch_column() {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetch(PDO::FETCH_KEY_PAIR);
+                    }',
+            ],
+            'pdoStatementFetchAllKeyPair' => [
+                'code' => '<?php
+                    /** @return array<array-key,scalar|null> */
+                    function fetch_column() {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_KEY_PAIR);
+                    }',
+            ],
             'pdoStatementFetchAssoc' => [
                 'code' => '<?php
                     /** @return array<string,null|scalar>|false */
@@ -724,19 +764,9 @@ class MethodCallTest extends TestCase
                         return $sth->fetch(PDO::FETCH_LAZY);
                     }',
             ],
-            'pdoStatementFetchAllLazy' => [
-                'code' => '<?php
-                    /** @return list<object> */
-                    function fetch_lazy() : array {
-                        $p = new PDO("sqlite::memory:");
-                        $sth = $p->prepare("SELECT 1");
-                        $sth->execute();
-                        return $sth->fetchAll(PDO::FETCH_LAZY);
-                    }',
-            ],
             'pdoStatementFetchNamed' => [
                 'code' => '<?php
-                    /** @return array<string,scalar|list<scalar>>|false */
+                    /** @return array<string,scalar|null|list<scalar|null>>|false */
                     function fetch_named() {
                         $p = new PDO("sqlite::memory:");
                         $sth = $p->prepare("SELECT 1");
@@ -746,7 +776,7 @@ class MethodCallTest extends TestCase
             ],
             'pdoStatementFetchAllNamed' => [
                 'code' => '<?php
-                    /** @return list<array<string,scalar|list<scalar>>> */
+                    /** @return list<array<string,scalar|null|list<scalar|null>>> */
                     function fetch_named() : array {
                         $p = new PDO("sqlite::memory:");
                         $sth = $p->prepare("SELECT 1");

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -507,10 +507,13 @@ class MethodCallTest extends TestCase
 
                     $db = new PDO("sqlite::memory:");
                     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+                    $db->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
                     $stmt = $db->prepare("select \"a\" as a");
                     $stmt->setFetchMode(PDO::FETCH_CLASS, A::class);
                     $stmt2 = $db->prepare("select \"a\" as a");
                     $stmt2->setFetchMode(PDO::FETCH_ASSOC);
+                    $stmt3 = $db->prepare("select \"a\" as a");
+                    $stmt3->setFetchMode(PDO::ATTR_DEFAULT_FETCH_MODE);
                     $stmt->execute();
                     $stmt2->execute();
                     /** @psalm-suppress MixedAssignment */
@@ -525,7 +528,9 @@ class MethodCallTest extends TestCase
                     $h = $stmt2->fetch();
                     $i = $stmt2->fetchAll();
                     $j = $stmt2->fetch(PDO::FETCH_BOTH);
-                    $k = $stmt2->fetchAll(PDO::FETCH_BOTH);',
+                    $k = $stmt2->fetchAll(PDO::FETCH_BOTH);
+                    /** @psalm-suppress MixedAssignment */
+                    $l = $stmt3->fetch();',
                 'assertions' => [
                     '$a' => 'mixed',
                     '$b' => 'array<array-key, mixed>|false',
@@ -538,6 +543,7 @@ class MethodCallTest extends TestCase
                     '$i' => 'array<array-key, mixed>|false',
                     '$j' => 'array<array-key, null|scalar>|false',
                     '$k' => 'list<array<array-key, null|scalar>>',
+                    '$l' => 'mixed',
                 ],
             ],
             'datePeriodConstructor' => [

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -503,14 +503,29 @@ class MethodCallTest extends TestCase
                         /** @var ?string */
                         public $a;
                     }
+                    class B extends A {}
 
                     $db = new PDO("sqlite::memory:");
                     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
                     $stmt = $db->prepare("select \"a\" as a");
                     $stmt->setFetchMode(PDO::FETCH_CLASS, A::class);
                     $stmt->execute();
-                    /** @psalm-suppress MixedAssignment */
-                    $a = $stmt->fetch();',
+                    $a = $stmt->fetch();
+                    $b = $stmt->fetchAll();
+                    $c = $stmt->fetch(PDO::FETCH_CLASS);
+                    $d = $stmt->fetchAll(PDO::FETCH_CLASS);
+                    $e = $stmt->fetchAll(PDO::FETCH_CLASS, B::class);
+                    $f = $stmt->fetch(PDO::FETCH_ASSOC);
+                    $g = $stmt->fetchAll(PDO::FETCH_ASSOC);',
+                'assertions' => [
+                    '$a' => 'A|false',
+                    '$b' => 'list<A>',
+                    '$c' => 'A|false',
+                    '$d' => 'list<A>',
+                    '$e' => 'list<B>',
+                    '$f' => 'array<string, null|scalar>|false',
+                    '$g' => 'list<array<string, null|scalar>>',
+                ],
             ],
             'datePeriodConstructor' => [
                 'code' => '<?php
@@ -617,6 +632,16 @@ class MethodCallTest extends TestCase
                         return $sth->fetch(PDO::FETCH_ASSOC);
                     }',
             ],
+            'pdoStatementFetchAllAssoc' => [
+                'code' => '<?php
+                    /** @return list<array<string,null|scalar>> */
+                    function fetch_assoc() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_ASSOC);
+                    }',
+            ],
             'pdoStatementFetchBoth' => [
                 'code' => '<?php
                     /** @return array<null|scalar>|false */
@@ -625,6 +650,16 @@ class MethodCallTest extends TestCase
                         $sth = $p->prepare("SELECT 1");
                         $sth->execute();
                         return $sth->fetch(PDO::FETCH_BOTH);
+                    }',
+            ],
+            'pdoStatementFetchAllBoth' => [
+                'code' => '<?php
+                    /** @return list<array<null|scalar>> */
+                    function fetch_both() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_BOTH);
                     }',
             ],
             'pdoStatementFetchBound' => [
@@ -637,6 +672,16 @@ class MethodCallTest extends TestCase
                         return $sth->fetch(PDO::FETCH_BOUND);
                     }',
             ],
+            'pdoStatementFetchAllBound' => [
+                'code' => '<?php
+                    /** @return list<bool> */
+                    function fetch_both() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_BOUND);
+                    }',
+            ],
             'pdoStatementFetchClass' => [
                 'code' => '<?php
                     /** @return object|false */
@@ -645,6 +690,28 @@ class MethodCallTest extends TestCase
                         $sth = $p->prepare("SELECT 1");
                         $sth->execute();
                         return $sth->fetch(PDO::FETCH_CLASS);
+                    }',
+            ],
+            'pdoStatementFetchAllClass' => [
+                'code' => '<?php
+                    /** @return list<object> */
+                    function fetch_class() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_CLASS);
+                    }',
+            ],
+            'pdoStatementFetchAllNamedClass' => [
+                'code' => '<?php
+                    class Foo {}
+
+                    /** @return list<Foo> */
+                    function fetch_class() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_CLASS, Foo::class);
                     }',
             ],
             'pdoStatementFetchLazy' => [
@@ -657,6 +724,16 @@ class MethodCallTest extends TestCase
                         return $sth->fetch(PDO::FETCH_LAZY);
                     }',
             ],
+            'pdoStatementFetchAllLazy' => [
+                'code' => '<?php
+                    /** @return list<object> */
+                    function fetch_lazy() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_LAZY);
+                    }',
+            ],
             'pdoStatementFetchNamed' => [
                 'code' => '<?php
                     /** @return array<string,scalar|list<scalar>>|false */
@@ -665,6 +742,16 @@ class MethodCallTest extends TestCase
                         $sth = $p->prepare("SELECT 1");
                         $sth->execute();
                         return $sth->fetch(PDO::FETCH_NAMED);
+                    }',
+            ],
+            'pdoStatementFetchAllNamed' => [
+                'code' => '<?php
+                    /** @return list<array<string,scalar|list<scalar>>> */
+                    function fetch_named() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_NAMED);
                     }',
             ],
             'pdoStatementFetchNum' => [
@@ -677,6 +764,16 @@ class MethodCallTest extends TestCase
                         return $sth->fetch(PDO::FETCH_NUM);
                     }',
             ],
+            'pdoStatementFetchAllNum' => [
+                'code' => '<?php
+                    /** @return list<list<null|scalar>> */
+                    function fetch_named() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_NUM);
+                    }',
+            ],
             'pdoStatementFetchObj' => [
                 'code' => '<?php
                     /** @return stdClass|false */
@@ -685,6 +782,16 @@ class MethodCallTest extends TestCase
                         $sth = $p->prepare("SELECT 1");
                         $sth->execute();
                         return $sth->fetch(PDO::FETCH_OBJ);
+                    }',
+            ],
+            'pdoStatementFetchAllObj' => [
+                'code' => '<?php
+                    /** @return list<stdClass> */
+                    function fetch_named() : array {
+                        $p = new PDO("sqlite::memory:");
+                        $sth = $p->prepare("SELECT 1");
+                        $sth->execute();
+                        return $sth->fetchAll(PDO::FETCH_OBJ);
                     }',
             ],
             'dateTimeSecondArg' => [

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -509,22 +509,35 @@ class MethodCallTest extends TestCase
                     $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
                     $stmt = $db->prepare("select \"a\" as a");
                     $stmt->setFetchMode(PDO::FETCH_CLASS, A::class);
+                    $stmt2 = $db->prepare("select \"a\" as a");
+                    $stmt2->setFetchMode(PDO::FETCH_ASSOC);
                     $stmt->execute();
+                    $stmt2->execute();
+                    /** @psalm-suppress MixedAssignment */
                     $a = $stmt->fetch();
                     $b = $stmt->fetchAll();
                     $c = $stmt->fetch(PDO::FETCH_CLASS);
                     $d = $stmt->fetchAll(PDO::FETCH_CLASS);
                     $e = $stmt->fetchAll(PDO::FETCH_CLASS, B::class);
                     $f = $stmt->fetch(PDO::FETCH_ASSOC);
-                    $g = $stmt->fetchAll(PDO::FETCH_ASSOC);',
+                    $g = $stmt->fetchAll(PDO::FETCH_ASSOC);
+                    /** @psalm-suppress MixedAssignment */
+                    $h = $stmt2->fetch();
+                    $i = $stmt2->fetchAll();
+                    $j = $stmt2->fetch(PDO::FETCH_BOTH);
+                    $k = $stmt2->fetchAll(PDO::FETCH_BOTH);',
                 'assertions' => [
-                    '$a' => 'A|false',
-                    '$b' => 'list<A>',
-                    '$c' => 'A|false',
-                    '$d' => 'list<A>',
+                    '$a' => 'mixed',
+                    '$b' => 'array<array-key, mixed>|false',
+                    '$c' => 'false|object',
+                    '$d' => 'list<object>',
                     '$e' => 'list<B>',
                     '$f' => 'array<string, null|scalar>|false',
                     '$g' => 'list<array<string, null|scalar>>',
+                    '$h' => 'mixed',
+                    '$i' => 'array<array-key, mixed>|false',
+                    '$j' => 'array<array-key, null|scalar>|false',
+                    '$k' => 'list<array<array-key, null|scalar>>',
                 ],
             ],
             'datePeriodConstructor' => [


### PR DESCRIPTION
related to #9974

- added return type detection for PDOStatement::fetchAll, extended return type detection for PDOStatement::fetch
- extended return type detection for PDOStatement::fetchAll/fetch with FETCH_COLUMN and FETCH_KEY_PAIR
- setFetchMode() is currently not memorized
- ATTR_DEFAULT_FETCH_MODE is currently not handled
