### PR TITLE
add function and consistent error for internal property

### DIFF
--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -29,6 +29,7 @@ use UnexpectedValueException;
 
 use function count;
 use function is_string;
+use function preg_grep;
 use function preg_match;
 use function preg_replace;
 use function preg_split;
@@ -198,6 +199,8 @@ final class CommentAnalyzer
         if (!$var_comments
             && (isset($parsed_docblock->tags['deprecated'])
                 || isset($parsed_docblock->tags['internal'])
+                || (isset($parsed_docblock->tags['access'])
+                    && preg_grep('/^private(?>\s|$)/', $parsed_docblock->tags['access']))
                 || isset($parsed_docblock->tags['readonly'])
                 || isset($parsed_docblock->tags['psalm-readonly'])
                 || isset($parsed_docblock->tags['psalm-readonly-allow-private-mutation'])
@@ -222,7 +225,11 @@ final class CommentAnalyzer
         ParsedDocblock $parsed_docblock,
     ): void {
         $var_comment->deprecated = isset($parsed_docblock->tags['deprecated']);
-        $var_comment->internal = isset($parsed_docblock->tags['internal']);
+        if (isset($parsed_docblock->tags['internal'])
+            || (isset($parsed_docblock->tags['access'])
+                && preg_grep('/^private(?>\s|$)/', $parsed_docblock->tags['access']))) {
+            $var_comment->internal = true;
+        }
         $var_comment->readonly = isset($parsed_docblock->tags['readonly'])
             || isset($parsed_docblock->tags['psalm-readonly'])
             || isset($parsed_docblock->tags['psalm-readonly-allow-private-mutation']);

--- a/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/NamespaceAnalyzer.php
@@ -190,11 +190,17 @@ final class NamespaceAnalyzer extends SourceAnalyzer
      */
     public static function isWithinAny(string $calling_identifier, array $identifiers): bool
     {
-        if (count($identifiers) === 0) {
+        if ($identifiers === []) {
             return true;
         }
 
         foreach ($identifiers as $identifier) {
+            if ($calling_identifier !== '' && $identifier === '') {
+                // if we have any non-empty, we ignore the empty one
+                // therefore continue instead of return
+                continue;
+            }
+
             if (self::isWithin($calling_identifier, $identifier)) {
                 return true;
             }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -16,7 +16,6 @@ use Psalm\FileManipulation;
 use Psalm\Internal\Analyzer\ClassAnalyzer;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Analyzer\FunctionLikeAnalyzer;
-use Psalm\Internal\Analyzer\NamespaceAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\ClassTemplateParamCollector;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\MethodCallAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
@@ -36,12 +35,9 @@ use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Internal\Type\TypeExpander;
-use Psalm\Issue\DeprecatedProperty;
 use Psalm\Issue\ImplicitToStringCast;
 use Psalm\Issue\ImpurePropertyAssignment;
 use Psalm\Issue\InaccessibleProperty;
-use Psalm\Issue\InternalClass;
-use Psalm\Issue\InternalProperty;
 use Psalm\Issue\InvalidPropertyAssignment;
 use Psalm\Issue\InvalidPropertyAssignmentValue;
 use Psalm\Issue\LoopInvalidation;
@@ -1282,30 +1278,22 @@ final class InstancePropertyAssignmentAnalyzer
         $declaring_class_storage = $codebase->classlike_storage_provider->get($declaring_property_class);
 
         if (isset($declaring_class_storage->properties[$prop_name])) {
+            AtomicPropertyFetchAnalyzer::checkPropertyDeprecation(
+                $prop_name,
+                $declaring_property_class,
+                $stmt,
+                $statements_analyzer,
+            );
+
+            AtomicPropertyFetchAnalyzer::checkPropertyInternal(
+                $prop_name,
+                $declaring_property_class,
+                $stmt,
+                $statements_analyzer,
+                $context,
+            );
+
             $property_storage = $declaring_class_storage->properties[$prop_name];
-
-            if ($property_storage->deprecated) {
-                IssueBuffer::maybeAdd(
-                    new DeprecatedProperty(
-                        $property_id . ' is marked deprecated',
-                        new CodeLocation($statements_analyzer->getSource(), $stmt),
-                        $property_id,
-                    ),
-                    $statements_analyzer->getSuppressedIssues(),
-                );
-            }
-
-            if ($context->self && !NamespaceAnalyzer::isWithinAny($context->self, $property_storage->internal)) {
-                IssueBuffer::maybeAdd(
-                    new InternalProperty(
-                        $property_id . ' is internal to ' . InternalClass::listToPhrase($property_storage->internal)
-                            . ' but called from ' . $context->self,
-                        new CodeLocation($statements_analyzer->getSource(), $stmt),
-                        $property_id,
-                    ),
-                    $statements_analyzer->getSuppressedIssues(),
-                );
-            }
 
             self::trackPropertyImpurity(
                 $statements_analyzer,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -12,6 +12,7 @@ use Psalm\Internal\Algebra;
 use Psalm\Internal\Algebra\FormulaGenerator;
 use Psalm\Internal\Analyzer\AlgebraAnalyzer;
 use Psalm\Internal\Analyzer\FunctionLikeAnalyzer;
+use Psalm\Internal\Analyzer\NamespaceAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
@@ -26,6 +27,8 @@ use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TypeCombiner;
 use Psalm\Issue\DeprecatedFunction;
 use Psalm\Issue\ImpureFunctionCall;
+use Psalm\Issue\InternalClass;
+use Psalm\Issue\InternalMethod;
 use Psalm\Issue\InvalidFunctionCall;
 use Psalm\Issue\MixedFunctionCall;
 use Psalm\Issue\NullFunctionCall;
@@ -401,6 +404,30 @@ final class FunctionCallAnalyzer extends CallAnalyzer
                     ),
                     $statements_analyzer->getSuppressedIssues(),
                 );
+            }
+
+            if (!$context->collect_initializations
+                && !$context->collect_mutations
+                && $function_call_info->function_id !== null
+            ) {
+                $caller_identifier = $statements_analyzer->getFullyQualifiedFunctionMethodOrNamespaceName();
+                if ($caller_identifier !== null
+                    && !NamespaceAnalyzer::isWithinAny(
+                        $caller_identifier,
+                        $function_call_info->function_storage->internal,
+                    )) {
+                    IssueBuffer::maybeAdd(
+                        new InternalMethod(
+                            'The function ' . $function_call_info->function_id
+                            . ' is internal to '
+                            . InternalClass::listToPhrase($function_call_info->function_storage->internal)
+                            . ' but called from ' . ($caller_identifier ?: 'root namespace'),
+                            $code_location,
+                            $function_call_info->function_id,
+                        ),
+                        $statements_analyzer->getSuppressedIssues(),
+                    );
+                }
             }
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -377,16 +377,16 @@ final class NewAnalyzer extends CallAnalyzer
             );
         }
 
-
-        if ($context->self
+        $caller_identifier = $context->self ?? $statements_analyzer->getNamespace();
+        if ($caller_identifier !== null
             && !$context->collect_initializations
             && !$context->collect_mutations
-            && !NamespaceAnalyzer::isWithinAny($context->self, $storage->internal)
+            && !NamespaceAnalyzer::isWithinAny($caller_identifier, $storage->internal)
         ) {
             IssueBuffer::maybeAdd(
                 new InternalClass(
                     $fq_class_name . ' is internal to ' . InternalClass::listToPhrase($storage->internal)
-                        . ' but called from ' . $context->self,
+                        . ' but called from ' . ($caller_identifier ?: 'root namespace'),
                     new CodeLocation($statements_analyzer->getSource(), $stmt),
                     $fq_class_name,
                 ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/AtomicStaticCallAnalyzer.php
@@ -842,11 +842,13 @@ final class AtomicStaticCallAnalyzer
             );
         }
 
-        if ($context->self && ! NamespaceAnalyzer::isWithinAny($context->self, $class_storage->internal)) {
+        $caller_identifier = $context->self ?? $statements_analyzer->getNamespace();
+        if ($caller_identifier !== null
+            && !NamespaceAnalyzer::isWithinAny($caller_identifier, $class_storage->internal)) {
             IssueBuffer::maybeAdd(
                 new InternalClass(
                     $fq_class_name . ' is internal to ' . InternalClass::listToPhrase($class_storage->internal)
-                        . ' but called from ' . $context->self,
+                        . ' but called from ' . ($caller_identifier ?: 'root namespace'),
                     new CodeLocation($statements_analyzer->getSource(), $stmt),
                     $fq_class_name,
                 ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/ClassConstAnalyzer.php
@@ -367,16 +367,17 @@ final class ClassConstAnalyzer
                 }
             }
 
-            if ($context->self
+            $caller_identifier = $context->self ?? $statements_analyzer->getNamespace();
+            if ($caller_identifier !== null
                 && !$context->collect_initializations
                 && !$context->collect_mutations
-                && !NamespaceAnalyzer::isWithinAny($context->self, $const_class_storage->internal)
+                && !NamespaceAnalyzer::isWithinAny($caller_identifier, $const_class_storage->internal)
             ) {
                 IssueBuffer::maybeAdd(
                     new InternalClass(
                         $fq_class_name . ' is internal to '
                             . InternalClass::listToPhrase($const_class_storage->internal)
-                            . ' but called from ' . $context->self,
+                            . ' but called from ' . ($caller_identifier ?: 'root namespace'),
                         new CodeLocation($statements_analyzer->getSource(), $stmt),
                         $fq_class_name,
                     ),
@@ -658,16 +659,17 @@ final class ClassConstAnalyzer
                 }
             }
 
-            if ($context->self
+            $caller_identifier = $context->self ?? $statements_analyzer->getNamespace();
+            if ($caller_identifier !== null
                 && !$context->collect_initializations
                 && !$context->collect_mutations
-                && !NamespaceAnalyzer::isWithinAny($context->self, $const_class_storage->internal)
+                && !NamespaceAnalyzer::isWithinAny($caller_identifier, $const_class_storage->internal)
             ) {
                 IssueBuffer::maybeAdd(
                     new InternalClass(
                         $fq_class_name . ' is internal to '
                             . InternalClass::listToPhrase($const_class_storage->internal)
-                            . ' but called from ' . $context->self,
+                            . ' but called from ' . ($caller_identifier ?: 'root namespace'),
                         new CodeLocation($statements_analyzer->getSource(), $stmt),
                         $fq_class_name,
                     ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -457,19 +457,9 @@ final class AtomicPropertyFetchAnalyzer
         if (isset($declaring_class_storage->properties[$prop_name])) {
             self::checkPropertyDeprecation($prop_name, $declaring_property_class, $stmt, $statements_analyzer);
 
-            $property_storage = $declaring_class_storage->properties[$prop_name];
+            self::checkPropertyInternal($prop_name, $declaring_property_class, $stmt, $statements_analyzer, $context);
 
-            if ($context->self && !NamespaceAnalyzer::isWithinAny($context->self, $property_storage->internal)) {
-                IssueBuffer::maybeAdd(
-                    new InternalProperty(
-                        $property_id . ' is internal to ' . InternalClass::listToPhrase($property_storage->internal)
-                            . ' but called from ' . $context->self,
-                        new CodeLocation($statements_analyzer->getSource(), $stmt),
-                        $property_id,
-                    ),
-                    $statements_analyzer->getSuppressedIssues(),
-                );
-            }
+            $property_storage = $declaring_class_storage->properties[$prop_name];
 
             if ($context->inside_unset) {
                 InstancePropertyAssignmentAnalyzer::trackPropertyImpurity(
@@ -564,6 +554,42 @@ final class AtomicPropertyFetchAnalyzer
                 IssueBuffer::maybeAdd(
                     new DeprecatedProperty(
                         $property_id . ' is marked deprecated',
+                        new CodeLocation($statements_analyzer->getSource(), $stmt),
+                        $property_id,
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+        }
+    }
+
+    /**
+     * @param PropertyFetch|StaticPropertyFetch $stmt
+     */
+    public static function checkPropertyInternal(
+        string $prop_name,
+        string $declaring_property_class,
+        PhpParser\Node\Expr $stmt,
+        StatementsAnalyzer $statements_analyzer,
+        Context $context
+    ): void {
+        $property_id = $declaring_property_class . '::$' . $prop_name;
+        $codebase = $statements_analyzer->getCodebase();
+        $declaring_class_storage = $codebase->classlike_storage_provider->get(
+            $declaring_property_class,
+        );
+
+        if (isset($declaring_class_storage->properties[$prop_name])) {
+            $property_storage = $declaring_class_storage->properties[$prop_name];
+
+            $caller_identifier = $context->self ?? $statements_analyzer->getNamespace();
+
+            if ($caller_identifier !== null
+                && !NamespaceAnalyzer::isWithinAny($caller_identifier, $property_storage->internal)) {
+                IssueBuffer::maybeAdd(
+                    new InternalProperty(
+                        $property_id . ' is internal to ' . InternalClass::listToPhrase($property_storage->internal)
+                        . ' but called from ' . ($caller_identifier ?: 'root namespace'),
                         new CodeLocation($statements_analyzer->getSource(), $stmt),
                         $property_id,
                     ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
@@ -438,6 +438,14 @@ final class InstancePropertyFetchAnalyzer
                             $stmt,
                             $statements_analyzer,
                         );
+
+                        AtomicPropertyFetchAnalyzer::checkPropertyInternal(
+                            $stmt->name->name,
+                            $declaring_property_class,
+                            $stmt,
+                            $statements_analyzer,
+                            $context,
+                        );
                     }
 
                     $codebase->properties->propertyExists(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/StaticPropertyFetchAnalyzer.php
@@ -297,6 +297,14 @@ final class StaticPropertyFetchAnalyzer
             $statements_analyzer,
         );
 
+        AtomicPropertyFetchAnalyzer::checkPropertyInternal(
+            $prop_name,
+            $declaring_property_class,
+            $stmt,
+            $statements_analyzer,
+            $context,
+        );
+
         $class_storage = $codebase->classlike_storage_provider->get($declaring_property_class);
         $property = $class_storage->properties[$prop_name];
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -32,6 +32,7 @@ use function count;
 use function explode;
 use function implode;
 use function in_array;
+use function preg_grep;
 use function preg_last_error_msg;
 use function preg_match;
 use function preg_replace;
@@ -203,7 +204,9 @@ final class ClassLikeDocblockParser
             $info->deprecated = true;
         }
 
-        if (isset($parsed_docblock->tags['internal'])) {
+        if (isset($parsed_docblock->tags['internal'])
+            || (isset($parsed_docblock->tags['access'])
+                && preg_grep('/^private(?>\s|$)/', $parsed_docblock->tags['access']))) {
             $info->internal = true;
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -635,6 +635,8 @@ final class ClassLikeNodeScanner
                 $storage->internal = $docblock_info->psalm_internal;
             } elseif ($docblock_info->internal && $this->aliases->namespace) {
                 $storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($this->aliases->namespace)];
+            } elseif ($docblock_info->internal) {
+                $storage->internal = [''];
             }
 
             if ($docblock_info->final && !$storage->final) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -26,6 +26,7 @@ use function explode;
 use function implode;
 use function in_array;
 use function pathinfo;
+use function preg_grep;
 use function preg_last_error_msg;
 use function preg_match;
 use function preg_replace;
@@ -441,7 +442,9 @@ final class FunctionLikeDocblockParser
             $info->deprecated = true;
         }
 
-        if (isset($parsed_docblock->tags['internal'])) {
+        if (isset($parsed_docblock->tags['internal'])
+            || (isset($parsed_docblock->tags['access'])
+                && preg_grep('/^private(?>\s|$)/', $parsed_docblock->tags['access']))) {
             $info->internal = true;
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -123,6 +123,10 @@ final class FunctionLikeDocblockScanner
             $storage->internal = $docblock_info->psalm_internal;
         } elseif ($docblock_info->internal && $aliases->namespace) {
             $storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($aliases->namespace)];
+        } elseif ($docblock_info->internal && $classlike_storage && $classlike_storage->name) {
+            $storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($classlike_storage->name)];
+        } elseif ($docblock_info->internal) {
+            $storage->internal = [''];
         }
 
         if (($storage->internal || ($classlike_storage && $classlike_storage->internal))

--- a/src/Psalm/Issue/InternalClass.php
+++ b/src/Psalm/Issue/InternalClass.php
@@ -15,10 +15,14 @@ final class InternalClass extends ClassIssue
     public const ERROR_LEVEL = 4;
     public const SHORTCODE = 174;
 
-    /** @param non-empty-list<non-empty-string> $words */
+    /** @param non-empty-list<string> $words */
     public static function listToPhrase(array $words): string
     {
         $words = array_unique($words);
+        if ($words === ['']) {
+            return 'root namespace';
+        }
+
         if (count($words) === 1) {
             return reset($words);
         }

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -43,7 +43,7 @@ final class ClassLikeStorage implements HasAttributesInterface
     public bool $deprecated = false;
 
     /**
-     * @var list<non-empty-string>
+     * @var list<string>
      */
     public array $internal = [];
 

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -56,7 +56,7 @@ abstract class FunctionLikeStorage implements HasAttributesInterface, Stringable
     public ?bool $deprecated = null;
 
     /**
-     * @var list<non-empty-string>
+     * @var list<string>
      */
     public array $internal = [];
 

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -1032,6 +1032,62 @@ final class InternalAnnotationTest extends TestCase
                     }',
                 'error_message' => 'InternalProperty',
             ],
+            'internalClassOutsideClass' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        class Foo {}
+                    }
+                    namespace B {
+                        $f = new \A\Foo();
+                    }',
+                'error_message' => 'InternalClass',
+            ],
+            'internalClassOutsideClassGlobalNamespace' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        class Foo {}
+                    }
+                    namespace {
+                        $f = new \A\Foo();
+                    }',
+                'error_message' => 'InternalClass',
+            ],
+            'internalClassInsideFunction' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        class Foo {}
+                    }
+                    namespace B {
+                        function hello(): void {
+                            $f = new \A\Foo();
+                        }
+                    }',
+                'error_message' => 'InternalClass',
+            ],
+            'internalClassInsideFunctionGlobalNamespace' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        class Foo {}
+                    }
+                    namespace {
+                        function hello(): void {
+                            $f = new \A\Foo();
+                        }
+                    }',
+                'error_message' => 'InternalClass',
+            ],
             'magicPropertyGetInternalExplicit' => [
                 'code' => '<?php
                     namespace A {

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -1088,6 +1088,96 @@ final class InternalAnnotationTest extends TestCase
                     }',
                 'error_message' => 'InternalClass',
             ],
+            'internalFunctionOutsideClass' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        function foo(): void {}
+                    }
+                    namespace B {
+                        \A\foo();
+                    }',
+                'error_message' => 'InternalMethod',
+            ],
+            'internalFunctionOutsideClassGlobalNamespace' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        function foo(): void {}
+                    }
+                    namespace {
+                        \A\foo();
+                    }',
+                'error_message' => 'InternalMethod',
+            ],
+            'internalFunctionInsideFunction' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        function foo(): void {}
+                    }
+                    namespace B {
+                        function hello(): void {
+                            \A\foo();
+                        }
+                    }',
+                'error_message' => 'InternalMethod',
+            ],
+            'internalFunctionInsideFunctionGlobalNamespace' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        function foo(): void {}
+                    }
+                    namespace {
+                        function hello(): void {
+                            \A\foo();
+                        }
+                    }',
+                'error_message' => 'InternalMethod',
+            ],
+            'internalFunctionInsideClass' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        function foo(): void {}
+                    }
+                    namespace B {
+                        class Bar {
+                            public function run(): void {
+                                \A\foo();
+                            }
+                        }
+                    }',
+                'error_message' => 'InternalMethod',
+            ],
+            'internalFunctionInsideClassGlobalNamespace' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @internal
+                         */
+                        function foo(): void {}
+                    }
+                    namespace {
+                        class Bar {
+                            public function run(): void {
+                                \A\foo();
+                            }
+                        }
+                    }',
+                'error_message' => 'InternalMethod',
+            ],
             'magicPropertyGetInternalExplicit' => [
                 'code' => '<?php
                     namespace A {

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -908,6 +908,130 @@ final class InternalAnnotationTest extends TestCase
                     }',
                 'error_message' => 'InternalProperty',
             ],
