### PR TITLE
Remove word possibly from error

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -1129,7 +1129,7 @@ class ArgumentAnalyzer
             if ($input_type->isFalsable() && !$input_type->ignore_falsable_issues) {
                 IssueBuffer::maybeAdd(
                     new PossiblyFalseArgument(
-                        'Argument ' . ($argument_offset + 1) . $method_identifier . ' cannot be false, possibly ' .
+                        'Argument ' . ($argument_offset + 1) . $method_identifier . ' cannot be false, ' .
                         $param_type->getId() . ' value expected',
                         $arg_location,
                         $cased_method_id,


### PR DESCRIPTION
This sentence is very difficult to read. Alternatively, it could be:

