### PR TITLE
Add constants from SOAP extension to stub

### DIFF
--- a/stubs/extensions/soap.phpstub
+++ b/stubs/extensions/soap.phpstub
@@ -1,5 +1,97 @@
 <?php
 
+<?php
+
+/**
+ * Constants that should be available via ext-soap in case the extension is not
+ * enabled in the Psalm-executing environment.
+ *
+ * Values derived from PHP docs here: https://www.php.net/manual/en/soap.constants.php
+ */
+
+const SOAP_1_1 = 1;
+const SOAP_1_2 = 2;
+const SOAP_PERSISTENCE_SESSION = 1;
+const SOAP_PERSISTENCE_REQUEST = 2;
+const SOAP_FUNCTIONS_ALL = 999;
+const SOAP_ENCODED = 1;
+const SOAP_LITERAL = 2;
+const SOAP_RPC = 1;
+const SOAP_DOCUMENT = 2;
+const SOAP_ACTOR_NEXT = 1;
+const SOAP_ACTOR_NONE = 2;
+const SOAP_ACTOR_UNLIMATERECEIVER = 3;
+const SOAP_COMPRESSION_ACCEPT = 32;
+const SOAP_COMPRESSION_GZIP = 0;
+const SOAP_COMPRESSION_DEFLATE = 16;
+const SOAP_AUTHENTICATION_BASIC = 0;
+const SOAP_AUTHENTICATION_DIGEST = 1;
+const SOAP_SSL_METHOD_TLS = 0;
+const SOAP_SSL_METHOD_SSLv2 = 1;
+const SOAP_SSL_METHOD_SSLv3 = 2;
+const SOAP_SSL_METHOD_SSLv23 = 3;
+const UNKNOWN_TYPE = 999998;
+const XSD_STRING = 101;
+const XSD_BOOLEAN = 102;
+const XSD_DECIMAL = 103;
+const XSD_FLOAT = 104;
+const XSD_DOUBLE = 105;
+const XSD_DURATION = 106;
+const XSD_DATETIME = 107;
+const XSD_TIME = 108;
+const XSD_DATE = 109;
+const XSD_GYEARMONTH = 110;
+const XSD_GYEAR = 111;
+const XSD_GMONTHDAY = 112;
+const XSD_GDAY = 113;
+const XSD_GMONTH = 114;
+const XSD_HEXBINARY = 115;
+const XSD_BASE64BINARY = 116;
+const XSD_ANYURI = 117;
+const XSD_QNAME = 118;
+const XSD_NOTATION = 119;
+const XSD_NORMALIZEDSTRING = 120;
+const XSD_TOKEN = 121;
+const XSD_LANGUAGE = 122;
+const XSD_NMTOKEN = 123;
+const XSD_NAME = 124;
+const XSD_NCNAME = 125;
+const XSD_ID = 126;
+const XSD_IDREF = 127;
+const XSD_IDREFS = 128;
+const XSD_ENTITY = 129;
+const XSD_ENTITIES = 130;
+const XSD_INTEGER = 131;
+const XSD_NONPOSITIVEINTEGER = 132;
+const XSD_NEGATIVEINTEGER = 133;
+const XSD_LONG = 134;
+const XSD_INT = 135;
+const XSD_SHORT = 136;
+const XSD_BYTE = 137;
+const XSD_NONNEGATIVEINTEGER = 138;
+const XSD_UNSIGNEDLONG = 139;
+const XSD_UNSIGNEDINT = 140;
+const XSD_UNSIGNEDSHORT = 141;
+const XSD_UNSIGNEDBYTE = 142;
+const XSD_POSITIVEINTEGER = 143;
+const XSD_NMTOKENS = 144;
+const XSD_ANYTYPE = 145;
+const XSD_ANYXML = 147;
+const APACHE_MAP = 200;
+const SOAP_ENC_ARRAY = 300;
+const SOAP_ENC_OBJECT = 301;
+const XSD_1999_TIMEINSTANT = 401;
+const XSD_NAMESPACE = 'http://www.w3.org/2001/XMLSchema';
+const XSD_1999_NAMESPACE = 'http://www.w3.org/1999/XMLSchema';
+const SOAP_SINGLE_ELEMENT_ARRAYS = 1;
+const SOAP_WAIT_ONE_WAY_CALLS = 2;
+const SOAP_USE_XSI_ARRAY_TYPE = 4;
+const WSDL_CACHE_NONE = 0;
+const WSDL_CACHE_DISK = 1;
+const WSDL_CACHE_MEMORY = 2;
+const WSDL_CACHE_BOTH = 3;
+
+
 /**
  * The SoapClient class provides a client for SOAP 1.1, SOAP 1.2 servers. It can be used in WSDL
  * or non-WSDL mode.

--- a/stubs/extensions/soap.phpstub
+++ b/stubs/extensions/soap.phpstub
@@ -1,7 +1,5 @@
 <?php
 
-<?php
-
 /**
  * Constants that should be available via ext-soap in case the extension is not
  * enabled in the Psalm-executing environment.


### PR DESCRIPTION
The SOAP extension stub was missing some constants we used (really just `SOAP_1_1` and `SOAP_1_2`), so I thought I'd add the rest of the constants declared by the extension to the stub. Values are all pulled straight from the PHP docs here:

https://www.php.net/manual/en/soap.constants.php