### PR TITLE
fix composer scripts running with inconsistent php versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -110,16 +110,16 @@
         "psalter"
     ],
     "scripts": {
-        "cs": "phpcs -ps",
-        "cs-fix": "phpcbf -ps",
-        "lint": "parallel-lint ./src ./tests",
+        "cs": "@php phpcs -ps",
+        "cs-fix": "@php phpcbf -ps",
+        "lint": "@php parallel-lint ./src ./tests",
         "phpunit": [
             "Composer\\Config::disableProcessTimeout",
-            "paratest --runner=WrapperRunner"
+            "@php paratest --runner=WrapperRunner"
         ],
         "phpunit-std": [
             "Composer\\Config::disableProcessTimeout",
-            "phpunit"
+            "@php phpunit"
         ],
         "verify-callmap": "@php phpunit tests/Internal/Codebase/InternalCallMapHandlerTest.php",
         "psalm": "@php ./psalm",


### PR DESCRIPTION
If composer is invoked with a specific php version, some of the scripts will run with that while others will use the default.

Fix this to ensure it will always use the php install used to invoke the script