### PR TITLE
Fix unstable `hasFullyQualified(Interface|Enum)()`

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -2406,7 +2406,6 @@ final class Codebase
 
     /**
      * @param array<string, mixed> $phantom_classes
-     * @psalm-suppress PossiblyUnusedMethod part of the public API
      */
     public function queueClassLikeForScanning(
         string $fq_classlike_name,

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -356,6 +356,7 @@ final class ClassLikes
             }
         }
 
+        // fixme: this looks like a crazy caching hack
         if (!isset($this->existing_classes_lc[$fq_class_name_lc])
             || !$this->existing_classes_lc[$fq_class_name_lc]
             || !$this->classlike_storage_provider->has($fq_class_name_lc)
@@ -396,13 +397,14 @@ final class ClassLikes
     ): bool {
         $fq_class_name_lc = strtolower($this->getUnAliasedName($fq_class_name));
 
+        // fixme: this looks like a crazy caching hack
         if (!isset($this->existing_interfaces_lc[$fq_class_name_lc])
             || !$this->existing_interfaces_lc[$fq_class_name_lc]
             || !$this->classlike_storage_provider->has($fq_class_name_lc)
         ) {
             if ((
-                !isset($this->existing_classes_lc[$fq_class_name_lc])
-                    || $this->existing_classes_lc[$fq_class_name_lc]
+                !isset($this->existing_interfaces_lc[$fq_class_name_lc])
+                    || $this->existing_interfaces_lc[$fq_class_name_lc]
                 )
                 && !$this->classlike_storage_provider->has($fq_class_name_lc)
             ) {
@@ -463,13 +465,14 @@ final class ClassLikes
     ): bool {
         $fq_class_name_lc = strtolower($this->getUnAliasedName($fq_class_name));
 
+        // fixme: this looks like a crazy caching hack
         if (!isset($this->existing_enums_lc[$fq_class_name_lc])
             || !$this->existing_enums_lc[$fq_class_name_lc]
             || !$this->classlike_storage_provider->has($fq_class_name_lc)
         ) {
             if ((
-                !isset($this->existing_classes_lc[$fq_class_name_lc])
-                    || $this->existing_classes_lc[$fq_class_name_lc]
+                !isset($this->existing_enums_lc[$fq_class_name_lc])
+                    || $this->existing_enums_lc[$fq_class_name_lc]
                 )
                 && !$this->classlike_storage_provider->has($fq_class_name_lc)
             ) {

--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -26,9 +26,11 @@ use ReflectionType;
 use function array_shift;
 use function class_exists;
 use function count;
+use function enum_exists;
 use function explode;
 use function function_exists;
 use function in_array;
+use function interface_exists;
 use function is_array;
 use function is_int;
 use function json_encode;
@@ -631,6 +633,8 @@ class InternalCallMapHandlerTest extends TestCase
         } catch (InvalidArgumentException $e) {
             if (preg_match('/^Could not get class storage for (.*)$/', $e->getMessage(), $matches)
                 && !class_exists($matches[1])
+                && !interface_exists($matches[1])
+                && !enum_exists($matches[1])
             ) {
                 $this->fail("Class used in CallMap does not exist: {$matches[1]}");
             }

--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -142,7 +142,6 @@ class InternalCallMapHandlerTest extends TestCase
         'oci_result',
         'ocigetbufferinglob',
         'ocisetbufferinglob',
-        'recursiveiteratoriterator::__construct', // Class used in CallMap does not exist: recursiveiterator
         'sqlsrv_fetch_array',
         'sqlsrv_fetch_object',
         'sqlsrv_get_field',

--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -174,7 +174,6 @@ class InternalCallMapHandlerTest extends TestCase
     private static array $ignoredReturnTypeOnlyFunctions = [
         'appenditerator::getinneriterator' => ['8.1', '8.2', '8.3'],
         'appenditerator::getiteratorindex' => ['8.1', '8.2', '8.3'],
-        'arrayobject::getiterator' => ['8.1', '8.2', '8.3'],
         'cachingiterator::getinneriterator' => ['8.1', '8.2', '8.3'],
         'callbackfilteriterator::getinneriterator' => ['8.1', '8.2', '8.3'],
         'curl_multi_getcontent',

--- a/tests/TypeReconciliation/ReconcilerTest.php
+++ b/tests/TypeReconciliation/ReconcilerTest.php
@@ -61,6 +61,7 @@ class ReconcilerTest extends TestCase
             class B {}
             interface SomeInterface {}
         ');
+        $this->project_analyzer->getCodebase()->queueClassLikeForScanning('Countable');
         $this->project_analyzer->getCodebase()->scanFiles();
     }
 


### PR DESCRIPTION
Before this change, calling:
```php
$classlikes->hasFullyQualifiedInterfaceName($i); // true
$classlikes->hasFullyQualifiedClassName($i); // false
$classlikes->hasFullyQualifiedInterfaceName($i); // false
```
would result in the last call returning `false`
