### PR TITLE
Fix callable/lowercase strings coercion

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -121,13 +121,21 @@ final class ScalarTypeComparator
             return false;
         }
 
-        if ($input_type_part instanceof TCallableString
-            && (get_class($container_type_part) === TSingleLetter::class
-                || get_class($container_type_part) === TNonEmptyString::class
+        if ($input_type_part instanceof TCallableString) {
+            if (get_class($container_type_part) === TNonEmptyString::class
                 || get_class($container_type_part) === TNonFalsyString::class
-                || get_class($container_type_part) === TLowercaseString::class)
-        ) {
-            return true;
+            ) {
+                return true;
+            }
+
+            if (get_class($container_type_part) === TLowercaseString::class
+                || get_class($container_type_part) === TSingleLetter::class
+            ) {
+                if ($atomic_comparison_result) {
+                    $atomic_comparison_result->type_coerced = true;
+                }
+                return false;
+            }
         }
 
         if (($container_type_part instanceof TLowercaseString

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -402,6 +402,14 @@ class FunctionCallTest extends TestCase
                 'assertions' => [],
                 'ignored_issues' => ['MixedAssignment', 'MixedArgument'],
             ],
+            'noRedundantErrorForCallableStrToLower' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /** @var callable-string */
+                    $function = "strlen";
+                    strtolower($function);
+                PHP,
+            ],
             'objectLikeArrayAssignmentInConditional' => [
                 'code' => '<?php
                     $a = [];


### PR DESCRIPTION
For callable/lowercase strings, neither is a proper subset of another,
but those sets intersect (are coercible to one another).

Fixes vimeo/psalm#11075
