### PR TITLE
Switch condition order

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/EncapsulatedStringAnalyzer.php
@@ -46,9 +46,12 @@ final class EncapsulatedStringAnalyzer
                 return false;
             }
 
-            $part_type = $statements_analyzer->node_data->getType($part);
-
-            if ($part_type !== null) {
+            if ($part instanceof EncapsedStringPart) {
+                if ($literal_string !== null) {
+                    $literal_string .= $part->value;
+                }
+                $non_empty = $non_empty || $part->value !== "";
+            } elseif ($part_type = $statements_analyzer->node_data->getType($part)) {
                 $casted_part_type = CastAnalyzer::castStringAttempt(
                     $statements_analyzer,
                     $context,
@@ -110,11 +113,6 @@ final class EncapsulatedStringAnalyzer
                         }
                     }
                 }
-            } elseif ($part instanceof EncapsedStringPart) {
-                if ($literal_string !== null) {
-                    $literal_string .= $part->value;
-                }
-                $non_empty = $non_empty || $part->value !== "";
             } else {
                 $all_literals = false;
                 $literal_string = null;


### PR DESCRIPTION
This change is for forward-compatibility with `nikic/php-parser` 5.0, where `InterpolatedStringPart` (née `EncapsedStringPart`) is no longer considered an expression. Thus we can't pass it to `NodeTypeProvider::getType()` anymore. Since that call returns `null` anyway, we can swap the condition order. Everything still works and Psalm type-checking is happy.

This also might be a tiny performance improvement since it lets the common, cheap `instanceof` check come before a method call, but I haven't actually benchmarked it.

I've extracted this change from #10567 to reduce the size of the diff, reduce merge conflicts, and make review easier. I will rebase that PR once this is merged and the 5.x branch is merged to master.