### PR TITLE
New MissingOverrideAttribute issue

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -42,6 +42,7 @@
         <xs:attribute name="checkForThrowsInGlobalScope" type="xs:boolean" default="false" />
         <xs:attribute name="ensureArrayIntOffsetsExist" type="xs:boolean" default="false" />
         <xs:attribute name="ensureArrayStringOffsetsExist" type="xs:boolean" default="false" />
+        <xs:attribute name="ensureOverrideAttribute" type="xs:boolean" default="false" />
         <xs:attribute name="findUnusedCode" type="xs:boolean" default="false" />
         <xs:attribute name="findUnusedVariablesAndParams" type="xs:boolean" default="false" />
         <xs:attribute name="findUnusedPsalmSuppress" type="xs:boolean" default="false" />
@@ -319,6 +320,7 @@
             <xs:element name="MissingDocblockType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MissingFile" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MissingImmutableAnnotation" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="MissingOverrideAttribute" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MissingParamType" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="MissingPropertyType" type="PropertyIssueHandlerType" minOccurs="0" />
             <xs:element name="MissingReturnType" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -273,6 +273,14 @@ When `true`, Psalm will complain when referencing an explicit string offset on a
 ```
 When `true`, Psalm will complain when referencing an explicit integer offset on an array e.g. `$arr[7]` without a user first asserting that it exists (either via an `isset` check or via an object-like array). Defaults to `false`.
 
+#### ensureOverrideAttribute
+```xml
+<psalm
+  ensureOverrideAttribute="[bool]"
+>
+```
+When `true`, Psalm will report class and interface methods that override a method on a parent, but do not have an `Override` attribute. Defaults to `false`.
+
 #### phpVersion
 ```xml
 <psalm

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -278,6 +278,7 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
 
 ## Feature-specific errors
 
+ - [MissingOverrideAttribute](issues/MissingOverrideAttribute.md)
  - [PossiblyUndefinedIntArrayOffset](issues/PossiblyUndefinedIntArrayOffset.md)
  - [PossiblyUndefinedStringArrayOffset](issues/PossiblyUndefinedStringArrayOffset.md)
  - [PossiblyUnusedMethod](issues/PossiblyUnusedMethod.md)

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -120,6 +120,7 @@
  - [MissingDocblockType](issues/MissingDocblockType.md)
  - [MissingFile](issues/MissingFile.md)
  - [MissingImmutableAnnotation](issues/MissingImmutableAnnotation.md)
+ - [MissingOverrideAttribute](issues/MissingOverrideAttribute.md)
  - [MissingParamType](issues/MissingParamType.md)
  - [MissingPropertyType](issues/MissingPropertyType.md)
  - [MissingReturnType](issues/MissingReturnType.md)

--- a/docs/running_psalm/issues/MissingOverrideAttribute.md
+++ b/docs/running_psalm/issues/MissingOverrideAttribute.md
@@ -1,0 +1,23 @@
+# MissingOverrideAttribute
+
+Emitted when the config flag `ensureOverrideAttribute` is set to `true` and a method on a child class or interface overrides a method on a parent, but no `Override` attribute is present.
+
+```php
+<?php
+
+class A {
+    function receive(): void
+    {
+    }
+}
+
+class B extends A {
+    function receive(): void
+    {
+    }
+}
+```
+
+## Why this is bad
+
+Having an `Override` attribute on overridden methods makes intentions clear. Read the [PHP RFC](https://wiki.php.net/rfc/marking_overriden_methods) for more details.

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -446,6 +446,11 @@ class Config
     public $ensure_array_int_offsets_exist = false;
 
     /**
+     * @var bool
+     */
+    public $ensure_override_attribute = false;
+
+    /**
      * @var array<lowercase-string, bool>
      */
     public $forbidden_functions = [];
@@ -1081,6 +1086,7 @@ class Config
             'includePhpVersionsInErrorBaseline' => 'include_php_versions_in_error_baseline',
             'ensureArrayStringOffsetsExist' => 'ensure_array_string_offsets_exist',
             'ensureArrayIntOffsetsExist' => 'ensure_array_int_offsets_exist',
+            'ensureOverrideAttribute' => 'ensure_override_attribute',
             'reportMixedIssues' => 'show_mixed_issues',
             'skipChecksOnUnresolvableIncludes' => 'skip_checks_on_unresolvable_includes',
             'sealAllMethods' => 'seal_all_methods',

--- a/src/Psalm/Issue/MissingOverrideAttribute.php
+++ b/src/Psalm/Issue/MissingOverrideAttribute.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Psalm\Issue;
+
+final class MissingOverrideAttribute extends CodeIssue
+{
+    public const ERROR_LEVEL = -2;
+    public const SHORTCODE = 358;
+}

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -293,36 +293,6 @@ class AttributeTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.2',
             ],
