### PR TITLE
Fix false-positive `ImpureVariable` issue

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -36,6 +36,7 @@ use Psalm\Type\Union;
 
 use function in_array;
 use function is_string;
+use function substr;
 use function time;
 
 /**
@@ -117,7 +118,7 @@ final class VariableFetchAnalyzer
             }
 
             if (!$context->collect_mutations && !$context->collect_initializations) {
-                if ($context->pure) {
+                if ($context->pure && substr($context->calling_method_id, -13) !== '::__construct') {
                     IssueBuffer::maybeAdd(
                         new ImpureVariable(
                             'Cannot reference $this in a pure context',

--- a/tests/PureAnnotationTest.php
+++ b/tests/PureAnnotationTest.php
@@ -538,6 +538,30 @@ class PureAnnotationTest extends TestCase
                     Date2::tt();
                     ',
             ],
+            'Issue #10974 - https://github.com/vimeo/psalm/issues/10974' => [
+                'code' => '<?php
+
+                    class Foo
+                    {
+                        private int $int;
+
+                        /** @psalm-pure */
+                        public function __construct(int $int)
+                        {
+                            $this->int = $int;
+                        }
+                    }
+
+                    class Factory
+                    {
+                        /** @psalm-pure */
+                        public function getFoo(): Foo
+                        {
+                            return new Foo(42);
+                        }
+                    }
+                    ',
+            ],
         ];
     }
 


### PR DESCRIPTION
This patch resolves #10974, via the following changes:

 - [Add test case](https://github.com/vimeo/psalm/commit/4b0690edc4d561f507792a392a2d7d5852eeecc9)
 - [Update VariableFetchAnalyzer.php](https://github.com/vimeo/psalm/commit/b92236f954a8a849f791c00109cc209c8e4cec72)