### PR TITLE
Fix key type in PossiblyUndefinedStringArrayOffset.md

### DIFF
--- a/docs/running_psalm/issues/PossiblyUndefinedStringArrayOffset.md
+++ b/docs/running_psalm/issues/PossiblyUndefinedStringArrayOffset.md
@@ -1,6 +1,6 @@
 # PossiblyUndefinedStringArrayOffset
 
-Emitted when the config flag `ensureArrayStringOffsetsExist` is set to `true` and an integer-keyed offset is not checked for existence
+Emitted when the config flag `ensureArrayStringOffsetsExist` is set to `true` and a string-keyed offset is not checked for existence
 
 ```php
 <?php


### PR DESCRIPTION
Fixed array key type mistake : string instead of int.