### PR TITLE
Greater > and Less Than < comparisons with non-numeric, non-string, non-resource types should report error

### DIFF
--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -167,7 +167,9 @@ final class MethodComparator
 
         foreach ($guide_method_storage->params as $i => $guide_param) {
             if (!isset($implementer_method_storage->params[$i])) {
-                if (!$prevent_abstract_override && $i >= $guide_method_storage->required_param_count) {
+                if (!$prevent_abstract_override
+                    && ($guide_method_storage->required_param_count === null
+                        || $i >= $guide_method_storage->required_param_count)) {
                     continue;
                 }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php
@@ -1208,7 +1208,7 @@ final class ArithmeticOpAnalyzer
             $min_value = $calculated_min_type !== null ? $calculated_min_type->getSingleIntLiteral()->value : null;
             $max_value = $calculated_max_type !== null ? $calculated_max_type->getSingleIntLiteral()->value : null;
 
-            if ($min_value > $max_value) {
+            if ($max_value === null || ($min_value !== null && $min_value > $max_value)) {
                 [$min_value, $max_value] = [$max_value, $min_value];
             }
 
@@ -1246,7 +1246,7 @@ final class ArithmeticOpAnalyzer
             $min_value = $calculated_min_type !== null ? $calculated_min_type->getSingleIntLiteral()->value : null;
             $max_value = $calculated_max_type !== null ? $calculated_max_type->getSingleIntLiteral()->value : null;
 
-            if ($min_value > $max_value) {
+            if ($max_value === null || ($min_value !== null && $min_value > $max_value)) {
                 [$min_value, $max_value] = [$max_value, $min_value];
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -23,15 +23,20 @@ use Psalm\Internal\MethodIdentifier;
 use Psalm\Issue\DocblockTypeContradiction;
 use Psalm\Issue\ImpureMethodCall;
 use Psalm\Issue\InvalidOperand;
+use Psalm\Issue\PossiblyInvalidOperand;
 use Psalm\Issue\RedundantCondition;
 use Psalm\Issue\RedundantConditionGivenDocblockType;
 use Psalm\Issue\TypeDoesNotContainType;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
 use Psalm\Type;
+use Psalm\Type\Atomic\TFloat;
+use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TResource;
+use Psalm\Type\Atomic\TString;
 use Psalm\Type\Union;
 use UnexpectedValueException;
 
@@ -251,19 +256,65 @@ final class BinaryOpAnalyzer
                     || $stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
                     || $stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
                     || $stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual)
-                && $statements_analyzer->getCodebase()->config->strict_binary_operands
                 && $stmt_left_type
                 && $stmt_right_type
-                && (($stmt_left_type->isSingle() && $stmt_left_type->hasBool())
-                    || ($stmt_right_type->isSingle() && $stmt_right_type->hasBool()))
             ) {
-                IssueBuffer::maybeAdd(
-                    new InvalidOperand(
-                        'Cannot compare ' . $stmt_left_type->getId() . ' to ' . $stmt_right_type->getId(),
-                        new CodeLocation($statements_analyzer, $stmt),
-                    ),
-                    $statements_analyzer->getSuppressedIssues(),
-                );
+                if ($statements_analyzer->getCodebase()->config->strict_binary_operands
+                    && (($stmt_left_type->isSingle() && $stmt_left_type->hasBool())
+                        || ($stmt_right_type->isSingle() && $stmt_right_type->hasBool()))) {
+                    IssueBuffer::maybeAdd(
+                        new InvalidOperand(
+                            'Cannot compare ' . $stmt_left_type->getId() . ' to ' . $stmt_right_type->getId(),
+                            new CodeLocation($statements_analyzer, $stmt),
+                        ),
+                        $statements_analyzer->getSuppressedIssues(),
+                    );
+                } else {
+                    foreach ($stmt_left_type->getAtomicTypes() as $atomic_type) {
+                        if ($atomic_type instanceof TString
+                            || $atomic_type instanceof TInt
+                            || $atomic_type instanceof TFloat
+                            || $atomic_type instanceof TResource) {
+                            continue;
+                        }
+
+                        // array and object behave extremely unexpectedly and might accidentally end up in a comparison
+                        // this can be further improved upon to reduce false positives, e.g. for keyed arrays
+                        // however these will mostly be fringe cases
+                        // https://www.php.net/manual/en/language.operators.comparison.php#language.operators.comparison.types
+                        IssueBuffer::maybeAdd(
+                            new PossiblyInvalidOperand(
+                                'Greater/Less than comparisons with type'
+                                . ' ' . $stmt_left_type->getId()
+                                . ' can behave unexpectedly.',
+                                new CodeLocation($statements_analyzer, $stmt),
+                            ),
+                            $statements_analyzer->getSuppressedIssues(),
+                        );
+
+                        break;
+                    }
+
+                    foreach ($stmt_right_type->getAtomicTypes() as $atomic_type) {
+                        if ($atomic_type instanceof TString
+                            || $atomic_type instanceof TInt
+                            || $atomic_type instanceof TFloat
+                            || $atomic_type instanceof TResource) {
+                            continue;
+                        }
+
+                        IssueBuffer::maybeAdd(
+                            new PossiblyInvalidOperand(
+                                'Greater/Less than comparisons with type'
+                                . ' ' . $stmt_right_type->getId()
+                                . ' can behave unexpectedly.',
+                                new CodeLocation($statements_analyzer, $stmt),
+                            ),
+                            $statements_analyzer->getSuppressedIssues(),
+                        );
+                        break;
+                    }
+                }
             }
 
             if (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Equal

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -46,6 +46,8 @@ use UnexpectedValueException;
 
 use function array_diff;
 use function in_array;
+use function max;
+use function min;
 use function strlen;
 
 /**
@@ -274,6 +276,9 @@ final class BinaryOpAnalyzer
                         $statements_analyzer->getSuppressedIssues(),
                     );
                 } else {
+                    $left_literal_int_floats = self::getMinMaxLiteralIntFloat($stmt_left_type);
+                    $right_literal_int_floats = self::getMinMaxLiteralIntFloat($stmt_right_type);
+
                     foreach ($stmt_left_type->getAtomicTypes() as $atomic_type) {
                         if ($atomic_type instanceof TString
                             || $atomic_type instanceof TInt
@@ -293,19 +298,20 @@ final class BinaryOpAnalyzer
 
                         if (($atomic_type instanceof TNull || $atomic_type instanceof TFalse)
                             && !$stmt_left_type->isSingle()
-                            && $stmt_right_type->isSingleIntLiteral()
+                            && $right_literal_int_floats !== []
                             && (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Greater
-                                 && $stmt_right_type->getSingleIntLiteral()->value >= 0)
+                                 && min($right_literal_int_floats) >= 0)
                                 || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
-                                    && $stmt_right_type->getSingleIntLiteral()->value > 0)
+                                    && min($right_literal_int_floats) > 0)
                                 || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
-                                    && $stmt_right_type->getSingleIntLiteral()->value <= 0)
+                                    && max($right_literal_int_floats) <= 0)
                                 || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
-                                    && $stmt_right_type->getSingleIntLiteral()->value < 0))
+                                    && max($right_literal_int_floats) < 0))
                         ) {
                             continue;
                         }
 
+                        // @todo for cases like int|null >= int report RiskyTruthyFalsyComparison instead?
                         // array and object behave extremely unexpectedly and might accidentally end up in a comparison
                         // this can be further improved upon to reduce false positives, e.g. for keyed arrays
                         // however these will mostly be fringe cases
@@ -342,15 +348,15 @@ final class BinaryOpAnalyzer
 
                         if (($atomic_type instanceof TNull || $atomic_type instanceof TFalse)
                             && !$stmt_right_type->isSingle()
-                            && $stmt_left_type->isSingleIntLiteral()
+                            && $left_literal_int_floats !== []
                             && (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Greater
-                                    && $stmt_left_type->getSingleIntLiteral()->value >= 0)
+                                    && min($left_literal_int_floats) >= 0)
                                 || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
-                                    && $stmt_left_type->getSingleIntLiteral()->value > 0)
+                                    && min($left_literal_int_floats) > 0)
                                 || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
-                                    && $stmt_left_type->getSingleIntLiteral()->value <= 0)
+                                    && max($left_literal_int_floats) <= 0)
                                 || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
-                                    && $stmt_left_type->getSingleIntLiteral()->value < 0))
+                                    && max($left_literal_int_floats) < 0))
                         ) {
                             continue;
                         }
@@ -480,6 +486,54 @@ final class BinaryOpAnalyzer
         );
 
         return true;
+    }
+
+    /**
+     * @return list<int|float>
+     */
+    private static function getMinMaxLiteralIntFloat(Union $union): array
+    {
+        if ($union->hasArrayKey()
+            || $union->hasScalar()
+            || $union->hasNumeric()
+            || (isset($union->getAtomicTypes()['int'])
+                && $union->getLiteralInts() === array())
+            || (isset($union->getAtomicTypes()['float'])
+                && $union->getLiteralFloats() === array())) {
+            return [];
+        }
+
+        $literal_int_float_values = [];
+        foreach ($union->getLiteralInts() as $literal_int) {
+            $literal_int_float_values[] = $literal_int->value;
+        }
+
+        foreach ($union->getRangeInts() as $int_range) {
+            if ($int_range->isNegative()) {
+                $literal_int_float_values[] = -1;
+                continue;
+            }
+
+            if ($int_range->isNegativeOrZero()) {
+                $literal_int_float_values[] = 0;
+                $literal_int_float_values[] = -1;
+                continue;
+            }
+
+            if ($int_range->isPositive()) {
+                $literal_int_float_values[] = 1;
+                continue;
+            }
+
+            $literal_int_float_values[] = 0;
+            $literal_int_float_values[] = 1;
+        }
+
+        foreach ($union->getLiteralFloats() as $literal_float) {
+            $literal_int_float_values[] = $literal_float->value;
+        }
+
+        return $literal_int_float_values;
     }
 
     public static function addDataFlow(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -276,101 +276,130 @@ final class BinaryOpAnalyzer
                         $statements_analyzer->getSuppressedIssues(),
                     );
                 } else {
-                    $left_literal_int_floats = self::getMinMaxLiteralIntFloat($stmt_left_type);
-                    $right_literal_int_floats = self::getMinMaxLiteralIntFloat($stmt_right_type);
+                    $is_valid_object_comparison = false;
+                    if ($stmt_left_type->isSingle()
+                        && $stmt_right_type->isSingle()
+                        && $stmt_left_type->isObjectType()
+                        && $stmt_right_type->isObjectType()) {
+                        $comparable_objects = [
+                            // DateTime/DateTimeImmutable
+                            'DateTimeInterface',
+                            'DateTimeZone',
+                        ];
 
-                    foreach ($stmt_left_type->getAtomicTypes() as $atomic_type) {
-                        if ($atomic_type instanceof TString
-                            || $atomic_type instanceof TInt
-                            || $atomic_type instanceof TArrayKey
-                            || $atomic_type instanceof TFloat
-                            || $atomic_type instanceof TResource) {
-                            continue;
+                        foreach ($comparable_objects as $name) {
+                            if (AtomicTypeComparator::isContainedBy(
+                                $statements_analyzer->getCodebase(),
+                                $stmt_left_type->getSingleAtomic(),
+                                new TNamedObject($name),
+                            ) && AtomicTypeComparator::isContainedBy(
+                                $statements_analyzer->getCodebase(),
+                                $stmt_right_type->getSingleAtomic(),
+                                new TNamedObject($name),
+                            )) {
+                                $is_valid_object_comparison = true;
+                                break;
+                            }
                         }
-
-                        if (AtomicTypeComparator::isContainedBy(
-                            $statements_analyzer->getCodebase(),
-                            $atomic_type,
-                            new TNamedObject('DateTimeInterface'),
-                        )) {
-                            continue;
-                        }
-
-                        if (($atomic_type instanceof TNull || $atomic_type instanceof TFalse)
-                            && !$stmt_left_type->isSingle()
-                            && $right_literal_int_floats !== []
-                            && (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Greater
-                                 && min($right_literal_int_floats) >= 0)
-                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
-                                    && min($right_literal_int_floats) > 0)
-                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
-                                    && max($right_literal_int_floats) <= 0)
-                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
-                                    && max($right_literal_int_floats) < 0))
-                        ) {
-                            continue;
-                        }
-
-                        // @todo for cases like int|null >= int report RiskyTruthyFalsyComparison instead?
-                        // array and object behave extremely unexpectedly and might accidentally end up in a comparison
-                        // this can be further improved upon to reduce false positives, e.g. for keyed arrays
-                        // however these will mostly be fringe cases
-                        // https://www.php.net/manual/en/language.operators.comparison.php#language.operators.comparison.types
-                        IssueBuffer::maybeAdd(
-                            new PossiblyInvalidOperand(
-                                'Greater/Less than comparisons with type'
-                                . ' ' . $stmt_left_type->getId()
-                                . ' can behave unexpectedly.',
-                                new CodeLocation($statements_analyzer, $stmt),
-                            ),
-                            $statements_analyzer->getSuppressedIssues(),
-                        );
-
-                        break;
                     }
 
-                    foreach ($stmt_right_type->getAtomicTypes() as $atomic_type) {
-                        if ($atomic_type instanceof TString
-                            || $atomic_type instanceof TInt
-                            || $atomic_type instanceof TArrayKey
-                            || $atomic_type instanceof TFloat
-                            || $atomic_type instanceof TResource) {
-                            continue;
+                    if (!$is_valid_object_comparison) {
+                        $left_literal_int_floats = self::getMinMaxLiteralIntFloat($stmt_left_type);
+                        $right_literal_int_floats = self::getMinMaxLiteralIntFloat($stmt_right_type);
+                        foreach ($stmt_left_type->getAtomicTypes() as $atomic_type) {
+                            if ($atomic_type instanceof TString
+                                || $atomic_type instanceof TInt
+                                || $atomic_type instanceof TArrayKey
+                                || $atomic_type instanceof TFloat
+                                || $atomic_type instanceof TResource) {
+                                continue;
+                            }
+
+                            if (AtomicTypeComparator::isContainedBy(
+                                $statements_analyzer->getCodebase(),
+                                $atomic_type,
+                                new TNamedObject('GMP'),
+                            )) {
+                                continue;
+                            }
+
+                            if (($atomic_type instanceof TNull || $atomic_type instanceof TFalse)
+                                && !$stmt_left_type->isSingle()
+                                && $right_literal_int_floats !== []
+                                && (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Greater
+                                     && min($right_literal_int_floats) >= 0)
+                                    || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
+                                        && min($right_literal_int_floats) > 0)
+                                    || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
+                                        && max($right_literal_int_floats) <= 0)
+                                    || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
+                                        && max($right_literal_int_floats) < 0))
+                            ) {
+                                continue;
+                            }
+
+                            // @todo for cases like int|null >= int report RiskyTruthyFalsyComparison instead?
+                            // array and object behave extremely unexpectedly
+                            // and might accidentally end up in a comparison
+                            // this can be further improved upon to reduce false positives, e.g. for keyed arrays
+                            // however these will mostly be fringe cases
+                            // https://www.php.net/manual/en/language.operators.comparison.php#language.operators.comparison.types
+                            IssueBuffer::maybeAdd(
+                                new PossiblyInvalidOperand(
+                                    'Greater/Less than comparisons with type'
+                                    . ' ' . $stmt_left_type->getId()
+                                    . ' can behave unexpectedly.',
+                                    new CodeLocation($statements_analyzer, $stmt),
+                                ),
+                                $statements_analyzer->getSuppressedIssues(),
+                            );
+
+                            break;
                         }
 
-                        if (AtomicTypeComparator::isContainedBy(
-                            $statements_analyzer->getCodebase(),
-                            $atomic_type,
-                            new TNamedObject('DateTimeInterface'),
-                        )) {
-                            continue;
-                        }
+                        foreach ($stmt_right_type->getAtomicTypes() as $atomic_type) {
+                            if ($atomic_type instanceof TString
+                                || $atomic_type instanceof TInt
+                                || $atomic_type instanceof TArrayKey
+                                || $atomic_type instanceof TFloat
+                                || $atomic_type instanceof TResource) {
+                                continue;
+                            }
 
-                        if (($atomic_type instanceof TNull || $atomic_type instanceof TFalse)
-                            && !$stmt_right_type->isSingle()
-                            && $left_literal_int_floats !== []
-                            && (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Greater
-                                    && min($left_literal_int_floats) <= 0)
-                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
-                                    && min($left_literal_int_floats) < 0)
-                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
-                                    && max($left_literal_int_floats) >= 0)
-                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
-                                    && max($left_literal_int_floats) > 0))
-                        ) {
-                            continue;
-                        }
+                            if (AtomicTypeComparator::isContainedBy(
+                                $statements_analyzer->getCodebase(),
+                                $atomic_type,
+                                new TNamedObject('GMP'),
+                            )) {
+                                continue;
+                            }
 
