### PR TITLE
Unit test improvements for php-parser 5

### DIFF
--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -464,7 +464,9 @@ class ClassTest extends TestCase
             ],
             'classAliasNoException' => [
                 'code' => '<?php
-                    class_alias("Bar\F1", "Bar\F2");
+                    namespace {
+                        class_alias("Bar\F1", "Bar\F2");
+                    }
 
                     namespace Bar {
                         class F1 {

--- a/tests/FileUpdates/TemporaryUpdateTest.php
+++ b/tests/FileUpdates/TemporaryUpdateTest.php
@@ -603,7 +603,7 @@ class TemporaryUpdateTest extends TestCase
 
                             class A {
                                 public function foo() : void {
-                                    throw new Error("bad", 5);
+                                    throw new Error("bad", []);
                                 }
                             }',
                     ],
@@ -613,7 +613,7 @@ class TemporaryUpdateTest extends TestCase
 
                             class A {
                                 public function foo() : void {
-                                    throw new Error("bad", 5);
+                                    throw new Error("bad", []);
                                 }
                             }',
                     ],
@@ -657,7 +657,7 @@ class TemporaryUpdateTest extends TestCase
 
                             class A {
                                 public function foo() : void {
-                                    throw new E("bad", 5);
+                                    throw new E("bad", []);
                                 }
                             }',
                     ],
@@ -667,7 +667,7 @@ class TemporaryUpdateTest extends TestCase
 
                             class A {
                                 public function foo() : void {
-                                    throw new E("bad", 5);
+                                    throw new E("bad", []);
                                 }
                             }',
                     ],
@@ -707,7 +707,7 @@ class TemporaryUpdateTest extends TestCase
 
                             class A {
                                 public function foo() : void {
-                                    throw new Error("bad", 5);
+                                    throw new Error("bad", []);
                                 }
                             }',
                     ],
@@ -717,7 +717,7 @@ class TemporaryUpdateTest extends TestCase
 
                             class A {
                                 public function foo() : void {
-                                    throw new Error("bad", 5);
+                                    throw new Error("bad", []);
                                 }
                             }',
                     ],
@@ -755,7 +755,7 @@ class TemporaryUpdateTest extends TestCase
 
                             class A {
                                 public function foo() : void {
-                                    throw new E("bad", 5);
+                                    throw new E("bad", []);
                                 }
                             }',
                     ],
@@ -765,7 +765,7 @@ class TemporaryUpdateTest extends TestCase
 
                             class A {
                                 public function foo() : void {
-                                    throw new E("bad", 5);
+                                    throw new E("bad", []);
                                 }
                             }',
                     ],

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -1166,7 +1166,7 @@ class PropertyTypeTest extends TestCase
                          * Constructs a finally node.
                          *
                          * @param list<Node\Stmt> $stmts      Statements
-                         * @param array  $attributes Additional attributes
+                         * @param array<string, mixed>  $attributes Additional attributes
                          */
                         public function __construct(array $stmts = array(), array $attributes = array()) {
                             parent::__construct($attributes);


### PR DESCRIPTION
These are some unit test fixes extracted from #10567 that are compatible with php-parser 4.0 and the 5.x Psalm branch. Extracting them reduces the size of the upgrade PR and creates fewer potential merge conflicts.