### PR TITLE
report error for invalid array key type

### DIFF
--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1366,7 +1366,15 @@ class AnnotationTest extends TestCase
                     }',
                 'error_message' => 'MissingDocblockType',
             ],
-
+            'invalidArrayKeyType' => [
+                'code' => '<?php
+                    /**
+                     * @param array<float, string> $arg
+                     * @return void
+                     */
+                    function foo($arg) {}',
+                'error_message' => 'InvalidDocblock',
+            ],
             'invalidClassMethodReturnBrackets' => [
                 'code' => '<?php
                     class C {

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -37,13 +37,13 @@ class ArrayAssignmentTest extends TestCase
             'assignUnionOfLiterals' => [
                 'code' => '<?php
                     $result = [];
-                    
+
                     foreach (["a", "b"] as $k) {
                         $result[$k] = true;
                     }
-                    
+
                     $resultOpt = [];
-                    
+
                     foreach (["a", "b"] as $k) {
                         if (random_int(0, 1)) {
                             continue;
@@ -2492,7 +2492,8 @@ class ArrayAssignmentTest extends TestCase
                         return $weird_array[$offset];
                     }
                 }',
-                'error_message' => 'InvalidArrayOffset',
+                'error_message' => 'MixedArrayAccess',
+                'ignored_issues' => ['InvalidDocblock'],
             ],
             'unpackTypedIterableWithStringKeysIntoArray' => [
                 'code' => '<?php

--- a/tests/ArrayAssignmentTest.php
+++ b/tests/ArrayAssignmentTest.php
@@ -2115,6 +2115,29 @@ class ArrayAssignmentTest extends TestCase
                         return $queryParams;
                     }',
             ],
+            'stringIntKeys' => [
+                'code' => '<?php
+                    /**
+                     * @param array<15|"17"|"hello", string> $arg
+                     * @return bool
+                     */
+                    function foo($arg) {
+                        foreach ($arg as $k => $v) {
+                            if ( $k === 15 ) {
+                                return true;
+                            }
+
+                            if ( $k === 17 ) {
+                                return false;
+                            }
+                        }
+
+                        return true;
+                    }
+
+                    $x = ["15" => "a", 17 => "b"];
+                    foo($x);',
+            ],
         ];
     }
 

--- a/tests/ArrayKeysTest.php
+++ b/tests/ArrayKeysTest.php
@@ -97,6 +97,33 @@ class ArrayKeysTest extends TestCase
                     }
                 ',
             ],
+            'literalStringAsIntArrayKey' => [
+                'code' => '<?php
+                    class a {
+                        private const REDIRECTS = [
+                            "a" => [
+                                "from" => "79268724911",
+                                "to" => "74950235931",
+                            ],
+                            "b" => [
+                                "from" => "79313044964",
+                                "to" => "78124169167",
+                            ],
+                        ];
+
+                        private const SIP_FORMAT = "sip:%s@voip.test.com:9090";
+
+                        /** @return array<int, string> */
+                        public function test(): array {
+                            $redirects = [];
+                            foreach (self::REDIRECTS as $redirect) {
+                                $redirects[$redirect["from"]] = sprintf(self::SIP_FORMAT, $redirect["to"]);
+                            }
+
+                            return $redirects;
+                        }
+                    }',
+            ],
         ];
     }
 
@@ -124,6 +151,34 @@ class ArrayKeysTest extends TestCase
                         return array_keys(["foo" => 42, "bar" => 42]);
                     }
                 ',
+                'error_message' => 'InvalidReturnStatement',
+            ],
+            'literalStringAsIntArrayKey' => [
+                'code' => '<?php
+                    class a {
+                        private const REDIRECTS = [
+                            "a" => [
+                                "from" => "79268724911",
+                                "to" => "74950235931",
+                            ],
+                            "b" => [
+                                "from" => "79313044964",
+                                "to" => "78124169167",
+                            ],
+                        ];
+
+                        private const SIP_FORMAT = "sip:%s@voip.test.com:9090";
+
+                        /** @return array<string, string> */
+                        public function test(): array {
+                            $redirects = [];
+                            foreach (self::REDIRECTS as $redirect) {
+                                $redirects[$redirect["from"]] = sprintf(self::SIP_FORMAT, $redirect["to"]);
+                            }
+
+                            return $redirects;
+                        }
+                    }',
                 'error_message' => 'InvalidReturnStatement',
             ],
         ];

--- a/tests/KeyOfArrayTest.php
+++ b/tests/KeyOfArrayTest.php
@@ -86,11 +86,11 @@ class KeyOfArrayTest extends TestCase
             'keyOfUnionArrayLiteral' => [
                 'code' => '<?php
                     /**
-                     * @return key-of<array<int, string>|array<float, string>>
+                     * @return key-of<array<int, string>|array<string, string>>
                      */
-                    function getKey(bool $asFloat) {
-                        if ($asFloat) {
-                            return 42.0;
+                    function getKey(bool $asString) {
+                        if ($asString) {
+                            return "42";
                         }
                         return 42;
                     }
@@ -194,14 +194,14 @@ class KeyOfArrayTest extends TestCase
                 ',
                 'error_message' => 'InvalidReturnStatement',
             ],
-            'noStringAllowedInKeyOfIntFloatArray' => [
+            'noStringAllowedInKeyOfIntFloatStringArray' => [
                 'code' => '<?php
                     /**
-                     * @return key-of<array<int, string>|array<float, string>>
+                     * @return key-of<array<int, string>|array<"42.0", string>>
                      */
-                    function getKey(bool $asFloat) {
-                        if ($asFloat) {
-                            return 42.0;
+                    function getKey(bool $asInt) {
+                        if ($asInt) {
+                            return 42;
                         }
                         return "42";
                     }


### PR DESCRIPTION
- Add error for invalid array key types in docblock
- Fix [#8680](https://github.com/vimeo/psalm/issues/8680)
See also [#9295](https://github.com/vimeo/psalm/issues/9295)

