### PR TITLE
Allow nikic/php-parser v5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "felixfbecker/language-server-protocol": "^1.5.2",
         "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-        "nikic/php-parser": "^4.16",
+        "nikic/php-parser": "^4.16 || ^5.0",
         "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
         "symfony/console": "^4.1.6 || ^5.0 || ^6.0 || ^7.0",

--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -397,14 +397,11 @@ final class StatementsProvider
         if (!self::$lexer) {
             $major_version = Codebase::transformPhpVersionId($analysis_php_version_id, 10_000);
             $minor_version = Codebase::transformPhpVersionId($analysis_php_version_id % 10_000, 100);
-            self::$lexer = new Emulative([
-                'usedAttributes' => $attributes,
-                'phpVersion' => $major_version . '.' . $minor_version,
-            ]);
+            self::$lexer = new Emulative(PhpParser\PhpVersion::fromComponents($major_version, $minor_version));
         }
 
         if (!self::$parser) {
-            self::$parser = (new PhpParser\ParserFactory())->create(PhpParser\ParserFactory::ONLY_PHP7, self::$lexer);
+            self::$parser = (new PhpParser\ParserFactory())->createForHostVersion();
         }
 
         $used_cached_statements = false;


### PR DESCRIPTION
 `phpunit/php-code-coverage 11.0.0 requires nikic/php-parser ^5.0`