### PR TITLE
Add PDO note

### DIFF
--- a/docs/security_analysis/index.md
+++ b/docs/security_analysis/index.md
@@ -51,6 +51,8 @@ You can also [define your own taint sources](custom_taint_sources.md).
 
 Psalm currently defines a number of different sinks for builtin functions and methods, including `echo`, `include`, `header`.
 
+In order for the PDO SQL sink to be used you must either define PDO as a platform dependency in your composer.json or enable it in in Psalm config see https://psalm.dev/docs/running_psalm/configuration/#enableextensions.
+
 You can also [define your own taint sinks](custom_taint_sinks.md).
 
 ## Avoiding False-Positives


### PR DESCRIPTION
### Summary
Added a note to describe how to enable the PDO extension in the security analysis.

### Reason
I spent a long time trying to understand why the SQLTaint errors were not showing for my project that uses PDO. I added the examples of SQL issues to my project but they still would still not be found despite other issues from the examples being found. Eventually after reading all the docs  I[ found the answer](https://psalm.dev/docs/running_psalm/configuration/#enableextensions) that PDO must be enabled as an extension if it is not defined in composer.json as a dependency. Requiring PHP PDO as a dependency had not been done which I think is probably fairly common.

I thought this requirement could do with pointing out more prominently in the documentation and when describe the sinks involved in security analysis which i think is Psalms killer feature. After all the PDO sink is described on this page but users may not know it needs further configuration to enable it.

If you think it belongs somewhere else or could be worded better then happy to work on it. Hope you find this helpful and thanks for the project.