### PR TITLE
Fix non-empty-lowercase-string handling with literal non-lowercase strings

### DIFF
--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -1103,18 +1103,53 @@ final class TypeCombiner
                         } else {
                             $combination->value_types['string'] = $type;
                         }
-                    } elseif ($type instanceof TNonEmptyString) {
+                    } elseif ($type instanceof TNonFalsyString) {
                         $has_empty_string = false;
+                        $has_falsy_string = false;
 
                         foreach ($combination->strings as $string_type) {
-                            if (!$string_type->value) {
+                            if ($string_type->value === '') {
                                 $has_empty_string = true;
+                                $has_falsy_string = true;
                                 break;
+                            }
+
+                            if ($string_type->value === '0') {
+                                $has_falsy_string = true;
                             }
                         }
 
                         if ($has_empty_string) {
                             $combination->value_types['string'] = new TString();
+                        } elseif ($has_falsy_string) {
+                            $combination->value_types['string'] = new TNonEmptyString();
+                        } else {
+                            $combination->value_types['string'] = $type;
+                        }
+                    } elseif ($type instanceof TNonEmptyString) {
+                        $has_empty_string = false;
+
+                        foreach ($combination->strings as $string_type) {
+                            if ($string_type->value === '') {
+                                $has_empty_string = true;
+                                break;
+                            }
+                        }
+
+                        $has_non_lowercase_string = false;
+                        if ($type instanceof TNonEmptyLowercaseString) {
+                            foreach ($combination->strings as $string_type) {
+                                if (strtolower($string_type->value) !== $string_type->value) {
+                                    $has_non_lowercase_string = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if ($has_empty_string) {
+                            $combination->value_types['string'] = new TString();
+                        } elseif ($has_non_lowercase_string && get_class($type) !== TNonEmptyString::class) {
+                            $combination->value_types['string'] = new TNonEmptyString();
                         } else {
                             $combination->value_types['string'] = $type;
                         }

--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -1048,11 +1048,18 @@ final class TypeCombiner
                 ) {
                     // do nothing
                 } elseif (isset($combination->value_types['string'])
+                    && $combination->value_types['string'] instanceof TNonFalsyString
+                    && $type->value
+                ) {
+                    // do nothing
+                } elseif (isset($combination->value_types['string'])
+                    && $combination->value_types['string'] instanceof TNonFalsyString
+                    && $type->value === '0'
+                ) {
+                    $combination->value_types['string'] = new TNonEmptyString();
+                } elseif (isset($combination->value_types['string'])
                     && $combination->value_types['string'] instanceof TNonEmptyString
-                    && ($combination->value_types['string'] instanceof TNonFalsyString
-                        ? $type->value
-                        : $type->value !== ''
-                    )
+                    && $type->value !== ''
                 ) {
                     // do nothing
                 } else {

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -934,7 +934,7 @@ class TypeCombinationTest extends TestCase
                 ],
             ],
             'nonFalsyStringAndFalsyLiteral' => [
-                'string',
+                'non-empty-string',
                 [
                     'non-falsy-string',
                     '"0"',

--- a/tests/TypeCombinationTest.php
+++ b/tests/TypeCombinationTest.php
@@ -127,6 +127,40 @@ class TypeCombinationTest extends TestCase
                     '$x===' => 'non-falsy-string',
                 ],
             ],
+            'loopNonFalsyWithZeroShouldBeNonEmpty' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-suppress InvalidReturnType
+                     * @return string[]
+                     */
+                    function getStringArray() {}
+
+                    $x = array();
+                    foreach (getStringArray() as $id) {
+                        $x[] = "0";
+                        $x[] = "some_" . $id;
+                    }',
+                'assertions' => [
+                    '$x===' => 'list<non-empty-string>',
+                ],
+            ],
+            'loopNonLowercaseLiteralWithNonEmptyLowercaseShouldBeNonEmptyAndNotLowercase' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-suppress InvalidReturnType
+                     * @return int[]
+                     */
+                    function getIntArray() {}
+
+                    $x = array();
+                    foreach (getIntArray() as $id) {
+                        $x[] = "TEXT";
+                        $x[] = "some_" . $id;
+                    }',
+                'assertions' => [
+                    '$x===' => 'list<non-empty-string>',
+                ],
+            ],
         ];
     }
 


### PR DESCRIPTION
* Fix https://github.com/vimeo/psalm/issues/9782 and related issues
* add explicit handling for non-falsy-string to not fallback non-falsy-string and 0 to string
* revert https://github.com/vimeo/psalm/pull/10039 to make it more exact and fix the test to be exact @danog @orklah 