### PR TITLE
Add @psalm-no-discard annotation and report UnusedFunctionCall for @psalm-taint-escape calls

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -535,7 +535,7 @@ $counter->count = 5; // This will fail, as it's mutating a property directly
 
 ### `@psalm-no-discard`
 
-Like PHP 8.5 `#[NoDiscard]` attribute
+Like PHP 8.5 `#[NoDiscard]` attribute, except that it can also be resolved with @psalm-suppress instead of using a `(void)` cast, since that is only available in PHP 8.5+. 
 
 ```php
 <?php

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -533,6 +533,25 @@ echo $counter->count; // outputs 1
 $counter->count = 5; // This will fail, as it's mutating a property directly
 ```
 
+### `@psalm-require-usage`
+
+Used to annotate an impure function or method the unused result of which Psalm should report.
+
+```php
+<?php
+/**
+ * @psalm-require-usage
+ *
+ * @return int
+ */
+function foo() {
+	return rand();
+}
+
+foo(); // reports UnusedFunctionCall
+echo foo(); // no error
+```
+
 ### `@psalm-trace`
 
 You can use this annotation to trace inferred type (applied to the *next* statement).

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -533,14 +533,14 @@ echo $counter->count; // outputs 1
 $counter->count = 5; // This will fail, as it's mutating a property directly
 ```
 
-### `@psalm-require-usage`
+### `@psalm-no-discard`
 
-Used to annotate an impure function or method the unused result of which Psalm should report.
+Like PHP 8.5 `#[NoDiscard]` attribute
 
 ```php
 <?php
 /**
- * @psalm-require-usage
+ * @psalm-no-discard
  *
  * @return int
  */

--- a/docs/running_psalm/issues/ImpureFunctionCall.md
+++ b/docs/running_psalm/issues/ImpureFunctionCall.md
@@ -17,7 +17,7 @@ function impure(array $a) : array {
 }
 
 /** @psalm-pure */
-function filterOdd(array $a) : void {
-    impure($a);
+function filterOdd(array $a) : array {
+    return impure($a);
 }
 ```

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -37,6 +37,7 @@ final class DocComment
         'require-extends', 'require-implements', 'param-out', 'ignore-var',
         'consistent-templates', 'if-this-is', 'this-out', 'check-type', 'check-type-exact',
         'api', 'inheritors',
