### PR TITLE
Fix check-type when using builtin types from within a namespace

### DIFF
--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -45,6 +45,8 @@ use Psalm\Internal\Provider\NodeDataProvider;
 use Psalm\Internal\ReferenceConstraint;
 use Psalm\Internal\Scanner\ParsedDocblock;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
+use Psalm\Internal\Type\TypeParser;
+use Psalm\Internal\Type\TypeTokenizer;
 use Psalm\Issue\CheckType;
 use Psalm\Issue\ComplexFunction;
 use Psalm\Issue\ComplexMethod;
@@ -678,11 +680,18 @@ final class StatementsAnalyzer extends SourceAnalyzer
                 } else {
                     try {
                         $checked_type = $context->vars_in_scope[$checked_var_id];
-                        $fq_check_type_string = Type::getFQCLNFromString(
+                        $check_tokens = TypeTokenizer::getFullyQualifiedTokens(
                             $check_type_string,
                             $statements_analyzer->getAliases(),
+                            $statements_analyzer->getTemplateTypeMap(),
                         );
-                        $check_type = Type::parseString($fq_check_type_string);
+                        $check_type = TypeParser::parseTokens(
+                            $check_tokens,
+                            null,
+                            $statements_analyzer->getTemplateTypeMap() ?? [],
+                            [],
+                            true,
+                        );
                         /** @psalm-suppress InaccessibleProperty We just created this type */
                         $check_type->possibly_undefined = $possibly_undefined;
 

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -680,16 +680,21 @@ final class StatementsAnalyzer extends SourceAnalyzer
                 } else {
                     try {
                         $checked_type = $context->vars_in_scope[$checked_var_id];
+
+                        $path = $statements_analyzer->getRootFilePath();
+                        $file_storage = $codebase->file_storage_provider->get($path);
+
                         $check_tokens = TypeTokenizer::getFullyQualifiedTokens(
                             $check_type_string,
                             $statements_analyzer->getAliases(),
                             $statements_analyzer->getTemplateTypeMap(),
+                            $file_storage->type_aliases,
                         );
                         $check_type = TypeParser::parseTokens(
                             $check_tokens,
                             null,
                             $statements_analyzer->getTemplateTypeMap() ?? [],
-                            [],
+                            $file_storage->type_aliases,
                             true,
                         );
                         /** @psalm-suppress InaccessibleProperty We just created this type */

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -2255,7 +2255,36 @@ class AssertAnnotationTest extends TestCase
                     function isNonEmptyString($_str): bool
                     {
                         return true;
-                    }',
+                    }
+                    ',
+            ],
+            'assertStringIsNonEmptyStringInNamespace' => [
+                'code' => '<?php
+                    namespace X;
+                    /** @var string $str */;
+                    /** @var string|int $stringOrInt */;
+
+                    if (isNonEmptyString($str)) {
+                        /** @psalm-check-type-exact $str = non-empty-string */;
+                    } else {
+                        /** @psalm-check-type-exact $str = string */;
+                    }
+
+                    if (isNonEmptyString($stringOrInt)) {
+                        /** @psalm-check-type-exact $stringOrInt = non-empty-string */;
+                    } else {
+                        /** @psalm-check-type-exact $stringOrInt = string|int */;
+                    }
+
+                    /**
+                     * @param mixed $_str
+                     * @psalm-assert-if-true non-empty-string $_str
+                     */
+                    function isNonEmptyString($_str): bool
+                    {
+                        return true;
+                    }
+                    ',
             ],
             'assertObjectWithClosedInheritance' => [
                 'code' => '<?php

--- a/tests/CheckTypeTest.php
+++ b/tests/CheckTypeTest.php
@@ -38,6 +38,15 @@ class CheckTypeTest extends TestCase
                 $_a = new stdClass();
                 /** @psalm-check-type-exact $_a = \stdClass */',
         ];
+        yield 'allowType' => [
+            'code' => '<?php
+                namespace X;
+
+                /** @psalm-type A = int|string */
+
+                $_a = 1;
+                /** @psalm-check-type $_a = A */',
+        ];
     }
 
     public function providerInvalidCodeParse(): iterable


### PR DESCRIPTION
Fix for #10573 

When looking for a better alternative to `Type::getFQCLNFromString` I found `TypeTokenizer::getFullyQualifiedTokens` also supports types defined with `psalm-type` so I've supported those too.
