### PR TITLE
Fix error message for implicitly returning functions with `never` return type

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -197,6 +197,7 @@ class ReturnTypeAnalyzer
                 )
             )
             && !$return_type->isVoid()
+            && !$return_type->isNever()
             && !$inferred_yield_types
             && (!$function_like_storage || !$function_like_storage->has_yield)
             && $function_returns_implicitly

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -223,7 +223,7 @@ class ReturnTypeAnalyzer
         ) {
             if (IssueBuffer::accepts(
                 new InvalidReturnType(
-                    $cased_method_id . ' is not expected to return any values but it does, '
+                    $cased_method_id . ' is not expected to return, but it does, '
                         . 'either implicitly or explicitly',
                     $return_type_location,
                 ),

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1279,6 +1279,26 @@ class ReturnTypeTest extends TestCase
                         return $t;
                     }',
             ],
+            'neverReturnType' => [
+                'code' => '<?php
+                    function exitProgram(bool $die): never
+                    {
+                        if ($die) {
+                            die;
+                        }
+
+                        exit;
+                    }
+
+                    function throwError(): never
+                    {
+                        throw new Exception();
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 
@@ -1806,6 +1826,36 @@ class ReturnTypeTest extends TestCase
                 'error_message' => 'InvalidReturnStatement',
                 'ignored_issues' => [],
                 'php_version' => '8.0',
+            ],
+            'implicitReturnFromFunctionWithNeverReturnType' => [
+                'code' => <<<'PHP'
+                    <?php
+                    function foo(): never
+                    {
+                        if (rand(0, 1)) {
+                            exit();
+                        }
+                    }
+                    PHP,
+                'error_message' => 'InvalidReturnType',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'implicitReturnFromFunctionWithNeverReturnType2' => [
+                'code' => <<<'PHP'
+                    <?php
+                    function foo(bool $x): never
+                    {
+                        while (true) {
+                            if ($x) {
+                                break;
+                            }
+                        }
+                    }
+                    PHP,
+                'error_message' => 'InvalidReturnType',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
         ];
     }


### PR DESCRIPTION
* Before code like this

```php
function foo(): never {}
```
resulted in:
```
ERROR: InvalidReturnType

Not all code paths of foo end in a return statement, return type never expected
```

now it results in:
```
ERROR: InvalidReturnType

foo is not expected to return, but it does, either implicitly or explicitly
```

* Changed wording from `is not expected to return any values` to just `is not expected to return`, since empty returns or implicit returns do not return values

* Added tests for `never` return type