### PR TITLE
Nicer PHP version checking

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -1184,25 +1184,16 @@ class ProjectAnalyzer
     public function setPhpVersion(string $version, string $source): void
     {
         if (!preg_match('/' . self::PHP_VERSION_REGEX . '/', $version)) {
-            fwrite(
-                STDERR,
-                'Expecting a version number in the format x.y or x.y.z'
-                . PHP_EOL,
-            );
-            exit(1);
+            throw new UnexpectedValueException('Expecting a version number in the format x.y or x.y.z');
         }
 
         if (!preg_match('/' . self::PHP_SUPPORTED_VERSIONS_REGEX . '/', $version)) {
-            fwrite(
-                STDERR,
+            throw new UnexpectedValueException(
                 'Psalm supports PHP version ">=5.4". The specified version '
                 . $version
-                . " is either not supported or doesn't exist."
-                . PHP_EOL,
+                . " is either not supported or doesn't exist.",
             );
-            exit(1);
         }
-
 
         [$php_major_version, $php_minor_version] = explode('.', $version);
 

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -200,6 +200,10 @@ class ProjectAnalyzer
         UnnecessaryVarAnnotation::class,
     ];
 
+    private const PHP_VERSION_REGEX = '^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\..*)?$';
+
+    private const PHP_SUPPORTED_VERSIONS_REGEX = '^(7\.4|8\.[012])(\..*)?$';
+
     /**
      * @param array<ReportOptions> $generated_report_options
      */
@@ -1179,9 +1183,26 @@ class ProjectAnalyzer
      */
     public function setPhpVersion(string $version, string $source): void
     {
-        if (!preg_match('/^(5\.[456]|7\.[01234]|8\.[012])(\..*)?$/', $version)) {
-            throw new UnexpectedValueException('Expecting a version number in the format x.y');
+        if (!preg_match('/' . self::PHP_VERSION_REGEX . '/', $version)) {
+            fwrite(
+                STDERR,
+                'Expecting a version number in the format x.y or x.y.z'
+                . PHP_EOL,
+            );
+            exit(1);
         }
+
+        if (!preg_match('/' . self::PHP_SUPPORTED_VERSIONS_REGEX . '/', $version)) {
+            fwrite(
+                STDERR,
+                'Psalm requires PHP version ">7.4". The specified version '
+                . $version
+                . " is either not supported or doesn't exist."
+                . PHP_EOL,
+            );
+            exit(1);
+        }
+
 
         [$php_major_version, $php_minor_version] = explode('.', $version);
 

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -202,7 +202,7 @@ class ProjectAnalyzer
 
     private const PHP_VERSION_REGEX = '^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\..*)?$';
 
-    private const PHP_SUPPORTED_VERSIONS_REGEX = '^(5\.[456]|7\.[01234]|8\.[012])(\..*)?$';
+    private const PHP_SUPPORTED_VERSIONS_REGEX = '^(5\.[456]|7\.[01234]|8\.[0123])(\..*)?$';
 
     /**
      * @param array<ReportOptions> $generated_report_options

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -202,7 +202,7 @@ class ProjectAnalyzer
 
     private const PHP_VERSION_REGEX = '^(0|[1-9]\d*)\.(0|[1-9]\d*)(?:\..*)?$';
 
-    private const PHP_SUPPORTED_VERSIONS_REGEX = '^(7\.4|8\.[012])(\..*)?$';
+    private const PHP_SUPPORTED_VERSIONS_REGEX = '^(5\.[456]|7\.[01234]|8\.[012])(\..*)?$';
 
     /**
      * @param array<ReportOptions> $generated_report_options
@@ -1195,7 +1195,7 @@ class ProjectAnalyzer
         if (!preg_match('/' . self::PHP_SUPPORTED_VERSIONS_REGEX . '/', $version)) {
             fwrite(
                 STDERR,
-                'Psalm requires PHP version ">7.4". The specified version '
+                'Psalm supports PHP version ">=5.4". The specified version '
                 . $version
                 . " is either not supported or doesn't exist."
                 . PHP_EOL,

--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -12,6 +12,7 @@ use Psalm\Exception\ConfigNotFoundException;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Report;
 use RuntimeException;
+use UnexpectedValueException;
 
 use function array_filter;
 use function array_key_exists;
@@ -485,7 +486,15 @@ final class CliUtils
         }
 
         if ($version !== null && $source !== null) {
-            $project_analyzer->setPhpVersion($version, $source);
+            try {
+                $project_analyzer->setPhpVersion($version, $source);
+            } catch (UnexpectedValueException $e) {
+                fwrite(
+                    STDERR,
+                    $e->getMessage() . PHP_EOL,
+                );
+                exit(2);
+            }
         }
     }
 


### PR DESCRIPTION
Resolves #10084 

There are now separate checks for version format and supported versions
If the version is invalid or unsupported, CLI now doesn't throw an error and print the stacktrace, just prints the error message and exits