+        'require-usage',
     ];
 
     /**

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -37,7 +37,7 @@ final class DocComment
         'require-extends', 'require-implements', 'param-out', 'ignore-var',
         'consistent-templates', 'if-this-is', 'this-out', 'check-type', 'check-type-exact',
         'api', 'inheritors',
-        'require-usage',
+        'no-discard',
     ];
 
     /**

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -834,7 +834,9 @@ final class ReturnTypeAnalyzer
             $incompatible_annotation_text = false;
             if ($storage->require_usage) {
                 $incompatible_annotation_text = '@psalm-require-usage';
-            } elseif ($storage->pure) {
+            } elseif ($storage->pure && !$storage->return_type->isNever()) {
+                // currently not for "never", since exit is pure atm
+                // see https://github.com/vimeo/psalm/issues/10762
                 $incompatible_annotation_text = '@psalm-pure';
             } elseif ($storage->removed_taints || $storage->conditionally_removed_taints) {
                 $incompatible_annotation_text = '@psalm-taint-escape';

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -834,7 +834,7 @@ final class ReturnTypeAnalyzer
             $incompatible_annotation_text = false;
             if ($storage->require_usage) {
                 $incompatible_annotation_text = '@psalm-require-usage';
-            } elseif ($storage->pure && !$storage->return_type->isNever()) {
+            } elseif ($storage->pure && !$storage->assertions && !$storage->return_type->isNever()) {
                 // currently not for "never", since exit is pure atm
                 // see https://github.com/vimeo/psalm/issues/10762
                 $incompatible_annotation_text = '@psalm-pure';

--- a/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLike/ReturnTypeAnalyzer.php
@@ -832,8 +832,8 @@ final class ReturnTypeAnalyzer
 
         if ($storage->return_type->isVoid() || $storage->return_type->isNever()) {
             $incompatible_annotation_text = false;
-            if ($storage->require_usage) {
-                $incompatible_annotation_text = '@psalm-require-usage';
+            if ($storage->no_discard) {
+                $incompatible_annotation_text = '@psalm-no-discard';
             } elseif ($storage->pure && !$storage->assertions && !$storage->return_type->isNever()) {
                 // currently not for "never", since exit is pure atm
                 // see https://github.com/vimeo/psalm/issues/10762

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -2035,7 +2035,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                     $this->getSuppressedIssues(),
                     true,
                 );
-                    
+
                 if ($codebase->alter_code
                     && $storage->stmt_location !== null
                     && isset($this->getProjectAnalyzer()->getIssuesToFix()['MissingOverrideAttribute'])

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -1144,7 +1144,7 @@ final class FunctionCallAnalyzer extends CallAnalyzer
             && $codebase->find_unused_variables
             && !$context->inside_unset
             && !$context->insideUse()
-            && ($function_call_info->function_storage->require_usage
+            && ($function_call_info->function_storage->no_discard
                 || $function_call_info->function_storage->removed_taints
                 || $function_call_info->function_storage->conditionally_removed_taints)
             && !(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -357,6 +357,14 @@ final class FunctionCallAnalyzer extends CallAnalyzer
             $context,
         );
 
+        self::checkFunctionUnused(
+            $statements_analyzer,
+            $codebase,
+            $function_name,
+            $function_call_info,
+            $context,
+        );
+
         if ($function_call_info->function_storage) {
             if ($function_call_info->function_storage->assertions && $function_name instanceof PhpParser\Node\Name) {
                 self::applyAssertionsToContext(
@@ -1118,6 +1126,41 @@ final class FunctionCallAnalyzer extends CallAnalyzer
                     $stmt->setAttribute('pure', true);
                 }
             }
+        }
+    }
+
+    private static function checkFunctionUnused(
+        StatementsAnalyzer $statements_analyzer,
+        Codebase $codebase,
+        PhpParser\Node $function_name,
+        FunctionCallInfo $function_call_info,
+        Context $context,
+    ): void {
+        if (!$context->collect_initializations
+            && !$context->collect_mutations
+            && $function_call_info->function_id !== null
+            && $function_call_info->function_storage
+            && !$function_call_info->function_storage->assertions
+            && $codebase->find_unused_variables
+            && !$context->inside_unset
+            && !$context->insideUse()
+            && ($function_call_info->function_storage->require_usage
+                || $function_call_info->function_storage->removed_taints
+                || $function_call_info->function_storage->conditionally_removed_taints)
+            && !(
+                $function_call_info->function_storage->return_type &&
+                ($function_call_info->function_storage->return_type->isVoid()
+                    || $function_call_info->function_storage->return_type->isNever())
+            )
+        ) {
+            IssueBuffer::maybeAdd(
+                new UnusedFunctionCall(
+                    'The call to ' . $function_call_info->function_id . ' is not used',
+                    new CodeLocation($statements_analyzer, $function_name),
+                    $function_call_info->function_id,
+                ),
+                $statements_analyzer->getSuppressedIssues(),
+            );
         }
     }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -148,7 +148,7 @@ final class MethodCallPurityAnalyzer
                 $method_storage->return_type &&
                 ($method_storage->return_type->isVoid() || $method_storage->return_type->isNever())
             )
-            && ($method_storage->require_usage
+            && ($method_storage->no_discard
                 || $method_storage->removed_taints
                 || $method_storage->conditionally_removed_taints)
         ) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -138,19 +138,23 @@ final class MethodCallPurityAnalyzer
             }
         }
 
-        if ($codebase->find_unused_variables
-            && !$context->inside_unset
+        // the PHP native NoDiscard attribute reports an error even for void and never
+        if (!$context->inside_unset
             && !$context->insideUse()
-            && !$method_storage->assertions
-            && (!$method_storage->throws
-                || !$context->inside_try)
-            && !(
-                $method_storage->return_type &&
-                ($method_storage->return_type->isVoid() || $method_storage->return_type->isNever())
-            )
             && ($method_storage->no_discard
-                || $method_storage->removed_taints
-                || $method_storage->conditionally_removed_taints)
+                || ($codebase->find_unused_variables
+                    && !$method_storage->assertions
+                    && (!$method_storage->throws
+                        || !$context->inside_try)
+                    && !(
+                        $method_storage->return_type &&
+                        ($method_storage->return_type->isVoid()
+                         || $method_storage->return_type->isNever())
+                    )
+                    && ($method_storage->removed_taints
+                        || $method_storage->conditionally_removed_taints)
+                )
+            )
         ) {
             IssueBuffer::maybeAdd(
                 new UnusedMethodCall(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -117,8 +117,11 @@ final class MethodCallPurityAnalyzer
                     && !$method_storage->assertions
                     && (!$method_storage->throws
                         || !$context->inside_try)
-                    && !($method_storage->return_type
-                          && ($method_storage->return_type->isVoid() || $method_storage->return_type->isNever()))
+                    && (($stmt->var instanceof PhpParser\Node\Expr\New_
+                         && $stmt->var->getAttribute('external_mutation_free') === true)
+                         || !($method_storage->return_type
+                            && ($method_storage->return_type->isVoid() || $method_storage->return_type->isNever()))
+                    )
                 ) {
                     IssueBuffer::maybeAdd(
                         new UnusedMethodCall(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -95,6 +95,7 @@ final class MethodCallPurityAnalyzer
                 if ($context->inside_conditional
                     && !$method_storage->assertions
                     && !$method_storage->if_true_assertions
+                    && !$method_storage->if_false_assertions
                 ) {
                     $stmt->setAttribute('memoizable', true);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -115,9 +115,10 @@ final class MethodCallPurityAnalyzer
                     && !$context->inside_call
                     && !$context->inside_return
                     && !$method_storage->assertions
-                    && !$method_storage->if_true_assertions
-                    && !$method_storage->if_false_assertions
-                    && !$method_storage->throws
+                    && (!$method_storage->throws
+                        || !$context->inside_try)
+                    && !($method_storage->return_type
+                          && ($method_storage->return_type->isVoid() || $method_storage->return_type->isNever()))
                 ) {
                     IssueBuffer::maybeAdd(
                         new UnusedMethodCall(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -298,6 +298,24 @@ final class CastAnalyzer
             return true;
         }
 
+        if ($stmt instanceof PhpParser\Node\Expr\Cast\Void_) {
+            if ($statements_analyzer->getCodebase()->analysis_php_version_id < 8_05_00) {
+                IssueBuffer::maybeAdd(
+                    new InvalidCast(
+                        'The (void) cast is only supported from PHP 8.5 and causes a fatal error in earlier versions',
+                        new CodeLocation($statements_analyzer->getSource(), $stmt),
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+
+            $expression_result = self::checkExprGeneralUse($statements_analyzer, $stmt, $context);
+
+            $statements_analyzer->node_data->setType($stmt, Type::getNever());
+
+            return $expression_result;
+        }
+
         IssueBuffer::maybeAdd(
             new UnrecognizedExpression(
                 'Psalm does not understand the cast ' . $stmt::class,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -15,6 +15,7 @@ use Psalm\Internal\Codebase\VariableUseGraph;
 use Psalm\Internal\FileManipulation\FileManipulationBuffer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\TypeCombiner;
+use Psalm\Issue\DeprecatedConstant;
 use Psalm\Issue\InvalidCast;
 use Psalm\Issue\PossiblyInvalidCast;
 use Psalm\Issue\RedundantCast;
@@ -286,9 +287,30 @@ final class CastAnalyzer
             return true;
         }
 
-        if ($stmt instanceof PhpParser\Node\Expr\Cast\Unset_
-            && $statements_analyzer->getCodebase()->analysis_php_version_id <= 7_04_00
-        ) {
+        if ($stmt instanceof PhpParser\Node\Expr\Cast\Unset_) {
+            if ($statements_analyzer->getCodebase()->analysis_php_version_id >= 8_00_00) {
+                IssueBuffer::maybeAdd(
+                    new InvalidCast(
+                        'The (unset) cast is no longer supported',
+                        new CodeLocation($statements_analyzer->getSource(), $stmt),
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+
+                $statements_analyzer->node_data->setType($stmt, Type::getNever());
+                return false;
+            }
+
+            if ($statements_analyzer->getCodebase()->analysis_php_version_id >= 7_02_00) {
+                IssueBuffer::maybeAdd(
+                    new DeprecatedConstant(
+                        'The (unset) cast is deprecated',
+                        new CodeLocation($statements_analyzer->getSource(), $stmt),
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->expr, $context) === false) {
                 return false;
             }

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -298,7 +298,6 @@ final class Reflection
 
             foreach ($callables[0]->params as $param) {
                 if ($param->type) {
-                    /** @psalm-suppress UnusedMethodCall */
                     $param->type->queueClassLikesForScanning($this->codebase);
                 }
             }