-                        IssueBuffer::maybeAdd(
-                            new PossiblyInvalidOperand(
-                                'Greater/Less than comparisons with type'
-                                . ' ' . $stmt_right_type->getId()
-                                . ' can behave unexpectedly.',
-                                new CodeLocation($statements_analyzer, $stmt),
-                            ),
-                            $statements_analyzer->getSuppressedIssues(),
-                        );
-                        break;
+                            if (($atomic_type instanceof TNull || $atomic_type instanceof TFalse)
+                                && !$stmt_right_type->isSingle()
+                                && $left_literal_int_floats !== []
+                                && (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Greater
+                                        && min($left_literal_int_floats) <= 0)
+                                    || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
+                                        && min($left_literal_int_floats) < 0)
+                                    || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
+                                        && max($left_literal_int_floats) >= 0)
+                                    || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
+                                        && max($left_literal_int_floats) > 0))
+                            ) {
+                                continue;
+                            }
+
+                            IssueBuffer::maybeAdd(
+                                new PossiblyInvalidOperand(
+                                    'Greater/Less than comparisons with type'
+                                    . ' ' . $stmt_right_type->getId()
+                                    . ' can behave unexpectedly.',
+                                    new CodeLocation($statements_analyzer, $stmt),
+                                ),
+                                $statements_analyzer->getSuppressedIssues(),
+                            );
+                            break;
+                        }
                     }
                 }
             }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -31,6 +31,7 @@ use Psalm\Issue\TypeDoesNotContainType;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
 use Psalm\Type;
