### PR TITLE
`key_exists()` is an alias for `array_key_exists()`

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -2055,7 +2055,9 @@ final class AssertionFinder
 
     protected static function hasArrayKeyExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
-        return $stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->getFirst()) === 'array_key_exists';
+        return $stmt->name instanceof PhpParser\Node\Name
+            && (strtolower($stmt->name->getFirst()) === 'array_key_exists'
+                || strtolower($stmt->name->getFirst()) === 'key_exists');
     }
 
     /**

--- a/tests/TypeReconciliation/ArrayKeyExistsTest.php
+++ b/tests/TypeReconciliation/ArrayKeyExistsTest.php
@@ -507,6 +507,19 @@ class ArrayKeyExistsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'keyExistsAsAliasForArrayKeyExists' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @param array<string, string> $arr
+                     */
+                    function foo(array $arr): void {
+                        if (key_exists("a", $arr)) {
+                            echo $arr["a"];
+                        }
+                    }
+                PHP,
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes vimeo/psalm#10346
