### PR TITLE
Casting int-range should keep literals

### DIFF
--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -49,5 +49,15 @@ class CastTest extends TestCase
                 '$a===' => 'array{a: int, b: string, ...<array-key, mixed>}',
             ],
         ];
+        yield 'castIntRangeToString' => [
+            'code' => '<?php
+                /** @var int<-5, 3> */
+                $int_range = 2;
+                $string = (string) $int_range;
+            ',
+            'assertions' => [
+                '$string===' => "'-1'|'-2'|'-3'|'-4'|'-5'|'0'|'1'|'2'|'3'",
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/10940
500 limit taken from TypeCombiner