### PR TITLE
Fix type of property-get with coalesce

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IssetAnalyzer.php
@@ -7,6 +7,7 @@ namespace Psalm\Internal\Analyzer\Statements\Expression;
 use PhpParser;
 use Psalm\CodeLocation;
 use Psalm\Context;
+use Psalm\Internal\Analyzer\Statements\Expression\Fetch\InstancePropertyFetchAnalyzer;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Issue\InvalidArgument;
@@ -32,7 +33,16 @@ final class IssetAnalyzer
                 $var_id = '$this->' . $isset_var->name->name;
 
                 if (!isset($context->vars_in_scope[$var_id])) {
-                    $context->vars_in_scope[$var_id] = Type::getMixed();
+                    if (isset($context->vars_in_scope['$this'])) {
+                        InstancePropertyFetchAnalyzer::analyze(
+                            $statements_analyzer,
+                            $isset_var,
+                            $context,
+                        );
+                    }
+                    if (!isset($context->vars_in_scope[$var_id])) {
+                        $context->vars_in_scope[$var_id] = Type::getMixed();
+                    }
                     $context->vars_possibly_in_scope[$var_id] = true;
                 }
             } elseif (!self::isValidStatement($isset_var)) {

--- a/tests/MagicPropertyTest.php
+++ b/tests/MagicPropertyTest.php
@@ -789,6 +789,20 @@ final class MagicPropertyTest extends TestCase
                         }
                     }',
             ],
+            'propertyFetchWithNullCoalesce' => [
+                'code' => '<?php
+                    /**
+                     * @property-read string|null $p
+                     */
+                    class A {
+                        public function __get(string $name) {
+                            return null;
+                        }
+                        public function f(): string {
+                           return $this->p ?? \'\';
+                        }
+                    }',
+            ],
         ];
     }
 
@@ -1245,6 +1259,21 @@ final class MagicPropertyTest extends TestCase
 
                     echo (new OrganizationObject)->errors;',
                 'error_message' => 'UndefinedMagicPropertyFetch',
+            ],
+            'invalidPropertyFetchWithNullCoalesce' => [
+                'code' => '<?php
+                    /**
+                     * @property-read string|null $p
+                     */
+                    class A {
+                        public function __get(string $name) {
+                            return null;
+                        }
+                        public function f(): string {
+                           return $this->q ?? \'\';
+                        }
+                    }',
+                'error_message' => 'MixedReturnStatement',
             ],
         ];
     }


### PR DESCRIPTION
Fixes #11151

If the property was not already known inside the IssetAnalyzer::analyze function, it was added as mixed to the context.

This adds a check for dynamic properties.