### PR TITLE
Properly inherit assertions from parents or implemented faces

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -684,6 +684,8 @@ final class Codebase
 
     /**
      * Check whether a class/interface exists
+     *
+     * @psalm-assert-if-true class-string|interface-string|enum-string $fq_class_name
      */
     public function classOrInterfaceOrEnumExists(
         string $fq_class_name,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -778,7 +778,9 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
 
                 $replacement->rule[] = new Assertion\IsType(new TTemplateParam(
                     $assertion->type->param_name,
-                    reset($potential_assertion_providing_classlike_storage->template_types[$assertion->type->param_name]),
+                    reset(
+                        $potential_assertion_providing_classlike_storage->template_types[$assertion->type->param_name],
+                    ),
                     $potential_assertion_providing_class,
                 ));
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -34,6 +34,8 @@ use Psalm\Issue\UndefinedThisPropertyFetch;
 use Psalm\IssueBuffer;
 use Psalm\Node\Expr\VirtualFuncCall;
 use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
+use Psalm\Storage\Assertion;
+use Psalm\Storage\ClassLikeStorage;
 use Psalm\Storage\Possibilities;
 use Psalm\Type;
 use Psalm\Type\Atomic;
@@ -44,10 +46,13 @@ use UnexpectedValueException;
 
 use function array_filter;
 use function array_map;
+use function array_merge;
+use function array_values;
 use function count;
 use function explode;
 use function in_array;
 use function is_string;
+use function reset;
 use function strpos;
 use function strtolower;
 
@@ -415,11 +420,45 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
                 }
             }
 
-            if ($method_storage->assertions) {
+            $assertions = $method_storage->assertions;
+            if ($method_storage->inheritdoc) {
+                $inherited_classes_and_interfaces = array_values(array_filter(array_merge(
+                    $class_storage->parent_classes,
+                    $class_storage->class_implements,
+                ), fn(string $classOrInterface) => $codebase->classOrInterfaceOrEnumExists($classOrInterface)));
+
+                foreach ($inherited_classes_and_interfaces as $potential_assertion_providing_class) {
+                    $potential_assertion_providing_classlike_storage = $codebase->classlike_storage_provider->get(
+                        $potential_assertion_providing_class,
+                    );
+                    if (!isset($potential_assertion_providing_classlike_storage->methods[$method_name_lc])) {
+                        continue;
+                    }
+
+                    $potential_assertion_providing_method_storage = $potential_assertion_providing_classlike_storage
+                        ->methods[$method_name_lc];
+
+                    /**
+                     * Since the inheritance does not provide its own assertions, we have to detect those
+                     * from inherited classes
+                     */
+                    $assertions += array_map(
+                        static fn(Possibilities $possibilities) => self::modifyAssertionsForInheritance(
+                            $possibilities,
+                            $codebase,
+                            $class_storage,
+                            $inherited_classes_and_interfaces,
+                        ),
+                        $potential_assertion_providing_method_storage->assertions,
+                    );
+                }
+            }
+
+            if ($assertions) {
                 self::applyAssertionsToContext(
                     $stmt_name,
                     ExpressionIdentifier::getExtendedVarId($stmt->var, null, $statements_analyzer),
-                    $method_storage->assertions,
+                    $assertions,
                     $args,
                     $template_result,
                     $context,
@@ -689,5 +728,66 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
         }
 
         return null;
+    }
+
+    /**
+     * In case the called class is either implementing or extending a class/interface which does also has the
+     * template we are searching for, we assume that the called method has the same assertions.
+     *
+     * @param list<class-string> $potential_assertion_providing_classes
+     */
+    private static function modifyAssertionsForInheritance(
+        Possibilities $possibilities,
+        Codebase $codebase,
+        ClassLikeStorage $called_class,
+        array $potential_assertion_providing_classes
+    ): Possibilities {
+        $replacement = new Possibilities($possibilities->var_id, []);
+        $extended_params = $called_class->template_extended_params;
+        foreach ($possibilities->rule as $assertion) {
+            if (!$assertion instanceof Assertion\IsType
+                || !$assertion->type instanceof TTemplateParam) {
+                $replacement->rule[] = $assertion;
+                continue;
+            }
+
+            /** Called class does not extend the template parameter */
+            $extended_templates = $called_class->template_extended_params;
+            if (!isset($extended_templates[$assertion->type->defining_class][$assertion->type->param_name])) {
+                $replacement->rule[] = $assertion;
+                continue;
+            }
+
+            foreach ($potential_assertion_providing_classes as $potential_assertion_providing_class) {
+                if (!isset($extended_params[$potential_assertion_providing_class][$assertion->type->param_name])) {
+                    continue;
+                }
+
+                if (!$codebase->classlike_storage_provider->has($potential_assertion_providing_class)) {
+                    continue;
+                }
+
+                $potential_assertion_providing_classlike_storage = $codebase->classlike_storage_provider->get(
+                    $potential_assertion_providing_class,
+                );
+                if (!isset(
+                    $potential_assertion_providing_classlike_storage->template_types[$assertion->type->param_name],
+                )) {
+                    continue;
+                }
+
+                $replacement->rule[] = new Assertion\IsType(new TTemplateParam(
+                    $assertion->type->param_name,
+                    reset($potential_assertion_providing_classlike_storage->template_types[$assertion->type->param_name]),
+                    $potential_assertion_providing_class,
+                ));
+
+                continue 2;
+            }
+
+            $replacement->rule[] = $assertion;
+        }
+
+        return $replacement;
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -15,6 +15,7 @@ use Psalm\Internal\Analyzer\Statements\Expression\Call\Method\MethodCallProhibit
 use Psalm\Internal\Analyzer\Statements\Expression\Call\StaticCallAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\Codebase\AssertionsFromInheritanceResolver;
 use Psalm\Internal\FileManipulation\FileManipulationBuffer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
@@ -317,11 +318,17 @@ class ExistingAtomicStaticCallAnalyzer
                 }
             }
 
