### PR TITLE
Fix memory explosion with calls to method_exists

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalysisResult.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalysisResult.php
@@ -26,7 +26,7 @@ class AtomicMethodCallAnalysisResult
     public array $invalid_method_call_types = [];
 
     /**
-     * @var array<string>
+     * @var array<string, bool>
      */
     public array $existent_method_ids = [];
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/AtomicMethodCallAnalyzer.php
@@ -338,7 +338,7 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
         $all_intersection_return_type = null;
         $all_intersection_existent_method_ids = [];
 
-        // insersection types are also fun, they also complicate matters
+        // intersection types are also fun, they also complicate matters
         if ($intersection_types) {
             [$all_intersection_return_type, $all_intersection_existent_method_ids]
                 = self::getIntersectionReturnType(
@@ -525,7 +525,7 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
     /**
      * @param  TNamedObject|TTemplateParam $lhs_type_part
      * @param   array<string, Atomic> $intersection_types
-     * @return  array{?Union, array<string>}
+     * @return  array{?Union, array<string, bool>}
      */
     private static function getIntersectionReturnType(
         StatementsAnalyzer $statements_analyzer,
@@ -646,7 +646,8 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
                     && $stmt->name instanceof PhpParser\Node\Identifier
                     && isset($lhs_type_part->methods[strtolower($stmt->name->name)])
                 ) {
-                    $result->existent_method_ids[] = $lhs_type_part->methods[strtolower($stmt->name->name)];
+                    $method_id = $lhs_type_part->methods[strtolower($stmt->name->name)];
+                    $result->existent_method_ids[$method_id] = true;
                 } elseif (!$is_intersection) {
                     if ($stmt->name instanceof PhpParser\Node\Identifier) {
                         $codebase->analyzer->addMixedMemberName(
@@ -915,7 +916,7 @@ class AtomicMethodCallAnalyzer extends CallAnalyzer
         ?TemplateResult $inferred_template_result = null
     ): void {
         $method_id = 'object::__invoke';
-        $result->existent_method_ids[] = $method_id;
+        $result->existent_method_ids[$method_id] = true;
         $result->has_valid_method_call_type = true;
 
         if ($lhs_type_part_callable !== null) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -87,7 +87,8 @@ class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
 
         $cased_method_id = $fq_class_name . '::' . $stmt_name->name;
 
-        $result->existent_method_ids[] = $method_id->__toString();
+
+        $result->existent_method_ids[$method_id->__toString()] = true;
 
         if ($context->collect_initializations && $context->calling_method_id) {
             [$calling_method_class] = explode('::', $context->calling_method_id);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MissingMethodCallHandler.php
@@ -52,7 +52,7 @@ class MissingMethodCallHandler
         if ($stmt->isFirstClassCallable()) {
             if (isset($class_storage->pseudo_methods[$method_name_lc])) {
                 $result->has_valid_method_call_type = true;
-                $result->existent_method_ids[] = $method_id->__toString();
+                $result->existent_method_ids[$method_id->__toString()] = true;
                 $result->return_type = self::createFirstClassCallableReturnType(
                     $class_storage->pseudo_methods[$method_name_lc],
                 );
@@ -110,7 +110,7 @@ class MissingMethodCallHandler
 
         if ($found_method_and_class_storage) {
             $result->has_valid_method_call_type = true;
-            $result->existent_method_ids[] = $method_id->__toString();
+            $result->existent_method_ids[$method_id->__toString()] = true;
 
             [$pseudo_method_storage, $defining_class_storage] = $found_method_and_class_storage;
 
@@ -198,7 +198,7 @@ class MissingMethodCallHandler
         }
 
         $result->has_valid_method_call_type = true;
-        $result->existent_method_ids[] = $method_id->__toString();
+        $result->existent_method_ids[$method_id->__toString()] = true;
 
         $array_values = array_map(
             static fn(PhpParser\Node\Arg $arg): PhpParser\Node\Expr\ArrayItem => new VirtualArrayItem(
@@ -235,7 +235,7 @@ class MissingMethodCallHandler
     }
 
     /**
-     * @param array<string> $all_intersection_existent_method_ids
+     * @param array<string, bool> $all_intersection_existent_method_ids
      */
     public static function handleMissingOrMagicMethod(
         StatementsAnalyzer $statements_analyzer,
@@ -267,7 +267,7 @@ class MissingMethodCallHandler
             && $found_method_and_class_storage
         ) {
             $result->has_valid_method_call_type = true;
-            $result->existent_method_ids[] = $method_id->__toString();
+            $result->existent_method_ids[$method_id->__toString()] = true;
 
             [$pseudo_method_storage, $defining_class_storage] = $found_method_and_class_storage;
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -556,6 +556,22 @@ class MethodCallTest extends TestCase
                         );
                     }',
             ],
+            'methodExistsDoesntExhaustMemory' => [
+                'code' => '<?php
+                    class C {}
+
+                    function f(C $c): void {
+                        method_exists($c, \'a\') ? $c->a() : [];
+                        method_exists($c, \'b\') ? $c->b() : [];
+                        method_exists($c, \'c\') ? $c->c() : [];
+                        method_exists($c, \'d\') ? $c->d() : [];
+                        method_exists($c, \'e\') ? $c->e() : [];
+                        method_exists($c, \'f\') ? $c->f() : [];
+                        method_exists($c, \'g\') ? $c->g() : [];
+                        method_exists($c, \'h\') ? $c->h() : [];
+                        method_exists($c, \'i\') ? $c->i() : [];
+                    }',
+            ],
             'callMethodAfterCheckingExistence' => [
                 'code' => '<?php
                     class A {}


### PR DESCRIPTION
Fixes #9808. 

Growth is still 2^n, but massively better than it was ( I didn't try and work the big-O for that)

https://github.com/vimeo/psalm/blob/35183b9542b82d46f7e0d53629677220aafe27d0/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php#L191

<img width="191" alt="image" src="https://github.com/vimeo/psalm/assets/5231691/27f2afa4-49ce-46dc-b640-9e7cbb28e709">
