### PR TITLE
Method annotation fixes

### DIFF
--- a/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/InterfaceAnalyzer.php
@@ -217,6 +217,10 @@ final class InterfaceAnalyzer extends ClassLikeAnalyzer
             }
         }
 
+        $pseudo_methods = $class_storage->pseudo_methods + $class_storage->pseudo_static_methods;
+
+        MethodComparator::comparePseudoMethods($pseudo_methods, $this->fq_class_name, $codebase, $class_storage);
+
         $statements_analyzer = new StatementsAnalyzer($this, new NodeDataProvider());
         $statements_analyzer->analyze($member_stmts, $interface_context, null, true);
 

--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -542,6 +542,7 @@ final class MethodComparator
 
             if ($guide_classlike_storage->user_defined
                 && $implementer_param->signature_type
+                && $guide_param->signature_type
             ) {
                 self::compareMethodSignatureParams(
                     $codebase,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -311,7 +311,6 @@ class CallAnalyzer
             $declaring_method_id = $class_storage->declaring_method_ids[$method_name];
 
             $declaring_fq_class_name = $declaring_method_id->fq_class_name;
-            $declaring_method_name = $declaring_method_id->method_name;
 
             if ($declaring_fq_class_name !== $fq_class_name) {
                 $declaring_class_storage = $codebase->classlike_storage_provider->get($declaring_fq_class_name);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -318,11 +318,7 @@ class CallAnalyzer
                 $declaring_class_storage = $class_storage;
             }
 
-            if (!isset($declaring_class_storage->methods[$declaring_method_name])) {
-                throw new UnexpectedValueException('Storage should not be empty here');
-            }
-
-            $method_storage = $declaring_class_storage->methods[$declaring_method_name];
+            $method_storage = $codebase->methods->getStorage($declaring_method_id);
 
             if ($declaring_class_storage->user_defined
                 && !$method_storage->has_docblock_param_types

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -459,6 +459,13 @@ final class Methods
             foreach ($params as $i => $param) {
                 if (isset($overridden_storage->params[$i]->type)
                     && $overridden_storage->params[$i]->has_docblock_type
+                    && (
+                        ! $param->type
+                        || $param->type->equals(
+                            $overridden_storage->params[$i]->signature_type
+                                ?? $overridden_storage->params[$i]->type,
+                        )
+                    )
                 ) {
                     $params[$i] = clone $param;
                     /** @var Union $params[$i]->type */

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -1148,14 +1148,18 @@ final class Methods
         }
 
         $method_name = $method_id->method_name;
+        $method_storage = $class_storage->methods[$method_name]
+            ?? $class_storage->pseudo_methods[$method_name]
+            ?? $class_storage->pseudo_static_methods[$method_name]
+            ?? null;
 
-        if (!isset($class_storage->methods[$method_name])) {
+        if (! $method_storage) {
             throw new UnexpectedValueException(
                 '$storage should not be null for ' . $method_id,
             );
         }
 
-        return $class_storage->methods[$method_name];
+        return $method_storage;
     }
 
     /** @psalm-mutation-free */

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -564,8 +564,16 @@ final class Populator
 
         $parent_storage->dependent_classlikes[strtolower($storage->name)] = true;
 
-        $storage->pseudo_methods += $parent_storage->pseudo_methods;
-        $storage->declaring_pseudo_method_ids += $parent_storage->declaring_pseudo_method_ids;
+        foreach ($parent_storage->pseudo_methods as $method_name => $pseudo_method) {
+            if (!isset($storage->methods[$method_name])) {
+                $storage->pseudo_methods[$method_name] = $pseudo_method;
+            }
+        }
+        foreach ($parent_storage->declaring_pseudo_method_ids as $method_name => $pseudo_method_id) {
+            if (!isset($storage->methods[$method_name])) {
+                $storage->declaring_pseudo_method_ids[$method_name] = $pseudo_method_id;
+            };
+        }
     }
 
     private function populateInterfaceData(

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -367,7 +367,9 @@ final class Populator
                     $declaring_method_name = $declaring_method_id->method_name;
                     $declaring_class_storage = $declaring_class_storages[$declaring_class];
 
-                    $declaring_method_storage = $declaring_class_storage->methods[$declaring_method_name];
+                    $declaring_method_storage = $declaring_class_storage->methods[$declaring_method_name]
+                        ?? $declaring_class_storage->pseudo_methods[$declaring_method_name]
+                        ?? $declaring_class_storage->pseudo_static_methods[$declaring_method_name];
 
                     if (($declaring_method_storage->has_docblock_param_types
                             || $declaring_method_storage->has_docblock_return_type)

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -623,11 +623,16 @@ final class ClassLikeNodeScanner
                     $storage->pseudo_static_methods[$lc_method_name] = $pseudo_method_storage;
                 } else {
                     $storage->pseudo_methods[$lc_method_name] = $pseudo_method_storage;
-                    $storage->declaring_pseudo_method_ids[$lc_method_name] = new MethodIdentifier(
-                        $fq_classlike_name,
-                        $lc_method_name,
-                    );
                 }
+                $method_identifier = new MethodIdentifier(
+                    $fq_classlike_name,
+                    $lc_method_name,
+                );
+                $storage->inheritable_method_ids[$lc_method_name] = $method_identifier;
+                if (!isset($storage->overridden_method_ids[$lc_method_name])) {
+                    $storage->overridden_method_ids[$lc_method_name] = [];
+                }
+                $storage->declaring_pseudo_method_ids[$lc_method_name] = $method_identifier;
             }
 
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -929,6 +929,7 @@ final class FunctionLikeNodeScanner
             $storage->is_static = $stmt->isStatic();
             $storage->final = $this->classlike_storage && $this->classlike_storage->final;
             $storage->final_from_docblock = $this->classlike_storage && $this->classlike_storage->final_from_docblock;
+            $storage->visibility = ClassLikeAnalyzer::VISIBILITY_PUBLIC;
         } elseif ($stmt instanceof PhpParser\Node\Stmt\Function_) {
             $cased_function_id =
                 ($this->aliases->namespace ? $this->aliases->namespace . '\\' : '') . $stmt->name->name;

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1045,13 +1045,13 @@ class ArrayAssignmentTest extends TestCase
                      * @template-implements ArrayAccess<?int, string>
                      */
                     class C implements ArrayAccess {
-                        public function offsetExists(int $offset) : bool { return true; }
+                        public function offsetExists($offset) : bool { return true; }
 
                         public function offsetGet($offset) : string { return "";}
 
-                        public function offsetSet(?int $offset, string $value) : void {}
+                        public function offsetSet($offset, string $value) : void {}
 
-                        public function offsetUnset(int $offset) : void { }
+                        public function offsetUnset($offset) : void { }
                     }
 
                     $c = new C();
@@ -1964,13 +1964,13 @@ class ArrayAssignmentTest extends TestCase
                      * @template-implements ArrayAccess<int, string>
                      */
                     class C implements ArrayAccess {
-                        public function offsetExists(int $offset) : bool { return true; }
+                        public function offsetExists($offset) : bool { return true; }
 
                         public function offsetGet($offset) : string { return "";}
 
-                        public function offsetSet(int $offset, string $value) : void {}
+                        public function offsetSet($offset, $value) : void {}
 
-                        public function offsetUnset(int $offset) : void { }
+                        public function offsetUnset($offset) : void { }
                     }
 
                     $c = new C();

--- a/tests/DocblockInheritanceTest.php
+++ b/tests/DocblockInheritanceTest.php
@@ -149,6 +149,32 @@ class DocblockInheritanceTest extends TestCase
                         return $f->map();
                     }',
             ],
+            'inheritCorrectParamOnTypeChange' => [
+                'code' => '<?php
+                    class A
+                    {
+                        /** @param array<int, int>|int $className */
+                        public function a(array|int $className): int
+                        {
+                            return 0;
+                        }
+                    }
+
+                    class B extends A
+                    {
+                        public function a(array|int|bool $className): int
+                        {
+                            return 0;
+                        }
+                    }
+
+                    print_r((new A)->a(1));
+                    print_r((new B)->a(true));
+                    ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
         ];
     }
 

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -1164,6 +1164,62 @@ class MagicMethodAnnotationTest extends TestCase
                     }',
                 'error_message' => 'UndefinedVariable',
             ],
