### PR TITLE
Fix `hash_pbkdf2` `$options` parameter

### DIFF
--- a/dictionaries/CallMap_81_delta.php
+++ b/dictionaries/CallMap_81_delta.php
@@ -94,6 +94,10 @@ return [
       'old' => ['int|false', 'fields'=>'array<array-key, null|scalar|Stringable>', 'separator='=>'string', 'enclosure='=>'string', 'escape='=>'string'],
       'new' => ['int|false', 'fields'=>'array<array-key, null|scalar|Stringable>', 'separator='=>'string', 'enclosure='=>'string', 'escape='=>'string', 'eol='=>'string'],
     ],
+    'hash_pbkdf2' => [
+      'old' => ['non-empty-string', 'algo'=>'string', 'password'=>'string', 'salt'=>'string', 'iterations'=>'int', 'length='=>'int', 'binary='=>'bool'],
+      'new' => ['non-empty-string', 'algo'=>'string', 'password'=>'string', 'salt'=>'string', 'iterations'=>'int', 'length='=>'int', 'binary='=>'bool', 'options=' => 'array'],
+    ],
     'finfo_buffer' => [
        'old' => ['string|false', 'finfo'=>'resource', 'string'=>'string', 'flags='=>'int', 'context='=>'resource'],
        'new' => ['string|false', 'finfo'=>'finfo', 'string'=>'string', 'flags='=>'int', 'context='=>'resource'],

--- a/dictionaries/CallMap_83_delta.php
+++ b/dictionaries/CallMap_83_delta.php
@@ -49,10 +49,6 @@ return [
       'old' => ['bool', '&rw_array'=>'array', 'flags='=>'int'],
       'new' => ['true', '&rw_array'=>'array', 'flags='=>'int'],
     ],
-    'hash_pbkdf2' => [
-      'old' => ['non-empty-string', 'algo'=>'string', 'password'=>'string', 'salt'=>'string', 'iterations'=>'int', 'length='=>'int', 'binary='=>'bool'],
-      'new' => ['non-empty-string', 'algo'=>'string', 'password'=>'string', 'salt'=>'string', 'iterations'=>'int', 'length='=>'int', 'binary='=>'bool', 'options=' => 'array'],
-    ],
     'imap_setflag_full' => [
       'old' => ['bool', 'imap'=>'IMAP\Connection', 'sequence'=>'string', 'flag'=>'string', 'options='=>'int'],
       'new' => ['true', 'imap'=>'IMAP\Connection', 'sequence'=>'string', 'flag'=>'string', 'options='=>'int'],


### PR DESCRIPTION
`$options` parameter actually appeared in 8.1[^1] but wasn't documented until 8.1.22 [^2]

[^1]: https://github.com/php/php-src/commit/110b4e90946b6d46864c54c0e15b7a0deb6ad4b3
[^2]: https://github.com/php/php-src/commit/7cae6eb8dbee7012691f89f5358ceee44c1b32c2