-            'override' => [
-                'code' => '<?php
-                    class C {
-                        public function f(): void {}
-                    }
-
-                    class C2 extends C {
-                        #[Override]
-                        public function f(): void {}
-                    }
-                ',
-                'assertions' => [],
-                'ignored_issues' => [],
-                'php_version' => '8.3',
-            ],
-            'overrideInterface' => [
-                'code' => '<?php
-                    interface I {
-                        public function f(): void;
-                    }
-
-                    interface I2 extends I {
-                        #[Override]
-                        public function f(): void;
-                    }
-                ',
-                'assertions' => [],
-                'ignored_issues' => [],
-                'php_version' => '8.3',
-            ],
             'sensitiveParameter' => [
                 'code' => '<?php
 
@@ -540,61 +510,6 @@ class AttributeTest extends TestCase
 
                     function foo(#[Pure] string $str) : void {}',
                 'error_message' => 'UndefinedAttributeClass - src' . DIRECTORY_SEPARATOR . 'somefile.php:4:36',
-            ],
-            'overrideWithNoParent' => [
-                'code' => '<?php
-                    class C {
-                        #[Override]
-                        public function f(): void {}
-                    }
-                ',
-                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:3:25',
-                'error_levels' => [],
-                'php_version' => '8.3',
-            ],
-            'overrideConstructor' => [
-                'code' => '<?php
-                    /**
-                     * @psalm-consistent-constructor
-                     */
-                    class C {
-                        public function __construct() {}
-                    }
-
-                    class C2 extends C {
-                        #[Override]
-                        public function __construct() {}
-                    }
-                ',
-                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:10:25',
-                'error_levels' => [],
-                'php_version' => '8.3',
-            ],
-            'overridePrivate' => [
-                'code' => '<?php
-                    class C {
-                        private function f(): void {}
-                    }
-
-                    class C2 extends C {
-                        #[Override]
-                        private function f(): void {}
-                    }
-                ',
-                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:7:25',
-                'error_levels' => [],
-                'php_version' => '8.3',
-            ],
-            'overrideInterfaceWithNoParent' => [
-                'code' => '<?php
-                    interface I {
-                        #[Override]
-                        public function f(): void;
-                    }
-                ',
-                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:3:25',
-                'error_levels' => [],
-                'php_version' => '8.3',
             ],
             'tooFewArgumentsToAttributeConstructor' => [
                 'code' => '<?php

--- a/tests/DocumentationTest.php
+++ b/tests/DocumentationTest.php
@@ -221,6 +221,8 @@ class DocumentationTest extends TestCase
         $this->project_analyzer->getConfig()->ensure_array_string_offsets_exist = $is_array_offset_test;
         $this->project_analyzer->getConfig()->ensure_array_int_offsets_exist = $is_array_offset_test;
 
+        $this->project_analyzer->getConfig()->ensure_override_attribute = $error_message === 'MissingOverrideAttribute';
+
         foreach ($ignored_issues as $error_level) {
             $this->project_analyzer->getCodebase()->config->setCustomErrorLevel($error_level, Config::REPORT_SUPPRESS);
         }
@@ -313,6 +315,7 @@ class DocumentationTest extends TestCase
                     break;
 
                 case 'InvalidOverride':
+                case 'MissingOverrideAttribute':
                     $php_version = '8.3';
                     break;
             }

--- a/tests/OverrideTest.php
+++ b/tests/OverrideTest.php
@@ -6,8 +6,6 @@ use Psalm\Config;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
-use const DIRECTORY_SEPARATOR;
-
 class OverrideTest extends TestCase
 {
     use ValidCodeAnalysisTestTrait;
@@ -83,7 +81,7 @@ class OverrideTest extends TestCase
                         public function f(): void {}
                     }
                 ',
-                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:3:25',
+                'error_message' => 'InvalidOverride',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],
@@ -97,7 +95,7 @@ class OverrideTest extends TestCase
                         public function f(): void {}
                     }
                 ',
-                'error_message' => 'MissingOverrideAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:7:25',
+                'error_message' => 'MissingOverrideAttribute',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],
@@ -113,7 +111,7 @@ class OverrideTest extends TestCase
                         public function f(): void {}
                     }
                 ',
-                'error_message' => 'MissingOverrideAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:9:25',
+                'error_message' => 'MissingOverrideAttribute',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],
@@ -131,7 +129,7 @@ class OverrideTest extends TestCase
                         public function __construct() {}
                     }
                 ',
-                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:10:25',
+                'error_message' => 'InvalidOverride',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],
@@ -145,7 +143,7 @@ class OverrideTest extends TestCase
                         public function f(): void;
                     }
                 ',
