### PR TITLE
Allow running generate_testsuites.php from a different dir

### DIFF
--- a/bin/ci/generate_testsuites.php
+++ b/bin/ci/generate_testsuites.php
@@ -2,46 +2,39 @@
 
 declare(strict_types=1);
 
-if (count($argv) < 2) {
+$number_of_chunks = count($argv) === 2 ? (int) $argv[1] : 0;
+if ($number_of_chunks <= 0) {
     fwrite(STDERR, 'Usage: ' . $argv[0] . ' <number_of_chunks>' . PHP_EOL);
     exit(1);
 }
 
-$number_of_chunks = (int) $argv[1];
-if ($number_of_chunks === 0) {
-    fwrite(STDERR, 'Usage: ' . $argv[0] . ' <number_of_chunks>' . PHP_EOL);
-    exit(1);
-}
+$root = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR;
 
 // find tests -name '*Test.php'
 $files = iterator_to_array(
     new RegexIterator(
         new RecursiveIteratorIterator(
             new RecursiveDirectoryIterator(
-                'tests',
+                $root . 'tests',
                 FilesystemIterator::CURRENT_AS_PATHNAME|FilesystemIterator::SKIP_DOTS,
             ),
             RecursiveIteratorIterator::LEAVES_ONLY,
         ),
-        '/.*Test.php$/',
+        '/Test\\.php$/',
     ),
 );
 
 mt_srand(4); // chosen by fair dice roll.
              // guaranteed to be random.
              // -- xkcd:221
-
-$order = array_map(
-    fn(): int => mt_rand(),
-    $files,
-);
+$order = array_map(fn(): int => mt_rand(), $files,);
 array_multisort($order, $files);
 
 $chunks = array_chunk($files, (int) ceil(count($files) / $number_of_chunks));
 
 $phpunit_config = new DOMDocument('1.0', 'UTF-8');
 $phpunit_config->preserveWhiteSpace = false;
-$phpunit_config->load('phpunit.xml.dist');
+$phpunit_config->load($root . 'phpunit.xml.dist');
 $suites_container = $phpunit_config->getElementsByTagName('testsuites')->item(0);
 
 while ($suites_container->firstChild) {
@@ -58,4 +51,4 @@ foreach ($chunks as $chunk_id => $chunk) {
 }
 
 $phpunit_config->formatOutput = true;
-$phpunit_config->save('phpunit.xml');
+$phpunit_config->save($root . 'phpunit.xml');


### PR DESCRIPTION
Now the script uses its own location as a basis instead of the current working dir.