### PR TITLE
Specify minimum PHP patch release in composer.json as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": "~8.1.17 || ~8.2.4 || ~8.3.0 || ~8.4.0",
+        "php": "~8.1.31 || ~8.2.27 || ~8.3.16 || ~8.4.3",
         "ext-SimpleXML": "*",
         "ext-ctype": "*",
         "ext-dom": "*",
@@ -43,9 +43,6 @@
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
         "symfony/console": "^6.0 || ^7.0",
         "symfony/filesystem": "^6.0 || ^7.0"
-    },
-    "conflict": {
-        "php": "<8.1.31 || <8.2.27 || <8.3.16 || <8.4.3"
     },
     "provide": {
         "psalm/psalm": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -44,6 +44,9 @@
         "symfony/console": "^6.0 || ^7.0",
         "symfony/filesystem": "^6.0 || ^7.0"
     },
+    "conflict": {
+        "php": "<8.1.31 || <8.2.27 || <8.3.16 || <8.4.3"
+    },
     "provide": {
         "psalm/psalm": "self.version"
     },


### PR DESCRIPTION
To avoid analysis crashes and false negatives/positives caused by PHP bugs.