### PR TITLE
`strip_tags()/$allowed_tags` can accept arrays since 7.4

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2258,6 +2258,10 @@ class Config
             $stubsDir . 'SPL.phpstub',
         ];
 
+        if ($codebase->analysis_php_version_id >= 7_04_00) {
+            $this->internal_stubs[] = $stubsDir . 'Php74.phpstub';
+        }
+
         if ($codebase->analysis_php_version_id >= 8_00_00) {
             $this->internal_stubs[] = $stubsDir . 'CoreGenericAttributes.phpstub';
             $this->internal_stubs[] = $stubsDir . 'Php80.phpstub';

--- a/stubs/Php74.phpstub
+++ b/stubs/Php74.phpstub
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * @psalm-pure
+ *
+ * @psalm-taint-escape html
+ * @psalm-flow ($string) -> return
+ *
+ * @param null|string|array<array-key,string> $allowed_tags
+ */
+function strip_tags(string $string, null|string|array $allowed_tags = null) : string {}


### PR DESCRIPTION
Fixes vimeo/psalm#4317
