### PR TITLE
Incompatible binary operands

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.x-dev@a46a07c5ca8bd7b54d1ca814c1f5b5ed38a0ba90">
+<files psalm-version="5.x-dev@f372770ac0475e5aeca3b3bccba9a65e716d1cc6">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$comment_block->tags['variablesfrom'][0]]]></code>
@@ -446,8 +446,6 @@
       <code><![CDATA[$count_inequality_position]]></code>
       <code><![CDATA[$false_position]]></code>
       <code><![CDATA[$false_position]]></code>
-      <code><![CDATA[$first_var_name]]></code>
-      <code><![CDATA[$first_var_name]]></code>
       <code><![CDATA[$first_var_name]]></code>
       <code><![CDATA[$first_var_name]]></code>
       <code><![CDATA[$first_var_name]]></code>
@@ -934,7 +932,6 @@
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[$dim_var_id]]></code>
       <code><![CDATA[$dim_var_id]]></code>
-      <code><![CDATA[$extended_var_id]]></code>
       <code><![CDATA[$extended_var_id]]></code>
       <code><![CDATA[$keyed_array_var_id]]></code>
       <code><![CDATA[$keyed_array_var_id]]></code>

--- a/tests/BinaryOperationTest.php
+++ b/tests/BinaryOperationTest.php
@@ -5,6 +5,7 @@ namespace Psalm\Tests;
 use Psalm\Config;
 use Psalm\Context;
 use Psalm\Exception\CodeException;
+use Psalm\Issue\InvalidOperand;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
@@ -316,6 +317,19 @@ class BinaryOperationTest extends TestCase
     public function providerValidCodeParse(): iterable
     {
         return [
+            'strict_binary_operands: objects of different shape' => [
+                'code' =><<<'PHP'
+                    <?php
+                    new \DateTime() > new \DateTime();
+                    new \DateTimeImmutable() > new \DateTimeImmutable();
+                    // special case for DateTimeInterface
+                    new \DateTime() > new \DateTimeImmutable();
+                    PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => null,
+                'config_options' => ['strict_binary_operands' => true],
+            ],
             'regularAddition' => [
                 'code' => '<?php
                     $a = 5 + 4;',
@@ -1089,6 +1103,26 @@ class BinaryOperationTest extends TestCase
     public function providerInvalidCodeParse(): iterable
     {
         return [
+            'strict_binary_operands: different objects' => [
+                'code' =><<<'PHP'
+                    <?php
+                    new \stdClass() > new \DateTimeImmutable();
+                    PHP,
+                'error_message' => InvalidOperand::getIssueType(),
+                'error_levels' => [],
+                'php_version' => null,
+                'config_options' => ['strict_binary_operands' => true],
+            ],
+            'strict_binary_operands: different object shapes' => [
+                'code' =><<<'PHP'
+                    <?php
+                    ((object) ['a' => 0, 'b' => 1]) > ((object) ['a' => 0, 'c' => 1]);
+                    PHP,
+                'error_message' => InvalidOperand::getIssueType(),
+                'error_levels' => [],
+                'php_version' => null,
+                'config_options' => ['strict_binary_operands' => true],
+            ],
             'badAddition' => [
                 'code' => '<?php
                     $a = "b" + 5;',


### PR DESCRIPTION
Comparing objects with anything other than identity/equality is already suspect, but let us at least ensure the objects are the same shape.

This came about when I made a custom `Date` class (no time component) and realized psalm would not complain if I did `Date::today() < new \DateTimeImmutable()`.