### PR TITLE
Do not add `callable` as a native property type

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1650,7 +1650,9 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
         $allow_native_type = !$docblock_only
             && $codebase->analysis_php_version_id >= 7_04_00
             && $codebase->allow_backwards_incompatible_changes
-            && !$inferred_type->hasCallableType() // PHP does not support callable properties
+            // PHP does not support callable properties, but does allow Closure properties
+            // hasCallableType() treats Closure as a callable, but getCallableTypes() does not
+            && $inferred_type->getCallableTypes() === []
             ;
 
         $manipulator->setType(

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -1649,7 +1649,9 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
 
         $allow_native_type = !$docblock_only
             && $codebase->analysis_php_version_id >= 7_04_00
-            && $codebase->allow_backwards_incompatible_changes;
+            && $codebase->allow_backwards_incompatible_changes
+            && !$inferred_type->hasCallableType() // PHP does not support callable properties
+            ;
 
         $manipulator->setType(
             $allow_native_type

--- a/src/Psalm/Type/Atomic/TClosure.php
+++ b/src/Psalm/Type/Atomic/TClosure.php
@@ -50,7 +50,8 @@ final class TClosure extends TNamedObject
 
     public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {
-        return false;
+        // it can, if it's just 'Closure'
+        return $this->params === null && $this->return_type === null && $this->is_pure === null;
     }
 
     /**

--- a/tests/FileManipulation/MissingPropertyTypeTest.php
+++ b/tests/FileManipulation/MissingPropertyTypeTest.php
@@ -330,6 +330,29 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                 'issues_to_fix' => ['MissingPropertyType'],
                 'safe_types' => true,
             ],
+            'addClosurePropertyType' => [
+                'input' => <<<'PHP'
+                    <?php
+                    class A {
+                        public $u;
+                        public function __construct(Closure $u) {
+                            $this->u = $u;
+                        }
+                    }
+                PHP,
+                'output' => <<<'PHP'
+                    <?php
+                    class A {
+                        public Closure $u;
+                        public function __construct(Closure $u) {
+                            $this->u = $u;
+                        }
+                    }
+                PHP,
+                'php_version' => '7.4',
+                'issues_to_fix' => ['MissingPropertyType'],
+                'safe_types' => true,
+            ],
         ];
     }
 }

--- a/tests/FileManipulation/MissingPropertyTypeTest.php
+++ b/tests/FileManipulation/MissingPropertyTypeTest.php
@@ -294,6 +294,42 @@ class MissingPropertyTypeTest extends FileManipulationTestCase
                 'issues_to_fix' => ['MissingPropertyType'],
                 'safe_types' => true,
             ],
+            'doNotAddCallablePropertyTypes' => [
+                'input' => <<<'PHP'
+                    <?php
+                    class A {
+                        public $u;
+                        public $v;
+
+                        public function __construct(?callable $u, callable $v) {
+                            $this->u = $u;
+                            $this->v = $v;
+                        }
+                    }
+                PHP,
+                'output' => <<<'PHP'
+                    <?php
+                    class A {
+                        /**
+                         * @var callable|null
+                         */
+                        public $u;
+
+                        /**
+                         * @var callable
+                         */
+                        public $v;
+
+                        public function __construct(?callable $u, callable $v) {
+                            $this->u = $u;
+                            $this->v = $v;
+                        }
+                    }
+                PHP,
+                'php_version' => '7.4',
+                'issues_to_fix' => ['MissingPropertyType'],
+                'safe_types' => true,
+            ],
         ];
     }
 }


### PR DESCRIPTION
It's invalid in all PHP versions: https://3v4l.org/bXWo2

Also see https://php.net/manual/en/language.types.declarations.php#language.types.declarations.base.function

Fixes vimeo/psalm#10650
