### PR TITLE
Set inside_isset = false when analyzing arguments

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -231,6 +231,9 @@ final class ArgumentsAnalyzer
             $was_inside_call = $context->inside_call;
             $context->inside_call = true;
 
+            $was_inside_isset = $context->inside_isset;
+            $context->inside_isset = false;
+
             if (ExpressionAnalyzer::analyze(
                 $statements_analyzer,
                 $arg->value,
@@ -240,11 +243,13 @@ final class ArgumentsAnalyzer
                 false,
                 $high_order_template_result,
             ) === false) {
+                $context->inside_isset = $was_inside_isset;
                 $context->inside_call = $was_inside_call;
 
                 return false;
             }
 
+            $context->inside_isset = $was_inside_isset;
             $context->inside_call = $was_inside_call;
 
             if ($high_order_callable_info && $high_order_template_result) {

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -2506,6 +2506,16 @@ class FunctionCallTest extends TestCase
                     }',
                 'error_message' => 'InvalidArgument',
             ],
+            'clearIssetContext' => [
+                'code' => '<?php
+                    function greet(bool $arg): ?string
+                    {
+                        return $arg ? "hi" : null;
+                    }
+
+                    echo greet($undef) ?? "bye";',
+                'error_message' => 'UndefinedGlobalVariable',
+            ],
             'mixedArgument' => [
                 'code' => '<?php
                     function fooFoo(int $a): void {}


### PR DESCRIPTION
This is similar to #10752, but for call arguments. This means that certain types of errors could go undetected when inside call arguments, eg: https://psalm.dev/r/1291966e74 `$a` should be flagged as undefined.

This luckily doesn't result in any new errors in the Psalm code base.