### PR TITLE
Re-work CheckTrivialExprVisitor

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
@@ -65,7 +65,7 @@ final class UnusedAssignmentRemover
                 $traverser->addVisitor($visitor);
                 $traverser->traverse([$rhs_exp]);
 
-                $rhs_exp_trivial = (count($visitor->getNonTrivialExpr()) === 0);
+                $rhs_exp_trivial = !$visitor->hasNonTrivialExpr();
 
                 if ($rhs_exp_trivial) {
                     $treat_as_expr = false;

--- a/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
@@ -9,10 +9,7 @@ use PhpParser;
  */
 final class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract
 {
-    /**
-     * @var array<int, PhpParser\Node\Expr>
-     */
-    protected array $non_trivial_expr = [];
+    private bool $has_non_trivial_expr = false;
 
     private function checkNonTrivialExpr(PhpParser\Node\Expr $node): bool
     {
@@ -55,7 +52,7 @@ final class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract
         if ($node instanceof PhpParser\Node\Expr) {
             // Check for Non-Trivial Expression first
             if ($this->checkNonTrivialExpr($node)) {
-                $this->non_trivial_expr[] = $node;
+                $this->has_non_trivial_expr = true;
                 return PhpParser\NodeTraverser::STOP_TRAVERSAL;
             }
 
@@ -70,11 +67,8 @@ final class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract
         return null;
     }
 
-    /**
-     * @return array<int, PhpParser\Node\Expr>
-     */
-    public function getNonTrivialExpr(): array
+    public function hasNonTrivialExpr(): bool
     {
-        return $this->non_trivial_expr;
+        return $this->has_non_trivial_expr;
     }
 }


### PR DESCRIPTION
In php-parser 5.0, `ClosureUse` is no longer considered an expression. This requires changes to Psalm's `CheckTrivialExprVisitor`, which stores an array of "non-trivial" `Expr` nodes.

However the only use of this array is to count whether or not it's empty. Instead of keeping the array, we can keep a boolean, and avoid needing to change the types in this class when we upgrade to php-parser 5.0.

See #10567, which this was extracted from.