### PR TITLE
Forbid faulty `nikic/php-parser` version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         "symfony/console": "^4.1.6 || ^5.0 || ^6.0",
         "symfony/filesystem": "^5.4 || ^6.0"
     },
+    "conflict": {
+      "nikic/php-parser": "4.17.0"
+    },
     "provide": {
         "psalm/psalm": "self.version"
     },


### PR DESCRIPTION
`4.17.0` had a bug that made our CI checks to fail. `4.17.1` fixed that issue (https://github.com/nikic/PHP-Parser/issues/939).


Fixes #10111 
