### PR TITLE
Show success message and type stats with GHA formatter

### DIFF
--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -706,7 +706,7 @@ final class IssueBuffer
 
         if (in_array(
             $project_analyzer->stdout_report_options->format,
-            [Report::TYPE_CONSOLE, Report::TYPE_PHP_STORM],
+            [Report::TYPE_CONSOLE, Report::TYPE_PHP_STORM, Report::TYPE_GITHUB_ACTIONS],
         )) {
             echo str_repeat('-', 30) . "\n";
 


### PR DESCRIPTION
Partially addresses vimeo/psalm#9789 (for GHA formatter only).

But the real reason I want this is that without that success message and no errors found, the output in GHA logs looks like Psalm just crashed, especially if it ran fast. 
