### PR TITLE
Finding methods and properties for auto completion feature

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1883,7 +1883,10 @@ final class Codebase
                 try {
                     $class_storage = $this->classlike_storage_provider->get($atomic_type->value);
 
-                    $method_storages = [...$class_storage->methods];
+                    $method_storages = [];
+                    foreach ($class_storage->declaring_method_ids as $declaring_method_id) {
+                        $method_storages[] = $this->methods->getStorage($declaring_method_id);
+                    }
                     if ($gap === '->') {
                         $method_storages += $class_storage->pseudo_methods;
                     }

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1899,7 +1899,11 @@ final class Codebase
 
                     $method_storages = [];
                     foreach ($class_storage->declaring_method_ids as $declaring_method_id) {
-                        $method_storages[] = $this->methods->getStorage($declaring_method_id);
+                        try {
+                            $method_storages[] = $this->methods->getStorage($declaring_method_id);
+                        } catch (UnexpectedValueException $e) {
+                            error_log($e->getMessage());
+                        }
                     }
                     if ($gap === '->') {
                         $method_storages += $class_storage->pseudo_methods;
@@ -1970,9 +1974,14 @@ final class Codebase
                     }
 
                     foreach ($class_storage->declaring_property_ids as $property_name => $declaring_class) {
-                        $property_storage = $this->properties->getStorage(
-                            $declaring_class . '::$' . $property_name,
-                        );
+                        try {
+                            $property_storage = $this->properties->getStorage(
+                                $declaring_class . '::$' . $property_name,
+                            );
+                        } catch (UnexpectedValueException $e) {
+                            error_log($e->getMessage());
+                            continue;
+                        }
 
                         if (!in_array($property_storage->visibility, $allow_visibilities)) {
                             continue;

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1869,13 +1869,15 @@ final class Codebase
 
     /**
      * @param list<int> $allow_visibilities
+     * @param list<string> $ignore_fq_class_names
      * @return list<CompletionItem>
      */
     public function getCompletionItemsForClassishThing(
         string $type_string,
         string $gap,
         bool $snippets_supported = false,
-        array $allow_visibilities = null
+        array $allow_visibilities = null,
+        array $ignore_fq_class_names = []
     ): array {
         if ($allow_visibilities === null) {
             $allow_visibilities = [
@@ -2002,11 +2004,15 @@ final class Codebase
 
                     if ($gap === '->') {
                         foreach ($class_storage->namedMixins as $mixin) {
+                            if (in_array($mixin->value, $ignore_fq_class_names)) {
+                                continue;
+                            }
                             $mixin_completion_items = $this->getCompletionItemsForClassishThing(
                                 $mixin->value,
                                 $gap,
                                 $snippets_supported,
                                 [ClassLikeAnalyzer::VISIBILITY_PUBLIC],
+                                [$type_string, ...$ignore_fq_class_names],
                             );
                             $completion_items = [...$completion_items, ...$mixin_completion_items];
                         }

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -69,7 +69,6 @@ use ReflectionType;
 use UnexpectedValueException;
 
 use function array_combine;
-use function array_merge;
 use function array_pop;
 use function array_reverse;
 use function array_values;
@@ -1884,12 +1883,15 @@ final class Codebase
                 try {
                     $class_storage = $this->classlike_storage_provider->get($atomic_type->value);
 
-                    $methods = array_merge(
-                        $class_storage->methods,
-                        $class_storage->pseudo_methods,
-                        $class_storage->pseudo_static_methods,
-                    );
-                    foreach ($methods as $method_storage) {
+                    $method_storages = [...$class_storage->methods];
+                    if ($gap === '->') {
+                        $method_storages += $class_storage->pseudo_methods;
+                    }
+                    if ($gap === '::') {
+                        $method_storages += $class_storage->pseudo_static_methods;
+                    }
+
+                    foreach ($method_storages as $method_storage) {
                         if ($method_storage->is_static || $gap === '->') {
                             $completion_item = new CompletionItem(
                                 $method_storage->cased_name,

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1952,7 +1952,7 @@ final class Codebase
                             $declaring_class . '::$' . $property_name,
                         );
 
-                        if ($property_storage->is_static || $gap === '->') {
+                        if ($property_storage->is_static === ($gap === '::')) {
                             $completion_items[] = new CompletionItem(
                                 $property_name,
                                 CompletionItemKind::PROPERTY,

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1954,7 +1954,7 @@ final class Codebase
 
                         if ($property_storage->is_static || $gap === '->') {
                             $completion_items[] = new CompletionItem(
-                                '$' . $property_name,
+                                $property_name,
                                 CompletionItemKind::PROPERTY,
                                 $property_storage->getInfo(),
                                 $property_storage->description,

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1918,34 +1918,34 @@ final class Codebase
                         }
                     }
 
-                    $pseudo_property_types = [];
-                    foreach ($class_storage->pseudo_property_get_types as $property_name => $type) {
-                        $pseudo_property_types[$property_name] = new CompletionItem(
-                            str_replace('$', '', $property_name),
-                            CompletionItemKind::PROPERTY,
-                            $type->__toString(),
-                            null,
-                            '1', //sort text
-                            str_replace('$', '', $property_name),
-                            ($gap === '::' ? '$' : '') .
+                    if ($gap === '->') {
+                        $pseudo_property_types = [];
+                        foreach ($class_storage->pseudo_property_get_types as $property_name => $type) {
+                            $pseudo_property_types[$property_name] = new CompletionItem(
                                 str_replace('$', '', $property_name),
-                        );
-                    }
-
-                    foreach ($class_storage->pseudo_property_set_types as $property_name => $type) {
-                        $pseudo_property_types[$property_name] = new CompletionItem(
-                            str_replace('$', '', $property_name),
-                            CompletionItemKind::PROPERTY,
-                            $type->__toString(),
-                            null,
-                            '1',
-                            str_replace('$', '', $property_name),
-                            ($gap === '::' ? '$' : '') .
+                                CompletionItemKind::PROPERTY,
+                                $type->__toString(),
+                                null,
+                                '1', //sort text
                                 str_replace('$', '', $property_name),
-                        );
+                                str_replace('$', '', $property_name),
+                            );
+                        }
+    
+                        foreach ($class_storage->pseudo_property_set_types as $property_name => $type) {
+                            $pseudo_property_types[$property_name] = new CompletionItem(
+                                str_replace('$', '', $property_name),
+                                CompletionItemKind::PROPERTY,
+                                $type->__toString(),
+                                null,
+                                '1',
+                                str_replace('$', '', $property_name),
+                                str_replace('$', '', $property_name),
+                            );
+                        }
+    
+                        $completion_items = [...$completion_items, ...array_values($pseudo_property_types)];
                     }
-
-                    $completion_items = [...$completion_items, ...array_values($pseudo_property_types)];
 
                     foreach ($class_storage->declaring_property_ids as $property_name => $declaring_class) {
                         $property_storage = $this->properties->getStorage(

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -560,6 +560,8 @@ final class Populator
 
         $parent_storage->dependent_classlikes[strtolower($storage->name)] = true;
 
+        $storage->pseudo_static_methods += $parent_storage->pseudo_static_methods;
+
         $storage->pseudo_methods += $parent_storage->pseudo_methods;
         $storage->declaring_pseudo_method_ids += $parent_storage->declaring_pseudo_method_ids;
     }

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -450,6 +450,8 @@ final class Populator
         $storage->pseudo_property_get_types += $trait_storage->pseudo_property_get_types;
         $storage->pseudo_property_set_types += $trait_storage->pseudo_property_set_types;
 
+        $storage->pseudo_static_methods += $trait_storage->pseudo_static_methods;
+        
         $storage->pseudo_methods += $trait_storage->pseudo_methods;
         $storage->declaring_pseudo_method_ids += $trait_storage->declaring_pseudo_method_ids;
     }

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -128,13 +128,13 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'magicObjMethod',
                 'magicStaticMethod',
     
-                '$publicObjProp',
-                '$protectedObjProp',
-                '$privateObjProp',
+                'publicObjProp',
+                'protectedObjProp',
+                'privateObjProp',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
-                '$privateStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
+                'privateStaticProp',
     
                 'publicObjMethod',
                 'protectedObjMethod',
@@ -149,9 +149,9 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'magicObjProp2',
                 'magicStaticMethod',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
-                '$privateStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
+                'privateStaticProp',
     
                 'publicStaticMethod',
                 'protectedStaticMethod',
@@ -209,13 +209,13 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'magicObjMethod',
                 'magicStaticMethod',
     
-                '$publicObjProp',
-                '$protectedObjProp',
-                '$privateObjProp',
+                'publicObjProp',
+                'protectedObjProp',
+                'privateObjProp',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
-                '$privateStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
+                'privateStaticProp',
     
                 'abstractPublicMethod',
                 'abstractProtectedMethod',
@@ -233,9 +233,9 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'magicObjProp2',
                 'magicStaticMethod',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
-                '$privateStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
+                'privateStaticProp',
     
                 'publicStaticMethod',
                 'protectedStaticMethod',
@@ -296,21 +296,21 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
     
                 'magicObjMethod',
     
-                '$publicObjProp',
-                '$protectedObjProp',
-                '$privateObjProp',
+                'publicObjProp',
+                'protectedObjProp',
+                'privateObjProp',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
-                '$privateStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
+                'privateStaticProp',
             ],
             '::' => [
                 'magicObjProp1',
                 'magicObjProp2',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
-                '$privateStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
+                'privateStaticProp',
             ],
         ];
 
@@ -367,21 +367,21 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
     
                 'magicObjMethod',
     
-                '$publicObjProp',
-                '$protectedObjProp',
-                '$privateObjProp',
+                'publicObjProp',
+                'protectedObjProp',
+                'privateObjProp',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
-                '$privateStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
+                'privateStaticProp',
             ],
             '::' => [
                 'magicObjProp1',
                 'magicObjProp2',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
-                '$privateStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
+                'privateStaticProp',
             ],
         ];
 
@@ -435,18 +435,18 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
     
                 'magicObjMethod',
     
-                '$publicObjProp',
-                '$protectedObjProp',
+                'publicObjProp',
+                'protectedObjProp',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
             ],
             '::' => [
                 'magicObjProp1',
                 'magicObjProp2',
 
-                '$publicStaticProp',
-                '$protectedStaticProp',
+                'publicStaticProp',
+                'protectedStaticProp',
             ],
         ];
 

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -141,8 +141,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'privateStaticMethod',
             ],
             '::' => [
-                'magicObjProp1',
-                'magicObjProp2',
                 'magicStaticMethod',
 
                 'publicStaticProp',
@@ -221,8 +219,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'privateStaticMethod',
             ],
             '::' => [
-                'magicObjProp1',
-                'magicObjProp2',
                 'magicStaticMethod',
 
                 'publicStaticProp',
@@ -293,9 +289,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'privateObjProp',
             ],
             '::' => [
-                'magicObjProp1',
-                'magicObjProp2',
-
                 'publicStaticProp',
                 'protectedStaticProp',
                 'privateStaticProp',
@@ -360,9 +353,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'privateObjProp',
             ],
             '::' => [
-                'magicObjProp1',
-                'magicObjProp2',
-
                 'publicStaticProp',
                 'protectedStaticProp',
                 'privateStaticProp',
@@ -423,9 +413,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'protectedObjProp',
             ],
             '::' => [
-                'magicObjProp1',
-                'magicObjProp2',
-
                 'publicStaticProp',
                 'protectedStaticProp',
             ],

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -447,6 +447,7 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'protectedStaticMethod',
             ],
             '::' => [
+                'magicStaticMethod',
                 'publicStaticProp',
                 'protectedStaticProp',
 

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -126,7 +126,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'magicObjProp2',
     
                 'magicObjMethod',
-                'magicStaticMethod',
     
                 'publicObjProp',
                 'protectedObjProp',
@@ -201,7 +200,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'magicObjProp2',
     
                 'magicObjMethod',
-                'magicStaticMethod',
     
                 'publicObjProp',
                 'protectedObjProp',

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -285,11 +285,26 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'publicObjProp',
                 'protectedObjProp',
                 'privateObjProp',
+
+                'abstractPublicMethod',
+                'abstractProtectedMethod',
+
+                'publicObjMethod',
+                'protectedObjMethod',
+                'privateObjMethod',
+
+                'publicStaticMethod',
+                'protectedStaticMethod',
+                'privateStaticMethod',
             ],
             '::' => [
                 'publicStaticProp',
                 'protectedStaticProp',
                 'privateStaticProp',
+
+                'publicStaticMethod',
+                'protectedStaticMethod',
+                'privateStaticMethod',
             ],
         ];
 
@@ -349,11 +364,26 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'publicObjProp',
                 'protectedObjProp',
                 'privateObjProp',
+
+                'abstractPublicMethod',
+                'abstractProtectedMethod',
+
+                'publicObjMethod',
+                'protectedObjMethod',
+                'privateObjMethod',
+
+                'publicStaticMethod',
+                'protectedStaticMethod',
+                'privateStaticMethod',
             ],
             '::' => [
                 'publicStaticProp',
                 'protectedStaticProp',
                 'privateStaticProp',
+
+                'publicStaticMethod',
+                'protectedStaticMethod',
+                'privateStaticMethod',
             ],
         ];
 
@@ -409,10 +439,19 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
     
                 'publicObjProp',
                 'protectedObjProp',
+
+                'publicObjMethod',
+                'protectedObjMethod',
+
+                'publicStaticMethod',
+                'protectedStaticMethod',
             ],
             '::' => [
                 'publicStaticProp',
                 'protectedStaticProp',
+
+                'publicStaticMethod',
+                'protectedStaticMethod',
             ],
         ];
 

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -554,4 +554,28 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
 
         $this->assertEqualsCanonicalizing($expected_labels[$gap], $actual_labels);
     }
+
+    public function testResolveCollisionWithMixin(): void
+    {
+        $content = <<<'EOF'
+            <?php
+            namespace B;
+
+            /** @mixin A */
+            class C {
+                public $myObjProp;
+            }
+
+            /** @mixin C */
+            class A {}
+        EOF;
+
+        $actual_labels = $this->getCompletionLabels($content, 'B\A', '->');
+
+        $expected_labels = [
+            'myObjProp',
+        ];
+
+        $this->assertEqualsCanonicalizing($expected_labels, $actual_labels);
+    }
 }

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -132,10 +132,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'protectedObjProp',
                 'privateObjProp',
 
