### PR TITLE
Fix Uncaught RuntimeException: PHP Error: Uninitialized string offset 0 when $pattern is empty

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -636,17 +636,19 @@ final class FunctionCallReturnTypeFetcher
                     $first_arg_value = $first_stmt_type->getSingleStringLiteral()->value;
 
                     $pattern = substr($first_arg_value, 1, -1);
+                    if (strlen(trim($pattern)) > 0) {
+                        $pattern = trim($pattern);
+                        if ($pattern[0] === '['
+                            && $pattern[1] === '^'
+                            && substr($pattern, -1) === ']'
+                        ) {
+                            $pattern = substr($pattern, 2, -1);
 
-                    if ($pattern[0] === '['
-                        && $pattern[1] === '^'
-                        && substr($pattern, -1) === ']'
-                    ) {
-                        $pattern = substr($pattern, 2, -1);
-
-                        if (self::simpleExclusion($pattern, $first_arg_value[0])) {
-                            $removed_taints[] = 'html';
-                            $removed_taints[] = 'has_quotes';
-                            $removed_taints[] = 'sql';
+                            if (self::simpleExclusion($pattern, $first_arg_value[0])) {
+                                $removed_taints[] = 'html';
+                                $removed_taints[] = 'has_quotes';
+                                $removed_taints[] = 'sql';
+                            }
                         }
                     }
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -51,6 +51,7 @@ use function strlen;
 use function strpos;
 use function strtolower;
 use function substr;
+use function trim;
 
 /**
  * @internal


### PR DESCRIPTION
When $pattern in src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php:638 was empty there were Uncaught RuntimeException: PHP Error: Uninitialized string offset 0. Added length check with result trimming.