### PR TITLE
Add missing reset of context inside_general_use

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/InstancePropertyFetchAnalyzer.php
@@ -49,6 +49,8 @@ final class InstancePropertyFetchAnalyzer
 
         if (!$stmt->name instanceof PhpParser\Node\Identifier) {
             if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->name, $context) === false) {
+                $context->inside_general_use = $was_inside_general_use;
+
                 return false;
             }
         }


### PR DESCRIPTION
Everywhere else this property is reset before returning, just here it seems to be missing.
Not sure what the ramifications are as the tests seem to pass either way.

See  #7195