### PR TITLE
Fix broken phpDocumentor links on Supported Annotations docs page

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -6,23 +6,23 @@ Psalm supports a wide range of docblock annotations.
 
 Psalm uses the following PHPDoc tags to understand your code:
 
-- [`@var`](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/var.html)
+- [`@var`](https://docs.phpdoc.org/guide/references/phpdoc/tags/var.html)
   Used for specifying the types of properties and variables
-- [`@return`](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/return.html)
+- [`@return`](https://docs.phpdoc.org/guide/references/phpdoc/tags/return.html)
   Used for specifying the return types of functions, methods and closures
-- [`@param`](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/param.html)
+- [`@param`](https://docs.phpdoc.org/guide/references/phpdoc/tags/param.html)
   Used for specifying types of parameters passed to functions, methods and closures
-- [`@property`](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/property.html)
+- [`@property`](https://docs.phpdoc.org/guide/references/phpdoc/tags/property.html)
   Used to specify what properties can be accessed on an object that uses `__get` and `__set`
-- [`@property-read`](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/property.html)
+- [`@property-read`](https://docs.phpdoc.org/guide/references/phpdoc/tags/property.html)
   Used to specify what properties can be read on object that uses `__get`
-- [`@property-write`](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/property.html)
+- [`@property-write`](https://docs.phpdoc.org/guide/references/phpdoc/tags/property.html)
   Used to specify what properties can be written on object that uses `__set`
-- [`@method`](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/method.html)
+- [`@method`](https://docs.phpdoc.org/guide/references/phpdoc/tags/method.html)
   Used to specify which magic methods are available on object that uses `__call`.
-- [`@deprecated`](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/deprecated.html)
+- [`@deprecated`](https://docs.phpdoc.org/guide/references/phpdoc/tags/deprecated.html)
   Used to mark functions, methods, classes and interfaces as being deprecated
-- [`@internal`](https://docs.phpdoc.org/latest/guide/references/phpdoc/tags/internal.html)
+- [`@internal`](https://docs.phpdoc.org/guide/references/phpdoc/tags/internal.html)
    Used to mark classes, functions and properties that are internal to an application or library.
 - [`@mixin`](#mixins)
     Used to tell Psalm that the current class proxies the methods and properties of the referenced class.


### PR DESCRIPTION
This PR fixes some phpDocumentor links on the "Supported Annotations" page in the Psalm docs.

These links became broken as a result of the phpDocumentor documentation path changing from using a `/latest` root path to using a `/` root path.

Prior related changes were made in https://github.com/vimeo/psalm/pull/11105. This PR fixes residual phpDocumentor links impacted by this change.