### PR TITLE
Fix return of BadSqlTainter::afterExpressionAnalysis()

### DIFF
--- a/docs/security_analysis/custom_taint_sources.md
+++ b/docs/security_analysis/custom_taint_sources.md
@@ -68,6 +68,7 @@ class BadSqlTainter implements AfterExpressionAnalysisInterface
                 );
             }
         }
+        return null;
     }
 }
 ```


### PR DESCRIPTION
Fix #10269 