### PR TITLE
fix PHP 8 tests running with wrong --php-version=/phpVersion= if not explicitly specified

### DIFF
--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -192,7 +192,7 @@ class CoreStubsTest extends TestCase
                 '$c3===' => 'bool',
             ],
         ];
-        yield 'PHP8 str_* function assert non-empty-string' => [
+        yield 'PHP80-str_* function assert non-empty-string' => [
             'code' => '<?php
                 /** @return non-empty-string */
                 function after_str_contains(): string
@@ -258,7 +258,7 @@ class CoreStubsTest extends TestCase
                 '$e===' => 'non-empty-string',
             ],
         ];
-        yield "PHP8 str_* function doesn't subtract string after assertion" => [
+        yield "PHP80-str_* function doesn't subtract string after assertion" => [
             'code' => '<?php
                 /** @return false|string */
                 function after_str_contains()

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -3498,6 +3498,10 @@ class ClassTemplateTest extends TestCase
                         $wm[$ex] = 42;
                     }
                 ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                // temporarily keep the old value until https://github.com/vimeo/psalm/issues/10773 is fixed by @weirdan
+                'php_version' => '7.4',
             ],
             'combineTwoTemplatedArrays' => [
                 'code' => '<?php

--- a/tests/Template/ClassTemplateTest.php
+++ b/tests/Template/ClassTemplateTest.php
@@ -3498,10 +3498,6 @@ class ClassTemplateTest extends TestCase
                         $wm[$ex] = 42;
                     }
                 ',
-                'assertions' => [],
-                'ignored_issues' => [],
-                // temporarily keep the old value until https://github.com/vimeo/psalm/issues/10773 is fixed by @weirdan
-                'php_version' => '7.4',
             ],
             'combineTwoTemplatedArrays' => [
                 'code' => '<?php

--- a/tests/Traits/InvalidCodeAnalysisTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisTestTrait.php
@@ -11,10 +11,9 @@ use function str_replace;
 use function strpos;
 use function strtoupper;
 use function substr;
-use function version_compare;
 
 use const PHP_OS;
-use const PHP_VERSION;
+use const PHP_VERSION_ID;
 
 /**
  * @psalm-type DeprecatedDataProviderArrayNotation = array{
@@ -53,7 +52,7 @@ trait InvalidCodeAnalysisTestTrait
     ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'PHP80-') !== false) {
-            if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+            if (PHP_VERSION_ID < 8_00_00) {
                 $this->markTestSkipped('Test case requires PHP 8.0.');
             }
 

--- a/tests/Traits/InvalidCodeAnalysisTestTrait.php
+++ b/tests/Traits/InvalidCodeAnalysisTestTrait.php
@@ -49,15 +49,23 @@ trait InvalidCodeAnalysisTestTrait
         string $code,
         string $error_message,
         array  $error_levels = [],
-        string $php_version = '7.4'
+        ?string $php_version = null
     ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'PHP80-') !== false) {
             if (version_compare(PHP_VERSION, '8.0.0', '<')) {
                 $this->markTestSkipped('Test case requires PHP 8.0.');
             }
+
+            if ($php_version === null) {
+                $php_version = '8.0';
+            }
         } elseif (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
+        }
+
+        if ($php_version === null) {
+            $php_version = '7.4';
         }
 
         // sanity check - do we have a PHP tag?

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -10,10 +10,9 @@ use function strlen;
 use function strpos;
 use function strtoupper;
 use function substr;
-use function version_compare;
 
 use const PHP_OS;
-use const PHP_VERSION;
+use const PHP_VERSION_ID;
 
 trait ValidCodeAnalysisTestTrait
 {
@@ -44,7 +43,7 @@ trait ValidCodeAnalysisTestTrait
     ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'PHP80-') !== false) {
-            if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+            if (PHP_VERSION_ID < 8_00_00) {
                 $this->markTestSkipped('Test case requires PHP 8.0.');
             }
 
@@ -52,7 +51,7 @@ trait ValidCodeAnalysisTestTrait
                 $php_version = '8.0';
             }
         } elseif (strpos($test_name, 'PHP81-') !== false) {
-            if (version_compare(PHP_VERSION, '8.1.0', '<')) {
+            if (PHP_VERSION_ID < 8_01_00) {
                 $this->markTestSkipped('Test case requires PHP 8.1.');
             }
 

--- a/tests/Traits/ValidCodeAnalysisTestTrait.php
+++ b/tests/Traits/ValidCodeAnalysisTestTrait.php
@@ -40,19 +40,31 @@ trait ValidCodeAnalysisTestTrait
         string $code,
         array $assertions = [],
         array $ignored_issues = [],
-        string $php_version = '7.4'
+        ?string $php_version = null
     ): void {
         $test_name = $this->getTestName();
         if (strpos($test_name, 'PHP80-') !== false) {
             if (version_compare(PHP_VERSION, '8.0.0', '<')) {
                 $this->markTestSkipped('Test case requires PHP 8.0.');
             }
+
+            if ($php_version === null) {
+                $php_version = '8.0';
+            }
         } elseif (strpos($test_name, 'PHP81-') !== false) {
             if (version_compare(PHP_VERSION, '8.1.0', '<')) {
                 $this->markTestSkipped('Test case requires PHP 8.1.');
             }
+
+            if ($php_version === null) {
+                $php_version = '8.1';
+            }
         } elseif (strpos($test_name, 'SKIPPED-') !== false) {
             $this->markTestSkipped('Skipped due to a bug.');
+        }
+
+        if ($php_version === null) {
+            $php_version = '7.4';
         }
 
         // sanity check - do we have a PHP tag?


### PR DESCRIPTION
Related https://github.com/vimeo/psalm/issues/10773