### PR TITLE
Parse uppercase-string

### DIFF
--- a/src/Psalm/Type/Atomic.php
+++ b/src/Psalm/Type/Atomic.php
@@ -184,6 +184,7 @@ abstract class Atomic implements TypeNode, Stringable
                 return new TFloat();
 
             case 'string':
+            case 'uppercase-string': // TODO implement TUppercaseString
                 return new TString();
 
             case 'bool':
@@ -270,6 +271,7 @@ abstract class Atomic implements TypeNode, Stringable
                 return Type::getNonEmptyListAtomic(Type::getMixed(false, $from_docblock));
 
             case 'non-empty-string':
+            case 'non-empty-uppercase-string': // TODO implement TNonEmptyUppercaseString
                 return new TNonEmptyString();
 
             case 'truthy-string':


### PR DESCRIPTION
Hi @danog 

As a quick workaround for https://github.com/vimeo/psalm/issues/11227, this avoid to duplicate annotation when using the new syntax `uppercase-string` from PHPStan.

Suggested by @orklah https://github.com/vimeo/psalm/issues/11227#issuecomment-2626442084