-                'publicStaticProp',
-                'protectedStaticProp',
-                'privateStaticProp',
-    
                 'publicObjMethod',
                 'protectedObjMethod',
                 'privateObjMethod',
@@ -212,10 +208,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'publicObjProp',
                 'protectedObjProp',
                 'privateObjProp',
-
-                'publicStaticProp',
-                'protectedStaticProp',
-                'privateStaticProp',
     
                 'abstractPublicMethod',
                 'abstractProtectedMethod',
@@ -299,10 +291,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'publicObjProp',
                 'protectedObjProp',
                 'privateObjProp',
-
-                'publicStaticProp',
-                'protectedStaticProp',
-                'privateStaticProp',
             ],
             '::' => [
                 'magicObjProp1',
@@ -370,10 +358,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'publicObjProp',
                 'protectedObjProp',
                 'privateObjProp',
-
-                'publicStaticProp',
-                'protectedStaticProp',
-                'privateStaticProp',
             ],
             '::' => [
                 'magicObjProp1',
@@ -437,9 +421,6 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
     
                 'publicObjProp',
                 'protectedObjProp',
-
-                'publicStaticProp',
-                'protectedStaticProp',
             ],
             '::' => [
                 'magicObjProp1',

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -538,7 +538,17 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
         $actual_labels = $this->getCompletionLabels($content, 'B\A', $gap);
 
         $expected_labels = [
-            '->' => [],
+            '->' => [
+                'magicObjProp1',
+                'magicObjProp2',
+                'magicObjMethod',
+
+                'publicObjProp',
+
+                'publicObjMethod',
+
+                'publicStaticMethod',
+            ],
             '::' => [],
         ];
 

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -298,6 +298,7 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'privateStaticMethod',
             ],
             '::' => [
+                'magicStaticMethod',
                 'publicStaticProp',
                 'protectedStaticProp',
                 'privateStaticProp',
@@ -377,6 +378,7 @@ final class MethodGetCompletionItemsForClassishThingTest extends TestCase
                 'privateStaticMethod',
             ],
             '::' => [
+                'magicStaticMethod',
                 'publicStaticProp',
                 'protectedStaticProp',
                 'privateStaticProp',

--- a/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
+++ b/tests/Internal/Codebase/MethodGetCompletionItemsForClassishThingTest.php
@@ -1,0 +1,539 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Internal\Codebase;
+
+use Psalm\Codebase;
+use Psalm\Context;
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\Internal\Provider\FakeFileProvider;
+use Psalm\Internal\Provider\Providers;
+use Psalm\Tests\Internal\Provider\FakeFileReferenceCacheProvider;
+use Psalm\Tests\Internal\Provider\ParserInstanceCacheProvider;
+use Psalm\Tests\Internal\Provider\ProjectCacheProvider;
+use Psalm\Tests\TestCase;
+use Psalm\Tests\TestConfig;
+
+use function array_map;
+
+/**
+ * Fat tests for method `getCompletionItemsForClassishThing` of class `Psalm\Codebase`.
+ */
+final class MethodGetCompletionItemsForClassishThingTest extends TestCase
+{
+    private Codebase $codebase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->file_provider = new FakeFileProvider();
+
+        $config = new TestConfig();
+
+        $providers = new Providers(
+            $this->file_provider,
+            new ParserInstanceCacheProvider(),
+            null,
+            null,
+            new FakeFileReferenceCacheProvider(),
+            new ProjectCacheProvider(),
+        );
+
+        $this->codebase = new Codebase($config, $providers);
+
+        $this->project_analyzer = new ProjectAnalyzer(
+            $config,
+            $providers,
+            null,
+            [],
+            1,
+            null,
+            $this->codebase,
+        );
+
+        $this->project_analyzer->setPhpVersion('7.3', 'tests');
+        $this->project_analyzer->getCodebase()->store_node_types = true;
+
+        $this->codebase->config->throw_exception = false;
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function getCompletionLabels(string $content, string $class_name, string $gap): array
+    {
+        $this->addFile('somefile.php', $content);
+
+        $this->analyzeFile('somefile.php', new Context());
+
+        $items = $this->codebase->getCompletionItemsForClassishThing($class_name, $gap, true);
+
+        return array_map(fn($item) => $item->label, $items);
+    }
+
+    /**
+     * @return iterable<array-key, array{0: string}>
+     */
+    public function providerGaps(): iterable
+    {
+        return [
+            'object-gap' => ['->'],
+            'static-gap' => ['::'],
+        ];
+    }
+
+    /**
+     * @dataProvider providerGaps
+     */
+    public function testSimpleOnceClass(string $gap): void
+    {
+        $content = <<<'EOF'
+            <?php
+            namespace B;
+
+            /**
+             * @property int $magicObjProp1
+             * @property-read string $magicObjProp2
+             * @method int magicObjMethod()
+             * @method static string magicStaticMethod()
+             */
+            class A {
+                public      $publicObjProp;
+                protected   $protectedObjProp;
+                private     $privateObjProp;
+
+                public      static  $publicStaticProp;
+                protected   static  $protectedStaticProp;
+                private     static  $privateStaticProp;
+
+                public      function    publicObjMethod() {}
+                protected   function    protectedObjMethod() {}
+                private     function    privateObjMethod() {}
+
+                public      static  function    publicStaticMethod() {}
+                protected   static  function    protectedStaticMethod() {}
+                private     static  function    privateStaticMethod() {}
+            }
+        EOF;
+
+        $actual_labels = $this->getCompletionLabels($content, 'B\A', $gap);
+
+        $expected_labels = [
+            '->' => [
+                'magicObjProp1',
+                'magicObjProp2',
+    
+                'magicObjMethod',
+                'magicStaticMethod',
+    
+                '$publicObjProp',
+                '$protectedObjProp',
+                '$privateObjProp',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+                '$privateStaticProp',
+    
+                'publicObjMethod',
+                'protectedObjMethod',
+                'privateObjMethod',
+                
+                'publicStaticMethod',
+                'protectedStaticMethod',
+                'privateStaticMethod',
+            ],
+            '::' => [
+                'magicObjProp1',
+                'magicObjProp2',
+                'magicStaticMethod',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+                '$privateStaticProp',
+    
+                'publicStaticMethod',
+                'protectedStaticMethod',
+                'privateStaticMethod',
+            ],
+        ];
+
+        $this->assertEqualsCanonicalizing($expected_labels[$gap], $actual_labels);
+    }
+
+    /**
+     * @dataProvider providerGaps
+     */
+    public function testAbstractClass(string $gap): void
+    {
+        $content = <<<'EOF'
+            <?php
+            namespace B;
+
+            /**
+            * @property int $magicObjProp1
+            * @property-read string $magicObjProp2
+            * @method int magicObjMethod()
+            * @method static string magicStaticMethod()
+            */
+            abstract class A {
+                public      $publicObjProp;
+                protected   $protectedObjProp;
+                private     $privateObjProp;
+
+                public      static  $publicStaticProp;
+                protected   static  $protectedStaticProp;
+                private     static  $privateStaticProp;
+
+                abstract    public      function    abstractPublicMethod();
+                abstract    protected   function    abstractProtectedMethod();
+
+                public      function    publicObjMethod() {}
+                protected   function    protectedObjMethod() {}
+                private     function    privateObjMethod() {}
+
+                public      static  function    publicStaticMethod() {}
+                protected   static  function    protectedStaticMethod() {}
+                private     static  function    privateStaticMethod() {}
+            }
+        EOF;
+
+        $actual_labels = $this->getCompletionLabels($content, 'B\A', $gap);
+
+        $expected_labels = [
+            '->' => [
+                'magicObjProp1',
+                'magicObjProp2',
+    
+                'magicObjMethod',
+                'magicStaticMethod',
+    
+                '$publicObjProp',
+                '$protectedObjProp',
+                '$privateObjProp',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+                '$privateStaticProp',
+    
+                'abstractPublicMethod',
+                'abstractProtectedMethod',
+
+                'publicObjMethod',
+                'protectedObjMethod',
+                'privateObjMethod',
+                
+                'publicStaticMethod',
+                'protectedStaticMethod',
+                'privateStaticMethod',
+            ],
+            '::' => [
+                'magicObjProp1',
+                'magicObjProp2',
+                'magicStaticMethod',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+                '$privateStaticProp',
+    
+                'publicStaticMethod',
+                'protectedStaticMethod',
+                'privateStaticMethod',
+            ],
+        ];
+
+        $this->assertEqualsCanonicalizing($expected_labels[$gap], $actual_labels);
+    }
+
+    /**
+     * @dataProvider providerGaps
+     */
+    public function testUseTrait(string $gap): void
+    {
+        $content = <<<'EOF'
+            <?php
+            namespace B;
+
+            /**
+             * @property int $magicObjProp1
+             * @property-read string $magicObjProp2
+             * @method int magicObjMethod()
+             * @method static string magicStaticMethod()
+             */
+            trait C {
+                public      $publicObjProp;
+                protected   $protectedObjProp;
+                private     $privateObjProp;
+
+                public      static  $publicStaticProp;
+                protected   static  $protectedStaticProp;
+                private     static  $privateStaticProp;
+
+                abstract    public      function    abstractPublicMethod();
+                abstract    protected   function    abstractProtectedMethod();
+
+                public      function    publicObjMethod() {}
+                protected   function    protectedObjMethod() {}
+                private     function    privateObjMethod() {}
+
+                public      static  function    publicStaticMethod() {}
+                protected   static  function    protectedStaticMethod() {}
+                private     static  function    privateStaticMethod() {}
+            }
+
+            class A {
+                use C;
+            }
+        EOF;
+
+        $actual_labels = $this->getCompletionLabels($content, 'B\A', $gap);
+
+        $expected_labels = [
+            '->' => [
+                'magicObjProp1',
+                'magicObjProp2',
+    
+                'magicObjMethod',
+    
+                '$publicObjProp',
+                '$protectedObjProp',
+                '$privateObjProp',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+                '$privateStaticProp',
+            ],
+            '::' => [
+                'magicObjProp1',
+                'magicObjProp2',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+                '$privateStaticProp',
+            ],
+        ];
+
+        $this->assertEqualsCanonicalizing($expected_labels[$gap], $actual_labels);
+    }
+
+    /**
+     * @dataProvider providerGaps
+     */
+    public function testUseTraitWithAbstractClass(string $gap): void
+    {
+        $content = <<<'EOF'
+            <?php
+            namespace B;
+
+            /**
+             * @property int $magicObjProp1
+             * @property-read string $magicObjProp2
+             * @method int magicObjMethod()
+             * @method static string magicStaticMethod()
+             */
+            trait C {
+                public      $publicObjProp;
+                protected   $protectedObjProp;
+                private     $privateObjProp;
+
+                public      static  $publicStaticProp;
+                protected   static  $protectedStaticProp;
+                private     static  $privateStaticProp;
+
+                abstract    public      function    abstractPublicMethod();
+                abstract    protected   function    abstractProtectedMethod();
+
+                public      function    publicObjMethod() {}
+                protected   function    protectedObjMethod() {}
+                private     function    privateObjMethod() {}
+
+                public      static  function    publicStaticMethod() {}
+                protected   static  function    protectedStaticMethod() {}
+                private     static  function    privateStaticMethod() {}
+            }
+
+            abstract class A {
+                use C;
+            }
+        EOF;
+
+        $actual_labels = $this->getCompletionLabels($content, 'B\A', $gap);
+
+        $expected_labels = [
+            '->' => [
+                'magicObjProp1',
+                'magicObjProp2',
+    
+                'magicObjMethod',
+    
+                '$publicObjProp',
+                '$protectedObjProp',
+                '$privateObjProp',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+                '$privateStaticProp',
+            ],
+            '::' => [
+                'magicObjProp1',
+                'magicObjProp2',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+                '$privateStaticProp',
+            ],
+        ];
+
+        $this->assertEqualsCanonicalizing($expected_labels[$gap], $actual_labels);
+    }
+
+    /**
+     * @dataProvider providerGaps
+     */
+    public function testClassWithExtends(string $gap): void
+    {
+        $content = <<<'EOF'
+            <?php
+            namespace B;
+
+            /**
+             * @property int $magicObjProp1
+             * @property-read string $magicObjProp2
+             * @method int magicObjMethod()
+             * @method static string magicStaticMethod()
+             */
+            class C {
+                public      $publicObjProp;
+                protected   $protectedObjProp;
+                private     $privateObjProp;
+
+                public      static  $publicStaticProp;
+                protected   static  $protectedStaticProp;
+                private     static  $privateStaticProp;
+
+                public      function    publicObjMethod() {}
+                protected   function    protectedObjMethod() {}
+                private     function    privateObjMethod() {}
+
+                public      static  function    publicStaticMethod() {}
+                protected   static  function    protectedStaticMethod() {}
+                private     static  function    privateStaticMethod() {}
+            }
+
+            class A extends C {
+                
+            }
+        EOF;
+
+        $actual_labels = $this->getCompletionLabels($content, 'B\A', $gap);
+
+        $expected_labels = [
+            '->' => [
+                'magicObjProp1',
+                'magicObjProp2',
+    
+                'magicObjMethod',
+    
+                '$publicObjProp',
+                '$protectedObjProp',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+            ],
+            '::' => [
+                'magicObjProp1',
+                'magicObjProp2',
+
+                '$publicStaticProp',
+                '$protectedStaticProp',
+            ],
+        ];
+
+        $this->assertEqualsCanonicalizing($expected_labels[$gap], $actual_labels);
+    }
+
+    /**
+     * @dataProvider providerGaps
+     */
+    public function testAstractClassWithInterface(string $gap): void
+    {
+        $content = <<<'EOF'
+            <?php
+            namespace B;
+
+            interface C {
+                public      function    publicObjMethod();
+                protected   function    protectedObjMethod();
+            }
+
+            abstract class A implements C {
+                abstract    public      function    publicObjMethod();
+                abstract    protected   function    protectedObjMethod();
+            }
+        EOF;
+
+        $actual_labels = $this->getCompletionLabels($content, 'B\A', $gap);
+
+        $expected_labels = [
+            '->' => [
+                'publicObjMethod',
+                'protectedObjMethod',
+            ],
+            '::' => [],
+        ];
+
+        $this->assertEqualsCanonicalizing($expected_labels[$gap], $actual_labels);
+    }
+
+    /**
+     * @dataProvider providerGaps
+     */
+    public function testClassWithAnnotationMixin(string $gap): void
+    {
+        $content = <<<'EOF'
+            <?php
+            namespace B;
+
+            /**
+             * @property int $magicObjProp1
+             * @property-read string $magicObjProp2
+             * @method int magicObjMethod()
+             * @method static string magicStaticMethod()
+             */
+            class C {
+                public      $publicObjProp;
+                protected   $protectedObjProp;
+                private     $privateObjProp;
+
+                public      static  $publicStaticProp;
+                protected   static  $protectedStaticProp;
+                private     static  $privateStaticProp;
+
+                public      function    publicObjMethod() {}
+                protected   function    protectedObjMethod() {}
+                private     function    privateObjMethod() {}
+
+                public      static  function    publicStaticMethod() {}
+                protected   static  function    protectedStaticMethod() {}
+                private     static  function    privateStaticMethod() {}
+            }
+
+            /**
+             * @mixin C
+             */
+            class A {
+                
+            }
+        EOF;
+
+        $actual_labels = $this->getCompletionLabels($content, 'B\A', $gap);
+
+        $expected_labels = [
+            '->' => [],
+            '::' => [],
+        ];
+
+        $this->assertEqualsCanonicalizing($expected_labels[$gap], $actual_labels);
+    }
+}


### PR DESCRIPTION
The method `Codebase::getCompletionItemsForClassishThing()` is important
for finding methods and properties in classes.

I wrote tests for it and fixed some bugs.