### PR TITLE
Fix false `MissingOverrideAttribute` issue

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1995,6 +1995,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
                 if (!$has_override_attribute
                     && $codebase->config->ensure_override_attribute
                     && $overridden_method_ids
+                    && $storage->visibility !== ClassLikeAnalyzer::VISIBILITY_PRIVATE
                     && $storage->cased_name !== '__construct'
                     && ($storage->cased_name !== '__toString'
                        || isset($appearing_class_storage->direct_class_interfaces['stringable']))

--- a/tests/OverrideTest.php
+++ b/tests/OverrideTest.php
@@ -98,6 +98,35 @@ class OverrideTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.3',
             ],
+            'Issue #10982 - https://github.com/vimeo/psalm/issues/10982' => [
+                'code' => '
+                    <?php
+                    trait Foo
+                    {
+                        private function inTrait(): void { echo "foobar\n"; }
+                    }
+
+                    class A {
+                        use Foo;
+
+                        public function bar(): void {
+                            $this->inTrait();
+                        }
+                    }
+
+                    class B extends A {
+                        use Foo;
+
+                        function baz(): void
+                        {
+                            $this->inTrait();
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
         ];
     }
 


### PR DESCRIPTION
This patch resolves #10982, via the following changes:
 
 - Add test case `tests/OverrideTest.php`
 -  Update `src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php`