### PR TITLE
Update `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,7 +10,6 @@
 /psalm-baseline.xml export-ignore
 /dictionaries/scripts export-ignore
 /.editorconfig export-ignore
-/examples export-ignore
 /.gitattributes export-ignore
 /.github export-ignore
 /.gitignore export-ignore


### PR DESCRIPTION
Hello there,

When downloading a snapshot archive from Github (example: https://github.com/vimeo/psalm/archive/refs/heads/5.x.zip) based on a specific commit ID, branch or tag for example, it is not possible to build PSalm because the `/examples` directory is missing, and it is required in `composer.json` (https://github.com/vimeo/psalm/blob/5.x/composer.json#L100).

This PR update the `.gitattributes` file so it doesn't get stripped out by Github. 