@@ -306,7 +305,6 @@ final class Reflection
             $storage->setParams($callables[0]->params);
 
             $storage->return_type = $callables[0]->return_type;
-            /** @psalm-suppress UnusedMethodCall */
             $storage->return_type->queueClassLikesForScanning($this->codebase);
         } else {
             $params = $method->getParameters();

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -247,7 +247,6 @@ final class Scanner
 
                 foreach ($public_mapped_properties as $public_mapped_property) {
                     $property_type = Type::parseString($public_mapped_property);
-                    /** @psalm-suppress UnusedMethodCall */
                     $property_type->queueClassLikesForScanning(
                         $this->codebase,
                         null,

--- a/src/Psalm/Internal/Json/Json.php
+++ b/src/Psalm/Internal/Json/Json.php
@@ -86,7 +86,6 @@ final class Json
         array_walk_recursive(
             $data,
             /**
-             * @psalm-pure
              * @param mixed $value
              */
             function (mixed &$value): void {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -493,7 +493,7 @@ final class ClassLikeNodeScanner
                         $this->type_aliases,
                         true,
                     );
-                    /** @psalm-suppress UnusedMethodCall */
+
                     $yield_type->queueClassLikesForScanning(
                         $this->codebase,
                         $this->file_storage,
@@ -579,7 +579,7 @@ final class ClassLikeNodeScanner
                             $this->type_aliases,
                             true,
                         );
-                        /** @psalm-suppress UnusedMethodCall */
+
                         $pseudo_property_type->queueClassLikesForScanning(
                             $this->codebase,
                             $this->file_storage,
@@ -678,7 +678,6 @@ final class ClassLikeNodeScanner
                     true,
                 );
 
-                /** @psalm-suppress UnusedMethodCall */
                 $mixin_type->queueClassLikesForScanning(
                     $this->codebase,
                     $this->file_storage,
@@ -833,7 +832,6 @@ final class ClassLikeNodeScanner
             foreach ($mapped_properties as $property_name => $public_mapped_property) {
                 $property_type = Type::parseString($public_mapped_property);
 
-                /** @psalm-suppress UnusedMethodCall */
                 $property_type->queueClassLikesForScanning($this->codebase, $this->file_storage);
 
                 if (!isset($classlike_storage->properties[$property_name])) {
@@ -1004,7 +1002,6 @@ final class ClassLikeNodeScanner
             );
         }
 
-        /** @psalm-suppress UnusedMethodCall */
         $extended_union_type->queueClassLikesForScanning(
             $this->codebase,
             $this->file_storage,
@@ -1090,7 +1087,6 @@ final class ClassLikeNodeScanner
             return;
         }
 
-        /** @psalm-suppress UnusedMethodCall */
         $implemented_union_type->queueClassLikesForScanning(
             $this->codebase,
             $this->file_storage,
@@ -1176,7 +1172,6 @@ final class ClassLikeNodeScanner
             return;
         }
 
-        /** @psalm-suppress UnusedMethodCall */
         $used_union_type->queueClassLikesForScanning(
             $this->codebase,
             $this->file_storage,
@@ -1641,7 +1636,6 @@ final class ClassLikeNodeScanner
         $doc_var_group_type = $var_comment->type ?? null;
 
         if ($doc_var_group_type) {
-            /** @psalm-suppress UnusedMethodCall */
             $doc_var_group_type->queueClassLikesForScanning($this->codebase, $this->file_storage);
         }
 
@@ -1754,7 +1748,6 @@ final class ClassLikeNodeScanner
                     }
                 }
 
-                /** @psalm-suppress UnusedMethodCall */
                 $property_storage->type->queueClassLikesForScanning($this->codebase, $this->file_storage);
             }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ExpressionScanner.php
@@ -119,7 +119,6 @@ final class ExpressionScanner
 
                 foreach ($callable->params as $function_param) {
                     if ($function_param->type) {
-                        /** @psalm-suppress UnusedMethodCall */
                         $function_param->type->queueClassLikesForScanning(
                             $codebase,
                             $file_storage,
@@ -128,7 +127,6 @@ final class ExpressionScanner
                 }
 
                 if ($callable->return_type && !$callable->return_type->hasMixed()) {
-                    /** @psalm-suppress UnusedMethodCall */
                     $callable->return_type->queueClassLikesForScanning($codebase, $file_storage);
                 }
             }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -582,7 +582,7 @@ final class FunctionLikeDocblockParser
             || isset($parsed_docblock->tags['phpstan-pure'])
             || isset($parsed_docblock->tags['pure']);
 
-        $info->require_usage = isset($parsed_docblock->tags['psalm-require-usage']);
+        $info->no_discard = isset($parsed_docblock->tags['psalm-no-discard']);
 
         if (isset($parsed_docblock->tags['psalm-mutation-free'])) {
             $info->mutation_free = true;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -582,6 +582,8 @@ final class FunctionLikeDocblockParser
             || isset($parsed_docblock->tags['phpstan-pure'])
             || isset($parsed_docblock->tags['pure']);
 
+        $info->require_usage = isset($parsed_docblock->tags['psalm-require-usage']);
+
         if (isset($parsed_docblock->tags['psalm-mutation-free'])) {
             $info->mutation_free = true;
         }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -146,6 +146,10 @@ final class FunctionLikeDocblockScanner
             }
         }
 
+        if ($docblock_info->require_usage) {
+            $storage->require_usage = true;
+        }
+
         if ($docblock_info->specialize_call) {
             $storage->specialize_call = true;
         }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -655,7 +655,6 @@ final class FunctionLikeDocblockScanner
             return null;
         }
 
-        /** @psalm-suppress UnusedMethodCall */
         $namespaced_type->queueClassLikesForScanning(
             $codebase,
             $file_storage,
@@ -824,7 +823,6 @@ final class FunctionLikeDocblockScanner
 
             $storage_param->has_docblock_type = true;
 
-            /** @psalm-suppress UnusedMethodCall */
             $new_param_type->queueClassLikesForScanning(
                 $codebase,
                 $file_storage,
@@ -1044,7 +1042,6 @@ final class FunctionLikeDocblockScanner
                 }
             }
 
-            /** @psalm-suppress UnusedMethodCall */
             $storage->return_type->queueClassLikesForScanning($codebase, $file_storage);
         } catch (TypeParseTreeException $e) {
             $storage->docblock_issues[] = new InvalidDocblock(
@@ -1194,7 +1191,6 @@ final class FunctionLikeDocblockScanner
                 $type_aliases,
             );
 
-            /** @psalm-suppress UnusedMethodCall */
             $removed_taint->queueClassLikesForScanning($codebase, $file_storage);
 
             $removed_taint_single = $removed_taint->getSingleAtomic();
@@ -1414,7 +1410,6 @@ final class FunctionLikeDocblockScanner
             return;
         }
 
-        /** @psalm-suppress UnusedMethodCall */
         $out_type->queueClassLikesForScanning(
             $codebase,
             $file_storage,

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -146,8 +146,8 @@ final class FunctionLikeDocblockScanner
             }
         }
 
