### PR TITLE
Remove usage of E_STRICT

### DIFF
--- a/src/Psalm/Internal/ErrorHandler.php
+++ b/src/Psalm/Internal/ErrorHandler.php
@@ -14,7 +14,6 @@ use function set_error_handler;
 use function set_exception_handler;
 
 use const E_ALL;
-use const E_STRICT;
 use const STDERR;
 
 /**
@@ -59,7 +58,7 @@ final class ErrorHandler
 
     private static function setErrorReporting(): void
     {
-        error_reporting(E_ALL | E_STRICT);
+        error_reporting(E_ALL);
         ini_set('display_errors', '1');
     }
 


### PR DESCRIPTION
This constant is deprecated in PHP 8.4. All `E_STRICT` warnings were converted to `E_NOTICE` in PHP 8.0. See [the RFC](https://wiki.php.net/rfc/deprecations_php_8_4#remove_e_strict_error_level_and_deprecate_e_strict_constant) for full details.

Psalm 5 still supports PHP 7.4, so _technically_ this constant could still be useful for people running it on that version, but I suspect most development and testing happens against 8.0+, and the few cases that apply to 7.4 are unlikely to matter to the Psalm code base. It doesn't seem worth more sophisticated PHP version detection in this code to me.