### PR TITLE
[PHP 8.4] Fixes for implicit nullability deprecation

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -889,7 +889,7 @@ final class Codebase
      */
     public function getMethodReturnTypeLocation(
         $method_id,
-        CodeLocation &$defined_location = null
+        ?CodeLocation &$defined_location = null
     ): ?CodeLocation {
         return $this->methods->getMethodReturnTypeLocation(
             MethodIdentifier::wrap($method_id),
@@ -1651,7 +1651,7 @@ final class Codebase
      */
     public function getSignatureInformation(
         string $function_symbol,
-        string $file_path = null
+        ?string $file_path = null
     ): ?SignatureInformation {
         $signature_label = '';
         $signature_documentation = null;
@@ -1876,7 +1876,7 @@ final class Codebase
         string $type_string,
         string $gap,
         bool $snippets_supported = false,
-        array $allow_visibilities = null,
+        ?array $allow_visibilities = null,
         array $ignore_fq_class_names = []
     ): array {
         if ($allow_visibilities === null) {

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1596,7 +1596,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
         StatementsAnalyzer $statements_analyzer,
         Context $context,
         Codebase $codebase,
-        PhpParser\Node $stmt = null
+        ?PhpParser\Node $stmt = null
     ): void {
         $storage = $this->getFunctionLikeStorage($statements_analyzer);
 

--- a/src/Psalm/Internal/Analyzer/IssueData.php
+++ b/src/Psalm/Internal/Analyzer/IssueData.php
@@ -122,7 +122,7 @@ final class IssueData
         int $shortcode = 0,
         int $error_level = -1,
         ?array $taint_trace = null,
-        array $other_references = null,
+        ?array $other_references = null,
         ?string $dupe_key = null
     ) {
         $this->severity = $severity;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
@@ -44,7 +44,7 @@ final class LoopAnalyzer
         array $pre_conditions,
         array $post_expressions,
         LoopScope $loop_scope,
-        Context &$continue_context = null,
+        ?Context &$continue_context = null,
         bool $is_do = false,
         bool $always_enters_loop = false
     ): ?bool {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php
@@ -309,7 +309,7 @@ final class ArithmeticOpAnalyzer
         bool &$has_valid_left_operand,
         bool &$has_valid_right_operand,
         bool &$has_string_increment,
-        Union &$result_type = null
+        ?Union &$result_type = null
     ): ?Union {
         if (($left_type_part instanceof TLiteralInt || $left_type_part instanceof TLiteralFloat)
             && ($right_type_part instanceof TLiteralInt || $right_type_part instanceof TLiteralFloat)

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -59,7 +59,7 @@ final class ConcatAnalyzer
         PhpParser\Node\Expr $left,
         PhpParser\Node\Expr $right,
         Context $context,
-        Union &$result_type = null
+        ?Union &$result_type = null
     ): void {
         $codebase = $statements_analyzer->getCodebase();
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgInfo.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/HighOrderFunctionArgInfo.php
@@ -35,7 +35,7 @@ final class HighOrderFunctionArgInfo
     public function __construct(
         string $type,
         FunctionLikeStorage $function_storage,
-        ClassLikeStorage $class_storage = null
+        ?ClassLikeStorage $class_storage = null
     ) {
         $this->type = $type;
         $this->function_storage = $function_storage;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -76,7 +76,7 @@ final class NewAnalyzer extends CallAnalyzer
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\New_ $stmt,
         Context $context,
-        TemplateResult $template_result = null
+        ?TemplateResult $template_result = null
     ): bool {
         $fq_class_name = null;
 
@@ -310,7 +310,7 @@ final class NewAnalyzer extends CallAnalyzer
         string $fq_class_name,
         bool $from_static,
         bool $can_extend,
-        TemplateResult $template_result = null
+        ?TemplateResult $template_result = null
     ): void {
         $storage = $codebase->classlike_storage_provider->get($fq_class_name);
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ArrayFetchAnalyzer.php
@@ -475,8 +475,8 @@ final class ArrayFetchAnalyzer
         bool $in_assignment,
         ?string $extended_var_id,
         Context $context,
-        PhpParser\Node\Expr $assign_value = null,
-        Union $replacement_type = null
+        ?PhpParser\Node\Expr $assign_value = null,
+        ?Union $replacement_type = null
     ): Union {
         $offset_type = $offset_type_original->getBuilder();
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/SimpleTypeInferer.php
@@ -56,7 +56,7 @@ final class SimpleTypeInferer
         NodeDataProvider $nodes,
         PhpParser\Node\Expr $stmt,
         Aliases $aliases,
-        FileSource $file_source = null,
+        ?FileSource $file_source = null,
         ?array $existing_class_constants = null,
         ?string $fq_classlike_name = null
     ): ?Union {
@@ -544,7 +544,7 @@ final class SimpleTypeInferer
         NodeDataProvider $nodes,
         PhpParser\Node\Expr\Array_ $stmt,
         Aliases $aliases,
-        FileSource $file_source = null,
+        ?FileSource $file_source = null,
         ?array $existing_class_constants = null,
         ?string $fq_classlike_name = null
     ): ?Union {
@@ -628,7 +628,7 @@ final class SimpleTypeInferer
         ArrayCreationInfo $array_creation_info,
         PhpParser\Node\Expr\ArrayItem $item,
         Aliases $aliases,
-        FileSource $file_source = null,
+        ?FileSource $file_source = null,
         ?array $existing_class_constants = null,
         ?string $fq_classlike_name = null
     ): bool {

--- a/src/Psalm/Internal/Codebase/Analyzer.php
+++ b/src/Psalm/Internal/Codebase/Analyzer.php
@@ -1188,7 +1188,7 @@ final class Analyzer
         string $file_path,
         PhpParser\Node $node,
         string $node_type,
-        PhpParser\Node $parent_node = null
+        ?PhpParser\Node $parent_node = null
     ): void {
         if ($node_type === '') {
             throw new UnexpectedValueException('non-empty node_type expected');

--- a/src/Psalm/Internal/Codebase/ConstantTypeResolver.php
+++ b/src/Psalm/Internal/Codebase/ConstantTypeResolver.php
@@ -58,7 +58,7 @@ final class ConstantTypeResolver
     public static function resolve(
         ClassLikes $classlikes,
         UnresolvedConstantComponent $c,
-        StatementsAnalyzer $statements_analyzer = null,
+        ?StatementsAnalyzer $statements_analyzer = null,
         array $visited_constant_ids = []
     ): Atomic {
         $c_id = spl_object_id($c);

--- a/src/Psalm/Internal/Codebase/Methods.php
+++ b/src/Psalm/Internal/Codebase/Methods.php
@@ -941,7 +941,7 @@ final class Methods
 
     public function getMethodReturnTypeLocation(
         MethodIdentifier $method_id,
-        CodeLocation &$defined_location = null
+        ?CodeLocation &$defined_location = null
     ): ?CodeLocation {
         $method_id = $this->getDeclaringMethodId($method_id);
 

--- a/src/Psalm/Internal/Provider/FakeFileProvider.php
+++ b/src/Psalm/Internal/Provider/FakeFileProvider.php
@@ -79,7 +79,7 @@ final class FakeFileProvider extends FileProvider
      * @param null|callable(string):bool $filter
      * @return list<string>
      */
-    public function getFilesInDir(string $dir_path, array $file_extensions, callable $filter = null): array
+    public function getFilesInDir(string $dir_path, array $file_extensions, ?callable $filter = null): array
     {
         $file_paths = parent::getFilesInDir($dir_path, $file_extensions, $filter);
 

--- a/src/Psalm/Internal/Provider/FileProvider.php
+++ b/src/Psalm/Internal/Provider/FileProvider.php
@@ -155,7 +155,7 @@ class FileProvider
      * @param null|callable(string):bool $filter
      * @return list<string>
      */
-    public function getFilesInDir(string $dir_path, array $file_extensions, callable $filter = null): array
+    public function getFilesInDir(string $dir_path, array $file_extensions, ?callable $filter = null): array
     {
         $file_paths = [];
 

--- a/src/Psalm/Internal/Type/ParseTree/Value.php
+++ b/src/Psalm/Internal/Type/ParseTree/Value.php
@@ -22,7 +22,7 @@ final class Value extends ParseTree
         int $offset_start,
         int $offset_end,
         ?string $text,
-        ParseTree $parent = null
+        ?ParseTree $parent = null
     ) {
         $this->offset_start = $offset_start;
         $this->offset_end = $offset_end;

--- a/src/Psalm/Plugin/DynamicTemplateProvider.php
+++ b/src/Psalm/Plugin/DynamicTemplateProvider.php
@@ -23,7 +23,7 @@ final class DynamicTemplateProvider
     /**
      * If {@see DynamicFunctionStorage} requires template params this method can create it.
      */
-    public function createTemplate(string $param_name, Union $as = null): TTemplateParam
+    public function createTemplate(string $param_name, ?Union $as = null): TTemplateParam
     {
         return new TTemplateParam($param_name, $as ?? Type::getMixed(), $this->defining_class);
     }

--- a/src/Psalm/Plugin/EventHandler/Event/AfterMethodCallAnalysisEvent.php
+++ b/src/Psalm/Plugin/EventHandler/Event/AfterMethodCallAnalysisEvent.php
@@ -43,7 +43,7 @@ final class AfterMethodCallAnalysisEvent
         StatementsSource $statements_source,
         Codebase $codebase,
         array $file_replacements = [],
-        Union $return_type_candidate = null
+        ?Union $return_type_candidate = null
     ) {
         $this->expr = $expr;
         $this->method_id = $method_id;

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -329,7 +329,7 @@ abstract class FunctionLikeStorage implements HasAttributesInterface
     /**
      * @internal
      */
-    public function addParam(FunctionLikeParameter $param, bool $lookup_value = null): void
+    public function addParam(FunctionLikeParameter $param, ?bool $lookup_value = null): void
     {
         $this->params[] = $param;
         $this->param_lookup[$param->name] = $lookup_value ?? true;

--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -753,7 +753,7 @@ abstract class Atomic implements TypeNode
         TemplateResult $template_result,
         Codebase $codebase,
         ?StatementsAnalyzer $statements_analyzer = null,
-        Atomic $input_type = null,
+        ?Atomic $input_type = null,
         ?int $input_arg_offset = null,
         ?string $calling_class = null,
         ?string $calling_function = null,


### PR DESCRIPTION
Fixes all issues that emit a deprecation notices PHP 8.4 for implicit nullable parameter type declarations.

See:
 - [RFC](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)
 - [PHP 8.4: Implicitly nullable parameter declarations deprecated](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated)