### PR TITLE
Declare we do not support document highlighting

### DIFF
--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -507,6 +507,11 @@ final class LanguageServer extends Dispatcher
                  * Support "Hover"
                  */
                 $serverCapabilities->hoverProvider = true;
+                /**
+                 * The server does not support documentHighlight-ing
+                 * Ref: https://github.com/vimeo/psalm/issues/10397
+                 */
+                $serverCapabilities->documentHighlightProvider = false;
 
                 /**
                  * The server provides completion support.


### PR DESCRIPTION
Explicitly state that we do not support document highlighting.

Fixes #10397