### PR TITLE
Forbid named arguments for ArrayAcccess methods

### DIFF
--- a/stubs/CoreGenericClasses.phpstub
+++ b/stubs/CoreGenericClasses.phpstub
@@ -82,6 +82,7 @@ interface ArrayAccess {
      *              The return value will be casted to boolean if non-boolean was returned.
      *
      * @since 5.0.0
+     * @no-named-arguments because of conflict with ArrayObject
      */
     public function offsetExists($offset);
 
@@ -94,6 +95,7 @@ interface ArrayAccess {
      * @psalm-ignore-nullable-return
      *
      * @since 5.0.0
+     * @no-named-arguments because of conflict with ArrayObject
      */
     public function offsetGet($offset);
 
@@ -106,6 +108,7 @@ interface ArrayAccess {
      * @return void
      *
      * @since 5.0.0
+     * @no-named-arguments because of conflict with ArrayObject
      */
     public function offsetSet($offset, $value);
 
@@ -117,6 +120,7 @@ interface ArrayAccess {
      * @return void
      *
      * @since 5.0.0
+     * @no-named-arguments because of conflict with ArrayObject
      */
     public function offsetUnset($offset);
 }
@@ -162,6 +166,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return bool true if the requested index exists, otherwise false
      *
      * @since 5.0.0
+     * @no-named-arguments because of conflict with ArrayAccess
      */
     public function offsetExists($offset) { }
 
@@ -173,6 +178,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return TValue The value at the specified index or false.
      *
      * @since 5.0.0
+     * @no-named-arguments because of conflict with ArrayAccess
      */
     public function offsetGet($offset) { }
 
@@ -185,6 +191,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return void
      *
      * @since 5.0.0
+     * @no-named-arguments because of conflict with ArrayAccess
      */
     public function offsetSet($offset, $value) { }
 
@@ -196,6 +203,7 @@ class ArrayObject implements IteratorAggregate, ArrayAccess, Serializable, Count
      * @return void
      *
      * @since 5.0.0
+     * @no-named-arguments because of conflict with ArrayAccess
      */
     public function offsetUnset($offset) { }
 

--- a/tests/ArrayAccessTest.php
+++ b/tests/ArrayAccessTest.php
@@ -1233,6 +1233,25 @@ class ArrayAccessTest extends TestCase
                 'assertions' => [],
                 'ignored_issues' => ['UndefinedDocblockClass'],
             ],
+            'canExtendArrayObjectOffsetSet' => [
+                'code' => <<<'PHP'
+                <?php
+                // parameter names in PHP are messed up:
+                // ArrayObject::offsetSet(mixed $key, mixed $value) : void;
+                // ArrayAccess::offsetSet(mixed $offset, mixed $value) : void;
+                // and yet ArrayObject implements ArrayAccess
+
+                /** @extends ArrayObject<int, int> */
+                class C extends ArrayObject {
+                    public function offsetSet(mixed $key, mixed $value): void {
+                        parent::offsetSet($key, $value);
+                    }
+                }
+                PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
         ];
     }
 
@@ -1559,6 +1578,16 @@ class ArrayAccessTest extends TestCase
                     //  should not report TypeDoesNotContainNull
                     if ($x === null) {}',
                 'error_message' => 'PossiblyUndefinedArrayOffset',
+            ],
+            'cannotUseNamedArgumentsForArrayAccess' => [
+                'code' => <<<'PHP'
+                <?php
+                /** @param ArrayAccess<int, string> $a */
+                function f(ArrayAccess $a): void {
+                    echo $a->offsetGet(offset: 0);
+                }
+                PHP,
+                'error_message' => 'NamedArgumentNotAllowed',
             ],
         ];
     }


### PR DESCRIPTION
Fixes vimeo/psalm#10533

Impact: I found a single repo across all of GitHub that uses named arguments to `offsetSet()`.