### PR TITLE
Fixed analysis of existing static methods if the `__callStatic()` method exists

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -789,7 +789,7 @@ final class AtomicStaticCallAnalyzer
             }
         }
 
-        if (!$callstatic_method_exists || $class_storage->hasSealedMethods($config)) {
+        if ($naive_method_exists || !$callstatic_method_exists || $class_storage->hasSealedMethods($config)) {
             $does_method_exist = MethodAnalyzer::checkMethodExists(
                 $codebase,
                 $method_id,

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -90,6 +90,36 @@ class AssertAnnotationTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
+    public function testAssertsAllongCallStaticMethodWork(): void
+    {
+        $this->addFile(
+            'somefile.php',
+            '<?php
+
+            class ImportedAssert
+            {
+                /** @psalm-assert non-empty-string $b */
+                public static function notEmptyStrOnly(string $b): void
+                {
+                    if ("" === $b) throw new \Exception("");
+                }
+
+                public function __callStatic() {}
+            }
+
+            /** @return non-empty-string */
+            function returnNonEmpty(string $b): string
+            {
+                ImportedAssert::notEmptyStrOnly($b);
+
+                return $b;
+            }
+            ',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
     public function testAssertInvalidDocblockMessageDoesNotIncludeTrace(): void
     {
         $this->expectException(CodeException::class);


### PR DESCRIPTION
Fixes #10807