### PR TITLE
dont combine empty string with numeric-string

### DIFF
--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -1080,6 +1080,9 @@ final class TypeCombiner
 
                         if ($has_only_numeric_strings) {
                             $combination->value_types['string'] = $type;
+                        } elseif (count($combination->strings) === 1 && !$has_only_non_empty_strings) {
+                            $combination->value_types['string'] = $type;
+                            return;
                         } elseif ($has_only_non_empty_strings) {
                             $combination->value_types['string'] = new TNonEmptyString();
                         } else {

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -88,6 +88,38 @@ class TypeCombinationTest extends TestCase
                     }
                     ',
             ],
+            'emptyStringNumericStringDontCombine' => [
+                'code' => '<?php
+                    /**
+                     * @param numeric-string $arg
+                     * @return void
+                     */
+                    function takesNumeric($arg) {}
+
+                    $b = rand(0, 10);
+                    $a = $b < 5 ? "" : (string) $b;
+                    if ($a !== "") {
+                        takesNumeric($a);
+                    }
+
+                    /** @var ""|numeric-string $c */
+                    if (is_numeric($c)) {
+                        takesNumeric($c);
+                    }',
+            ],
+            'emptyStringNumericStringDontCombineNegation' => [
+                'code' => '<?php
+                    /**
+                     * @param ""|"hello" $arg
+                     * @return void
+                     */
+                    function takesLiteralString($arg) {}
+
+                    /** @var ""|numeric-string $c */
+                    if (!is_numeric($c)) {
+                        takesLiteralString($c);
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/6646

`''|numeric-string` shouldn't be combined as often it's useful for functions that accept numeric or when typecasting.