### PR TITLE
Fix stub for RecursiveArrayIterator::getChildren

### DIFF
--- a/stubs/CoreGenericIterators.phpstub
+++ b/stubs/CoreGenericIterators.phpstub
@@ -774,7 +774,7 @@ class RecursiveArrayIterator extends ArrayIterator implements RecursiveIterator 
     const CHILD_ARRAYS_ONLY = 4 ;
 
     /**
-     * @return RecursiveArrayIterator<TKey, TValue>
+     * @return ?RecursiveArrayIterator<TKey, TValue>
      */
     public function getChildren() {}
 


### PR DESCRIPTION
fixes #10327 