### PR TITLE
Fix storage not available in thread for intersection doc types

### DIFF
--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -1685,7 +1685,9 @@ final class TypeParser
         $normalized_intersection_types = [];
         $modified = false;
         foreach ($intersection_types as $intersection_type) {
-            if (!$intersection_type instanceof TTypeAlias) {
+            if (!$intersection_type instanceof TTypeAlias
+                || !$codebase->classlike_storage_provider->has($intersection_type->declaring_fq_classlike_name)
+            ) {
                 $normalized_intersection_types[] = [$intersection_type];
                 continue;
             }


### PR DESCRIPTION
This should fix #10739 at least does it for me.
After looking into this again, I think I got a decent understanding of what the failing code tries to do and what is causing the issue.
If a class was scanned in one thread and a `@psalm-import-type` to that class was utilized from another class and thread then that ends in a crash if it is from type `TTypeAlias`.

I fear my fix may loose this extended type information, but I am not sure about. In my tests I see no issue difference between 1 or more threads. Likely the type is not really challenged in our code tho.
From what I have seen multiple comparable issues are solved in a similar manner and I couldn't see an alternative way as well.