### PR TITLE
Fix return type of IteratorIterator::getInnerIterator

### DIFF
--- a/stubs/CoreGenericIterators.phpstub
+++ b/stubs/CoreGenericIterators.phpstub
@@ -127,6 +127,11 @@ class IteratorIterator implements OuterIterator {
      * @psalm-ignore-nullable-return
      */
     public function key() {}
+
+    /**
+     * @return TIterator
+     */
+    public function getInnerIterator();
 }
 
 /**


### PR DESCRIPTION
When creating an `IteratorIterator` with an iterator of `TIterator`, we can assume that `getInnerIterator` will return that same `TIterator` type. Technically, this change could be applied to `OuterIterator`, although that would require us to introduce a `TIterator` template to `OuterIterator`, which may break existing usages beyond the default iterators for which stubs are provided. Please advise if it's ok to change `OuterIterator` to get an additional template for the iterator it's wrapping.