-            if ($method_storage->assertions) {
+            $assertionsResolver = new AssertionsFromInheritanceResolver($codebase);
+            $assertions = $assertionsResolver->resolve(
+                $method_storage,
+                $class_storage,
+            );
+
+            if ($assertions) {
                 CallAnalyzer::applyAssertionsToContext(
                     $stmt_name,
                     null,
-                    $method_storage->assertions,
+                    $assertions,
                     $stmt->getArgs(),
                     $template_result,
                     $context,

--- a/src/Psalm/Internal/Codebase/AssertionsFromInheritanceResolver.php
+++ b/src/Psalm/Internal/Codebase/AssertionsFromInheritanceResolver.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Codebase;
+
+use Psalm\Codebase;
+use Psalm\Storage\Assertion\IsType;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\MethodStorage;
+use Psalm\Storage\Possibilities;
+use Psalm\Type\Atomic\TTemplateParam;
+
+use function array_filter;
+use function array_map;
+use function array_merge;
+use function array_values;
+use function reset;
+use function strtolower;
+
+/**
+ * @internal
+ */
+final class AssertionsFromInheritanceResolver
+{
+    private Codebase $codebase;
+
+    public function __construct(
+        Codebase $codebase
+    ) {
+        $this->codebase = $codebase;
+    }
+
+    /**
+     * @return array<int,Possibilities>
+     */
+    public function resolve(
+        MethodStorage $method_storage,
+        ClassLikeStorage $called_class
+    ): array {
+        $method_name_lc = strtolower($method_storage->cased_name ?? '');
+
+        $assertions = $method_storage->assertions;
+        $inherited_classes_and_interfaces = array_values(array_filter(array_merge(
+            $called_class->parent_classes,
+            $called_class->class_implements,
+        ), fn(string $classOrInterface) => $this->codebase->classOrInterfaceOrEnumExists($classOrInterface)));
+
+        foreach ($inherited_classes_and_interfaces as $potential_assertion_providing_class) {
+            $potential_assertion_providing_classlike_storage = $this->codebase->classlike_storage_provider->get(
+                $potential_assertion_providing_class,
+            );
+            if (!isset($potential_assertion_providing_classlike_storage->methods[$method_name_lc])) {
+                continue;
+            }
+
+            $potential_assertion_providing_method_storage = $potential_assertion_providing_classlike_storage
+                ->methods[$method_name_lc];
+
+            /**
+             * Since the inheritance does not provide its own assertions, we have to detect those
+             * from inherited classes
+             */
+            $assertions += array_map(
+                fn(Possibilities $possibilities) => $this->modifyAssertionsForInheritance(
+                    $possibilities,
+                    $this->codebase,
+                    $called_class,
+                    $inherited_classes_and_interfaces,
+                ),
+                $potential_assertion_providing_method_storage->assertions,
+            );
+        }
+
+        return $assertions;
+    }
+
+    /**
+     * In case the called class is either implementing or extending a class/interface which does also has the
+     * template we are searching for, we assume that the called method has the same assertions.
+     *
+     * @param list<class-string> $potential_assertion_providing_classes
+     */
+    private function modifyAssertionsForInheritance(
+        Possibilities $possibilities,
+        Codebase $codebase,
+        ClassLikeStorage $called_class,
+        array $potential_assertion_providing_classes
+    ): Possibilities {
+        $replacement = new Possibilities($possibilities->var_id, []);
+        $extended_params = $called_class->template_extended_params;
+        foreach ($possibilities->rule as $assertion) {
+            if (!$assertion instanceof IsType
+                || !$assertion->type instanceof TTemplateParam) {
+                $replacement->rule[] = $assertion;
+                continue;
+            }
+
+            /** Called class does not extend the template parameter */
+            $extended_templates = $called_class->template_extended_params;
+            if (!isset($extended_templates[$assertion->type->defining_class][$assertion->type->param_name])) {
+                $replacement->rule[] = $assertion;
+                continue;
+            }
+
+            foreach ($potential_assertion_providing_classes as $potential_assertion_providing_class) {
+                if (!isset($extended_params[$potential_assertion_providing_class][$assertion->type->param_name])) {
+                    continue;
+                }
+
+                if (!$codebase->classlike_storage_provider->has($potential_assertion_providing_class)) {
+                    continue;
+                }
+
+                $potential_assertion_providing_classlike_storage = $codebase->classlike_storage_provider->get(
+                    $potential_assertion_providing_class,
+                );
+                if (!isset(
+                    $potential_assertion_providing_classlike_storage->template_types[$assertion->type->param_name],
+                )) {
+                    continue;
+                }
+
+                $replacement->rule[] = new IsType(new TTemplateParam(
+                    $assertion->type->param_name,
+                    reset(
+                        $potential_assertion_providing_classlike_storage->template_types[$assertion->type->param_name],
+                    ),
+                    $potential_assertion_providing_class,
+                ));
+
+                continue 2;
+            }
+
+            $replacement->rule[] = $assertion;
+        }
+
+        return $replacement;
+    }
+}


### PR DESCRIPTION
As stated in https://github.com/vimeo/psalm/pull/10010#discussion_r1306718602, psalm does not properly detect assertions on methods using `{@inheritdoc}` where the inherited method does provide assertions.

Not 100% sure if this also fixes #10010 but at least a part of it.