### PR TITLE
Issue handlers priority

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1481,10 +1481,24 @@ class Config
         $this->issue_handlers[$issue_key]->setCustomLevels($config, $this->base_dir);
     }
 
+    public function safeSetAdvancedErrorLevel(string $issue_key, array $config, ?string $default_error_level = null): void
+    {
+        if (!isset($this->issue_handlers[$issue_key])) {
+            $this->setAdvancedErrorLevel($issue_key, $config, $default_error_level);
+        }
+    }
+
     public function setCustomErrorLevel(string $issue_key, string $error_level): void
     {
         $this->issue_handlers[$issue_key] = new IssueHandler();
         $this->issue_handlers[$issue_key]->setErrorLevel($error_level);
+    }
+
+    public function safeSetCustomErrorLevel(string $issue_key, string $error_level): void
+    {
+        if (!isset($this->issue_handlers[$issue_key])) {
+            $this->setCustomErrorLevel($issue_key, $error_level);
+        }
     }
 
     /**

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1481,8 +1481,11 @@ class Config
         $this->issue_handlers[$issue_key]->setCustomLevels($config, $this->base_dir);
     }
 
-    public function safeSetAdvancedErrorLevel(string $issue_key, array $config, ?string $default_error_level = null): void
-    {
+    public function safeSetAdvancedErrorLevel(
+        string $issue_key,
+        array $config,
+        ?string $default_error_level = null
+    ): void {
         if (!isset($this->issue_handlers[$issue_key])) {
             $this->setAdvancedErrorLevel($issue_key, $config, $default_error_level);
         }


### PR DESCRIPTION
Fix #10201

New "Config::safeSetCustomErrorLevel" and "Config::safeSetAdvancedErrorLevel" are added (to not break the current behavior and create unexpected errors). Those methods will create a IssueHandler object only if the issueHandlers array doesn't already contain this issue key.

Tests have been added to validate the behavior of the current ("Config::setCustomErrorLevel" and "Config::setAdvancedErrorLevel") and new methods.
