### PR TITLE
Update master from 5.x

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -13,6 +13,7 @@ use Psalm\Internal\Analyzer\ClassAnalyzer;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Analyzer\FunctionLikeAnalyzer;
 use Psalm\Internal\Analyzer\NamespaceAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\Call\Method\MethodCallReturnTypeFetcher;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\Method\MethodVisibilityAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
@@ -23,6 +24,7 @@ use Psalm\Internal\DataFlow\TaintSink;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TemplateStandinTypeReplacer;
+use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\AbstractInstantiation;
 use Psalm\Issue\DeprecatedClass;
 use Psalm\Issue\ImpureMethodCall;
@@ -60,6 +62,7 @@ use Psalm\Type\Union;
 
 use function array_map;
 use function array_values;
+use function count;
 use function in_array;
 use function md5;
 use function preg_match;
@@ -431,6 +434,8 @@ final class NewAnalyzer extends CallAnalyzer
 
             $declaring_method_id = $codebase->methods->getDeclaringMethodId($method_id);
 
+            $method_storage = null;
+
             if ($declaring_method_id) {
                 $method_storage = $codebase->methods->getStorage($declaring_method_id);
 
@@ -502,6 +507,7 @@ final class NewAnalyzer extends CallAnalyzer
             }
 
             $generic_param_types = null;
+            $self_out_candidate = null;
 
             if ($storage->template_types) {
                 foreach ($storage->template_types as $template_name => $base_type) {
@@ -539,9 +545,49 @@ final class NewAnalyzer extends CallAnalyzer
                         'had_template' => true,
                     ]);
                 }
+
+                if ($method_storage && $method_storage->self_out_type) {
+                    $self_out_candidate = $method_storage->self_out_type;
+
+                    if ($template_result->lower_bounds) {
+                        $self_out_candidate = TypeExpander::expandUnion(
+                            $codebase,
+                            $self_out_candidate,
+                            $fq_class_name,
+                            null,
+                            $storage->parent_class,
+                            true,
+                            false,
+                            false,
+                            true,
+                        );
+                    }
+
+                    $self_out_candidate = MethodCallReturnTypeFetcher::replaceTemplateTypes(
+                        $self_out_candidate,
+                        $template_result,
+                        $method_id,
+                        count($stmt->getArgs()),
+                        $codebase,
+                    );
+
+                    $self_out_candidate = TypeExpander::expandUnion(
+                        $codebase,
+                        $self_out_candidate,
+                        $fq_class_name,
+                        $fq_class_name,
+                        $storage->parent_class,
+                        true,
+                        false,
+                        false,
+                        true,
+                    );
+                    $statements_analyzer->node_data->setType($stmt, $self_out_candidate);
+                }
             }
 
-            if ($generic_param_types) {
+            // XXX: what if we need both?
+            if ($generic_param_types && !$self_out_candidate) {
                 $result_atomic_type = new TGenericObject(
                     $fq_class_name,
                     $generic_param_types,

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -78,6 +78,7 @@ use function array_values;
 use function assert;
 use function count;
 use function implode;
+use function ltrim;
 use function preg_match;
 use function preg_split;
 use function strtolower;
@@ -1925,7 +1926,7 @@ final class ClassLikeNodeScanner
                 continue;
             }
 
-            if ($var_line_parts[0] === ' ') {
+            while (isset($var_line_parts[0]) && $var_line_parts[0] === ' ') {
                 array_shift($var_line_parts);
             }
 
@@ -1941,11 +1942,12 @@ final class ClassLikeNodeScanner
                 continue;
             }
 
-            if ($var_line_parts[0] === ' ') {
+            while (isset($var_line_parts[0]) && $var_line_parts[0] === ' ') {
                 array_shift($var_line_parts);
             }
 
             $type_string = implode('', $var_line_parts);
+            $type_string = ltrim($type_string, "* \n\r");
             try {
                 $type_string = CommentAnalyzer::splitDocLine($type_string)[0];
             } catch (DocblockParseException $e) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -242,6 +242,13 @@ final class FunctionLikeDocblockParser
 
                 if (count($param_parts) >= 2) {
                     $info->taint_sink_params[] = ['name' => $param_parts[1], 'taint' => $param_parts[0]];
+                } else {
+                    IssueBuffer::maybeAdd(
+                        new InvalidDocblock(
+                            '@psalm-taint-sink expects 2 arguments',
+                            $code_location,
+                        ),
+                    );
                 }
             }
         }
@@ -283,6 +290,13 @@ final class FunctionLikeDocblockParser
 
                 if ($param_parts[0]) {
                     $info->taint_source_types[] = $param_parts[0];
+                } else {
+                    IssueBuffer::maybeAdd(
+                        new InvalidDocblock(
+                            '@psalm-taint-source expects 1 argument',
+                            $code_location,
+                        ),
+                    );
                 }
             }
         } elseif (isset($parsed_docblock->tags['return-taint'])) {

--- a/stubs/extensions/random.phpstub
+++ b/stubs/extensions/random.phpstub
@@ -87,10 +87,20 @@ namespace Random
          */
         public function getBytes(int $length): string {}
 
+        /**
+         * @template TValue
+         * @param array<TValue> $array
+         * @return list<TValue>
+         */
         public function shuffleArray(array $array): array {}
 
         public function shuffleBytes(string $bytes): string {}
 
+        /**
+         * @template TKey as array-key
+         * @param array<TKey, mixed> $array
+         * @return list<TKey>
+         */
         public function pickArrayKeys(array $array, int $num): array {}
 
         public function __serialize(): array {}

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -515,6 +515,28 @@ class AnnotationTest extends TestCase
                      */
                     class A {}',
             ],
