### PR TITLE
Inherited assertions v2

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
@@ -48,9 +48,6 @@ class ClassTemplateParamCollector
         if ($static_class_storage->template_extended_params
             && $method_name
             && !empty($non_trait_class_storage->overridden_method_ids[$method_name])
-            && isset($class_storage->methods[$method_name])
-            && (!isset($non_trait_class_storage->methods[$method_name]->return_type)
-                || $class_storage->methods[$method_name]->inherited_return_type)
         ) {
             foreach ($non_trait_class_storage->overridden_method_ids[$method_name] as $overridden_method_id) {
                 $overridden_storage = $codebase->methods->getStorage($overridden_method_id);

--- a/src/Psalm/Internal/Codebase/AssertionsFromInheritanceResolver.php
+++ b/src/Psalm/Internal/Codebase/AssertionsFromInheritanceResolver.php
@@ -5,17 +5,13 @@ declare(strict_types=1);
 namespace Psalm\Internal\Codebase;
 
 use Psalm\Codebase;
-use Psalm\Storage\Assertion\IsType;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Storage\MethodStorage;
 use Psalm\Storage\Possibilities;
-use Psalm\Type\Atomic\TTemplateParam;
 
 use function array_filter;
-use function array_map;
 use function array_merge;
 use function array_values;
-use function reset;
 use function strtolower;
 
 /**
@@ -61,80 +57,9 @@ final class AssertionsFromInheritanceResolver
              * Since the inheritance does not provide its own assertions, we have to detect those
              * from inherited classes
              */
-            $assertions += array_map(
-                fn(Possibilities $possibilities) => $this->modifyAssertionsForInheritance(
-                    $possibilities,
-                    $this->codebase,
-                    $called_class,
-                    $inherited_classes_and_interfaces,
-                ),
-                $potential_assertion_providing_method_storage->assertions,
-            );
+            $assertions += $potential_assertion_providing_method_storage->assertions;
         }
 
         return $assertions;
-    }
-
-    /**
-     * In case the called class is either implementing or extending a class/interface which does also has the
-     * template we are searching for, we assume that the called method has the same assertions.
-     *
-     * @param list<class-string> $potential_assertion_providing_classes
-     */
-    private function modifyAssertionsForInheritance(
-        Possibilities $possibilities,
-        Codebase $codebase,
-        ClassLikeStorage $called_class,
-        array $potential_assertion_providing_classes
-    ): Possibilities {
-        $replacement = new Possibilities($possibilities->var_id, []);
-        $extended_params = $called_class->template_extended_params;
-        foreach ($possibilities->rule as $assertion) {
-            if (!$assertion instanceof IsType
-                || !$assertion->type instanceof TTemplateParam) {
-                $replacement->rule[] = $assertion;
-                continue;
-            }
-
-            /** Called class does not extend the template parameter */
-            $extended_templates = $called_class->template_extended_params;
-            if (!isset($extended_templates[$assertion->type->defining_class][$assertion->type->param_name])) {
-                $replacement->rule[] = $assertion;
-                continue;
-            }
-
-            foreach ($potential_assertion_providing_classes as $potential_assertion_providing_class) {
-                if (!isset($extended_params[$potential_assertion_providing_class][$assertion->type->param_name])) {
-                    continue;
-                }
-
-                if (!$codebase->classlike_storage_provider->has($potential_assertion_providing_class)) {
-                    continue;
-                }
-
-                $potential_assertion_providing_classlike_storage = $codebase->classlike_storage_provider->get(
-                    $potential_assertion_providing_class,
-                );
-                if (!isset(
-                    $potential_assertion_providing_classlike_storage->template_types[$assertion->type->param_name],
-                )) {
-                    continue;
-                }
-
-                $replacement->rule[] = new IsType(new TTemplateParam(
-                    $assertion->type->param_name,
-                    reset(
-                        $potential_assertion_providing_classlike_storage->template_types[$assertion->type->param_name],
-                    ),
-                    $potential_assertion_providing_class,
-                ));
-
-                continue 2;
-            }
-
-            $replacement->rule[] = $assertion;
-        }
-
-        return $replacement;
     }
 }

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -2942,7 +2942,8 @@ class AssertAnnotationTest extends TestCase
                 }
 
                 namespace Namespace2 {
-                    use Namespace1\AbstractSingleInstancePluginManager;
+                    use InvalidArgumentException;use Namespace1\AbstractSingleInstancePluginManager;
+                    use Namespace1\AbstractPluginManager;
                     use stdClass;
 
                     /** @template-extends AbstractSingleInstancePluginManager<stdClass> */
@@ -2950,6 +2951,14 @@ class AssertAnnotationTest extends TestCase
                     {
                         /** @var class-string<stdClass> */
                         protected string $instanceOf = stdClass::class;
+                    }
+
+                    /** @template-extends AbstractPluginManager<callable> */
+                    final class Ooq extends AbstractPluginManager
+                    {
+                        public function validate(mixed $value): void
+                        {
+                        }
                     }
                 }
 
