### PR TITLE
Allow `Override` attribute to be used in pure contexts

### DIFF
--- a/stubs/CoreGenericAttributes.phpstub
+++ b/stubs/CoreGenericAttributes.phpstub
@@ -1,17 +1,20 @@
 <?php
 
+/** @psalm-immutable */
 #[Attribute(Attribute::TARGET_CLASS)]
 final class AllowDynamicProperties
 {
     public function __construct() {}
 }
 
+/** @psalm-immutable */
 #[Attribute(Attribute::TARGET_METHOD)]
 final class Override
 {
     public function __construct() {}
 }
 
+/** @psalm-immutable */
 #[Attribute(Attribute::TARGET_PARAMETER)]
 final class SensitiveParameter
 {

--- a/tests/OverrideTest.php
+++ b/tests/OverrideTest.php
@@ -68,6 +68,23 @@ class OverrideTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.3',
             ],
+            'canBeUsedOnPureMethods' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class A {
+                        /** @psalm-pure */
+                        public function f(): void {}
+                    }
+                    class B extends A {
+                        /** @psalm-pure */
+                        #[Override]
+                        public function f(): void {}
+                    }
+                    PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes vimeo/psalm#10731