### PR TITLE
Fix detecting magic static methods

### DIFF
--- a/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
@@ -13,6 +13,7 @@ use Psalm\Issue\InvalidEnumMethod;
 use Psalm\Issue\InvalidStaticInvocation;
 use Psalm\Issue\MethodSignatureMustOmitReturnType;
 use Psalm\Issue\NonStaticSelfCall;
+use Psalm\Issue\UndefinedMagicMethod;
 use Psalm\Issue\UndefinedMethod;
 use Psalm\IssueBuffer;
 use Psalm\StatementsSource;
@@ -165,7 +166,8 @@ final class MethodAnalyzer extends FunctionLikeAnalyzer
         MethodIdentifier $method_id,
         CodeLocation $code_location,
         array $suppressed_issues,
-        ?string $calling_method_id = null
+        ?string $calling_method_id = null,
+        bool $with_pseudo = false
     ): ?bool {
         if ($codebase->methods->methodExists(
             $method_id,
@@ -176,15 +178,31 @@ final class MethodAnalyzer extends FunctionLikeAnalyzer
                 : null,
             null,
             $code_location->file_path,
+            true,
+            false,
+            $with_pseudo,
         )) {
             return true;
         }
 
-        if (IssueBuffer::accepts(
-            new UndefinedMethod('Method ' . $method_id . ' does not exist', $code_location, (string) $method_id),
-            $suppressed_issues,
-        )) {
-            return false;
+        if ($with_pseudo) {
+            if (IssueBuffer::accepts(
+                new UndefinedMagicMethod(
+                    'Magic method ' . $method_id . ' does not exist',
+                    $code_location,
+                    (string) $method_id,
+                ),
+                $suppressed_issues,
+            )) {
+                return false;
+            }
+        } else {
+            if (IssueBuffer::accepts(
+                new UndefinedMethod('Method ' . $method_id . ' does not exist', $code_location, (string) $method_id),
+                $suppressed_issues,
+            )) {
+                return false;
+            }
         }
 
         return null;

--- a/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/MethodAnalyzer.php
@@ -111,8 +111,9 @@ final class MethodAnalyzer extends FunctionLikeAnalyzer
         }
 
         $original_method_id = $method_id;
+        $with_pseudo = true;
 
-        $method_id = $codebase_methods->getDeclaringMethodId($method_id);
+        $method_id = $codebase_methods->getDeclaringMethodId($method_id, $with_pseudo);
 
         if (!$method_id) {
             if (InternalCallMapHandler::inCallMap((string) $original_method_id)) {
@@ -122,7 +123,7 @@ final class MethodAnalyzer extends FunctionLikeAnalyzer
             throw new LogicException('Declaring method for ' . $original_method_id . ' should not be null');
         }
 
-        $storage = $codebase_methods->getStorage($method_id);
+        $storage = $codebase_methods->getStorage($method_id, $with_pseudo);
 
         if (!$storage->is_static) {
             if ($self_call) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodVisibilityAnalyzer.php
@@ -40,6 +40,8 @@ final class MethodVisibilityAnalyzer
         $fq_classlike_name = $method_id->fq_class_name;
         $method_name = $method_id->method_name;
 
+        $with_pseudo = true;
+
         if ($codebase_methods->visibility_provider->has($fq_classlike_name)) {
             $method_visible = $codebase_methods->visibility_provider->isMethodVisible(
                 $source,
@@ -65,7 +67,7 @@ final class MethodVisibilityAnalyzer
             }
         }
 
-        $declaring_method_id = $codebase_methods->getDeclaringMethodId($method_id);
+        $declaring_method_id = $codebase_methods->getDeclaringMethodId($method_id, $with_pseudo);
 
         if (!$declaring_method_id) {
             if ($method_name === '__construct'
@@ -109,7 +111,7 @@ final class MethodVisibilityAnalyzer
             return null;
         }
 
-        $storage = $codebase->methods->getStorage($declaring_method_id);
+        $storage = $codebase->methods->getStorage($declaring_method_id, $with_pseudo);
         $visibility = $storage->visibility;
 
         if ($appearing_method_name

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -567,20 +567,7 @@ final class AtomicStaticCallAnalyzer
             '__callstatic',
         );
 
-        $callstatic_method_exists = $codebase->methods->methodExists(
-            $callstatic_id,
-            $context->calling_method_id,
-            $codebase->collect_locations
-                ? new CodeLocation($statements_analyzer, $stmt_name)
-                : null,
-            !$context->collect_initializations
-                && !$context->collect_mutations
-                ? $statements_analyzer
-                : null,
-            $statements_analyzer->getFilePath(),
-            true,
-            $context->insideUse(),
-        );
+        $callstatic_method_exists = $codebase->methods->methodExists($callstatic_id);
 
         if (!$naive_method_exists
             || !MethodAnalyzer::isMethodVisible(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -562,6 +562,26 @@ final class AtomicStaticCallAnalyzer
             return true;
         }
 
+        $callstatic_id = new MethodIdentifier(
+            $fq_class_name,
+            '__callstatic',
+        );
+
+        $callstatic_method_exists = $codebase->methods->methodExists(
+            $callstatic_id,
+            $context->calling_method_id,
+            $codebase->collect_locations
+                ? new CodeLocation($statements_analyzer, $stmt_name)
+                : null,
+            !$context->collect_initializations
+                && !$context->collect_mutations
+                ? $statements_analyzer
+                : null,
+            $statements_analyzer->getFilePath(),
+            true,
+            $context->insideUse(),
+        );
+
         if (!$naive_method_exists
             || !MethodAnalyzer::isMethodVisible(
                 $method_id,
@@ -572,25 +592,7 @@ final class AtomicStaticCallAnalyzer
             || ($found_method_and_class_storage
                 && ($config->use_phpdoc_method_without_magic_or_parent || $class_storage->parent_class))
         ) {
-            $callstatic_id = new MethodIdentifier(
-                $fq_class_name,
-                '__callstatic',
-            );
-
-            if ($codebase->methods->methodExists(
-                $callstatic_id,
-                $context->calling_method_id,
-                $codebase->collect_locations
-                    ? new CodeLocation($statements_analyzer, $stmt_name)
-                    : null,
-                !$context->collect_initializations
-                    && !$context->collect_mutations
-                    ? $statements_analyzer
-                    : null,
-                $statements_analyzer->getFilePath(),
-                true,
-                $context->insideUse(),
-            )) {
+            if ($callstatic_method_exists) {
                 $callstatic_declaring_id = $codebase->methods->getDeclaringMethodId($callstatic_id);
                 assert($callstatic_declaring_id !== null);
                 $callstatic_pure = false;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -710,7 +710,7 @@ final class AtomicStaticCallAnalyzer
                         return false;
                     }
                 }
-            } elseif ($found_method_and_class_storage) {
+            } elseif ($found_method_and_class_storage && ($naive_method_exists || $with_pseudo)) {
                 [$pseudo_method_storage, $defining_class_storage] = $found_method_and_class_storage;
 
                 if (self::checkPseudoMethod(
@@ -727,9 +727,7 @@ final class AtomicStaticCallAnalyzer
                     return false;
                 }
 
-                if ($pseudo_method_storage->return_type
-                    && ($naive_method_exists || $with_pseudo)
-                ) {
+                if ($pseudo_method_storage->return_type) {
                     return true;
                 }
             } elseif ($stmt->class instanceof PhpParser\Node\Name && $stmt->class->getFirst() === 'parent'

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -758,14 +758,18 @@ final class AtomicStaticCallAnalyzer
             }
         }
 
-        $does_method_exist = MethodAnalyzer::checkMethodExists(
-            $codebase,
-            $method_id,
-            new CodeLocation($statements_analyzer, $stmt),
-            $statements_analyzer->getSuppressedIssues(),
-            $context->calling_method_id,
-            $with_pseudo,
-        );
+        if (!$callstatic_method_exists || $class_storage->hasSealedMethods($config)) {
+            $does_method_exist = MethodAnalyzer::checkMethodExists(
+                $codebase,
+                $method_id,
+                new CodeLocation($statements_analyzer, $stmt),
+                $statements_analyzer->getSuppressedIssues(),
+                $context->calling_method_id,
+                $with_pseudo,
+            );
+        } else {
+            $does_method_exist = null;
+        }
 
         if (!$does_method_exist) {
             if (ArgumentsAnalyzer::analyze(

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -99,7 +99,8 @@ final class Methods
         ?StatementsSource $source = null,
         ?string $source_file_path = null,
         bool $use_method_existence_provider = true,
-        bool $is_used = false
+        bool $is_used = false,
+        bool $with_pseudo = false
     ): bool {
         $fq_class_name = $method_id->fq_class_name;
         $method_name = $method_id->method_name;
@@ -147,9 +148,11 @@ final class Methods
             $calling_class_name = explode('::', $calling_method_id)[0];
         }
 
-        if (isset($class_storage->declaring_method_ids[$method_name])) {
-            $declaring_method_id = $class_storage->declaring_method_ids[$method_name];
-
+        $declaring_method_id = $class_storage->declaring_method_ids[$method_name] ?? null;
+        if ($declaring_method_id === null && $with_pseudo) {
+            $declaring_method_id = $class_storage->declaring_pseudo_method_ids[$method_name] ?? null;
+        }
+        if ($declaring_method_id !== null) {
             if ($calling_method_id === strtolower((string) $declaring_method_id)) {
                 return true;
             }
@@ -1008,7 +1011,8 @@ final class Methods
 
     /** @psalm-mutation-free */
     public function getDeclaringMethodId(
-        MethodIdentifier $method_id
+        MethodIdentifier $method_id,
+        bool $with_pseudo = false
     ): ?MethodIdentifier {
         $fq_class_name = $this->classlikes->getUnAliasedName($method_id->fq_class_name);
 
@@ -1022,6 +1026,10 @@ final class Methods
 
         if ($class_storage->abstract && isset($class_storage->overridden_method_ids[$method_name])) {
             return reset($class_storage->overridden_method_ids[$method_name]);
+        }
+
+        if ($with_pseudo && isset($class_storage->declaring_pseudo_method_ids[$method_name])) {
+            return $class_storage->declaring_pseudo_method_ids[$method_name];
         }
 
         return null;
@@ -1131,7 +1139,7 @@ final class Methods
     }
 
     /** @psalm-mutation-free */
-    public function getStorage(MethodIdentifier $method_id): MethodStorage
+    public function getStorage(MethodIdentifier $method_id, bool $with_pseudo = false): MethodStorage
     {
         try {
             $class_storage = $this->classlike_storage_provider->get($method_id->fq_class_name);
@@ -1141,13 +1149,21 @@ final class Methods
 
         $method_name = $method_id->method_name;
 
-        if (!isset($class_storage->methods[$method_name])) {
+        $storage = $class_storage->methods[$method_name] ?? null;
+
+        if ($storage === null && $with_pseudo) {
+            $storage = $class_storage->pseudo_methods[$method_name]
+                ?? $class_storage->pseudo_static_methods[$method_name]
+                ?? null;
+        }
+
+        if ($storage === null) {
             throw new UnexpectedValueException(
                 '$storage should not be null for ' . $method_id,
             );
         }
 
-        return $class_storage->methods[$method_name];
+        return $storage;
     }
 
     /** @psalm-mutation-free */

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -368,7 +368,7 @@ final class Methods
             }
         }
 
-        $declaring_method_id = $this->getDeclaringMethodId($method_id);
+        $declaring_method_id = $this->getDeclaringMethodId($method_id, true);
 
         $callmap_id = $declaring_method_id ?? $method_id;
 
@@ -424,7 +424,7 @@ final class Methods
         }
 
         if ($declaring_method_id) {
-            $storage = $this->getStorage($declaring_method_id);
+            $storage = $this->getStorage($declaring_method_id, true);
 
             $params = $storage->params;
 
@@ -1088,7 +1088,7 @@ final class Methods
 
     public function getUserMethodStorage(MethodIdentifier $method_id): ?MethodStorage
     {
-        $declaring_method_id = $this->getDeclaringMethodId($method_id);
+        $declaring_method_id = $this->getDeclaringMethodId($method_id, true);
 
         if (!$declaring_method_id) {
             if (InternalCallMapHandler::inCallMap((string) $method_id)) {
@@ -1098,7 +1098,7 @@ final class Methods
             throw new UnexpectedValueException('$storage should not be null for ' . $method_id);
         }
 
-        $storage = $this->getStorage($declaring_method_id);
+        $storage = $this->getStorage($declaring_method_id, true);
 
         if (!$storage->location) {
             return null;

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -150,6 +150,54 @@ class MagicMethodAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', $context);
     }
 
+    public function testAnnotationWithoutCallConfigWithExtends(): void
+    {
+        $this->expectExceptionMessage('UndefinedMethod');
+        $this->expectException(CodeException::class);
+        Config::getInstance()->use_phpdoc_method_without_magic_or_parent = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                class MyParent {}
+                /**
+                 * @method string getString()
+                 */
+                class Child extends MyParent {}
+
+                $child = new Child();
+
+                $child->getString();',
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
+    public function testAnnotationWithoutCallConfigWithExtendsWithStatic(): void
+    {
+        $this->expectExceptionMessage('UndefinedMethod');
+        $this->expectException(CodeException::class);
+        Config::getInstance()->use_phpdoc_method_without_magic_or_parent = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                class MyParent {}
+                /**
+                 * @method static string getString()
+                 */
+                class Child extends MyParent {}
+
+                Child::getString();',
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+
     public function testOverrideParentClassRetunType(): void
     {
         Config::getInstance()->use_phpdoc_method_without_magic_or_parent = true;

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -1303,6 +1303,68 @@ class MagicMethodAnnotationTest extends TestCase
                     }',
                 'error_message' => 'UndefinedVariable',
             ],
+            'staticInvocationWithMagicMethodFoo' => [
+                'code' => '<?php
+                    /**
+                     * @method string foo()
+                     */
+                    class A {
+                        // Has "magic methods"
+                        public function __call(string $method, array $args) {}
+                        public static function __callStatic(string $method, array $args) {}
+                    }
+
+                    A::foo();',
+                'error_message' => 'InvalidStaticInvocation',
+            ],
+            'nonStaticSelfCallWithMagicMethodFoo' => [
+                'code' => '<?php
+                    /**
+                     * @method string foo()
+                     */
+                    class A {
+                        // Has "magic methods"
+                        public function __call(string $method, array $args) {}
+                        public static function __callStatic(string $method, array $args) {}
+                    }
+
+                    class B extends A {
+                        public static function bar(): void {
+                            self::foo();
+                        }
+                    }',
+                'error_message' => 'NonStaticSelfCall',
+            ],
+            'staticInvocationWithInstanceMethodFoo' => [
+                'code' => '<?php
+                    class A {
+                        public function foo(): void {}
+
+                        // Has "magic methods"
+                        public function __call(string $method, array $args) {}
+                        public static function __callStatic(string $method, array $args) {}
+                    }
+
+                    A::foo();',
+                'error_message' => 'InvalidStaticInvocation',
+            ],
+            'nonStaticSelfCallWithInstanceMethodFoo' => [
+                'code' => '<?php
+                    class A {
+                        public function foo(): void {}
+
+                        // Has "magic methods"
+                        public function __call(string $method, array $args) {}
+                        public static function __callStatic(string $method, array $args) {}
+                    }
+
+                    class B extends A {
+                        public static function bar(): void {
+                            self::foo();
+                        }
+                    }',
+                'error_message' => 'NonStaticSelfCall',
+            ],
         ];
     }
 

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -958,6 +958,7 @@ class MagicMethodAnnotationTest extends TestCase
                     class B extends A {}
                     function consumeInt(int $i): void {}
 
+                    /** @psalm-suppress UndefinedMethod */
                     consumeInt(B::bar());',
             ],
             'callUsingParent' => [

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -6,12 +6,14 @@ use Psalm\Config;
 use Psalm\Context;
 use Psalm\Exception\CodeException;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\InvalidCodeAnalysisWithIssuesTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
 use const DIRECTORY_SEPARATOR;
 
 class MagicMethodAnnotationTest extends TestCase
 {
+    use InvalidCodeAnalysisWithIssuesTestTrait;
     use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
 

--- a/tests/MagicMethodAnnotationTest.php
+++ b/tests/MagicMethodAnnotationTest.php
@@ -960,8 +960,43 @@ class MagicMethodAnnotationTest extends TestCase
                     class B extends A {}
                     function consumeInt(int $i): void {}
 
-                    /** @psalm-suppress UndefinedMethod */
+                    /** @psalm-suppress UndefinedMethod, MixedArgument */
                     consumeInt(B::bar());',
+            ],
+            'magicStaticMethodInheritanceWithoutCallStatic_WithReturnAndManyArgs' => [
+                // This is compatible with "magicMethodInheritanceWithoutCall_WithReturnAndManyArgs"
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @method static void bar()
+                     */
+                    class A {}
+                    class B extends A {}
+
+                    /** @psalm-suppress UndefinedMethod, MixedAssignment */
+                    $a = B::bar(123, "whatever");
+                    PHP,
+                'assertions' => [
+                    '$a===' => 'mixed',
+                ],
+            ],
+            'magicMethodInheritanceWithoutCall_WithReturnAndManyArgs' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @method void bar()
+                     */
+                    class A {}
+                    class B extends A {}
+
+                    $obj = new B();
+
+                    /** @psalm-suppress UndefinedMethod, MixedAssignment */
+                    $a = $obj->bar(123, "whatever");
+                    PHP,
+                'assertions' => [
+                    '$a===' => 'mixed',
+                ],
             ],
             'callUsingParent' => [
                 'code' => '<?php
@@ -1366,6 +1401,32 @@ class MagicMethodAnnotationTest extends TestCase
                         }
                     }',
                 'error_message' => 'NonStaticSelfCall',
+            ],
+            'suppressUndefinedMethodWithObjectCall_WithNotExistsFunc' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @method int bar() */
+                    class A {}
+                    class B extends A {}
+
+                    $obj = new B();
+                
+                    /** @psalm-suppress UndefinedMethod */
+                    $a = $obj->bar(function_does_not_exist(123));
+                    PHP,
+                'error_message' => 'UndefinedFunction',
+            ],
+            'suppressUndefinedMethodWithStaticCall_WithNotExistsFunc' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @method static int bar() */
+                    class A {}
+                    class B extends A {}
+                
+                    /** @psalm-suppress UndefinedMethod */
+                    $a = B::bar(function_does_not_exist(123));
+                    PHP,
+                'error_message' => 'UndefinedFunction',
             ],
         ];
     }

--- a/tests/MagicPropertyTest.php
+++ b/tests/MagicPropertyTest.php
@@ -6,12 +6,14 @@ use Psalm\Config;
 use Psalm\Context;
 use Psalm\Exception\CodeException;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\InvalidCodeAnalysisWithIssuesTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
 use const DIRECTORY_SEPARATOR;
 
 class MagicPropertyTest extends TestCase
 {
+    use InvalidCodeAnalysisWithIssuesTestTrait;
     use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
 

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -4,12 +4,14 @@ namespace Psalm\Tests;
 
 use Psalm\Context;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\InvalidCodeAnalysisWithIssuesTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
 use const DIRECTORY_SEPARATOR;
 
 class MethodCallTest extends TestCase
 {
+    use InvalidCodeAnalysisWithIssuesTestTrait;
     use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
 

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -5,12 +5,14 @@ namespace Psalm\Tests;
 use Psalm\Context;
 use Psalm\Exception\CodeException;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\InvalidCodeAnalysisWithIssuesTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
 use const DIRECTORY_SEPARATOR;
 
 class MethodSignatureTest extends TestCase
 {
+    use InvalidCodeAnalysisWithIssuesTestTrait;
     use ValidCodeAnalysisTestTrait;
     use InvalidCodeAnalysisTestTrait;
 

--- a/tests/MixinAnnotationTest.php
+++ b/tests/MixinAnnotationTest.php
@@ -3,10 +3,12 @@
 namespace Psalm\Tests;
 
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\InvalidCodeAnalysisWithIssuesTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
 class MixinAnnotationTest extends TestCase
 {
+    use InvalidCodeAnalysisWithIssuesTestTrait;
     use ValidCodeAnalysisTestTrait;
     use InvalidCodeAnalysisTestTrait;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -160,22 +160,22 @@ class TestCase extends BaseTestCase
 
     public static function assertHasIssueType(string $expected, string $message = ''): void
     {
-        $issueMessages = [];
+        $issue_messages = [];
         $res = false;
         $issues = IssueBuffer::getIssuesData();
         foreach ($issues as $file_issues) {
             foreach ($file_issues as $issue) {
-                $fullIssueMessage = $issue->type . ' - ' . $issue->file_name . ':' . $issue->line_from . ':' . $issue->column_from . ' - ' . $issue->message;
-                $issueMessages[] = $fullIssueMessage;
-                if (preg_match('/\b' . preg_quote($expected, '/') . '\b/', $fullIssueMessage)) {
+                $full_issue_message = $issue->type . ' - ' . $issue->file_name . ':' . $issue->line_from . ':' . $issue->column_from . ' - ' . $issue->message;
+                $issue_messages[] = $full_issue_message;
+                if (preg_match('/\b' . preg_quote($expected, '/') . '\b/', $full_issue_message)) {
                     $res = true;
                 }
             }
         }
         if (!$message) {
             $message = "Failed asserting that issue with \"$expected\" was emitted.";
-            if (count($issueMessages)) {
-                $message .= "\n" . 'Other issues reported:' . "\n  - " . implode("\n  - ", $issueMessages);
+            if (count($issue_messages)) {
+                $message .= "\n" . 'Other issues reported:' . "\n  - " . implode("\n  - ", $issue_messages);
             } else {
                 $message .= ' No issues reported.';
             }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -173,11 +173,11 @@ class TestCase extends BaseTestCase
             }
         }
         if (!$message) {
-            $message = "Failed asserting that issue with \"$expected\".";
+            $message = "Failed asserting that issue with \"$expected\" was emitted.";
             if (count($issueMessages)) {
-                $message .= "\n" . 'Other exists issues:' . "\n  - " . implode("\n  - ", $issueMessages);
+                $message .= "\n" . 'Other issues reported:' . "\n  - " . implode("\n  - ", $issueMessages);
             } else {
-                $message .= ' Issues is not exists.';
+                $message .= ' No issues reported.';
             }
         }
         self::assertTrue($res, $message);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -158,7 +158,7 @@ class TestCase extends BaseTestCase
         return $this->getName($withDataSet);
     }
 
-    public static function assertHasIssueType(string $expected, string $message = ''): void
+    public static function assertHasIssue(string $expected, string $message = ''): void
     {
         $issue_messages = [];
         $res = false;

--- a/tests/Traits/InvalidCodeAnalysisWithIssuesTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisWithIssuesTestTrait.php
@@ -27,10 +27,12 @@ use const PHP_VERSION;
  * $codebase->config->throw_exception = true; // or false
  * ```
  *
- * If "throw_exception" is set to `true`, code execution stops.
+ * When `throw_exception` is set to `true`, code execution stops once
+ * the first issue is emitted, thus it may mask any problems after
+ * that point.
  *
- * If "throw_exception" is set to `false`, the code may continue
- * to execute, and an error may potentially occur.
+ * When `throw_exception` is set to `false`, the code will continue
+ * to be executed and we can uncover some additional bugs.
  *
  * This is trait allows testing for the second case, when the value of
  * "throw_exception" will be "false".

--- a/tests/Traits/InvalidCodeAnalysisWithIssuesTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisWithIssuesTestTrait.php
@@ -107,6 +107,6 @@ trait InvalidCodeAnalysisWithIssuesTestTrait
         $this->addFile($file_path, $code);
         $this->analyzeFile($file_path, new Context());
 
-        $this->assertHasIssueType($error_message);
+        $this->assertHasIssue($error_message);
     }
 }

--- a/tests/Traits/InvalidCodeAnalysisWithIssuesTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisWithIssuesTestTrait.php
@@ -32,7 +32,7 @@ use const PHP_VERSION;
  * If "throw_exception" is set to `false`, the code may continue
  * to execute, and an error may potentially occur.
  *
- * This commit allows testing for the second case, when the value of
+ * This is trait allows testing for the second case, when the value of
  * "throw_exception" will be "false".
  *
  * @psalm-type DeprecatedDataProviderArrayNotation = array{

--- a/tests/Traits/InvalidCodeAnalysisWithIssuesTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisWithIssuesTestTrait.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Psalm\Tests\Traits;
+
+use Psalm\Config;
+use Psalm\Context;
+
+use function str_replace;
+use function strpos;
+use function strtoupper;
+use function substr;
+use function version_compare;
+
+use const PHP_OS;
+use const PHP_VERSION;
+
+/**
+ * Support for testing with the creation of a list of issues
+ *
+ *
+ * #### Description of motivation
+ *
+ * We have two different behaviors for the code related to
+ * "CodeException":
+ *
+ * ```
+ * $codebase->config->throw_exception = true; // or false
+ * ```
+ *
+ * If "throw_exception" is set to `true`, code execution stops.
+ *
+ * If "throw_exception" is set to `false`, the code may continue
+ * to execute, and an error may potentially occur.
+ *
+ * This commit allows testing for the second case, when the value of
+ * "throw_exception" will be "false".
+ *
+ * @psalm-type DeprecatedDataProviderArrayNotation = array{
+ *     code: string,
+ *     error_message: string,
+ *     ignored_issues?: list<string>,
+ *     php_version?: string
+ * }
+ * @psalm-type NamedArgumentsDataProviderArrayNotation = array{
+ *     code: string,
+ *     error_message: string,
+ *     error_levels?: list<string>,
+ *     php_version?: string
+ * }
+ */
+trait InvalidCodeAnalysisWithIssuesTestTrait
+{
+    /**
+     * @return iterable<
+     *     string,
+     *     DeprecatedDataProviderArrayNotation|NamedArgumentsDataProviderArrayNotation
+     * >
+     */
+    abstract public function providerInvalidCodeParse(): iterable;
+
+    /**
+     * @dataProvider providerInvalidCodeParse
+     * @small
+     * @param list<string> $error_levels
+     */
+    public function testInvalidCodeWithIssues(
+        string $code,
+        string $error_message,
+        array  $error_levels = [],
+        string $php_version = '7.4'
+    ): void {
+        $test_name = $this->getTestName();
+        if (strpos($test_name, 'PHP80-') !== false) {
+            if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+                $this->markTestSkipped('Test case requires PHP 8.0.');
+            }
+        } elseif (strpos($test_name, 'SKIPPED-') !== false) {
+            $this->markTestSkipped('Skipped due to a bug.');
+        }
+
+        // sanity check - do we have a PHP tag?
+        if (strpos($code, '<?php') === false) {
+            $this->fail('Test case must have a <?php tag');
+        }
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $code = str_replace("\n", "\r\n", $code);
+        }
+
+        foreach ($error_levels as $error_level) {
+            $issue_name = $error_level;
+            $error_level = Config::REPORT_SUPPRESS;
+
+            Config::getInstance()->setCustomErrorLevel($issue_name, $error_level);
+        }
+
+        $this->project_analyzer->setPhpVersion($php_version, 'tests');
+
+        $file_path = self::$src_dir_path . 'somefile.php';
+
+        $codebase = $this->project_analyzer->getCodebase();
+        $codebase->enterServerMode();
+        $codebase->config->visitPreloadedStubFiles($codebase);
+
+        $codebase->config->throw_exception = false;
+
+        $this->addFile($file_path, $code);
+        $this->analyzeFile($file_path, new Context());
+
+        $this->assertHasIssueType($error_message);
+    }
+}


### PR DESCRIPTION
Key fixes for static magic methods:
- behavior with `@psalm-seal-methods` and related...
- detection the issue "InvalidStaticInvocation"
- detection the issue "NonStaticSelfCall"