### PR TITLE
Reprocess missing class-like storage events

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -433,11 +433,16 @@ final class Codebase
      */
     public function scanFiles(int $threads = 1): void
     {
-        $has_changes = $this->scanner->scanFiles($this->classlikes, $threads);
-
-        if ($has_changes) {
-            $this->populator->populateCodebase();
-        }
+        $max = 10;
+        do {
+            $has_changes = $this->scanner->scanFiles($this->classlikes, $threads);
+            if ($has_changes) {
+                $this->populator->populateCodebase();
+            }
+            // in case previous scans failed, let's try again after previously found
+            // references (class-like storage items and dependencies) were populated
+            $shall_rescan = $this->scanner->prepareRescanFiles();
+        } while ($max-- > 0 && $shall_rescan);
     }
 
     public function getFileContents(string $file_path): string

--- a/src/Psalm/Exception/ClassStorageNotFoundException.php
+++ b/src/Psalm/Exception/ClassStorageNotFoundException.php
@@ -5,22 +5,19 @@ declare(strict_types=1);
 namespace Psalm\Exception;
 
 use InvalidArgumentException;
+use Throwable;
 
 /**
  * To be thrown when a `\Psalm\Storage\ClassLikeStorage` for a given name could not be resolved.
  */
 final class ClassStorageNotFoundException extends InvalidArgumentException
 {
-    private ?string $name = null;
+    /** @psalm-suppress PossiblyUnusedProperty */
+    public readonly ?string $name;
 
-    public function setName(string $name): self
+    public function __construct(string $message = '', int $code = 0, Throwable $previous = null, string $name = null)
     {
+        parent::__construct($message, $code, $previous);
         $this->name = $name;
-        return $this;
-    }
-
-    public function getName(): ?string
-    {
-        return $this->name;
     }
 }

--- a/src/Psalm/Exception/ClassStorageNotFoundException.php
+++ b/src/Psalm/Exception/ClassStorageNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Exception;
+
+use InvalidArgumentException;
+
+/**
+ * To be thrown when a `\Psalm\Storage\ClassLikeStorage` for a given name could not be resolved.
+ */
+final class ClassStorageNotFoundException extends InvalidArgumentException
+{
+    private ?string $name = null;
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+        return $this;
+    }
+
+    public function getName(): ?string
+    {
+        return $this->name;
+    }
+}

--- a/src/Psalm/Internal/Fork/Pool.php
+++ b/src/Psalm/Internal/Fork/Pool.php
@@ -370,6 +370,7 @@ final class Pool
                                  */
                                 posix_kill($child_pid, SIGTERM);
                             }
+                            // @todo add more meta-data why the process failed for a potential auto-recovery
                             throw new Exception($message->message);
                         } else {
                             error_log('Child should return ForkMessage - response type=' . gettype($message));

--- a/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
@@ -41,9 +41,12 @@ final class ClassLikeStorageProvider
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
         /** @psalm-suppress ImpureStaticProperty Used only for caching */
         if (!isset(self::$storage[$fq_classlike_name_lc])) {
-            throw (new ClassStorageNotFoundException(
-                'Could not get class storage for ' . $fq_classlike_name_lc)
-            )->setName($fq_classlike_name_lc);
+            throw new ClassStorageNotFoundException(
+                'Could not get class storage for ' . $fq_classlike_name_lc,
+                0,
+                null,
+                $fq_classlike_name_lc,
+            );
         }
 
         /** @psalm-suppress ImpureStaticProperty Used only for caching */

--- a/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageProvider.php
@@ -6,6 +6,7 @@ namespace Psalm\Internal\Provider;
 
 use InvalidArgumentException;
 use LogicException;
+use Psalm\Exception\ClassStorageNotFoundException;
 use Psalm\Storage\ClassLikeStorage;
 
 use function strtolower;
@@ -40,7 +41,9 @@ final class ClassLikeStorageProvider
         $fq_classlike_name_lc = strtolower($fq_classlike_name);
         /** @psalm-suppress ImpureStaticProperty Used only for caching */
         if (!isset(self::$storage[$fq_classlike_name_lc])) {
-            throw new InvalidArgumentException('Could not get class storage for ' . $fq_classlike_name_lc);
+            throw (new ClassStorageNotFoundException(
+                'Could not get class storage for ' . $fq_classlike_name_lc)
+            )->setName($fq_classlike_name_lc);
         }
 
         /** @psalm-suppress ImpureStaticProperty Used only for caching */

--- a/tests/NativeIntersectionsTest.php
+++ b/tests/NativeIntersectionsTest.php
@@ -53,6 +53,64 @@ class NativeIntersectionsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'nativeTypeIntersectionAsClassProperty' => [
+                'code' => '<?php
+                    interface A {}
+                    interface B {}
+                    class C implements A, B {}
+                    class D {
+                        private A&B $intersection;
+                        public function __construct()
+                        {
+                            $this->intersection = new C();
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nativeTypeIntersectionAsClassPropertyUsingProcessedInterfaces' => [
+                'code' => '<?php
+                    interface A {}
+                    interface B {}
+                    class AB implements A, B {}
+                    class C {
+                        private A&B $other;
+                        public function __construct()
+                        {
+                            $this->other = new AB();
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nativeTypeIntersectionAsClassPropertyUsingUnprocessedInterfaces' => [
+                'code' => '<?php
+                    class StringableJson implements \Stringable, \JsonSerializable {
+                        public function jsonSerialize(): array
+                        {
+                            return [];
+                        }
+                        public function __toString(): string
+                        {
+                            return json_encode($this);
+                        }
+                    }
+                    class C {
+                        private \Stringable&\JsonSerializable $other;
+                        public function __construct()
+                        {
+                            $this->other = new StringableJson();
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 


### PR DESCRIPTION
The scenario described in #10350 fails, since not all other references used in intersection types were complete resolved when scanning a particular file. Instead of catching exceptions during the type resolution process - which would just "mute" the problem and drop important information - those failures in resolving class-like storages are tracked for a potential rescanning.

This PR does the following:

* introduces a new `ClassStorageNotFoundException` (instead of  global `InvalidArgumentException`) to handle missing class-like storage references specifically
* tracks those storage failures during the scanning process in `$files_to_rescan` for later processing
* adds bool return type to `\Psalm\Internal\Codebase\Scanner::scanAPath()` - whether scan was successful
* modifies `Codebase::scanFiles()` to actually reprocess those files to be rescanned - after changes of the previous run were populated to the codebase
* adds test cases for the known scenario of issue #10350 

---

Fixes: https://github.com/vimeo/psalm/issues/7520
Fixes: https://github.com/vimeo/psalm/issues/10350
Fixes: https://github.com/vimeo/psalm/issues/10152

---

### TODO

+ [ ] tackle `\Psalm\Internal\Codebase\Scanner::scanAPath()` return type in forked processes - currently only tested with `$pool_size = 1` in test cases