### PR TITLE
Fix misc callable bugs

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -371,7 +371,7 @@ return [
 'array_diff_ukey\'1' => ['array', 'array'=>'array', 'rest'=>'array', 'arr3'=>'array', 'arg4'=>'array|callable(mixed,mixed):int', '...rest='=>'array|callable(mixed,mixed):int'],
 'array_fill' => ['array<int,mixed>', 'start_index'=>'int', 'count'=>'int', 'value'=>'mixed'],
 'array_fill_keys' => ['array', 'keys'=>'array', 'value'=>'mixed'],
-'array_filter' => ['array', 'array'=>'array', 'callback='=>'callable(mixed,mixed=):scalar|null', 'mode='=>'int'],
+'array_filter' => ['array', 'array'=>'array', 'callback='=>'callable(mixed,array-key=):mixed|null', 'mode='=>'int'],
 'array_flip' => ['array<string|int>', 'array'=>'array<string|int>'],
 'array_intersect' => ['array', 'array'=>'array', '...arrays='=>'array'],
 'array_intersect_assoc' => ['array', 'array'=>'array', '...arrays='=>'array'],

--- a/dictionaries/CallMap_80_delta.php
+++ b/dictionaries/CallMap_80_delta.php
@@ -553,8 +553,8 @@ return [
       'new' => ['array', 'array'=>'array', '...arrays='=>'array'],
     ],
     'array_filter' => [
-      'old' => ['array', 'array'=>'array', 'callback='=>'callable(mixed,mixed=):scalar', 'mode='=>'int'],
-      'new' => ['array', 'array'=>'array', 'callback='=>'callable(mixed,mixed=):scalar|null', 'mode='=>'int'],
+      'old' => ['array', 'array'=>'array', 'callback='=>'callable(mixed,array-key=):mixed', 'mode='=>'int'],
+      'new' => ['array', 'array'=>'array', 'callback='=>'callable(mixed,array-key=):mixed|null', 'mode='=>'int'],
     ],
     'array_key_exists' => [
       'old' => ['bool', 'key'=>'string|int', 'array'=>'array|object'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -9288,7 +9288,7 @@ return [
     'array_diff_ukey\'1' => ['array', 'array'=>'array', 'rest'=>'array', 'arr3'=>'array', 'arg4'=>'array|callable(mixed,mixed):int', '...rest='=>'array|callable(mixed,mixed):int'],
     'array_fill' => ['array<int,mixed>', 'start_index'=>'int', 'count'=>'int', 'value'=>'mixed'],
     'array_fill_keys' => ['array', 'keys'=>'array', 'value'=>'mixed'],
-    'array_filter' => ['array', 'array'=>'array', 'callback='=>'callable(mixed,mixed=):scalar', 'mode='=>'int'],
+    'array_filter' => ['array', 'array'=>'array', 'callback='=>'callable(mixed,array-key=):mixed', 'mode='=>'int'],
     'array_flip' => ['array<string|int>', 'array'=>'array<string|int>'],
     'array_intersect' => ['array', 'array'=>'array', '...arrays'=>'array'],
     'array_intersect_assoc' => ['array', 'array'=>'array', '...arrays'=>'array'],

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -17,7 +17,6 @@ use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Analyzer\TraitAnalyzer;
 use Psalm\Internal\Codebase\ConstantTypeResolver;
-use Psalm\Internal\Codebase\InternalCallMapHandler;
 use Psalm\Internal\Codebase\TaintFlowGraph;
 use Psalm\Internal\Codebase\VariableUseGraph;
 use Psalm\Internal\DataFlow\DataFlowNode;
@@ -840,21 +839,55 @@ final class ArgumentAnalyzer
             // $statements_analyzer, which is necessary to understand string function names
             $input_type = $input_type->getBuilder();
             foreach ($input_type->getAtomicTypes() as $key => $atomic_type) {
-                if (!$atomic_type instanceof TLiteralString
-                    || InternalCallMapHandler::inCallMap($atomic_type->value)
-                ) {
-                    continue;
-                }
+                $container_callable_type = $param_type->getSingleAtomic();
+                $container_callable_type = $container_callable_type instanceof TCallable
+                    ? $container_callable_type
+                    : null;
 
                 $candidate_callable = CallableTypeComparator::getCallableFromAtomic(
                     $codebase,
                     $atomic_type,
-                    null,
+                    $container_callable_type,
                     $statements_analyzer,
                     true,
                 );
 
-                if ($candidate_callable) {
+                if ($candidate_callable && $candidate_callable !== $atomic_type) {
+                    // if we had an array callable, mark it as used now, since it's not possible later
+                    $potential_method_id = null;
+                    if ($atomic_type instanceof TList) {
+                        $atomic_type = $atomic_type->getKeyedArray();
+                    }
+
+                    if ($atomic_type instanceof TKeyedArray) {
+                        $potential_method_id = CallableTypeComparator::getCallableMethodIdFromTKeyedArray(
+                            $atomic_type,
+                            $codebase,
+                            $context->calling_method_id,
+                            $statements_analyzer->getFilePath(),
+                        );
+                    } elseif ($atomic_type instanceof TLiteralString
+                              && strpos($atomic_type->value, '::')
+                    ) {
+                        $parts = explode('::', $atomic_type->value);
+                        $potential_method_id = new MethodIdentifier(
+                            $parts[0],
+                            strtolower($parts[1]),
+                        );
+                    }
+
+                    if ($potential_method_id && $potential_method_id !== 'not-callable') {
+                        $codebase->methods->methodExists(
+                            $potential_method_id,
+                            $context->calling_method_id,
+                            $arg_location,
+                            $statements_analyzer,
+                            $statements_analyzer->getFilePath(),
+                            true,
+                            $context->insideUse(),
+                        );
+                    }
+
                     $input_type->removeType($key);
                     $input_type->addType($candidate_callable);
                 }
@@ -937,7 +970,7 @@ final class ArgumentAnalyzer
                 $codebase->methods->methodExists(
                     $potential_method_id,
                     $context->calling_method_id,
-                    null,
+                    $arg_location,
                     $statements_analyzer,
                     $statements_analyzer->getFilePath(),
                     true,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -959,6 +959,7 @@ final class ArgumentAnalyzer
                     && strpos($input_type_part->value, '::')
                 ) {
                     $parts = explode('::', $input_type_part->value);
+                    /** @psalm-suppress PossiblyUndefinedIntArrayOffset */
                     $potential_method_ids[] = new MethodIdentifier(
                         $parts[0],
                         strtolower($parts[1]),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -205,7 +205,9 @@ final class FunctionCallAnalyzer extends CallAnalyzer
                     $statements_analyzer->node_data,
                 );
 
-                $function_call_info->function_params = $function_callable->params;
+                if (!$codebase->functions->params_provider->has($function_call_info->function_id)) {
+                    $function_call_info->function_params = $function_callable->params;
+                }
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -10,6 +10,7 @@ use Psalm\Exception\CircularReferenceException;
 use Psalm\FileSource;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\BinaryOp\ArithmeticOpAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ConstFetchAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Provider\NodeDataProvider;
 use Psalm\Internal\Type\TypeCombiner;
@@ -143,6 +144,17 @@ final class SimpleTypeInferer
                 $fq_classlike_name,
             );
 
+            if (!$stmt_left_type
+                && $file_source instanceof StatementsAnalyzer
+                && $stmt->left instanceof PhpParser\Node\Expr\ConstFetch) {
+                $stmt_left_type = ConstFetchAnalyzer::getConstType(
+                    $file_source,
+                    $stmt->left->name->toString(),
+                    true,
+                    null,
+                );
+            }
+
             $stmt_right_type = self::infer(
                 $codebase,
                 $nodes,
@@ -152,6 +164,17 @@ final class SimpleTypeInferer
                 $existing_class_constants,
                 $fq_classlike_name,
             );
+
+            if (!$stmt_right_type
+                && $file_source instanceof StatementsAnalyzer
+                && $stmt->right instanceof PhpParser\Node\Expr\ConstFetch) {
+                $stmt_right_type = ConstFetchAnalyzer::getConstType(
+                    $file_source,
+                    $stmt->right->name->toString(),
+                    true,
+                    null,
+                );
+            }
 
             if (!$stmt_left_type || !$stmt_right_type) {
                 return null;

--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -282,7 +282,14 @@ final class CliUtils
             }
 
             if (strpos($input_path, '--') === 0 && strlen($input_path) > 2) {
-                if (substr($input_path, 2) === 'config') {
+                // ignore --config psalm.xml
+                // ignore common phpunit args that accept a class instead of a path, as this can cause issues on Windows
+                $ignored_arguments = array(
+                    'config',
+                    'printer',
+                );
+
+                if (in_array(substr($input_path, 2), $ignored_arguments, true)) {
                     ++$i;
                 }
                 continue;

--- a/src/Psalm/Internal/LanguageServer/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/LanguageServer/Provider/ClassLikeStorageCacheProvider.php
@@ -13,7 +13,7 @@ use function strtolower;
  */
 final class ClassLikeStorageCacheProvider extends InternalClassLikeStorageCacheProvider
 {
-    /** @var array<string, ClassLikeStorage> */
+    /** @var array<lowercase-string, ClassLikeStorage> */
     private array $cache = [];
 
     public function __construct()
@@ -26,6 +26,9 @@ final class ClassLikeStorageCacheProvider extends InternalClassLikeStorageCacheP
         $this->cache[$fq_classlike_name_lc] = $storage;
     }
 
+    /**
+     * @param lowercase-string $fq_classlike_name_lc
+     */
     public function getLatestFromCache(
         string $fq_classlike_name_lc,
         ?string $file_path,
@@ -40,6 +43,9 @@ final class ClassLikeStorageCacheProvider extends InternalClassLikeStorageCacheP
         return $cached_value;
     }
 
+    /**
+     * @param lowercase-string $fq_classlike_name_lc
+     */
     private function loadFromCache(string $fq_classlike_name_lc): ?ClassLikeStorage
     {
         return $this->cache[$fq_classlike_name_lc] ?? null;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -176,6 +176,15 @@ final class ClassLikeNodeScanner
             if ($this->codebase->classlike_storage_provider->has($fq_classlike_name_lc)) {
                 $duplicate_storage = $this->codebase->classlike_storage_provider->get($fq_classlike_name_lc);
 
+                // don't override data from files that are getting analyzed with data from stubs
+                // if the stubs contain the same class
+                if (!$duplicate_storage->stubbed
+                    && $this->codebase->register_stub_files
+                    && $duplicate_storage->stmt_location
+                    && $this->config->isInProjectDirs($duplicate_storage->stmt_location->file_path)) {
+                    return false;
+                }
+
                 if (!$this->codebase->register_stub_files) {
                     if (!$duplicate_storage->stmt_location
                         || $duplicate_storage->stmt_location->file_path !== $this->file_path

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -152,12 +152,12 @@ final class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements Fi
                 $this->namespace_name,
             );
 
-            $this->classlike_node_scanners[] = $classlike_node_scanner;
-
             if ($classlike_node_scanner->start($node) === false) {
                 $this->bad_classes[spl_object_id($node)] = true;
-                return PhpParser\NodeTraverser::DONT_TRAVERSE_CHILDREN;
+                return PhpParser\NodeTraverser::DONT_TRAVERSE_CURRENT_AND_CHILDREN;
             }
+
+            $this->classlike_node_scanners[] = $classlike_node_scanner;
 
             $this->type_aliases = array_merge($this->type_aliases, $classlike_node_scanner->type_aliases);
         } elseif ($node instanceof PhpParser\Node\Stmt\TryCatch) {

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -77,6 +77,9 @@ class ClassLikeStorageCacheProvider
         $this->cache->saveItem($cache_location, $storage);
     }
 
+    /**
+     * @param lowercase-string $fq_classlike_name_lc
+     */
     public function getLatestFromCache(
         string $fq_classlike_name_lc,
         ?string $file_path,
@@ -108,6 +111,9 @@ class ClassLikeStorageCacheProvider
         return PHP_VERSION_ID >= 8_01_00 ? hash('xxh128', $data) : hash('md4', $data);
     }
 
+    /**
+     * @param lowercase-string $fq_classlike_name_lc
+     */
     private function loadFromCache(string $fq_classlike_name_lc, ?string $file_path): ?ClassLikeStorage
     {
         $storage = $this->cache->getItem($this->getCacheLocationForClass($fq_classlike_name_lc, $file_path));
@@ -118,6 +124,9 @@ class ClassLikeStorageCacheProvider
         return null;
     }
 
+    /**
+     * @param lowercase-string $fq_classlike_name_lc
+     */
     private function getCacheLocationForClass(
         string $fq_classlike_name_lc,
         ?string $file_path,

--- a/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
@@ -103,7 +103,7 @@ class FileStorageCacheProvider
 
     public function removeCacheForFile(string $file_path): void
     {
-        $this->cache->deleteItem($this->getCacheLocationForPath($file_path));
+        $this->cache->deleteItem($this->getCacheLocationForPath(strtolower($file_path)));
     }
 
     private function getCacheHash(string $_unused_file_path, string $file_contents): string

--- a/src/Psalm/Internal/Provider/FunctionParamsProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionParamsProvider.php
@@ -6,6 +6,8 @@ use Closure;
 use PhpParser\Node\Arg;
 use Psalm\CodeLocation;
 use Psalm\Context;
+use Psalm\Internal\Provider\ParamsProvider\ArrayFilterParamsProvider;
+use Psalm\Internal\Provider\ParamsProvider\ArrayMultisortParamsProvider;
 use Psalm\Plugin\EventHandler\Event\FunctionParamsProviderEvent;
 use Psalm\Plugin\EventHandler\FunctionParamsProviderInterface;
 use Psalm\StatementsSource;
@@ -29,6 +31,9 @@ final class FunctionParamsProvider
     public function __construct()
     {
         self::$handlers = [];
+
+        $this->registerClass(ArrayFilterParamsProvider::class);
+        $this->registerClass(ArrayMultisortParamsProvider::class);
     }
 
     /**

--- a/src/Psalm/Internal/Provider/ParamsProvider/ArrayFilterParamsProvider.php
+++ b/src/Psalm/Internal/Provider/ParamsProvider/ArrayFilterParamsProvider.php
@@ -1,0 +1,263 @@
+<?php
+
+namespace Psalm\Internal\Provider\ParamsProvider;
+
+use PhpParser\Node\Expr\ConstFetch;
+use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
+use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ConstFetchAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\SimpleTypeInferer;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Issue\InvalidArgument;
+use Psalm\Issue\PossiblyInvalidArgument;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\EventHandler\Event\FunctionParamsProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionParamsProviderInterface;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TCallable;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Union;
+
+use function strtolower;
+
+use const ARRAY_FILTER_USE_BOTH;
+use const ARRAY_FILTER_USE_KEY;
+
+/**
+ * @internal
+ */
+class ArrayFilterParamsProvider implements FunctionParamsProviderInterface
+{
+    /**
+     * @return array<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'array_filter',
+        ];
+    }
+
+    /**
+     * @return ?list<FunctionLikeParameter>
+     */
+    public static function getFunctionParams(FunctionParamsProviderEvent $event): ?array
+    {
+        $call_args = $event->getCallArgs();
+        if (!isset($call_args[0]) || !isset($call_args[1])) {
+            return null;
+        }
+
+        $statements_source = $event->getStatementsSource();
+        if (!($statements_source instanceof StatementsAnalyzer)) {
+            // this is practically impossible
+            // but the type in the caller is parent type StatementsSource
+            // even though all callers provide StatementsAnalyzer
+            return null;
+        }
+
+        $code_location = $event->getCodeLocation();
+        if ($call_args[1]->value instanceof ConstFetch
+            && strtolower($call_args[1]->value->name->toString()) === 'null'
+            && isset($call_args[2])
+        ) {
+            if ($code_location) {
+                // using e.g. ARRAY_FILTER_USE_KEY as 3rd arg won't have any effect if the 2nd arg is null
+                // as it will still filter on the values
+                IssueBuffer::maybeAdd(
+                    new InvalidArgument(
+                        'The 3rd argument of array_filter is not used, when the 2nd argument is null',
+                        $code_location,
+                        'array_filter',
+                    ),
+                    $statements_source->getSuppressedIssues(),
+                );
+            }
+
+            return null;
+        }
+
+        // currently only supports literal types and variables (but not function calls)
+        // due to https://github.com/vimeo/psalm/issues/8905
+        $first_arg_type = SimpleTypeInferer::infer(
+            $statements_source->getCodebase(),
+            $statements_source->node_data,
+            $call_args[0]->value,
+            $statements_source->getAliases(),
+            $statements_source,
+        );
+
+        if (!$first_arg_type) {
+            $extended_var_id = ExpressionIdentifier::getExtendedVarId(
+                $call_args[0]->value,
+                null,
+                $statements_source,
+            );
+
+            $first_arg_type = $event->getContext()->vars_in_scope[$extended_var_id] ?? null;
+        }
+
+        $fallback = new TArray([Type::getArrayKey(), Type::getMixed()]);
+        if (!$first_arg_type || $first_arg_type->isMixed()) {
+            $first_arg_array = $fallback;
+        } else {
+            $first_arg_array = $first_arg_type->hasType('array')
+                               && ($array_atomic_type = $first_arg_type->getArray())
+                               && ($array_atomic_type instanceof TArray
+                                   || $array_atomic_type instanceof TKeyedArray)
+                ? $array_atomic_type
+                : $fallback;
+        }
+
+        if ($first_arg_array instanceof TArray) {
+            $inner_type = $first_arg_array->type_params[1];
+            $key_type = $first_arg_array->type_params[0];
+        } else {
+            $inner_type = $first_arg_array->getGenericValueType();
+            $key_type   = $first_arg_array->getGenericKeyType();
+        }
+
+        $has_both = false;
+        if (isset($call_args[2])) {
+            $mode_type = SimpleTypeInferer::infer(
+                $statements_source->getCodebase(),
+                $statements_source->node_data,
+                $call_args[2]->value,
+                $statements_source->getAliases(),
+                $statements_source,
+            );
+
+            if (!$mode_type && $call_args[2]->value instanceof ConstFetch) {
+                $mode_type = ConstFetchAnalyzer::getConstType(
+                    $statements_source,
+                    $call_args[2]->value->name->toString(),
+                    true,
+                    $event->getContext(),
+                );
+            } elseif (!$mode_type) {
+                $extended_var_id = ExpressionIdentifier::getExtendedVarId(
+                    $call_args[2]->value,
+                    null,
+                    $statements_source,
+                );
+
+                $mode_type = $event->getContext()->vars_in_scope[$extended_var_id] ?? null;
+            }
+
+            if (!$mode_type || !$mode_type->allIntLiterals()) {
+                // if we have multiple possible types, keep the default args
+                return null;
+            }
+
+            if ($mode_type->isSingleIntLiteral()) {
+                $mode = $mode_type->getSingleIntLiteral()->value;
+            } else {
+                $mode = 0;
+                foreach ($mode_type->getLiteralInts() as $atomic) {
+                    if ($atomic->value === ARRAY_FILTER_USE_BOTH) {
+                        // we have one which uses both keys and values and one that uses only keys/values
+                        $has_both = true;
+                        continue;
+                    }
+
+                    if ($atomic->value === ARRAY_FILTER_USE_KEY) {
+                        // if one of them is ARRAY_FILTER_USE_KEY, all the other types will behave like mode 0
+                        $inner_type = Type::combineUnionTypes(
+                            $inner_type,
+                            $key_type,
+                            $statements_source->getCodebase(),
+                        );
+
+                        continue;
+                    }
+
+                    // to report an error later on
+                    if ($mode === 0 && $atomic->value !== 0) {
+                        $mode = $atomic->value;
+                    }
+                }
+            }
+
+            if ($mode > ARRAY_FILTER_USE_KEY || $mode < 0) {
+                if ($code_location) {
+                    IssueBuffer::maybeAdd(
+                        new PossiblyInvalidArgument(
+                            'The provided 3rd argument of array_filter contains a value of ' . $mode
+                            . ', which will behave like 0 and filter on values only',
+                            $code_location,
+                            'array_filter',
+                        ),
+                        $statements_source->getSuppressedIssues(),
+                    );
+                }
+
+                $mode = 0;
+            }
+        } else {
+            $mode = 0;
+        }
+
+        $callback_arg_value = new FunctionLikeParameter(
+            'value',
+            false,
+            $inner_type,
+            null,
+            null,
+            null,
+            false,
+        );
+
+        $callback_arg_key = new FunctionLikeParameter(
+            'key',
+            false,
+            $key_type,
+            null,
+            null,
+            null,
+            false,
+        );
+
+        if ($mode === ARRAY_FILTER_USE_BOTH) {
+            $callback_arg = [
+                $callback_arg_value,
+                $callback_arg_key,
+            ];
+        } elseif ($mode === ARRAY_FILTER_USE_KEY) {
+            $callback_arg = [
+                $callback_arg_key,
+            ];
+        } elseif ($has_both) {
+            // if we have both + other flags, the 2nd arg is optional
+            $callback_arg_key->is_optional = true;
+            $callback_arg = [
+                $callback_arg_value,
+                $callback_arg_key,
+            ];
+        } else {
+            $callback_arg = [
+                $callback_arg_value,
+            ];
+        }
+
+        $callable = new TCallable(
+            'callable',
+            $callback_arg,
+            Type::getMixed(),
+        );
+
+        return [
+            new FunctionLikeParameter(
+                'array',
+                false,
+                Type::getArray(),
+                Type::getArray(),
+                null,
+                null,
+                false,
+            ),
+            new FunctionLikeParameter('callback', false, new Union([$callable])),
+            new FunctionLikeParameter('mode', false, Type::getInt(), Type::getInt()),
+        ];
+    }
+}

--- a/src/Psalm/Internal/Provider/ParamsProvider/ArrayMultisortParamsProvider.php
+++ b/src/Psalm/Internal/Provider/ParamsProvider/ArrayMultisortParamsProvider.php
@@ -1,0 +1,309 @@
+<?php
+
+namespace Psalm\Internal\Provider\ParamsProvider;
+
+use PhpParser\Node\Expr\ConstFetch;
+use PhpParser\Node\Expr\FuncCall;
+use PhpParser\Node\Expr\MethodCall;
+use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
+use Psalm\Internal\Analyzer\Statements\Expression\Fetch\ConstFetchAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\SimpleTypeInferer;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Issue\InvalidArgument;
+use Psalm\IssueBuffer;
+use Psalm\Plugin\EventHandler\Event\FunctionParamsProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionParamsProviderInterface;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+
+use function in_array;
+
+use const SORT_ASC;
+use const SORT_DESC;
+use const SORT_FLAG_CASE;
+use const SORT_LOCALE_STRING;
+use const SORT_NATURAL;
+use const SORT_NUMERIC;
+use const SORT_REGULAR;
+use const SORT_STRING;
+
+/**
+ * @internal
+ */
+class ArrayMultisortParamsProvider implements FunctionParamsProviderInterface
+{
+    /**
+     * @return array<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return [
+            'array_multisort',
+        ];
+    }
+
+    /**
+     * @return ?list<FunctionLikeParameter>
+     */
+    public static function getFunctionParams(FunctionParamsProviderEvent $event): ?array
+    {
+        $call_args = $event->getCallArgs();
+        if (!isset($call_args[0])) {
+            return null;
+        }
+
+        $statements_source = $event->getStatementsSource();
+        if (!($statements_source instanceof StatementsAnalyzer)) {
+            // this is practically impossible
+            // but the type in the caller is parent type StatementsSource
+            // even though all callers provide StatementsAnalyzer
+            return null;
+        }
+
+        $code_location = $event->getCodeLocation();
+        $params = [];
+        $previous_param = false;
+        $last_array_index = 0;
+        $last_by_ref_index = -1;
+        $first_non_ref_index_after_by_ref = -1;
+        foreach ($call_args as $key => $call_arg) {
+            $param_type = SimpleTypeInferer::infer(
+                $statements_source->getCodebase(),
+                $statements_source->node_data,
+                $call_arg->value,
+                $statements_source->getAliases(),
+                $statements_source,
+            );
+
+            if (!$param_type && $call_arg->value instanceof ConstFetch) {
+                $param_type = ConstFetchAnalyzer::getConstType(
+                    $statements_source,
+                    $call_arg->value->name->toString(),
+                    true,
+                    $event->getContext(),
+                );
+            }
+
+            // @todo currently assumes any function calls are for array types not for sort order/flags
+            // actually need to check the return type
+            // which isn't possible atm due to https://github.com/vimeo/psalm/issues/8905
+            if (!$param_type && ($call_arg->value instanceof FuncCall || $call_arg->value instanceof MethodCall)) {
+                if ($first_non_ref_index_after_by_ref < $last_by_ref_index) {
+                    $first_non_ref_index_after_by_ref = $key;
+                }
+
+                $last_array_index = $key;
+                $previous_param = 'array';
+                $params[] = new FunctionLikeParameter(
+                    'array' . ($last_array_index + 1),
+                    // function calls will not be used by reference
+                    false,
+                    Type::getArray(),
+                    $key === 0 ? Type::getArray() : null,
+                );
+
+                continue;
+            }
+
+            $extended_var_id = null;
+            if (!$param_type) {
+                $extended_var_id = ExpressionIdentifier::getExtendedVarId(
+                    $call_arg->value,
+                    null,
+                    $statements_source,
+                );
+
+                $param_type = $event->getContext()->vars_in_scope[$extended_var_id] ?? null;
+            }
+
+            if (!$param_type) {
+                return null;
+            }
+
+            if ($key === 0 && !$param_type->isArray()) {
+                return null;
+            }
+
+            if ($param_type->isArray() && $extended_var_id) {
+                $last_by_ref_index = $key;
+                $last_array_index = $key;
+                $previous_param = 'array';
+                $params[] = new FunctionLikeParameter(
+                    'array' . ($last_array_index + 1),
+                    true,
+                    $param_type,
+                    $key === 0 ? Type::getArray() : null,
+                );
+
+                continue;
+            }
+
+            if ($param_type->allIntLiterals()) {
+                $sort_order = [
+                    SORT_ASC,
+                    SORT_DESC,
+                ];
+
+                $sort_flags = [
+                    SORT_REGULAR,
+                    SORT_NUMERIC,
+                    SORT_STRING,
+                    SORT_LOCALE_STRING,
+                    SORT_NATURAL,
+                    SORT_STRING|SORT_FLAG_CASE,
+                    SORT_NATURAL|SORT_FLAG_CASE,
+                ];
+
+                $sort_param = false;
+                foreach ($param_type->getLiteralInts() as $atomic) {
+                    if (in_array($atomic->value, $sort_order, true)) {
+                        if ($sort_param === 'sort_order_flags') {
+                            continue;
+                        }
+
+                        if ($sort_param === 'sort_order') {
+                            continue;
+                        }
+
+                        if ($sort_param === 'sort_flags') {
+                            $sort_param = 'sort_order_flags';
+                            continue;
+                        }
+
+                        $sort_param = 'sort_order';
+
+                        continue;
+                    }
+
+                    if (in_array($atomic->value, $sort_flags, true)) {
+                        if ($sort_param === 'sort_order_flags') {
+                            continue;
+                        }
+
+                        if ($sort_param === 'sort_flags') {
+                            continue;
+                        }
+
+                        if ($sort_param === 'sort_order') {
+                            $sort_param = 'sort_order_flags';
+                            continue;
+                        }
+
+                        $sort_param = 'sort_flags';
+
+                        continue;
+                    }
+
+                    if ($code_location) {
+                        IssueBuffer::maybeAdd(
+                            new InvalidArgument(
+                                'Argument ' . ( $key + 1 )
+                                . ' of array_multisort sort order/flag contains an invalid value of ' . $atomic->value,
+                                $code_location,
+                                'array_multisort',
+                            ),
+                            $statements_source->getSuppressedIssues(),
+                        );
+                    }
+                }
+
+                if ($sort_param === false) {
+                    return null;
+                }
+
+                if (($sort_param === 'sort_order' || $sort_param === 'sort_order_flags')
+                    && $previous_param !== 'array') {
+                    if ($code_location) {
+                        IssueBuffer::maybeAdd(
+                            new InvalidArgument(
+                                'Argument ' . ( $key + 1 )
+                                . ' of array_multisort contains sort order flags'
+                                . ' and can only be used after an array parameter',
+                                $code_location,
+                                'array_multisort',
+                            ),
+                            $statements_source->getSuppressedIssues(),
+                        );
+                    }
+
+                    return null;
+                }
+
+                if ($sort_param === 'sort_flags' && $previous_param !== 'array' && $previous_param !== 'sort_order') {
+                    if ($code_location) {
+                        IssueBuffer::maybeAdd(
+                            new InvalidArgument(
+                                'Argument ' . ( $key + 1 )
+                                . ' of array_multisort are sort flags'
+                                . ' and cannot be used after a parameter with sort flags',
+                                $code_location,
+                                'array_multisort',
+                            ),
+                            $statements_source->getSuppressedIssues(),
+                        );
+                    }
+
+                    return null;
+                }
+
+                if ($sort_param === 'sort_order_flags') {
+                    $previous_param = 'sort_order';
+                } else {
+                    $previous_param = $sort_param;
+                }
+
+                $params[] = new FunctionLikeParameter(
+                    'array' . ($last_array_index + 1) . '_' . $previous_param,
+                    false,
+                    Type::getInt(),
+                );
+
+                continue;
+            }
+
+            if (!$param_type->isArray()) {
+                // too complex for now
+                return null;
+            }
+
+            if ($first_non_ref_index_after_by_ref < $last_by_ref_index) {
+                $first_non_ref_index_after_by_ref = $key;
+            }
+
+            $last_array_index = $key;
+            $previous_param = 'array';
+            $params[] = new FunctionLikeParameter(
+                'array' . ($last_array_index + 1),
+                false,
+                Type::getArray(),
+            );
+        }
+
+        if ($code_location) {
+            if ($last_by_ref_index === - 1) {
+                IssueBuffer::maybeAdd(
+                    new InvalidArgument(
+                        'At least 1 array argument of array_multisort must be a variable,'
+                        . ' since the sorting happens by reference and otherwise this function call does nothing',
+                        $code_location,
+                        'array_multisort',
+                    ),
+                    $statements_source->getSuppressedIssues(),
+                );
+            } elseif ($first_non_ref_index_after_by_ref > $last_by_ref_index) {
+                IssueBuffer::maybeAdd(
+                    new InvalidArgument(
+                        'All arguments of array_multisort after argument ' . $first_non_ref_index_after_by_ref
+                        . ', which are after the last by reference passed array argument and its flags,'
+                        . ' are redundant and can be removed, since the sorting happens by reference',
+                        $code_location,
+                        'array_multisort',
+                    ),
+                    $statements_source->getSuppressedIssues(),
+                );
+            }
+        }
+
+        return $params;
+    }
+}

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -58,19 +58,22 @@ final class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderI
             return Type::getMixed();
         }
 
+        $fallback = new TArray([Type::getArrayKey(), Type::getMixed()]);
         $array_arg = $call_args[0]->value ?? null;
-
-        $first_arg_array = $array_arg
-            && ($first_arg_type = $statements_source->node_data->getType($array_arg))
-            && $first_arg_type->hasType('array')
-            && ($array_atomic_type = $first_arg_type->getArray())
-            && ($array_atomic_type instanceof TArray
-                || $array_atomic_type instanceof TKeyedArray)
-            ? $array_atomic_type
-            : null;
-
-        if (!$first_arg_array) {
-            return Type::getArray();
+        if (!$array_arg) {
+            $first_arg_array = $fallback;
+        } else {
+            $first_arg_type = $statements_source->node_data->getType($array_arg);
+            if (!$first_arg_type || $first_arg_type->isMixed()) {
+                $first_arg_array = $fallback;
+            } else {
+                $first_arg_array = $first_arg_type->hasType('array')
+                                   && ($array_atomic_type = $first_arg_type->getArray())
+                                   && ($array_atomic_type instanceof TArray
+                                       || $array_atomic_type instanceof TKeyedArray)
+                    ? $array_atomic_type
+                    : $fallback;
+            }
         }
 
         if ($first_arg_array instanceof TArray) {

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -164,14 +164,34 @@ final class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderI
         if (!isset($call_args[2])) {
             $function_call_arg = $call_args[1];
 
+            $callable_extended_var_id = ExpressionIdentifier::getExtendedVarId(
+                $function_call_arg->value,
+                null,
+                $statements_source,
+            );
+
+            $mapping_function_ids = array();
+            if ($callable_extended_var_id) {
+                $possibly_function_ids = $context->vars_in_scope[$callable_extended_var_id] ?? null;
+                // @todo for array callables
+                if ($possibly_function_ids && $possibly_function_ids->allStringLiterals()) {
+                    foreach ($possibly_function_ids->getLiteralStrings() as $atomic) {
+                        $mapping_function_ids[] = $atomic->value;
+                    }
+                }
+            }
+
             if ($function_call_arg->value instanceof PhpParser\Node\Scalar\String_
                 || $function_call_arg->value instanceof PhpParser\Node\Expr\Array_
                 || $function_call_arg->value instanceof PhpParser\Node\Expr\BinaryOp\Concat
+                || $mapping_function_ids !== array()
             ) {
-                $mapping_function_ids = CallAnalyzer::getFunctionIdsFromCallableArg(
-                    $statements_source,
-                    $function_call_arg->value,
-                );
+                if ($mapping_function_ids === array()) {
+                    $mapping_function_ids = CallAnalyzer::getFunctionIdsFromCallableArg(
+                        $statements_source,
+                        $function_call_arg->value,
+                    );
+                }
 
                 if ($array_arg && $mapping_function_ids) {
                     $assertions = [];

--- a/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
@@ -30,6 +30,7 @@ use Psalm\Type\Union;
 use UnexpectedValueException;
 
 use function array_slice;
+use function count;
 use function end;
 use function strtolower;
 use function substr;
@@ -477,6 +478,7 @@ final class CallableTypeComparator
     ) {
         if (!isset($input_type_part->properties[0])
             || !isset($input_type_part->properties[1])
+            || count($input_type_part->properties) > 2
         ) {
             return 'not-callable';
         }

--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -145,7 +145,7 @@ final class UnionTypeComparator
                     $container_all_param_count = count($container_type_part->params);
                     $container_required_param_count = 0;
                     foreach ($container_type_part->params as $index => $container_param) {
-                        if ($container_param->is_optional === false) {
+                        if (!$container_param->is_optional) {
                             $container_required_param_count = $index + 1;
                         }
 
@@ -161,7 +161,8 @@ final class UnionTypeComparator
                     } else {
                         $input_all_param_count = count($input_type_part->params);
                         foreach ($input_type_part->params as $index => $input_param) {
-                            if ($input_param->is_optional === false) {
+                            // can be false or not set at all
+                            if (!$input_param->is_optional) {
                                 $input_required_param_count = $index + 1;
                             }
 
@@ -172,8 +173,10 @@ final class UnionTypeComparator
                     }
 
                     // too few or too many non-optional params provided in callback
-                    if ($container_required_param_count > $input_all_param_count
-                        || $container_all_param_count < $input_required_param_count
+                    if ($container_all_param_count > $input_all_param_count
+                        || $container_required_param_count > $input_all_param_count
+                        || $input_required_param_count > $container_all_param_count
+                        || $input_required_param_count > $container_required_param_count
                     ) {
                         continue;
                     }

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -7,6 +7,7 @@ use Psalm\CodeLocation;
 use Psalm\Codebase;
 use Psalm\Internal\Codebase\ClassConstantByWildcardResolver;
 use Psalm\Internal\Codebase\InternalCallMapHandler;
+use Psalm\Internal\Type\Comparator\CallableTypeComparator;
 use Psalm\Storage\Assertion;
 use Psalm\Storage\Assertion\Any;
 use Psalm\Storage\Assertion\ArrayKeyExists;
@@ -2695,6 +2696,13 @@ final class SimpleAssertionReconciler extends Reconciler
                 $redundant = false;
 
                 $callable_types[] = $type;
+            } elseif ($candidate_callable = CallableTypeComparator::getCallableFromAtomic(
+                $codebase,
+                $type,
+            )) {
+                $redundant = false;
+
+                $callable_types[] = $candidate_callable;
             } else {
                 $redundant = false;
             }

--- a/src/Psalm/Plugin/EventHandler/Event/FunctionParamsProviderEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/FunctionParamsProviderEvent.php
@@ -12,7 +12,7 @@ final class FunctionParamsProviderEvent
     private StatementsSource $statements_source;
     private string $function_id;
     /**
-     * @var PhpParser\Node\Arg[]
+     * @var list<PhpParser\Node\Arg>
      */
     private array $call_args;
     private ?Context $context;
@@ -47,7 +47,7 @@ final class FunctionParamsProviderEvent
     }
 
     /**
-     * @return PhpParser\Node\Arg[]
+     * @return list<PhpParser\Node\Arg>
      */
     public function getCallArgs(): array
     {

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -348,11 +348,10 @@ class ArgTest extends TestCase
 
                     /**
                      * @param string $a
-                     * @param int $b
-                     * @param int $c
+                     * @param int ...$b
                      * @return void
                      */
-                    function foo($a, $b, $c) {}
+                    function foo($a, ...$b) {}
 
                     var_caller("foo");',
             ],

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -907,20 +907,20 @@ class ArrayAccessTest extends TestCase
                         }
 
                         /**
-                         * @param ?string $name
+                         * @param ?string $offset
                          * @param scalar|array $value
                          * @psalm-suppress MixedArgumentTypeCoercion
                          */
-                        public function offsetSet($name, $value) : void
+                        public function offsetSet($offset, $value) : void
                         {
                             if (is_array($value)) {
                                 $value = new static($value);
                             }
 
-                            if (null === $name) {
+                            if (null === $offset) {
                                 $this->data[] = $value;
                             } else {
-                                $this->data[$name] = $value;
+                                $this->data[$offset] = $value;
                             }
                         }
 
@@ -1053,12 +1053,12 @@ class ArrayAccessTest extends TestCase
                         }
 
                         /**
-                         * @param string $name
+                         * @param string $offset
                          * @param mixed $value
                          */
-                        public function offsetSet($name, $value) : void
+                        public function offsetSet($offset, $value) : void
                         {
-                            $this->data[$name] = $value;
+                            $this->data[$offset] = $value;
                         }
 
                         public function __isset(string $name) : bool

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -1043,17 +1043,20 @@ class ArrayAssignmentTest extends TestCase
                      * @template-implements ArrayAccess<?int, string>
                      */
                     class C implements ArrayAccess {
-                        public function offsetExists(int $offset) : bool { return true; }
+                        public function offsetExists(mixed $offset) : bool { return true; }
 
                         public function offsetGet($offset) : string { return "";}
 
-                        public function offsetSet(?int $offset, string $value) : void {}
+                        public function offsetSet(mixed $offset, mixed $value) : void {}
 
-                        public function offsetUnset(int $offset) : void { }
+                        public function offsetUnset(mixed $offset) : void { }
                     }
 
                     $c = new C();
                     $c[] = "hello";',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'checkEmptinessAfterConditionalArrayAdjustment' => [
                 'code' => '<?php
@@ -1962,17 +1965,20 @@ class ArrayAssignmentTest extends TestCase
                      * @template-implements ArrayAccess<int, string>
                      */
                     class C implements ArrayAccess {
-                        public function offsetExists(int $offset) : bool { return true; }
+                        public function offsetExists(mixed $offset) : bool { return true; }
 
                         public function offsetGet($offset) : string { return "";}
 
-                        public function offsetSet(int $offset, string $value) : void {}
+                        public function offsetSet(mixed $offset, mixed $value) : void {}
 
-                        public function offsetUnset(int $offset) : void { }
+                        public function offsetUnset(mixed $offset) : void { }
                     }
 
                     $c = new C();
                     $c[] = "hello";',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'conditionalRestrictedDocblockKeyAssignment' => [
                 'code' => '<?php

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -29,6 +29,18 @@ class ArrayFunctionCallTest extends TestCase
                     '$e' => 'array<string, int<0, 10>|null>',
                 ],
             ],
+            'arrayFilterObject' => [
+                'code' => '<?php
+                    $e = array_filter(
+                        [(object) [], null],
+                        function($i) {
+                            return $i;
+                        }
+                    );',
+                'assertions' => [
+                    '$e' => 'array<int<0, 1>, object>',
+                ],
+            ],
             'positiveIntArrayFilter' => [
                 'code' => '<?php
                     /**

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -41,6 +41,19 @@ class ArrayFunctionCallTest extends TestCase
                     '$e' => 'array<int<0, 1>, object>',
                 ],
             ],
+            'arrayFilterStringCallable' => [
+                'code' => '<?php
+                    $arg = "is_string";
+
+                    /**
+                     * @var array<string|int, float> $bar
+                     */
+                    $keys = array_keys( $bar );
+                    $strings = array_filter( $keys, $arg );',
+                'assertions' => [
+                    '$strings' => 'array<int<0, max>, string>',
+                ],
+            ],
             'positiveIntArrayFilter' => [
                 'code' => '<?php
                     /**

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -54,6 +54,14 @@ class ArrayFunctionCallTest extends TestCase
                     '$strings' => 'array<int<0, max>, string>',
                 ],
             ],
+            'arrayFilterMixed' => [
+                'code' => '<?php
+                    /** @psalm-suppress UndefinedGlobalVariable, MixedArgument, MixedArrayAccess */
+                    $x = array_filter($foo, "is_string");',
+                'assertions' => [
+                    '$x' => 'array<array-key, string>',
+                ],
+            ],
             'positiveIntArrayFilter' => [
                 'code' => '<?php
                     /**

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -2637,17 +2637,6 @@ class ArrayFunctionCallTest extends TestCase
     public function providerInvalidCodeParse(): iterable
     {
         return [
-            'arrayFilterWithoutTypes' => [
-                'code' => '<?php
-                    $e = array_filter(
-                        ["a" => 5, "b" => 12, "c" => null],
-                        function(?int $i) {
-                            return $GLOBALS["a"];
-                        }
-                    );',
-                'error_message' => 'MixedArgumentTypeCoercion',
-                'ignored_issues' => ['MissingClosureParamType', 'MissingClosureReturnType'],
-            ],
             'arrayFilterUseMethodOnInferrableInt' => [
                 'code' => '<?php
                     $a = array_filter([1, 2, 3, 4], function ($i) { return $i->foo(); });',

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -252,6 +252,32 @@ class AttributeTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'returnTypeWillChangeNoSignatureType' => [
+                'code' => '<?php
+                    class Foo {
+                        /**
+                         * @param array<string> $arg
+                         * @return string
+                         */
+                        public function run($arg) : string {
+                            return implode("s", $arg);
+                        }
+                    }
+
+                    class Bar extends Foo {
+                        /**
+                         * @param array<string> $arg
+                         * @return string
+                         */
+                        #[ReturnTypeWillChange]
+                        public function run($arg) {
+                            return implode(" ", $arg);
+                        }
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
             'allowDynamicProperties' => [
                 'code' => '<?php
 

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -1805,6 +1805,30 @@ class CallableTest extends TestCase
 
                     foo(["a", "b"]);',
             ],
+            'callableOptionalOrAdditionalOptional' => [
+                'code' => '<?php
+                    /**
+                     * @param callable(string, string, string, string=):bool $arg
+                     * @return void
+                     */
+                    function foo($arg) {}
+
+                    function bar(string $a, string $b, string $c, string $d = ""): bool {}
+
+                    foo("bar");
+
+                    /**
+                     * @param callable(string, string, string):bool $arg
+                     * @return void
+                     */
+                    function foo1($arg) {}
+
+                    function bar1(string $a, string $b, string $c, string $d = ""): bool {}
+
+                    foo1("bar1");',
+                'assertions' => [],
+                'ignored_issues' => ['InvalidReturnType'],
+            ],
             'abstractInvokeInTrait' => [
                 'code' => '<?php
                     function testFunc(callable $func) : void {}
@@ -2121,6 +2145,115 @@ class CallableTest extends TestCase
 
                     foo([Bar::class, "baz", 1231233]);',
                 'error_message' => 'InvalidArgument',
+            ],
+            'callableMissingOptional' => [
+                'code' => '<?php
+                    /**
+                     * @param callable(string=):bool $arg
+                     * @return void
+                     */
+                    function foo($arg) {}
+
+                    function bar(): bool {
+                        return rand(0, 10) > 5 ? true : false;
+                    }
+
+                    foo("bar");',
+                'error_message' => 'PossiblyInvalidArgument',
+            ],
+            'callableMissingOptionalThisArray' => [
+                'code' => '<?php
+                    /**
+                     * @param callable(string=):bool $arg
+                     * @return void
+                     */
+                    function foo($arg) {}
+
+                    class A {
+                        public function __construct() {
+                            foo([$this, "bar"]);
+                        }
+
+                        public function bar(): bool {
+                            return true;
+                        }
+                    }',
+                'error_message' => 'PossiblyInvalidArgument',
+            ],
+            'callableMissingOptionalVariableInstanceArray' => [
+                'code' => '<?php
+                    /**
+                     * @param callable(string=):bool $arg
+                     * @return void
+                     */
+                    function foo($arg) {}
+
+                    class A {
+                        public function bar(): bool {
+                            return true;
+                        }
+                    }
+
+                    $a_instance = new A();
+                    $y = [$a_instance, "bar"];
+                    foo($y);',
+                'error_message' => 'PossiblyInvalidArgument',
+            ],
+            'callableMissingOptionalMultipleParams' => [
+                'code' => '<?php
+                    /**
+                     * @param callable(string, string, string, string=):bool $arg
+                     * @return void
+                     */
+                    function foo($arg) {}
+
+                    function bar(string $a, string $b, string $c): bool {}
+
+                    foo("bar");',
+                'error_message' => 'PossiblyInvalidArgument',
+                'ignored_issues' => ['InvalidReturnType'],
+            ],
+            'callableMissingRequiredMultipleParams' => [
+                'code' => '<?php
+                    /**
+                     * @param callable(string, string, string, string):bool $arg
+                     * @return void
+                     */
+                    function foo($arg) {}
+
+                    function bar(string $a, string $b, string $c): bool {}
+
+                    foo("bar");',
+                'error_message' => 'PossiblyInvalidArgument',
+                'ignored_issues' => ['InvalidReturnType'],
+            ],
+            'callableAdditionalRequiredParam' => [
+                'code' => '<?php
+                    /**
+                     * @param callable(string, string, string):bool $arg
+                     * @return void
+                     */
+                    function foo($arg) {}
+
+                    function bar(string $a, string $b, string $c, string $d): bool {}
+
+                    foo("bar");',
+                'error_message' => 'InvalidArgument',
+                'ignored_issues' => ['InvalidReturnType'],
+            ],
+            'callableMultipleParamsWithOptional' => [
+                'code' => '<?php
+                    /**
+                     * @param callable(string, string, string=):bool $arg
+                     * @return void
+                     */
+                    function foo($arg) {}
+
+                    function bar(string $a, string $b, string $c): bool {}
+
+                    foo("bar");',
+                'error_message' => 'PossiblyInvalidArgument',
+                'ignored_issues' => ['InvalidReturnType'],
             ],
             'preventStringDocblockType' => [
                 'code' => '<?php

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -1827,16 +1827,16 @@ class CallableTest extends TestCase
                     {
                         return 0;
                     }
-                    
+
                     /** @param Closure(int, int): int $f */
                     function int_int(Closure $f): void {}
-                    
+
                     /** @param Closure(int, int, int): int $f */
                     function int_int_int(Closure $f): void {}
-                    
+
                     /** @param Closure(int, int, int, int): int $f */
                     function int_int_int_int(Closure $f): void {}
-                    
+
                     int_int(withVariadic(...));
                     int_int_int(withVariadic(...));
                     int_int_int_int(withVariadic(...));',
@@ -2109,6 +2109,19 @@ class CallableTest extends TestCase
                     new Func("f", ["Foo", "bar"]);',
                 'error_message' => 'InvalidArgument',
             ],
+            'invalidArrayCallable' => [
+                'code' => '<?php
+                    function foo(callable $callback) : void {
+                        $callback();
+                    }
+
+                    final class Bar {
+                        public static function baz() : void {}
+                    }
+
+                    foo([Bar::class, "baz", 1231233]);',
+                'error_message' => 'InvalidArgument',
+            ],
             'preventStringDocblockType' => [
                 'code' => '<?php
                     /**
@@ -2325,16 +2338,16 @@ class CallableTest extends TestCase
                     {
                         return 0;
                     }
-                    
+
                     /** @param Closure(int, int, string, int, int): int $f */
                     function int_int_string_int_int(Closure $f): void {}
-                    
+
                     /** @param Closure(int, int, int, string, int): int $f */
                     function int_int_int_string_int(Closure $f): void {}
-                    
+
                     /** @param Closure(int, int, int, int, string): int $f */
                     function int_int_int_int_string(Closure $f): void {}
-                    
+
                     int_int_string_int_int(add(...));
                     int_int_int_string_int(add(...));
                     int_int_int_int_string(add(...));',

--- a/tests/Internal/Provider/ClassLikeStorageInstanceCacheProvider.php
+++ b/tests/Internal/Provider/ClassLikeStorageInstanceCacheProvider.php
@@ -10,7 +10,7 @@ use function strtolower;
 
 class ClassLikeStorageInstanceCacheProvider extends ClassLikeStorageCacheProvider
 {
-    /** @var array<string, ClassLikeStorage> */
+    /** @var array<lowercase-string, ClassLikeStorage> */
     private array $cache = [];
 
     public function __construct()
@@ -23,6 +23,9 @@ class ClassLikeStorageInstanceCacheProvider extends ClassLikeStorageCacheProvide
         $this->cache[$fq_classlike_name_lc] = $storage;
     }
 
+    /**
+     * @param lowercase-string $fq_classlike_name_lc
+     */
     public function getLatestFromCache(string $fq_classlike_name_lc, ?string $file_path, ?string $file_contents): ClassLikeStorage
     {
         $cached_value = $this->loadFromCache($fq_classlike_name_lc);
@@ -34,6 +37,9 @@ class ClassLikeStorageInstanceCacheProvider extends ClassLikeStorageCacheProvide
         return $cached_value;
     }
 
+    /**
+     * @param lowercase-string $fq_classlike_name_lc
+     */
     private function loadFromCache(string $fq_classlike_name_lc): ?ClassLikeStorage
     {
         return $this->cache[$fq_classlike_name_lc] ?? null;

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -499,22 +499,22 @@ class MethodSignatureTest extends TestCase
 
                     class Observer implements \SplObserver
                     {
-                        public function update(SplSubject $subject)
+                        public function update(SplSubject $subject): void
                         {
                         }
                     }
 
                     class Subject implements \SplSubject
                     {
-                        public function attach(SplObserver $observer)
+                        public function attach(SplObserver $observer): void
                         {
                         }
 
-                        public function detach(SplObserver $observer)
+                        public function detach(SplObserver $observer): void
                         {
                         }
 
-                        public function notify()
+                        public function notify(): void
                         {
                         }
                     }',

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -317,10 +317,10 @@ class StubTest extends TestCase
             '<?php
                 namespace Ns {
                     class MyClass {
-                    
+
                         public const OBJECT = "object";
                         private const EXCEPTION = "exception";
-                        
+
                         /**
                          * @return mixed
                          * @psalm-suppress InvalidReturnType
@@ -332,7 +332,7 @@ class StubTest extends TestCase
                          * @psalm-suppress InvalidReturnType
                          */
                         public function create2(string $s) {}
-                        
+
                         /**
                          * @return mixed
                          * @psalm-suppress InvalidReturnType
@@ -384,7 +384,7 @@ class StubTest extends TestCase
 
                     $y1 = (new \Ns\MyClass)->creAte2("object");
                     $y2 = (new \Ns\MyClass)->creaTe2("exception");
-                    
+
                     $const1 = (new \Ns\MyClass)->creAte3(\Ns\MyClass::OBJECT);
                     $const2 = (new \Ns\MyClass)->creaTe3("exception");
 
@@ -1189,94 +1189,6 @@ class StubTest extends TestCase
                 class Bar extends PartiallyStubbedClass  {}
 
                 new Bar();',
-        );
-
-        $this->analyzeFile($file_path, new Context());
-    }
-
-    public function testStubFileWithPartialClassDefinitionWithCoercion(): void
-    {
-        $this->expectExceptionMessage('TypeCoercion');
-        $this->expectException(CodeException::class);
-        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
-            TestConfig::loadFromXML(
-                dirname(__DIR__),
-                '<?xml version="1.0"?>
-                <psalm
-                    errorLevel="1"
-                >
-                    <projectFiles>
-                        <directory name="src" />
-                    </projectFiles>
-
-                    <stubs>
-                        <file name="tests/fixtures/stubs/partial_class.phpstub" />
-                    </stubs>
-                </psalm>',
-            ),
-        );
-
-        $file_path = getcwd() . '/src/somefile.php';
-
-        $this->addFile(
-            $file_path,
-            '<?php
-                namespace Foo;
-
-                class PartiallyStubbedClass  {
-                    /**
-                     * @param string $a
-                     * @return object
-                     */
-                    public function foo(string $a) {
-                        return new self;
-                    }
-                }
-
-                (new PartiallyStubbedClass())->foo("dasda");',
-        );
-
-        $this->analyzeFile($file_path, new Context());
-    }
-
-    public function testStubFileWithPartialClassDefinitionGeneralReturnType(): void
-    {
-        $this->expectExceptionMessage('InvalidReturnStatement');
-        $this->expectException(CodeException::class);
-        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
-            TestConfig::loadFromXML(
-                dirname(__DIR__),
-                '<?xml version="1.0"?>
-                <psalm
-                    errorLevel="1"
-                >
-                    <projectFiles>
-                        <directory name="src" />
-                    </projectFiles>
-
-                    <stubs>
-                        <file name="tests/fixtures/stubs/partial_class.phpstub" />
-                    </stubs>
-                </psalm>',
-            ),
-        );
-
-        $file_path = getcwd() . '/src/somefile.php';
-
-        $this->addFile(
-            $file_path,
-            '<?php
-                namespace Foo;
-
-                class PartiallyStubbedClass  {
-                    /**
-                     * @param string $a
-                     * @return object
-                     */
-                    public function foo(string $a) {
-                        return new \stdClass;
-                    }
-                }',
         );
 
         $this->analyzeFile($file_path, new Context());

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -217,7 +217,7 @@ class StubTest extends TestCase
     public function testStubFileParentClass(): void
     {
         $this->expectException(CodeException::class);
-        $this->expectExceptionMessage('ImplementedParamTypeMismatch');
+        $this->expectExceptionMessage('MethodSignatureMismatch');
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
                 dirname(__DIR__),

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -2348,7 +2348,7 @@ class ClassTemplateTest extends TestCase
 
                         /**
                          * @template U
-                         * @param callable(T=):U $callback
+                         * @param callable(T):U $callback
                          * @return static<U>
                          */
                         public function map(callable $callback) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -32,10 +32,23 @@ class TestCase extends BaseTestCase
 {
     protected static string $src_dir_path;
 
+    /**
+     * caused by phpunit using setUp() instead of __construct
+     * could perhaps use psalm-plugin-phpunit once https://github.com/psalm/psalm-plugin-phpunit/issues/129
+     * to remove this suppression
+     *
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
     protected ProjectAnalyzer $project_analyzer;
 
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
     protected FakeFileProvider $file_provider;
 
+    /**
+     * @psalm-suppress PropertyNotSetInConstructor
+     */
     protected Config $testConfig;
 
     public static function setUpBeforeClass(): void

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -14,7 +14,6 @@ use function version_compare;
 
 use const PHP_OS;
 use const PHP_VERSION;
-use const PHP_VERSION_ID;
 
 trait ValidCodeAnalysisTestTrait
 {
@@ -76,20 +75,6 @@ trait ValidCodeAnalysisTestTrait
         $codebase = $this->project_analyzer->getCodebase();
         $codebase->enterServerMode();
         $codebase->config->visitPreloadedStubFiles($codebase);
-
-        // avoid MethodSignatureMismatch for __unserialize/() when extending DateTime
-        if (PHP_VERSION_ID >= 8_02_00) {
-            $this->addStubFile(
-                'stubOne.phpstub',
-                '<?php
-                    namespace {
-                        interface DateTimeInterface {
-                            public function __unserialize(mixed[] $data) {}
-                        }
-                    }
-                ',
-            );
-        }
 
         $file_path = self::$src_dir_path . 'somefile.php';
 


### PR DESCRIPTION
Sorry, this is a quite comprehensive PR, I couldn't break it up though, as earlier commits caused me to fix issues in later commits (which sent me down a rabbit hole...)

- Fix https://github.com/vimeo/psalm/issues/9068 + array_filter callback type for keys
- Fix https://github.com/vimeo/psalm/issues/8919
- Fix https://github.com/vimeo/psalm/issues/10371
- Fix param providers for native methods not working
- Fix array_filter params callable incorrect required params depending on the 3rd argument value (at this commit psalm doesn't report an error, due to https://github.com/vimeo/psalm/issues/8438, which gets fixed by this PR later on though)
- Fix https://github.com/vimeo/psalm/issues/3047 and further improve types for array_multisort and add errors for invalid params
- Fix SimpleTypeInferer failing on bitwise operations with constants
- Fix https://psalm.dev/r/7f112fd745 - MethodComparator only reported an error for this if the parent class was user defined (= not in stubs), which is wrong, since this will cause a fatal error when running the code
- Fix ReturnTypeWillChange false positive https://psalm.dev/r/91c6992bf1 with missing return type signature
- Fix that files passed via CLI but are not in projectFiles reported only a limited, random selection of errors instead of all - treat all files passed as CLI args as if they were in projectFiles
- Fix for classes what https://github.com/vimeo/psalm/pull/8503 fixed for functions (as some issues didn't report for other reasons, which were solved since then)
- Fix https://github.com/vimeo/psalm/issues/6085
- Fix optional args not enforced in callable (fix for non-closure/arrow functions of https://github.com/vimeo/psalm/issues/8438)
- Fix array callables not treated as callable https://psalm.dev/r/23f3787207 (this is needed to fix the optional args enforcement for array callables too)
- Fix potential cache race conditions/cache not deleted with non-lowercase file paths and add missing docs


The MethodComparator change caused tons of failing tests/shepherd errors, because psalm just ignored those for itself until now, e.g. suppressedIssues should be list<string>, but some extending classes used array<int, string>,...