+            'MagicMethodReturnTypesCheckedForClasses' => [
+                'code' => '<?php
+                    class A
+                    {
+                        public function a(int $className): int { return 0; }
+                    }
+
+                    /**
+                     * @method stdClass a(int $a)
+                     */
+                    class B extends A {}
+                    ',
+                'error_message' => 'ImplementedReturnTypeMismatch',
+            ],
+            'MagicMethodParamTypesCheckedForClasses' => [
+                'code' => '<?php
+                    class A
+                    {
+                        public function a(int $className): int { return 0; }
+                    }
+
+                    /**
+                     * @method int a(string $a)
+                     */
+                    class B extends A {}
+                    ',
+                'error_message' => 'ImplementedParamTypeMismatch',
+            ],
+            'MagicMethodReturnTypesCheckedForInterfaces' => [
+                'code' => '<?php
+                    interface A
+                    {
+                        public function a(int $className): int;
+                    }
+
+                    /**
+                     * @method stdClass a(int $a)
+                     */
+                    interface B extends A {}
+                    ',
+                'error_message' => 'ImplementedReturnTypeMismatch',
+            ],
+            'MagicMethodParamTypesCheckedForInterfaces' => [
+                'code' => '<?php
+                    interface A
+                    {
+                        public function a(string $className): int;
+                    }
+
+                    /**
+                     * @method int a(int $a)
+                     */
+                    interface B extends A {}
+                    ',
+                'error_message' => 'ImplementedParamTypeMismatch',
+            ],
         ];
     }
 

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -824,7 +824,7 @@ class MagicMethodAnnotationTest extends TestCase
             'callUsingParent' => [
                 'code' => '<?php
                     /**
-                     * @method static create(array $data)
+                     * @method static create(array $input)
                      */
                     class Model {
                         public function __call(string $name, array $arguments) {
@@ -1218,6 +1218,23 @@ class MagicMethodAnnotationTest extends TestCase
                      */
                     interface B extends A {}
                     ',
+                'error_message' => 'ImplementedParamTypeMismatch',
+            ],
+            'MagicMethodMadeConcreteChecksParams' => [
+                'code' => '<?php
+                    /**
+                     * @method static void create(array $x)
+                     */
+                    class Model {
+                        public static function __callStatic(string $method, array $params) {
+                        }
+                    }
+
+                    class FooModel extends Model {
+                        public static function create(object $x): void {
+                            $x;
+                        }
+                    }',
                 'error_message' => 'ImplementedParamTypeMismatch',
             ],
         ];

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -949,6 +949,21 @@ class MagicMethodAnnotationTest extends TestCase
                     //C::array();
                     PHP,
             ],
