### PR TITLE
Report `MissingConstructor` for natively typed mixed properties

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1127,8 +1127,11 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
             $uninitialized_variables[] = '$this->' . $property_name;
             $uninitialized_properties[$property_class_name . '::$' . $property_name] = $property;
 
-            if ($property->type && !$property->type->isMixed()) {
-                $uninitialized_typed_properties[$property_class_name . '::$' . $property_name] = $property;
+            if ($property->type) {
+                // Complain about all natively typed properties and all non-mixed docblock typed properties
+                if (!$property->type->from_docblock || !$property->type->isMixed()) {
+                    $uninitialized_typed_properties[$property_class_name . '::$' . $property_name] = $property;
+                }
             }
         }
 

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -3827,6 +3827,15 @@ class PropertyTypeTest extends TestCase
                 ',
                 'error_message' => 'UndefinedPropertyAssignment',
             ],
+            'nativeMixedPropertyWithNoConstructor' => [
+                'code' => <<< 'PHP'
+                    <?php
+                    class A {
+                        public mixed $foo;
+                    }
+                PHP,
+                'error_message' => 'MissingConstructor',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fixes vimeo/psalm#10589