+use Psalm\Type\Atomic\TArrayKey;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TLiteralInt;
@@ -274,6 +275,7 @@ final class BinaryOpAnalyzer
                     foreach ($stmt_left_type->getAtomicTypes() as $atomic_type) {
                         if ($atomic_type instanceof TString
                             || $atomic_type instanceof TInt
+                            || $atomic_type instanceof TArrayKey
                             || $atomic_type instanceof TFloat
                             || $atomic_type instanceof TResource) {
                             continue;
@@ -307,6 +309,7 @@ final class BinaryOpAnalyzer
                     foreach ($stmt_right_type->getAtomicTypes() as $atomic_type) {
                         if ($atomic_type instanceof TString
                             || $atomic_type instanceof TInt
+                            || $atomic_type instanceof TArrayKey
                             || $atomic_type instanceof TFloat
                             || $atomic_type instanceof TResource) {
                             continue;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -32,11 +32,13 @@ use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
 use Psalm\Type;
 use Psalm\Type\Atomic\TArrayKey;
+use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TResource;
 use Psalm\Type\Atomic\TString;
 use Psalm\Type\Union;
@@ -289,6 +291,21 @@ final class BinaryOpAnalyzer
                             continue;
                         }
 
+                        if (($atomic_type instanceof TNull || $atomic_type instanceof TFalse)
+                            && !$stmt_left_type->isSingle()
+                            && $stmt_right_type->isSingleIntLiteral()
+                            && (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Greater
+                                 && $stmt_right_type->getSingleIntLiteral()->value >= 0)
+                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
+                                    && $stmt_right_type->getSingleIntLiteral()->value > 0)
+                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
+                                    && $stmt_right_type->getSingleIntLiteral()->value <= 0)
+                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
+                                    && $stmt_right_type->getSingleIntLiteral()->value < 0))
+                        ) {
+                            continue;
+                        }
+
                         // array and object behave extremely unexpectedly and might accidentally end up in a comparison
                         // this can be further improved upon to reduce false positives, e.g. for keyed arrays
                         // however these will mostly be fringe cases
