### PR TITLE
Fix empty literal string becomes non-empty-string

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -258,6 +258,19 @@ final class ConcatAnalyzer
 
                 $has_numeric_and_non_empty = $has_numeric_type && $has_non_empty;
 
+                $non_falsy_string = $numeric_type->getBuilder()->addType(new TNonFalsyString())->freeze();
+                $left_non_falsy = UnionTypeComparator::isContainedBy(
+                    $codebase,
+                    $left_type,
+                    $non_falsy_string,
+                );
+
+                $right_non_falsy = UnionTypeComparator::isContainedBy(
+                    $codebase,
+                    $right_type,
+                    $non_falsy_string,
+                );
+
                 $all_literals = $left_type->allLiterals() && $right_type->allLiterals();
 
                 if ($has_non_empty) {
@@ -265,9 +278,10 @@ final class ConcatAnalyzer
                         $result_type = new Union([new TNonEmptyNonspecificLiteralString]);
                     } elseif ($all_lowercase) {
                         $result_type = Type::getNonEmptyLowercaseString();
+                    } elseif ($all_non_empty || $has_numeric_and_non_empty || $left_non_falsy || $right_non_falsy) {
+                        $result_type = Type::getNonFalsyString();
                     } else {
-                        $result_type = $all_non_empty || $has_numeric_and_non_empty ?
-                            Type::getNonFalsyString() : Type::getNonEmptyString();
+                        $result_type = Type::getNonEmptyString();
                     }
                 } else {
                     if ($all_literals) {

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -287,7 +287,7 @@ abstract class Type
         $type = $config->eventDispatcher->dispatchStringInterpreter($event);
 
         if (!$type) {
-            if (strlen($value) < $config->max_string_length) {
+            if ($value === '' || strlen($value) < $config->max_string_length) {
                 $type = new TLiteralString($value, $from_docblock);
             } else {
                 $type = new TNonEmptyString($from_docblock);

--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -277,7 +277,7 @@ abstract class Type
         return new Union([$value === null ? new TString() : self::getAtomicStringFromLiteral($value)]);
     }
 
-    /** @return TLiteralString|TNonEmptyString */
+    /** @return TLiteralString|TNonEmptyString|TNonFalsyString */
     public static function getAtomicStringFromLiteral(string $value, bool $from_docblock = false): TString
     {
         $config = Config::getInstance();
@@ -289,8 +289,10 @@ abstract class Type
         if (!$type) {
             if ($value === '' || strlen($value) < $config->max_string_length) {
                 $type = new TLiteralString($value, $from_docblock);
-            } else {
+            } elseif ($value === '0') {
                 $type = new TNonEmptyString($from_docblock);
+            } else {
+                $type = new TNonFalsyString($from_docblock);
             }
         }
 

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -357,6 +357,15 @@ class BinaryOperationTest extends TestCase
                 'code' => '<?php
                     $a = "Hey " . "Jude,";',
             ],
+            'concatenationNonFalsyLiteralStringWithString' => [
+                'code' => '<?php
+                    function foo(): string {}
+                    $a = "Hey " . foo();',
+                'assertions' => [
+                    '$a===' => 'non-falsy-string',
+                ],
+                'ignored_issues' => ['InvalidReturnType'],
+            ],
             'concatenationWithNumberInWeakMode' => [
                 'code' => '<?php
                     $a = "hi" . 5;',

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -120,6 +120,13 @@ class TypeCombinationTest extends TestCase
                         takesLiteralString($c);
                     }',
             ],
+            'tooLongLiteralShouldBeNonFalsyString' => [
+                'code' => '<?php
+                    $x = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";',
+                'assertions' => [
+                    '$x===' => 'non-falsy-string',
+                ]
+            ],
         ];
     }
 

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -125,7 +125,7 @@ class TypeCombinationTest extends TestCase
                     $x = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";',
                 'assertions' => [
                     '$x===' => 'non-falsy-string',
-                ]
+                ],
             ],
         ];
     }


### PR DESCRIPTION
- when max literal string length is 0, which means literal strings are disabled, an empty literal string suddenly became a non-empty-string
- change default fallback type to non-falsy-string, unless it's 0; see https://github.com/vimeo/psalm/issues/8075
-- this also fixes concat of literal non-falsy-string with generic string to stay non-falsy-string instead of becoming a non-empty-string https://psalm.dev/r/323e33ae8a