### PR TITLE
Fix getFunctionIdsFromCallableArg to return the function id for array($this, 'foo') in params providers for example

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -37,6 +37,7 @@ use Psalm\IssueBuffer;
 use Psalm\Node\Expr\BinaryOp\VirtualIdentical;
 use Psalm\Node\Expr\VirtualConstFetch;
 use Psalm\Node\VirtualName;
+use Psalm\StatementsSource;
 use Psalm\Storage\Assertion\Falsy;
 use Psalm\Storage\Assertion\IsIdentical;
 use Psalm\Storage\Assertion\IsType;
@@ -558,6 +559,14 @@ abstract class CallAnalyzer
         if (!$file_source instanceof StatementsAnalyzer
             || !($class_arg_type = $file_source->node_data->getType($class_arg))
         ) {
+            if ($file_source instanceof StatementsSource
+                && ($fqcln = $file_source->getFQCLN()) !== null
+                && $class_arg instanceof PhpParser\Node\Expr\Variable
+                && $class_arg->name === 'this'
+            ) {
+                return [$fqcln . '::' . $method_name_arg->value];
+            }
+
             return [];
         }
 

--- a/tests/Config/Plugin/FunctionPlugin.php
+++ b/tests/Config/Plugin/FunctionPlugin.php
@@ -7,6 +7,7 @@ namespace Psalm\Test\Config\Plugin;
 use Override;
 use Psalm\Plugin\PluginEntryPointInterface;
 use Psalm\Plugin\RegistrationInterface;
+use Psalm\Test\Config\Plugin\Hook\CallUserFuncLikeParamsProvider;
 use Psalm\Test\Config\Plugin\Hook\MagicFunctionProvider;
 use SimpleXMLElement;
 
@@ -16,8 +17,10 @@ final class FunctionPlugin implements PluginEntryPointInterface
     #[Override]
     public function __invoke(RegistrationInterface $registration, ?SimpleXMLElement $config = null): void
     {
+        require_once __DIR__ . '/Hook/CallUserFuncLikeParamsProvider.php';
         require_once __DIR__ . '/Hook/MagicFunctionProvider.php';
 
+        $registration->registerHooksFromClass(CallUserFuncLikeParamsProvider::class);
         $registration->registerHooksFromClass(MagicFunctionProvider::class);
     }
 }

--- a/tests/Config/Plugin/Hook/CallUserFuncLikeParamsProvider.php
+++ b/tests/Config/Plugin/Hook/CallUserFuncLikeParamsProvider.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Psalm\Test\Config\Plugin\Hook;
+
+use PhpParser;
+use Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Plugin\EventHandler\Event\FunctionParamsProviderEvent;
+use Psalm\Plugin\EventHandler\FunctionParamsProviderInterface;
+use Psalm\Storage\FunctionLikeParameter;
+use Psalm\Type;
+use Psalm\Type\Atomic\TCallable;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Union;
+
+class CallUserFuncLikeParamsProvider implements
+    FunctionParamsProviderInterface
+{
+    /**
+     * @return array<lowercase-string>
+     */
+    public static function getFunctionIds(): array
+    {
+        return ['call_user_func_like'];
+    }
+
+    /**
+     * @return ?array<int, FunctionLikeParameter>
+     */
+    public static function getFunctionParams(FunctionParamsProviderEvent $event): ?array
+    {
+        $statements_source = $event->getStatementsSource();
+        if (!$statements_source instanceof StatementsAnalyzer) {
+            return null;
+        }
+
+        $call_args = $event->getCallArgs();
+        if (!isset($call_args[0])) {
+            return null;
+        }
+
+        $function_call_arg = $call_args[0];
+
+        $mapping_function_ids = array();
+        if ($function_call_arg->value instanceof PhpParser\Node\Scalar\String_
+            || $function_call_arg->value instanceof PhpParser\Node\Expr\Array_
+            || $function_call_arg->value instanceof PhpParser\Node\Expr\BinaryOp\Concat
+        ) {
+            $mapping_function_ids = CallAnalyzer::getFunctionIdsFromCallableArg(
+                $statements_source,
+                $function_call_arg->value,
+            );
+        }
+
+        if (!isset($mapping_function_ids[0])) {
+            return null;
+        }
+
+        $codebase = $event->getStatementsSource()->getCodebase();
+        $function_like_storage = $codebase->getFunctionLikeStorage($statements_source, $mapping_function_ids[0]);
+
+        $callback_param_types = [];
+        foreach ($function_like_storage->params as $function_like_parameter) {
+            $param_type_union = $function_like_parameter->type;
+            if (!$param_type_union) {
+                $param_type_union = Type::getMixed();
+            }
+
+            if ($function_like_parameter->is_nullable || $function_like_parameter->is_optional) {
+                $param_type_union = $param_type_union->setPossiblyUndefined(true);
+            }
+
+            $callback_param_types[] = $param_type_union;
+        }
+
+        if ($callback_param_types === []) {
+            $callback_params = Type::getEmptyArrayAtomic();
+        } else {
+            $callback_params = new TKeyedArray(
+                $callback_param_types,
+            );
+        }
+
+        return array(
+            new FunctionLikeParameter('callable', false, new Union([new TCallable()]), null, null, null, false),
+            new FunctionLikeParameter('params', false, new Union([$callback_params]), null, null, null, false),
+        );
+    }
+}

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -778,6 +778,60 @@ final class PluginTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
+    public function testFunctionProviderHooksThisClassInvalidArg(): void
+    {
+        $this->expectExceptionMessage('InvalidScalarArgument');
+        $this->expectException(CodeException::class);
+        require_once __DIR__ . '/Plugin/FunctionPlugin.php';
+
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__, 2) . DIRECTORY_SEPARATOR,
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+                    <plugins>
+                        <pluginClass class="Psalm\\Test\\Config\\Plugin\\FunctionPlugin" />
+                    </plugins>
+                </psalm>',
+            ),
+        );
+
+        $this->project_analyzer->getCodebase()->config->initializePlugins($this->project_analyzer);
+
+        $file_path = getcwd() . '/src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                namespace {
+                    /**
+                     * @param callable $callable
+                     * @param array $params
+                     */
+                    function call_user_func_like($callable, $params): void {}
+                }
+
+                namespace Foo\Acme {
+                    class Bar {
+                        public function run(int $a): int {
+                            return ($a + 2);
+                        }
+
+                        public function init(): void {
+                            call_user_func_like(array($this, "run"), array("hello"));
+                        }
+                    }
+                }',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
+
     public function testAfterAnalysisHooks(): void
     {
         require_once __DIR__ . '/Plugin/AfterAnalysisPlugin.php';


### PR DESCRIPTION
Required to get consistent types in e.g. params providers used in plugins.