### PR TITLE
Allow sebastian/diff v6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
         "nikic/php-parser": "^4.16",
-        "sebastian/diff": "^4.0 || ^5.0",
+        "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
         "symfony/console": "^4.1.6 || ^5.0 || ^6.0 || ^7.0",
         "symfony/filesystem": "^5.4 || ^6.0 || ^7.0"


### PR DESCRIPTION
This allows installing phpunit v11 in consumer apps since it requires sebastian/diff v6.