-                'error_message' => 'MissingOverrideAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:7:25',
+                'error_message' => 'MissingOverrideAttribute',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],
@@ -160,7 +158,7 @@ class OverrideTest extends TestCase
                         private function f(): void {}
                     }
                 ',
-                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:7:25',
+                'error_message' => 'InvalidOverride',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],
@@ -171,7 +169,7 @@ class OverrideTest extends TestCase
                         public function f(): void;
                     }
                 ',
-                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:3:25',
+                'error_message' => 'InvalidOverride',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],

--- a/tests/OverrideTest.php
+++ b/tests/OverrideTest.php
@@ -2,6 +2,7 @@
 
 namespace Psalm\Tests;
 
+use Psalm\Config;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
@@ -12,9 +13,33 @@ class OverrideTest extends TestCase
     use ValidCodeAnalysisTestTrait;
     use InvalidCodeAnalysisTestTrait;
 
+    protected function makeConfig(): Config
+    {
+        $config = parent::makeConfig();
+        $config->ensure_override_attribute = true;
+        return $config;
+    }
+
     public function providerValidCodeParse(): iterable
     {
         return [
+            'constructor' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-consistent-constructor
+                     */
+                    class C {
+                        public function __construct() {}
+                    }
+
+                    class C2 extends C {
+                        public function __construct() {}
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
             'overrideClass' => [
                 'code' => '<?php
                     class C {
@@ -62,6 +87,36 @@ class OverrideTest extends TestCase
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],
+            'classMissingAttribute' => [
+                'code' => '<?php
+                    class C {
+                        public function f(): void {}
+                    }
+
+                    class C2 extends C {
+                        public function f(): void {}
+                    }
+                ',
+                'error_message' => 'MissingOverrideAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:7:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'classUsingTrait' => [
+                'code' => '<?php
+                    trait T {
+                        abstract public function f(): void;
+                    }
+
+                    class C {
+                        use T;
+
+                        public function f(): void {}
+                    }
+                ',
+                'error_message' => 'MissingOverrideAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:9:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
             'constructor' => [
                 'code' => '<?php
                     /**
@@ -77,6 +132,20 @@ class OverrideTest extends TestCase
                     }
                 ',
                 'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:10:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'interfaceMissingAttribute' => [
+                'code' => '<?php
+                    interface I {
+                        public function f(): void;
+                    }
+
+                    interface I2 extends I {
+                        public function f(): void;
+                    }
+                ',
+                'error_message' => 'MissingOverrideAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:7:25',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],

--- a/tests/OverrideTest.php
+++ b/tests/OverrideTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Psalm\Tests;
+
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+use const DIRECTORY_SEPARATOR;
+
+class OverrideTest extends TestCase
+{
+    use ValidCodeAnalysisTestTrait;
+    use InvalidCodeAnalysisTestTrait;
+
+    public function providerValidCodeParse(): iterable
+    {
+        return [
+            'overrideClass' => [
+                'code' => '<?php
+                    class C {
+                        public function f(): void {}
+                    }
+
+                    class C2 extends C {
+                        #[Override]
+                        public function f(): void {}
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
+            'overrideInterface' => [
+                'code' => '<?php
+                    interface I {
+                        public function f(): void;
+                    }
+
+                    interface I2 extends I {
+                        #[Override]
+                        public function f(): void;
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
+        ];
+    }
+
+    public function providerInvalidCodeParse(): iterable
+    {
+        return [
+            'noParent' => [
+                'code' => '<?php
+                    class C {
+                        #[Override]
+                        public function f(): void {}
+                    }
+                ',
+                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:3:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'constructor' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-consistent-constructor
+                     */
+                    class C {
+                        public function __construct() {}
+                    }
+
+                    class C2 extends C {
+                        #[Override]
+                        public function __construct() {}
+                    }
+                ',
+                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:10:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'privateMethod' => [
+                'code' => '<?php
+                    class C {
+                        private function f(): void {}
+                    }
+
+                    class C2 extends C {
+                        #[Override]
+                        private function f(): void {}
+                    }
+                ',
+                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:7:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'interfaceWithNoParent' => [
+                'code' => '<?php
+                    interface I {
+                        #[Override]
+                        public function f(): void;
+                    }
+                ',
+                'error_message' => 'InvalidOverride - src' . DIRECTORY_SEPARATOR . 'somefile.php:3:25',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
`MissingOverrideAttribute` is a new issue emitted when a method overrides a parent method, but does not have the PHP 8.3 `Override` attribute. This issue is only emitted under PHP 8.3 when the Psalm config flag `ensureOverrideAttribute` is turned on.

Fixes #10626.