@@ -2959,10 +2968,16 @@ class AssertAnnotationTest extends TestCase
                     /** @var mixed $object */
                     $object = null;
                     $baz->validate($object);
+
+                    $ooq = new \Namespace2\Ooq(function (): void {});
+                    /** @var mixed $callable */
+                    $callable = null;
+                    $ooq->validate($callable);
                 }
                 ',
                 'assertions' => [
                     '$object===' => 'stdClass',
+                    '$callable===' => 'callable',
                 ],
                 'ignored_issues' => [],
                 'php_version' => '8.1',

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -2890,9 +2890,6 @@ class AssertAnnotationTest extends TestCase
                     /** @template InstanceType */
                     interface PluginManagerInterface
                     {
-                        /** @return InstanceType */
-                        public function get(): mixed;
-
                         /** @psalm-assert InstanceType $value */
                         public function validate(mixed $value): void;
                     }
@@ -2903,15 +2900,6 @@ class AssertAnnotationTest extends TestCase
                      */
                     abstract class AbstractPluginManager implements PluginManagerInterface
                     {
-                        /** @param InstanceType $value */
-                        public function __construct(private readonly mixed $value)
-                        {}
-
-                        /** {@inheritDoc} */
-                        public function get(): mixed
-                        {
-                            return $this->value;
-                        }
                     }
 
                     /**
@@ -2920,21 +2908,6 @@ class AssertAnnotationTest extends TestCase
                      */
                     abstract class AbstractSingleInstancePluginManager extends AbstractPluginManager
                     {
-                        /**
-                         * An object type that the created instance must be instanced of
-                         *
-                         * @var class-string<InstanceType>
-                         */
-                        protected string $instanceOf;
-
-                        /** {@inheritDoc} */
-                        public function get(): object
-                        {
-                            return parent::get();
-                        }
-
-
-                        /** {@inheritDoc} */
                         public function validate(mixed $value): void
                         {
                         }
@@ -2949,8 +2922,6 @@ class AssertAnnotationTest extends TestCase
                     /** @template-extends AbstractSingleInstancePluginManager<stdClass> */
                     final class Qoo extends AbstractSingleInstancePluginManager
                     {
-                        /** @var class-string<stdClass> */
-                        protected string $instanceOf = stdClass::class;
                     }
 
                     /** @template-extends AbstractPluginManager<callable> */
@@ -2963,13 +2934,13 @@ class AssertAnnotationTest extends TestCase
                 }
 
                 namespace {
-                    $baz = new \Namespace2\Qoo(new stdClass);
+                    $baz = new \Namespace2\Qoo();
 
                     /** @var mixed $object */
                     $object = null;
                     $baz->validate($object);
 
-                    $ooq = new \Namespace2\Ooq(function (): void {});
+                    $ooq = new \Namespace2\Ooq();
                     /** @var mixed $callable */
                     $callable = null;
                     $ooq->validate($callable);


### PR DESCRIPTION
With #10157, some type-juggling was introduced regarding assertions which were inherited.

Since there were still some issues (which are now reflected by the tests), I tried to fix these as well.

I found a check in https://github.com/vimeo/psalm/blob/f782767438dd1678e60f3f97cfc66e1252e79b10/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php#L51-L53 where I do not understand why these are made. By removing them, the inheritance issues are gone (due to the fact that template parameters from class level are now properly parsed).

