### PR TITLE
Types in lazy objects

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2237,6 +2237,16 @@ final class Config
             $core_generic_files[] = $stringable_path;
         }
 
+        if (PHP_VERSION_ID < 8_04_00 && $codebase->analysis_php_version_id >= 8_04_00) {
+            $stringable_path = dirname(__DIR__, 2) . '/stubs/Php84.phpstub';
+
+            if (!file_exists($stringable_path)) {
+                throw new UnexpectedValueException('Cannot locate PHP 8.4 classes');
+            }
+
+            $core_generic_files[] = $stringable_path;
+        }
+
         $stub_files = array_merge($core_generic_files, $this->preloaded_stub_files);
 
         if (!$stub_files) {
@@ -2298,6 +2308,10 @@ final class Config
         if ($codebase->analysis_php_version_id >= 8_02_00) {
             $this->internal_stubs[] = $stubsDir . 'Php82.phpstub';
             $this->php_extensions['random'] = true; // random is a part of the PHP core starting from PHP 8.2
+        }
+
+        if ($codebase->analysis_php_version_id >= 8_04_00) {
+            $this->internal_stubs[] = $stubsDir . 'Php84.phpstub';
         }
 
         $ext_stubs_dir = $dir_lvl_2 . DIRECTORY_SEPARATOR . "stubs" . DIRECTORY_SEPARATOR . "extensions";

--- a/stubs/Php84.phpstub
+++ b/stubs/Php84.phpstub
@@ -1,0 +1,58 @@
+<?php
+namespace {
+    /**
+     * @template T of object
+     */
+    class ReflectionClass implements Reflector {
+        /**
+         * @param T|class-string<T> $objectOrClass
+         */
+        public function __construct(object|string $objectOrClass) {}
+
+        /**
+         * @param T $object
+         */
+        public function getLazyInitializer(object $object): ?callable {}
+
+        /**
+         * @param T $object
+         * @return T
+         */
+        public function initializeLazyObject(object $object): object {}
+
+        /**
+         * @param T $object
+         */
+        public function isUninitializedLazyObject(object $object): bool {}
+
+        /**
+         * @param T $object
+         * @return T
+         */
+        public function markLazyObjectAsInitialized(object $object): object {}
+
+        /**
+         * @param callable(T $object): void $initializer
+         * @return T
+         */
+        public function newLazyGhost(callable $initializer, int $options = 0): object {}
+
+        /**
+         * @param callable(T $object): T $factory
+         * @return T
+         */
+        public function newLazyProxy(callable $factory, int $options = 0): object {}
+
+        /**
+         * @param T $object
+         * @param callable(T $object): void $initializer
+         */
+        public function resetAsLazyGhost(object $object, callable $initializer, int $options = 0): void {}
+
+        /**
+         * @param T $object
+         * @param callable(T $object): T $factory
+         */
+        public function resetAsLazyProxy(object $object, callable $factory, int $options = 0): void {}
+    }
+}

--- a/tests/Php84Test.php
+++ b/tests/Php84Test.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests;
+
+use Override;
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+final class Php84Test extends TestCase
+{
+    use InvalidCodeAnalysisTestTrait;
+    use ValidCodeAnalysisTestTrait;
+
+    #[Override]
+    public function providerValidCodeParse(): iterable
+    {
+        return [
+            'initializeLazyObject' => [
+                'code' => '<?php
+                    class Foo {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $lazyProxy = $reflectionClass->newLazyProxy(fn() => new Foo);
+                    $realInstance = $reflectionClass->initializeLazyObject($lazyProxy);',
+                'assertions' => [
+                    '$realInstance' => 'Foo',
+                ],
+                'ignored_issues' => ['UnusedVariable'],
+                'php_version' => '8.4',
+            ],
+            'markLazyObjectAsInitialized' => [
+                'code' => '<?php
+                    class Foo {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $lazyProxy = $reflectionClass->newLazyProxy(fn() => new Foo);
+                    $lazyProxyReturned = $reflectionClass->markLazyObjectAsInitialized($lazyProxy);',
+                'assertions' => [
+                    '$lazyProxyReturned' => 'Foo',
+                ],
+                'ignored_issues' => ['UnusedVariable'],
+                'php_version' => '8.4',
+            ],
+            'newLazyGhost' => [
+                'code' => '<?php
+                    class Foo {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $lazyGhost = $reflectionClass->newLazyGhost(function (Foo $foo) {});',
+                'assertions' => [
+                    '$lazyGhost' => 'Foo',
+                ],
+                'ignored_issues' => ['UnusedVariable'],
+                'php_version' => '8.4',
+            ],
+            'newLazyProxy' => [
+                'code' => '<?php
+                    class Foo {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $lazyProxy = $reflectionClass->newLazyProxy(fn() => new Foo);',
+                'assertions' => [
+                    '$lazyProxy' => 'Foo',
+                ],
+                'ignored_issues' => ['UnusedVariable'],
+                'php_version' => '8.4',
+            ],
+        ];
+    }
+
+    #[Override]
+    public function providerInvalidCodeParse(): iterable
+    {
+        return [
+            'getLazyInitializerWithBadType' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->getLazyInitializer(new Bar);',
+                'error_message' => 'Argument 1 of ReflectionClass::getLazyInitializer expects Foo, but Bar provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'initializeLazyObjectWithBadType' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->initializeLazyObject(new Bar);',
+                'error_message' => 'Argument 1 of ReflectionClass::initializeLazyObject expects Foo, but Bar provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'isUninitializedLazyObjectWithBadType' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->isUninitializedLazyObject(new Bar);',
+                'error_message' => 'Argument 1 of ReflectionClass::isUninitializedLazyObject expects Foo, but Bar provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'markLazyObjectAsInitializedWithBadType' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->markLazyObjectAsInitialized(new Bar);',
+                'error_message' => 'Argument 1 of ReflectionClass::markLazyObjectAsInitialized expects Foo, but Bar provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'newLazyGhostWithBadType' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->newLazyGhost(function (Bar $foo) {});',
+                'error_message' => 'Argument 1 of ReflectionClass::newLazyGhost expects callable(Foo):void, but pure-Closure(Bar):void provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'newLazyProxyWithBadType_1' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->newLazyProxy(fn(Bar $bar) => new Foo);',
+                'error_message' => 'Argument 1 of ReflectionClass::newLazyProxy expects callable(Foo):Foo, but pure-Closure(Bar):Foo provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'newLazyProxyWithBadType_2' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->newLazyProxy(fn(Foo $foo) => new Bar);',
+                'error_message' => 'Argument 1 of ReflectionClass::newLazyProxy expects callable(Foo):Foo, but pure-Closure(Foo):Bar provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'resetAsLazyGhostWithBadType_1' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->resetAsLazyGhost(new Bar, function (Foo $foo) {});',
+                'error_message' => 'Argument 1 of ReflectionClass::resetAsLazyGhost expects Foo, but Bar provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'resetAsLazyGhostWithBadType_2' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->resetAsLazyGhost(new Foo, function (Bar $foo) {});',
+                'error_message' => 'Argument 2 of ReflectionClass::resetAsLazyGhost expects callable(Foo):void, but pure-Closure(Bar):void provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'resetAsLazyProxyWithBadType_1' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->resetAsLazyProxy(new Bar, fn(Foo $foo) => new Foo);',
+                'error_message' => 'Argument 1 of ReflectionClass::resetAsLazyProxy expects Foo, but Bar provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'resetAsLazyProxyWithBadType_2' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->resetAsLazyProxy(new Foo, fn(Bar $bar) => new Foo);',
+                'error_message' => 'Argument 2 of ReflectionClass::resetAsLazyProxy expects callable(Foo):Foo, but pure-Closure(Bar):Foo provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+            'resetAsLazyProxyWithBadType_3' => [
+                'code' => '<?php
+                    class Foo {}
+                    class Bar {}
+                    $reflectionClass = new ReflectionClass(Foo::class);
+                    $reflectionClass->resetAsLazyProxy(new Foo, fn(Foo $foo) => new Bar);',
+                'error_message' => 'Argument 2 of ReflectionClass::resetAsLazyProxy expects callable(Foo):Foo, but pure-Closure(Foo):Bar provided',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This adds type checks and inference for reflection of [lazy objects](https://wiki.php.net/rfc/lazy-objects) introduced in PHP 8.4:

- `ReflectionClass::initializeLazyObject()`
- `ReflectionClass::markLazyObjectAsInitialized()`
- `ReflectionClass::getLazyInitializer()`
- `ReflectionClass::isUninitializedLazyObject()`
- `ReflectionClass::newLazyGhost()`
- `ReflectionClass::newLazyProxy()`
- `ReflectionClass::resetAsLazyGhost()`
- `ReflectionClass::resetAsLazyProxy()`