@@ -320,6 +337,21 @@ final class BinaryOpAnalyzer
                             $atomic_type,
                             new TNamedObject('DateTimeInterface'),
                         )) {
+                            continue;
+                        }
+
+                        if (($atomic_type instanceof TNull || $atomic_type instanceof TFalse)
+                            && !$stmt_right_type->isSingle()
+                            && $stmt_left_type->isSingleIntLiteral()
+                            && (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Greater
+                                    && $stmt_left_type->getSingleIntLiteral()->value >= 0)
+                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
+                                    && $stmt_left_type->getSingleIntLiteral()->value > 0)
+                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
+                                    && $stmt_left_type->getSingleIntLiteral()->value <= 0)
+                                || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
+                                    && $stmt_left_type->getSingleIntLiteral()->value < 0))
+                        ) {
                             continue;
                         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -20,6 +20,7 @@ use Psalm\Internal\Codebase\VariableUseGraph;
 use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\Internal\DataFlow\TaintSource;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\Comparator\AtomicTypeComparator;
 use Psalm\Issue\DocblockTypeContradiction;
 use Psalm\Issue\ImpureMethodCall;
 use Psalm\Issue\InvalidOperand;
@@ -278,6 +279,14 @@ final class BinaryOpAnalyzer
                             continue;
                         }
 
