### PR TITLE
Assertion enhancements regarding `value-of` in combination with backed enums

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -631,12 +631,6 @@ class AtomicTypeComparator
             }
         }
 
-        if ($input_type_part instanceof TEnumCase
-            && !$container_type_part instanceof TEnumCase
-        ) {
-            return false;
-        }
-
         if ($container_type_part instanceof TString || $container_type_part instanceof TScalar) {
             if ($input_type_part instanceof TNamedObject) {
                 // check whether the object has a __toString method

--- a/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/AtomicTypeComparator.php
@@ -4,7 +4,6 @@ namespace Psalm\Internal\Type\Comparator;
 
 use Psalm\Codebase;
 use Psalm\Internal\MethodIdentifier;
-use Psalm\Type;
 use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\Scalar;
 use Psalm\Type\Atomic\TArray;
@@ -18,12 +17,10 @@ use Psalm\Type\Atomic\TConditional;
 use Psalm\Type\Atomic\TEmptyMixed;
 use Psalm\Type\Atomic\TEnumCase;
 use Psalm\Type\Atomic\TGenericObject;
-use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TIterable;
 use Psalm\Type\Atomic\TKeyOf;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TList;
-use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
@@ -46,7 +43,6 @@ use function array_values;
 use function assert;
 use function count;
 use function get_class;
-use function is_int;
 use function strtolower;
 
 /**
@@ -636,37 +632,9 @@ class AtomicTypeComparator
         }
 
         if ($input_type_part instanceof TEnumCase
-            && $codebase->classlike_storage_provider->has($input_type_part->value)
+            && !$container_type_part instanceof TEnumCase
         ) {
-            if ($container_type_part instanceof TString || $container_type_part instanceof TInt) {
-                $input_type_classlike_storage = $codebase->classlike_storage_provider->get($input_type_part->value);
-                if ($input_type_classlike_storage->enum_type === null
-                    || !isset($input_type_classlike_storage->enum_cases[$input_type_part->case_name])
-                ) {
-                    // Not a backed enum or non-existent enum case
-                    return false;
-                }
-
-                $input_type_enum_case_storage = $input_type_classlike_storage->enum_cases[$input_type_part->case_name];
-                assert(
-                    $input_type_enum_case_storage->value !== null,
-                    'Backed enums cannot have values without a value.',
-                );
-
-                if (is_int($input_type_enum_case_storage->value)) {
-                    return self::isContainedBy(
-                        $codebase,
-                        new TLiteralInt($input_type_enum_case_storage->value),
-                        $container_type_part,
-                    );
-                }
-
-                return self::isContainedBy(
-                    $codebase,
-                    Type::getAtomicStringFromLiteral($input_type_enum_case_storage->value),
-                    $container_type_part,
-                );
-            }
+            return false;
         }
 
         if ($container_type_part instanceof TString || $container_type_part instanceof TScalar) {

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -2991,7 +2991,10 @@ class SimpleAssertionReconciler extends Reconciler
             // For value-of<MyBackedEnum>, the assertion is meant to return *ANY* value of *ANY* enum case
             if ($enum_case_to_assert === null) {
                 foreach ($class_storage->enum_cases as $enum_case) {
-                    assert($enum_case->value !== null, 'Verified enum type above, value can not contain `null` anymore.');
+                    assert(
+                        $enum_case->value !== null,
+                        'Verified enum type above, value can not contain `null` anymore.',
+                    );
                     $reconciled_types[] = Type::getLiteral($enum_case->value);
                 }
 

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -83,6 +83,7 @@ use function assert;
 use function count;
 use function explode;
 use function get_class;
+use function in_array;
 use function is_int;
 use function min;
 use function strlen;
@@ -533,7 +534,10 @@ class SimpleAssertionReconciler extends Reconciler
         }
 
         if ($assertion_type instanceof TValueOf) {
-            return $assertion_type->type;
+            return self::reconcileValueOf(
+                $codebase,
+                $assertion_type
+            );
         }
 
         return null;
@@ -2949,6 +2953,58 @@ class SimpleAssertionReconciler extends Reconciler
         }
 
         return TypeCombiner::combine(array_values($matched_class_constant_types), $codebase);
+    }
+
+    private static function reconcileValueOf(
+        Codebase $codebase,
+        TValueOf $assertion_type
+    ): ?Union {
+        $reconciled_types = [];
+
+        // For now, only enums are supported here
+        foreach ($assertion_type->type->getAtomicTypes() as $atomic_type) {
+            $class_name = null;
+            $enum_case_to_assert = null;
+            if ($atomic_type instanceof TClassConstant) {
+                $class_name = $atomic_type->fq_classlike_name;
+                $enum_case_to_assert = $atomic_type->const_name;
+            } elseif ($atomic_type instanceof TNamedObject) {
+                $class_name = $atomic_type->value;
+            } else {
+                return null;
+            }
+
+            if (!$codebase->classOrInterfaceOrEnumExists($class_name)) {
+                return null;
+            }
+
+            $class_storage = $codebase->classlike_storage_provider->get($class_name);
+            if (!$class_storage->is_enum) {
+                return null;
+            }
+
+            if (!in_array($class_storage->enum_type, ['string', 'int'], true)) {
+                return null;
+            }
+
+            // For value-of<MyBackedEnum>, the assertion is meant to return *ANY* value of *ANY* enum case
+            if ($enum_case_to_assert === null) {
+                foreach ($class_storage->enum_cases as $enum_case) {
+                    $reconciled_types[] = Type::getLiteral($enum_case->value);
+                }
+
+                continue;
+            }
+
+            $enum_case = $class_storage->enum_cases[$atomic_type->const_name] ?? null;
+            if ($enum_case === null) {
+                return null;
+            }
+
+            $reconciled_types[] = Type::getLiteral($enum_case->value);
+        }
+
+        return new Union($reconciled_types);
     }
 
     /**

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -537,6 +537,7 @@ class SimpleAssertionReconciler extends Reconciler
             return self::reconcileValueOf(
                 $codebase,
                 $assertion_type,
+                $failed_reconciliation,
             );
         }
 
@@ -2957,7 +2958,8 @@ class SimpleAssertionReconciler extends Reconciler
 
     private static function reconcileValueOf(
         Codebase $codebase,
-        TValueOf $assertion_type
+        TValueOf $assertion_type,
+        int &$failed_reconciliation
     ): ?Union {
         $reconciled_types = [];
 
@@ -3003,6 +3005,11 @@ class SimpleAssertionReconciler extends Reconciler
 
             assert($enum_case->value !== null, 'Verified enum type above, value can not contain `null` anymore.');
             $reconciled_types[] = Type::getLiteral($enum_case->value);
+        }
+
+        if ($reconciled_types === []) {
+            $failed_reconciliation = Reconciler::RECONCILIATION_EMPTY;
+            return Type::getNever();
         }
 
         return TypeCombiner::combine($reconciled_types, $codebase, false, false);

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -536,7 +536,7 @@ class SimpleAssertionReconciler extends Reconciler
         if ($assertion_type instanceof TValueOf) {
             return self::reconcileValueOf(
                 $codebase,
-                $assertion_type
+                $assertion_type,
             );
         }
 

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -2956,6 +2956,9 @@ class SimpleAssertionReconciler extends Reconciler
         return TypeCombiner::combine(array_values($matched_class_constant_types), $codebase);
     }
 
+    /**
+     * @param Reconciler::RECONCILIATION_* $failed_reconciliation
+     */
     private static function reconcileValueOf(
         Codebase $codebase,
         TValueOf $assertion_type,

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -2963,7 +2963,6 @@ class SimpleAssertionReconciler extends Reconciler
 
         // For now, only enums are supported here
         foreach ($assertion_type->type->getAtomicTypes() as $atomic_type) {
-            $class_name = null;
             $enum_case_to_assert = null;
             if ($atomic_type instanceof TClassConstant) {
                 $class_name = $atomic_type->fq_classlike_name;
@@ -2990,6 +2989,7 @@ class SimpleAssertionReconciler extends Reconciler
             // For value-of<MyBackedEnum>, the assertion is meant to return *ANY* value of *ANY* enum case
             if ($enum_case_to_assert === null) {
                 foreach ($class_storage->enum_cases as $enum_case) {
+                    assert($enum_case->value !== null, 'Verified enum type above, value can not contain `null` anymore.');
                     $reconciled_types[] = Type::getLiteral($enum_case->value);
                 }
 
@@ -3001,10 +3001,11 @@ class SimpleAssertionReconciler extends Reconciler
                 return null;
             }
 
+            assert($enum_case->value !== null, 'Verified enum type above, value can not contain `null` anymore.');
             $reconciled_types[] = Type::getLiteral($enum_case->value);
         }
 
-        return new Union($reconciled_types);
+        return TypeCombiner::combine($reconciled_types, $codebase, false, false);
     }
 
     /**

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -58,6 +58,7 @@ use function array_values;
 use function explode;
 use function get_class;
 use function implode;
+use function is_int;
 use function preg_quote;
 use function preg_replace;
 use function stripos;
@@ -256,6 +257,19 @@ abstract class Type
         $type = new TNumericString;
 
         return new Union([$type]);
+    }
+
+    /**
+     * @param int|string $value
+     * @return TLiteralString|TLiteralInt
+     */
+    public static function getLiteral($value)
+    {
+        if (is_int($value)) {
+            return new TLiteralInt($value);
+        }
+
+        return new TLiteralString($value);
     }
 
     public static function getString(?string $value = null): Union

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -263,7 +263,7 @@ abstract class Type
      * @param int|string $value
      * @return TLiteralString|TLiteralInt
      */
-    public static function getLiteral($value)
+    public static function getLiteral($value): Atomic
     {
         if (is_int($value)) {
             return new TLiteralInt($value);

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -269,7 +269,7 @@ abstract class Type
             return new TLiteralInt($value);
         }
 
-        return new TLiteralString($value);
+        return TLiteralString::make($value);
     }
 
     public static function getString(?string $value = null): Union

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -2194,6 +2194,10 @@ class AssertAnnotationTest extends TestCase
                     function assertSomeInt(int $foo): void
                     {}
 
+                    /** @psalm-assert value-of<StringEnum|IntEnum> $foo */
+                    function assertAnyEnumValue(string|int $foo): void
+                    {}
+
                     /** @param "foo"|"bar" $foo */
                     function takesSomeStringFromEnum(string $foo): StringEnum
                     {
@@ -2216,8 +2220,14 @@ class AssertAnnotationTest extends TestCase
 
                     assertSomeInt($int);
                     takesSomeIntFromEnum($int);
+
+                    /** @var string|int $potentialEnumValue */
+                    $potentialEnumValue = null;
+                    assertAnyEnumValue($potentialEnumValue);
                 ',
-                'assertions' => [],
+                'assertions' => [
+                    '$potentialEnumValue===' => "'bar'|'baz'|'foo'|1|2|3",
+                ],
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -1015,6 +1015,21 @@ class EnumTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'backedEnumDoesNotPassNativeType' => [
+                'code' => '<?php
+                    enum State: string
+                    {
+                        case A = "A";
+                        case B = "B";
+                        case C = "C";
+                    }
+                    function f(string $state): void {}
+                    f(State::A);
+                ',
+                'error_message' => 'InvalidArgument',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 }


### PR DESCRIPTION
This patch reworks the way how psalm is interacting with enums.

In #9655, the initial `value-of` feature was introduced but also introduced a regression regarding backed enum cases were incorrectly detected as their literal representations.
This problem was reported in #10082.

While I was already working on a fix, I also extended the `value-of` assertion to reconcile `value-of<MyEnum>` to allow to assert *ANY* value of an enum case.

Fixes #10082

/cc @weirdan 
