### PR TITLE
Die when PHP doc not found in update-property-map.php

### DIFF
--- a/bin/stubs/update-property-map.php
+++ b/bin/stubs/update-property-map.php
@@ -52,6 +52,7 @@ $docDir = realpath(__DIR__ . '/../../build/doc-en');
 if (false === $docDir) {
     echo 'PHP doc not found!' . PHP_EOL;
     echo 'Please execute: git clone git@github.com:php/doc-en.git ' . dirname(__DIR__) . '/build/doc-en';
+    die(1);
 }
 
 $files = new RegexIterator(


### PR DESCRIPTION
Otherwise an exception is thrown right below, where `$docDir` is used.