### PR TITLE
handle instanceof $this

### DIFF
--- a/examples/plugins/TaintActiveRecords.php
+++ b/examples/plugins/TaintActiveRecords.php
@@ -17,13 +17,14 @@ use Psalm\Type\Union;
  * ActiveRecords are model-representation of database entries, which can always
  * contain user-input and therefor should be tainted.
  */
-class TaintActiveRecords implements AddTaintsInterface
+final class TaintActiveRecords implements AddTaintsInterface
 {
     /**
      * Called to see what taints should be added
      *
      * @return list<string>
      */
+    #[\Override]
     public static function addTaints(AddRemoveTaintsEvent $event): array
     {
         $expr = $event->getExpr();

--- a/examples/plugins/TaintActiveRecords.php
+++ b/examples/plugins/TaintActiveRecords.php
@@ -1,16 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Psalm\Example\Plugin;
 
+use Override;
 use PhpParser\Node\ArrayItem;
-use PhpParser\Node\Expr\PropertyFetch;
 use PhpParser\Node\Expr;
+use PhpParser\Node\Expr\PropertyFetch;
 use Psalm\Plugin\EventHandler\AddTaintsInterface;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
 use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\TaintKindGroup;
 use Psalm\Type\Union;
+
+use function strpos;
 
 /**
  * Marks all property fetches of models inside namespace \app\models as tainted.
@@ -24,7 +29,7 @@ final class TaintActiveRecords implements AddTaintsInterface
      *
      * @return list<string>
      */
-    #[\Override]
+    #[Override]
     public static function addTaints(AddRemoveTaintsEvent $event): array
     {
         $expr = $event->getExpr();

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -480,9 +480,6 @@
       <code><![CDATA[$inferior_value_position]]></code>
       <code><![CDATA[$other_var_name]]></code>
       <code><![CDATA[$superior_value_position]]></code>
-      <code><![CDATA[$this_class_name]]></code>
-      <code><![CDATA[$this_class_name]]></code>
-      <code><![CDATA[$this_class_name]]></code>
       <code><![CDATA[$true_position]]></code>
       <code><![CDATA[$true_position]]></code>
       <code><![CDATA[$typed_value_position]]></code>

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -1257,7 +1257,7 @@ final class AssertionFinder
                 return [new IsType(TNamedObject::createFromName($instanceof_class))];
             }
 
-            if ($this_class_name
+            if ($this_class_name !== null
                 && (in_array(strtolower($stmt->class->getFirst()), ['self', 'static'], true))) {
                 $is_static = $stmt->class->getFirst() === 'static';
                 $named_object = new TNamedObject($this_class_name, $is_static);
@@ -1267,6 +1267,12 @@ final class AssertionFinder
                 }
 
                 return [new IsType($named_object)];
+            }
+        } elseif ($stmt->class instanceof PhpParser\Node\Expr\Variable && $stmt->class->name === 'this') {
+            if ($this_class_name !== null) {
+                $named_object = new TNamedObject($this_class_name, true);
+
+                return [new IsIdentical($named_object)];
             }
         } elseif ($source instanceof StatementsAnalyzer) {
             $stmt_class_type = $source->node_data->getType($stmt->class);
@@ -1536,7 +1542,7 @@ final class AssertionFinder
                 }
             }
         }
