### PR TITLE
Don't show backtrace in `InvalidDocblock` issue message

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -624,7 +624,7 @@ final class FunctionLikeDocblockScanner
             );
         } catch (TypeParseTreeException $e) {
             $storage->docblock_issues[] = new InvalidDocblock(
-                'Invalid @psalm-assert union type ' . $e,
+                'Invalid @psalm-assert union type: ' . $e->getMessage(),
                 new CodeLocation($file_scanner, $stmt, null, true),
             );
 

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -90,6 +90,33 @@ class AssertAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
+    public function testAssertInvalidDocblockMessageDoesNotIncludeTrace(): void
+    {
+        $this->expectException(CodeException::class);
+        $this->expectExceptionMessageMatches(
+            '!^InvalidDocblock - ' . 'somefile\\.php:10:5 - Invalid @psalm-assert union type: Invalid type \'\\$expected\'$!',
+        );
+
+        $this->addFile(
+            'somefile.php',
+            <<<'PHP'
+            <?php
+                /**
+                 * Asserts that two variables are not the same.
+                 *
+                 * @template T
+                 * @param T      $expected
+                 * @param mixed  $actual
+                 * @psalm-assert !=$expected $actual
+                 */
+                function assertNotSame($expected, $actual) : void {}
+            PHP,
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+
     public function providerValidCodeParse(): iterable
     {
         return [


### PR DESCRIPTION
Fixes vimeo/psalm#8323
