### PR TITLE
Prevent infinite-loop when resolving type-aliases

### DIFF
--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -1629,9 +1629,7 @@ class TypeParser
                 continue;
             }
 
-            $modified = true;
-
-            $normalized_intersection_types[] = TypeExpander::expandAtomic(
+            $expanded_intersection_type = TypeExpander::expandAtomic(
                 $codebase,
                 $intersection_type,
                 null,
@@ -1644,6 +1642,9 @@ class TypeParser
                 true,
                 true,
             );
+
+            $modified = $expanded_intersection_type[0] !== $intersection_type;
+            $normalized_intersection_types[] = $expanded_intersection_type;
         }
 
         if ($modified === false) {

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -1643,7 +1643,7 @@ class TypeParser
                 true,
             );
 
-            $modified = $expanded_intersection_type[0] !== $intersection_type;
+            $modified = $modified || $expanded_intersection_type[0] !== $intersection_type;
             $normalized_intersection_types[] = $expanded_intersection_type;
         }
 


### PR DESCRIPTION
The type-expander returns the same `intersection_type` in case something is not properly expandable. To avoid infinite-loop, we do explicitly verify that the expanded  alias is actually resolved