### PR TITLE
Implement __set method in SimpleXMLElement stub

### DIFF
--- a/stubs/extensions/simplexml.phpstub
+++ b/stubs/extensions/simplexml.phpstub
@@ -66,6 +66,8 @@ class SimpleXMLElement implements Traversable, Countable
     public function count(): int {}
 
     public function __get(string $name): SimpleXMLElement|SimpleXMLIterator|null {}
+
+    public function __set(string $name, $value): void {}
 }
 
 /**

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -3825,22 +3825,6 @@ class PropertyTypeTest extends TestCase
                 ',
                 'error_message' => 'UndefinedPropertyAssignment',
             ],
-            'setPropertiesOfSimpleXMLElement1' => [
-                'code' => '<?php
-                    $a = new SimpleXMLElement("<person><child role=\"son\"></child></person>");
-                    $a->b = "c";
-                ',
-                'error_message' => 'UndefinedPropertyAssignment',
-            ],
-            'setPropertiesOfSimpleXMLElement2' => [
-                'code' => '<?php
-                    $a = new SimpleXMLElement("<person><child role=\"son\"></child></person>");
-                    if (isset($a->b)) {
-                        $a->b = "c";
-                    }
-                ',
-                'error_message' => 'UndefinedPropertyAssignment',
-            ],
         ];
     }
 }


### PR DESCRIPTION
Adds the magic `__set` method to the SimpleXMLElement class in the simplexml stub to handle property assignments.

Closes https://github.com/vimeo/psalm/issues/10535