### PR TITLE
Allow specifying a custom default template type

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/MethodCallAnalyzer.php
@@ -30,11 +30,13 @@ use Psalm\Issue\UndefinedMagicMethod;
 use Psalm\Issue\UndefinedMethod;
 use Psalm\IssueBuffer;
 use Psalm\Type;
+use Psalm\Type\Atomic\TConditional;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TObject;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\Union;
 
+use function array_merge;
 use function array_reduce;
 use function count;
 use function is_string;
@@ -176,6 +178,17 @@ final class MethodCallAnalyzer extends CallAnalyzer
         }
 
         $lhs_types = $class_type->getAtomicTypes();
+
+        foreach ($lhs_types as $k => $lhs_type_part) {
+            if ($lhs_type_part instanceof TConditional) {
+                $lhs_types = array_merge(
+                    $lhs_types,
+                    $lhs_type_part->if_type->getAtomicTypes(),
+                    $lhs_type_part->else_type->getAtomicTypes(),
+                );
+                unset($lhs_types[$k]);
+            }
+        }
 
         $result = new AtomicMethodCallAnalysisResult();
 
@@ -400,7 +413,7 @@ final class MethodCallAnalyzer extends CallAnalyzer
             $types = $class_type->getAtomicTypes();
 
             foreach ($types as $key => &$type) {
-                if (!$type instanceof TNamedObject && !$type instanceof TObject) {
+                if (!$type instanceof TNamedObject && !$type instanceof TObject && !$type instanceof TConditional) {
                     unset($types[$key]);
                 } else {
                     $type = $type->setFromDocblock(false);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -492,8 +492,8 @@ final class NewAnalyzer extends CallAnalyzer
 
             $generic_param_types = null;
 
-            if ($storage->template_types) {
-                foreach ($storage->template_types as $template_name => $base_type) {
+            if ($storage->default_template_types) {
+                foreach ($storage->default_template_types as $template_name => $base_type) {
                     if (isset($template_result->lower_bounds[$template_name][$fq_class_name])) {
                         $generic_param_type = TemplateStandinTypeReplacer::getMostSpecificTypeFromBounds(
                             $template_result->lower_bounds[$template_name][$fq_class_name],
@@ -517,11 +517,7 @@ final class NewAnalyzer extends CallAnalyzer
                             ),
                         );
                     } else {
-                        if ($fq_class_name === 'SplObjectStorage') {
-                            $generic_param_type = Type::getNever();
-                        } else {
-                            $generic_param_type = array_values($base_type)[0];
-                        }
+                        $generic_param_type = array_values($base_type)[0];
                     }
 
                     $generic_param_types[] = $generic_param_type->setProperties([
@@ -552,13 +548,13 @@ final class NewAnalyzer extends CallAnalyzer
                 ),
                 $statements_analyzer->getSuppressedIssues(),
             );
-        } elseif ($storage->template_types) {
+        } elseif ($storage->default_template_types) {
             $result_atomic_type = new TGenericObject(
                 $fq_class_name,
                 array_values(
                     array_map(
                         static fn($map) => reset($map),
-                        $storage->template_types,
+                        $storage->default_template_types,
                     ),
                 ),
                 false,

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -275,6 +275,17 @@ final class ClassLikeStorage implements HasAttributesInterface
     public ?array $template_types = null;
 
     /**
+     * An array holding the class template default types.
+     *
+     * The name of the template is the first key. The nested array is keyed by the defining class
+     * (i.e. the same as the class name). This allows operations with the same-named template defined
+     * across multiple classes to not run into trouble.
+     *
+     * @var array<string, non-empty-array<string, Union>>|null
+     */
+    public $default_template_types;
+
+    /**
      * @var array<int, bool>|null
      */
     public ?array $template_covariants = null;

--- a/stubs/SPL.phpstub
+++ b/stubs/SPL.phpstub
@@ -735,8 +735,8 @@ class SplPriorityQueue implements Iterator, Countable {
  * cases involving the need to uniquely identify objects.
  * @link https://php.net/manual/en/class.splobjectstorage.php
  *
- * @template TObject as object
- * @template TArrayValue
+ * @template TObject as object = never
+ * @template TArrayValue as mixed = never
  * @template-implements ArrayAccess<TObject, TArrayValue>
  * @template-implements Iterator<int, TObject>
  */

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -1232,6 +1232,27 @@ class MethodCallTest extends TestCase
                     $x = new Foo();
                     $x->bar($x);',
             ],
+            'conditional' => [
+                'code' => '<?php
+
+                    class Old {
+                        public function x(): void {}
+                    }
+                    class Child1 extends Old {}
+                    class Child2 extends Old {}
+                    
+                    /**
+                     * @template IsClient of bool
+                     */
+                    class A {
+                        /**
+                         * @psalm-param (IsClient is true ? Child1 : Child2) $var
+                         */
+                        public function test(Old $var): void {
+                            $var->x();
+                        }
+                    }',
+            ],
         ];
     }
 

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -4211,6 +4211,28 @@ class ClassTemplateTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'defaultTemplateType' => [
+                'code' => '<?php
+                    /**
+                     * @template T as mixed = never
+                     */
+                    class a {
+                        public function __construct() {}
+                    }
+                    
+                    $a = new a;',
+                'assertions' => [
+                    '$a===' => 'a<never>',
+                ],
+            ],
+            'initializeSplObjectStorage' => [
+                'code' => '<?php
+                    $a = new SplObjectStorage();
+                ',
+                'assertions' => [
+                    '$a===' => 'SplObjectStorage<never, never>',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
This is the first step in my plan to fix https://github.com/vimeo/psalm/issues/9838.

First of all, the default template types all SPL datastructures will be changed to `never`; then, a new `@satisfies` assertion will be introduced to avoid the (ab)use of `@var`.

The semantics of `@satisfies` will be entirely similar to typescript's [satisfies operator](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-9.html), and will allow, among other things, typechecked call-site specification of template parameters.  

Here's a few examples of how I generally plan `@satifies` to work (and how the SPL stubs will be tweaked), I'm open to suggestions:

- https://psalm.dev/r/fcc7e48e65
- https://psalm.dev/r/59402fff1a