-        if ($docblock_info->require_usage) {
-            $storage->require_usage = true;
+        if ($docblock_info->no_discard) {
+            $storage->no_discard = true;
         }
 
         if ($docblock_info->specialize_call) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -683,6 +683,10 @@ final class FunctionLikeNodeScanner
                     }
                 }
 
+                if ($attribute->fq_class_name === 'NoDiscard') {
+                    $storage->no_discard = true;
+                }
+
                 if ($attribute->fq_class_name === 'Psalm\\Deprecated'
                     || $attribute->fq_class_name === 'Deprecated'
                     || $attribute->fq_class_name === 'JetBrains\\PhpStorm\\Deprecated'

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -261,7 +261,6 @@ final class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements Fi
 
                             if (isset($this->codebase->config->globals[$var_id])) {
                                 $var_type = Type::parseString($this->codebase->config->globals[$var_id]);
-                                /** @psalm-suppress UnusedMethodCall */
                                 $var_type->queueClassLikesForScanning($this->codebase, $this->file_storage);
                             }
                         }
@@ -384,7 +383,6 @@ final class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements Fi
                 }
 
                 $var_type = $var_comment->type;
-                /** @psalm-suppress UnusedMethodCall */
                 $var_type->queueClassLikesForScanning($this->codebase, $this->file_storage);
             }
         }

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -82,6 +82,11 @@ final class FunctionDocblockComment
     public bool $pure = false;
 
     /**
+     * Whether or not the function return type must not be unused if the function is impure
+     */
+    public bool $require_usage = false;
+
+    /**
      * Whether or not to specialize a given call (useful for taint analysis)
      */
     public bool $specialize_call = false;

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -82,9 +82,9 @@ final class FunctionDocblockComment
     public bool $pure = false;
 
     /**
-     * Whether or not the function return type must not be unused if the function is impure
+     * Whether or not the function return value must be used
      */
