### PR TITLE
Report `parent` being used in callable context when the class does not extend anything

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -38,6 +38,7 @@ use Psalm\Issue\MixedArgumentTypeCoercion;
 use Psalm\Issue\NamedArgumentNotAllowed;
 use Psalm\Issue\NoValue;
 use Psalm\Issue\NullArgument;
+use Psalm\Issue\ParentNotFound;
 use Psalm\Issue\PossiblyFalseArgument;
 use Psalm\Issue\PossiblyInvalidArgument;
 use Psalm\Issue\PossiblyNullArgument;
@@ -1297,6 +1298,16 @@ final class ArgumentAnalyzer
 
                                         if ($callable_fq_class_name === 'parent') {
                                             $container_class = $statements_analyzer->getParentFQCLN();
+                                            if ($container_class === null) {
+                                                IssueBuffer::accepts(
+                                                    new ParentNotFound(
+                                                        'Cannot call method on parent'
+                                                        . ' as this class does not extend another',
+                                                        $arg_location,
+                                                    ),
+                                                    $statements_analyzer->getSuppressedIssues(),
+                                                );
+                                            }
                                         }
 
                                         if (!$container_class) {

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -2518,6 +2518,40 @@ class CallableTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'parentCallableArrayWithoutParent' => [
+                'code' => '<?php
+                class A {
+                    public function __construct() {
+                        $this->run(["parent", "hello"]);
+                    }
+
+                    /**
+                     * @param callable $callable
+                     * @return void
+                     */
+                    public function run($callable) {
+                        call_user_func($callable);
+                    }
+                }',
+                'error_message' => 'ParentNotFound',
+            ],
+            'parentCallableWithoutParent' => [
+                'code' => '<?php
+                class A {
+                    public function __construct() {
+                        $this->run("parent::hello");
+                    }
+
+                    /**
+                     * @param callable $callable
+                     * @return void
+                     */
+                    public function run($callable) {
+                        call_user_func($callable);
+                    }
+                }',
+                'error_message' => 'ParentNotFound',
+            ],
         ];
     }
 }


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/10836