### PR TITLE
Promoted properties missing in extended __construct should report PropertyNotSetInConstructor

### DIFF
--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -587,6 +587,22 @@ class PropertyTypeTest extends TestCase
                     'MixedAssignment',
                 ],
             ],
+            'promotedPropertyNoExtendedConstructor' => [
+                'code' => '<?php
+                    class A
+                    {
+                        public function __construct(
+                            public string $name,
+                        ) {}
+                    }
+
+                    class B extends A
+                    {
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
             'propertyWithoutTypeSuppressingIssueAndAssertingNull' => [
                 'code' => '<?php
                     class A {
@@ -3572,6 +3588,23 @@ class PropertyTypeTest extends TestCase
                         }
                     }',
                 'error_message' => 'PropertyNotSetInConstructor',
+            ],
+            'promotedPropertyNotSetInExtendedConstructor' => [
+                'code' => '<?php
+                    class A
+                    {
+                        public function __construct(
+                            public string $name,
+                        ) {}
+                    }
+
+                    class B extends A
+                    {
+                        public function __construct() {}
+                    }',
+                'error_message' => 'PropertyNotSetInConstructor',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'nullableTypedPropertyNoConstructor' => [
                 'code' => '<?php


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/10786