-    public bool $require_usage = false;
+    public bool $no_discard = false;
 
     /**
      * Whether or not to specialize a given call (useful for taint analysis)

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -143,10 +143,7 @@ abstract class FunctionLikeStorage implements HasAttributesInterface, Stringable
 
     public bool $pure = false;
 
-    /**
-     * Whether or not the function return type must not be unused if the function is impure
-     */
-    public bool $require_usage = false;
+    public bool $no_discard = false;
 
     /**
      * Whether or not the function output is dependent solely on input - a function can be

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -144,6 +144,11 @@ abstract class FunctionLikeStorage implements HasAttributesInterface, Stringable
     public bool $pure = false;
 
     /**
+     * Whether or not the function return type must not be unused if the function is impure
+     */
+    public bool $require_usage = false;
+
+    /**
      * Whether or not the function output is dependent solely on input - a function can be
      * impure but still have this property (e.g. var_export). Useful for taint analysis.
      */

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1481,6 +1481,47 @@ final class AnnotationTest extends TestCase
                     function foo($arg) {}',
                 'error_message' => 'InvalidDocblock',
             ],
+            'invalidVoidPure' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-pure
+                     * @param array<int, string> $arg
+                     * @return void
+                     */
+                    function foo($arg) {}',
+                'error_message' => 'InvalidDocblock',
+            ],
+            'invalidVoidRequireUsage' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-require-usage
+                     * @param array<int, string> $arg
+                     * @return void
+                     */
+                    function foo($arg) {}',
+                'error_message' => 'InvalidDocblock',
+            ],
+            'invalidNeverRequireUsage' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-require-usage
+                     * @return never
+                     */
+                    function foo() {
+                        exit;
+                    }',
+                'error_message' => 'InvalidDocblock',
+            ],
+            'invalidVoidTaintEscape' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-taint-escape html
+                     * @param array<int, string> $arg
+                     * @return void
+                     */
+                    function foo($arg) {}',
+                'error_message' => 'InvalidDocblock',
+            ],
             'invalidClassMethodReturnBrackets' => [
                 'code' => '<?php
                     class C {

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1501,6 +1501,16 @@ final class AnnotationTest extends TestCase
                     function foo($arg) {}',
                 'error_message' => 'InvalidDocblock',
             ],
+            'invalidVoidNoDiscardAttribute' => [
+                'code' => '<?php
+                    /**
+                     * @param array<int, string> $arg
+                     * @return void
+                     */
+                     #[NoDiscard]
+                    function foo($arg) {}',
+                'error_message' => 'InvalidAttribute',
+            ],
             'invalidNeverNoDiscard' => [
                 'code' => '<?php
                     /**
@@ -1511,6 +1521,17 @@ final class AnnotationTest extends TestCase
                         exit;
                     }',
                 'error_message' => 'InvalidDocblock',
+            ],
+            'invalidNeverNoDiscardAttribute' => [
+                'code' => '<?php
+                    /**
+                     * @return never
+                     */
+                    #[NoDiscard]
+                    function foo() {
+                        exit;
+                    }',
+                'error_message' => 'InvalidAttribute',
             ],
             'invalidVoidTaintEscape' => [
                 'code' => '<?php

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1491,20 +1491,20 @@ final class AnnotationTest extends TestCase
                     function foo($arg) {}',
                 'error_message' => 'InvalidDocblock',
             ],
-            'invalidVoidRequireUsage' => [
+            'invalidVoidNoDiscard' => [
                 'code' => '<?php
                     /**
-                     * @psalm-require-usage
+                     * @psalm-no-discard
                      * @param array<int, string> $arg
                      * @return void
                      */
                     function foo($arg) {}',
                 'error_message' => 'InvalidDocblock',
             ],
-            'invalidNeverRequireUsage' => [
+            'invalidNeverNoDiscard' => [
                 'code' => '<?php
                     /**
-                     * @psalm-require-usage
+                     * @psalm-no-discard
                      * @return never
                      */
                     function foo() {

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -94,5 +94,25 @@ final class CastTest extends TestCase
             'error_levels' => [],
             'php_version' => '8.4',
         ];
+        yield 'castUnsetDeprecated' => [
+            'code' => '<?php
+                /** @var int<-5, 3> */
+                $int_range = 2;
+                (unset) $int_range;
+            ',
+            'error_message' => 'The (unset) cast is deprecated',
+            'error_levels' => [],
+            'php_version' => '7.4',
+        ];
+        yield 'castUnsetNotSupported' => [
+            'code' => '<?php
+                /** @var int<-5, 3> */
+                $int_range = 2;
+                (unset) $int_range;
+            ',
+            'error_message' => 'The (unset) cast is no longer supported',
+            'error_levels' => [],
+            'php_version' => '8.0',
+        ];
     }
 }

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -77,6 +77,34 @@ final class CastTest extends TestCase
             'ignored_issues' => [],
             'php_version' => '8.5',
         ];
+        yield 'castNoDiscardToVoid' => [
+            'code' => '<?php
+                #[NoDiscard]
+                function foo(): string {
+                    return "a";
+                }
+
+                (void) foo();
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+        yield 'castPsalmNoDiscardToVoid' => [
+            'code' => '<?php
+                /**
+                 * @psalm-no-discard
+                 */
+                function foo(): string {
+                    return "a";
+                }
+
+                (void) foo();
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
     }
 
     #[Override]

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace Psalm\Tests;
 
 use Override;
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+use const DIRECTORY_SEPARATOR;
 
 final class CastTest extends TestCase
 {
+    use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
 
     #[Override]
@@ -62,6 +66,33 @@ final class CastTest extends TestCase
             'assertions' => [
                 '$string===' => "'-1'|'-2'|'-3'|'-4'|'-5'|'0'|'1'|'2'|'3'",
             ],
+        ];
+        yield 'castAnythingToVoid' => [
+            'code' => '<?php
+                /** @var int<-5, 3> */
+                $int_range = 2;
+                (void) $int_range;
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+    }
+
+    #[Override]
+    public function providerInvalidCodeParse(): iterable
+    {
+        yield 'castAnythingToVoidNotYetSupported' => [
+            'code' => '<?php
+                /** @var int<-5, 3> */
+                $int_range = 2;
+                (void) $int_range;
+            ',
+            // 'error_message' => 'The (void) cast is only supported from PHP 8.5 and causes a fatal error in earlier versions',
+            // if not just the config php version but the PHP parser/executable is <8.5, it will result in a ParseError
+            'error_message' => 'ParseError - src' . DIRECTORY_SEPARATOR . 'somefile.php:4:24 - Syntax error, unexpected T_VARIABLE on line 4',
+            'error_levels' => [],
+            'php_version' => '8.4',
         ];
     }
 }

--- a/tests/OverrideTest.php
+++ b/tests/OverrideTest.php
@@ -99,12 +99,16 @@ final class OverrideTest extends TestCase
                     <?php
                     class A {
                         /** @psalm-pure */
-                        public function f(): void {}
+                        public function f(): int {
+                            return 15;
+                        }
                     }
                     class B extends A {
                         /** @psalm-pure */
                         #[Override]
-                        public function f(): void {}
+                        public function f(): int {
+                            return 20;
+                        }
                     }
                     PHP,
             ],