+            'multipeLineGenericArray2' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-type TRelAlternate =
+                     * list<
+                     *      array{
+                     *          href: string,
+                     *          lang: string
+                     *      }
+                     * >
+                     */
+                    class A {
+                        /** @return TRelAlternate */
+                        public function ret(): array { return []; }
+                    }
+
+                    $_ = (new A)->ret();
+                ',
+                'assertions' => [
+                    '$_===' => 'list<array{href: string, lang: string}>',
+                ],
+            ],
             'builtInClassInAShape' => [
                 'code' => '<?php
                     /**

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -1807,6 +1807,22 @@ class MethodCallTest extends TestCase
                 PHP,
                 'error_message' => 'TooManyArguments',
             ],
+            'firstClassCallableWithUnknownStaticMethod' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class A {}
+                    $_a = A::foo(...);
+                PHP,
+                'error_message' => 'UndefinedMethod',
+            ],
+            'firstClassCallableWithUnknownInstanceMethod' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class A {}
+                    $_a = (new A)->foo(...);
+                PHP,
+                'error_message' => 'UndefinedMethod',
+            ],
         ];
     }
 }

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -786,7 +786,7 @@ class ConditionalReturnTypeTest extends TestCase
                          * @template TSource as self::SOURCE_*
                          * @param TSource $source
                          * @return (TSource is "BODY" ? object|list : array)
-                         * @psalm-taint-source
+                         * @psalm-taint-source input
                          */
                         public function getParams(
                             string $source = self::SOURCE_GET

--- a/tests/ThisOutTest.php
+++ b/tests/ThisOutTest.php
@@ -86,6 +86,26 @@ class ThisOutTest extends TestCase
                     '$data3===' => 'list<2|3>',
                 ],
             ],
+            'provideDefaultTypeToTypeArguments' => [
+                'code' => <<<'PHP'
+                <?php
+                    /** @template T of 'idle'|'running' */
+                    class App {
+                        /** @psalm-this-out self<'idle'> */
+                        public function __construct() {}
+
+                        /**
+                         * @psalm-if-this-is self<'idle'>
+                         * @psalm-this-out self<'running'>
+                         */
+                        public function start(): void {}
+                    }
+                    $app = new App();
+                PHP,
+                'assertions' => [
+                    '$app===' => "App<'idle'>",
+                ],
+            ],
         ];
     }
 }

--- a/tests/TypeAnnotationTest.php
+++ b/tests/TypeAnnotationTest.php
@@ -940,6 +940,22 @@ class TypeAnnotationTest extends TestCase
                     }
                 PHP,
             ],
+            'typeWithMultipleSpaces' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @psalm-type Foo      =     string
+                     * @psalm-type Bar           int
+                     */
+                    class A {
+                        /**
+                         * @psalm-param Foo $foo
+                         * @psalm-param Bar $bar
+                         */
+                        public function bar(string $foo, int $bar): void {}
+                    }
+                PHP,
+            ],
         ];
     }
 


### PR DESCRIPTION
- Process `@psalm-this-out` on `__construct()` as well
- Report first class callables generated for unknown static methods
- Handle taking references to unspecified magic methods
- Report invalid number of arguments for psalm-taint-*
- fix test
- Use IssueBuffer::maybeAdd() instead of throwing
- Improve randomizer stubs
- Improve parsing of psalm-type
- Allow multiple spaces between type name and type definition
