### PR TITLE
Fix parameter having `object` type in PHPDoc and only `&` in the method's definition, used with code having an object calling it's method with itself as an argument for mentioned parameter

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -29,6 +29,7 @@ use Psalm\Issue\UndefinedMethod;
 use Psalm\IssueBuffer;
 use Psalm\Type;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TObject;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\Union;
 
@@ -412,7 +413,7 @@ class MethodCallAnalyzer extends CallAnalyzer
             $types = $class_type->getAtomicTypes();
 
             foreach ($types as $key => &$type) {
-                if (!$type instanceof TNamedObject) {
+                if (!$type instanceof TNamedObject && !$type instanceof TObject) {
                     unset($types[$key]);
                 } else {
                     $type = $type->setFromDocblock(false);

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -1203,6 +1203,17 @@ class MethodCallTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'phpdocObjectTypeAndReferenceInParameter' => [
+                'code' => '<?php
+                    class Foo {
+                        /**
+                         * @param object $object
+                         */
+                        public function bar(&$object): void {}
+                    }
+                    $x = new Foo();
+                    $x->bar($x);',
+            ],
         ];
     }
 


### PR DESCRIPTION
Sorry for the title, see the explanation below:

Having such code:
```php
<?php
class Foo {
    /**
    * @param object $o
    */
    public function bar(&$o): void {}
}
$x = new Foo();
$x->bar($x);
```
will result in [internal Psalm error](https://psalm.dev/r/3374fc1feb).

1. Removing `object` from PHPDoc, or
2. removing `&` from the function's definition, or
3. not passing `$x` to method of `$x`

will result in Psalm not crashing, so this is quite an edge case.