--- a/tests/PureAnnotationTest.php
+++ b/tests/PureAnnotationTest.php
@@ -189,6 +189,8 @@ final class PureAnnotationTest extends TestCase
                         exit;
                     }
                 ',
+                'assertions' => [],
+                'ignored_issues' => ['InvalidDocblock'],
             ],
             'exitFunctionWithIntegerArgumentIsPure' => [
                 'code' => '<?php
@@ -197,6 +199,8 @@ final class PureAnnotationTest extends TestCase
                         exit(0);
                     }
                 ',
+                'assertions' => [],
+                'ignored_issues' => ['InvalidDocblock'],
             ],
             'dieFunctionWithNoArgumentIsPure' => [
                 'code' => '<?php
@@ -205,6 +209,8 @@ final class PureAnnotationTest extends TestCase
                         die;
                     }
                 ',
+                'assertions' => [],
+                'ignored_issues' => ['InvalidDocblock'],
             ],
             'dieFunctionWithIntegerArgumentIsPure' => [
                 'code' => '<?php
@@ -213,6 +219,8 @@ final class PureAnnotationTest extends TestCase
                         die(0);
                     }
                 ',
+                'assertions' => [],
+                'ignored_issues' => ['InvalidDocblock'],
             ],
             'allowPureToString' => [
                 'code' => '<?php
@@ -611,6 +619,7 @@ final class PureAnnotationTest extends TestCase
                         impure();
                     }',
                 'error_message' => 'ImpureFunctionCall',
+                'ignored_issues' => ['InvalidDocblock'],
             ],
             'impureConstructorCall' => [
                 'code' => '<?php
@@ -703,8 +712,9 @@ final class PureAnnotationTest extends TestCase
             'printFunctionIsImpure' => [
                 'code' => '<?php
                     /** @psalm-pure */
-                    function foo(): void {
+                    function foo(): int {
                         print("x");
+                        return 15;
                     }
                 ',
                 'error_message' => 'ImpureFunctionCall',
@@ -717,6 +727,7 @@ final class PureAnnotationTest extends TestCase
                     }
                 ',
                 'error_message' => 'ImpureFunctionCall',
+                'ignored_issues' => ['InvalidDocblock'],
             ],
             'dieFunctionWithNonIntegerArgumentIsImpure' => [
                 'code' => '<?php
@@ -726,6 +737,7 @@ final class PureAnnotationTest extends TestCase
                     }
                 ',
                 'error_message' => 'ImpureFunctionCall',
+                'ignored_issues' => ['InvalidDocblock'],
             ],
             'impureByRef' => [
                 'code' => '<?php
@@ -952,6 +964,7 @@ final class PureAnnotationTest extends TestCase
                     }
                     ',
                 'error_message' => 'ImpureMethodCall',
