### PR TITLE
Fix int-range concat to behave like union of int types

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ConcatAnalyzer.php
@@ -7,6 +7,7 @@ namespace Psalm\Internal\Analyzer\Statements\Expression\BinaryOp;
 use AssertionError;
 use PhpParser;
 use Psalm\CodeLocation;
+use Psalm\Codebase;
 use Psalm\Config;
 use Psalm\Context;
 use Psalm\Internal\Analyzer\FunctionLikeAnalyzer;
@@ -17,6 +18,7 @@ use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\Comparator\AtomicTypeComparator;
 use Psalm\Internal\Type\Comparator\TypeComparisonResult;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
+use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\FalseOperand;
 use Psalm\Issue\ImplicitToStringCast;
 use Psalm\Issue\ImpureMethodCall;
@@ -31,6 +33,9 @@ use Psalm\Type;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;
+use Psalm\Type\Atomic\TIntRange;
+use Psalm\Type\Atomic\TLiteralFloat;
+use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TNamedObject;
@@ -42,9 +47,11 @@ use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TNumericString;
 use Psalm\Type\Atomic\TString;
 use Psalm\Type\Atomic\TTemplateParam;
+use Psalm\Type\Atomic\TTrue;
 use Psalm\Type\Union;
 use UnexpectedValueException;
 
+use function assert;
 use function count;
 use function reset;
 use function strlen;