+                        if (AtomicTypeComparator::isContainedBy(
+                            $statements_analyzer->getCodebase(),
+                            $atomic_type,
+                            new TNamedObject('DateTimeInterface'),
+                        )) {
+                            continue;
+                        }
+
                         // array and object behave extremely unexpectedly and might accidentally end up in a comparison
                         // this can be further improved upon to reduce false positives, e.g. for keyed arrays
                         // however these will mostly be fringe cases
@@ -300,6 +309,14 @@ final class BinaryOpAnalyzer
                             || $atomic_type instanceof TInt
                             || $atomic_type instanceof TFloat
                             || $atomic_type instanceof TResource) {
+                            continue;
+                        }
+
+                        if (AtomicTypeComparator::isContainedBy(
+                            $statements_analyzer->getCodebase(),
+                            $atomic_type,
+                            new TNamedObject('DateTimeInterface'),
+                        )) {
                             continue;
                         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOpAnalyzer.php
@@ -350,13 +350,13 @@ final class BinaryOpAnalyzer
                             && !$stmt_right_type->isSingle()
                             && $left_literal_int_floats !== []
                             && (($stmt instanceof PhpParser\Node\Expr\BinaryOp\Greater
-                                    && min($left_literal_int_floats) >= 0)
+                                    && min($left_literal_int_floats) <= 0)
                                 || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\GreaterOrEqual
-                                    && min($left_literal_int_floats) > 0)
+                                    && min($left_literal_int_floats) < 0)
                                 || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\Smaller
