### PR TITLE
Fix wrong PHP_INT_MAX/MIN and PHP_DEBUG PHP 8.4 type

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/ConstFetchAnalyzer.php
@@ -25,6 +25,9 @@ use function explode;
 use function implode;
 use function strtolower;
 
+use const PHP_INT_MAX;
+use const PHP_INT_MIN;
+
 /**
  * @internal
  */
@@ -164,13 +167,22 @@ final class ConstFetchAnalyzer
                 case 'PHP_MAJOR_VERSION':
                 case 'PHP_MINOR_VERSION':
                 case 'PHP_RELEASE_VERSION':
-                case 'PHP_DEBUG':
                 case 'PHP_FLOAT_DIG':
-                case 'PHP_INT_MIN':
-                case 'PHP_ZTS':
                     return Type::getInt();
 
+                case 'PHP_INT_MIN':
+                    return Type::getInt(false, PHP_INT_MIN);
+
+                case 'PHP_DEBUG':
+                case 'PHP_ZTS':
+                    if ($codebase->analysis_php_version_id >= 8_04_00) {
+                        return Type::getBool();
+                    }
+                    return Type::getIntRange(0, 1);
+
                 case 'PHP_INT_MAX':
+                    return Type::getInt(false, PHP_INT_MAX);
+
                 case 'PHP_INT_SIZE':
                 case 'PHP_MAXPATHLEN':
                 case 'PHP_VERSION_ID':

--- a/tests/ConstantTest.php
+++ b/tests/ConstantTest.php
@@ -2157,6 +2157,19 @@ class ConstantTest extends TestCase
                     class FooBar implements FooInterface, BarInterface {}
                     PHP,
             ],
+            'phpDebugValid' => [
+                'code' => '<?php
+                    if (PHP_DEBUG === 0) {}
+                ',
+            ],
+            /*'phpDebugValid84' => [
+                'code' => '<?php
+                    if (PHP_DEBUG === false) {}
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.4',
+            ],*/
         ];
     }
 
@@ -2724,6 +2737,48 @@ class ConstantTest extends TestCase
                 'error_levels' => [],
                 'php_version' => '8.2',
             ],
+            'phpIntMaxValue' => [
+                'code' => '<?php
+                    $max = PHP_INT_MAX;
+                    if ($max < 100) {}
+                ',
+                'error_message' => 'TypeDoesNotContainType',
+            ],
+            'phpIntMinValue' => [
+                'code' => '<?php
+                    $min = PHP_INT_MIN;
+                    if ($min > -100) {}
+                ',
+                'error_message' => 'TypeDoesNotContainType',
+            ],
+            'phpIntMaxValueRedundant' => [
+                'code' => '<?php
+                    $max = PHP_INT_MAX;
+                    if ($max > 100) {}
+                ',
+                'error_message' => 'RedundantCondition',
+            ],
+            'phpIntMinValueRedundant' => [
+                'code' => '<?php
+                    $min = PHP_INT_MIN;
+                    if ($min < -100) {}
+                ',
+                'error_message' => 'RedundantCondition',
+            ],
+            'phpDebug' => [
+                'code' => '<?php
+                    if (PHP_DEBUG === false) {}
+                ',
+                'error_message' => 'TypeDoesNotContainType',
+            ],
+            /*'phpDebug84' => [
+                'code' => '<?php
+                    if (PHP_DEBUG === 0) {}
+                ',
+                'error_message' => 'TypeDoesNotContainType',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],*/
         ];
     }
 }


### PR DESCRIPTION
* Fix https://github.com/vimeo/psalm/issues/11189
=> technically on 32-bit systems the values are different, however 32-bit systems don't have any practical relevance anymore (e.g. PhpStorm IDE is only available as 64-bit since years, therefore it's safe to assume 32-bit PHP can be ignored)
* Fix PHP_DEBUG constant for PHP 8.4 part of https://github.com/vimeo/psalm/issues/11107 => https://php.watch/versions/8.4/PHP_ZTS-PHP_DEBUG-const-type-change