### PR TITLE
argv and argc were inconsistent in Context with VariableFetchAnalyzer

### DIFF
--- a/src/Psalm/Context.php
+++ b/src/Psalm/Context.php
@@ -12,7 +12,8 @@ use Psalm\Internal\Scope\LoopScope;
 use Psalm\Internal\Type\AssertionReconciler;
 use Psalm\Storage\FunctionLikeStorage;
 use Psalm\Type\Atomic\DependentType;
-use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TIntRange;
+use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Union;
 use RuntimeException;
 
@@ -868,10 +869,19 @@ final class Context
     public function defineGlobals(): void
     {
         $globals = [
+            // not sure why this is declared here again, see VariableFetchAnalyzer
             '$argv' => new Union([
-                new TArray([Type::getInt(), Type::getString()]),
+                Type::getNonEmptyListAtomic(Type::getString()),
+                new TNull(),
+            ], [
+                'ignore_nullable_issues' => true,
             ]),
-            '$argc' => Type::getInt(),
+            '$argc' => new Union([
+                new TIntRange(1, null),
+                new TNull(),
+            ], [
+                'ignore_nullable_issues' => true,
+            ]),
         ];
 
         $config = Config::getInstance();


### PR DESCRIPTION
Not sure why argv/argc are declared in context independently in the first place though