### PR TITLE
Fix enum crash

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -1437,10 +1437,16 @@ final class ClassLikeNodeScanner
         $case_location = new CodeLocation($this->file_scanner, $stmt);
 
         if ($stmt->expr !== null) {
+            $expr = $stmt->expr;
+
+            if ($expr instanceof PhpParser\Node\Expr\PropertyFetch) {
+                $expr = $expr->var;
+            }
+
             $case_type = SimpleTypeInferer::infer(
                 $this->codebase,
                 new NodeDataProvider(),
-                $stmt->expr,
+                $expr,
                 $this->aliases,
                 $this->file_scanner,
                 $storage->constants,

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -1453,6 +1453,10 @@ final class ClassLikeNodeScanner
                 $fq_classlike_name,
             );
 
+            if ($case_type && $case_type->isSingleEnumCase()) {
+                $case_type = Type\Atomic\TValueOf::getValueType($case_type, $this->codebase);
+            }
+
             if ($case_type) {
                 if ($case_type->isSingleIntLiteral()) {
                     $enum_value = $case_type->getSingleIntLiteral()->value;

--- a/src/Psalm/Type/MutableUnion.php
+++ b/src/Psalm/Type/MutableUnion.php
@@ -9,6 +9,7 @@ use Psalm\Type;
 use Psalm\Type\Atomic\Scalar;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TClassString;
+use Psalm\Type\Atomic\TEnumCase;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;
@@ -173,6 +174,11 @@ final class MutableUnion implements TypeNode
      * @var array<string, TLiteralFloat>
      */
     private array $literal_float_types = [];
+
+    /**
+     * @var array<string, TEnumCase>
+     */
+    private array $enum_case_types = [];
 
     /**
      * True if the type was passed or returned by reference, or if the type refers to an object's

--- a/src/Psalm/Type/Union.php
+++ b/src/Psalm/Type/Union.php
@@ -6,6 +6,7 @@ use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\Internal\TypeVisitor\FromDocblockSetter;
 use Psalm\Storage\ImmutableNonCloneableTrait;
 use Psalm\Type\Atomic\TClassString;
+use Psalm\Type\Atomic\TEnumCase;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
@@ -185,6 +186,11 @@ final class Union implements TypeNode
      * @var array<string, TLiteralFloat>
      */
     private array $literal_float_types = [];
+
+    /**
+     * @var array<string, TEnumCase>
+     */
+    private array $enum_case_types = [];
 
     /**
      * True if the type was passed or returned by reference, or if the type refers to an object's

--- a/src/Psalm/Type/UnionTrait.php
+++ b/src/Psalm/Type/UnionTrait.php
@@ -21,6 +21,7 @@ use Psalm\Type\Atomic\TClassStringMap;
 use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Atomic\TConditional;
 use Psalm\Type\Atomic\TEmptyMixed;
+use Psalm\Type\Atomic\TEnumCase;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TIntRange;
@@ -97,6 +98,8 @@ trait UnionTrait
                 && ($type->as_type || $type instanceof TTemplateParamClass)
             ) {
                 $this->typed_class_strings[$key] = $type;
+            } elseif ($type instanceof TEnumCase) {
+                $this->enum_case_types[$key] = $type;
             } elseif ($type instanceof TNever) {
                 $this->explicit_never = true;
             }
@@ -1557,5 +1560,10 @@ trait UnionTrait
         }
 
         return true;
+    }
+
+    public function isSingleEnumCase(): bool
+    {
+        return count($this->types) === 1 && count($this->enum_case_types) === 1;
     }
 }

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -679,6 +679,42 @@ class EnumTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'stringBackedEnumCaseValueFromStringBackedEnumCaseValue' => [
+                'code' => <<<'PHP'
+                    <?php
+
+                    enum Foo: string
+                    {
+                        case Bar = 'bar';
+                    }
+
+                    enum Baz: string
+                    {
+                        case Qux = Foo::Bar->value;
+                    }
+                PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'intBackedEnumCaseValueFromIntBackedEnumCaseValue' => [
+                'code' => <<<'PHP'
+                    <?php
+
+                    enum Foo: int
+                    {
+                        case Bar = 123;
+                    }
+
+                    enum Baz: int
+                    {
+                        case Qux = Foo::Bar->value;
+                    }
+                PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes https://github.com/vimeo/psalm/issues/10560.

First commit fixes the crash.

Second commit fixes the `InvalidEnumCaseValue` revealed once the crashing is fixed.

Third commit adds two test cases for the crash fix.

I'd like to add some more test cases to validate the value is resolved correctly, but not sure where.
