### PR TITLE
Variadic params should always be optional and fix redundant optional variadic annotation

### DIFF
--- a/examples/TemplateChecker.php
+++ b/examples/TemplateChecker.php
@@ -62,7 +62,7 @@ final class TemplateAnalyzer extends Psalm\Internal\Analyzer\FileAnalyzer
                     throw new InvalidArgumentException('Could not interpret doc comment correctly');
                 }
 
-                /** @psalm-suppress ArgumentTypeCoercion */
+                /** @psalm-suppress ArgumentTypeCoercion, TooFewArguments */
                 $method_id = new MethodIdentifier(...explode('::', $matches[1]));
 
                 $this_params = $this->checkMethod($method_id, $first_stmt, $codebase);

--- a/examples/plugins/FunctionCasingChecker.php
+++ b/examples/plugins/FunctionCasingChecker.php
@@ -35,7 +35,7 @@ final class FunctionCasingChecker implements AfterFunctionCallAnalysisInterface,
         }
 
         try {
-            /** @psalm-suppress ArgumentTypeCoercion */
+            /** @psalm-suppress ArgumentTypeCoercion, TooFewArguments */
             $method_id = new MethodIdentifier(...explode('::', $declaring_method_id));
             $function_storage = $codebase->methods->getStorage($method_id);
 

--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -889,7 +889,7 @@ final class Codebase
     {
         if (strpos($symbol, '::')) {
             $symbol = substr($symbol, 0, -2);
-            /** @psalm-suppress ArgumentTypeCoercion */
+            /** @psalm-suppress ArgumentTypeCoercion, TooFewArguments */
             $method_id = new MethodIdentifier(...explode('::', $symbol));
 
             $declaring_method_id = $this->methods->getDeclaringMethodId($method_id);
@@ -938,7 +938,7 @@ final class Codebase
             if (strpos($reference->symbol, '()')) {
                 $symbol = substr($reference->symbol, 0, -2);
 
-                /** @psalm-suppress ArgumentTypeCoercion */
+                /** @psalm-suppress ArgumentTypeCoercion, TooFewArguments */
                 $method_id = new MethodIdentifier(...explode('::', $symbol));
 
                 $declaring_method_id = $this->methods->getDeclaringMethodId(
@@ -1158,7 +1158,7 @@ final class Codebase
                 if (strpos($reference->symbol, '()')) {
                     $symbol = substr($reference->symbol, 0, -2);
 
-                    /** @psalm-suppress ArgumentTypeCoercion */
+                    /** @psalm-suppress ArgumentTypeCoercion, TooFewArguments */
                     $method_id = new MethodIdentifier(
                         ...explode('::', $symbol),
                     );

--- a/src/Psalm/Config/Creator.php
+++ b/src/Psalm/Config/Creator.php
@@ -165,6 +165,7 @@ final class Creator
             return array_keys($issues_at_level)[0] + 1;
         }
 
+        /** @psalm-suppress TooFewArguments */
         return max(...array_keys($issues_at_level)) + 1;
     }
 

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1163,7 +1163,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $var_type = $param_type;
 
             if ($function_param->is_variadic) {
-                if ($storage->allow_named_arg_calls) {
+                if ($codebase->analysis_php_version_id >= 8_00_00 && $storage->allow_named_arg_calls) {
                     $var_type = new Union([
                         new TArray([Type::getArrayKey(), $param_type]),
                     ], [

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -292,6 +292,22 @@ final class ArgumentAnalyzer
         bool $specialize_taint,
         bool $in_call_map,
     ): ?bool {
+        if ($codebase->analysis_php_version_id < 8_00_00 || !$codebase->config->allow_named_arg_calls) {
+            $allow_named_args = false;
+        }
+
+        // before we possibly return early
+        if (!$allow_named_args && $arg->name !== null) {
+            IssueBuffer::maybeAdd(
+                new NamedArgumentNotAllowed(
+                    'Method ' . $cased_method_id. ' called with named argument ' . $arg->name->name,
+                    new CodeLocation($statements_analyzer->getSource(), $arg->value),
+                    $cased_method_id,
+                ),
+                $statements_analyzer->getSuppressedIssues(),
+            );
+        }
+
         if (!$function_param->type) {
             if (!$codebase->infer_types_from_usage && !$statements_analyzer->data_flow_graph) {
                 return null;
@@ -655,17 +671,6 @@ final class ArgumentAnalyzer
                 }
 
                 return null;
-            }
-        } else {
-            if (!$allow_named_args && $arg->name !== null) {
-                IssueBuffer::maybeAdd(
-                    new NamedArgumentNotAllowed(
-                        'Method ' . $cased_method_id. ' called with named argument ' . $arg->name->name,
-                        new CodeLocation($statements_analyzer->getSource(), $arg->value),
-                        $cased_method_id,
-                    ),
-                    $statements_analyzer->getSuppressedIssues(),
-                );
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -538,16 +538,21 @@ final class ArgumentAnalyzer
 
             if ($arg_value_type->hasArray()) {
                 $unpacked_atomic_array = $arg_value_type->getArray();
+                $has_string_key = false;
                 $arg_key_allowed = true;
 
                 if ($unpacked_atomic_array instanceof TKeyedArray) {
-                    if (!$allow_named_args && !$unpacked_atomic_array->getGenericKeyType()->isInt()) {
-                        $arg_key_allowed = false;
+                    if (!$unpacked_atomic_array->getGenericKeyType()->isInt()) {
+                        $has_string_key = true;
+
+                        if (!$allow_named_args) {
+                            $arg_key_allowed = false;
+                        }
                     }
 
                     if ($function_param->is_variadic) {
                         $arg_value_type = $unpacked_atomic_array->getGenericValueType();
-                    } elseif ($codebase->analysis_php_version_id >= 8_00_00
+                    } elseif ($codebase->analysis_php_version_id >= 8_01_00
                         && $allow_named_args
                         && isset($unpacked_atomic_array->properties[$function_param->name])
                     ) {
@@ -574,12 +579,30 @@ final class ArgumentAnalyzer
                         $arg_value_type = Type::getMixed();
                     }
                 } elseif ($unpacked_atomic_array instanceof TClassStringMap) {
-                    $arg_value_type = Type::getMixed();
+                    $has_string_key = true;
+                    $arg_value_type = $unpacked_atomic_array->value_param;
                 } else {
-                    if (!$allow_named_args && !$unpacked_atomic_array->type_params[0]->isInt()) {
-                        $arg_key_allowed = false;
+                    if (!$unpacked_atomic_array->type_params[0]->isInt()) {
+                        $has_string_key = true;
+
+                        if (!$allow_named_args) {
+                            $arg_key_allowed = false;
+                        }
                     }
+
                     $arg_value_type = $unpacked_atomic_array->type_params[1];
+                }
+
+                if ($codebase->analysis_php_version_id < 8_01_00
+                    && $has_string_key) {
+                    IssueBuffer::maybeAdd(
+                        new InvalidArgument(
+                            'String keys not supported in unpacked arguments',
+                            new CodeLocation($statements_analyzer->getSource(), $arg->value),
+                            $cased_method_id,
+                        ),
+                        $statements_analyzer->getSuppressedIssues(),
+                    );
                 }
 
                 if (!$arg_key_allowed) {
@@ -613,7 +636,9 @@ final class ArgumentAnalyzer
 
                             continue;
                         }
-                        if (($codebase->analysis_php_version_id < 8_00_00 || !$allow_named_args)
+
+                        // string unpacking is supported from PHP 8.1
+                        if (($codebase->analysis_php_version_id < 8_01_00 || !$allow_named_args)
                             && !$key_type->isInt()
                         ) {
                             $invalid_string_key = true;
@@ -641,7 +666,7 @@ final class ArgumentAnalyzer
                             'Method ' . $cased_method_id
                                 . ' called with unpacked iterable ' . $arg_value_type->getId()
                                 . ' with invalid key (must be '
-                                . ($codebase->analysis_php_version_id < 8_00_00 ? 'int' : 'int|string') . ')',
+                                . ($codebase->analysis_php_version_id < 8_01_00 ? 'int' : 'int|string') . ')',
                             new CodeLocation($statements_analyzer->getSource(), $arg->value),
                             $cased_method_id,
                         ),
@@ -649,7 +674,7 @@ final class ArgumentAnalyzer
                     );
                 }
                 if ($invalid_string_key) {
-                    if ($codebase->analysis_php_version_id < 8_00_00) {
+                    if ($codebase->analysis_php_version_id < 8_01_00) {
                         IssueBuffer::maybeAdd(
                             new $issue_type(
                                 'String keys not supported in unpacked arguments',

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -548,7 +548,7 @@ final class ArgumentAnalyzer
             $invalid_string_key = false;
             $possibly_matches = false;
             foreach ($arg_value_type->getAtomicTypes() as $atomic_type) {
-                if (!$atomic_type->isIterable($codebase)) {
+                if (!$atomic_type->isIterable($codebase) && !$atomic_type instanceof TClassStringMap) {
                     $non_iterable = true;
                     continue;
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -875,7 +875,7 @@ final class ArgumentAnalyzer
             $codebase->analyzer->incrementNonMixedCount($statements_analyzer->getFilePath());
         }
 
-        if ($function_param->by_ref || $function_param->is_optional) {
+        if ($function_param->by_ref || ($function_param->is_optional && !$function_param->is_variadic)) {
             //if the param is optional or a ref, we'll allow the input to be possibly_undefined
             $param_type = $param_type->setPossiblyUndefined(true);
         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -294,6 +294,8 @@ final class ArgumentAnalyzer
     ): ?bool {
         if ($codebase->analysis_php_version_id < 8_00_00 || !$codebase->config->allow_named_arg_calls) {
             $allow_named_args = false;
+        } elseif ($function_param->is_variadic && $in_call_map === true) {
+            $allow_named_args = false;
         }
 
         // before we possibly return early

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -536,36 +536,41 @@ final class ArgumentAnalyzer
                 return null;
             }
 
+            $arg_value_type_from_array = null;
             if ($arg_value_type->hasArray()) {
                 $unpacked_atomic_array = $arg_value_type->getArray();
-                $has_string_key = false;
-                $arg_key_allowed = true;
+            }
 
-                if ($unpacked_atomic_array instanceof TKeyedArray) {
-                    if (!$unpacked_atomic_array->getGenericKeyType()->isInt()) {
-                        $has_string_key = true;
+            $is_array = $arg_value_type->isArray();
 
-                        if (!$allow_named_args) {
-                            $arg_key_allowed = false;
-                        }
-                    }
+            $non_iterable = false;
+            $invalid_key = false;
+            $invalid_string_key = false;
+            $possibly_matches = false;
+            foreach ($arg_value_type->getAtomicTypes() as $atomic_type) {
+                if (!$atomic_type->isIterable($codebase)) {
+                    $non_iterable = true;
+                    continue;
+                }
 
+                if ($atomic_type instanceof TKeyedArray) {
+                    $key_type = $atomic_type->getGenericKeyType();
                     if ($function_param->is_variadic) {
-                        $arg_value_type = $unpacked_atomic_array->getGenericValueType();
+                        $arg_value_type_from_array = $atomic_type->getGenericValueType();
                     } elseif ($codebase->analysis_php_version_id >= 8_01_00
-                        && $allow_named_args
-                        && isset($unpacked_atomic_array->properties[$function_param->name])
+                              && $allow_named_args
+                              && isset($atomic_type->properties[$function_param->name])
                     ) {
-                        $arg_value_type = $unpacked_atomic_array->properties[$function_param->name];
-                    } elseif ($unpacked_atomic_array->is_list
-                        && isset($unpacked_atomic_array->properties[$unpacked_argument_offset])
+                        $arg_value_type_from_array = $atomic_type->properties[$function_param->name];
+                    } elseif ($atomic_type->is_list
+                              && isset($atomic_type->properties[$unpacked_argument_offset])
                     ) {
-                        $arg_value_type = $unpacked_atomic_array->properties[$unpacked_argument_offset];
-                    } elseif ($unpacked_atomic_array->fallback_params) {
-                        $arg_value_type = $unpacked_atomic_array->fallback_params[1];
+                        $arg_value_type_from_array = $atomic_type->properties[$unpacked_argument_offset];
+                    } elseif ($atomic_type->fallback_params) {
+                        $arg_value_type_from_array = $atomic_type->fallback_params[1];
                     } elseif ($function_param->is_optional && $function_param->default_type) {
                         if ($function_param->default_type instanceof Union) {
-                            $arg_value_type = $function_param->default_type;
+                            $arg_value_type_from_array = $function_param->default_type;
                         } else {
                             $arg_value_type_atomic = ConstantTypeResolver::resolve(
                                 $codebase->classlikes,
@@ -573,131 +578,96 @@ final class ArgumentAnalyzer
                                 $statements_analyzer,
                             );
 
-                            $arg_value_type = new Union([$arg_value_type_atomic]);
+                            $arg_value_type_from_array = new Union([$arg_value_type_atomic]);
                         }
                     } else {
-                        $arg_value_type = Type::getMixed();
+                        $arg_value_type_from_array = Type::getMixed();
                     }
-                } elseif ($unpacked_atomic_array instanceof TClassStringMap) {
-                    $has_string_key = true;
-                    $arg_value_type = $unpacked_atomic_array->value_param;
+                } elseif ($atomic_type instanceof TClassStringMap) {
+                    $key_type = Type::getNonFalsyString();
+                    $arg_value_type_from_array = $atomic_type->value_param;
+                } elseif ($atomic_type instanceof TArray) {
+                    $key_type = $atomic_type->type_params[0];
+                    $arg_value_type_from_array = $atomic_type->type_params[1];
                 } else {
-                    if (!$unpacked_atomic_array->type_params[0]->isInt()) {
-                        $has_string_key = true;
-
-                        if (!$allow_named_args) {
-                            $arg_key_allowed = false;
-                        }
-                    }
-
-                    $arg_value_type = $unpacked_atomic_array->type_params[1];
+                    $key_type = $codebase->getKeyValueParamsForTraversableObject($atomic_type)[0];
                 }
 
-                if ($codebase->analysis_php_version_id < 8_01_00
-                    && $has_string_key) {
+                if (!UnionTypeComparator::isContainedBy(
+                    $codebase,
+                    $key_type,
+                    Type::getArrayKey(),
+                )) {
+                    $invalid_key = true;
+
+                    continue;
+                }
+
+                // string unpacking is supported from PHP 8.1
+                if (($codebase->analysis_php_version_id < 8_01_00 || !$allow_named_args)
+                    && !$key_type->isInt()
+                ) {
+                    $invalid_string_key = true;
+
+                    continue;
+                }
+                $possibly_matches = true;
+            }
+
+            $issue_type = $possibly_matches ? PossiblyInvalidArgument::class : InvalidArgument::class;
+            if ($non_iterable) {
+                IssueBuffer::maybeAdd(
+                    new $issue_type(
+                        'Tried to unpack non-iterable ' . $arg_value_type->getId(),
+                        new CodeLocation($statements_analyzer->getSource(), $arg->value),
+                        $cased_method_id,
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+            if ($invalid_key) {
+                IssueBuffer::maybeAdd(
+                    new $issue_type(
+                        'Method ' . $cased_method_id
+                            . ' called with unpacked iterable ' . $arg_value_type->getId()
+                            . ' with invalid key (must be '
+                            . ($codebase->analysis_php_version_id < 8_01_00 ? 'int' : 'int|string') . ')',
+                        new CodeLocation($statements_analyzer->getSource(), $arg->value),
+                        $cased_method_id,
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+            if ($invalid_string_key) {
+                if ($codebase->analysis_php_version_id < 8_01_00) {
                     IssueBuffer::maybeAdd(
-                        new InvalidArgument(
+                        new $issue_type(
                             'String keys not supported in unpacked arguments',
                             new CodeLocation($statements_analyzer->getSource(), $arg->value),
                             $cased_method_id,
                         ),
                         $statements_analyzer->getSuppressedIssues(),
                     );
-                }
-
-                if (!$arg_key_allowed) {
+                } else {
                     IssueBuffer::maybeAdd(
                         new NamedArgumentNotAllowed(
                             'Method ' . $cased_method_id
-                                . ' called with named unpacked array ' . $unpacked_atomic_array->getId()
-                                . ' (array with string keys)',
+                                . ' called with named unpacked iterable ' . $arg_value_type->getId()
+                                . ' (iterable with string keys)',
                             new CodeLocation($statements_analyzer->getSource(), $arg->value),
                             $cased_method_id,
                         ),
                         $statements_analyzer->getSuppressedIssues(),
                     );
                 }
-            } else {
-                $non_iterable = false;
-                $invalid_key = false;
-                $invalid_string_key = false;
-                $possibly_matches = false;
-                foreach ($arg_value_type->getAtomicTypes() as $atomic_type) {
-                    if (!$atomic_type->isIterable($codebase)) {
-                        $non_iterable = true;
-                    } else {
-                        $key_type = $codebase->getKeyValueParamsForTraversableObject($atomic_type)[0];
-                        if (!UnionTypeComparator::isContainedBy(
-                            $codebase,
-                            $key_type,
-                            Type::getArrayKey(),
-                        )) {
-                            $invalid_key = true;
+            }
 
-                            continue;
-                        }
-
-                        // string unpacking is supported from PHP 8.1
-                        if (($codebase->analysis_php_version_id < 8_01_00 || !$allow_named_args)
-                            && !$key_type->isInt()
-                        ) {
-                            $invalid_string_key = true;
-
-                            continue;
-                        }
-                        $possibly_matches = true;
-                    }
-                }
-
-                $issue_type = $possibly_matches ? PossiblyInvalidArgument::class : InvalidArgument::class;
-                if ($non_iterable) {
-                    IssueBuffer::maybeAdd(
-                        new $issue_type(
-                            'Tried to unpack non-iterable ' . $arg_value_type->getId(),
-                            new CodeLocation($statements_analyzer->getSource(), $arg->value),
-                            $cased_method_id,
-                        ),
-                        $statements_analyzer->getSuppressedIssues(),
-                    );
-                }
-                if ($invalid_key) {
-                    IssueBuffer::maybeAdd(
-                        new $issue_type(
-                            'Method ' . $cased_method_id
-                                . ' called with unpacked iterable ' . $arg_value_type->getId()
-                                . ' with invalid key (must be '
-                                . ($codebase->analysis_php_version_id < 8_01_00 ? 'int' : 'int|string') . ')',
-                            new CodeLocation($statements_analyzer->getSource(), $arg->value),
-                            $cased_method_id,
-                        ),
-                        $statements_analyzer->getSuppressedIssues(),
-                    );
-                }
-                if ($invalid_string_key) {
-                    if ($codebase->analysis_php_version_id < 8_01_00) {
-                        IssueBuffer::maybeAdd(
-                            new $issue_type(
-                                'String keys not supported in unpacked arguments',
-                                new CodeLocation($statements_analyzer->getSource(), $arg->value),
-                                $cased_method_id,
-                            ),
-                            $statements_analyzer->getSuppressedIssues(),
-                        );
-                    } else {
-                        IssueBuffer::maybeAdd(
-                            new NamedArgumentNotAllowed(
-                                'Method ' . $cased_method_id
-                                    . ' called with named unpacked iterable ' . $arg_value_type->getId()
-                                    . ' (iterable with string keys)',
-                                new CodeLocation($statements_analyzer->getSource(), $arg->value),
-                                $cased_method_id,
-                            ),
-                            $statements_analyzer->getSuppressedIssues(),
-                        );
-                    }
-                }
-
+            if (!$is_array) {
                 return null;
+            }
+
+            if ($arg_value_type_from_array) {
+                $arg_value_type = $arg_value_type_from_array;
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -778,9 +778,6 @@ final class ArgumentsAnalyzer
                     && $arg_value_type->hasArray()) {
                     $named_args_was_used_before_array = $named_args_was_used;
 
-                    /**
-                     * @var TArray|TKeyedArray
-                     */
                     $array_type = $arg_value_type->getArray();
 
                     if ($array_type instanceof TCallableArray ||
@@ -832,7 +829,7 @@ final class ArgumentsAnalyzer
 
                         $args_provided_min += $array_type->count ? ($array_type->count - 1) : 0;
                     } else {
-                        if ($array_type->type_params[1]->isNever()) {
+                        if (isset($array_type->type_params[1]) && $array_type->type_params[1]->isNever()) {
                             $args_provided_max--;
                         } else {
                             $args_provided_max = $function_param_count + 10_00_00_00_00;
@@ -843,9 +840,16 @@ final class ArgumentsAnalyzer
                         $has_unpacked_non_keyed_array = true;
                     }
 
-                    $key_types = $array_type->type_params[0]->getAtomicTypes();
+                    $key_types = Type::getArrayKey();
+                    if ($array_type instanceof Type\Atomic\TClassStringMap) {
+                        $key_types = Type::getNonFalsyString();
+                    } elseif ($array_type instanceof TCallableKeyedArray) {
+                        $key_types = Type::getInt();
+                    } elseif (isset($array_type->type_params[0])) {
+                        $key_types = $array_type->type_params[0];
+                    }
 
-                    if ($array_type->type_params[0]->isString()) {
+                    if ($key_types->isString()) {
                         $named_args_was_used = true;
                     } elseif ($named_args_was_used) {
                         IssueBuffer::maybeAdd(
@@ -856,7 +860,7 @@ final class ArgumentsAnalyzer
                             ),
                             $statements_analyzer->getSuppressedIssues(),
                         );
-                    } elseif (!$array_type->type_params[0]->isInt()) {
+                    } elseif (!$key_types->isInt()) {
                         // e.g. array-key or a mix of literal strings with int or just int|string
                         IssueBuffer::maybeAdd(
                             new PossiblyInvalidArgument(
@@ -870,7 +874,7 @@ final class ArgumentsAnalyzer
                         $named_args_was_used = true;
                     }
 
-                    foreach ($key_types as $key_type) {
+                    foreach ($key_types->getAtomicTypes() as $key_type) {
                         if ($function_storage && !$function_storage->allow_named_arg_calls) {
                             continue;
                         }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -1140,7 +1140,8 @@ final class ArgumentsAnalyzer
                 }
 
                 if ($by_ref_type && $function_param->is_variadic && $arg->unpack) {
-                    if ($codebase->analysis_php_version_id >= 80000
+                    // string unpacking available since 8.1
+                    if ($codebase->analysis_php_version_id >= 8_01_00
                         && $codebase->getFunctionLikeStorage($statements_analyzer, $method_id)->allow_named_arg_calls
                     ) {
                         $by_ref_type = new Union([

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -829,7 +829,9 @@ final class ArgumentsAnalyzer
 
                         $args_provided_min += $array_type->count ? ($array_type->count - 1) : 0;
                     } else {
-                        if (isset($array_type->type_params[1]) && $array_type->type_params[1]->isNever()) {
+                        if (isset($array_type->type_params[1])
+                            && $array_type->type_params[1] instanceof Union
+                            && $array_type->type_params[1]->isNever()) {
                             $args_provided_max--;
                         } else {
                             $args_provided_max = $function_param_count + 10_00_00_00_00;
@@ -992,11 +994,12 @@ final class ArgumentsAnalyzer
         if ($has_unpacked_non_keyed_array && $args_provided_min < $required_args_count && $has_packed_var) {
             IssueBuffer::maybeAdd(
                 new TooFewArguments(
-                    'Possibly too few arguments for ' . ($cased_method_id ?: $method_id)
+                    'Possibly too few arguments for '
+                    . ($cased_method_id ?? (string) $method_id)
                     . ' - expecting ' . $required_args_count . ' but possibly only'
                     . ' ' . $args_provided_min . ' provided',
                     $code_location,
-                    ($cased_method_id ?: $method_id),
+                    ($cased_method_id ?? (string) $method_id),
                 ),
                 $statements_analyzer->getSuppressedIssues(),
             );
@@ -1007,11 +1010,12 @@ final class ArgumentsAnalyzer
             // as it would often together otherwise
             IssueBuffer::maybeAdd(
                 new TooManyArguments(
-                    'Possibly too many arguments for ' . ($cased_method_id ?: $method_id)
+                    'Possibly too many arguments for '
+                    . ($cased_method_id ?? (string) $method_id)
                     . ' - expecting ' . $function_param_count . ' but saw'
                     . ' ' . ($args_provided_max > 5000 ? 'unlimited from unpacking' : $args_provided_max),
                     $code_location,
-                    ($cased_method_id ?: $method_id),
+                    ($cased_method_id ?? (string) $method_id),
                 ),
                 $statements_analyzer->getSuppressedIssues(),
             );
@@ -1320,6 +1324,7 @@ final class ArgumentsAnalyzer
                 if ($by_ref_type && $function_param->is_variadic && $arg->unpack) {
                     // string unpacking available since 8.1
                     if ($codebase->analysis_php_version_id >= 8_01_00
+                        && $method_id
                         && $codebase->getFunctionLikeStorage($statements_analyzer, $method_id)->allow_named_arg_calls
                     ) {
                         $by_ref_type = new Union([
@@ -1789,7 +1794,8 @@ final class ArgumentsAnalyzer
         ) {
             IssueBuffer::maybeAdd(
                 new TooManyArguments(
-                    'Too many arguments for ' . ($cased_method_id ?: $method_id)
+                    'Too many arguments for '
+                    . ($cased_method_id ?? (string) $method_id)
                     . ' - expecting ' . count($function_params) . ' but saw ' . count($args),
                     $code_location,
                     (string)$method_id,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -32,6 +32,7 @@ use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\InvalidArgument;
 use Psalm\Issue\InvalidNamedArgument;
 use Psalm\Issue\InvalidPassByReference;
+use Psalm\Issue\PossiblyInvalidArgument;
 use Psalm\Issue\PossiblyUndefinedVariable;
 use Psalm\Issue\TooFewArguments;
 use Psalm\Issue\TooManyArguments;
@@ -50,6 +51,8 @@ use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNonEmptyArray;
+use Psalm\Type\Atomic\TNumericString;
+use Psalm\Type\Atomic\TString;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\Union;
 use UnexpectedValueException;
@@ -723,6 +726,7 @@ final class ArgumentsAnalyzer
         $matched_args = [];
         $named_args_was_used = false;
         $unpacked_arg_was_used = false;
+        $generic_named_used = false;
 
         $args_provided_max = 0;
         $args_provided_min = 0;
@@ -734,6 +738,15 @@ final class ArgumentsAnalyzer
                 IssueBuffer::maybeAdd(
                     new InvalidNamedArgument(
                         'Cannot use positional argument after named argument',
+                        new CodeLocation($statements_analyzer, $arg),
+                        (string)$method_id,
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            } elseif ($generic_named_used && ($arg->name || $arg->unpack)) {
+                IssueBuffer::maybeAdd(
+                    new InvalidNamedArgument(
+                        'Possibly the named parameter has already been used from unpack',
                         new CodeLocation($statements_analyzer, $arg),
                         (string)$method_id,
                     ),
@@ -763,6 +776,8 @@ final class ArgumentsAnalyzer
 
                 if (($arg_value_type = $statements_analyzer->node_data->getType($arg->value))
                     && $arg_value_type->hasArray()) {
+                    $named_args_was_used_before_array = $named_args_was_used;
+
                     /**
                      * @var TArray|TKeyedArray
                      */
@@ -787,13 +802,11 @@ final class ArgumentsAnalyzer
                             }
 
                             if ($named_args_was_used) {
-                                // the docblock annotation syntax is insensitive to position
-                                // maybe change it to PossiblyInvalidArgument for $arg_value_type->from_docblock
                                 IssueBuffer::maybeAdd(
-                                    new InvalidNamedArgument(
-                                        'Cannot use positional argument after named argument',
+                                    new PossiblyInvalidArgument(
+                                        'Possibly used positional argument after named argument',
                                         new CodeLocation($statements_analyzer, $arg),
-                                        (string) $method_id,
+                                        (string)$method_id,
                                     ),
                                     $statements_analyzer->getSuppressedIssues(),
                                 );
@@ -832,13 +845,60 @@ final class ArgumentsAnalyzer
 
                     $key_types = $array_type->type_params[0]->getAtomicTypes();
 
+                    if ($array_type->type_params[0]->isString()) {
+                        $named_args_was_used = true;
+                    } elseif ($named_args_was_used) {
+                        IssueBuffer::maybeAdd(
+                            new InvalidNamedArgument(
+                                'Cannot use positional argument after named argument',
+                                new CodeLocation($statements_analyzer, $arg),
+                                (string)$method_id,
+                            ),
+                            $statements_analyzer->getSuppressedIssues(),
+                        );
+                    } elseif (!$array_type->type_params[0]->isInt()) {
+                        // e.g. array-key or a mix of literal strings with int or just int|string
+                        IssueBuffer::maybeAdd(
+                            new PossiblyInvalidArgument(
+                                'Possibly used positional argument after named argument',
+                                new CodeLocation($statements_analyzer, $arg),
+                                (string)$method_id,
+                            ),
+                            $statements_analyzer->getSuppressedIssues(),
+                        );
+
+                        $named_args_was_used = true;
+                    }
+
                     foreach ($key_types as $key_type) {
-                        if (!$key_type instanceof TLiteralString
-                            || ($function_storage && !$function_storage->allow_named_arg_calls)) {
+                        if ($function_storage && !$function_storage->allow_named_arg_calls) {
                             continue;
                         }
 
-                        $named_args_was_used = true;
+                        if ($key_type instanceof TString
+                            && !$key_type instanceof TNumericString
+                            && !$key_type instanceof TLiteralString
+                            && !$generic_named_used) {
+                            // only report an error if the named args were used before this array
+                            // since array keys are unique, this isn't an issue within the array
+                            if ($named_args_was_used_before_array && $argument_offset !== 0) {
+                                IssueBuffer::maybeAdd(
+                                    new InvalidNamedArgument(
+                                        'Possibly the generic named parameter from unpack has already been used',
+                                        new CodeLocation($statements_analyzer, $arg),
+                                        (string)$method_id,
+                                    ),
+                                    $statements_analyzer->getSuppressedIssues(),
+                                );
+                            }
+
+                            $generic_named_used = true;
+                            $named_args_was_used = true;
+                        }
+
+                        if (!$key_type instanceof TLiteralString) {
+                            continue;
+                        }
 
                         $param_found = false;
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -996,7 +996,9 @@ final class ArgumentsAnalyzer
                 ),
                 $statements_analyzer->getSuppressedIssues(),
             );
-        } elseif ($has_unpacked_non_keyed_array && $args_provided_max > $function_param_count && !$is_variadic && $has_packed_var) {
+        } elseif ($has_unpacked_non_keyed_array
+                  && $args_provided_max > $function_param_count
+                  && !$is_variadic && $has_packed_var) {
             // only report it if we don't have TooFewArguments too, as this is less severe of an issue
             // as it would often together otherwise
             IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -60,6 +60,7 @@ use function array_values;
 use function assert;
 use function count;
 use function in_array;
+use function is_numeric;
 use function is_string;
 use function max;
 use function min;
@@ -569,6 +570,7 @@ final class ArgumentsAnalyzer
         $cased_method_id = (string) $method_id;
 
         $is_variadic = false;
+        $required_args_count = 0;
 
         $fq_class_name = null;
 
@@ -618,9 +620,11 @@ final class ArgumentsAnalyzer
             }
         }
 
-        if ($function_params && !$is_variadic) {
-            foreach ($function_params as $function_param) {
-                $is_variadic = $is_variadic || $function_param->is_variadic;
+        foreach ($function_params as $function_param) {
+            $is_variadic = $is_variadic || $function_param->is_variadic;
+
+            if (!$function_param->is_optional && !$function_param->is_variadic) {
+                $required_args_count++;
             }
         }
 
@@ -718,7 +722,12 @@ final class ArgumentsAnalyzer
         $matched_args = [];
         $named_args_was_used = false;
 
+        $args_provided_max = 0;
+        $args_provided_min = 0;
+        $has_unpacked_non_keyed_array = false;
         foreach ($args as $argument_offset => $arg) {
+            $args_provided_max++;
+            $args_provided_min++;
             if ($named_args_was_used && !$arg->name) {
                 IssueBuffer::maybeAdd(
                     new InvalidNamedArgument(
@@ -744,52 +753,113 @@ final class ArgumentsAnalyzer
                      */
                     $array_type = $arg_value_type->getArray();
 
-                    if ($array_type instanceof TKeyedArray) {
-                        $array_type = $array_type->getGenericArrayType();
-                        $key_types = $array_type->type_params[0]->getAtomicTypes();
+                    if ($array_type instanceof TCallableArray ||
+                        $array_type instanceof TCallableKeyedArray
+                    ) {
+                        $args_provided_max++;
+                        $args_provided_min++;
+                        $has_unpacked_non_keyed_array = true;
+                    } elseif ($array_type instanceof TKeyedArray) {
+                        $always_defined_count = 0;
+                        foreach ($array_type->properties as $key => $value) {
+                            if (!$value->possibly_undefined) {
+                                $always_defined_count++;
+                            }
 
-                        foreach ($key_types as $key_type) {
-                            if (!$key_type instanceof TLiteralString
-                                || ($function_storage && !$function_storage->allow_named_arg_calls)) {
+                            if (!is_numeric($key)) {
+                                $named_args_was_used = true;
                                 continue;
                             }
 
-                            $param_found = false;
-
-                            foreach ($function_params as $candidate_param) {
-                                if ($candidate_param->name === $key_type->value || $candidate_param->is_variadic) {
-                                    if ($candidate_param->name === $key_type->value) {
-                                        if (isset($matched_args[$candidate_param->name])) {
-                                            IssueBuffer::maybeAdd(
-                                                new InvalidNamedArgument(
-                                                    'Parameter $' . $key_type->value . ' has already been used in '
-                                                    . ($cased_method_id ?: $method_id),
-                                                    new CodeLocation($statements_analyzer, $arg),
-                                                    (string)$method_id,
-                                                ),
-                                                $statements_analyzer->getSuppressedIssues(),
-                                            );
-                                        }
-
-                                        $matched_args[$candidate_param->name] = true;
-                                    }
-
-                                    $param_found = true;
-                                    break;
-                                }
-                            }
-
-                            if (!$param_found) {
+                            if ($named_args_was_used) {
+                                // the docblock annotation syntax is insensitive to position
+                                // maybe change it to PossiblyInvalidArgument for $arg_value_type->from_docblock
                                 IssueBuffer::maybeAdd(
                                     new InvalidNamedArgument(
-                                        'Parameter $' . $key_type->value . ' does not exist on function '
-                                            . ($cased_method_id ?: $method_id),
+                                        'Cannot use positional argument after named argument',
                                         new CodeLocation($statements_analyzer, $arg),
-                                        (string)$method_id,
+                                        (string) $method_id,
                                     ),
                                     $statements_analyzer->getSuppressedIssues(),
                                 );
                             }
+                        }
+
+                        if (!$array_type->isSealed()) {
+                            $has_unpacked_non_keyed_array = true;
+                            $args_provided_max = $function_param_count + 10_00_00_00_00;
+                        } else {
+                            // since we ++ already for the type in the beginning
+                            $args_provided_max += count($array_type->properties) - 1;
+                        }
+
+                        $args_provided_min += $always_defined_count - 1;
+
+                        $array_type = $array_type->getGenericArrayType();
+                    } elseif ($array_type instanceof TNonEmptyArray) {
+                        $has_unpacked_non_keyed_array = true;
+
+                        // any high value
+                        $args_provided_max = $function_param_count + 10_00_00_00_00;
+
+                        $args_provided_min += $array_type->count ? ($array_type->count - 1) : 0;
+                    } else {
+                        if ($array_type->type_params[1]->isNever()) {
+                            $args_provided_max--;
+                        } else {
+                            $args_provided_max = $function_param_count + 10_00_00_00_00;
+                        }
+
+                        // array could be empty
+                        $args_provided_min--;
+                        $has_unpacked_non_keyed_array = true;
+                    }
+
+                    $key_types = $array_type->type_params[0]->getAtomicTypes();
+
+                    foreach ($key_types as $key_type) {
+                        if (!$key_type instanceof TLiteralString
+                            || ($function_storage && !$function_storage->allow_named_arg_calls)) {
+                            continue;
+                        }
+
+                        $named_args_was_used = true;
+
+                        $param_found = false;
+
+                        foreach ($function_params as $candidate_param) {
+                            if ($candidate_param->name === $key_type->value || $candidate_param->is_variadic) {
+                                if ($candidate_param->name === $key_type->value) {
+                                    if (isset($matched_args[$candidate_param->name])) {
+                                        IssueBuffer::maybeAdd(
+                                            new InvalidNamedArgument(
+                                                'Parameter $' . $key_type->value . ' has already been used in '
+                                                . ($cased_method_id ?: $method_id),
+                                                new CodeLocation($statements_analyzer, $arg),
+                                                (string)$method_id,
+                                            ),
+                                            $statements_analyzer->getSuppressedIssues(),
+                                        );
+                                    }
+
+                                    $matched_args[$candidate_param->name] = true;
+                                }
+
+                                $param_found = true;
+                                break;
+                            }
+                        }
+
+                        if (!$param_found) {
+                            IssueBuffer::maybeAdd(
+                                new InvalidNamedArgument(
+                                    'Parameter $' . $key_type->value . ' does not exist on function '
+                                    . ($cased_method_id ?: $method_id),
+                                    new CodeLocation($statements_analyzer, $arg),
+                                    (string)$method_id,
+                                ),
+                                $statements_analyzer->getSuppressedIssues(),
+                            );
                         }
                     }
                 }
@@ -837,6 +907,33 @@ final class ArgumentsAnalyzer
                 $arg_function_params[$argument_offset] = [$last_param];
                 $matched_args[$last_param->name] = true;
             }
+        }
+
+        // keyed arrays are reported already as InvalidArgument elsewhere
+        if ($has_unpacked_non_keyed_array && $args_provided_min < $required_args_count && $has_packed_var) {
+            IssueBuffer::maybeAdd(
+                new TooFewArguments(
+                    'Possibly too few arguments for ' . ($cased_method_id ?: $method_id)
+                    . ' - expecting ' . $required_args_count . ' but possibly only'
+                    . ' ' . $args_provided_min . ' provided',
+                    $code_location,
+                    ($cased_method_id ?: $method_id),
+                ),
+                $statements_analyzer->getSuppressedIssues(),
+            );
+        } elseif ($has_unpacked_non_keyed_array && $args_provided_max > $function_param_count && !$is_variadic && $has_packed_var) {
+            // only report it if we don't have TooFewArguments too, as this is less severe of an issue
+            // as it would often together otherwise
+            IssueBuffer::maybeAdd(
+                new TooManyArguments(
+                    'Possibly too many arguments for ' . ($cased_method_id ?: $method_id)
+                    . ' - expecting ' . $function_param_count . ' but saw'
+                    . ' ' . ($args_provided_max > 5000 ? 'unlimited from unpacking' : $args_provided_max),
+                    $code_location,
+                    ($cased_method_id ?: $method_id),
+                ),
+                $statements_analyzer->getSuppressedIssues(),
+            );
         }
 
         foreach ($args as $argument_offset => $arg) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -1641,6 +1641,14 @@ final class ArgumentsAnalyzer
                             && $atomic_arg_type instanceof TKeyedArray
                             && !$atomic_arg_type->is_list
                         ) {
+                            if ($atomic_arg_type->fallback_params !== null) {
+                                return;
+                            }
+
+                            if (!$atomic_arg_type->allShapeKeysAlwaysDefined()) {
+                                return;
+                            }
+
                             //if we have a single shape, we'll check param names
                             foreach ($atomic_arg_type->properties as $property_name => $_property_type) {
                                 foreach ($function_params as $k => $param) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -1140,12 +1140,18 @@ final class ArgumentsAnalyzer
                 }
 
                 if ($by_ref_type && $function_param->is_variadic && $arg->unpack) {
-                    $by_ref_type = new Union([
-                        new TArray([
-                            Type::getInt(),
-                            $by_ref_type,
-                        ]),
-                    ]);
+                    if ($codebase->analysis_php_version_id >= 80000
+                        && $codebase->getFunctionLikeStorage($statements_analyzer, $method_id)->allow_named_arg_calls
+                    ) {
+                        $by_ref_type = new Union([
+                            new TArray([
+                                Type::getArrayKey(),
+                                $by_ref_type,
+                            ]),
+                        ]);
+                    } else {
+                        $by_ref_type = new Union([Type::getListAtomic($by_ref_type)]);
+                    }
                 }
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -29,6 +29,7 @@ use Psalm\Internal\Type\TemplateInferredTypeReplacer;
 use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Internal\Type\TypeExpander;
+use Psalm\Issue\InvalidArgument;
 use Psalm\Issue\InvalidNamedArgument;
 use Psalm\Issue\InvalidPassByReference;
 use Psalm\Issue\PossiblyUndefinedVariable;
@@ -721,6 +722,7 @@ final class ArgumentsAnalyzer
         $arg_function_params = [];
         $matched_args = [];
         $named_args_was_used = false;
+        $unpacked_arg_was_used = false;
 
         $args_provided_max = 0;
         $args_provided_min = 0;
@@ -739,7 +741,20 @@ final class ArgumentsAnalyzer
                 );
             }
 
+            // this would be a fatal error in all PHP versions (7, 8, 8.3)
+            if ($unpacked_arg_was_used && !$arg->name && !$arg->unpack) {
+                IssueBuffer::maybeAdd(
+                    new InvalidArgument(
+                        'Cannot use positional argument after argument unpacking',
+                        new CodeLocation($statements_analyzer, $arg),
+                        (string) $method_id,
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+
             if ($arg->unpack) {
+                $unpacked_arg_was_used = true;
                 if ($function_param_count > $argument_offset) {
                     for ($i = $argument_offset; $i < $function_param_count; $i++) {
                         $arg_function_params[$argument_offset][] = $function_params[$i];

--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -973,6 +973,7 @@ final class ClassLikes
             $source_parts = explode('::', $source);
 
             try {
+                /** @psalm-suppress TooFewArguments */
                 $source_method_storage = $methods->getStorage(
                     new MethodIdentifier(...$source_parts),
                 );

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -815,7 +815,7 @@ final class FunctionLikeNodeScanner
             }
         }
 
-        $is_optional = $param->default !== null;
+        $is_optional = $param->default !== null || $param->variadic;
 
         if ($param->var instanceof PhpParser\Node\Expr\Error || !is_string($param->var->name)) {
             throw new UnexpectedValueException('Not expecting param name to be non-string');

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -24,6 +24,7 @@ use Psalm\Internal\Algebra\FormulaGenerator;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Analyzer\CommentAnalyzer;
 use Psalm\Internal\Analyzer\NamespaceAnalyzer;
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Analyzer\ScopeAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\SimpleTypeInferer;
 use Psalm\Internal\MethodIdentifier;
@@ -750,15 +751,23 @@ final class FunctionLikeNodeScanner
 
                 $param_type = $storage->params[$param_index]->type;
 
-                $assigned_properties[$property_name] =
-                    $storage->params[$param_index]->is_variadic
-                        ? new Union([
+                if ($storage->params[$param_index]->is_variadic) {
+                    $codebase = ProjectAnalyzer::getInstance()->getCodebase();
+                    if ($codebase->analysis_php_version_id >= 8_00_00
+                        && $storage->allow_named_arg_calls
+                    ) {
+                        $assigned_properties[$property_name] = new Union([
                             new TArray([
-                                Type::getInt(),
+                                Type::getArrayKey(),
                                 $param_type,
                             ]),
-                        ])
-                        : $param_type;
+                        ]);
+                    } else {
+                        $assigned_properties[$property_name] = new Union([Type::getListAtomic($param_type)]);
+                    }
+                } else {
+                    $assigned_properties[$property_name] = $param_type;
+                }
             } else {
                 $assigned_properties = [];
                 break;

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -1290,7 +1290,7 @@ final class TypeParser
                 }
 
                 $is_variadic = $child_tree->variadic;
-                $is_optional = $child_tree->has_default;
+                $is_optional = $child_tree->has_default || $is_variadic;
                 $param_name = $child_tree->name ?? '';
             } else {
                 if ($child_tree instanceof Value && strpos($child_tree->value, '$') > 0) {

--- a/src/Psalm/Storage/FunctionLikeParameter.php
+++ b/src/Psalm/Storage/FunctionLikeParameter.php
@@ -58,7 +58,13 @@ final class FunctionLikeParameter implements HasAttributesInterface, TypeNode
         public Union|UnresolvedConstantComponent|null $default_type = null,
         public ?Union $out_type = null,
     ) {
+
+		// variadic parameters are always optional by default
+        // except some native PHP params in certain versions, e.g. array_intersect
+        // which is why we cannot do $this->is_optional = $is_optional || $is_variadic;
         $this->signature_type_location = $type_location;
+		$this->default_type = $is_variadic ? null : $default_type;
+        $this->out_type = $by_ref ? $out_type : null;
     }
 
     /** @psalm-mutation-free */
@@ -66,7 +72,7 @@ final class FunctionLikeParameter implements HasAttributesInterface, TypeNode
     {
         return ($this->type ? $this->type->getId() : 'mixed')
             . ($this->is_variadic ? '...' : '')
-            . ($this->is_optional ? '=' : '');
+            . ($this->is_optional && !$this->is_variadic ? '=' : '');
     }
 
     /** @psalm-mutation-free */

--- a/src/Psalm/Type/Atomic/CallableTrait.php
+++ b/src/Psalm/Type/Atomic/CallableTrait.php
@@ -149,7 +149,8 @@ trait CallableTrait
                     $type_string = $param->type->toNamespacedString($namespace, $aliased_classes, $this_class, false);
                 }
 
-                $params_array[] = ($param->is_variadic ? '...' : '') . $type_string . ($param->is_optional ? '=' : '');
+                $params_array[] = ($param->is_variadic ? '...' : '') . $type_string
+                                  . ($param->is_optional && !$param->is_variadic ? '=' : '');
             }
 
             $param_string = '(' . implode(', ', $params_array) . ')';

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -856,6 +856,30 @@ final class ArgTest extends TestCase
                 ',
                 'error_message' => 'InvalidArgument - src'  . DIRECTORY_SEPARATOR . 'somefile.php:8:23 - Argument 1 of a expects array{test: string}, but array{somethingElse: \'test\', test: \'str\'} with additional array shape fields (somethingElse) was provided',
             ],
+            'unpackTooFewFallback' => [
+                'code' => '<?php
+                    function Foo(string $a, string $b) : void {}
+
+                    /** @param array{a: string}&array<string, string> $c */
+                    function Baz($c) :void  {
+                        Foo(...$c);
+                    }
+                ',
+                'error_message' => 'TooFewArguments',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'unpackTooFewGenericArray' => [
+                'code' => '<?php
+                    function Foo(string $a, string $b) : void {}
+
+                    /** @param array<int, string> $c */
+                    function Baz($c) :void  {
+                        Foo("hello", ...$c);
+                    }
+                ',
+                'error_message' => 'TooFewArguments',
+            ],
             'callbackArgsCountMismatch' => [
                 'code' => '<?php
                     /**

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -107,6 +107,20 @@ final class ArgTest extends TestCase
                     '$z' => 'array<int, int>',
                 ],
             ],
+            'namedArgAfterUnpack' => [
+                'code' => '<?php
+                    function Foo(string $a, string $b) : void {}
+
+                    /**
+                     * @param non-empty-array<int, string> $c
+                     */
+                    function Baz($c): void {
+                        Foo(...$c, b: "hello");
+                    }',
+                'assertions' => [],
+                'ignored_issues' => ['TooManyArguments'],
+                'php_version' => '8.0',
+            ],
             'callMapClassOptionalArg' => [
                 'code' => '<?php
                     class Hello {}
@@ -631,6 +645,31 @@ final class ArgTest extends TestCase
                 'error_message' => 'InvalidScalarArgument',
                 'ignored_issues' => [],
                 'php_version' => '8.0',
+            ],
+            'positionalArgAfterUnpackNotNamed' => [
+                'code' => '<?php
+                    function Foo(string $a, string $b) : void {}
+
+                    /**
+                     * @param array{0: string} $c
+                     */
+                    function Baz($c): void {
+                        Foo(...$c, "hello");
+                    }',
+                'error_message' => 'InvalidArgument',
+            ],
+            'positionalArgAfterUnpackGenericArrayNotNamed' => [
+                'code' => '<?php
+                    function Foo(string $a, string $b) : void {}
+
+                    /**
+                     * @param non-empty-array<int, string> $c
+                     */
+                    function Baz($c): void {
+                        Foo(...$c, "hello");
+                    }',
+                'error_message' => 'InvalidArgument',
+                'ignored_issues' => ['TooManyArguments'],
             ],
             'byrefVarSetsPossible' => [
                 'code' => '<?php

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -121,6 +121,24 @@ final class ArgTest extends TestCase
                 'ignored_issues' => ['TooManyArguments'],
                 'php_version' => '8.0',
             ],
+            'unpackIntKeyedArg' => [
+                'code' => '<?php
+                    function Foo(string $a, string ...$b) : void {}
+
+                    /** @param non-empty-list<string> $c */
+                    function Baz($c) : void {
+                        Foo("hello", ...$c);
+                    }',
+            ],
+            'unpackStringKeyedArg' => [
+                'code' => '<?php
+                    function Foo(string $a, string ...$b) : void {}
+
+                    /** @param array<string, string> $c */
+                    function Baz($c) : void {
+                        Foo("hello", ...$c);
+                    }',
+            ],
             'callMapClassOptionalArg' => [
                 'code' => '<?php
                     class Hello {}
@@ -587,6 +605,45 @@ final class ArgTest extends TestCase
                         );
                     }',
                 'error_message' => 'NamedArgumentNotAllowed',
+            ],
+            'unpackGenericArg' => [
+                'code' => '<?php
+                    function Foo(string $a, string ...$b) : void {}
+
+                    /** @param array<string> $c */
+                    function Baz($c) : void {
+                        Foo(...$c);
+                    }',
+                // possibly positional after named
+                'error_message' => 'PossiblyInvalidArgument',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'unpackGenericStringArgHasExistingNamed' => [
+                'code' => '<?php
+                    function Foo(string $a, string ...$b) : void {}
+
+                    /** @param array<string, string> $c */
+                    function Baz($c) : void {
+                        Foo(a: "hello", ...$c);
+                    }',
+                // "a" could be there twice
+                'error_message' => 'InvalidNamedArgument',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'unpackGenericArrayHasExistingNamed' => [
+                'code' => '<?php
+                    function Foo(string $a, string ...$b) : void {}
+
+                    /** @param array<string> $c */
+                    function Baz($c) : void {
+                        Foo(a: "hello", ...$c);
+                    }',
+                // possibly positional after named
+                'error_message' => 'InvalidNamedArgument',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
             'noNamedArgsFunction' => [
                 'code' => '<?php

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -469,6 +469,20 @@ final class ArgTest extends TestCase
                     }',
                 'error_message' => 'InvalidNamedArgument',
             ],
+            'invalidNamedArgumentPHP7' => [
+                'code' => '<?php
+                    /**
+                     * @param int $a
+                     * @param string $b
+                     * @return void
+                     */
+                    function foo($a, $b) {}
+
+                    foo(b: "hello", a: 15);',
+                'error_message' => 'NamedArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '7.4',
+            ],
             'usePositionalArgAfterNamed' => [
                 'code' => '<?php
                     final class Person

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -702,7 +702,7 @@ final class ArgTest extends TestCase
                 ',
                 'error_message' => 'PossiblyInvalidArgument',
             ],
-            'SKIPPED-preventUnpackingPossiblyArray' => [
+            'preventUnpackingPossiblyArray' => [
                 'code' => '<?php
                     function foo(int $arg1, int $arg2): void {}
 

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -91,8 +91,23 @@ final class ArgTest extends TestCase
 
                     /** @return array<array-key, string> */
                     function Baz(string ...$c) {
-                        Foo(...$c);
+                        if ($c !== array()) {
+                            Foo(...array_values($c));
+                        }
+
                         return $c;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'unpackArgNonNamed' => [
+                'code' => '<?php
+                    function Foo(string $a, string ...$b) : void {}
+
+                    /** @param non-empty-array<int, string> $c */
+                    function Baz($c): void {
+                        Foo(...$c);
                     }',
             ],
             'unpackByRefArg' => [
@@ -104,7 +119,7 @@ final class ArgTest extends TestCase
                     example(...$z);',
                 'assertions' => [
                     '$y' => 'int',
-                    '$z' => 'array<int, int>',
+                    '$z' => 'list<int>',
                 ],
             ],
             'namedArgAfterUnpack' => [
@@ -138,6 +153,9 @@ final class ArgTest extends TestCase
                     function Baz($c) : void {
                         Foo("hello", ...$c);
                     }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
             'callMapClassOptionalArg' => [
                 'code' => '<?php
@@ -285,6 +303,9 @@ final class ArgTest extends TestCase
                             email: $input["email"],
                         );
                     }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'useNamedArgumentsSimple' => [
                 'code' => '<?php
@@ -292,6 +313,9 @@ final class ArgTest extends TestCase
 
                     takesArguments(name: "hello", age: 5);
                     takesArguments(age: 5, name: "hello");',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'useNamedArgumentsSpread' => [
                 'code' => '<?php
@@ -301,7 +325,7 @@ final class ArgTest extends TestCase
                     takesArguments(...$args);',
                 'assertions' => [],
                 'ignored_issues' => [],
-                'php_version' => '8.0',
+                'php_version' => '8.1',
             ],
             'useNamedVariadicArguments' => [
                 'code' => '<?php
@@ -319,7 +343,7 @@ final class ArgTest extends TestCase
                     takesArguments(...["age" => 5]);',
                 'assertions' => [],
                 'ignored_issues' => [],
-                'php_version' => '8.0',
+                'php_version' => '8.1',
             ],
             'variadicArgsOptional' => [
                 'code' => '<?php
@@ -412,6 +436,20 @@ final class ArgTest extends TestCase
     public function providerInvalidCodeParse(): iterable
     {
         return [
+            'unpackArgPossiblyPositionalArrayKeyOrdering' => [
+                'code' => '<?php
+                    function Foo(string $a, string ...$b) : void {}
+
+                    /** @return array<array-key, string> */
+                    function Baz(string ...$c) {
+                        Foo(...$c);
+                        return $c;
+                    }',
+                // possibly positional after named
+                'error_message' => 'PossiblyInvalidArgument',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
             'arrayPushArgumentUnpackingWithBadArg' => [
                 'code' => '<?php
                     $a = [];
@@ -671,7 +709,7 @@ final class ArgTest extends TestCase
                     }',
                 'error_message' => 'MixedArgument',
                 'ignored_issues' => [],
-                'php_version' => '8.0',
+                'php_version' => '8.1',
             ],
             'arrayWithoutAllNamedParametersSuppressMixed' => [
                 'code' => '<?php
@@ -692,7 +730,7 @@ final class ArgTest extends TestCase
                     }',
                 'error_message' => 'TooFewArguments',
                 'ignored_issues' => [],
-                'php_version' => '8.0',
+                'php_version' => '8.1',
             ],
             'wrongTypeVariadicArguments' => [
                 'code' => '<?php
@@ -787,6 +825,8 @@ final class ArgTest extends TestCase
                     }
                 ',
                 'error_message' => 'LessSpecificReturnStatement',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'preventUnpackingPossiblyIterable' => [
                 'code' => '<?php
@@ -807,6 +847,7 @@ final class ArgTest extends TestCase
                     foo(...$test);
                 ',
                 'error_message' => 'PossiblyInvalidArgument',
+                'ignored_issues' => ['TooFewArguments'],
             ],
             'noNamedArguments' => [
                 'code' => '<?php
@@ -836,7 +877,7 @@ final class ArgTest extends TestCase
                 ',
                 'error_message' => 'NamedArgumentNotAllowed',
                 'ignored_issues' => [],
-                'php_version' => '8.0',
+                'php_version' => '8.1',
             ],
             'variadicArgumentWithNoNamedArgumentsPreventsPassingArrayWithStringKey' => [
                 'code' => '<?php
@@ -852,6 +893,8 @@ final class ArgTest extends TestCase
                     foo(...["a" => 0]);
                 ',
                 'error_message' => 'NamedArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
             'unpackNonArrayKeyIterable' => [
                 'code' => '<?php
@@ -926,6 +969,8 @@ final class ArgTest extends TestCase
                 );
                 ',
                 'error_message' => 'TooFewArguments',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'SealedRefuseUnsealed' => [
                 'code' => '<?php

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -390,6 +390,40 @@ final class ArgTest extends TestCase
                     array_push($a, ...$b);',
                 'error_message' => 'InvalidArgument',
             ],
+            'inCallmapVariadicParamCalledNamedInvalid' => [
+                'code' => '<?php
+                    /**
+                     * @var array $a
+                     * @var array $b
+                     */
+                    array_intersect(arrays: $a, array: $b);',
+                'error_message' => 'NamedArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'inCallmapVariadicParamCalledNamedInvalidCorrectOrder' => [
+                'code' => '<?php
+                    /**
+                     * @var array $a
+                     * @var array $b
+                     */
+                    array_intersect(array: $b, arrays: $a);',
+                'error_message' => 'NamedArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'inCallmapVariadicParamWrongNameCalledNamedInvalid' => [
+                'code' => '<?php
+                    /**
+                     * @var array $a
+                     * @var array $b
+                     * @var array $c
+                     */
+                    array_intersect(hello: $a, array: $b);',
+                'error_message' => 'NamedArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
             'possiblyInvalidArgument' => [
                 'code' => '<?php
                     $foo = [

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -3048,6 +3048,8 @@ final class ArrayFunctionCallTest extends TestCase
                     array_merge(...$map);
                 ',
                 'error_message' => 'NamedArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
             'arrayMergeRecursiveNoNamed' => [
                 'code' => '<?php
@@ -3055,6 +3057,8 @@ final class ArrayFunctionCallTest extends TestCase
                     array_merge_recursive(...$map);
                 ',
                 'error_message' => 'NamedArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
             'arrayUniquePreservesEmptyInput' => [
                 'code' => '<?php

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -76,6 +76,9 @@ final class AttributeTest extends TestCase
                             public string $name = "",
                         ) {}
                     }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'functionAttributeExists' => [
                 'code' => '<?php
@@ -149,6 +152,9 @@ final class AttributeTest extends TestCase
                     #[Route(methods: ["GET"])]
                     class HealthController
                     {}',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'allowsRepeatableFlag' => [
                 'code' => '<?php
@@ -172,6 +178,9 @@ final class AttributeTest extends TestCase
 
                     #[Foo(_className: Baz::class)]
                     class Baz {}',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'allowsClassStringFromDifferentNamespace' => [
                 'code' => '<?php
@@ -207,6 +216,9 @@ final class AttributeTest extends TestCase
                         class Baz {}
                     }
                 ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'returnTypeWillChange7.1' => [
                 'code' => '<?php

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -111,7 +111,7 @@ final class CallableTest extends TestCase
                     '$a' => 'int',
                 ],
                 'ignored_issues' => [],
-                'php_version' => '7.4',
+                'php_version' => '8.0',
             ],
             'inferArgFromClassContextInGenericContext' => [
                 'code' => '<?php

--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -452,12 +452,16 @@ final class CoreStubsTest extends TestCase
                 json_decode("true", depth: -1);
             ',
             'error_message' => 'InvalidArgument',
+            'ignored_issues' => [],
+            'php_version' => '8.0',
         ];
         yield 'json_encode invalid depth' => [
             'code' => '<?php
                 json_encode([], depth: 439877348953739);
             ',
             'error_message' => 'InvalidArgument',
+            'ignored_issues' => [],
+            'php_version' => '8.0',
         ];
         yield 'str_contains literal haystack' => [
             'code' => '<?php

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -672,8 +672,8 @@ final class IntRangeTest extends TestCase
                     $i = max($b, $c, $d);
                     $j = max($d, $e);
                     $k = max($e, 40);
-                    $l = min($a, ...[$b, $c], $d);
-                    $m = max(...[$a, ...[$b, $c]], $d);
+                    $l = min($a, $d, ...[$b, $c]);
+                    $m = max($d, ...[$a, ...[$b, $c]]);
                     ',
                 'assertions' => [
                     '$f===' => 'int<min, -16>',

--- a/tests/Template/ClassStringMapTest.php
+++ b/tests/Template/ClassStringMapTest.php
@@ -86,6 +86,9 @@ final class ClassStringMapTest extends TestCase
                     function foo(array $arr) : void {
                         takesVariadic(...$arr);
                     }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
             ],
             'assignClassStringMapInConstruct' => [
                 'code' => '<?php

--- a/tests/Template/ClassTemplateCovarianceTest.php
+++ b/tests/Template/ClassTemplateCovarianceTest.php
@@ -319,7 +319,9 @@ final class ClassTemplateCovarianceTest extends TestCase
                          */
                         public function add($a) : Collection
                         {
-                          return new Collection(...$this->arr, $a);
+                          $data = $this->arr;
+                          $data[] = $a;
+                          return new Collection(...$data);
                         }
                     }
 

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1770,6 +1770,8 @@ final class UnusedCodeTest extends TestCase
                         return $f;
                     }',
                 'error_message' => 'UnusedFunctionCall',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'propertyWrittenButNotRead' => [
                 'code' => '<?php

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -79,11 +79,21 @@ final class UnusedCodeTest extends TestCase
      * @dataProvider providerInvalidCodeParse
      * @param array<string> $ignored_issues
      */
-    public function testInvalidCode(string $code, string $error_message, array $ignored_issues = []): void
-    {
+    public function testInvalidCode(
+        string $code,
+        string $error_message,
+        array  $ignored_issues = [],
+        ?string $php_version = null
+    ): void {
         if (strpos($this->getTestName(), 'SKIPPED-') !== false) {
             $this->markTestSkipped();
         }
+
+        if ($php_version === null) {
+            $php_version = '7.4';
+        }
+
+        $this->project_analyzer->setPhpVersion($php_version, 'tests');
 
         $this->expectException(CodeException::class);
         $this->expectExceptionMessageMatches('/\b' . preg_quote($error_message, '/') . '\b/');
@@ -1389,7 +1399,7 @@ final class UnusedCodeTest extends TestCase
     }
 
     /**
-     * @return array<string,array{code:string,error_message:string,ignored_issues?:list<string>}>
+     * @return array<string,array{code:string,error_message:string,ignored_issues?:list<string>, php_version?: string}>
      */
     public function providerInvalidCodeParse(): array
     {

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -2232,8 +2232,7 @@ final class UnusedVariableTest extends TestCase
             'funcGetArgs' => [
                 'code' => '<?php
                     function validate(bool $b, bool $c) : void {
-                        /** @psalm-suppress MixedArgument */
-                        print_r(...func_get_args());
+                        print_r(func_get_args());
                     }',
             ],
             'nullCoalesce' => [


### PR DESCRIPTION
- fix variadic params have wrong type in PHP 8/8.1
- Fix https://github.com/vimeo/psalm/issues/10787
- add error when using named arguments in PHP <8
- fix report an error in all cases when unpacking string keyed array in PHP < 8.1 in all cases (reported for < 8.0 in some incorrectly)
- fix no errors reported for unpacked union (e.g. array<string>|int)
- fix keyed array with fallback didn't report the same errors as unkeyed array for toomany/toofewarguments
- add error for possibly too many/few arguments with array unpacking
- fix named arguments after positional arguments not reported in unpacking
- fix https://github.com/vimeo/psalm/issues/9188