+                'ignored_issues' => ['InvalidDocblock'],
             ],
             'impureCallableInImmutableContext' => [
                 'code' => '<?php

--- a/tests/PureCallableTest.php
+++ b/tests/PureCallableTest.php
@@ -72,7 +72,9 @@ final class PureCallableTest extends TestCase
                     /**
                      * @psalm-pure
                      */
-                    function asd(): void {}
+                    function asd(): int {
+                        return 15;
+                    }
                     class B {}
 
                     /**
@@ -87,7 +89,9 @@ final class PureCallableTest extends TestCase
                     /**
                      * @psalm-pure
                      */
-                    function asd(): void {}
+                    function asd(): int {
+                        return 15;
+                    }
                     class A {public function __invoke(): void {} }
 
                     /**
@@ -102,12 +106,16 @@ final class PureCallableTest extends TestCase
                     /**
                      * @psalm-pure
                      */
-                    function asd(): void {}
+                    function asd(): int {
+                        return 15;
+                    }
                     class A {
                         /**
                          * @psalm-pure
                          */
-                        public function __invoke(): void {}
+                        public function __invoke(): int {
+                            return 20;
+                        }
                     }
 
                     /**

--- a/tests/Type/UnionTest.php
+++ b/tests/Type/UnionTest.php
@@ -27,6 +27,7 @@ final class UnionTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $union = new Union([new TFloat()]);
+        /** @psalm-suppress UnusedMethodCall */
         $union->getSingleFloatLiteral();
     }
 }

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1998,6 +1998,22 @@ final class UnusedCodeTest extends TestCase
                     PHP,
                 'error_message' => 'UnusedFunctionCall',
             ],
+            'unusedFunctionCallNoDiscardAttribute' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @return int
+                     */
+                    #[NoDiscard]
+                    function foo() {
+                        return rand();
+                    }
+
+                    foo();
+                    PHP,
+                'error_message' => 'UnusedFunctionCall',
+                'ignored_issues' => ['UndefinedAttributeClass'],
+            ],
             'unusedFunctionCallTaintEscapeAnnotation' => [
                 'code' => <<<'PHP'
                     <?php
@@ -2040,6 +2056,28 @@ final class UnusedCodeTest extends TestCase
                     PHP,
                 'error_message' => 'UnusedMethodCall',
                 'ignored_issues' => ['PossiblyUnusedReturnValue'],
+            ],
+            'unusedMethodCallNoDiscardAttribute' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class Bar {
+                        /**
+                         * @return int
+                         */
+                        #[NoDiscard]
+                        public function foo() {
+                            return rand();
+                        }
+                    }
+
+                    $bar = new Bar();
+                    $bar->foo();
+                    PHP,
+                'error_message' => 'UnusedMethodCall',
+                'ignored_issues' => [
+                    'PossiblyUnusedReturnValue',
+                    'UndefinedAttributeClass',
+                ],
             ],
             'unusedMethodCallTaintEscapeAnnotation' => [
                 'code' => <<<'PHP'

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1625,6 +1625,7 @@ final class UnusedCodeTest extends TestCase
                         (new A("hello"))->setFoo("goodbye");
                     }',
                 'error_message' => 'UnusedMethodCall',
+                'ignored_issues' => ['UnusedProperty'],
             ],
             'unusedMethodCallForGeneratingMethod' => [
                 'code' => '<?php

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1981,6 +1981,92 @@ final class UnusedCodeTest extends TestCase
                     new a;',
                 'error_message' => 'ClassMustBeFinal',
             ],
+            'unusedFunctionCallRequireUsageAnnotation' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @psalm-require-usage
+                     *
+                     * @return int
+                     */
+                    function foo() {
+                        return rand();
+                    }
+
+                    foo();
+                    PHP,
+                'error_message' => 'UnusedFunctionCall',
+            ],
+            'unusedFunctionCallTaintEscapeAnnotation' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @param string|array $str
+                     * @param bool $escape
+                     * @psalm-taint-escape ($escape is true ? "html" : null)
+                     */
+                    function processVar($str, bool $escape = true) : string {
+                        if (is_array($str)) {
+                                return "";
+                        }
+
+                        if ($escape) {
+                            $str = str_replace(["<", ">"], "", $str);
+                        }
+                        return $str;
+                    }
+
+                    processVar($_GET["text"], true);
+                    PHP,
+                'error_message' => 'UnusedFunctionCall',
+            ],
+            'unusedMethodCallRequireUsageAnnotation' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class Bar {
+                        /**
+                         * @psalm-require-usage
+                         *
+                         * @return int
+                         */
+                        public function foo() {
+                            return rand();
+                        }
+                    }
+
+                    $bar = new Bar();
+                    $bar->foo();
+                    PHP,
+                'error_message' => 'UnusedMethodCall',
+                'ignored_issues' => ['PossiblyUnusedReturnValue'],
+            ],
+            'unusedMethodCallTaintEscapeAnnotation' => [
+                'code' => <<<'PHP'
+                    <?php
+                    class Bar {
+                        /**
+                         * @param string|array $str
+                         * @param bool $escape
+                         * @psalm-taint-escape ($escape is true ? "html" : null)
+                         */
+                        public function processVar($str, bool $escape = true) : string {
+                            if (is_array($str)) {
+                                return "";
+                            }
+
+                            if ($escape) {
+                                $str = str_replace(["<", ">"], "", $str);
+                            }
+                            return $str;
+                        }
+                    }
+
+                    $bar = new Bar();
+                    $bar->processVar($_GET["text"], true);
+                    PHP,
+                'error_message' => 'UnusedMethodCall',
+                'ignored_issues' => ['PossiblyUnusedReturnValue'],
+            ],
         ];
     }
 }

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1356,6 +1356,94 @@ final class UnusedCodeTest extends TestCase
                     new A;
                     PHP,
             ],
