### PR TITLE
Allow parameter names in callable docblocks with templates

### DIFF
--- a/src/Psalm/Internal/Type/ParseTreeCreator.php
+++ b/src/Psalm/Internal/Type/ParseTreeCreator.php
@@ -553,24 +553,23 @@ class ParseTreeCreator
 
         $current_parent = $this->current_leaf->parent;
 
-        if ($current_parent instanceof CallableTree) {
-            return;
-        }
-
-        while ($current_parent && !$current_parent instanceof MethodTree) {
+        //while ($current_parent && !$method_or_callable_parent) {
+        while ($current_parent && !$current_parent instanceof MethodTree && !$current_parent instanceof CallableTree) {
             $this->current_leaf = $current_parent;
             $current_parent = $current_parent->parent;
         }
 
         $next_token = $this->t + 1 < $this->type_token_count ? $this->type_tokens[$this->t + 1] : null;
 
-        if (!$current_parent instanceof MethodTree || !$next_token) {
+        if (!($current_parent instanceof MethodTree || $current_parent instanceof CallableTree) || !$next_token) {
             throw new TypeParseTreeException('Unexpected space');
         }
 
         ++$this->t;
 
-        $this->createMethodParam($next_token, $current_parent);
+        if ($current_parent instanceof MethodTree) {
+            $this->createMethodParam($next_token, $current_parent);
+        }
     }
 
     private function handleQuestionMark(): void

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -686,11 +686,14 @@ class TypeAnnotationTest extends TestCase
                      * @psalm-type B callable(int, int=): string
                      * @psalm-type C callable(int $a, string $b): void
                      * @psalm-type D callable(string $c): mixed
-                     * @psalm-type E callable(float...): (int|null)
-                     * @psalm-type F callable(float ...$d): (int|null)
-                     * @psalm-type G callable(array<int>): array<string>
-                     * @psalm-type H callable(array<string, int> $e): array<int, string>
-                     * @psalm-type I \Closure(int, int): string
+                     * @psalm-type E callable(string $c): mixed
+                     * @psalm-type F callable(float...): (int|null)
+                     * @psalm-type G callable(float ...$d): (int|null)
+                     * @psalm-type H callable(array<int>): array<string>
+                     * @psalm-type I callable(array<string, int> $e): array<int, string>
+                     * @psalm-type J callable(array<int> ...): string
+                     * @psalm-type K callable(array<int> ...$e): string
+                     * @psalm-type L \Closure(int, int): string
                      *
                      * @method ma(): A
                      * @method mb(): B
@@ -701,6 +704,9 @@ class TypeAnnotationTest extends TestCase
                      * @method mg(): G
                      * @method mh(): H
                      * @method mi(): I
+                     * @method mj(): J
+                     * @method mk(): K
+                     * @method ml(): L
                      */
                     class Foo {
                         public function __call(string $method, array $params) { return 1; }
@@ -716,17 +722,23 @@ class TypeAnnotationTest extends TestCase
                     $output_mg = $foo->mg();
                     $output_mh = $foo->mh();
                     $output_mi = $foo->mi();
+                    $output_mj = $foo->mj();
+                    $output_mk = $foo->mk();
+                    $output_ml = $foo->ml();
                 ',
                 'assertions' => [
                     '$output_ma===' => 'callable(int, int):string',
                     '$output_mb===' => 'callable(int, int=):string',
                     '$output_mc===' => 'callable(int, string):void',
                     '$output_md===' => 'callable(string):mixed',
-                    '$output_me===' => 'callable(float...):(int|null)',
+                    '$output_me===' => 'callable(string):mixed',
                     '$output_mf===' => 'callable(float...):(int|null)',
-                    '$output_mg===' => 'callable(array<array-key, int>):array<array-key, string>',
-                    '$output_mh===' => 'callable(array<string, int>):array<int, string>',
-                    '$output_mi===' => 'Closure(int, int):string',
+                    '$output_mg===' => 'callable(float...):(int|null)',
+                    '$output_mh===' => 'callable(array<array-key, int>):array<array-key, string>',
+                    '$output_mi===' => 'callable(array<string, int>):array<int, string>',
+                    '$output_mj===' => 'callable(array<array-key, int>...):string',
+                    '$output_mk===' => 'callable(array<array-key, int>...):string',
+                    '$output_ml===' => 'Closure(int, int):string',
                 ],
             ],
             'unionOfStringsContainingBraceChar' => [

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -679,6 +679,56 @@ class TypeAnnotationTest extends TestCase
                     '$output===' => 'callable():int',
                 ],
             ],
+            'callableFormats' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-type A callable(int, int): string
+                     * @psalm-type B callable(int, int=): string
+                     * @psalm-type C callable(int $a, string $b): void
+                     * @psalm-type D callable(string $c): mixed
+                     * @psalm-type E callable(float...): (int|null)
+                     * @psalm-type F callable(float ...$d): (int|null)
+                     * @psalm-type G callable(array<int>): array<string>
+                     * @psalm-type H callable(array<string, int> $e): array<int, string>
+                     * @psalm-type I \Closure(int, int): string
+                     *
+                     * @method ma(): A
+                     * @method mb(): B
+                     * @method mc(): C
+                     * @method md(): D
+                     * @method me(): E
+                     * @method mf(): F
+                     * @method mg(): G
+                     * @method mh(): H
+                     * @method mi(): I
+                     */
+                    class Foo {
+                        public function __call(string $method, array $params) { return 1; }
+                    }
+
+                    $foo = new \Foo();
+                    $output_ma = $foo->ma();
+                    $output_mb = $foo->mb();
+                    $output_mc = $foo->mc();
+                    $output_md = $foo->md();
+                    $output_me = $foo->me();
+                    $output_mf = $foo->mf();
+                    $output_mg = $foo->mg();
+                    $output_mh = $foo->mh();
+                    $output_mi = $foo->mi();
+                ',
+                'assertions' => [
+                    '$output_ma===' => 'callable(int, int):string',
+                    '$output_mb===' => 'callable(int, int=):string',
+                    '$output_mc===' => 'callable(int, string):void',
+                    '$output_md===' => 'callable(string):mixed',
+                    '$output_me===' => 'callable(float...):(int|null)',
+                    '$output_mf===' => 'callable(float...):(int|null)',
+                    '$output_mg===' => 'callable(array<array-key, int>):array<array-key, string>',
+                    '$output_mh===' => 'callable(array<string, int>):array<int, string>',
+                    '$output_mi===' => 'Closure(int, int):string',
+                ],
+            ],
             'unionOfStringsContainingBraceChar' => [
                 'code' => '<?php
                     /** @psalm-type T \'{\'|\'}\' */


### PR DESCRIPTION
fixes #10217. They are simply skipped, which is how `@method` is handled.

```
/**
 * @phpstan-type ErrorsHandler callable(array<Error> $errors, ErrorFormatter $formatter): SerializableErrors
 */
```

This docblock was throwing

> ERROR: [InvalidDocblock](https://psalm.dev/008) - 28:1 - Unexpected space