### PR TITLE
Don't emit MissingOverrideAttribute for implicit Stringable implementations

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1996,6 +1996,8 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                     && $codebase->config->ensure_override_attribute
                     && $overridden_method_ids
                     && $storage->cased_name !== '__construct'
+                    && ($storage->cased_name !== '__toString'
+                       || isset($appearing_class_storage->direct_class_interfaces['stringable']))
                 ) {
                     IssueBuffer::maybeAdd(
                         new MissingOverrideAttribute(

--- a/tests/OverrideTest.php
+++ b/tests/OverrideTest.php
@@ -85,6 +85,19 @@ class OverrideTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.3',
             ],
+            'ignoreImplicitStringable' => [
+                'code' => '
+                    <?php
+                    class A {
+                        public function __toString(): string {
+                            return "";
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
         ];
     }
 
@@ -187,6 +200,19 @@ class OverrideTest extends TestCase
                     }
                 ',
                 'error_message' => 'InvalidOverride',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'explicitStringable' => [
+                'code' => '
+                    <?php
+                    class A implements Stringable {
+                        public function __toString(): string {
+                            return "";
+                        }
+                    }
+                ',
+                'error_message' => 'MissingOverrideAttribute',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],


### PR DESCRIPTION
Fixes #10846.