### PR TITLE
Fix signature of Locale::canonicalize.

### DIFF
--- a/dictionaries/CallMap.php
+++ b/dictionaries/CallMap.php
@@ -6446,7 +6446,7 @@ return [
 'litespeed_request_headers' => ['array'],
 'litespeed_response_headers' => ['array'],
 'Locale::acceptFromHttp' => ['string|false', 'header'=>'string'],
-'Locale::canonicalize' => ['string', 'locale'=>'string'],
+'Locale::canonicalize' => ['?string', 'locale'=>'string'],
 'Locale::composeLocale' => ['string', 'subtags'=>'array'],
 'Locale::filterMatches' => ['?bool', 'languageTag'=>'string', 'locale'=>'string', 'canonicalize='=>'bool'],
 'Locale::getAllVariants' => ['array', 'locale'=>'string'],

--- a/dictionaries/CallMap_historical.php
+++ b/dictionaries/CallMap_historical.php
@@ -3393,7 +3393,7 @@ return [
     'LimitIterator::seek' => ['int', 'offset'=>'int'],
     'LimitIterator::valid' => ['bool'],
     'Locale::acceptFromHttp' => ['string|false', 'header'=>'string'],
-    'Locale::canonicalize' => ['string', 'locale'=>'string'],
+    'Locale::canonicalize' => ['?string', 'locale'=>'string'],
     'Locale::composeLocale' => ['string', 'subtags'=>'array'],
     'Locale::filterMatches' => ['?bool', 'languageTag'=>'string', 'locale'=>'string', 'canonicalize='=>'bool'],
     'Locale::getAllVariants' => ['array', 'locale'=>'string'],

--- a/tests/Internal/Codebase/InternalCallMapHandlerTest.php
+++ b/tests/Internal/Codebase/InternalCallMapHandlerTest.php
@@ -198,7 +198,6 @@ class InternalCallMapHandlerTest extends TestCase
         'infiniteiterator::getinneriterator' => ['8.1', '8.2', '8.3'],
         'iteratoriterator::getinneriterator' => ['8.1', '8.2', '8.3'],
         'limititerator::getinneriterator' => ['8.1', '8.2', '8.3'],
-        'locale::canonicalize' => ['8.1', '8.2', '8.3'],
         'locale::getallvariants' => ['8.1', '8.2', '8.3'],
         'locale::getkeywords' => ['8.1', '8.2', '8.3'],
         'locale::getprimarylanguage' => ['8.1', '8.2', '8.3'],


### PR DESCRIPTION
The method can return null, https://www.php.net/manual/en/locale.canonicalize.php.