### PR TITLE
Fix static magic method pureness not being inherited from traits

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -566,12 +566,12 @@ final class AtomicStaticCallAnalyzer
                 true,
                 $context->insideUse(),
             )) {
-                $callstatic_appearing_id = $codebase->methods->getAppearingMethodId($callstatic_id);
-                assert($callstatic_appearing_id !== null);
+                $callstatic_declaring_id = $codebase->methods->getDeclaringMethodId($callstatic_id);
+                assert($callstatic_declaring_id !== null);
                 $callstatic_pure = false;
                 $callstatic_mutation_free = false;
-                if ($codebase->methods->hasStorage($callstatic_appearing_id)) {
-                    $callstatic_storage = $codebase->methods->getStorage($callstatic_appearing_id);
+                if ($codebase->methods->hasStorage($callstatic_declaring_id)) {
+                    $callstatic_storage = $codebase->methods->getStorage($callstatic_declaring_id);
                     $callstatic_pure = $callstatic_storage->pure;
                     $callstatic_mutation_free = $callstatic_storage->mutation_free;
                 }

--- a/tests/PureAnnotationTest.php
+++ b/tests/PureAnnotationTest.php
@@ -446,6 +446,81 @@ class PureAnnotationTest extends TestCase
                         return MyEnum::FOO();
                     }',
             ],
+            'pureThroughCallStaticInTrait' => [
+                'code' => '<?php
+                    /**
+                     * @method static static foo()
+                     */
+                    trait TestTrait {
+                        /** @psalm-pure */
+                        public static function __callStatic(string $name, array $params): static
+                        {
+                            throw new BadMethodCallException("not implemented");
+                        }
+                    }
+
+                    class Test {
+                        use TestTrait;
+                    }
+
+                    /** @psalm-pure */
+                    function gimmeFoo(): Test
+                    {
+                        return Test::foo();
+                    }',
+            ],
+            'pureThroughCallStaticInNestedTrait' => [
+                'code' => '<?php
+                    /**
+                     * @method static static foo()
+                     */
+                    trait InnerTestTrait {
+                        /** @psalm-pure */
+                        public static function __callStatic(string $name, array $params): static
+                        {
+                            throw new BadMethodCallException("not implemented");
+                        }
+                    }
+
+                    trait TestTrait {
+                        use InnerTestTrait;
+                    }
+
+                    class Test {
+                        use TestTrait;
+                    }
+
+                    /** @psalm-pure */
+                    function gimmeFoo(): Test
+                    {
+                        return Test::foo();
+                    }',
+            ],
+            'pureThroughAliasedCallStaticInTrait' => [
+                'code' => '<?php
+                    /**
+                     * @method static static foo()
+                     */
+                    trait TestTrait {
+                        /** @psalm-pure */
+                        public static function toBeCallStatic(string $name, array $params): static
+                        {
+                            throw new BadMethodCallException("not implemented");
+                        }
+                    }
+
+                    class Test {
+                        use TestTrait {
+                            TestTrait::toBeCallStatic as __callStatic;
+                        }
+                    }
+
+                    /** @psalm-pure */
+                    function gimmeFoo(): Test
+                    {
+                        return Test::foo();
+                    }',
+            ],
             'dontCrashWhileCheckingPurityOnCallStaticInATrait' => [
                 'code' => '<?php
                     /**


### PR DESCRIPTION
https://github.com/vimeo/psalm/pull/10385 "broke" this by propagating pseudo static methods from traits to using classes.
`AtomicStaticCallAnalyzer` was then not capable of dealing with this, because now these static pseudo methods actually exist.

As long as the methods from traits aren't actually transferred to the using class, it seems right that the logic in `AtomicStaticCallAnalyzer` uses `::getDeclaringMethodId()` instead of `::getAppearingMethodId()` for this purpose.