### PR TITLE
use branch name to randomize tests to ensure test dependencies will error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
       CHUNK_COUNT: "${{ matrix.count }}"
       CHUNK_NUMBER: "${{ matrix.chunk }}"
       PARALLEL_PROCESSES: 5
+      BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
     steps:
       - name: Set up PHP


### PR DESCRIPTION
Tests were run randomized in the same order in all cases, which could hide dependency issues between tests.
Changed so tests will randomize using the PR branch name instead of a static string. Like that the tests will stay in the same ordering for a given PR, but each PR has them ordered in another, random way, ensuring any problematic test dependencies will at least report eventually with subsequent PRs.