+            'DoubleInheritedDontComplain' => [
+                'code' => '<?php
+                    /**
+                     * @method void func(int ...$args)
+                     */
+                    class Foo {}
+
+                    class Bar extends Foo {
+                        public function func(int $i = 0, int ...$args): void {}
+                    }
+
+                    class UhOh extends Bar {}',
+                'assertions' => [],
+                'ignored_issues' => ['ParamNameMismatch'],
+            ],
         ];
     }
 

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -926,6 +926,9 @@ class MethodSignatureTest extends TestCase
                     {
                         public function a(mixed $a): void {}
                     }',
+                'assertions' => [],
+                'ignored_errors' => [],
+                'php_version' => '8.0',
             ],
             'doesNotRequireInterfaceDestructorsToHaveReturnType' => [
                 'code' => '<?php

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -1639,6 +1639,28 @@ class MethodSignatureTest extends TestCase
                 ',
                 'error_message' => 'MethodSignatureMismatch',
             ],
+            'methodAnnotationReturnMismatch' => [
+                'code' => '<?php
+                /**
+                * @method array bar()
+                */
+                interface Foo
+                {
+                    public function bar(): string;
+                }',
+                'error_message' => 'MismatchingDocblockReturnType',
+            ],
+            'methodAnnotationParamMismatch' => [
+                'code' => '<?php
+                /**
+                * @method string bar(string $i)
+                */
+                interface Foo
+                {
+                    public function bar(int $i): string;
+                }',
+                'error_message' => 'MismatchingDocblockParamType',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes #5786 
Fixes #3871
Fixes #4546 
Fixes #5990
Also fixes this https://psalm.dev/r/edaea88e00, where an extend with an `@method` silently overwrites the parent return type