### PR TITLE
Fix type not equal when parent

### DIFF
--- a/src/Psalm/Type/Atomic/TArray.php
+++ b/src/Psalm/Type/Atomic/TArray.php
@@ -84,7 +84,7 @@ class TArray extends Atomic
         }
 
         foreach ($this->type_params as $i => $type_param) {
-            if (!$type_param->equals($other_type->type_params[$i], $ensure_source_equality)) {
+            if (!$type_param->equals($other_type->type_params[$i], $ensure_source_equality, false)) {
                 return false;
             }
         }

--- a/src/Psalm/Type/Atomic/TClassStringMap.php
+++ b/src/Psalm/Type/Atomic/TClassStringMap.php
@@ -216,7 +216,7 @@ final class TClassStringMap extends Atomic
             return false;
         }
 
-        if (!$this->value_param->equals($other_type->value_param, $ensure_source_equality)) {
+        if (!$this->value_param->equals($other_type->value_param, $ensure_source_equality, false)) {
             return false;
         }
 

--- a/src/Psalm/Type/Atomic/TGenericObject.php
+++ b/src/Psalm/Type/Atomic/TGenericObject.php
@@ -111,7 +111,7 @@ final class TGenericObject extends TNamedObject
         }
 
         foreach ($this->type_params as $i => $type_param) {
-            if (!$type_param->equals($other_type->type_params[$i], $ensure_source_equality)) {
+            if (!$type_param->equals($other_type->type_params[$i], $ensure_source_equality, false)) {
                 return false;
             }
         }

--- a/src/Psalm/Type/Atomic/TIterable.php
+++ b/src/Psalm/Type/Atomic/TIterable.php
@@ -115,7 +115,7 @@ final class TIterable extends Atomic
         }
 
         foreach ($this->type_params as $i => $type_param) {
-            if (!$type_param->equals($other_type->type_params[$i], $ensure_source_equality)) {
+            if (!$type_param->equals($other_type->type_params[$i], $ensure_source_equality, false)) {
                 return false;
             }
         }

--- a/src/Psalm/Type/Atomic/TKeyedArray.php
+++ b/src/Psalm/Type/Atomic/TKeyedArray.php
@@ -658,11 +658,11 @@ class TKeyedArray extends Atomic
         }
 
         if ($this->fallback_params !== null && $other_type->fallback_params !== null) {
-            if (!$this->fallback_params[0]->equals($other_type->fallback_params[0])) {
+            if (!$this->fallback_params[0]->equals($other_type->fallback_params[0], false, false)) {
                 return false;
             }
 
-            if (!$this->fallback_params[1]->equals($other_type->fallback_params[1])) {
+            if (!$this->fallback_params[1]->equals($other_type->fallback_params[1], false, false)) {
                 return false;
             }
         }
@@ -672,7 +672,7 @@ class TKeyedArray extends Atomic
                 return false;
             }
 
-            if (!$property_type->equals($other_type->properties[$property_name], $ensure_source_equality)) {
+            if (!$property_type->equals($other_type->properties[$property_name], $ensure_source_equality, false)) {
                 return false;
             }
         }

--- a/src/Psalm/Type/Atomic/TList.php
+++ b/src/Psalm/Type/Atomic/TList.php
@@ -205,7 +205,7 @@ class TList extends Atomic
             return false;
         }
 
-        if (!$this->type_param->equals($other_type->type_param, $ensure_source_equality)) {
+        if (!$this->type_param->equals($other_type->type_param, $ensure_source_equality, false)) {
             return false;
         }
 

--- a/src/Psalm/Type/Atomic/TObjectWithProperties.php
+++ b/src/Psalm/Type/Atomic/TObjectWithProperties.php
@@ -207,7 +207,7 @@ final class TObjectWithProperties extends TObject
                 return false;
             }
 
-            if (!$property_type->equals($other_type->properties[$property_name], $ensure_source_equality)) {
+            if (!$property_type->equals($other_type->properties[$property_name], $ensure_source_equality, false)) {
                 return false;
             }
         }


### PR DESCRIPTION
parent nodes are only populated if taint/unused variable analysis is enabled

Partial, temporary fix for https://github.com/vimeo/psalm/issues/10478