+            'internalPropertyStatic' => [
+                'code' => '<?php
+                    namespace A {
+                        class Foo {
+                            /**
+                             * @internal
+                             * @var string
+                             */
+                            public static $foo = "bar";
+                        }
+                    }
+                    namespace B {
+                        class Bat {
+                            public function batBat() : void {
+                                echo \A\Foo::$foo;
+                            }
+                        }
+                    }',
+                'error_message' => 'InternalProperty',
+            ],
+            'internalPropertyStaticOutsideClass' => [
+                'code' => '<?php
+                    namespace A {
+                        class Foo {
+                            /**
+                             * @internal
+                             * @var string
+                             */
+                            public static $foo = "bar";
+                        }
+                    }
+                    namespace B {
+                        echo \A\Foo::$foo;
+                    }',
+                'error_message' => 'InternalProperty',
+            ],
+            'internalPropertyStaticOutsideClassGlobalNamespace' => [
+                'code' => '<?php
+                    namespace A {
+                        class Foo {
+                            /**
+                             * @internal
+                             * @var string
+                             */
+                            public static $foo = "bar";
+                        }
+                    }
+                    namespace {
+                        echo \A\Foo::$foo;
+                    }',
+                'error_message' => 'InternalProperty',
+            ],
+            'internalPropertyInsideFunction' => [
+                'code' => '<?php
+                    namespace A {
+                        class Foo {
+                            /**
+                             * @internal
+                             * @var string
+                             */
+                            public $foo = "bar";
+                        }
+                    }
+                    namespace B {
+                        function hello(): void {
+                            $f = new \A\Foo();
+                            echo $f->foo;
+                        }
+                    }',
+                'error_message' => 'InternalProperty',
+            ],
+            'internalPropertyInsideFunctionGlobalNamespace' => [
+                'code' => '<?php
+                    namespace A {
+                        class Foo {
+                            /**
+                             * @internal
+                             * @var string
+                             */
+                            public $foo = "bar";
+                        }
+                    }
+                    namespace {
+                        function hello(): void {
+                            $f = new \A\Foo();
+                            echo $f->foo;
+                        }
+                    }',
+                'error_message' => 'InternalProperty',
+            ],
+            'internalPropertyOutsideClass' => [
+                'code' => '<?php
+                    namespace A {
+                        class Foo {
+                            /**
+                             * @internal
+                             * @var string
+                             */
+                            public $foo = "bar";
+                        }
+                    }
+                    namespace B {
+                        $f = new \A\Foo();
+                        echo $f->foo;
+                    }',
+                'error_message' => 'InternalProperty',
+            ],
+            'internalPropertyOutsideClassGlobalNamespace' => [
+                'code' => '<?php
+                    namespace A {
+                        class Foo {
+                            /**
+                             * @internal
+                             * @var string
+                             */
+                            public $foo = "bar";
+                        }
+                    }
+                    namespace {
+                        $f = new \A\Foo();
+                        echo $f->foo;
+                    }',
+                'error_message' => 'InternalProperty',
+            ],
             'magicPropertyGetInternalExplicit' => [
                 'code' => '<?php
                     namespace A {

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -1456,6 +1456,90 @@ final class InternalAnnotationTest extends TestCase
                 ',
                 'error_message' => 'InternalMethod',
             ],
+            'accessPrivateClass' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @access private
+                         */
+                        class C {}
+                    }
+                    namespace B {
+                        use A\C;
+                        new C;
+                    }
+                ',
+                'error_message' => 'InternalClass',
+            ],
+            'accessPrivateConstructor' => [
+                'code' => '<?php
+                    namespace A {
+                        class C {
+                            /**
+                             * @access private
+                             */
+                            public function __construct() {}
+                        }
+                    }
+                    namespace B {
+                        use A\C;
+                        new C;
+                    }
+                ',
+                'error_message' => 'InternalMethod',
+            ],
+            'accessPrivateMethod' => [
+                'code' => '<?php
+                    namespace A {
+                        class C {
+                            /**
+                             * @access private
+                             */
+                            public function run(): void {}
+                        }
+                    }
+                    namespace B {
+                        use A\C;
+                        $c = new C;
+                        $c->run();
+                    }
+                ',
+                'error_message' => 'InternalMethod',
+            ],
+            'accessPrivateFunction' => [
+                'code' => '<?php
+                    namespace A {
+                        /**
+                         * @access private
+                         */
+                        function run(): void {}
+                    }
+                    namespace B {
+                        \A\run();
+                    }
+                ',
+                'error_message' => 'InternalMethod',
+            ],
+            'accessPrivateProperty' => [
+                'code' => '<?php
+                    namespace A {
+                        class C {
+                            /**
+                             * @access private
+                             *
+                             * @var string
+                             */
+                            public $foo = "hello";
+                        }
+                    }
+                    namespace B {
+                        use A\C;
+                        $c = new C;
+                        echo $c->foo;
+                    }
+                ',
+                'error_message' => 'InternalProperty',
+            ],
             'psalmInternalClassWithCallClass' => [
                 'code' => '<?php
                     namespace A {

--- a/tests/InternalAnnotationTest.php
+++ b/tests/InternalAnnotationTest.php
@@ -653,6 +653,30 @@ final class InternalAnnotationTest extends TestCase
                         }
                     }',
             ],
