### PR TITLE
Add backed enum type annotation

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -2592,6 +2592,8 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
                 }
 
                 if ($is_string_case_value && $storage->enum_type === 'string') {
+                    $case_value = (string) $case_value;
+
                     if ($enum_implemented_type instanceof Type\Atomic\TNonEmptyString) {
                         if (trim($case_value) === '') {
                             IssueBuffer::maybeAdd(
@@ -2610,6 +2612,8 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
                 }
 
                 if ($is_int_case_value && $storage->enum_type === 'int') {
+                    $case_value = (int) $case_value;
+
                     if ($enum_implemented_type instanceof Type\Atomic\TIntRange) {
                         if ($enum_implemented_type->isPositive() && $case_value < 1) {
                             IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -74,6 +74,7 @@ use Psalm\Storage\ClassLikeStorage;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Storage\MethodStorage;
 use Psalm\Type;
+use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
@@ -84,6 +85,7 @@ use Psalm\Type\Union;
 use UnexpectedValueException;
 
 use function array_filter;
+use function array_key_first;
 use function array_keys;
 use function array_map;
 use function array_merge;
@@ -99,9 +101,11 @@ use function is_string;
 use function preg_match;
 use function preg_replace;
 use function reset;
+use function sprintf;
 use function str_replace;
 use function strtolower;
 use function substr;
+use function trim;
 
 /**
  * @internal
@@ -2193,6 +2197,18 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
                 );
             }
 
+            if ($fq_interface_name_lc === 'backedenum' &&
+                $codebase->analysis_php_version_id >= 8_01_00
+            ) {
+                $this->checkTemplateParams(
+                    $codebase,
+                    $storage,
+                    $interface_storage,
+                    $code_location,
+                    $storage->template_type_implements_count[$fq_interface_name_lc] ?? 0,
+                );
+            }
+
             if (($fq_interface_name_lc === 'unitenum'
                     || $fq_interface_name_lc === 'backedenum')
                 && !$storage->is_enum
@@ -2521,6 +2537,25 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
     {
         $storage = $this->storage;
 
+        /** @var Atomic|null $enum_implemented_type */
+        $enum_implemented_type = null;
+
+        foreach ($storage->template_extended_params ?? [] as $template_extended_params_map) {
+            foreach ($template_extended_params_map as $template) {
+                if (count($template_extended_params_map) > 1) {
+                    throw new LogicException('BackedEnum should only have 1 template parameter in its stub');
+                }
+
+                $enum_implemented_types = $template->getAtomicTypes();
+
+                if (count($enum_implemented_types) === 1) {
+                    $enum_implemented_type = $enum_implemented_types[array_key_first($enum_implemented_types)] ?? null;
+
+                    break 2;
+                }
+            }
+        }
+
         $seen_values = [];
         foreach ($storage->enum_cases as $case_storage) {
             $case_value = $case_storage->getValue($this->getCodebase()->classlikes);
@@ -2541,8 +2576,11 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
                     ),
                 );
             } elseif ($case_value !== null) {
-                if ((is_int($case_value) && $storage->enum_type === 'string')
-                    || (is_string($case_value) && $storage->enum_type === 'int')
+                $is_int_case_value    = is_int($case_value);
+                $is_string_case_value = is_string($case_value);
+
+                if (($is_int_case_value && $storage->enum_type === 'string') ||
+                    ($is_string_case_value && $storage->enum_type === 'int')
                 ) {
                     IssueBuffer::maybeAdd(
                         new InvalidEnumCaseValue(
@@ -2551,6 +2589,98 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
                             $storage->name,
                         ),
                     );
+                }
+
+                if ($is_string_case_value && $storage->enum_type === 'string') {
+                    if ($enum_implemented_type instanceof Type\Atomic\TNonEmptyString) {
+                        if (trim($case_value) === '') {
+                            IssueBuffer::maybeAdd(
+                                new InvalidEnumCaseValue(
+                                    sprintf(
+                                        'Enum case value type should be %s, got `%s`',
+                                        $enum_implemented_type->getId(),
+                                        $case_value,
+                                    ),
+                                    $case_storage->stmt_location,
+                                    $storage->name,
+                                ),
+                            );
+                        }
+                    }
+                }
+
+                if ($is_int_case_value && $storage->enum_type === 'int') {
+                    if ($enum_implemented_type instanceof Type\Atomic\TIntRange) {
+                        if ($enum_implemented_type->isPositive() && $case_value < 1) {
+                            IssueBuffer::maybeAdd(
+                                new InvalidEnumCaseValue(
+                                    sprintf(
+                                        'Enum case value type should be %s, got `%d`',
+                                        $enum_implemented_type->getId(),
+                                        $case_value,
+                                    ),
+                                    $case_storage->stmt_location,
+                                    $storage->name,
+                                ),
+                            );
+                        }
+
+                        if ($enum_implemented_type->isPositiveOrZero() && $case_value < 0) {
+                            IssueBuffer::maybeAdd(
+                                new InvalidEnumCaseValue(
+                                    sprintf(
+                                        'Enum case value type should be %s, got `%d`',
+                                        $enum_implemented_type->getId(),
+                                        $case_value,
+                                    ),
+                                    $case_storage->stmt_location,
+                                    $storage->name,
+                                ),
+                            );
+                        }
+
+                        if ($enum_implemented_type->isNegative() && $case_value >= 0) {
+                            IssueBuffer::maybeAdd(
+                                new InvalidEnumCaseValue(
+                                    sprintf(
+                                        'Enum case value type should be %s, got `%d`',
+                                        $enum_implemented_type->getId(),
+                                        $case_value,
+                                    ),
+                                    $case_storage->stmt_location,
+                                    $storage->name,
+                                ),
+                            );
+                        }
+
+                        if ($enum_implemented_type->isNegativeOrZero() && $case_value > 0) {
+                            IssueBuffer::maybeAdd(
+                                new InvalidEnumCaseValue(
+                                    sprintf(
+                                        'Enum case value type should be %s, got `%d`',
+                                        $enum_implemented_type->getId(),
+                                        $case_value,
+                                    ),
+                                    $case_storage->stmt_location,
+                                    $storage->name,
+                                ),
+                            );
+                        }
+
+                        if ($enum_implemented_type->contains($case_value) === false) {
+                            IssueBuffer::maybeAdd(
+                                new InvalidEnumCaseValue(
+                                    sprintf(
+                                        'Enum case value type should be %s, got `%d`',
+                                        $enum_implemented_type->getId(),
+                                        $case_value,
+                                    ),
+                                    $case_storage->stmt_location,
+                                    $storage->name,
+                                ),
+                            );
+                        }
+                    }
                 }
             }
 

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -645,7 +645,7 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
                 $enum_type,
                 array_keys(
                     count($parent_storage_class_template_types) ?
-                        $parent_storage_class_template_types[0]->getAtomicTypes() ?? []
+                        $parent_storage_class_template_types[0]->getAtomicTypes()
                         : [],
                     true,
                 ),

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -662,7 +662,6 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
          */
         if (($is_backed_enum_like && $given_param_count === 0) ||
             (
-                $storage->is_interface === false &&
                 $is_backed_enum_like === false &&
                 $parent_storage->name === 'BackedEnum'
             )

--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -32,6 +32,7 @@ use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\Union;
 use UnexpectedValueException;
 
+use function array_filter;
 use function array_keys;
 use function array_pop;
 use function array_search;
@@ -636,9 +637,38 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
         CodeLocation $code_location,
         int $given_param_count
     ): void {
+        $enum_type = $storage->enum_type;
+        $parent_storage_class_template_types = $parent_storage->getClassTemplateTypes();
+
+        $is_backed_enum_like = $storage->is_enum &&
+            in_array(
+                $enum_type,
+                array_keys(
+                    count($parent_storage_class_template_types) ?
+                        $parent_storage_class_template_types[0]->getAtomicTypes() ?? []
+                        : [],
+                    true,
+                ),
+            );
+
         $expected_param_count = $parent_storage->template_types === null
             ? 0
             : count($parent_storage->template_types);
+
+        /**
+         * 1) BackedEnum do not always need a template to infer the type as it must be specified by default when
+         * it is declared, the template is only needed for more specific types such as non-empty-string
+         * 2) BackedEnum can only be extended by interfaces and cannot be implemented by classes
+         */
+        if (($is_backed_enum_like && $given_param_count === 0) ||
+            (
+                $storage->is_interface === false &&
+                $is_backed_enum_like === false &&
+                $parent_storage->name === 'BackedEnum'
+            )
+        ) {
+            $expected_param_count = 0;
+        }
 
         if ($expected_param_count > $given_param_count) {
             IssueBuffer::maybeAdd(
@@ -702,7 +732,13 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
                     if (isset($parent_storage->template_covariants[$i])
                         && !$parent_storage->template_covariants[$i]
                     ) {
-                        foreach ($extended_type->getAtomicTypes() as $t) {
+                        $extended_type_atomic_types           = $extended_type->getAtomicTypes();
+                        $extended_type_atomic_types_int_string_diff = array_filter(
+                            $extended_type_atomic_types,
+                            fn($at) => !$at instanceof Type\Atomic\TInt && !$at instanceof Type\Atomic\TString,
+                        );
+
+                        foreach ($extended_type_atomic_types as $t) {
                             if ($t instanceof TTemplateParam
                                 && $storage->template_types
                                 && $storage->template_covariants
@@ -719,6 +755,30 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
                                     ),
                                     $storage->suppressed_issues + $this->getSuppressedIssues(),
                                 );
+                            }
+
+                            if ($is_backed_enum_like && $extended_type_atomic_types_int_string_diff === []) {
+                                if ($t instanceof Type\Atomic\TInt && $enum_type === 'string') {
+                                    IssueBuffer::maybeAdd(
+                                        new InvalidTemplateParam(
+                                            'Extended template param ' . $template_name
+                                            . ' expects type ' . $enum_type
+                                            . ', type ' . $extended_type->getId() . ' given',
+                                            $code_location,
+                                        ),
+                                    );
+                                }
+
+                                if ($t instanceof Type\Atomic\TString && $enum_type === 'int') {
+                                    IssueBuffer::maybeAdd(
+                                        new InvalidTemplateParam(
+                                            'Extended template param ' . $template_name
+                                            . ' expects type ' . $enum_type
+                                            . ', type ' . $extended_type->getId() . ' given',
+                                            $code_location,
+                                        ),
+                                    );
+                                }
                             }
                         }
                     }

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -699,19 +699,20 @@ final class Populator
     }
 
     /**
-     * @param non-empty-string $mapped_name from the BackedEnum stub
-     * @return array{Union}|null
+     * @return array{T: Union}|null
      */
     private static function getDefaultTemplateForInterfaceImplementingBackedEnum(
         ClassLikeStorage $storage,
         ClassLikeStorage $parent_storage,
-        string $mapped_name = 'T'
     ): ?array {
         $is_interface = $storage->is_interface;
 
-        if ($is_interface === null || $parent_storage->name !== "BackedEnum") {
+        if ($is_interface === false || $parent_storage->name !== "BackedEnum") {
             return null;
         }
+
+        // it comes from the BackedEnum stub
+        $mapped_name = 'T';
 
         $t_template_param = new TTemplateParam(
             $mapped_name,
@@ -726,18 +727,17 @@ final class Populator
      * This allows a BackedEnum to not implement any template via docblock as the default type is inferred
      * by the backed type, unless the user wants to define a more specific type for the backed enum.
      *
-     * @param non-empty-string           $mapped_name from the BackedEnum stub
-     * @return array{Union}|null
+     * @return array{T: Union}|null
      */
-    private static function getDefaultTemplateForBackedEnum(
-        ClassLikeStorage $storage,
-        string $mapped_name = 'T'
-    ): ?array {
+    private static function getDefaultTemplateForBackedEnum(ClassLikeStorage $storage): ?array {
         $enum_type = $storage->enum_type;
 
         if ($enum_type === null || $storage->template_type_implements_count !== null) {
             return null;
         }
+
+        // it comes from the BackedEnum stub
+        $mapped_name = 'T';
 
         if ($enum_type === 'string') {
             return [$mapped_name => new Union(['string' => new TString()])];

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -649,12 +649,26 @@ final class Populator
                 $backedEnumDefaultTemplateType = self::getBackedEnumDefaultTemplateTypeIfNotImplemented($storage);
 
                 if ($backedEnumDefaultTemplateType !== null) {
-                    $storage->template_extended_offsets["BackedEnum"] = $backedEnumDefaultTemplateType;
+                    /**
+                     * @psalm-suppress TypeDoesNotContainNull It contains it according to the code
+                     */
+                    if ($storage->template_extended_offsets === null) {
+                        $storage->template_extended_offsets = [];
+                    }
+
+                    $storage->template_extended_offsets['BackedEnum'] = $backedEnumDefaultTemplateType;
                 }
             } else {
                 $backedEnumDefaultTemplateType = self::getBackedEnumDefaultTemplateTypeIfNotImplemented($storage);
 
                 if ($backedEnumDefaultTemplateType !== null) {
+                    /**
+                     * @psalm-suppress DocblockTypeContradiction It contains it according to the code
+                     */
+                    if ($storage->template_extended_params === null) {
+                        $storage->template_extended_params = [];
+                    }
+
                     $storage->template_extended_params['BackedEnum'] = $backedEnumDefaultTemplateType;
                 } else {
                     foreach ($parent_storage->template_types as $template_name => $template_type_map) {
@@ -696,13 +710,14 @@ final class Populator
             return null;
         }
 
+        /**
+         * The T comes from the BackedEnum stub
+         */
         if ($enum_type === 'string') {
             return ['T' => new Union(['string' => new TString()])];
-        } elseif ($enum_type === 'int') {
-            return ['T' => new Union(['int' => new TInt()])];
         }
 
-        return null;
+        return ['T' => new Union(['int' => new TInt()])];
     }
 
     private function populateInterfaceDataFromParentInterface(

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -703,7 +703,7 @@ final class Populator
      */
     private static function getDefaultTemplateForInterfaceImplementingBackedEnum(
         ClassLikeStorage $storage,
-        ClassLikeStorage $parent_storage,
+        ClassLikeStorage $parent_storage
     ): ?array {
         $is_interface = $storage->is_interface;
 
@@ -729,7 +729,8 @@ final class Populator
      *
      * @return array{T: Union}|null
      */
-    private static function getDefaultTemplateForBackedEnum(ClassLikeStorage $storage): ?array {
+    private static function getDefaultTemplateForBackedEnum(ClassLikeStorage $storage): ?array
+    {
         $enum_type = $storage->enum_type;
 
         if ($enum_type === null || $storage->template_type_implements_count !== null) {

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -354,7 +354,7 @@ final class ClassLikeStorage implements HasAttributesInterface
     /**
      * A map of which generic classlikes are extended or implemented by this class or interface.
      *
-     * This is only used in the populator, which poulates the $template_extended_params property below.
+     * This is only used in the populator, which populates the $template_extended_params property below.
      *
      * @internal
      * @var array<string, non-empty-array<int, Union>>|null

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -357,7 +357,7 @@ final class ClassLikeStorage implements HasAttributesInterface
      * This is only used in the populator, which populates the $template_extended_params property below.
      *
      * @internal
-     * @var array<string, non-empty-array<int, Union>>|null
+     * @var array<string, non-empty-array<int|string, Union>>|null
      */
     public $template_extended_offsets;
 

--- a/stubs/Php81.phpstub
+++ b/stubs/Php81.phpstub
@@ -11,19 +11,25 @@ namespace {
         public static function cases(): array;
     }
 
+    /** @template T of int|string */
     interface BackedEnum extends UnitEnum
     {
         /** @var non-empty-string $name */
         public readonly string $name;
+        /** @var T $value */
         public readonly int|string $value;
 
         /**
+         * @template T of int|string
          * @psalm-pure
+         * @param T $value
          */
         public static function from(string|int $value): static;
 
         /**
+         * @template T of int|string
          * @psalm-pure
+         * @param T $value
          */
         public static function tryFrom(string|int $value): ?static;
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -713,6 +713,98 @@ class EnumTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'positiveIntTemplateType' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<positive-int>
+                     */
+                    enum PositiveNumber: int {
+                        case One = 1;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nonNegativeIntTemplateType' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<non-negative-int>
+                     */
+                    enum NonNegativeNumber: int {
+                        case Zero = 0;
+                        case One = 1;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'negativeIntTemplateType' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<negative-int>
+                     */
+                    enum NegativeNumber: int {
+                        case MinusOne = -1;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'intRangeTemplateType' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<int<0, 1>>
+                     */
+                    enum IntRangeNumber: int {
+                        case Zero = 0;
+                        case One = 1;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nonEmptyStringTemplateType' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<non-empty-string>
+                     */
+                    enum StringEnum: string {
+                        case Zero = "0";
+                        case One = "1";
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'validTemplateParameterTypePassedToFromMethod' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<non-negative-int>
+                     */
+                    enum NumberEnum: int {
+                        case Zero = 0;
+                        case One = 1;
+                    };
+                
+                    $nonNegativeNumber = NumberEnum::from(0);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'validTemplateParameterTypePassedToTryFromMethod' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<positive-int>
+                     */
+                    enum NumberEnum: int {
+                        case One = 1;
+                    };
+                
+                    $negativeNumber = NumberEnum::tryFrom(1);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 
@@ -1204,6 +1296,157 @@ class EnumTest extends TestCase
                     }
                 ',
                 'error_message' => 'InvalidEnumCaseValue',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'positiveIntTemplateTypeDoesNotMatchEnumValue' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<positive-int>
+                     */
+                    enum PositiveNumber: int {
+                        case Zero = 0;
+                        case One = 1;
+                    }',
+                'error_message' => 'InvalidEnumCaseValue',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nonNegativeIntTemplateTypeDoesNotMatchEnumValue' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<non-negative-int>
+                     */
+                    enum NonNegativeNumber: int {
+                        case MinusOne = -1;
+                        case Zero = 0;
+                        case One = 1;
+                    }',
+                'error_message' => 'InvalidEnumCaseValue',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'negativeIntTemplateTypeDoesNotMatchEnumValue' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<negative-int>
+                     */
+                    enum NegativeNumber: int {
+                        case MinusOne = -1;
+                        case Zero = 0;
+                        case One = 1;
+                    }',
+                'error_message' => 'InvalidEnumCaseValue',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'intRangeTemplateTypeDoesNotMatchEnumValue' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<int<99, 110>>
+                     */
+                    enum IntRangeNumber: int {
+                        case TwoHundred = 200;
+                        case Zero = 0;
+                        case One = 1;
+                        case OneHundred = 100;
+                    }',
+                'error_message' => 'InvalidEnumCaseValue',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nonEmptyStringTemplateTypeDoesNotMatchEnumValue' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<non-empty-string>
+                     */
+                    enum StringEnum: string {
+                        case Zero = "0";
+                        case One = "1";
+                        case Empty = "";
+                    }',
+                'error_message' => 'InvalidEnumCaseValue',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'stringTemplateTypeDoesNotMatchBackingType' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<non-empty-string>
+                     */
+                    enum Number: int {
+                        case Zero = 0;
+                        case One = 1;
+                    }',
+                'error_message' => 'InvalidTemplateParam',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'intTemplateTypeDoesNotMatchBackingType' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<non-negative-int>
+                     */
+                    enum Number: string {
+                        case Zero = "0";
+                        case One = "1";
+                    }',
+                'error_message' => 'InvalidTemplateParam',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nonAllowedTemplateType' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<float>
+                     */
+                    enum NumberEnum: int {
+                        case Zero = 0;
+                        case One = 1;
+                    }',
+                'error_message' => 'InvalidTemplateParam',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nonAllowedTemplateUnionType' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<string|int>
+                     */
+                    enum NumberEnum: int {
+                        case Zero = 0;
+                        case One = 1;
+                    }',
+                'error_message' => 'InvalidTemplateParam',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'invalidTemplateParameterTypePassedToFromMethod' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<non-negative-int>
+                     */
+                    enum NumberEnum: int {
+                        case Zero = 0;
+                        case One = 1;
+                    };
+                
+                    $negativeNumber = NumberEnum::from(-10);',
+                'error_message' => 'InvalidArgument',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'invalidTemplateParameterTypePassedToTryFromMethod' => [
+                'code' => '<?php
+                    /**
+                     * @implements BackedEnum<positive-int>
+                     */
+                    enum NumberEnum: int {
+                        case One = 1;
+                    };
+                
+                    $nonPositiveNumber = NumberEnum::tryFrom(0);',
+                'error_message' => 'InvalidArgument',
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -436,6 +436,10 @@ class EnumTest extends TestCase
                     interface ExtendedUnitEnum extends \UnitEnum {}
                     static fn (ExtendedUnitEnum $tag): string => $tag->name;
 
+                    /**
+                     * @template T of int|string
+                     * @extends BackedEnum<T>
+                     */
                     interface ExtendedBackedEnum extends \BackedEnum {}
                     static fn (ExtendedBackedEnum $tag): string|int => $tag->value;
                     ',
@@ -513,6 +517,10 @@ class EnumTest extends TestCase
             ],
             'methodInheritanceByInterfaces' => [
                 'code' => '<?php
+                    /**
+                     * @template T of int|string
+                     * @extends BackedEnum<T>
+                     */
                     interface I extends BackedEnum {}
                     /** @var I $i */
                     $a = $i::cases();
@@ -636,6 +644,10 @@ class EnumTest extends TestCase
                     interface I {}
 
                     interface UE extends UnitEnum {}
+                    /**
+                     * @template T of int|string
+                     * @extends BackedEnum<T>
+                     */
                     interface BE extends BackedEnum {}
 
                     function f(I $i): void {

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -436,10 +436,6 @@ class EnumTest extends TestCase
                     interface ExtendedUnitEnum extends \UnitEnum {}
                     static fn (ExtendedUnitEnum $tag): string => $tag->name;
 
-                    /**
-                     * @template T of int|string
-                     * @extends BackedEnum<T>
-                     */
                     interface ExtendedBackedEnum extends \BackedEnum {}
                     static fn (ExtendedBackedEnum $tag): string|int => $tag->value;
                     ',
@@ -517,10 +513,6 @@ class EnumTest extends TestCase
             ],
             'methodInheritanceByInterfaces' => [
                 'code' => '<?php
-                    /**
-                     * @template T of int|string
-                     * @extends BackedEnum<T>
-                     */
                     interface I extends BackedEnum {}
                     /** @var I $i */
                     $a = $i::cases();
@@ -644,10 +636,6 @@ class EnumTest extends TestCase
                     interface I {}
 
                     interface UE extends UnitEnum {}
-                    /**
-                     * @template T of int|string
-                     * @extends BackedEnum<T>
-                     */
                     interface BE extends BackedEnum {}
 
                     function f(I $i): void {

--- a/tests/ReturnTypeProvider/GetObjectVarsTest.php
+++ b/tests/ReturnTypeProvider/GetObjectVarsTest.php
@@ -291,6 +291,10 @@ class GetObjectVarsTest extends TestCase
         yield 'Interface extending BackedEnum' => [
             'code' => <<<'PHP'
                 <?php
+                /**
+                 * @template T of int|string
+                 * @extends BackedEnum<T>
+                 */
                 interface A extends BackedEnum {}
                 enum B: int implements A { case One = 1; }
                 function getA(): A { return B::One; }

--- a/tests/ReturnTypeProvider/GetObjectVarsTest.php
+++ b/tests/ReturnTypeProvider/GetObjectVarsTest.php
@@ -291,10 +291,6 @@ class GetObjectVarsTest extends TestCase
         yield 'Interface extending BackedEnum' => [
             'code' => <<<'PHP'
                 <?php
-                /**
-                 * @template T of int|string
-                 * @extends BackedEnum<T>
-                 */
                 interface A extends BackedEnum {}
                 enum B: int implements A { case One = 1; }
                 function getA(): A { return B::One; }


### PR DESCRIPTION
This fixes #8268.

Basically I added the `/** @template T of int|string */` in the BackedEnum stub and then i managed to add issues when
the implemented template type mismatches with the backing type. 
// will give an error
```
                    // will give an error
                    /**
                     * @implements BackedEnum<string>
                     */
                    enum NumberEnum: int {
                        case Zero = 0;
                        case One = 1;
                    }
```
```
                    // won't give an error
                    /**
                     * @implements BackedEnum<non-negative-int>
                     */
                    enum NumberEnum: int {
                        case Zero = 0;
                        case One = 1;
                    }
```
Furhtermore, it's not mandatory to add the@implements annotation if the backing type is just int or string

```
                    // won't give an error
                    /**
                     * @implements BackedEnum<int>
                     */
                    enum NumberEnum: int {
                        case Zero = 0;
                        case One = 1;
                    }
```
```
                    // won't give an error
                    enum NumberEnum: int {
                        case Zero = 0;
                        case One = 1;
                    }
```
Further cases can be seen in the tests.
I am not sure this is the right implementation. Let me know if, in case, we can make some adjustments.