### PR TITLE
Encourage using DOMDocument factory methods to prevent objects broken state

### DIFF
--- a/stubs/extensions/dom.phpstub
+++ b/stubs/extensions/dom.phpstub
@@ -256,6 +256,9 @@ class DOMDocumentFragment extends DOMNode implements DOMParentNode
     /** @readonly */
     public int $childElementCount;
 
+    /**
+     * @psalm-internal DOMDocument::createDocumentFragment
+     */
     public function __construct() {}
 
     public function appendXML(string $data): bool {}
@@ -729,6 +732,10 @@ class DOMAttr extends DOMNode
      */
     public string $localName;
 
+    /**
+     * @psalm-internal DOMDocument::createAttribute
+     * @psalm-internal DOMDocument::createAttributeNS
+     */
     public function __construct(string $name, string $value = '') {}
 
     public function isId(): bool {}
@@ -765,6 +772,10 @@ class DOMElement extends DOMNode implements DOMParentNode, DOMChildNode
      */
     public string $localName;
 
+    /**
+     * @psalm-internal DOMDocument::createElement
+     * @psalm-internal DOMDocument::createElementNS
+     */
     public function __construct(string $qualifiedName, ?string $value = null, string $namespace = '') {}
 
     public function getAttribute(string $qualifiedName): string {}
@@ -874,6 +885,9 @@ class DOMText extends DOMCharacterData
     /** @readonly */
     public string $wholeText;
 
+    /**
+     * @psalm-internal DOMDocument::createTextNode
+     */
     public function __construct(string $data = '') {}
 
     public function isWhitespaceInElementContent(): bool {}
@@ -892,11 +906,17 @@ class DOMText extends DOMCharacterData
 
 class DOMComment extends DOMCharacterData
 {
+    /**
+     * @psalm-internal DOMDocument::createComment
+     */
     public function __construct(string $data = '') {}
 }
 
 class DOMCdataSection extends DOMText
 {
+    /**
+     * @psalm-internal DOMDocument::createCDATASection
+     */
     public function __construct(string $data) {}
 }
 
@@ -954,6 +974,9 @@ class DOMEntity extends DOMNode
 
 class DOMEntityReference extends DOMNode
 {
+    /**
+     * @psalm-internal DOMDocument::createEntityReference
+     */
     public function __construct(string $name) {}
 }
 
@@ -963,6 +986,9 @@ class DOMProcessingInstruction extends DOMNode
     public string $target;
     public string $data;
 
+    /**
+     * @psalm-internal DOMDocument::createProcessingInstruction
+     */
     public function __construct(string $name, string $value = '') {}
 }
 

--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -437,6 +437,7 @@ class CoreStubsTest extends TestCase
                 '$c===' => 'DOMDocument',
                 '$d===' => 'DOMDocument',
             ],
+            'ignored_issues' => ['InternalMethod'],
         ];
     }
 

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -720,6 +720,7 @@ class PropertyTypeTest extends TestCase
                 'assertions' => [
                     '$owner' => 'DOMDocument',
                 ],
+                'ignored_issues' => ['InternalMethod'],
             ],
             'propertyMapHydration' => [
                 'code' => '<?php


### PR DESCRIPTION
Manually created DOMNode objects have broken internal state because they don't have `ownerDocument` until added to one.
It leads to DOMException/warning `Invalid State Error` when calling `ownerDocument` field.
This PR encourages using factory methods that immediately bind freshly created object to `ownerDocument` and thus their internal state is valid.