### PR TITLE
Report invalid number of arguments for psalm-taint-*

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -239,7 +239,12 @@ final class FunctionLikeDocblockParser
                 if (count($param_parts) >= 2) {
                     $info->taint_sink_params[] = ['name' => $param_parts[1], 'taint' => $param_parts[0]];
                 } else {
-                    throw new IncorrectDocblockException('@psalm-taint-sink expects 2 arguments');
+                    IssueBuffer::maybeAdd(
+                        new InvalidDocblock(
+                            '@psalm-taint-sink expects 2 arguments',
+                            $code_location,
+                        ),
+                    );
                 }
             }
         }
@@ -282,7 +287,12 @@ final class FunctionLikeDocblockParser
                 if ($param_parts[0]) {
                     $info->taint_source_types[] = $param_parts[0];
                 } else {
-                    throw new IncorrectDocblockException('@psalm-taint-source expects 1 argument');
+                    IssueBuffer::maybeAdd(
+                        new InvalidDocblock(
+                            '@psalm-taint-source expects 1 argument',
+                            $code_location,
+                        ),
+                    );
                 }
             }
         } elseif (isset($parsed_docblock->tags['return-taint'])) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -238,6 +238,8 @@ final class FunctionLikeDocblockParser
 
                 if (count($param_parts) >= 2) {
                     $info->taint_sink_params[] = ['name' => $param_parts[1], 'taint' => $param_parts[0]];
+                } else {
+                    throw new IncorrectDocblockException('@psalm-taint-sink expects 2 arguments');
                 }
             }
         }
@@ -279,6 +281,8 @@ final class FunctionLikeDocblockParser
 
                 if ($param_parts[0]) {
                     $info->taint_source_types[] = $param_parts[0];
+                } else {
+                    throw new IncorrectDocblockException('@psalm-taint-source expects 1 argument');
                 }
             }
         } elseif (isset($parsed_docblock->tags['return-taint'])) {

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -759,7 +759,7 @@ class ConditionalReturnTypeTest extends TestCase
                          * @template TSource as self::SOURCE_*
                          * @param TSource $source
                          * @return (TSource is "BODY" ? object|list : array)
-                         * @psalm-taint-source html
+                         * @psalm-taint-source input
                          */
                         public function getParams(
                             string $source = self::SOURCE_GET

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -759,7 +759,7 @@ class ConditionalReturnTypeTest extends TestCase
                          * @template TSource as self::SOURCE_*
                          * @param TSource $source
                          * @return (TSource is "BODY" ? object|list : array)
-                         * @psalm-taint-source
+                         * @psalm-taint-source html
                          */
                         public function getParams(
                             string $source = self::SOURCE_GET


### PR DESCRIPTION
closes https://github.com/vimeo/psalm/issues/7046

I tried testing the change via `TaintTest.php` but was not able to figure out how to properly assert the new error/exception