### PR TITLE
Fix false positives for UnusedIssueHandlerSuppression

### DIFF
--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -653,7 +653,7 @@ final class IssueBuffer
             if ($is_full && !$codebase->diff_run) {
                 foreach ($codebase->config->getIssueHandlers() as $type => $handler) {
                     foreach ($handler->getFilters() as $filter) {
-                        if ($filter->suppressions > 0 && $filter->getErrorLevel() == Config::REPORT_SUPPRESS) {
+                        if ($filter->suppressions > 0 || $filter->getErrorLevel() != Config::REPORT_SUPPRESS) {
                             continue;
                         }
                         $issues_data['config'][] = new IssueData(


### PR DESCRIPTION
`UnusedIssueHandlerSuppression` would be emitted for any issue handler rather than just suppressions.

For example, this would trigger it, even if it was used:

```
<UndefinedClass errorLevel="info" />
```

This fixes up an if statement so that the issue is only emitted for `errorLevel="suppress"`.

I tried writing a test for this change, but didn't find it very straightforward and settled for not writing one:

* `TestCase` doesn't have very good hooks for providing a custom configuration or issue handlers, though it is doable.
* `IssueBuffer::finish` doesn't provide a way to inspect the final issues, except by capturing and parsing output (`ob_start`, etc.)

Happy to receive feedback or advice on testing.