### PR TITLE
Proposal to Update composer.json to Resolve Dependency Conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "felixfbecker/language-server-protocol": "^1.5.2",
         "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-        "nikic/php-parser": "^4.16",
+        "nikic/php-parser": "^4.16 || ^5.0",
         "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
         "symfony/console": "^4.1.6 || ^5.0 || ^6.0 || ^7.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2",
         "amphp/amp": "^2.4.2 || ^3.0",
-        "amphp/byte-stream": "^1.5",
+        "amphp/byte-stream": "^1.5 || ^2.1",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "composer/xdebug-handler": "^2.0 || ^3.0",
         "dnoegel/php-xdg-base-dir": "^0.1.1",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "ext-mbstring": "*",
         "ext-tokenizer": "*",
         "composer-runtime-api": "^2",
-        "amphp/amp": "^2.4.2",
+        "amphp/amp": "^2.4.2 || ^3.0",
         "amphp/byte-stream": "^1.5",
         "composer/semver": "^1.4 || ^2.0 || ^3.0",
         "composer/xdebug-handler": "^2.0 || ^3.0",


### PR DESCRIPTION
Hello,

I've been working with your package and encountered some dependency conflicts when trying to install it alongside other packages. Specifically, the conflicts arise with the versions of nikic/php-parser, amphp/amp, and amphp/byte-stream. These conflicts prevent the successful installation of the packages when certain version combinations are required by other dependencies in the project.

## Issues Encountered:
1. nikic/php-parser Version Conflict:

The requirement for nikic/php-parser as "^4.16 || ^5.0" clashes with other packages that require different versions, leading to an unresolvable set of packages.

Error Details
```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires psalm/plugin-laravel ^2.11 -> satisfiable by psalm/plugin-laravel[v2.11.0].
    - Root composer.json requires phpunit/phpunit ^11.0 -> satisfiable by phpunit/phpunit[11.0.0, ..., 11.2.x-dev].
    - Conclusion: don't install nikic/php-parser v5.0.2 (conflict analysis result)
    - psalm/plugin-laravel v2.11.0 requires vimeo/psalm ^5.20 -> satisfiable by vimeo/psalm[5.23.0, 5.23.1, 5.23.x-dev, 5.x-dev].
    - vimeo/psalm[5.23.0, ..., 5.x-dev] require nikic/php-parser ^4.16 -> satisfiable by nikic/php-parser[v4.16.0, ..., 4.x-dev].
    - You can only install one version of a package, so only one of these can be installed: nikic/php-parser[v3.1.0, ..., 3.x-dev, v4.0.0alpha1, ..., 4.x-dev, v5.0.0alpha1, ..., 5.0.x-dev].
    - phpunit/php-code-coverage[11.0.0, ..., 11.0.x-dev] require nikic/php-parser ^5.0 -> satisfiable by nikic/php-parser[v5.0.0alpha1, ..., 5.0.x-dev].
    - Conclusion: install phpunit/php-code-coverage 11.0.3 (conflict analysis result)
```


2. amphp/amp Version Conflict:

Similarly, specifying amphp/amp as "^2.4.2 || ^3.0" creates conflicts with packages that have fixed requirements for either the 2.x or 3.x versions.


Error Details

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires phpro/grumphp ^2.5 -> satisfiable by phpro/grumphp[v2.5.0, v2.x-dev].
    - Conclusion: don't install amphp/amp v3.0.0-beta.9 (conflict analysis result)
    - Conclusion: don't install amphp/amp v3.0.0 (conflict analysis result)
    - Root composer.json requires vimeo/psalm 5.x-dev -> satisfiable by vimeo/psalm[5.x-dev].
    - phpro/grumphp[v2.5.0, ..., v2.x-dev] require amphp/amp ^3.0 -> satisfiable by amphp/amp[v3.0.0-beta.1, ..., 3.x-dev].
    - You can only install one version of a package, so only one of these can be installed: amphp/amp[v2.0.0-RC1, ..., 2.x-dev, v3.0.0-beta.1, ..., 3.x-dev].
    - vimeo/psalm 5.x-dev requires amphp/amp ^2.4.2 -> satisfiable by amphp/amp[v2.4.2, ..., 2.x-dev].
    - Conclusion: don't install amphp/amp v2.6.4 (conflict analysis result)

```

3. amphp/byte-stream Version Conflict:

The requirement for amphp/byte-stream as "^1.5 || ^2.1" also leads to installation issues, as some dependencies strictly require versions within the 1.x or 2.x ranges.

Error Details

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires phpro/grumphp ^2.5 -> satisfiable by phpro/grumphp[v2.5.0, v2.x-dev].
    - Root composer.json requires vimeo/psalm 5.x-dev -> satisfiable by vimeo/psalm[5.x-dev].
    - phpro/grumphp[v2.5.0, ..., v2.x-dev] require amphp/parallel ^2.1 -> satisfiable by amphp/parallel[v2.1.0, ..., 2.x-dev].
    - amphp/parallel[v2.1.0, ..., 2.x-dev] require amphp/byte-stream ^2 -> satisfiable by amphp/byte-stream[v2.0.0-beta.1, ..., 2.x-dev].
    - You can only install one version of a package, so only one of these can be installed: amphp/byte-stream[v1.5.0, ..., 1.x-dev, v2.0.0-beta.1, ..., 2.x-dev].
    - vimeo/psalm 5.x-dev requires amphp/byte-stream ^1.5 -> satisfiable by amphp/byte-stream[v1.5.0, ..., 1.x-dev].
    - Conclusion: don't install amphp/byte-stream v1.8.1 (conflict analysis result)
```



## Proposed Changes:
I propose updating the composer.json to accommodate broader compatibility with these dependencies. By allowing more flexible version constraints, we can enhance the package's compatibility with a wider range of project environments and other dependencies.

- For nikic/php-parser: Suggest updating to "^4.16 || ^5.0", to include support for both major versions.
- For amphp/amp: Suggest updating to "^2.4.2 || ^3.0", to resolve conflicts by supporting both the 2.x and 3.x version lines.
- For amphp/byte-stream: Suggest updating to "^1.5 || ^2.1", allowing compatibility across major versions.

## Conclusion:
These changes aim to mitigate potential conflicts with other packages requiring different versions of the same dependencies, thus facilitating smoother installation and usage alongside a broader array of packages.

I have forked the repository and made these adjustments in my branch. If you agree with these proposed changes, I would be happy to submit a pull request for your review.

Thank you for considering my proposal. I believe these changes will make [Package Name] more versatile and easier to incorporate into various projects.

Best regards,

victor