### PR TITLE
JetBrains IDE SARIF support improvement

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -336,6 +336,7 @@ final class ProjectAnalyzer
             'summary.json' => Report::TYPE_JSON_SUMMARY,
             'junit.xml' => Report::TYPE_JUNIT,
             '.xml' => Report::TYPE_XML,
+            '.sarif.json' => Report::TYPE_SARIF,    // must be place here to avoid JSON type detection
             '.json' => Report::TYPE_JSON,
             '.txt' => Report::TYPE_TEXT,
             '.emacs' => Report::TYPE_EMACS,


### PR DESCRIPTION
Hello,

As PHPStorm user, I've noticed that auto-detection of SARIF reports are not well handled when file report extension is only `.sarif`

> [!TIP] 
> See appendix M for files extension supported : 
> https://docs.oasis-open.org/sarif/sarif/v2.1.0/errata01/os/sarif-v2.1.0-errata01-os-complete.html#_Toc141791204

With this PR, the `.sarif.json` extension is also supported and PHPStorm integration is better.

See screenshots 

With only `.sarif` extension 

![psalm sarif](https://github.com/vimeo/psalm/assets/364342/2069ea5d-5926-4498-9ca4-de8d6a2d445a)

With `.sarif.json` extension

![psalm sarif json](https://github.com/vimeo/psalm/assets/364342/412953eb-0bfa-49bc-b4ae-0d4379833c9d)
