### PR TITLE
Decrease opcache.jit_buffer_size to 128M

### DIFF
--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -29,7 +29,7 @@ final class PsalmRestarter extends XdebugHandler
     private const REQUIRED_OPCACHE_SETTINGS = [
         'enable_cli' => true,
         'jit' => 1205,
-        'jit_buffer_size' => 512 * 1024 * 1024,
+        'jit_buffer_size' => 128 * 1024 * 1024,
         'optimization_level' => '0x7FFEBFFF',
         'preload' => '',
         'log_verbosity_level' => 0,
@@ -151,7 +151,7 @@ final class PsalmRestarter extends XdebugHandler
         if (PHP_VERSION_ID >= 8_00_00 && $opcache_loaded) {
             $additional_options = [
                 '-dopcache.enable_cli=true',
-                '-dopcache.jit_buffer_size=512M',
+                '-dopcache.jit_buffer_size=128M',
                 '-dopcache.jit=1205',
                 '-dopcache.optimization_level=0x7FFEBFFF',
                 '-dopcache.preload=',


### PR DESCRIPTION
As of PHP 8.4, this is the maximum value available for AArch64. Without this change, running Psalm with PHP 8.4 on that architecture results in a warning:

```
Warning: JIT on AArch64 doesn't support opcache.jit_buffer_size above 128M.
```

It's still possible to configure up to 2G for x86_64, so we could keep the 512M value on that architecture at the cost of a bit more complexity to detect the PHP version and current CPU architecture. (Looks like `php_uname('m')` would be the way to check CPU arch.)