+            'usedFunctionCallNoDiscardAnnotation' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @psalm-no-discard
+                     *
+                     * @return int
+                     */
+                    function foo() {
+                        return rand();
+                    }
+
+                    echo foo();
+                    PHP,
+            ],
+            'usedFunctionCallNoDiscardAttribute' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @psalm-suppress UndefinedAttributeClass
+                     * @return int
+                     */
+                    #[NoDiscard]
+                    function foo() {
+                        return rand();
+                    }
+
+                    echo foo();
+                    PHP,
+            ],
+            'usedFunctionCallTaintEscapeAnnotation' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @param string|array $str
+                     * @param bool $escape
+                     * @psalm-taint-escape ($escape is true ? "html" : null)
+                     */
+                    function processVar($str, bool $escape = true) : string {
+                        if (is_array($str)) {
+                                return "";
+                        }
+
+                        if ($escape) {
+                            $str = str_replace(["<", ">"], "", $str);
+                        }
+                        return $str;
+                    }
+
+                    echo processVar($_GET["text"], true);
+                    PHP,
+            ],
+            'usedMethodCallNoDiscardAnnotation' => [
+                'code' => <<<'PHP'
+                    <?php
+                    final class Bar {
+                        /**
+                         * @psalm-no-discard
+                         *
+                         * @return int
+                         */
+                        public function foo() {
+                            return rand();
+                        }
+                    }
+
+                    $bar = new Bar();
+                    echo $bar->foo();
+                    PHP,
+            ],
+            'usedMethodCallNoDiscardAttribute' => [
+                'code' => <<<'PHP'
+                    <?php
+                    final class Bar {
+                        /**
+                         * @psalm-suppress UndefinedAttributeClass
+                         * @return int
+                         */
+                        #[NoDiscard]
+                        public function foo() {
+                            return rand();
+                        }
+                    }
+
+                    $bar = new Bar();
+                    echo $bar->foo();
+                    PHP,
+            ],
             'callNeverReturnsSuppressed' => [
                 'code' => '<?php
                     namespace Foo;

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1982,11 +1982,11 @@ final class UnusedCodeTest extends TestCase
                     new a;',
                 'error_message' => 'ClassMustBeFinal',
             ],
-            'unusedFunctionCallRequireUsageAnnotation' => [
+            'unusedFunctionCallNoDiscardAnnotation' => [
                 'code' => <<<'PHP'
                     <?php
                     /**
-                     * @psalm-require-usage
+                     * @psalm-no-discard
                      *
                      * @return int
                      */
@@ -2021,12 +2021,12 @@ final class UnusedCodeTest extends TestCase
                     PHP,
                 'error_message' => 'UnusedFunctionCall',
             ],
-            'unusedMethodCallRequireUsageAnnotation' => [
+            'unusedMethodCallNoDiscardAnnotation' => [
                 'code' => <<<'PHP'
                     <?php
                     class Bar {
                         /**
-                         * @psalm-require-usage
+                         * @psalm-no-discard
                          *
                          * @return int
                          */


### PR DESCRIPTION
By default psalm considers all functions as impure and UnusedFunctionCall errors are only emitted for pure functions, since pure functions have no side-effects and therefore their return value must be used (otherwise the function call is useless)

There are some cases, where you want to force people to use the return value of a function call even if it's not pure - e.g. for escaping functions or when upgrading legacy code bases where a function returned void/never previously, but now returns a value that must get validated.
Currently, there is no valid way to do that (you could add @psalm-pure and suppress that on the function, but that will lead to other issues)

I propose a new @psalm-no-discard to get this behavior.
~~(I'd prefer @psalm-require-use however I think that might lead to confusion with @use/@template-use/@psalm-use)~~

Additionally, anything annotated with @psalm-taint-escape will also report unused function calls by default, since the escape function call only makes sense if the returned value is used.

Since phpstan doesn't offer this functionality in the first place (since by default it treats everything as pure https://phpstan.org/writing-php-code/phpdocs-basics#impure-functions), there are no PHP eco-system big picture concerns either.

Another benefit of the annotation is that atm the attribute will result in a fatal https://github.com/php/php-src/issues/20879 if a class is autoloaded, but the class it extends is stubbed

---

Summary:
- fix @psalm-pure + @psalm-assert-if-true not reporting UnusedFunctionCalls on methods https://psalm.dev/r/7093ba0a35 (already worked for functions https://psalm.dev/r/afb33d970e)
- fix methods that return void should not be reporting UnusedMethodCall since the return value can't be used
- report unused function/method calls if the function is annotated with `@psalm-no-discard` or has a `@psalm-taint-escape` annotation
- add support for PHP 8.5 `#[NoDiscard]` to report unused return value. Fix https://github.com/vimeo/psalm/issues/11381
- add support for PHP 8.5 `(void)` typecase, as this is required to handle NoDiscard attribute. Fix https://github.com/vimeo/psalm/issues/11638
- fix bad error message and wrong handling for deprecated and removed `(unset)` typecast. Fix https://github.com/vimeo/psalm/issues/11639
