### PR TITLE
Reduce memory consumption of caching and parallel processing without igbinary

### DIFF
--- a/src/Psalm/Aliases.php
+++ b/src/Psalm/Aliases.php
@@ -2,8 +2,12 @@
 
 namespace Psalm;
 
+use Psalm\Storage\UnserializeMemoryUsageSuppressionTrait;
+
 final class Aliases
 {
+    use UnserializeMemoryUsageSuppressionTrait;
+
     /**
      * @var array<lowercase-string, string>
      */

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -100,6 +100,32 @@ class CodeLocation
     public const CATCH_VAR = 6;
     public const FUNCTION_PHPDOC_METHOD = 7;
 
+    private const PROPERTY_KEYS_FOR_UNSERIALIZE = [
+        'file_path' => 'file_path',
+        'file_name' => 'file_name',
+        'raw_line_number' => 'raw_line_number',
+        "\0" . self::class . "\0" . 'end_line_number' => 'end_line_number',
+        'raw_file_start' => 'raw_file_start',
+        'raw_file_end' => 'raw_file_end',
+        "\0*\0" . 'file_start' => 'file_start',
+        "\0*\0" . 'file_end' => 'file_end',
+        "\0*\0" . 'single_line' => 'single_line',
+        "\0*\0" . 'preview_start' => 'preview_start',
+        "\0" . self::class . "\0" . 'preview_end' => 'preview_end',
+        "\0" . self::class . "\0" . 'selection_start' => 'selection_start',
+        "\0" . self::class . "\0" . 'selection_end' => 'selection_end',
+        "\0" . self::class . "\0" . 'column_from' => 'column_from',
+        "\0" . self::class . "\0" . 'column_to' => 'column_to',
+        "\0" . self::class . "\0" . 'snippet' => 'snippet',
+        "\0" . self::class . "\0" . 'text' => 'text',
+        'docblock_start' => 'docblock_start',
+        "\0" . self::class . "\0" . 'docblock_start_line_number' => 'docblock_start_line_number',
+        "\0*\0" . 'docblock_line_number' => 'docblock_line_number',
+        "\0" . self::class . "\0" . 'regex_type' => 'regex_type',
+        "\0" . self::class . "\0" . 'have_recalculated' => 'have_recalculated',
+        'previous_location' => 'previous_location',
+    ];
+
     public function __construct(
         FileSource $file_source,
         PhpParser\Node $stmt,
@@ -134,6 +160,19 @@ class CodeLocation
         $this->raw_line_number = $stmt->getLine();
 
         $this->docblock_line_number = $comment_line;
+    }
+
+    /**
+     * Suppresses memory usage when unserializing objects.
+     *
+     * @see \Psalm\Storage\UnserializeMemoryUsageSuppressionTrait
+     */
+    public function __unserialize(array $properties): void
+    {
+        foreach (self::PROPERTY_KEYS_FOR_UNSERIALIZE as $key => $property_name) {
+            /** @psalm-suppress PossiblyUndefinedStringArrayOffset */
+            $this->$property_name = $properties[$key];
+        }
     }
 
     /**

--- a/src/Psalm/Internal/MethodIdentifier.php
+++ b/src/Psalm/Internal/MethodIdentifier.php
@@ -4,6 +4,7 @@ namespace Psalm\Internal;
 
 use InvalidArgumentException;
 use Psalm\Storage\ImmutableNonCloneableTrait;
+use Psalm\Storage\UnserializeMemoryUsageSuppressionTrait;
 
 use function explode;
 use function is_string;
@@ -18,6 +19,7 @@ use function strtolower;
 final class MethodIdentifier
 {
     use ImmutableNonCloneableTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
 
     public string $fq_class_name;
     /** @var lowercase-string  */

--- a/src/Psalm/Storage/Assertion.php
+++ b/src/Psalm/Storage/Assertion.php
@@ -10,6 +10,7 @@ use Psalm\Type\Atomic;
 abstract class Assertion
 {
     use ImmutableNonCloneableTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
 
     abstract public function getNegation(): Assertion;
 

--- a/src/Psalm/Storage/AttributeArg.php
+++ b/src/Psalm/Storage/AttributeArg.php
@@ -12,6 +12,7 @@ use Psalm\Type\Union;
 final class AttributeArg
 {
     use ImmutableNonCloneableTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
     /**
      * @var ?string
      * @psalm-suppress PossiblyUnusedProperty It's part of the public API for now

--- a/src/Psalm/Storage/AttributeStorage.php
+++ b/src/Psalm/Storage/AttributeStorage.php
@@ -10,6 +10,7 @@ use Psalm\CodeLocation;
 final class AttributeStorage
 {
     use ImmutableNonCloneableTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
     /**
      * @var string
      */

--- a/src/Psalm/Storage/ClassConstantStorage.php
+++ b/src/Psalm/Storage/ClassConstantStorage.php
@@ -19,6 +19,7 @@ final class ClassConstantStorage
     /** @psalm-suppress MutableDependency Mutable by design */
     use CustomMetadataTrait;
     use ImmutableNonCloneableTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
 
     public ?CodeLocation $type_location;
 

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -19,6 +19,7 @@ use function array_values;
 final class ClassLikeStorage implements HasAttributesInterface
 {
     use CustomMetadataTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
 
     /**
      * @var array<string, ClassConstantStorage>

--- a/src/Psalm/Storage/EnumCaseStorage.php
+++ b/src/Psalm/Storage/EnumCaseStorage.php
@@ -6,6 +6,8 @@ use Psalm\CodeLocation;
 
 final class EnumCaseStorage
 {
+    use UnserializeMemoryUsageSuppressionTrait;
+
     /**
      * @var int|string|null
      */

--- a/src/Psalm/Storage/FileStorage.php
+++ b/src/Psalm/Storage/FileStorage.php
@@ -10,6 +10,7 @@ use Psalm\Type\Union;
 final class FileStorage
 {
     use CustomMetadataTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
 
     /**
      * @var array<lowercase-string, string>

--- a/src/Psalm/Storage/FunctionLikeParameter.php
+++ b/src/Psalm/Storage/FunctionLikeParameter.php
@@ -12,6 +12,7 @@ use Psalm\Type\Union;
 final class FunctionLikeParameter implements HasAttributesInterface, TypeNode
 {
     use CustomMetadataTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
 
     /**
      * @var string

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -16,6 +16,7 @@ use function implode;
 abstract class FunctionLikeStorage implements HasAttributesInterface
 {
     use CustomMetadataTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
 
     /**
      * @var CodeLocation|null

--- a/src/Psalm/Storage/Possibilities.php
+++ b/src/Psalm/Storage/Possibilities.php
@@ -12,6 +12,8 @@ use function str_replace;
 
 final class Possibilities
 {
+    use UnserializeMemoryUsageSuppressionTrait;
+
     /**
      * @var list<Assertion> the rule being asserted
      */

--- a/src/Psalm/Storage/PropertyStorage.php
+++ b/src/Psalm/Storage/PropertyStorage.php
@@ -9,6 +9,7 @@ use Psalm\Type\Union;
 final class PropertyStorage implements HasAttributesInterface
 {
     use CustomMetadataTrait;
+    use UnserializeMemoryUsageSuppressionTrait;
 
     /**
      * @var ?bool

--- a/src/Psalm/Storage/UnserializeMemoryUsageSuppressionTrait.php
+++ b/src/Psalm/Storage/UnserializeMemoryUsageSuppressionTrait.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Psalm\Storage;
+
+/**
+ * Suppresses memory usage when unserializing objects.
+ *
+ * Workaround for the problem that objects retrieved with `\unserialize()`
+ * build unnecessary dynamic property tables, resulting in larger memory
+ * consumption.
+ *
+ * @see https://github.com/php/php-src/issues/10126
+ * @psalm-immutable
+ */
+trait UnserializeMemoryUsageSuppressionTrait
+{
+    public function __unserialize(array $properties): void
+    {
+        /** @psalm-suppress MixedAssignment */
+        foreach ($properties as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+}

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -11,6 +11,7 @@ use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Internal\Type\TypeAlias;
 use Psalm\Internal\Type\TypeAlias\LinkableTypeAlias;
 use Psalm\Internal\TypeVisitor\ClasslikeReplacer;
+use Psalm\Storage\UnserializeMemoryUsageSuppressionTrait;
 use Psalm\Type;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TArrayKey;
@@ -82,6 +83,8 @@ use function strtolower;
  */
 abstract class Atomic implements TypeNode
 {
+    use UnserializeMemoryUsageSuppressionTrait;
+
     public function __construct(bool $from_docblock = false)
     {
         $this->from_docblock = $from_docblock;

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -233,6 +233,52 @@ final class Union implements TypeNode
      */
     public $different = false;
 
+    private const PROPERTY_KEYS_FOR_UNSERIALIZE = [
+        "\0" . self::class . "\0" . 'types' => 'types',
+        'from_docblock' => 'from_docblock',
+        'from_calculation' => 'from_calculation',
+        'from_property' => 'from_property',
+        'from_static_property' => 'from_static_property',
+        'initialized' => 'initialized',
+        'initialized_class' => 'initialized_class',
+        'checked' => 'checked',
+        'failed_reconciliation' => 'failed_reconciliation',
+        'ignore_nullable_issues' => 'ignore_nullable_issues',
+        'ignore_falsable_issues' => 'ignore_falsable_issues',
+        'ignore_isset' => 'ignore_isset',
+        'possibly_undefined' => 'possibly_undefined',
+        'possibly_undefined_from_try' => 'possibly_undefined_from_try',
+        'explicit_never' => 'explicit_never',
+        'had_template' => 'had_template',
+        'from_template_default' => 'from_template_default',
+        "\0" . self::class . "\0" . 'literal_string_types' => 'literal_string_types',
+        "\0" . self::class . "\0" . 'typed_class_strings' => 'typed_class_strings',
+        "\0" . self::class . "\0" . 'literal_int_types' => 'literal_int_types',
+        "\0" . self::class . "\0" . 'literal_float_types' => 'literal_float_types',
+        'by_ref' => 'by_ref',
+        'reference_free' => 'reference_free',
+        'allow_mutations' => 'allow_mutations',
+        'has_mutations' => 'has_mutations',
+        "\0" . self::class . "\0" . 'id' => 'id',
+        "\0" . self::class . "\0" . 'exact_id' => 'exact_id',
+        'parent_nodes' => 'parent_nodes',
+        'propagate_parent_nodes' => 'propagate_parent_nodes',
+        'different' => 'different',
+    ];
+
+    /**
+     * Suppresses memory usage when unserializing objects.
+     *
+     * @see \Psalm\Storage\UnserializeMemoryUsageSuppressionTrait
+     */
+    public function __unserialize(array $properties): void
+    {
+        foreach (self::PROPERTY_KEYS_FOR_UNSERIALIZE as $key => $property_name) {
+            /** @psalm-suppress PossiblyUndefinedStringArrayOffset */
+            $this->$property_name = $properties[$key];
+        }
+    }
+
     /**
      * @param TProperties $properties
      * @return static


### PR DESCRIPTION
This fix reduces the memory consumption of caching and parallel processing with default serialization.

See https://github.com/vimeo/psalm/issues/10522#issuecomment-1881729504 for more detail.

With this fix, the test script in the above issue can be analyzed with 3GB memory_limit, doesn't hit 5GB or 8GB memory consumption per process.

```
./vendor/bin/psalm --memory-limit=3G test.php
```