### PR TITLE
fix tests running with other than called PHP binary if called with a non-default PHP binary

### DIFF
--- a/tests/EndToEnd/PsalmEndToEndTest.php
+++ b/tests/EndToEnd/PsalmEndToEndTest.php
@@ -25,6 +25,7 @@ use function tempnam;
 use function unlink;
 
 use const DIRECTORY_SEPARATOR;
+use const PHP_BINARY;
 
 /**
  * Tests some of the most important use cases of the psalm and psalter commands, by launching a new
@@ -116,7 +117,7 @@ class PsalmEndToEndTest extends TestCase
     public function testPsalter(): void
     {
         $this->runPsalmInit();
-        (new Process(['php', $this->psalter, '--alter', '--issues=InvalidReturnType'], self::$tmpDir))->mustRun();
+        (new Process([PHP_BINARY, $this->psalter, '--alter', '--issues=InvalidReturnType'], self::$tmpDir))->mustRun();
         $this->assertSame(0, $this->runPsalm([], self::$tmpDir)['CODE']);
     }
 
@@ -229,7 +230,7 @@ class PsalmEndToEndTest extends TestCase
 
         file_put_contents(self::$tmpDir . '/src/psalm.xml', $psalmXmlContent);
 
-        $process = new Process(['php', $this->psalm, '--config=src/psalm.xml'], self::$tmpDir);
+        $process = new Process([PHP_BINARY, $this->psalm, '--config=src/psalm.xml'], self::$tmpDir);
         $process->run();
         $this->assertSame(2, $process->getExitCode());
         $this->assertStringContainsString('InvalidReturnType', $process->getOutput());

--- a/tests/EndToEnd/PsalmRunnerTrait.php
+++ b/tests/EndToEnd/PsalmRunnerTrait.php
@@ -8,6 +8,8 @@ use function array_merge;
 use function array_unshift;
 use function in_array;
 
+use const PHP_BINARY;
+
 trait PsalmRunnerTrait
 {
     private string $psalm = __DIR__ . '/../../psalm';
@@ -37,9 +39,9 @@ trait PsalmRunnerTrait
         // we run `php psalm` rather than just `psalm`.
 
         if ($relyOnConfigDir) {
-            $process = new Process(array_merge(['php', $this->psalm, '-c=' . $workingDir . '/psalm.xml'], $args), null);
+            $process = new Process(array_merge([PHP_BINARY, $this->psalm, '-c=' . $workingDir . '/psalm.xml'], $args), null);
         } else {
-            $process = new Process(array_merge(['php', $this->psalm], $args), $workingDir);
+            $process = new Process(array_merge([PHP_BINARY, $this->psalm], $args), $workingDir);
         }
 
         if (!$shouldFail) {


### PR DESCRIPTION
e.g. you run the tests with a php83 executable but your default php is PHP 7.4, it will suddenly change while running the tests leading to false positive errors