### PR TITLE
Bump `symfony/filesystem`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
         "symfony/console": "^6.0 || ^7.0",
-        "symfony/filesystem": "^6.0 || ^7.0"
+        "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3"
     },
     "provide": {
         "psalm/psalm": "self.version"


### PR DESCRIPTION
The versions listed are the earliest in their respective branches that
do not crash Psalm on PHP 8.4.

The crash was due to implicit nullable parameter in
`Symfony\Component\Filesystem\Path::getFilenameWithoutExtension()`
