### PR TITLE
Skip symlink test on Windows

### DIFF
--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -158,6 +158,9 @@ class ConfigTest extends TestCase
         $this->assertFalse($config->isInProjectDirs(realpath('examples/TemplateScanner.php')));
     }
 
+    /**
+     * @requires OS ^(?!WIN)
+     */
     public function testIgnoreSymlinkedProjectDirectory(): void
     {
         @unlink(dirname(__DIR__, 1) . '/fixtures/symlinktest/ignored/b');


### PR DESCRIPTION
Fixes vimeo/psalm#6449

Symlinks on Windows are rare (and quite unreliable)