### PR TITLE
Fix remaining POSIX-only absolute path detection

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -1315,7 +1315,7 @@ class Config
                 }
 
                 // we need an absolute path for checks
-                if ($path[0] !== '/' && DIRECTORY_SEPARATOR === '/') {
+                if (Path::isRelative($path)) {
                     $prospective_path = $base_dir . DIRECTORY_SEPARATOR . $path;
                 } else {
                     $prospective_path = $path;

--- a/src/Psalm/Config/FileFilter.php
+++ b/src/Psalm/Config/FileFilter.php
@@ -247,7 +247,7 @@ class FileFilter
             foreach ($config['file'] as $file) {
                 $file_path = (string) ($file['name'] ?? '');
 
-                if ($file_path[0] === '/' && DIRECTORY_SEPARATOR === '/') {
+                if (Path::isAbsolute($file_path)) {
                     /** @var non-empty-string */
                     $prospective_file_path = $file_path;
                 } else {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -20,6 +20,7 @@ use Psalm\Issue\UnresolvableInclude;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
 use Psalm\Type\TaintKind;
+use Symfony\Component\Filesystem\Path;
 
 use function constant;
 use function defined;
@@ -93,13 +94,7 @@ final class IncludeAnalyzer
             $include_path = self::resolveIncludePath($path_to_file, dirname($statements_analyzer->getFilePath()));
             $path_to_file = $include_path ?: $path_to_file;
 
-            if (DIRECTORY_SEPARATOR === '/') {
-                $is_path_relative = $path_to_file[0] !== DIRECTORY_SEPARATOR;
-            } else {
-                $is_path_relative = !preg_match('~^[A-Z]:\\\\~i', $path_to_file);
-            }
-
-            if ($is_path_relative) {
+            if (Path::isRelative($path_to_file)) {
                 $path_to_file = $config->base_dir . DIRECTORY_SEPARATOR . $path_to_file;
             }
         } else {
@@ -285,13 +280,7 @@ final class IncludeAnalyzer
         string $file_name,
         Config $config
     ): ?string {
-        if (DIRECTORY_SEPARATOR === '/') {
-            $is_path_relative = $file_name[0] !== DIRECTORY_SEPARATOR;
-        } else {
-            $is_path_relative = !preg_match('~^[A-Z]:\\\\~i', $file_name);
-        }
-
-        if ($is_path_relative) {
+        if (Path::isRelative($file_name)) {
             $file_name = $config->base_dir . DIRECTORY_SEPARATOR . $file_name;
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionScanner.php
@@ -20,13 +20,13 @@ use Psalm\Internal\Scanner\FileScanner;
 use Psalm\Storage\FileStorage;
 use Psalm\Storage\FunctionLikeStorage;
 use Psalm\Type;
+use Symfony\Component\Filesystem\Path;
 
 use function assert;
 use function defined;
 use function dirname;
 use function explode;
 use function in_array;
-use function preg_match;
 use function strpos;
 use function strtolower;
 use function substr;
@@ -316,13 +316,7 @@ final class ExpressionScanner
             $include_path = IncludeAnalyzer::resolveIncludePath($path_to_file, dirname($file_storage->file_path));
             $path_to_file = $include_path ?: $path_to_file;
 
-            if (DIRECTORY_SEPARATOR === '/') {
-                $is_path_relative = $path_to_file[0] !== DIRECTORY_SEPARATOR;
-            } else {
-                $is_path_relative = !preg_match('~^[A-Z]:\\\\~i', $path_to_file);
-            }
-
-            if ($is_path_relative) {
+            if (Path::isRelative($path_to_file)) {
                 $path_to_file = $config->base_dir . DIRECTORY_SEPARATOR . $path_to_file;
             }
         } else {


### PR DESCRIPTION
These were missed in #10441. Fixes "Could not resolve config path" error on Windows (#10418).

Hopefully this can be released soon since Psalm 5.17 always crashes in PhpStorm on Windows.