### PR TITLE
introduces absolutePathReporting configuration setting

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -342,6 +342,17 @@ When `true`, Psalm will run [Taint Analysis](../security_analysis/index.md) on y
 
 When `false`, Psalm will not consider issue at lower level than `errorLevel` as `info` (they will be suppressed instead). This can be a big improvement in analysis time for big projects. However, this config will prevent Psalm to count or suggest fixes for suppressed issue
 
+#### absolutePathReporting
+
+```xml
+<psalm 
+  absolutePathReporting="[bool]"
+/>
+```
+
+Setting this to `"true"` allows to use absolute paths on report that accept it (currently `junit` and `checkstyle`). 
+If not given, this defaults to `"false"` means report still use relative paths.
+
 #### allowNamedArgumentCalls
 
 ```xml

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -727,6 +727,11 @@ class Config
     /** @var list<string> */
     public array $config_warnings = [];
 
+    /**
+     * Whether to report files with absolute path or relative path (default))
+     */
+    public bool $absolute_path_reporting = false;
+
     /** @internal */
     protected function __construct()
     {
@@ -1100,6 +1105,7 @@ class Config
             'reportInfo' => 'report_info',
             'restrictReturnTypes' => 'restrict_return_types',
             'limitMethodComplexity' => 'limit_method_complexity',
+            'absolutePathReporting' => 'absolute_path_reporting',
         ];
 
         foreach ($booleanAttributes as $xmlName => $internalName) {

--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -325,8 +325,11 @@ final class ProjectAnalyzer
      * @param  array<string>  $report_file_paths
      * @return list<ReportOptions>
      */
-    public static function getFileReportOptions(array $report_file_paths, bool $show_info = true): array
-    {
+    public static function getFileReportOptions(
+        array $report_file_paths,
+        bool $show_info = true,
+        bool $absolute_path_reporting = false
+    ): array {
         $report_options = [];
 
         $mapping = Report::getMapping();
@@ -340,6 +343,13 @@ final class ProjectAnalyzer
                     $o->show_info = $show_info;
                     $o->output_path = $report_file_path;
                     $o->use_color = false;
+
+                    // list of report that allow absolute path reporting
+                    $allowedReports = [Report::TYPE_CHECKSTYLE, Report::TYPE_JUNIT];
+                    if (in_array($type, $allowedReports)) {
+                        $o->absolute_path = $absolute_path_reporting;
+                    }
+
                     $report_options[] = $o;
                     continue 2;
                 }

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -347,6 +347,7 @@ final class Psalm
                 isset($options['report-show-info'])
                     ? $options['report-show-info'] !== 'false' && $options['report-show-info'] !== '0'
                     : true,
+                $config->absolute_path_reporting,
             ),
             $threads,
             $progress,

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -60,6 +60,9 @@ abstract class Report
     /** @var int */
     protected $total_expression_count;
 
+    /** @var bool */
+    protected $absolute_path;
+
     /**
      * @param array<int, IssueData> $issues_data
      * @param array<string, int> $fixable_issue_counts
@@ -86,6 +89,7 @@ abstract class Report
         $this->show_info = $report_options->show_info;
         $this->pretty = $report_options->pretty;
         $this->in_ci = $report_options->in_ci;
+        $this->absolute_path = $report_options->absolute_path;
 
         $this->mixed_expression_count = $mixed_expression_count;
         $this->total_expression_count = $total_expression_count;

--- a/src/Psalm/Report/CheckstyleReport.php
+++ b/src/Psalm/Report/CheckstyleReport.php
@@ -21,7 +21,9 @@ final class CheckstyleReport extends Report
                 $issue_data->message,
             );
 
-            $output .= '<file name="' . $this->xmlEncode($issue_data->file_name) . '">' . "\n";
+            $filename = $this->absolute_path ? $issue_data->file_path : $issue_data->file_name;
+
+            $output .= '<file name="' . $this->xmlEncode($filename) . '">' . "\n";
             $output .= ' ';
             $output .= '<error';
             $output .= ' line="' . $issue_data->line_from . '"';

--- a/src/Psalm/Report/JunitReport.php
+++ b/src/Psalm/Report/JunitReport.php
@@ -40,7 +40,7 @@ final class JunitReport extends Report
 
             $tests++;
 
-            $fname = $error->file_name;
+            $fname = $this->absolute_path ? $error->file_path : $error->file_name;
 
             if (!isset($ndata[$fname])) {
                 $ndata[$fname] = [

--- a/src/Psalm/Report/ReportOptions.php
+++ b/src/Psalm/Report/ReportOptions.php
@@ -43,4 +43,6 @@ final class ReportOptions
 
     /** @var bool */
     public $in_ci = false;
+
+    public bool $absolute_path = false;
 }


### PR DESCRIPTION
Fixes #11048 

While this PR accept only `junit` and `checkstyle` reports, we could also think to introduce it with `pylint` that can be configured to use both absolute and relative paths  (see https://pylint.readthedocs.io/en/latest/user_guide/usage/output.html).

See ProjectAnalyser and ```$allowedReports = [Report::TYPE_CHECKSTYLE, Report::TYPE_JUNIT];``` that accept this feature.