### PR TITLE
Update master from 5.x

### DIFF
--- a/dictionaries/ImpureFunctionsList.php
+++ b/dictionaries/ImpureFunctionsList.php
@@ -85,6 +85,7 @@ return [
     'ob_end_clean' => true,
     'ob_get_clean' => true,
     'readfile' => true,
+    'readgzfile' => true,
     'printf' => true,
     'var_dump' => true,
     'phpinfo' => true,

--- a/src/Psalm/CodeLocation.php
+++ b/src/Psalm/CodeLocation.php
@@ -147,7 +147,7 @@ class CodeLocation
         $this->preview_start = $this->docblock_start ?: $this->file_start;
 
         /** @psalm-suppress ImpureMethodCall Actually mutation-free just not marked */
-        $this->raw_line_number = $stmt->getLine();
+        $this->raw_line_number = $stmt->getStartLine();
 
         $this->docblock_line_number = $comment_line;
     }

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1091,8 +1091,11 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
             $uninitialized_variables[] = '$this->' . $property_name;
             $uninitialized_properties[$property_class_name . '::$' . $property_name] = $property;
 
-            if ($property->type && !$property->type->isMixed()) {
-                $uninitialized_typed_properties[$property_class_name . '::$' . $property_name] = $property;
+            if ($property->type) {
+                // Complain about all natively typed properties and all non-mixed docblock typed properties
+                if (!$property->type->from_docblock || !$property->type->isMixed()) {
+                    $uninitialized_typed_properties[$property_class_name . '::$' . $property_name] = $property;
+                }
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1195,7 +1195,7 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
                 $fake_stmt = new VirtualClassMethod(
                     new VirtualIdentifier('__construct'),
                     [
-                        'type' => PhpParser\Node\Stmt\Class_::MODIFIER_PUBLIC,
+                        'flags' => PhpParser\Node\Stmt\Class_::MODIFIER_PUBLIC,
                         'params' => $fake_constructor_params,
                         'stmts' => $fake_constructor_stmts,
                     ],

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -2042,7 +2042,9 @@ final class AssertionFinder
 
     private static function hasArrayKeyExistsCheck(PhpParser\Node\Expr\FuncCall $stmt): bool
     {
-        return $stmt->name instanceof PhpParser\Node\Name && strtolower($stmt->name->getFirst()) === 'array_key_exists';
+        return $stmt->name instanceof PhpParser\Node\Name
+            && (strtolower($stmt->name->getFirst()) === 'array_key_exists'
+                || strtolower($stmt->name->getFirst()) === 'key_exists');
     }
 
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -1347,6 +1347,7 @@ final class ArgumentAnalyzer
                         } else {
                             if (!$param_type->hasString()
                                 && !$param_type->hasArray()
+                                && $context->check_functions
                                 && CallAnalyzer::checkFunctionExists(
                                     $statements_analyzer,
                                     $function_id,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -1133,6 +1133,8 @@ final class AtomicPropertyFetchAnalyzer
 
             $override_property_visibility = $interface_storage->override_property_visibility;
 
+            $intersects_with_enum = false;
+
             foreach ($intersection_types as $intersection_type) {
                 if ($intersection_type instanceof TNamedObject
                     && $codebase->classExists($intersection_type->value)
@@ -1141,12 +1143,19 @@ final class AtomicPropertyFetchAnalyzer
                     $class_exists = true;
                     return;
                 }
+                if ($intersection_type instanceof TNamedObject
+                    && (in_array($intersection_type->value, ['UnitEnum', 'BackedEnum'], true)
+                        || in_array('UnitEnum', $codebase->getParentInterfaces($intersection_type->value)))
+                ) {
+                    $intersects_with_enum = true;
+                }
             }
 
             if (!$class_exists &&
                 //interfaces can't have properties. Except when they do... In PHP Core, they can
                 !in_array($fq_class_name, ['UnitEnum', 'BackedEnum'], true) &&
-                !in_array('UnitEnum', $codebase->getParentInterfaces($fq_class_name))
+                !in_array('UnitEnum', $codebase->getParentInterfaces($fq_class_name)) &&
+                !$intersects_with_enum
             ) {
                 if (IssueBuffer::accepts(
                     new NoInterfaceProperties(

--- a/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
+++ b/src/Psalm/Internal/Analyzer/Statements/UnusedAssignmentRemover.php
@@ -67,7 +67,7 @@ final class UnusedAssignmentRemover
                 $traverser->addVisitor($visitor);
                 $traverser->traverse([$rhs_exp]);
 
-                $rhs_exp_trivial = (count($visitor->getNonTrivialExpr()) === 0);
+                $rhs_exp_trivial = !$visitor->hasNonTrivialExpr();
 
                 if ($rhs_exp_trivial) {
                     $treat_as_expr = false;

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -99,6 +99,11 @@ final class PsalmRestarter extends XdebugHandler
             }
         }
 
+        // opcache.save_comments is required for json mapper (used in language server) to work
+        if ($opcache_loaded && in_array(ini_get('opcache.save_comments'), ['0', 'false', 0, false])) {
+            return true;
+        }
+
         return $default || $this->required;
     }
 
@@ -161,6 +166,10 @@ final class PsalmRestarter extends XdebugHandler
             foreach (self::REQUIRED_OPCACHE_SETTINGS as $key => $value) {
                 $additional_options []= "-dopcache.{$key}={$value}";
             }
+        }
+
+        if ($opcache_loaded) {
+            $additional_options[] = '-dopcache.save_comments=1';
         }
 
         array_splice(

--- a/src/Psalm/Internal/LanguageServer/LanguageServer.php
+++ b/src/Psalm/Internal/LanguageServer/LanguageServer.php
@@ -697,7 +697,7 @@ final class LanguageServer extends Dispatcher
             $diagnostics = array_map(
                 function (IssueData $issue_data): Diagnostic {
                     //$check_name = $issue->check_name;
-                    $description = $issue_data->message;
+                    $description = '[' . $issue_data->type . '] ' . $issue_data->message;
                     $severity = $issue_data->severity;
 
                     $start_line = max($issue_data->line_from, 1);

--- a/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/CheckTrivialExprVisitor.php
@@ -11,10 +11,7 @@ use PhpParser;
  */
 final class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract
 {
-    /**
-     * @var array<int, PhpParser\Node\Expr>
-     */
-    private array $non_trivial_expr = [];
+    private bool $has_non_trivial_expr = false;
 
     private function checkNonTrivialExpr(PhpParser\Node\Expr $node): bool
     {
@@ -57,7 +54,7 @@ final class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract
         if ($node instanceof PhpParser\Node\Expr) {
             // Check for Non-Trivial Expression first
             if ($this->checkNonTrivialExpr($node)) {
-                $this->non_trivial_expr[] = $node;
+                $this->has_non_trivial_expr = true;
                 return PhpParser\NodeTraverser::STOP_TRAVERSAL;
             }
 
@@ -72,11 +69,8 @@ final class CheckTrivialExprVisitor extends PhpParser\NodeVisitorAbstract
         return null;
     }
 
-    /**
-     * @return array<int, PhpParser\Node\Expr>
-     */
-    public function getNonTrivialExpr(): array
+    public function hasNonTrivialExpr(): bool
     {
-        return $this->non_trivial_expr;
+        return $this->has_non_trivial_expr;
     }
 }

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -533,7 +533,7 @@ final class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements Fi
                 }
 
                 throw new UnexpectedValueException(
-                    'There should be function storages for line ' . $this->file_path . ':' . $node->getLine(),
+                    'There should be function storages for line ' . $this->file_path . ':' . $node->getStartLine(),
                 );
             }
 

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -278,7 +278,7 @@ final class TypeExpander
                 $declaring_fq_classlike_name = $self_class;
             }
 
-            if (!($evaluate_class_constants && $codebase->classOrInterfaceExists($declaring_fq_classlike_name))) {
+            if (!($evaluate_class_constants && $codebase->classOrInterfaceOrEnumExists($declaring_fq_classlike_name))) {
                 return [$return_type];
             }
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -679,6 +679,33 @@ class EnumTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'allowPropertiesOnIntersectionsWithEnumInterfaces' => [
+                'code' => <<<'PHP'
+                    <?php
+                    interface I {}
+
+                    interface UE extends UnitEnum {}
+                    interface BE extends BackedEnum {}
+
+                    function f(I $i): void {
+                        if ($i instanceof BackedEnum) {
+                            echo $i->name;
+                        }
+                        if ($i instanceof UnitEnum) {
+                            echo $i->name;
+                        }
+                        if ($i instanceof UE) {
+                            echo $i->name;
+                        }
+                        if ($i instanceof BE) {
+                            echo $i->name;
+                        }
+                    }
+                    PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -1649,6 +1649,14 @@ class FunctionCallTest extends TestCase
                         }
                     }',
             ],
+            'callableArgumentWithFunctionExists' => [
+                'code' => <<<'PHP'
+                    <?php
+                    if (function_exists('foo')) {
+                        register_shutdown_function('foo');
+                    }
+                    PHP,
+            ],
             'pregMatch' => [
                 'code' => '<?php
                     function takesInt(int $i) : void {}

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -3829,6 +3829,15 @@ class PropertyTypeTest extends TestCase
                 ',
                 'error_message' => 'UndefinedPropertyAssignment',
             ],
+            'nativeMixedPropertyWithNoConstructor' => [
+                'code' => <<< 'PHP'
+                    <?php
+                    class A {
+                        public mixed $foo;
+                    }
+                PHP,
+                'error_message' => 'MissingConstructor',
+            ],
         ];
     }
 }

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -889,6 +889,25 @@ class TypeAnnotationTest extends TestCase
                         }
                     }',
             ],
