### PR TITLE
Analyze dynamic names for static property and const fetches

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
@@ -206,7 +206,15 @@ final class ClassConstAnalyzer
             }
 
             if (!$stmt->name instanceof PhpParser\Node\Identifier) {
-                return true;
+                $was_inside_general_use = $context->inside_general_use;
+
+                $context->inside_general_use = true;
+
+                $ret = ExpressionAnalyzer::analyze($statements_analyzer, $stmt->name, $context);
+
+                $context->inside_general_use = $was_inside_general_use;
+
+                return $ret;
             }
 
             $const_id = $fq_class_name . '::' . $stmt->name;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
@@ -206,6 +206,16 @@ final class ClassConstAnalyzer
             }
 
             if (!$stmt->name instanceof PhpParser\Node\Identifier) {
+                if ($codebase->analysis_php_version_id < 8_03_00) {
+                    IssueBuffer::maybeAdd(
+                        new ParseError(
+                            'Dynamically fetching class constants and enums requires PHP 8.3',
+                            new CodeLocation($statements_analyzer->getSource(), $stmt),
+                        ),
+                        $statements_analyzer->getSuppressedIssues(),
+                    );
+                }
+
                 $was_inside_general_use = $context->inside_general_use;
 
                 $context->inside_general_use = true;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
@@ -134,12 +134,26 @@ final class StaticPropertyFetchAnalyzer
 
         if ($stmt->name instanceof PhpParser\Node\VarLikeIdentifier) {
             $prop_name = $stmt->name->name;
-        } elseif (($stmt_name_type = $statements_analyzer->node_data->getType($stmt->name))
-            && $stmt_name_type->isSingleStringLiteral()
-        ) {
-            $prop_name = $stmt_name_type->getSingleStringLiteral()->value;
         } else {
-            $prop_name = null;
+            $was_inside_general_use = $context->inside_general_use;
+
+            $context->inside_general_use = true;
+
+            if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->name, $context) === false) {
+                $context->inside_general_use = $was_inside_general_use;
+
+                return false;
+            }
+
+            $context->inside_general_use = $was_inside_general_use;
+
+            if (($stmt_name_type = $statements_analyzer->node_data->getType($stmt->name))
+                && $stmt_name_type->isSingleStringLiteral()
+            ) {
+                $prop_name = $stmt_name_type->getSingleStringLiteral()->value;
+            } else {
+                $prop_name = null;
+            }
         }
 
         if (!$prop_name) {

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -2485,7 +2485,7 @@ class ConstantTest extends TestCase
                     $a = C::{"A"};
                 ',
                 'error_message' => 'ParseError',
-                'errors_levels' => [],
+                'error_levels' => [],
                 'php_version' => '8.2',
             ],
         ];

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -2476,6 +2476,18 @@ class ConstantTest extends TestCase
                     PHP,
                 'error_message' => 'InvalidArrayOffset',
             ],
+            'unsupportedDynamicFetch' => [
+                'code' => '<?php
+                    class C {
+                        const A = 0;
+                    }
+
+                    $a = C::{"A"};
+                ',
+                'error_message' => 'ParseError',
+                'errors_levels' => [],
+                'php_version' => '8.2',
+            ],
         ];
     }
 }

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -1012,6 +1012,23 @@ class UnusedVariableTest extends TestCase
                         A::$method();
                     }',
             ],
+            'usedAsClassConstFetch' => [
+                'code' => '<?php
+                    class A {
+                        const bool something = false;
+
+                        public function foo() : void {
+                            $var = "something";
+
+                            if (rand(0, 1)) {
+                                static::{$var};
+                            }
+                        }
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
             'usedAsStaticPropertyAssign' => [
                 'code' => '<?php
                     class A {

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -1029,6 +1029,25 @@ class UnusedVariableTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.3',
             ],
+            'usedAsEnumFetch' => [
+                'code' => '<?php
+                    enum E {
+                        case C;
+                    }
+
+                    class A {
+                        public function foo() : void {
+                            $var = "C";
+
+                            if (rand(0, 1)) {
+                                E::{$var};
+                            }
+                        }
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
             'usedAsStaticPropertyAssign' => [
                 'code' => '<?php
                     class A {

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -1012,7 +1012,7 @@ class UnusedVariableTest extends TestCase
                         A::$method();
                     }',
             ],
-            'usedAsStaticPropertyName' => [
+            'usedAsStaticPropertyAssign' => [
                 'code' => '<?php
                     class A {
                         private static bool $something = false;
@@ -1022,6 +1022,20 @@ class UnusedVariableTest extends TestCase
 
                             if (rand(0, 1)) {
                                 static::${$var} = true;
+                            }
+                        }
+                    }',
+            ],
+            'usedAsStaticPropertyFetch' => [
+                'code' => '<?php
+                    class A {
+                        private static bool $something = false;
+
+                        public function foo() : void {
+                            $var = "something";
+
+                            if (rand(0, 1)) {
+                                static::${$var};
                             }
                         }
                     }',


### PR DESCRIPTION
While trying to use PHP 8.3's new dynamic class constant syntax, I found that the dynamic constant name wasn't being analyzed. Then I tried to see what dynamic static properties were doing and noticed that they had the same problem!

This fixes both issues.