### PR TITLE
Fix Phar build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,8 @@ jobs:
           command: bin/build-phar.sh
       - run:
           name: Smoke test Phar file
-          command: build/psalm.phar --version
+          # Change the root away from the project root to avoid conflicts with the Composer autoloader
+          command: build/psalm.phar --version --root build
       - store_artifacts:
           path: build/psalm.phar
       - run:


### PR DESCRIPTION
The issue was likely caused by Composer 2.6.4 making the autoloader generation (more) reproducible (composer/composer#11663)

We can either try to change the generated autoloader with an autoloader suffix, or just change the Psalm root directory for the smoke test. The latter approach seems easier. :P

Fixes https://github.com/vimeo/psalm/issues/10390