-                                    && max($left_literal_int_floats) <= 0)
+                                    && max($left_literal_int_floats) >= 0)
                                 || ($stmt instanceof PhpParser\Node\Expr\BinaryOp\SmallerOrEqual
-                                    && max($left_literal_int_floats) < 0))
+                                    && max($left_literal_int_floats) > 0))
                         ) {
                             continue;
                         }

--- a/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/PartialParserVisitor.php
@@ -307,7 +307,8 @@ final class PartialParserVisitor extends PhpParser\NodeVisitorAbstract
                         ) + 1;
 
                         if ($stmt_inner_end_pos < $this->a_file_contents_length) {
-                            $stmt_inner_end_pos = strpos($this->a_file_contents, '}', $stmt_inner_end_pos + 1);
+                            $new_pos = strpos($this->a_file_contents, '}', $stmt_inner_end_pos + 1);
+                            $stmt_inner_end_pos = $new_pos !== false ? $new_pos : $stmt_inner_end_pos;
                         }
                     }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -407,6 +407,11 @@ final class ClassLikeNodeScanner
             if ($docblock_info->templates) {
                 $storage->template_types = [];
 
+                /**
+                 * not sure what exactly is checked here, suppress it instead of changing it
+                 *
+                 * @psalm-suppress PossiblyInvalidOperand
+                 */
                 usort(
                     $docblock_info->templates,
                     static fn(array $l, array $r): int => $l[4] > $r[4] ? 1 : -1,

--- a/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/IntegerRangeComparator.php
@@ -26,19 +26,18 @@ final class IntegerRangeComparator
         TIntRange $input_type_part,
         TIntRange $container_type_part,
     ): bool {
-        $is_input_min = $input_type_part->min_bound === null;
-        $is_input_max = $input_type_part->max_bound === null;
-        $is_container_min = $container_type_part->min_bound === null;
-        $is_container_max = $container_type_part->max_bound === null;
-
         $is_input_min_in_container = (
-                $is_container_min ||
-                (!$is_input_min && $container_type_part->min_bound <= $input_type_part->min_bound)
-            );
+            $container_type_part->min_bound === null
+            || (!($input_type_part->min_bound === null)
+                && $container_type_part->min_bound <= $input_type_part->min_bound)
+        );
+
         $is_input_max_in_container = (
-                $is_container_max ||
-                (!$is_input_max && $container_type_part->max_bound >= $input_type_part->max_bound)
-            );
+            $container_type_part->max_bound === null
+            || (!($input_type_part->max_bound === null)
+                && $container_type_part->max_bound >= $input_type_part->max_bound)
+        );
+
         return $is_input_min_in_container && $is_input_max_in_container;
     }
 

