### PR TITLE
Update help panel

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -329,21 +329,7 @@ final class ProjectAnalyzer
     {
         $report_options = [];
 
-        $mapping = [
-            'checkstyle.xml' => Report::TYPE_CHECKSTYLE,
-            'sonarqube.json' => Report::TYPE_SONARQUBE,
-            'codeclimate.json' => Report::TYPE_CODECLIMATE,
-            'summary.json' => Report::TYPE_JSON_SUMMARY,
-            'junit.xml' => Report::TYPE_JUNIT,
-            '.xml' => Report::TYPE_XML,
-            '.json' => Report::TYPE_JSON,
-            '.txt' => Report::TYPE_TEXT,
-            '.emacs' => Report::TYPE_EMACS,
-            '.pylint' => Report::TYPE_PYLINT,
-            '.console' => Report::TYPE_CONSOLE,
-            '.sarif' => Report::TYPE_SARIF,
-            'count.txt' => Report::TYPE_COUNT,
-        ];
+        $mapping = Report::getMapping();
 
         foreach ($report_file_paths as $report_file_path) {
             foreach ($mapping as $extension => $type) {

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -31,6 +31,7 @@ use Psalm\Progress\Progress;
 use Psalm\Progress\VoidProgress;
 use Psalm\Report;
 use Psalm\Report\ReportOptions;
+use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\Filesystem\Path;
 
@@ -67,11 +68,13 @@ use function preg_match;
 use function preg_replace;
 use function realpath;
 use function setlocale;
+use function sort;
 use function str_repeat;
 use function str_replace;
 use function strlen;
 use function strpos;
 use function substr;
+use function wordwrap;
 
 use const DIRECTORY_SEPARATOR;
 use const JSON_THROW_ON_ERROR;
@@ -87,6 +90,7 @@ require_once __DIR__ . '/../CliUtils.php';
 require_once __DIR__ . '/../Composer.php';
 require_once __DIR__ . '/../IncludeCollector.php';
 require_once __DIR__ . '/../../IssueBuffer.php';
+require_once __DIR__ . '/../../Report.php';
 
 /**
  * @internal
@@ -1250,6 +1254,16 @@ final class Psalm
      */
     private static function getHelpText(): string
     {
+        $formats = [];
+        /** @var string $value */
+        foreach ((new ReflectionClass(Report::class))->getConstants() as $constant => $value) {
+            if (strpos($constant, 'TYPE_') === 0) {
+                $formats[] = $value;
+            }
+        }
+        sort($formats);
+        $outputFormats = wordwrap(implode(', ', $formats), 75, "\n            ");
+
         return <<<HELP
         Usage:
             psalm [options] [file...]
@@ -1333,8 +1347,8 @@ final class Psalm
 
             --output-format=console
                 Changes the output format.
-                Available formats: compact, console, text, emacs, json, pylint, xml, checkstyle, junit, sonarqube,
-                                   github, phpstorm, codeclimate, by-issue-level
+                Available formats:
+                    $outputFormats
 
             --no-progress
                 Disable the progress indicator

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -37,6 +37,7 @@ use Symfony\Component\Filesystem\Path;
 
 use function array_filter;
 use function array_key_exists;
+use function array_keys;
 use function array_map;
 use function array_merge;
 use function array_slice;
@@ -1264,6 +1265,10 @@ final class Psalm
         sort($formats);
         $outputFormats = wordwrap(implode(', ', $formats), 75, "\n            ");
 
+        $reports = array_keys(Report::getMapping());
+        sort($reports);
+        $reportFormats = wordwrap('"' . implode('", "', $reports) . '"', 75, "\n        ");
+
         return <<<HELP
         Usage:
             psalm [options] [file...]
@@ -1362,8 +1367,7 @@ final class Psalm
         Reports:
             --report=PATH
                 The path where to output report file. The output format is based on the file extension.
-                (Currently supported formats: ".json", ".xml", ".txt", ".emacs", ".pylint", ".console",
-                ".sarif", "checkstyle.xml", "sonarqube.json", "codeclimate.json", "summary.json", "junit.xml")
+                (Currently supported formats: $reportFormats)
 
             --report-show-info[=BOOLEAN]
                 Whether the report should include non-errors in its output (defaults to true)

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -1265,6 +1265,7 @@ final class Psalm
         sort($formats);
         $outputFormats = wordwrap(implode(', ', $formats), 75, "\n            ");
 
+        /** @psalm-suppress ImpureMethodCall */
         $reports = array_keys(Report::getMapping());
         sort($reports);
         $reportFormats = wordwrap('"' . implode('", "', $reports) . '"', 75, "\n        ");

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -98,6 +98,9 @@ abstract class Report
 
     abstract public function create(): string;
 
+    /**
+     * @return array<string, self::TYPE_*>
+     */
     public static function getMapping(): array
     {
         return [

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -97,4 +97,24 @@ abstract class Report
     }
 
     abstract public function create(): string;
+
+    public static function getMapping(): array
+    {
+        return [
+            'checkstyle.xml' => self::TYPE_CHECKSTYLE,
+            'sonarqube.json' => self::TYPE_SONARQUBE,
+            'codeclimate.json' => self::TYPE_CODECLIMATE,
+            'summary.json' => self::TYPE_JSON_SUMMARY,
+            'junit.xml' => self::TYPE_JUNIT,
+            '.xml' => self::TYPE_XML,
+            '.sarif.json' => self::TYPE_SARIF,
+            '.json' => self::TYPE_JSON,
+            '.txt' => self::TYPE_TEXT,
+            '.emacs' => self::TYPE_EMACS,
+            '.pylint' => self::TYPE_PYLINT,
+            '.console' => self::TYPE_CONSOLE,
+            '.sarif' => self::TYPE_SARIF,
+            'count.txt' => self::TYPE_COUNT,
+        ];
+    }
 }


### PR DESCRIPTION
Hello,

While I try SARIF renderer, I've noticed that both `--report` and `--output-format` did not provide all available options.

Main reason (I suppose) is because values are hard-coded and not modified when new values were provided.

I suggest by this PR a dynamic contents (with alphabetic sort).

Old panel for `--output-format` option :

```text
    --output-format=console
        Changes the output format.
        Available formats: compact, console, text, emacs, json, pylint, xml, checkstyle, junit, sonarqube,
                           github, phpstorm, codeclimate, by-issue-level
```

Compares to new panel 

```text
    --output-format=console
        Changes the output format.
        Available formats:
            by-issue-level, checkstyle, codeclimate, compact, console, count, emacs,
            github, json, json-summary, junit, phpstorm, pylint, sarif, sonarqube,
            text, xml
```

Old panel for `--report` option :

```text
Reports:
    --report=PATH
        The path where to output report file. The output format is based on the file extension.
        (Currently supported formats: ".json", ".xml", ".txt", ".emacs", ".pylint", ".console",
        ".sarif", "checkstyle.xml", "sonarqube.json", "codeclimate.json", "summary.json", "junit.xml")
```

Compares to new panel 

```text
Reports:
    --report=PATH
        The path where to output report file. The output format is based on the file extension.
        (Currently supported formats: ".console", ".emacs", ".json", ".pylint", ".sarif", ".sarif.json", ".txt",
        ".xml", "checkstyle.xml", "codeclimate.json", "count.txt", "junit.xml",
        "sonarqube.json", "summary.json")
```

> [!WARNING]
> I've included patch provided by PR #10999 

> [!NOTE]
> Benefit of code refactoring is IMO the Report mapping feature in right place (into `Report` class)
