### PR TITLE
Update master from  5.x

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1054,6 +1054,7 @@
   <file src="src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php">
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$method_name]]></code>
+      <code><![CDATA[$method_name]]></code>
     </PossiblyUndefinedIntArrayOffset>
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[!$context->calling_function_id]]></code>

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -277,6 +277,18 @@ final class ReturnAnalyzer
                         $statements_analyzer,
                         null,
                     );
+
+                    [, $method_name] = explode('::', $cased_method_id);
+                    if ($method_name === '__construct') {
+                        IssueBuffer::maybeAdd(
+                            new InvalidReturnStatement(
+                                'No return values are expected for ' . $cased_method_id,
+                                new CodeLocation($source, $stmt->expr),
+                            ),
+                            $statements_analyzer->getSuppressedIssues(),
+                        );
+                        return;
+                    }
                 } else {
                     $declared_return_type = $storage->return_type;
                 }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -804,7 +804,9 @@ final class FunctionLikeNodeScanner
                 $this->codebase->analysis_php_version_id,
             );
 
-            if ($is_nullable) {
+            if ($param_type->isMixed()) {
+                $is_nullable = false;
+            } elseif ($is_nullable) {
                 $param_type = $param_type->getBuilder()->addType(new TNull)->freeze();
             } else {
                 $is_nullable = $param_type->isNullable();

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -357,6 +357,20 @@ class ArgTest extends TestCase
 
                     var_caller("foo");',
             ],
+            'mixedNullable' => [
+                'code' => '<?php
+                    class A {
+                        public function __construct(public mixed $default = null) {
+                        }
+                    }
+                    $a = new A;
+                    $_v = $a->default;',
+                'assertions' => [
+                    '$_v===' => 'mixed',
+                ],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
         ];
     }
 

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1914,6 +1914,17 @@ class ReturnTypeTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'constructorsShouldReturnVoid' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class A {
+                        public function __construct() {
+                            return 5;
+                        }
+                    }
+                    PHP,
+                'error_message' => 'InvalidReturnStatement',
+            ],
         ];
     }
 }


### PR DESCRIPTION
- Prevent mixed|null when function param is mixed with a null default value
- Forbid constructors from returning any values
