### PR TITLE
Fix ElseIfAnalyzer inconsistency and remove dead code

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseIfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/ElseIfAnalyzer.php
@@ -92,6 +92,10 @@ final class ElseIfAnalyzer
             $codebase,
         );
 
+        if (count($elseif_clauses) > 200) {
+            $elseif_clauses = [];
+        }
+
         $elseif_clauses_handled = [];
 
         foreach ($elseif_clauses as $clause) {
@@ -101,7 +105,7 @@ final class ElseIfAnalyzer
             foreach ($keys as $key) {
                 foreach ($mixed_var_ids as $mixed_var_id) {
                     if (preg_match('/^' . preg_quote($mixed_var_id, '/') . '(\[|-)/', $key)) {
-                        $elseif_clauses_handled[] = new Clause([], $elseif_cond_id, $elseif_cond_id, true);
+                        $clause = new Clause([], $elseif_cond_id, $elseif_cond_id, true);
                         break 2;
                     }
                 }
@@ -118,7 +122,7 @@ final class ElseIfAnalyzer
             foreach ($c->possibilities as $key => $_value) {
                 foreach ($assigned_in_conditional_var_ids as $conditional_assigned_var_id => $_) {
                     if (preg_match('/^'.preg_quote($conditional_assigned_var_id, '/').'(\[|-|$)/', $key)) {
-                        $entry_clauses[] =  new Clause([], $elseif_cond_id, $elseif_cond_id, true);
+                        $c =  new Clause([], $elseif_cond_id, $elseif_cond_id, true);
                         break 2;
                     }
                 }
@@ -136,20 +140,22 @@ final class ElseIfAnalyzer
             $assigned_in_conditional_var_ids,
         );
 
-        $elseif_context_clauses = [...$entry_clauses, ...$elseif_clauses];
+        $elseif_clauses = Algebra::simplifyCNF($elseif_clauses);
+
+        $elseif_context->clauses = $entry_clauses
+            ? Algebra::simplifyCNF([...$entry_clauses, ...$elseif_clauses])
+            : $elseif_clauses;
 
         if ($elseif_context->reconciled_expression_clauses) {
             $reconciled_expression_clauses = $elseif_context->reconciled_expression_clauses;
 
-            $elseif_context_clauses = array_values(
+            $elseif_context->clauses = array_values(
                 array_filter(
-                    $elseif_context_clauses,
+                    $elseif_context->clauses,
                     static fn(Clause $c): bool => !in_array($c->hash, $reconciled_expression_clauses, true)
                 ),
             );
         }
-
-        $elseif_context->clauses = Algebra::simplifyCNF($elseif_context_clauses);
 
         $active_elseif_types = [];
 

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
@@ -167,12 +167,12 @@ final class IfAnalyzer
             $outer_context->removeVarFromConflictingClauses($var_id);
         }
 
-        $if_scope->if_actions = $final_actions = ScopeAnalyzer::getControlActions(
+        $final_actions = ScopeAnalyzer::getControlActions(
             $stmt->stmts,
             $statements_analyzer->node_data,
             [],
         );
-
+        // has a return/throw at end
         $has_ending_statements = $final_actions === [ScopeAnalyzer::ACTION_END];
 
         $has_leaving_statements = $has_ending_statements

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
@@ -94,6 +94,8 @@ final class IfElseAnalyzer
             }
         }
 
+        $branch_point = $context->branch_point ?: (int) $stmt->getAttribute('startFilePos');
+
         try {
             $if_conditional_scope = IfConditionalAnalyzer::analyze(
                 $statements_analyzer,
@@ -101,7 +103,7 @@ final class IfElseAnalyzer
                 $context,
                 $codebase,
                 $if_scope,
-                $context->branch_point ?: (int) $stmt->getAttribute('startFilePos'),
+                $branch_point,
             );
 
             // this is the context for stuff that happens within the `if` block
@@ -140,7 +142,6 @@ final class IfElseAnalyzer
         $if_clauses_handled = [];
         foreach ($if_clauses as $clause) {
             $keys = array_keys($clause->possibilities);
-
             $mixed_var_ids = array_diff($mixed_var_ids, $keys);
 
             foreach ($keys as $key) {
@@ -161,7 +162,7 @@ final class IfElseAnalyzer
 
         // this will see whether any of the clauses in set A conflict with the clauses in set B
         AlgebraAnalyzer::checkForParadox(
-            $context->clauses,
+            $entry_clauses,
             $if_clauses,
             $statements_analyzer,
             $stmt->cond,
@@ -170,11 +171,9 @@ final class IfElseAnalyzer
 
         $if_clauses = Algebra::simplifyCNF($if_clauses);
 
-        $if_context_clauses = [...$entry_clauses, ...$if_clauses];
-
         $if_context->clauses = $entry_clauses
-            ? Algebra::simplifyCNF($if_context_clauses)
-            : $if_context_clauses;
+            ? Algebra::simplifyCNF([...$entry_clauses, ...$if_clauses])
+            : $if_clauses;
 
         if ($if_context->reconciled_expression_clauses) {
             $reconciled_expression_clauses = $if_context->reconciled_expression_clauses;
@@ -182,7 +181,7 @@ final class IfElseAnalyzer
             $if_context->clauses = array_values(
                 array_filter(
                     $if_context->clauses,
-                    static fn(Clause $c): bool => !in_array($c->hash, $reconciled_expression_clauses)
+                    static fn(Clause $c): bool => !in_array($c->hash, $reconciled_expression_clauses, true)
                 ),
             );
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/ArrayAssignmentAnalyzer.php
@@ -572,8 +572,6 @@ final class ArrayAssignmentAnalyzer
 
         $from_countable_object_like = false;
 
-        $new_child_type = null;
-
         $array_atomic_type = null;
         if (!$current_dim && !$context->inside_loop) {
             $atomic_root_types = $root_type->getAtomicTypes();
@@ -638,11 +636,6 @@ final class ArrayAssignmentAnalyzer
                             $array_atomic_type_array,
                             count($atomic_root_type_array->properties),
                         );
-                    } elseif ($atomic_root_type_array->is_list) {
-                        $array_atomic_type = $atomic_root_type_array;
-                        $new_child_type = new Union([$array_atomic_type], [
-                            'parent_nodes' => $root_type->parent_nodes,
-                        ]);
                     } else {
                         assert($array_atomic_type_list !== null);
                         $array_atomic_type = array_fill(
@@ -685,18 +678,16 @@ final class ArrayAssignmentAnalyzer
 
         $array_assignment_type = new Union([$array_atomic_type]);
 
-        if (!$new_child_type) {
-            if ($templated_assignment) {
-                $new_child_type = $root_type;
-            } else {
-                $new_child_type = Type::combineUnionTypes(
-                    $root_type,
-                    $array_assignment_type,
-                    $codebase,
-                    true,
-                    true,
-                );
-            }
+        if ($templated_assignment) {
+            $new_child_type = $root_type;
+        } else {
+            $new_child_type = Type::combineUnionTypes(
+                $root_type,
+                $array_assignment_type,
+                $codebase,
+                true,
+                true,
+            );
         }
 
         if ($from_countable_object_like) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/TernaryAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/TernaryAnalyzer.php
@@ -120,7 +120,7 @@ final class TernaryAnalyzer
 
         // this will see whether any of the clauses in set A conflict with the clauses in set B
         AlgebraAnalyzer::checkForParadox(
-            $context->clauses,
+            $entry_clauses,
             $if_clauses,
             $statements_analyzer,
             $stmt->cond,
@@ -139,7 +139,7 @@ final class TernaryAnalyzer
             $ternary_context_clauses = array_values(
                 array_filter(
                     $ternary_context_clauses,
-                    static fn(Clause $c): bool => !in_array($c->hash, $reconciled_expression_clauses)
+                    static fn(Clause $c): bool => !in_array($c->hash, $reconciled_expression_clauses, true)
                 ),
             );
 


### PR DESCRIPTION
Changing `ElseIfAnalyzer` to match the corresponding code in `IfElseAnalyzer` found a dead code branch in `ArrayAssignmentAnalyzer`.