### PR TITLE
Fix auto completion by partial property or method

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -69,6 +69,7 @@ use ReflectionType;
 use UnexpectedValueException;
 
 use function array_combine;
+use function array_merge;
 use function array_pop;
 use function array_reverse;
 use function array_values;
@@ -1883,9 +1884,12 @@ final class Codebase
                 try {
                     $class_storage = $this->classlike_storage_provider->get($atomic_type->value);
 
-                    foreach ($class_storage->appearing_method_ids as $declaring_method_id) {
-                        $method_storage = $this->methods->getStorage($declaring_method_id);
-
+                    $methods = array_merge(
+                        $class_storage->methods,
+                        $class_storage->pseudo_methods,
+                        $class_storage->pseudo_static_methods,
+                    );
+                    foreach ($methods as $method_storage) {
                         if ($method_storage->is_static || $gap === '->') {
                             $completion_item = new CompletionItem(
                                 $method_storage->cased_name,

--- a/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
+++ b/src/Psalm/Internal/LanguageServer/Server/TextDocument.php
@@ -297,6 +297,7 @@ class TextDocument
 
         try {
             $completion_data = $this->codebase->getCompletionDataAtPosition($file_path, $position);
+            $literal_part = $this->codebase->getBeginedLiteralPart($file_path, $position);
             if ($completion_data) {
                 [$recent_type, $gap, $offset] = $completion_data;
 
@@ -305,6 +306,8 @@ class TextDocument
                         ->textDocument->completion->completionItem->snippetSupport ?? false;
                     $completion_items =
                         $this->codebase->getCompletionItemsForClassishThing($recent_type, $gap, $snippetSupport);
+                    $completion_items =
+                        $this->codebase->filterCompletionItemsByBeginLiteralPart($completion_items, $literal_part);
                 } elseif ($gap === '[') {
                     $completion_items = $this->codebase->getCompletionItemsForArrayKeys($recent_type);
                 } else {

--- a/tests/LanguageServer/CompletionTest.php
+++ b/tests/LanguageServer/CompletionTest.php
@@ -1456,6 +1456,38 @@ class CompletionTest extends TestCase
         $this->assertCount(2, $completion_items);
     }
 
+    public function testCompletionStaticMethodOnDocBlock(): void
+    {
+        $codebase = $this->codebase;
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace Bar;
+
+                /**
+                 * @method static void foo()
+                 */
+                class Alpha {}
+                Alpha::',
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+        $this->analyzeFile('somefile.php', new Context());
+
+        $position = new Position(7, 23);
+        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', $position);
+
+        $this->assertSame(['Bar\Alpha', '::', 177], $completion_data);
+
+        $completion_items = $codebase->getCompletionItemsForClassishThing($completion_data[0], $completion_data[1], true);
+        $this->assertCount(1, $completion_items);
+        $this->assertSame('foo()', $completion_items[0]->insertText);
+    }
+
     public function testCompletionOnClassInstanceReferenceWithAssignmentAfter(): void
     {
 

--- a/tests/LanguageServer/CompletionTest.php
+++ b/tests/LanguageServer/CompletionTest.php
@@ -15,6 +15,7 @@ use Psalm\Tests\TestCase;
 use Psalm\Tests\TestConfig;
 use Psalm\Type;
 
+use function array_map;
 use function count;
 
 class CompletionTest extends TestCase
@@ -370,7 +371,7 @@ class CompletionTest extends TestCase
         $codebase->scanFiles();
         $this->analyzeFile('somefile.php', new Context());
 
-        $this->assertNull($codebase->getCompletionDataAtPosition('somefile.php', new Position(16, 41)));
+        $this->assertSame(['B\C', '->', 456], $codebase->getCompletionDataAtPosition('somefile.php', new Position(16, 41)));
     }
 
     public function testCompletionOnTemplatedThisProperty(): void
@@ -723,6 +724,201 @@ class CompletionTest extends TestCase
 
         $this->assertSame('bar($0)', $completion_items[0]->insertText);
         $this->assertSame('baz()', $completion_items[1]->insertText);
+    }
+
+    public function testObjectPropertyOnAppendToEnd(): void
+    {
+        $codebase = $this->codebase;
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace B;
+
+                class A {
+                    public $aProp = 123;
+                    public $bProp = 234;
+
+                    public function bar() {
+                        $this->aPr
+                    }
+                }',
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+
+        $this->analyzeFile('somefile.php', new Context());
+
+        $position = new Position(8, 34);
+        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', $position);
+        $literal_part = $codebase->getBeginedLiteralPart('somefile.php', $position);
+
+        $this->assertSame(['B\A&static', '->', 223], $completion_data);
+
+        $completion_items = $codebase->getCompletionItemsForClassishThing($completion_data[0], $completion_data[1], true);
+        $completion_items = $codebase->filterCompletionItemsByBeginLiteralPart($completion_items, $literal_part);
+        $completion_item_texts = array_map(fn($item) => $item->insertText, $completion_items);
+
+        $this->assertSame(['aProp'], $completion_item_texts);
+    }
+
+    public function testObjectPropertyOnReplaceEndPart(): void
+    {
+        $codebase = $this->codebase;
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace B;
+
+                class A {
+                    public $aProp1 = 123;
+                    public $aProp2 = 234;
+
+                    public function bar() {
+                        $this->aProp2;
+                    }
+                }',
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+
+        $this->analyzeFile('somefile.php', new Context());
+
+        $position = new Position(8, 34);
+        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', $position);
+        $literal_part = $codebase->getBeginedLiteralPart('somefile.php', $position);
+
+        $this->assertSame(['B\A&static', '->', 225], $completion_data);
+
+        $completion_items = $codebase->getCompletionItemsForClassishThing($completion_data[0], $completion_data[1], true);
+        $completion_items = $codebase->filterCompletionItemsByBeginLiteralPart($completion_items, $literal_part);
+        $completion_item_texts = array_map(fn($item) => $item->insertText, $completion_items);
+
+        $this->assertSame(['aProp1', 'aProp2'], $completion_item_texts);
+    }
+
+    public function testSelfPropertyOnAppendToEnd(): void
+    {
+        $codebase = $this->codebase;
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace B;
+
+                class A {
+                    public static $aProp = 123;
+                    public static $bProp = 234;
+
+                    public function bar() {
+                        self::$aPr
+                    }
+                }',
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+
+        $this->analyzeFile('somefile.php', new Context());
+
+        $position = new Position(8, 34);
+        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', $position);
+        $literal_part = $codebase->getBeginedLiteralPart('somefile.php', $position);
+
+        $this->assertSame(['B\A', '::', 237], $completion_data);
+
+        $completion_items = $codebase->getCompletionItemsForClassishThing($completion_data[0], $completion_data[1], true);
+        $completion_items = $codebase->filterCompletionItemsByBeginLiteralPart($completion_items, $literal_part);
+        $completion_item_texts = array_map(fn($item) => $item->insertText, $completion_items);
+
+        $this->assertSame(['$aProp'], $completion_item_texts);
+    }
+
+    public function testStaticPropertyOnAppendToEnd(): void
+    {
+        $codebase = $this->codebase;
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace B;
+
+                class A {
+                    public static $aProp = 123;
+                    public static $bProp = 234;
+
+                    public function bar() {
+                        static::$aPr
+                    }
+                }',
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+
+        $this->analyzeFile('somefile.php', new Context());
+
+        $position = new Position(8, 36);
+        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', $position);
+        $literal_part = $codebase->getBeginedLiteralPart('somefile.php', $position);
+
+        $this->assertSame(['B\A', '::', 239], $completion_data);
+
+        $completion_items = $codebase->getCompletionItemsForClassishThing($completion_data[0], $completion_data[1], true);
+        $completion_items = $codebase->filterCompletionItemsByBeginLiteralPart($completion_items, $literal_part);
+        $completion_item_texts = array_map(fn($item) => $item->insertText, $completion_items);
+
+        $this->assertSame(['$aProp'], $completion_item_texts);
+    }
+
+    public function testStaticPropertyOnReplaceEndPart(): void
+    {
+        $codebase = $this->codebase;
+        $config = $codebase->config;
+        $config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace B;
+
+                class A {
+                    public static $aProp1 = 123;
+                    public static $aProp2 = 234;
+
+                    public function bar() {
+                        self::$aProp2;
+                    }
+                }',
+        );
+
+        $codebase->file_provider->openFile('somefile.php');
+        $codebase->scanFiles();
+
+        $this->analyzeFile('somefile.php', new Context());
+
+        $position = new Position(8, 34);
+        $completion_data = $codebase->getCompletionDataAtPosition('somefile.php', $position);
+        $literal_part = $codebase->getBeginedLiteralPart('somefile.php', $position);
+
+        $this->assertSame(['B\A', '::', 239], $completion_data);
+
+        $completion_items = $codebase->getCompletionItemsForClassishThing($completion_data[0], $completion_data[1], true);
+        $completion_items = $codebase->filterCompletionItemsByBeginLiteralPart($completion_items, $literal_part);
+        $completion_item_texts = array_map(fn($item) => $item->insertText, $completion_items);
+
+        $this->assertSame(['$aProp1', '$aProp2'], $completion_item_texts);
     }
 
     public function testCompletionOnNewExceptionWithoutNamespace(): void


### PR DESCRIPTION
Supprot auto completion with usage partial string of property or method.

    namespace B;
    class A {
        public $aProp = 123;
        public $bProp = 234;
        public function bar() {
            $this->aPr
        }
    }

Expected result for auto completion `aProp`.

Full result partial code in IDE -- `$this->aProp`.