### PR TITLE
Drop unused local composer repo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,12 +94,6 @@
             "Psalm\\Tests\\": "tests/"
         }
     },
-    "repositories": [
-        {
-            "type": "path",
-            "url": "examples/plugins/composer-based/echo-checker"
-        }
-    ],
     "minimum-stability": "dev",
     "prefer-stable": true,
     "bin": [


### PR DESCRIPTION
This was intended to show how you could convert legacy plugins to
composer format, but it breaks `composer install` in snapshots.

An alternative to vimeo/psalm#10645
