### PR TITLE
Fix return type of DOMXPath::query

### DIFF
--- a/stubs/extensions/dom.phpstub
+++ b/stubs/extensions/dom.phpstub
@@ -975,7 +975,7 @@ class DOMXPath
     public function evaluate(string $expression, ?DOMNode $contextNode = null, bool $registerNodeNS = true): mixed {}
 
     /**
-     * @return DOMNodeList<DOMNode>|false
+     * @return DOMNodeList<DOMNode|DOMNameSpaceNode>|false
      */
     public function query(string $expression, ?DOMNode $contextNode = null, bool $registerNodeNS = true): mixed {}
 


### PR DESCRIPTION
This can also return namespace nodes, which are not a child class of DOMNode.