+            'importFromEnum' => [
+                'code' => <<<'PHP'
+                <?php
+                /** @psalm-type _Foo = array{foo: string} */
+                enum E {}
+                /**
+                 * @psalm-import-type _Foo from E
+                 */
+                class C {
+                    /** @param _Foo $foo */
+                    public function f(array $foo): void {
+                        echo $foo['foo'];
+                    }
+                }
+                PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 

--- a/tests/TypeReconciliation/ArrayKeyExistsTest.php
+++ b/tests/TypeReconciliation/ArrayKeyExistsTest.php
@@ -509,6 +509,19 @@ class ArrayKeyExistsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'keyExistsAsAliasForArrayKeyExists' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @param array<string, string> $arr
+                     */
+                    function foo(array $arr): void {
+                        if (key_exists("a", $arr)) {
+                            echo $arr["a"];
+                        }
+                    }
+                PHP,
+            ],
         ];
     }
 


### PR DESCRIPTION
- `key_exists()` is an alias for `array_key_exists()`
- Allow properties on intersections with enum interfaces
- `readgzfile()` is impure
- Do not validate callable arguments in lenient contexts
- [LSP] Add issue type in description
- Re-work CheckTrivialExprVisitor
- Fix language server running with `opcache.save_comments=0`
- Report `MissingConstructor` for natively typed mixed properties
- Allow importing typedefs from enums
