### PR TITLE
PHAR: add `config.xsd` to generated PHAR package

### DIFF
--- a/bin/github-deploy-phar.sh
+++ b/bin/github-deploy-phar.sh
@@ -18,6 +18,7 @@ cd phar
 rm -rf *
 cp ../build/psalm.phar ../assets/psalm-phar/* .
 cp ../build/psalm.phar.asc . || true # not all users have GPG keys
+cp ../config.xsd . # add XML schema definition to packaged phar
 mv dot-gitignore .gitignore
 git config user.email "github@muglug.com"
 git config user.name "Automated commit"


### PR DESCRIPTION
In most projects I am working on, the `config.xsd` is referenced from within the projects `psalm.xml` (via `xsi:noNamespaceSchemaLocation`).
That provides decent auto-completion, etc. and thus is usually recommended to represent the latest configuration schema.
That was done by having `vendor/vimeo/psalm/config.xsd` as that schema is located for `vimeo/psalm` usage.

When using `psalm/phar`, that does not work as the file is not part of the pacakge. This PR is changing that and will add the `config.xsd` with whatever next version is generated after merging these changes.