### PR TITLE
Narrow `ArrayObject` `TKey` template

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -125,7 +125,7 @@ interface ArrayAccess {
  * This class allows objects to work as arrays.
  * @link http://php.net/manual/en/class.arrayobject.php
  *
- * @template TKey
+ * @template TKey of array-key
  * @template TValue
  * @template-implements IteratorAggregate<TKey, TValue>
  * @template-implements ArrayAccess<TKey, TValue>

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1297,7 +1297,6 @@ class ArrayAssignmentTest extends TestCase
 
                         /**
                          * @psalm-suppress MixedAssignment
-                         * @psalm-suppress MixedArrayOffset
                          */
                         foreach ($a as $k => $v) {
                             $arr[$k] = $v;

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -640,7 +640,7 @@ class ClassTest extends TestCase
                 'code' => '<?php
 
                     /**
-                     * @template TTKey
+                     * @template TTKey of array-key
                      * @template TTValue
                      *
                      * @extends ArrayObject<TTKey, TTValue>
@@ -675,7 +675,7 @@ class ClassTest extends TestCase
             'preventDoubleStaticResolution2' => [
                 'code' => '<?php
                     /**
-                     * @template TTKey
+                     * @template TTKey of array-key
                      * @template TTValue
                      *
                      * @extends ArrayObject<TTKey, TTValue>
@@ -712,7 +712,7 @@ class ClassTest extends TestCase
             'preventDoubleStaticResolution3' => [
                 'code' => '<?php
                     /**
-                     * @template TTKey
+                     * @template TTKey of array-key
                      * @template TTValue
                      *
                      * @extends ArrayObject<TTKey, TTValue>

--- a/tests/Template/ClassTemplateExtendsTest.php
+++ b/tests/Template/ClassTemplateExtendsTest.php
@@ -1390,7 +1390,7 @@ class ClassTemplateExtendsTest extends TestCase
             'extendArrayObjectWithTemplateParams' => [
                 'code' => '<?php
                     /**
-                     * @template TKey
+                     * @template TKey of array-key
                      * @template TValue
                      * @template-extends \ArrayObject<TKey,TValue>
                      */


### PR DESCRIPTION
Since arrays cannot have `mixed` array keys, this patch is narrowing the `ArrowObject`.

I had a quick check in PHPStan and this change aligns with how PHPStan is handling `ArrayObject` keys as well:
https://github.com/phpstan/phpstan-src/blob/ab154e1da54d42fec751e17a1199b3e07591e85e/stubs/ArrayObject.stub#L38