### PR TITLE
redis: add possible types for `Redis#auth` method

### DIFF
--- a/stubs/extensions/redis.phpstub
+++ b/stubs/extensions/redis.phpstub
@@ -36,7 +36,8 @@ class Redis {
 	/** @return false|int|Redis */
     public function append(string $key, string $value) {}
 
-    public function auth(mixed $credentials): bool {}
+    /** @param array{string,string}|array{string}|string $credentials */
+    public function auth(#[\SensitiveParameter] mixed $credentials): bool {}
 
     public function bgSave(): bool {}
 

--- a/stubs/extensions/redis.phpstub
+++ b/stubs/extensions/redis.phpstub
@@ -37,7 +37,7 @@ class Redis {
     public function append(string $key, string $value) {}
 
     /** @param array{string,string}|array{string}|string $credentials */
-    public function auth(#[\SensitiveParameter] mixed $credentials): bool {}
+    public function auth(mixed $credentials): bool {}
 
     public function bgSave(): bool {}
 


### PR DESCRIPTION
With v6.0.0, `Redis#auth` also accepts an array with 2 values where the first value represents the `user` and the second `password`.

I am not sure if they accept `array` as of 6.0 but as of the "official" stub, `auth` does also accept an array with just the password:
https://github.com/phpredis/phpredis/blob/f350dc342cb3520b2ee663664a22c25f29bc8aaf/redis.stub.php#L581-L594