### PR TITLE
Strip callmap prefixes from parameter names

### DIFF
--- a/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
+++ b/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
@@ -285,9 +285,18 @@ final class InternalCallMapHandler
 
                 $out_type = null;
 
-                if (strlen($arg_name) > 2 && $arg_name[0] === 'w' && $arg_name[1] === '_') {
+                if ($by_reference && strlen($arg_name) > 2 && $arg_name[0] === 'w' && $arg_name[1] === '_') {
+                    // strip prefix that is not actually a part of the parameter name
+                    $arg_name = substr($arg_name, 2);
                     $out_type = $param_type;
                     $param_type = Type::getMixed();
+                }
+
+                // removes `rw_` leftover from `&rw_haystack` or `&rw_needle` or `&rw_actual_name`
+                // it doesn't have any specific meaning apart from `&` signifying that
+                // the parameter is passed by reference (handled above)
+                if ($by_reference && strlen($arg_name) > 3 && strpos($arg_name, 'rw_') === 0) {
+                    $arg_name = substr($arg_name, 3);
                 }
 
                 $function_param = new FunctionLikeParameter(

--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -312,6 +312,26 @@ class InternalCallMapHandlerTest extends TestCase
         }
     }
 
+    public function testGetCallablesFromCallmapRemovesRwPrefixFromParameterNames(): void
+    {
+        $entries = InternalCallMapHandler::getCallablesFromCallMap('collator_sort'); // has &rw_array parameter as second parameter
+        $this->assertNotNull($entries);
+        $collator_sort_entry = $entries[0];
+        $this->assertIsArray($collator_sort_entry->params);
+        $this->assertArrayHasKey(1, $collator_sort_entry->params);
+        $this->assertEquals('array', $collator_sort_entry->params[1]->name);
+    }
+
+    public function testGetCallablesFromCallmapRemovesWPrefixFromParameterNames(): void
+    {
+        $entries = InternalCallMapHandler::getCallablesFromCallMap('curl_multi_exec'); // has &w_still_running parameter as second parameter
+        $this->assertNotNull($entries);
+        $curl_multi_exec_entry = $entries[0];
+        $this->assertIsArray($curl_multi_exec_entry->params);
+        $this->assertArrayHasKey(1, $curl_multi_exec_entry->params);
+        $this->assertEquals('still_running', $curl_multi_exec_entry->params[1]->name);
+    }
+
     /**
      * @return iterable<string, array{string, array<int|string, string>}>
      */

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -957,6 +957,24 @@ class MethodSignatureTest extends TestCase
                     }
                 ',
             ],
+            'callmapInheritedMethodParamsDoNotHavePrefixes' => [
+                'code' => <<<'PHP'
+                    <?php
+
+                    class NoopFilter extends \php_user_filter
+                    {
+                        /**
+                         * @param resource $in
+                         * @param resource $out
+                         * @param int $consumed   -- this is called &rw_consumed in the callmap
+                         */
+                        public function filter($in, $out, &$consumed, bool $closing): int
+                        {
+                            return PSFS_PASS_ON;
+                        }
+                    }
+                PHP,
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes vimeo/psalm#10662
