### PR TITLE
Narrow down `get_browser` returning array or object

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1797,3 +1797,9 @@ if (defined('GLOB_BRACE')) {
  * @psalm-taint-sink shell $command
  */
 function exec(string $command, &$output = null, int &$result_code = null): string|false {}
+
+/**
+* @return ($return_array is true ? array|false : object|false)
+* @psalm-ignore-falsable-return
+*/
+function get_browser(?string $user_agent = null, bool $return_array = false): object|array|false {}


### PR DESCRIPTION
The `$return_array` parameter decides if `get_browser` returns either `array|false` or `object|false`

Validator:
https://psalm.dev/r/9a12681e2c