### PR TITLE
Introduce NonVariableReferenceReturn issue

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -350,6 +350,7 @@
             <xs:element name="NonInvariantDocblockPropertyType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NonInvariantPropertyType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NonStaticSelfCall" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="NonVariableReferenceReturn" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NoValue" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NullableReturnStatement" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="NullArgument" type="ArgumentIssueHandlerType" minOccurs="0" />

--- a/docs/contributing/adding_issues.md
+++ b/docs/contributing/adding_issues.md
@@ -17,8 +17,8 @@ namespace Psalm\Issue;
 
 final class MyNewIssue extends CodeIssue 
 {
-    public const SHORTCODE = 123;
     public const ERROR_LEVEL = 2;
+    public const SHORTCODE = 123;
 }
 ```
 
@@ -26,7 +26,7 @@ For `SHORTCODE` value use `$max_shortcode + 1`. To choose appropriate error leve
 
 There a number of abstract classes you can extend:
 
-* `CodeIssue` - non specific, default issue. It's a base class for all issues.
+* `CodeIssue` - non-specific, default issue. It's a base class for all issues.
 * `ClassIssue` - issue related to a specific class (also interface, trait, enum). These issues can be suppressed for specific classes in `psalm.xml` by using `referencedClass` attribute
 * `PropertyIssue` - issue related to a specific property. Can be targeted by using `referencedProperty` in `psalm.xml`
 * `FunctionIssue` - issue related to a specific function. Can be suppressed with `referencedFunction` attribute.

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -100,6 +100,7 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
 - [ContinueOutsideLoop](issues/ContinueOutsideLoop.md)
 - [InvalidTypeImport](issues/InvalidTypeImport.md)
 - [MethodSignatureMismatch](issues/MethodSignatureMismatch.md)
+- [NonVariableReferenceReturn](issues/NonVariableReferenceReturn.md)
 - [OverriddenMethodAccess](issues/OverriddenMethodAccess.md)
 - [ParamNameMismatch](issues/ParamNameMismatch.md)
 - [ReservedWord](issues/ReservedWord.md)

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -151,6 +151,7 @@
  - [NonInvariantDocblockPropertyType](issues/NonInvariantDocblockPropertyType.md)
  - [NonInvariantPropertyType](issues/NonInvariantPropertyType.md)
  - [NonStaticSelfCall](issues/NonStaticSelfCall.md)
+ - [NonVariableReferenceReturn](issues/NonVariableReferenceReturn.md)
  - [NoValue](issues/NoValue.md)
  - [NullableReturnStatement](issues/NullableReturnStatement.md)
  - [NullArgument](issues/NullArgument.md)

--- a/docs/running_psalm/issues/NonVariableReferenceReturn.md
+++ b/docs/running_psalm/issues/NonVariableReferenceReturn.md
@@ -1,0 +1,11 @@
+# NonVariableReferenceReturn
+
+Emitted when a function returns by reference expression that is not a variable
+
+```php
+<?php
+
+function &getByRef(): int {
+    return 5;
+}
+```

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -32,6 +32,7 @@ use Psalm\Issue\LessSpecificReturnStatement;
 use Psalm\Issue\MixedReturnStatement;
 use Psalm\Issue\MixedReturnTypeCoercion;
 use Psalm\Issue\NoValue;
+use Psalm\Issue\NonVariableReferenceReturn;
 use Psalm\Issue\NullableReturnStatement;
 use Psalm\IssueBuffer;
 use Psalm\Storage\FunctionLikeStorage;
@@ -226,6 +227,23 @@ class ReturnAnalyzer
             $source->examineParamTypes($statements_analyzer, $context, $codebase, $stmt);
 
             $storage = $source->getFunctionLikeStorage($statements_analyzer);
+
+            if ($storage->signature_return_type
+                && $storage->signature_return_type->by_ref
+                && $stmt->expr !== null
+                && !($stmt->expr instanceof PhpParser\Node\Expr\Variable
+                    || $stmt->expr instanceof PhpParser\Node\Expr\PropertyFetch
+                    || $stmt->expr instanceof PhpParser\Node\Expr\StaticPropertyFetch
+                )
+            ) {
+                IssueBuffer::maybeAdd(
+                    new NonVariableReferenceReturn(
+                        'Only variable references should be returned by reference',
+                        new CodeLocation($source, $stmt->expr),
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
 
             $cased_method_id = $source->getCorrectlyCasedMethodId();
 

--- a/src/Psalm/Issue/NonVariableReferenceReturn.php
+++ b/src/Psalm/Issue/NonVariableReferenceReturn.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Issue;
+
+final class NonVariableReferenceReturn extends CodeIssue
+{
+    public const ERROR_LEVEL = 7;
+    public const SHORTCODE = 323;
+}

--- a/tests/ClosureTest.php
+++ b/tests/ClosureTest.php
@@ -957,6 +957,20 @@ class ClosureTest extends TestCase
                     }
                     PHP,
             ],
+            'returnByReferenceVariableInClosure' => [
+                'code' => '<?php
+                    function &(): int {
+                        /** @var int $x */
+                        static $x = 1;
+                        return $x;
+                    };
+                ',
+            ],
+            'returnByReferenceVariableInShortClosure' => [
+                'code' => '<?php
+                    fn &(int &$x): int => $x;
+                ',
+            ],
         ];
     }
 
@@ -1427,6 +1441,20 @@ class ClosureTest extends TestCase
                 'error_message' => 'ParseError',
                 'ignored_issues' => [],
                 'php_version' => '8.1',
+            ],
+            'returnByReferenceNonVariableInClosure' => [
+                'code' => '<?php
+                    function &(): int {
+                        return 45;
+                    };
+                ',
+                'error_message' => 'NonVariableReferenceReturn',
+            ],
+            'returnByReferenceNonVariableInShortClosure' => [
+                'code' => '<?php
+                    fn &(): int => 45;
+                ',
+                'error_message' => 'NonVariableReferenceReturn',
             ],
         ];
     }

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1279,6 +1279,40 @@ class ReturnTypeTest extends TestCase
                         return $t;
                     }',
             ],
+            'returnByReferenceVariableInStaticMethod' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class Foo {
+                        private static string $foo = "foo";
+
+                        public static function &foo(): string {
+                            return self::$foo;
+                        }
+                    }
+                    PHP,
+            ],
+            'returnByReferenceVariableInInstanceMethod' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class Foo {
+                        private float $foo = 3.3;
+
+                        public function &foo(): float {
+                            return $this->foo;
+                        }
+                    }
+                    PHP,
+            ],
+            'returnByReferenceVariableInFunction' => [
+                'code' => <<<'PHP'
+                    <?php
+                    function &foo(): array {
+                        /** @var array $x */
+                        static $x = [1, 2, 3];
+                        return $x;
+                    }
+                    PHP,
+            ],
         ];
     }
 
@@ -1806,6 +1840,37 @@ class ReturnTypeTest extends TestCase
                 'error_message' => 'InvalidReturnStatement',
                 'ignored_issues' => [],
                 'php_version' => '8.0',
+            ],
+            'returnByReferenceNonVariableInStaticMethod' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class Foo {
+                        public static function &foo(string $x): string {
+                            return $x . "bar";
+                        }
+                    }
+                    PHP,
+                'error_message' => 'NonVariableReferenceReturn',
+            ],
+            'returnByReferenceNonVariableInInstanceMethod' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class Foo {
+                        public function &foo(): iterable {
+                            return [] + [1, 2];
+                        }
+                    }
+                    PHP,
+                'error_message' => 'NonVariableReferenceReturn',
+            ],
+            'returnByReferenceNonVariableInFunction' => [
+                'code' => <<<'PHP'
+                    <?php
+                    function &foo(): array {
+                        return [1, 2, 3];
+                    }
+                    PHP,
+                'error_message' => 'NonVariableReferenceReturn',
             ],
         ];
     }


### PR DESCRIPTION
Emit a NonVariableReferenceReturn issue when returning by-reference functions return a non-variable reference.

Currently, PHP produces a notice when such a function is invoked: https://3v4l.org/bMabU

Close: #8047 