### PR TITLE
void|never shouldn't be combined to null but keep void

### DIFF
--- a/src/Psalm/Internal/Type/TypeCombiner.php
+++ b/src/Psalm/Internal/Type/TypeCombiner.php
@@ -149,14 +149,18 @@ final class TypeCombiner
             if (isset($combination->value_types['true'])) {
                 return Type::getTrue($from_docblock);
             }
-        } elseif (isset($combination->value_types['void'])) {
-            unset($combination->value_types['void']);
+        } elseif (isset($combination->value_types['void']) && count($combination->value_types) > 1) {
+            if (count($combination->value_types) === 2 && isset($combination->value_types['never'])) {
+                // this is handled separately below, we can keep void
+            } else {
+                unset($combination->value_types['void']);
 
-            // if we're merging with another type, we cannot represent it in PHP
-            $from_docblock = true;
+                // if we're merging with another type, we cannot represent it in PHP
+                $from_docblock = true;
 
-            if (!isset($combination->value_types['null'])) {
-                $combination->value_types['null'] = new TNull($from_docblock);
+                if (!isset($combination->value_types['null'])) {
+                    $combination->value_types['null'] = new TNull($from_docblock);
+                }
             }
         }
 

--- a/tests/FileManipulation/MissingReturnTypeTest.php
+++ b/tests/FileManipulation/MissingReturnTypeTest.php
@@ -538,9 +538,9 @@ final class MissingReturnTypeTest extends FileManipulationTestCase
                     }',
                 'output' => '<?php
                     /**
-                     * @return null|string
+                     * @return string|void
                      *
-                     * @psalm-return \'hello\'|null
+                     * @psalm-return \'hello\'|void
                      */
                     function foo() {
                       if (rand(0, 1)) {

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -3209,6 +3209,18 @@ final class FunctionCallTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'disallowVoidNeverTypeForParam' => [
+                'code' => '<?php
+                    /**
+                     * this is just one example where psalm uses isVoid and isNever, which is why void|never should not be collapsed to null
+                     * @param void|never $i
+                     * @return int
+                     */
+                    function takesAnInt($i) {
+                        return rand(10, 15);
+                    }',
+                'error_message' => 'ReservedWord',
+            ],
             'extractVarCheckInvalid' => [
                 'code' => '<?php
                     function takesInt(int $i): void {}


### PR DESCRIPTION
Since psalm internally often checks for isVoid (or isNever) which should include cases of void|never from what I saw, but since the type is changed to null some errors aren't reported.
Initiated by https://github.com/vimeo/psalm/pull/10742#pullrequestreview-1899640189