### PR TITLE
Since annotations outside phpstub should not infer php version

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2781,8 +2781,22 @@ class Config
                 $version_parser = new VersionParser();
 
                 $constraint = $version_parser->parseConstraints($php_version);
+                $php_versions = [
+                    '5.4',
+                    '5.5',
+                    '5.6',
+                    '7.0',
+                    '7.1',
+                    '7.2',
+                    '7.3',
+                    '7.4',
+                    '8.0',
+                    '8.1',
+                    '8.2',
+                    '8.3',
+                ];
 
-                foreach (['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1'] as $candidate) {
+                foreach ($php_versions as $candidate) {
                     if ($constraint->matches(new Constraint('<=', "$candidate.0.0-dev"))
                         || $constraint->matches(new Constraint('<=', "$candidate.999"))
                     ) {

--- a/tests/AnnotationTest.php
+++ b/tests/AnnotationTest.php
@@ -1384,6 +1384,16 @@ class AnnotationTest extends TestCase
                     class Foo {}',
                 'assertions' => [],
             ],
+            'sinceTagNonPhpVersion' => [
+                'code' => '<?php
+                    class Foo {
+                        /**
+                         * @since 8.9.9
+                         */
+                        public function bar() : void {
+                        }
+                    };',
+            ],
         ];
     }
 


### PR DESCRIPTION
- `@since` annotations should only infer PHP version in .phpstub files or for `@since 8.0.0 PHP` refs https://github.com/vimeo/psalm/issues/10761
- fix composer PHP versions 8.2 and 8.3 ignored

Fixes #10761 
