### PR TITLE
Restore support for null coalesce on match expressions

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
@@ -39,6 +39,7 @@ final class CoalesceAnalyzer
             || $root_expr instanceof PhpParser\Node\Expr\MethodCall
             || $root_expr instanceof PhpParser\Node\Expr\StaticCall
             || $root_expr instanceof PhpParser\Node\Expr\Cast
+            || $root_expr instanceof PhpParser\Node\Expr\Match_
             || $root_expr instanceof PhpParser\Node\Expr\NullsafePropertyFetch
             || $root_expr instanceof PhpParser\Node\Expr\NullsafeMethodCall
             || $root_expr instanceof PhpParser\Node\Expr\Ternary

--- a/tests/MatchTest.php
+++ b/tests/MatchTest.php
@@ -167,6 +167,21 @@ class MatchTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'nullCoalesce' => [
+                'code' => <<<'PHP'
+                    <?php
+                    function foo(): bool { return false; }
+                    $match = match (foo()) {
+                        false => null,
+                        true => 1,
+                    } ?? 2;
+                    PHP,
+                'assertions' => [
+                    '$match' => 'int',
+                ],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
         ];
     }
 


### PR DESCRIPTION
https://github.com/vimeo/psalm/pull/10068 added `isset()` restrictions that didn't consider null coalesces on match expressions.
This restores that support by converting the match expression to a virtual variable for the isset analysis, similar to other incompatible expressions.