### PR TITLE
Avoid exceptions on fetching uninitialized names in ClassLikes

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -613,6 +613,9 @@ final class ClassLikes
             return false;
         }
 
+        if (!$this->classlike_storage_provider->has($unaliased_fq_class_name)) {
+            return false;
+        }
         $class_storage = $this->classlike_storage_provider->get($unaliased_fq_class_name);
 
         if ($from_api && !$class_storage->populated) {
@@ -722,7 +725,9 @@ final class ClassLikes
     public function getParentInterfaces(string $fq_interface_name): array
     {
         $fq_interface_name = strtolower($fq_interface_name);
-
+        if (!$this->classlike_storage_provider->has($fq_interface_name)) {
+            return [];
+        }
         return $this->classlike_storage_provider->get($fq_interface_name)->parent_interfaces;
     }
 

--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -496,7 +496,7 @@ final class UnionTypeComparator
     /**
      * @return list<Atomic>
      */
-    private static function getTypeParts(
+    public static function getTypeParts(
         Codebase $codebase,
         Union $union_type
     ): array {

--- a/tests/NativeIntersectionsTest.php
+++ b/tests/NativeIntersectionsTest.php
@@ -51,6 +51,64 @@ class NativeIntersectionsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'nativeTypeIntersectionAsClassProperty' => [
+                'code' => '<?php
+                    interface A {}
+                    interface B {}
+                    class C implements A, B {}
+                    class D {
+                        private A&B $intersection;
+                        public function __construct()
+                        {
+                            $this->intersection = new C();
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nativeTypeIntersectionAsClassPropertyUsingProcessedInterfaces' => [
+                'code' => '<?php
+                    interface A {}
+                    interface B {}
+                    class AB implements A, B {}
+                    class C {
+                        private A&B $other;
+                        public function __construct()
+                        {
+                            $this->other = new AB();
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nativeTypeIntersectionAsClassPropertyUsingUnprocessedInterfaces' => [
+                'code' => '<?php
+                    class StringableJson implements \Stringable, \JsonSerializable {
+                        public function jsonSerialize(): array
+                        {
+                            return [];
+                        }
+                        public function __toString(): string
+                        {
+                            return json_encode($this);
+                        }
+                    }
+                    class C {
+                        private \Stringable&\JsonSerializable $other;
+                        public function __construct()
+                        {
+                            $this->other = new StringableJson();
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 
@@ -135,6 +193,22 @@ class NativeIntersectionsTest extends TestCase
                 'error_message' => 'ParseError',
                 'ignored_issues' => [],
                 'php_version' => '8.0',
+            ],
+            'nativeTypeIntersectionAsClassPropertyUsingUnknownInterfaces' => [
+                'code' => '<?php
+                    class C {
+                        private \Example\Unknown\A&\Example\Unknown\B $other;
+                        public function __construct()
+                        {
+                            $this->other = new \Example\Unknown\AB();
+                        }
+                    }
+                ',
+                // @todo decide whether a fall-back should be implemented, that allows to by-pass this failure (opt-in config)
+                // `UndefinedClass - src/somefile.php:3:33 - Class, interface or enum named Example\Unknown\B does not exist`
+                'error_message' => 'UndefinedClass',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
         ];
     }


### PR DESCRIPTION
Similar to the behavior of `ClassLikes::classImplements()` (#5984),
the following methods will return a false/empty value in case a
specific class name has not been initialized yet:

+ `ClassLikes::classExtends()` returns `false`
+ `ClassLikes::getParentInterfaces()` returns `[]`

---

Fixes: https://github.com/vimeo/psalm/issues/7520
Fixes: https://github.com/vimeo/psalm/issues/10350
Fixes: https://github.com/vimeo/psalm/issues/10152
