### PR TITLE
New InvalidOverride issue for Override attribute

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -283,6 +283,7 @@
             <xs:element name="InvalidNamedArgument" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidNullableReturnType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidOperand" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="InvalidOverride" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidParamDefault" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidParent" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="InvalidPassByReference" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -98,6 +98,7 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
 - [CircularReference](issues/CircularReference.md)
 - [ConflictingReferenceConstraint](issues/ConflictingReferenceConstraint.md)
 - [ContinueOutsideLoop](issues/ContinueOutsideLoop.md)
+- [InvalidOverride](issues/InvalidOverride.md)
 - [InvalidTypeImport](issues/InvalidTypeImport.md)
 - [MethodSignatureMismatch](issues/MethodSignatureMismatch.md)
 - [OverriddenMethodAccess](issues/OverriddenMethodAccess.md)

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -84,6 +84,7 @@
  - [InvalidNamedArgument](issues/InvalidNamedArgument.md)
  - [InvalidNullableReturnType](issues/InvalidNullableReturnType.md)
  - [InvalidOperand](issues/InvalidOperand.md)
+ - [InvalidOverride](issues/InvalidOverride.md)
  - [InvalidParamDefault](issues/InvalidParamDefault.md)
  - [InvalidParent](issues/InvalidParent.md)
  - [InvalidPassByReference](issues/InvalidPassByReference.md)

--- a/docs/running_psalm/issues/InvalidOverride.md
+++ b/docs/running_psalm/issues/InvalidOverride.md
@@ -1,0 +1,24 @@
+# InvalidOverride
+
+Emitted when an `Override` attribute was added to a method that does not override a method from a parent class or implemented interface.
+
+```php
+<?php
+
+class A {
+    function receive(): void
+    {
+    }
+}
+
+class B extends A {
+    #[Override]
+    function recieve(): void
+    {
+    }
+}
+```
+
+## Why this is bad
+
+A fatal error will be thrown.

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -31,6 +31,7 @@ use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\InvalidDocblockParamName;
+use Psalm\Issue\InvalidOverride;
 use Psalm\Issue\InvalidParamDefault;
 use Psalm\Issue\InvalidThrow;
 use Psalm\Issue\MethodSignatureMismatch;
@@ -48,6 +49,7 @@ use Psalm\IssueBuffer;
 use Psalm\Node\Expr\VirtualVariable;
 use Psalm\Node\Stmt\VirtualWhile;
 use Psalm\Plugin\EventHandler\Event\AfterFunctionLikeAnalysisEvent;
+use Psalm\Storage\AttributeStorage;
 use Psalm\Storage\ClassLikeStorage;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Storage\FunctionLikeStorage;
@@ -65,6 +67,7 @@ use UnexpectedValueException;
 
 use function array_combine;
 use function array_diff_key;
+use function array_filter;
 use function array_key_exists;
 use function array_keys;
 use function array_merge;
@@ -1969,6 +1972,22 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 null,
                 true,
             );
+
+            if ($codebase->analysis_php_version_id >= 8_03_00
+                && (!$overridden_method_ids || $storage->cased_name === '__construct')
+                && array_filter(
+                    $storage->attributes,
+                    static fn(AttributeStorage $s): bool => $s->fq_class_name === 'Override',
+                )
+            ) {
+                IssueBuffer::maybeAdd(
+                    new InvalidOverride(
+                        'Method ' . $storage->cased_name . ' does not match any parent method',
+                        $codeLocation,
+                    ),
+                    $this->getSuppressedIssues(),
+                );
+            }
 
             if ($overridden_method_ids
                 && !$context->collect_initializations

--- a/src/Psalm/Issue/InvalidOverride.php
+++ b/src/Psalm/Issue/InvalidOverride.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+final class InvalidOverride extends CodeIssue
+{
+    public const ERROR_LEVEL = 7;
+    public const SHORTCODE = 357;
+}

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -295,14 +295,28 @@ class AttributeTest extends TestCase
             ],
             'override' => [
                 'code' => '<?php
+                    class C {
+                        public function f(): void {}
+                    }
 
-                    namespace OverrideAttribute;
-
-                    use Override;
-
-                    class HelloWorld {
+                    class C2 extends C {
                         #[Override]
-                        public function __invoke() {}
+                        public function f(): void {}
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
+            'overrideInterface' => [
+                'code' => '<?php
+                    interface I {
+                        public function f(): void;
+                    }
+
+                    interface I2 extends I {
+                        #[Override]
+                        public function f(): void;
                     }
                 ',
                 'assertions' => [],
@@ -526,6 +540,61 @@ class AttributeTest extends TestCase
 
                     function foo(#[Pure] string $str) : void {}',
                 'error_message' => 'UndefinedAttributeClass - src' . DIRECTORY_SEPARATOR . 'somefile.php:4:36',
+            ],
+            'overrideWithNoParent' => [
+                'code' => '<?php
+                    class C {
+                        #[Override]
+                        public function f(): void {}
+                    }
+                ',
+                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:3:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'overrideConstructor' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-consistent-constructor
+                     */
+                    class C {
+                        public function __construct() {}
+                    }
+
+                    class C2 extends C {
+                        #[Override]
+                        public function __construct() {}
+                    }
+                ',
+                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:10:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'overridePrivate' => [
+                'code' => '<?php
+                    class C {
+                        private function f(): void {}
+                    }
+
+                    class C2 extends C {
+                        #[Override]
+                        private function f(): void {}
+                    }
+                ',
+                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:7:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'overrideInterfaceWithNoParent' => [
+                'code' => '<?php
+                    interface I {
+                        #[Override]
+                        public function f(): void;
+                    }
+                ',
+                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:3:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
             ],
             'tooFewArgumentsToAttributeConstructor' => [
                 'code' => '<?php

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -311,6 +311,10 @@ class DocumentationTest extends TestCase
                 case 'InvalidInterfaceImplementation':
                     $php_version = '8.1';
                     break;
+
+                case 'InvalidOverride':
+                    $php_version = '8.3';
+                    break;
             }
 
             $invalid_code_data[$issue_name] = [


### PR DESCRIPTION
`InvalidOverride` is a new issue emitted when the PHP 8.3 `Override` attribute is added to a method, but there is no matching method in a parent class/interface. This results in a fatal runtime error and only affects code that has opted in (by using the attribute in the first place), so I've added it to error level 7.

There are other cases where an `Override` attribute could cause a fatal runtime error due to mismatching signatures, but I believe all these cases are already covered by `MethodSignatureMismatch`. This happens regardless of whether or not the `Override` attribute is present and is already enabled at error level 7, so I don't think there are any further changes necessary.

This implements half of #10626.