### PR TITLE
Fix broken links to PHPDoc Types page in documentation

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -755,6 +755,6 @@ class BazClass extends BaseClass {} // this is an error
 
 ## Type Syntax
 
-Psalm supports PHPDoc’s [type syntax](https://docs.phpdoc.org/latest/guide/guides/types.html), and also the [proposed PHPDoc PSR type syntax](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types).
+Psalm supports PHPDoc’s [type syntax](https://docs.phpdoc.org/guide/guides/types.html), and also the [proposed PHPDoc PSR type syntax](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types).
 
 A detailed write-up is found in [Typing in Psalm](typing_in_psalm.md)

--- a/docs/annotating_code/type_syntax/array_types.md
+++ b/docs/annotating_code/type_syntax/array_types.md
@@ -40,7 +40,7 @@ You can also specify that an array is non-empty with the special type `non-empty
 
 ### PHPDoc syntax
 
-PHPDoc [allows you to specify](https://docs.phpdoc.org/latest/guide/references/phpdoc/types.html#arrays) the  type of values a generic array holds with the annotation:
+PHPDoc [allows you to specify](https://docs.phpdoc.org/guide/guides/types.html#arrays) the type of values a generic array holds with the annotation:
 
 ```php
 /** @return ValueType[] */

--- a/docs/annotating_code/typing_in_psalm.md
+++ b/docs/annotating_code/typing_in_psalm.md
@@ -10,7 +10,7 @@ Psalm allows you to express a lot of complicated type information in docblocks.
 
 All docblock types are either [atomic types](type_syntax/atomic_types.md), [union types](type_syntax/union_types.md) or [intersection types](type_syntax/intersection_types.md).
 
-Additionally, Psalm supports PHPDoc’s [type syntax](https://docs.phpdoc.org/latest/guide/guides/types.html), and also the [proposed PHPDoc PSR type syntax](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types).
+Additionally, Psalm supports PHPDoc’s [type syntax](https://docs.phpdoc.org/guide/guides/types.html#supported-types), and also the [proposed PHPDoc PSR type syntax](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#appendix-a-types).
 
 ## Property declaration types vs Assignment typehints
 


### PR DESCRIPTION
Multiple links related to PHPDoc types in the documentation currently return a 404 response.

This PR updates those links to what appear to be the equivalent pages that are presently available.