### PR TITLE
Emit `MethodSignatureMismatch` when descendant does not return by reference

### DIFF
--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -313,6 +313,16 @@ class MethodComparator
             );
         }
 
+        if ($guide_method_storage->returns_by_ref && !$implementer_method_storage->returns_by_ref) {
+            IssueBuffer::maybeAdd(
+                new MethodSignatureMismatch(
+                    'Method ' . $cased_implementer_method_id . ' must return by-reference',
+                    $code_location,
+                ),
+                $suppressed_issues + $implementer_classlike_storage->suppressed_issues,
+            );
+        }
+
         if ($guide_method_storage->external_mutation_free
             && !$implementer_method_storage->external_mutation_free
             && !$guide_method_storage->mutation_free_inferred

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -929,6 +929,34 @@ class MethodSignatureTest extends TestCase
                     }
                 ',
             ],
+            'allowByRefReturn' => [
+                'code' => '<?php
+                    interface Foo {
+                        public function &foo(): int;
+                    }
+
+                    class Bar implements Foo {
+                        private int $x = 0;
+                        public function &foo(): int {
+                            return $this->x;
+                        }
+                    }
+                ',
+            ],
+            'descendantAddsByRefReturn' => [
+                'code' => '<?php
+                    interface Foo {
+                        public function foo(): int;
+                    }
+
+                    class Bar implements Foo {
+                        private int $x = 0;
+                        public function &foo(): int {
+                            return $this->x;
+                        }
+                    }
+                ',
+            ],
         ];
     }
 
@@ -1585,6 +1613,20 @@ class MethodSignatureTest extends TestCase
                 'error_message' => 'MethodSignatureMustProvideReturnType',
                 'ignored_issues' => [],
                 'php_version' => '8.1',
+            ],
+            'absentByRefReturnInDescendant' => [
+                'code' => '<?php
+                    interface Foo {
+                        public function &foo(): int;
+                    }
+
+                    class Bar implements Foo {
+                        public function foo(): int {
+                            return 1;
+                        }
+                    }
+                ',
+                'error_message' => 'MethodSignatureMismatch',
             ],
         ];
     }


### PR DESCRIPTION
Closes #10247