### PR TITLE
Fix some more tests when running phpunit with args

### DIFF
--- a/tests/AsyncTestCase.php
+++ b/tests/AsyncTestCase.php
@@ -15,6 +15,7 @@ use Psalm\Internal\Provider\Providers;
 use Psalm\Internal\RuntimeCaches;
 use Psalm\Internal\Type\TypeParser;
 use Psalm\Internal\Type\TypeTokenizer;
+use Psalm\Internal\VersionUtils;
 use Psalm\IssueBuffer;
 use Psalm\Tests\Internal\Provider\FakeParserCacheProvider;
 use Psalm\Type\Union;
@@ -44,11 +45,11 @@ abstract class AsyncTestCase extends BaseAsyncTestCase
         ini_set('memory_limit', '-1');
 
         if (!defined('PSALM_VERSION')) {
-            define('PSALM_VERSION', '5.0.0');
+            define('PSALM_VERSION', VersionUtils::getPsalmVersion());
         }
 
         if (!defined('PHP_PARSER_VERSION')) {
-            define('PHP_PARSER_VERSION', '5.0.0');
+            define('PHP_PARSER_VERSION', VersionUtils::getPhpParserVersion());
         }
 
         parent::setUpBeforeClass();

--- a/tests/Cache/CacheTest.php
+++ b/tests/Cache/CacheTest.php
@@ -28,6 +28,16 @@ use const DIRECTORY_SEPARATOR;
 final class CacheTest extends TestCase
 {
     #[Override]
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        // hack to isolate Psalm from PHPUnit cli arguments
+        global $argv;
+        $argv = [];
+    }
+
+    #[Override]
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/Config/ConfigFileTest.php
+++ b/tests/Config/ConfigFileTest.php
@@ -28,6 +28,16 @@ final class ConfigFileTest extends TestCase
     private string $file_path;
 
     #[Override]
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        // hack to isolate Psalm from PHPUnit cli arguments
+        global $argv;
+        $argv = [];
+    }
+
+    #[Override]
     public function setUp(): void
     {
         RuntimeCaches::clearAll();

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -20,7 +20,6 @@ use Psalm\Internal\Provider\FakeFileProvider;
 use Psalm\Internal\Provider\Providers;
 use Psalm\Internal\RuntimeCaches;
 use Psalm\Internal\Scanner\FileScanner;
-use Psalm\Internal\VersionUtils;
 use Psalm\Issue\TooManyArguments;
 use Psalm\Issue\UndefinedFunction;
 use Psalm\Tests\Config\Plugin\FileTypeSelfRegisteringPlugin;
@@ -29,8 +28,6 @@ use Psalm\Tests\TestCase;
 use Psalm\Tests\TestConfig;
 
 use function array_map;
-use function define;
-use function defined;
 use function dirname;
 use function error_get_last;
 use function get_class;
@@ -60,19 +57,13 @@ final class ConfigTest extends TestCase
     #[Override]
     public static function setUpBeforeClass(): void
     {
+        parent::setUpBeforeClass();
+
         // hack to isolate Psalm from PHPUnit cli arguments
         global $argv;
         $argv = [];
 
         self::$config = new TestConfig();
-
-        if (!defined('PSALM_VERSION')) {
-            define('PSALM_VERSION', VersionUtils::getPsalmVersion());
-        }
-
-        if (!defined('PHP_PARSER_VERSION')) {
-            define('PHP_PARSER_VERSION', VersionUtils::getPhpParserVersion());
-        }
     }
 
     #[Override]

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -60,6 +60,10 @@ final class ConfigTest extends TestCase
     #[Override]
     public static function setUpBeforeClass(): void
     {
+        // hack to isolate Psalm from PHPUnit cli arguments
+        global $argv;
+        $argv = [];
+
         self::$config = new TestConfig();
 
         if (!defined('PSALM_VERSION')) {
@@ -1339,10 +1343,6 @@ final class ConfigTest extends TestCase
 
     public function testModularConfig(): void
     {
-        // hack to isolate Psalm from PHPUnit arguments
-        global $argv;
-        $argv = [];
-
         $root = __DIR__ . '/../fixtures/ModularConfig';
         $config = Config::loadFromXMLFile($root . '/psalm.xml', $root);
         $this->assertEquals(

--- a/tests/Config/PluginTest.php
+++ b/tests/Config/PluginTest.php
@@ -15,7 +15,6 @@ use Psalm\Internal\IncludeCollector;
 use Psalm\Internal\Provider\FakeFileProvider;
 use Psalm\Internal\Provider\Providers;
 use Psalm\Internal\RuntimeCaches;
-use Psalm\Internal\VersionUtils;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
 use Psalm\Plugin\EventHandler\AfterEveryFunctionCallAnalysisInterface;
@@ -29,8 +28,6 @@ use Psalm\Tests\TestCase;
 use Psalm\Tests\TestConfig;
 use stdClass;
 
-use function define;
-use function defined;
 use function dirname;
 use function get_class;
 use function getcwd;
@@ -48,19 +45,13 @@ final class PluginTest extends TestCase
     #[Override]
     public static function setUpBeforeClass(): void
     {
+        parent::setUpBeforeClass();
+
         // hack to isolate Psalm from PHPUnit cli arguments
         global $argv;
         $argv = [];
 
         self::$config = new TestConfig();
-
-        if (!defined('PSALM_VERSION')) {
-            define('PSALM_VERSION', VersionUtils::getPsalmVersion());
-        }
-
-        if (!defined('PHP_PARSER_VERSION')) {
-            define('PHP_PARSER_VERSION', VersionUtils::getPhpParserVersion());
-        }
     }
 
     #[Override]

--- a/tests/ForbiddenCodeTest.php
+++ b/tests/ForbiddenCodeTest.php
@@ -23,6 +23,16 @@ final class ForbiddenCodeTest extends TestCase
     use ValidCodeAnalysisTestTrait;
 
     #[Override]
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        // hack to isolate Psalm from PHPUnit cli arguments
+        global $argv;
+        $argv = [];
+    }
+
+    #[Override]
     public function providerInvalidCodeParse(): iterable
     {
         return [

--- a/tests/ProjectCheckerTest.php
+++ b/tests/ProjectCheckerTest.php
@@ -11,7 +11,6 @@ use Psalm\Internal\IncludeCollector;
 use Psalm\Internal\Provider\FakeFileProvider;
 use Psalm\Internal\Provider\Providers;
 use Psalm\Internal\RuntimeCaches;
-use Psalm\Internal\VersionUtils;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\AfterCodebasePopulatedInterface;
 use Psalm\Plugin\EventHandler\Event\AfterCodebasePopulatedEvent;
@@ -24,8 +23,6 @@ use Psalm\Tests\Internal\Provider\ParserInstanceCacheProvider;
 use Psalm\Tests\Internal\Provider\ProjectCacheProvider;
 use Psalm\Tests\Progress\EchoProgress;
 
-use function define;
-use function defined;
 use function get_class;
 use function getcwd;
 use function microtime;
@@ -45,19 +42,13 @@ final class ProjectCheckerTest extends TestCase
     #[Override]
     public static function setUpBeforeClass(): void
     {
+        parent::setUpBeforeClass();
+
         // hack to stop Psalm seeing the phpunit arguments
         global $argv;
         $argv = [];
 
         self::$config = new TestConfig();
-
-        if (!defined('PSALM_VERSION')) {
-            define('PSALM_VERSION', VersionUtils::getPsalmVersion());
-        }
-
-        if (!defined('PHP_PARSER_VERSION')) {
-            define('PHP_PARSER_VERSION', VersionUtils::getPhpParserVersion());
-        }
     }
 
     #[Override]

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -40,6 +40,10 @@ final class StubTest extends TestCase
     #[Override]
     public static function setUpBeforeClass(): void
     {
+        // hack to isolate Psalm from PHPUnit cli arguments
+        global $argv;
+        $argv = [];
+
         self::$config = new TestConfig();
 
         if (!defined('PSALM_VERSION')) {

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -16,12 +16,9 @@ use Psalm\Internal\IncludeCollector;
 use Psalm\Internal\Provider\FakeFileProvider;
 use Psalm\Internal\Provider\Providers;
 use Psalm\Internal\RuntimeCaches;
-use Psalm\Internal\VersionUtils;
 use Psalm\Tests\Internal\Provider\FakeParserCacheProvider;
 
 use function assert;
-use function define;
-use function defined;
 use function dirname;
 use function explode;
 use function getcwd;
@@ -40,19 +37,13 @@ final class StubTest extends TestCase
     #[Override]
     public static function setUpBeforeClass(): void
     {
+        parent::setUpBeforeClass();
+
         // hack to isolate Psalm from PHPUnit cli arguments
         global $argv;
         $argv = [];
 
         self::$config = new TestConfig();
-
-        if (!defined('PSALM_VERSION')) {
-            define('PSALM_VERSION', VersionUtils::getPsalmVersion());
-        }
-
-        if (!defined('PHP_PARSER_VERSION')) {
-            define('PHP_PARSER_VERSION', VersionUtils::getPhpParserVersion());
-        }
     }
 
     #[Override]

--- a/tests/VariadicTest.php
+++ b/tests/VariadicTest.php
@@ -22,6 +22,16 @@ final class VariadicTest extends TestCase
 {
     use ValidCodeAnalysisTestTrait;
 
+    #[Override]
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        // hack to isolate Psalm from PHPUnit cli arguments
+        global $argv;
+        $argv = [];
+    }
+
     public function testVariadicArrayBadParam(): void
     {
         $this->expectExceptionMessage('InvalidScalarArgument');


### PR DESCRIPTION
Related to  #11122

Running this failed because of the argv values
```sh
./vendor/bin/phpunit --filter '/^Psalm\\Tests\\VariadicTest/'
```