### PR TITLE
Ignore jsonSerialize for implementors of JsonSerializable

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -1755,6 +1755,12 @@ final class ClassLikes
                             continue;
                         }
 
+                        if ($codebase->classImplements($classlike_storage->name, 'JsonSerializable')
+                            && ($method_name === 'jsonserialize')
+                        ) {
+                            continue;
+                        }
+
                         $has_variable_calls = $codebase->analyzer->hasMixedMemberName($method_name)
                             || $codebase->analyzer->hasMixedMemberName(strtolower($classlike_storage->name . '::'));
 

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -757,6 +757,16 @@ class UnusedCodeTest extends TestCase
                         }
                     }',
             ],
+            'ignoreJsonSerialize' => [
+                'code' => '<?php
+                    class Foo implements JsonSerializable {
+                        public function jsonSerialize() : array {
+                            return [];
+                        }
+                    }
+
+                    new Foo();',
+            ],
             'ignoreSerializerSerialize' => [
                 'code' => '<?php
                     class Foo implements Serializable {


### PR DESCRIPTION
This is my proposed fix for #10890. It follows the same pattern as the special case for serialize/unserialize introduced in 02fd1659ef74a41e6c4a7dcbf52df60fe43862ea.