### PR TITLE
Allow int keys when calling Redis methods

### DIFF
--- a/stubs/extensions/redis.phpstub
+++ b/stubs/extensions/redis.phpstub
@@ -276,12 +276,12 @@ class Redis {
     public function move(string $key, int $index): bool {}
 
     /**
-     * @param array<string, string>
+     * @param array<int|string, string>
      */
     public function mset($key_values): Redis|bool {}
 
     /**
-     * @param array<string, string>
+     * @param array<int|string, string>
      */
     public function msetnx($key_values): Redis|bool {}
 


### PR DESCRIPTION
In 5bfc0f960be71093c4b4dc754aa94c6142b44bd9, risky casting was invoked as a way to show there is an issue here. However, it is not always possible to use a string. For instance, there is no such thing as this in PHP: `["1" => "whatever"]`. [If you try to create such an array, you will obtain `[1 => "whatever"]` instead](https://3v4l.org/F4WTh).

Ironically, [this was copied to jetbrains/phpstorm]( https://github.com/JetBrains/phpstorm-stubs/pull/1454), which is used in PHPStan, which exhibited that false positive.