### PR TITLE
Up the minimum required version of nikic/php-parser to 4.17

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "felixfbecker/language-server-protocol": "^1.5.2",
         "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
         "netresearch/jsonmapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
-        "nikic/php-parser": "^4.16",
+        "nikic/php-parser": "^4.17",
         "sebastian/diff": "^4.0 || ^5.0 || ^6.0",
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
         "symfony/console": "^4.1.6 || ^5.0 || ^6.0 || ^7.0",


### PR DESCRIPTION
psalm is not compatible with nikic/php-parser 4.16

```
Uncaught RuntimeException: PHP Error: Undefined property: PhpParser\Node\Stmt\ClassConst::$type in /home/runner/work/drupal-code-generator/drupal-code-generator/vendor/vimeo/psalm/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php:1425 for command with CLI args "./vendor/bin/psalm" in /home/runner/work/drupal-code-generator/drupal-code-generator/vendor/vimeo/psalm/src/Psalm/Internal/ErrorHandler.php:75
```

More https://github.com/Chi-teck/drupal-code-generator/actions/runs/9006216243/job/24743242733?pr=149#step:7:29