--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -633,7 +633,8 @@ final class SimpleAssertionReconciler extends Reconciler
             if ($array_atomic_type instanceof TArray) {
                 if (!$array_atomic_type instanceof TNonEmptyArray
                     || ($assertion instanceof HasAtLeastCount
-                        && $array_atomic_type->min_count < $assertion->count)
+                        && ($array_atomic_type->min_count === null
+                            || $array_atomic_type->min_count < $assertion->count))
                 ) {
                     if ($array_atomic_type->isEmptyArray()) {
                         $existing_var_type->removeType('array');

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -64,6 +64,9 @@ abstract class FunctionLikeStorage implements HasAttributesInterface, Stringable
 
     public bool $returns_by_ref = false;
 
+    /**
+     * @var ?int<0, max>
+     */
     public ?int $required_param_count = null;
 
     /**

--- a/src/Psalm/Type/Atomic/TIntRange.php
+++ b/src/Psalm/Type/Atomic/TIntRange.php
@@ -78,10 +78,8 @@ final class TIntRange extends TInt
     public function contains(int $i): bool
     {
         return
-            ($this->min_bound === null && $this->max_bound === null) ||
-            ($this->min_bound === null && $this->max_bound >= $i) ||
-            ($this->max_bound === null && $this->min_bound <= $i) ||
-            ($this->min_bound <= $i && $this->max_bound >= $i);
+            ($this->min_bound === null || $this->min_bound <= $i)
+            && ($this->max_bound === null || $this->max_bound >= $i);
     }
 
     /**

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -1360,6 +1360,62 @@ final class BinaryOperationTest extends TestCase
                     }',
                 'error_message' => 'LessSpecificReturnStatement',
             ],
+            'greaterEqualRedundant' => [
+                'code' => '<?php
+                    $a = array();
+                    if ($a > PHP_INT_MAX) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'lessEqualThanImpossible' => [
+                'code' => '<?php
+                    $a = array();
+                    if ($a < PHP_INT_MAX) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'greaterRisky' => [
+                'code' => '<?php
+                    $a = rand(0, 1) > 0 ? array() : rand();
+                    if ($a > 0) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'greaterEqualRisky' => [
+                'code' => '<?php
+                    $a = rand(0, 1) > 0 ? false : rand();
+                    if ($a >= 0) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'lessEqualRisky' => [
+                'code' => '<?php
+                    $a = rand(0, 1) > 0 ? false : rand();
+                    if ($a <= 0) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'greaterObjectNotice' => [
+                'code' => '<?php
+                    $a = new stdClass();
+                    if ($a > 0) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'greaterEqualObjectNotice' => [
+                'code' => '<?php
+                    $a = rand(0, 1) > 0 ? rand() : new stdClass();
+                    if ($a >= 0) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
         ];
     }
 }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -1477,6 +1477,14 @@ final class BinaryOperationTest extends TestCase
                     }',
                 'error_message' => 'PossiblyInvalidOperand',
             ],
+            'reverseGreaterEqualMinusOneFalse' => [
+                'code' => '<?php
+                    $a = $a = rand(0, 1) > 0 ? rand() : false;
+                    if (-1 < $a) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
             'greaterEqualIntNull' => [
                 'code' => '<?php
                     $a = $a = rand(0, 1) > 0 ? rand(0, 1000) : null;

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -1469,6 +1469,22 @@ final class BinaryOperationTest extends TestCase
                     }',
                 'error_message' => 'PossiblyInvalidOperand',
             ],
+            'greaterEqualIntNull' => [
+                'code' => '<?php
+                    $a = $a = rand(0, 1) > 0 ? rand(0, 1000) : null;
+                    if ($a >= 0) {
+                        echo "can be null";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'smallerIntNull' => [
+                'code' => '<?php
+                    $a = $a = rand(0, 1) > 0 ? rand(0, 1000) : null;
+                    if ($a < rand(0, 1000)) {
+                        echo "can be null";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
         ];
     }
 }

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -1232,6 +1232,34 @@ final class BinaryOperationTest extends TestCase
                         echo "yes";
                     }',
             ],
+            'greaterThanZeroFalse' => [
+                'code' => '<?php
+                    $a = $a = rand(0, 1) > 0 ? rand() : false;
+                    if ($a > 0) {
+                        echo "yes";
+                    }',
+            ],
+            'greaterThanOneFalse' => [
+                'code' => '<?php
+                    $a = $a = rand(0, 1) > 0 ? rand() : false;
+                    if ($a > 1) {
+                        echo "yes";
+                    }',
+            ],
+            'greaterEqualOneFalse' => [
+                'code' => '<?php
+                    $a = $a = rand(0, 1) > 0 ? rand() : false;
+                    if ($a >= 1) {
+                        echo "yes";
+                    }',
+            ],
+            'smallerThanZeroFalse' => [
+                'code' => '<?php
+                    $a = $a = rand(0, 1) > 0 ? rand() : false;
+                    if ($a < 0) {
+                        echo "yes";
+                    }',
+            ],
         ];
     }
 
@@ -1429,6 +1457,14 @@ final class BinaryOperationTest extends TestCase
                     $a = new DateTime();
                     $b = new stdClass();
                     if ($a < $b) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'greaterEqualMinusOneFalse' => [
+                'code' => '<?php
+                    $a = $a = rand(0, 1) > 0 ? rand() : false;
+                    if ($a > -1) {
                         echo "yes";
                     }',
                 'error_message' => 'PossiblyInvalidOperand',

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -1224,6 +1224,14 @@ final class BinaryOperationTest extends TestCase
                 ],
                 'ignored_issues' => ['InvalidOperand'],
             ],
+            'lessDateTimeInterface' => [
+                'code' => '<?php
+                    $a = new DateTime();
+                    $b = new DateTimeImmutable(rand(0, 1) > 0 ? "now" : "yesterday");
+                    if ($a < $b) {
+                        echo "yes";
+                    }',
+            ],
         ];
     }
 
@@ -1412,6 +1420,15 @@ final class BinaryOperationTest extends TestCase
                 'code' => '<?php
                     $a = rand(0, 1) > 0 ? rand() : new stdClass();
                     if ($a >= 0) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'lessDateTimeInterfaceInvalid' => [
+                'code' => '<?php
+                    $a = new DateTime();
+                    $b = new stdClass();
+                    if ($a < $b) {
                         echo "yes";
                     }',
                 'error_message' => 'PossiblyInvalidOperand',

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -1260,6 +1260,14 @@ final class BinaryOperationTest extends TestCase
                         echo "yes";
                     }',
             ],
+            'positiveRangeIntNull' => [
+                'code' => '<?php
+                    $a = rand(0, 1) > 0 ? rand() : null;
+                    $b = rand(1, PHP_INT_MAX);
+                    if ($a >= $b) {
+                        echo "yes";
+                    }',
+            ],
         ];
     }
 
@@ -1482,6 +1490,15 @@ final class BinaryOperationTest extends TestCase
                     $a = $a = rand(0, 1) > 0 ? rand(0, 1000) : null;
                     if ($a < rand(0, 1000)) {
                         echo "can be null";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'rangeIntNull' => [
+                'code' => '<?php
+                    $a = rand(0, 1) > 0 ? rand() : null;
+                    $b = rand(0, PHP_INT_MAX);
+                    if ($a >= $b) {
+                        echo "yes";
                     }',
                 'error_message' => 'PossiblyInvalidOperand',
             ],

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -1232,6 +1232,13 @@ final class BinaryOperationTest extends TestCase
                         echo "yes";
                     }',
             ],
+            'greaterThanGmp' => [
+                'code' => '<?php
+                    $a = gmp_init(15);
+                    if ($a > 0) {
+                        echo "yes";
+                    }',
+            ],
             'greaterThanZeroFalse' => [
                 'code' => '<?php
                     $a = $a = rand(0, 1) > 0 ? rand() : false;
@@ -1465,6 +1472,14 @@ final class BinaryOperationTest extends TestCase
                     $a = new DateTime();
                     $b = new stdClass();
                     if ($a < $b) {
+                        echo "yes";
+                    }',
+                'error_message' => 'PossiblyInvalidOperand',
+            ],
+            'greaterDateTimeInterfaceInvalid' => [
+                'code' => '<?php
+                    $a = new DateTime();
+                    if ($a > 0) {
                         echo "yes";
                     }',
                 'error_message' => 'PossiblyInvalidOperand',

--- a/tests/SwitchTypeTest.php
+++ b/tests/SwitchTypeTest.php
@@ -248,7 +248,8 @@ final class SwitchTypeTest extends TestCase
                             case 1:
                                 $x = rand() % 4;
                             case 2:
-                                if (isset($x) && $x > 2) {
+                                // @todo type should be correctly inferred as int instead of mixed
+                                if (isset($x) && is_int($x) && $x > 2) {
                                     echo "$x is large";
                                 }
                                 break;

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -2832,6 +2832,7 @@ final class ConditionalTest extends TestCase
                         echo $a + 3;
                     }
 
+                    /** @psalm-suppress PossiblyInvalidOperand */
                     if ($a <= 0) {
                         /** @psalm-suppress PossiblyNullOperand */
                         echo $a + 3;
@@ -2841,6 +2842,7 @@ final class ConditionalTest extends TestCase
                         echo $a + 3;
                     }
 
+                    /** @psalm-suppress PossiblyInvalidOperand */
                     if ($a >= 0) {
                         /** @psalm-suppress PossiblyNullOperand */
                         echo $a + 3;
@@ -2850,6 +2852,7 @@ final class ConditionalTest extends TestCase
                         echo $a + 3;
                     }
 
+                    /** @psalm-suppress PossiblyInvalidOperand */
                     if (0 <= $a) {
                         /** @psalm-suppress PossiblyNullOperand */
                         echo $a + 3;
@@ -2859,6 +2862,7 @@ final class ConditionalTest extends TestCase
                         echo $a + 3;
                     }
 
+                    /** @psalm-suppress PossiblyInvalidOperand */
                     if (0 >= $a) {
                         /** @psalm-suppress PossiblyNullOperand */
                         echo $a + 3;
@@ -2875,6 +2879,7 @@ final class ConditionalTest extends TestCase
                         echo $a + 3;
                     }
 
+                    /** @psalm-suppress PossiblyInvalidOperand */
                     if ($a <= 0) {
                         /** @psalm-suppress PossiblyFalseOperand */
                         echo $a + 3;
@@ -2884,6 +2889,7 @@ final class ConditionalTest extends TestCase
                         echo $a + 3;
                     }
 
+                    /** @psalm-suppress PossiblyInvalidOperand */
                     if ($a >= 0) {
                         /** @psalm-suppress PossiblyFalseOperand */
                         echo $a + 3;
@@ -2893,6 +2899,7 @@ final class ConditionalTest extends TestCase
                         echo $a + 3;
                     }
 
+                    /** @psalm-suppress PossiblyInvalidOperand */
                     if (0 <= $a) {
                         /** @psalm-suppress PossiblyFalseOperand */
                         echo $a + 3;
@@ -2902,6 +2909,7 @@ final class ConditionalTest extends TestCase
                         echo $a + 3;
                     }
 
+                    /** @psalm-suppress PossiblyInvalidOperand */
                     if (0 >= $a) {
                         /** @psalm-suppress PossiblyFalseOperand */
                         echo $a + 3;


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/10833

For int|null cases the errors could be slightly annoying, however null can refer to the minimum value (PHP_INT_MIN) but is compared as 0, or it refers to a non-numeric state and shouldn't be used in comparison in the first place (similar to what RiskyTruthyFalsyComparison checks, which I guess would apply here too, but I want to keep it simple for now)