### PR TITLE
Clarify that Pull request labels failure is to be resolved by maintainers

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -1,4 +1,4 @@
-name: Pull Request Labels
+name: Pull Request Labels (to be added by maintainers)
 on:
   pull_request:
     types: [opened, reopened, labeled, unlabeled, synchronize]


### PR DESCRIPTION
I think there was at least one complaint from a contributor claiming any CI failure that a contributor cannot fix themselves was a terrible developer experience. I can't find the issue at the moment though. While I disagree with that, we certainly could clarify that failure not being the contributor's fault, by updating the workflow title, thus this PR.
