### PR TITLE
Stub constants for ZipArchive from ext-zip

### DIFF
--- a/stubs/extensions/zip.phpstub
+++ b/stubs/extensions/zip.phpstub
@@ -1,0 +1,109 @@
+<?php
+
+/**
+ * Constants gathered using ReflectionClass::getConstants on PHP 8.2
+ */
+
+class ZipArchive implements Countable
+{
+    /** Constants */
+    public const CREATE = 1;
+    public const EXCL = 2;
+    public const CHECKCONS = 4;
+    public const OVERWRITE = 8;
+    public const RDONLY = 16;
+    public const FL_NOCASE = 1;
+    public const FL_NODIR = 2;
+    public const FL_COMPRESSED = 4;
+    public const FL_UNCHANGED = 8;
+    public const FL_RECOMPRESS = 16;
+    public const FL_ENCRYPTED = 32;
+    public const FL_OVERWRITE = 8192;
+    public const FL_LOCAL = 256;
+    public const FL_CENTRAL = 512;
+    public const FL_ENC_GUESS = 0;
+    public const FL_ENC_RAW = 64;
+    public const FL_ENC_STRICT = 128;
+    public const FL_ENC_UTF_8 = 2048;
+    public const FL_ENC_CP437 = 4096;
+    public const CM_DEFAULT = -1;
+    public const CM_STORE = 0;
+    public const CM_SHRINK = 1;
+    public const CM_REDUCE_1 = 2;
+    public const CM_REDUCE_2 = 3;
+    public const CM_REDUCE_3 = 4;
+    public const CM_REDUCE_4 = 5;
+    public const CM_IMPLODE = 6;
+    public const CM_DEFLATE = 8;
+    public const CM_DEFLATE64 = 9;
+    public const CM_PKWARE_IMPLODE = 10;
+    public const CM_BZIP2 = 12;
+    public const CM_LZMA = 14;
+    public const CM_LZMA2 = 33;
+    public const CM_XZ = 95;
+    public const CM_TERSE = 18;
+    public const CM_LZ77 = 19;
+    public const CM_WAVPACK = 97;
+    public const CM_PPMD = 98;
+    public const ER_OK = 0;
+    public const ER_MULTIDISK = 1;
+    public const ER_RENAME = 2;
+    public const ER_CLOSE = 3;
+    public const ER_SEEK = 4;
+    public const ER_READ = 5;
+    public const ER_WRITE = 6;
+    public const ER_CRC = 7;
+    public const ER_ZIPCLOSED = 8;
+    public const ER_NOENT = 9;
+    public const ER_EXISTS = 10;
+    public const ER_OPEN = 11;
+    public const ER_TMPOPEN = 12;
+    public const ER_ZLIB = 13;
+    public const ER_MEMORY = 14;
+    public const ER_CHANGED = 15;
+    public const ER_COMPNOTSUPP = 16;
+    public const ER_EOF = 17;
+    public const ER_INVAL = 18;
+    public const ER_NOZIP = 19;
+    public const ER_INTERNAL = 20;
+    public const ER_INCONS = 21;
+    public const ER_REMOVE = 22;
+    public const ER_DELETED = 23;
+    public const ER_ENCRNOTSUPP = 24;
+    public const ER_RDONLY = 25;
+    public const ER_NOPASSWD = 26;
+    public const ER_WRONGPASSWD = 27;
+    public const ER_OPNOTSUPP = 28;
+    public const ER_INUSE = 29;
+    public const ER_TELL = 30;
+    public const ER_COMPRESSED_DATA = 31;
+    public const ER_CANCELLED = 32;
+    public const OPSYS_DOS = 0;
+    public const OPSYS_AMIGA = 1;
+    public const OPSYS_OPENVMS = 2;
+    public const OPSYS_UNIX = 3;
+    public const OPSYS_VM_CMS = 4;
+    public const OPSYS_ATARI_ST = 5;
+    public const OPSYS_OS_2 = 6;
+    public const OPSYS_MACINTOSH = 7;
+    public const OPSYS_Z_SYSTEM = 8;
+    public const OPSYS_CPM = 9;
+    public const OPSYS_WINDOWS_NTFS = 10;
+    public const OPSYS_MVS = 11;
+    public const OPSYS_VSE = 12;
+    public const OPSYS_ACORN_RISC = 13;
+    public const OPSYS_VFAT = 14;
+    public const OPSYS_ALTERNATE_MVS = 15;
+    public const OPSYS_BEOS = 16;
+    public const OPSYS_TANDEM = 17;
+    public const OPSYS_OS_400 = 18;
+    public const OPSYS_OS_X = 19;
+    public const OPSYS_DEFAULT = 3;
+    public const EM_NONE = 0;
+    public const EM_TRAD_PKWARE = 1;
+    public const EM_AES_128 = 257;
+    public const EM_AES_192 = 258;
+    public const EM_AES_256 = 259;
+    public const EM_UNKNOWN = 65535;
+    public const LIBZIP_VERSION = 1.7.3;
+}


### PR DESCRIPTION
This stubs out the class constants for `ZipArchive`, which I believe are the only constants introduced by the `zip` extension. This should allow Psalm to run over code utilizing any of these constants even if the analyzing system doesn't have ext-zip installed/enabled (e.g. a GitHub Actions container).