### PR TITLE
Specify array return type of session_get_cookie_params

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -11100,7 +11100,7 @@ return [
 'session_destroy' => ['bool'],
 'session_encode' => ['string|false'],
 'session_gc' => ['int|false'],
-'session_get_cookie_params' => ['array'],
+'session_get_cookie_params' => ['array{lifetime:?int,path:?string,domain:?string,secure:?bool,httponly:?bool,samesite:?string}'],
 'session_id' => ['string|false', 'id='=>'?string'],
 'session_is_registered' => ['bool', 'name'=>'string'],
 'session_module_name' => ['string|false', 'module='=>'?string'],

--- a/dictionaries/CallMap_73_delta.php
+++ b/dictionaries/CallMap_73_delta.php
@@ -120,6 +120,10 @@ return [
         'old' => ['bool', 'directory'=>'string', 'permissions='=>'int', 'recursive='=>'bool', 'context='=>'resource'],
         'new' => ['bool', 'directory'=>'string', 'permissions='=>'int', 'recursive='=>'bool', 'context='=>'null|resource'],
     ],
+    'session_get_cookie_params' => [
+        'old' => ['array{lifetime:?int,path:?string,domain:?string,secure:?bool,httponly:?bool}'],
+        'new' => ['array{lifetime:?int,path:?string,domain:?string,secure:?bool,httponly:?bool,samesite:?string}'],
+    ]
   ],
   'removed' => [
   ],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -13840,7 +13840,7 @@ return [
     'session_decode' => ['bool', 'data'=>'string'],
     'session_destroy' => ['bool'],
     'session_encode' => ['string|false'],
-    'session_get_cookie_params' => ['array'],
+    'session_get_cookie_params' => ['array{lifetime:?int,path:?string,domain:?string,secure:?bool,httponly:?bool}'],
     'session_id' => ['string|false', 'id='=>'string'],
     'session_is_registered' => ['bool', 'name'=>'string'],
     'session_module_name' => ['string|false', 'module='=>'string'],


### PR DESCRIPTION
Specifies the return type of function `session_get_cookie_params`. The options have been changed in PHP 7.3.