### PR TITLE
Set inside_isset false when analyzing ArrayDimFetch index

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfConditionalAnalyzer.php
@@ -23,7 +23,7 @@ use Psalm\Type\Reconciler;
 
 use function array_diff_key;
 use function array_filter;
-use function array_keys;
+use function array_key_first;
 use function array_merge;
 use function array_values;
 use function count;
@@ -80,7 +80,7 @@ final class IfConditionalAnalyzer
                             $entry_clauses,
                             static fn(Clause $c): bool => count($c->possibilities) > 1
                                 || $c->wedge
-                                || !isset($changed_var_ids[array_keys($c->possibilities)[0]])
+                                || !isset($changed_var_ids[array_key_first($c->possibilities)])
                         ),
                     );
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -120,12 +120,18 @@ final class ArrayFetchAnalyzer
             $was_inside_unset = $context->inside_unset;
             $context->inside_unset = false;
 
+            $was_inside_isset = $context->inside_isset;
+            $context->inside_isset = false;
+
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->dim, $context) === false) {
+                $context->inside_isset = $was_inside_isset;
                 $context->inside_unset = $was_inside_unset;
                 $context->inside_general_use = $was_inside_general_use;
 
                 return false;
             }
+
+            $context->inside_isset = $was_inside_isset;
 
             $context->inside_unset = $was_inside_unset;
 

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -2982,7 +2982,7 @@ final class SimpleAssertionReconciler extends Reconciler
                 continue;
             }
 
-            $enum_case = $class_storage->enum_cases[$atomic_type->const_name] ?? null;
+            $enum_case = $class_storage->enum_cases[$enum_case_to_assert] ?? null;
             if ($enum_case === null) {
                 return null;
             }

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -1281,6 +1281,11 @@ class ArrayAccessTest extends TestCase
                     echo $a[0];',
                 'error_message' => 'PossiblyInvalidArrayAccess',
             ],
+            'insideIssetDisabledForDim' => [
+                'code' => '<?php
+                    isset($a[$b]);',
+                'error_message' => 'UndefinedGlobalVariable',
+            ],
             'mixedArrayAccess' => [
                 'code' => '<?php
                     /** @var mixed */


### PR DESCRIPTION
For an expression like `isset($a[$b])`, the `inside_isset` context flag wasn't being reset to `false` while analyzing the index (`$b` in this case). This meant that certain issues would not be detected for the index expression, such as undefined variables or possibly undefined offset. I found this while working on a fix for #10578 and decided to address it separately.

This resulted in new errors in two places in the Psalm code base, which I've also fixed.