-        
+
         if (($left_get_class || $left_static_class || $left_variable_class_const)
             && ($right_class_string || $right_class_string_t)
         ) {
@@ -3593,13 +3599,13 @@ final class AssertionFinder
                     $class_node = $second_arg->class;
 
                     if ($class_node->getParts() === ['static']) {
-                        if ($this_class_name) {
+                        if ($this_class_name !== null) {
                             $object = new TNamedObject($this_class_name, true);
 
                             $if_types[$first_var_name] = [[new IsAClass($object, $third_arg_value === 'true')]];
                         }
                     } elseif ($class_node->getParts() === ['self']) {
-                        if ($this_class_name) {
+                        if ($this_class_name !== null) {
                             $object = new TNamedObject($this_class_name);
                             $if_types[$first_var_name] = [[new IsAClass($object, $third_arg_value === 'true')]];
                         }

--- a/tests/Config/Plugin/EventHandler/AddTaints/AddTaintsInterfaceTest.php
+++ b/tests/Config/Plugin/EventHandler/AddTaints/AddTaintsInterfaceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\Tests\Config\Plugin\EventHandler\AddTaints;
 
+use Override;
 use Psalm\Config;
 use Psalm\Context;
 use Psalm\Exception\CodeException;
@@ -28,7 +29,7 @@ final class AddTaintsInterfaceTest extends TestCase
 {
     protected static TestConfig $config;
 
-    #[\Override]
+    #[Override]
     public static function setUpBeforeClass(): void
     {
         self::$config = new TestConfig();
@@ -107,7 +108,7 @@ final class AddTaintsInterfaceTest extends TestCase
         $this->expectExceptionMessage('TaintedHtml');
     }
 
-    #[\Override]
+    #[Override]
     public function setUp(): void
     {
         RuntimeCaches::clearAll();

--- a/tests/Config/Plugin/EventHandler/AddTaints/AddTaintsInterfaceTest.php
+++ b/tests/Config/Plugin/EventHandler/AddTaints/AddTaintsInterfaceTest.php
@@ -24,10 +24,11 @@ use function getcwd;
 
 use const DIRECTORY_SEPARATOR;
 
-class AddTaintsInterfaceTest extends TestCase
+final class AddTaintsInterfaceTest extends TestCase
 {
     protected static TestConfig $config;
 
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         self::$config = new TestConfig();
@@ -106,6 +107,7 @@ class AddTaintsInterfaceTest extends TestCase
         $this->expectExceptionMessage('TaintedHtml');
     }
 
+    #[\Override]
     public function setUp(): void
     {
         RuntimeCaches::clearAll();

--- a/tests/Config/Plugin/EventHandler/AddTaints/TaintBadDataPlugin.php
+++ b/tests/Config/Plugin/EventHandler/AddTaints/TaintBadDataPlugin.php
@@ -15,13 +15,14 @@ use Psalm\Type\TaintKindGroup;
  *
  * @psalm-suppress UnusedClass
  */
-class TaintBadDataPlugin implements AddTaintsInterface
+final class TaintBadDataPlugin implements AddTaintsInterface
 {
     /**
      * Called to see what taints should be added
      *
      * @return list<string>
      */
+    #[\Override]
     public static function addTaints(AddRemoveTaintsEvent $event): array
     {
         $expr = $event->getExpr();

--- a/tests/Config/Plugin/EventHandler/AddTaints/TaintBadDataPlugin.php
+++ b/tests/Config/Plugin/EventHandler/AddTaints/TaintBadDataPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\Example\Plugin;
 
+use Override;
 use PhpParser\Node\Expr\Variable;
 use Psalm\Plugin\EventHandler\AddTaintsInterface;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
@@ -22,7 +23,7 @@ final class TaintBadDataPlugin implements AddTaintsInterface
      *
      * @return list<string>
      */
-    #[\Override]
+    #[Override]
     public static function addTaints(AddRemoveTaintsEvent $event): array
     {
         $expr = $event->getExpr();

--- a/tests/Config/Plugin/EventHandler/RemoveTaints/RemoveAllTaintsPlugin.php
+++ b/tests/Config/Plugin/EventHandler/RemoveTaints/RemoveAllTaintsPlugin.php
@@ -11,13 +11,14 @@ use Psalm\Type\TaintKindGroup;
 /**
  * @psalm-suppress UnusedClass
  */
-class RemoveAllTaintsPlugin implements RemoveTaintsInterface
+final class RemoveAllTaintsPlugin implements RemoveTaintsInterface
 {
     /**
      * Called to see what taints should be removed
      *
      * @return list<string>
      */
+    #[\Override]
     public static function removeTaints(AddRemoveTaintsEvent $event): array
     {
         return TaintKindGroup::ALL_INPUT;

--- a/tests/Config/Plugin/EventHandler/RemoveTaints/RemoveAllTaintsPlugin.php
+++ b/tests/Config/Plugin/EventHandler/RemoveTaints/RemoveAllTaintsPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\Tests\Config\Plugin\EventHandler\RemoveTaints;
 
+use Override;
 use Psalm\Plugin\EventHandler\Event\AddRemoveTaintsEvent;
 use Psalm\Plugin\EventHandler\RemoveTaintsInterface;
 use Psalm\Type\TaintKindGroup;
@@ -18,7 +19,7 @@ final class RemoveAllTaintsPlugin implements RemoveTaintsInterface
      *
      * @return list<string>
      */
-    #[\Override]
+    #[Override]
     public static function removeTaints(AddRemoveTaintsEvent $event): array
     {
         return TaintKindGroup::ALL_INPUT;

--- a/tests/Config/Plugin/EventHandler/RemoveTaints/RemoveTaintsInterfaceTest.php
+++ b/tests/Config/Plugin/EventHandler/RemoveTaints/RemoveTaintsInterfaceTest.php
@@ -24,10 +24,11 @@ use function getcwd;
 
 use const DIRECTORY_SEPARATOR;
 
-class RemoveTaintsInterfaceTest extends TestCase
+final class RemoveTaintsInterfaceTest extends TestCase
 {
     protected static TestConfig $config;
 
+    #[\Override]
     public static function setUpBeforeClass(): void
     {
         self::$config = new TestConfig();
@@ -54,6 +55,7 @@ class RemoveTaintsInterfaceTest extends TestCase
         );
     }
 
+    #[\Override]
     public function setUp(): void
     {
         RuntimeCaches::clearAll();

--- a/tests/Config/Plugin/EventHandler/RemoveTaints/RemoveTaintsInterfaceTest.php
+++ b/tests/Config/Plugin/EventHandler/RemoveTaints/RemoveTaintsInterfaceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\Tests\Config\Plugin\EventHandler\RemoveTaints;
 
+use Override;
 use Psalm\Config;
 use Psalm\Context;
 use Psalm\Exception\CodeException;
@@ -28,7 +29,7 @@ final class RemoveTaintsInterfaceTest extends TestCase
 {
     protected static TestConfig $config;
 
-    #[\Override]
+    #[Override]
     public static function setUpBeforeClass(): void
     {
         self::$config = new TestConfig();
@@ -55,7 +56,7 @@ final class RemoveTaintsInterfaceTest extends TestCase
         );
     }
 
-    #[\Override]
+    #[Override]
     public function setUp(): void
     {
         RuntimeCaches::clearAll();

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -1232,6 +1232,18 @@ final class ConditionalTest extends TestCase
                         }
                     }',
             ],
+            'thingInstanceOfThis' => [
+                'code' => '<?php
+                    abstract class A {
+                        public function equals(mixed $other): void {
+                            if ($other instanceof $this) {
+                                /** @psalm-check-type $other = A&static */
+                                return;
+                            }
+                        }
+                    }
+                ',
+            ],
             'reconcileCallable' => [
                 'code' => '<?php
                     function reflectCallable(callable $callable): ReflectionFunctionAbstract {

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -1235,7 +1235,8 @@ final class ConditionalTest extends TestCase
             'thingInstanceOfThis' => [
                 'code' => '<?php
                     abstract class A {
-                        public function equals(mixed $other): void {
+                        /** @psalm-param mixed $other */
+                        public function equals($other): void {
                             if ($other instanceof $this) {
                                 /** @psalm-check-type $other = A&static */
                                 return;


### PR DESCRIPTION
This is a first step to solve #11281, however, there's a deep issue where Psalm can't invert some assertions (here, `!$other instanceof $this` but the same issue exists with `!$other instanceof static`: https://psalm.dev/r/3569841f52) and I couldn't solve it