+            'globalNamespaceInternalValidClass' => [
+                'code' => '<?php
+                    namespace {
+                        /**
+                         * @internal
+                         */
+                        class C {}
+
+                        new C;
+                    }
+                ',
+            ],
+            'globalNamespaceInternalValidFunction' => [
+                'code' => '<?php
+                    namespace {
+                        /**
+                         * @internal
+                         */
+                        function run(): void {}
+
+                        run();
+                    }
+                ',
+            ],
             'psalmInternalMethodWithMethod' => [
                 'code' => '<?php
                     namespace X {
@@ -1534,6 +1558,90 @@ final class InternalAnnotationTest extends TestCase
                     }
                     namespace B {
                         use A\C;
+                        $c = new C;
+                        echo $c->foo;
+                    }
+                ',
+                'error_message' => 'InternalProperty',
+            ],
+            'globalNamespaceInternalClass' => [
+                'code' => '<?php
+                    namespace {
+                        /**
+                         * @access private
+                         */
+                        class C {}
+                    }
+                    namespace B {
+                        use C;
+                        new C;
+                    }
+                ',
+                'error_message' => 'InternalClass',
+            ],
+            'globalNamespaceInternalConstructor' => [
+                'code' => '<?php
+                    namespace {
+                        class C {
+                            /**
+                             * @internal
+                             */
+                            public function __construct() {}
+                        }
+                    }
+                    namespace B {
+                        use C;
+                        new C;
+                    }
+                ',
+                'error_message' => 'InternalMethod',
+            ],
+            'globalNamespaceInternalMethod' => [
+                'code' => '<?php
+                    namespace {
+                        class C {
+                            /**
+                             * @internal
+                             */
+                            public function run(): void {}
+                        }
+                    }
+                    namespace B {
+                        use C;
+                        $c = new C;
+                        $c->run();
+                    }
+                ',
+                'error_message' => 'InternalMethod',
+            ],
+            'globalNamespaceInternalFunction' => [
+                'code' => '<?php
+                    namespace {
+                        /**
+                         * @internal
+                         */
+                        function run(): void {}
+                    }
+                    namespace B {
+                        run();
+                    }
+                ',
+                'error_message' => 'InternalMethod',
+            ],
+            'globalNamespaceInternalProperty' => [
+                'code' => '<?php
+                    namespace {
+                        class C {
+                            /**
+                             * @internal
+                             *
+                             * @var string
+                             */
+                            public $foo = "hello";
+                        }
+                    }
+                    namespace B {
+                        use C;
                         $c = new C;
                         echo $c->foo;
                     }


### PR DESCRIPTION
- Fix https://github.com/vimeo/psalm/issues/10025
- Fix examples from https://github.com/vimeo/psalm/issues/10025#issuecomment-1681172163
- Feature: allow functions to use @internal annotations too
- Feature: treat legacy PHP `@access private` annotations as `@internal` annotations
- Fix global namespace @internal methods should be treated as internal to the class, just like properties are already
- Fix https://github.com/vimeo/psalm/issues/10868