@@ -54,7 +61,7 @@ use function strlen;
  */
 final class ConcatAnalyzer
 {
-    private const MAX_LITERALS = 64;
+    private const MAX_LITERALS = 500;
 
     public static function analyze(
         StatementsAnalyzer $statements_analyzer,
@@ -158,17 +165,26 @@ final class ConcatAnalyzer
 
             // If both types are specific literals, combine them into new literals
             $literal_concat = false;
-
-            if ($left_type->allSpecificLiterals() && $right_type->allSpecificLiterals()) {
+            if ($left_type->allSpecificLiteralsOrRange() && $right_type->allSpecificLiteralsOrRange()) {
                 $left_type_parts = $left_type->getAtomicTypes();
                 $right_type_parts = $right_type->getAtomicTypes();
+
                 $combinations = count($left_type_parts) * count($right_type_parts);
-                if ($combinations < self::MAX_LITERALS) {
+                if ($combinations > self::MAX_LITERALS) {
+                    $left_type_parts = [];
+                    $right_type_parts = [];
+                } else {
+                    $left_type_parts = self::intRangeToInts($codebase, $left_type_parts);
+                    $right_type_parts = self::intRangeToInts($codebase, $right_type_parts);
+                    $combinations = count($left_type_parts) * count($right_type_parts);
+                }
+
+                if ($combinations !== 0 && $combinations <= self::MAX_LITERALS) {
                     $literal_concat = true;
                     $result_type_parts = [];
 
-                    foreach ($left_type->getAtomicTypes() as $left_type_part) {
-                        foreach ($right_type->getAtomicTypes() as $right_type_part) {
+                    foreach ($left_type_parts as $left_type_part) {
+                        foreach ($right_type_parts as $right_type_part) {
                             $literal = $left_type_part->value . $right_type_part->value;
                             if (strlen($literal) >= $config->max_string_length) {
                                 // Literal too long, use non-literal type instead
@@ -487,5 +503,43 @@ final class ConcatAnalyzer
                 );
             }
         }
+    }
+
+    /**
+     * @param array<TLiteralString|TLiteralInt|TLiteralFloat|TFalse|TTrue|TIntRange> $type_parts
+     * @return list<TLiteralString|TLiteralInt|TLiteralFloat|TFalse|TTrue>
+     */
+    private static function intRangeToInts(
+        Codebase $codebase,
+        array $type_parts
+    ): array {
+        $new_type_parts = [];
+        foreach ($type_parts as $atomic) {
+            if ($atomic instanceof TIntRange) {
+                $atomic_from_range = TypeExpander::expandAtomic(
+                    $codebase,
+                    $atomic,
+                    null,
+                    null,
+                    null,
+                );
+
+                if ($atomic_from_range[0] === $atomic || count($atomic_from_range) > self::MAX_LITERALS) {
+                    $new_type_parts = [];
+                    break;
+                }
+
+                foreach ($atomic_from_range as $atomic_int) {
+                    assert($atomic_int instanceof TLiteralInt);
+                    $new_type_parts[] = $atomic_int;
+                }
+
+                continue;
+            }
+
+            $new_type_parts[] = $atomic;
+        }
+
+        return $new_type_parts;
     }
 }

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -22,6 +22,7 @@ use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TInt;
 use Psalm\Type\Atomic\TIntMask;
 use Psalm\Type\Atomic\TIntMaskOf;
+use Psalm\Type\Atomic\TIntRange;
 use Psalm\Type\Atomic\TIterable;
 use Psalm\Type\Atomic\TKeyOf;
 use Psalm\Type\Atomic\TKeyedArray;
@@ -46,6 +47,7 @@ use function array_merge;
 use function array_values;
 use function count;
 use function is_string;
+use function range;
 use function reset;
 use function strtolower;
 
@@ -409,6 +411,18 @@ final class TypeExpander
             }
 
             return TypeParser::getComputedIntsFromMask($potential_ints);
+        }
+
+        if ($return_type instanceof TIntRange
+            && $return_type->min_bound !== null
+            && $return_type->max_bound !== null
+            && ($return_type->max_bound - $return_type->min_bound) < 500
+        ) {
+            $literal_ints = [];
+            foreach (range($return_type->min_bound, $return_type->max_bound) as $literal_int) {
+                $literal_ints[] = new TLiteralInt($literal_int);
+            }
+            return $literal_ints;
         }
 
         if ($return_type instanceof TConditional) {

--- a/src/Psalm/Type/UnionTrait.php
+++ b/src/Psalm/Type/UnionTrait.php
@@ -1209,6 +1209,7 @@ trait UnionTrait
     }
 
     /**
+     * @psalm-suppress PossiblyUnusedMethod
      * @psalm-mutation-free
      * @psalm-assert-if-true array<
      *     array-key,
@@ -1218,6 +1219,37 @@ trait UnionTrait
     public function allSpecificLiterals(): bool
     {
         foreach ($this->types as $atomic_key_type) {
+            if (!$atomic_key_type instanceof TLiteralString
+                && !$atomic_key_type instanceof TLiteralInt
+                && !$atomic_key_type instanceof TLiteralFloat
+                && !$atomic_key_type instanceof TFalse
+                && !$atomic_key_type instanceof TTrue
+            ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @psalm-mutation-free
+     * @psalm-assert-if-true array<
+     *     array-key,
+     *     TLiteralString|TLiteralInt|TLiteralFloat|TFalse|TTrue|TIntRange
+     * > $this->getAtomicTypes()
+     */
+    public function allSpecificLiteralsOrRange(): bool
+    {
+        foreach ($this->types as $atomic_key_type) {
+            if ($atomic_key_type instanceof TIntRange
+                && $atomic_key_type->min_bound !== null
+                && $atomic_key_type->max_bound !== null
+                && ($atomic_key_type->max_bound - $atomic_key_type->min_bound) < 500
+            ) {
+                continue;
+            }
+
             if (!$atomic_key_type instanceof TLiteralString
                 && !$atomic_key_type instanceof TLiteralInt
                 && !$atomic_key_type instanceof TLiteralFloat

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1749,7 +1749,19 @@ final class ArrayFunctionCallTest extends TestCase
 
                     $bar = array_intersect(... $foo);',
                 'assertions' => [
-                    '$bar' => 'array<int<0, 2>, int>',
+                    '$bar' => 'array<int, int>',
+                ],
+            ],
+            'splatArrayIntersectExact' => [
+                'code' => '<?php
+                    $foo = [
+                        [1, 2, 3],
+                        [1, 2],
+                    ];
+
+                    $bar = array_intersect(... $foo);',
+                'assertions' => [
+                    '$bar===' => 'array<0|1|2, 1|2|3>',
                 ],
             ],
             'arrayIntersectIsVariadic' => [

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -892,6 +892,24 @@ final class BinaryOperationTest extends TestCase
                     '$a' => 'float',
                 ],
             ],
+            'concatWithIntsKeepsLiteral' => [
+                'code' => '<?php
+                    /**
+                     * @var "a"|"b" $a
+                     * @var 0|1|2 $b
+                     */
+                    $interpolated = $a . $b;',
+                'assertions' => ['$interpolated===' => "'a0'|'a1'|'a2'|'b0'|'b1'|'b2'"],
+            ],
+            'concatWithIntRangeKeepsLiteral' => [
+                'code' => '<?php
+                    /**
+                     * @var "a"|"b" $a
+                     * @var int<0, 2> $b
+                     */
+                    $interpolated = $a . $b;',
+                'assertions' => ['$interpolated===' => "'a0'|'a1'|'a2'|'b0'|'b1'|'b2'"],
+            ],
             'literalConcatCreatesLiteral' => [
                 'code' => '<?php
                     /**

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -290,8 +290,8 @@ final class IntRangeTest extends TestCase
                     '$u===' => 'int<-2, 0>',
                     '$v===' => 'int<2, 0>',
                     '$w===' => 'mixed',
-                    '$x===' => 'int<0, 2>',
-                    '$y===' => 'int<-2, 0>',
+                    '$x===' => '0',
+                    '$y===' => '0',
                     '$z===' => 'mixed',
                     '$aa===' => 'int<-2, 2>',
                     '$ab===' => 'int<-2, 2>',
@@ -339,7 +339,7 @@ final class IntRangeTest extends TestCase
                     '$h===' => '0|1|float',
                     '$i===' => 'int',
                     '$j===' => 'float',
-                    '$k===' => '-1',
+                    '$k===' => '1',
                     '$l===' => 'float|int',
                     '$m===' => 'int<1, max>',
                     '$n===' => 'float',
@@ -353,7 +353,7 @@ final class IntRangeTest extends TestCase
                     '$v===' => 'float',
                     '$w===' => '1',
                     '$x===' => '0',
-                    '$y===' => 'float',
+                    '$y===' => 'float(INF)',
                     '$z===' => '1',
                     '$aa===' => 'int<1, max>',
                     '$ab===' => 'float',
@@ -655,7 +655,7 @@ final class IntRangeTest extends TestCase
                     }
                     ',
                 'assertions' => [
-                    '$c===' => 'int<0, 0>|null',
+                    '$c===' => '0|null',
                 ],
             ],
             'minMax' => [

--- a/tests/Template/FunctionTemplateTest.php
+++ b/tests/Template/FunctionTemplateTest.php
@@ -354,7 +354,7 @@ final class FunctionTemplateTest extends TestCase
 
                     $a = splat_proof(...$foo);',
                 'assertions' => [
-                    '$a' => 'array<int<0, 2>, int>',
+                    '$a===' => 'array<0|1|2, 1|2|3>',
                 ],
             ],
             'passArrayByRef' => [


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/10947
Fix https://github.com/vimeo/psalm/issues/10965
500 limit taken from TypeCombiner (to ensure int-range will behave exactly like union of ints)
