### PR TITLE
Regenerate callmap, add \Roundable parameter possibility to round PHP8.4

### DIFF
--- a/bin/stubs/gen_callmap.sh
+++ b/bin/stubs/gen_callmap.sh
@@ -3,7 +3,7 @@
 VERSIONS="7.0 7.1 7.2 7.3 7.4 8.0 8.1 8.2 8.3 8.4"
 
 for f in $VERSIONS; do
-    docker build --build-arg VERSION=$f . -f bin/Dockerfile_$f -t psalm_test_$f &
+    docker build --build-arg VERSION=$f . -f bin/stubs/Dockerfile_$f -t psalm_test_$f &
     if [ "$f" == "7.1" ] || [ "$f" == "7.3" ] || [ "$f" == "8.0" ] || [ "$f" == "8.2" ] || [ "$f" == "8.4" ]; then wait; fi
 done
 

--- a/dictionaries/CallMap_70.php
+++ b/dictionaries/CallMap_70.php
@@ -21157,7 +21157,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',

--- a/dictionaries/CallMap_71.php
+++ b/dictionaries/CallMap_71.php
@@ -21773,7 +21773,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',
@@ -86117,12 +86117,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (

--- a/dictionaries/CallMap_72.php
+++ b/dictionaries/CallMap_72.php
@@ -22039,7 +22039,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',
@@ -88099,12 +88099,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (

--- a/dictionaries/CallMap_73.php
+++ b/dictionaries/CallMap_73.php
@@ -22096,7 +22096,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',
@@ -88352,12 +88352,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (

--- a/dictionaries/CallMap_74.php
+++ b/dictionaries/CallMap_74.php
@@ -22177,7 +22177,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',
@@ -88850,12 +88850,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (

--- a/dictionaries/CallMap_80.php
+++ b/dictionaries/CallMap_80.php
@@ -4085,6 +4085,49 @@ return array (
     0 => 'mixed',
     'data' => 'string',
   ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'co\\defer' => 
   array (
     0 => 'mixed',
@@ -85247,6 +85290,49 @@ return array (
     0 => 'mixed',
     'data' => 'string',
   ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
     0 => 'mixed',
@@ -88192,12 +88278,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -93566,6 +93652,134 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/CallMap_81.php
+++ b/dictionaries/CallMap_81.php
@@ -4072,6 +4072,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'co\\defer' => 
   array (
     0 => 'mixed',
@@ -38290,7 +38333,7 @@ return array (
   ),
   'imagickpixel::getcolorvaluequantum' => 
   array (
-    0 => '5',
+    0 => 'float',
     'color' => 'int',
   ),
   'imagickpixel::gethsl' => 
@@ -38344,7 +38387,7 @@ return array (
   array (
     0 => 'bool',
     'color' => 'int',
-    'value' => 'IMAGICK_QUANTUM_TYPE',
+    'value' => 'float',
   ),
   'imagickpixel::sethsl' => 
   array (
@@ -38356,7 +38399,7 @@ return array (
   'imagickpixel::setindex' => 
   array (
     0 => 'bool',
-    'index' => 'IMAGICK_QUANTUM_TYPE',
+    'index' => 'float',
   ),
   'imagickpixelexception::__construct' => 
   array (
@@ -84936,6 +84979,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
     0 => 'mixed',
@@ -85639,6 +85725,27 @@ return array (
     'data' => 'string',
   ),
   'swoole\\coroutine\\iterator::valid' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__construct' => 
+  array (
+    0 => 'void',
+    'shared=' => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__destruct' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\lock::lock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::trylock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::unlock' => 
   array (
     0 => 'bool',
   ),
@@ -86495,12 +86602,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -89165,10 +89272,6 @@ return array (
   array (
     0 => 'void',
   ),
-  'swoole\\lock::destroy' => 
-  array (
-    0 => 'void',
-  ),
   'swoole\\lock::lock' => 
   array (
     0 => 'bool',
@@ -89773,6 +89876,10 @@ return array (
   array (
     0 => 'bool',
   ),
+  'swoole\\process::getaffinity' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
   'swoole\\process::getpriority' => 
   array (
     0 => 'false|int',
@@ -89809,6 +89916,11 @@ return array (
   array (
     0 => 'void',
     'settings' => 'array<array-key, mixed>',
+  ),
+  'swoole\\process::setaffinity' => 
+  array (
+    0 => 'bool',
+    'cpu_settings' => 'array<array-key, mixed>',
   ),
   'swoole\\process::setblocking' => 
   array (
@@ -92010,6 +92122,134 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/CallMap_82.php
+++ b/dictionaries/CallMap_82.php
@@ -4076,6 +4076,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'co\\defer' => 
   array (
     0 => 'mixed',
@@ -85357,6 +85400,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
     0 => 'mixed',
@@ -86060,6 +86146,27 @@ return array (
     'data' => 'string',
   ),
   'swoole\\coroutine\\iterator::valid' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__construct' => 
+  array (
+    0 => 'void',
+    'shared=' => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__destruct' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\lock::lock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::trylock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::unlock' => 
   array (
     0 => 'bool',
   ),
@@ -86916,12 +87023,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -89586,10 +89693,6 @@ return array (
   array (
     0 => 'void',
   ),
-  'swoole\\lock::destroy' => 
-  array (
-    0 => 'void',
-  ),
   'swoole\\lock::lock' => 
   array (
     0 => 'bool',
@@ -90194,6 +90297,10 @@ return array (
   array (
     0 => 'bool',
   ),
+  'swoole\\process::getaffinity' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
   'swoole\\process::getpriority' => 
   array (
     0 => 'false|int',
@@ -90230,6 +90337,11 @@ return array (
   array (
     0 => 'void',
     'settings' => 'array<array-key, mixed>',
+  ),
+  'swoole\\process::setaffinity' => 
+  array (
+    0 => 'bool',
+    'cpu_settings' => 'array<array-key, mixed>',
   ),
   'swoole\\process::setblocking' => 
   array (
@@ -92431,6 +92543,134 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/CallMap_83.php
+++ b/dictionaries/CallMap_83.php
@@ -4076,6 +4076,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'co\\defer' => 
   array (
     0 => 'mixed',
@@ -86206,6 +86249,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
     0 => 'mixed',
@@ -86909,6 +86995,27 @@ return array (
     'data' => 'string',
   ),
   'swoole\\coroutine\\iterator::valid' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__construct' => 
+  array (
+    0 => 'void',
+    'shared=' => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__destruct' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\lock::lock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::trylock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::unlock' => 
   array (
     0 => 'bool',
   ),
@@ -87765,12 +87872,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -90435,10 +90542,6 @@ return array (
   array (
     0 => 'void',
   ),
-  'swoole\\lock::destroy' => 
-  array (
-    0 => 'void',
-  ),
   'swoole\\lock::lock' => 
   array (
     0 => 'bool',
@@ -91043,6 +91146,10 @@ return array (
   array (
     0 => 'bool',
   ),
+  'swoole\\process::getaffinity' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
   'swoole\\process::getpriority' => 
   array (
     0 => 'false|int',
@@ -91079,6 +91186,11 @@ return array (
   array (
     0 => 'void',
     'settings' => 'array<array-key, mixed>',
+  ),
+  'swoole\\process::setaffinity' => 
+  array (
+    0 => 'bool',
+    'cpu_settings' => 'array<array-key, mixed>',
   ),
   'swoole\\process::setblocking' => 
   array (
@@ -93280,6 +93392,134 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/CallMap_84.php
+++ b/dictionaries/CallMap_84.php
@@ -4216,6 +4216,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'co\\defer' => 
   array (
     0 => 'mixed',
@@ -75355,7 +75398,7 @@ return array (
     0 => 'float',
     'num' => 'float|int',
     'precision=' => 'int',
-    'mode=' => 'int<0, max>',
+    'mode=' => 'RoundingMode|int<0, max>',
   ),
   'roundingmode::cases' => 
   array (
@@ -90521,6 +90564,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
     0 => 'mixed',
@@ -91224,6 +91310,27 @@ return array (
     'data' => 'string',
   ),
   'swoole\\coroutine\\iterator::valid' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__construct' => 
+  array (
+    0 => 'void',
+    'shared=' => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__destruct' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\lock::lock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::trylock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::unlock' => 
   array (
     0 => 'bool',
   ),
@@ -92080,12 +92187,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -94750,10 +94857,6 @@ return array (
   array (
     0 => 'void',
   ),
-  'swoole\\lock::destroy' => 
-  array (
-    0 => 'void',
-  ),
   'swoole\\lock::lock' => 
   array (
     0 => 'bool',
@@ -95358,6 +95461,10 @@ return array (
   array (
     0 => 'bool',
   ),
+  'swoole\\process::getaffinity' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
   'swoole\\process::getpriority' => 
   array (
     0 => 'false|int',
@@ -95394,6 +95501,11 @@ return array (
   array (
     0 => 'void',
     'settings' => 'array<array-key, mixed>',
+  ),
+  'swoole\\process::setaffinity' => 
+  array (
+    0 => 'bool',
+    'cpu_settings' => 'array<array-key, mixed>',
   ),
   'swoole\\process::setblocking' => 
   array (
@@ -97595,6 +97707,153 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_multi_strerror' => 
+  array (
+    0 => 'null|string',
+    'error_code' => 'int',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_strerror' => 
+  array (
+    0 => 'null|string',
+    'error_code' => 'int',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_upkeep' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_version' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/autogen/CallMap_70.php
+++ b/dictionaries/autogen/CallMap_70.php
@@ -1444,7 +1444,7 @@ return array (
     '&arr1' => 'mixed',
     '&sort_order=' => 'mixed',
     '&sort_flags=' => 'mixed',
-    '...&arr2=' => 'mixed',
+    '&...arr2=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -15781,7 +15781,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',
@@ -16866,7 +16866,7 @@ return array (
     0 => 'mixed',
     'stream' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -38445,7 +38445,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -39337,7 +39337,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -39772,7 +39772,7 @@ return array (
     0 => 'mixed',
     'str' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (

--- a/dictionaries/autogen/CallMap_71.php
+++ b/dictionaries/autogen/CallMap_71.php
@@ -1516,7 +1516,7 @@ return array (
     '&arr1' => 'mixed',
     '&sort_order=' => 'mixed',
     '&sort_flags=' => 'mixed',
-    '...&arr2=' => 'mixed',
+    '&...arr2=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -16397,7 +16397,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',
@@ -17482,7 +17482,7 @@ return array (
     0 => 'mixed',
     'stream' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -39423,7 +39423,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -40315,7 +40315,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -40752,7 +40752,7 @@ return array (
     0 => 'mixed',
     'str' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (
@@ -44939,12 +44939,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (

--- a/dictionaries/autogen/CallMap_72.php
+++ b/dictionaries/autogen/CallMap_72.php
@@ -1516,7 +1516,7 @@ return array (
     '&arr1' => 'mixed',
     '&sort_order=' => 'mixed',
     '&sort_flags=' => 'mixed',
-    '...&arr2=' => 'mixed',
+    '&...arr2=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -16663,7 +16663,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',
@@ -17748,7 +17748,7 @@ return array (
     0 => 'mixed',
     'stream' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -41323,7 +41323,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -42215,7 +42215,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -42653,7 +42653,7 @@ return array (
     0 => 'mixed',
     'str' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (
@@ -47201,12 +47201,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (

--- a/dictionaries/autogen/CallMap_73.php
+++ b/dictionaries/autogen/CallMap_73.php
@@ -1516,7 +1516,7 @@ return array (
     '&arr1' => 'mixed',
     '&sort_order=' => 'mixed',
     '&sort_flags=' => 'mixed',
-    '...&arr2=' => 'mixed',
+    '&...arr2=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -16720,7 +16720,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',
@@ -17805,7 +17805,7 @@ return array (
     0 => 'mixed',
     'stream' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -41515,7 +41515,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -42407,7 +42407,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -42850,7 +42850,7 @@ return array (
     0 => 'mixed',
     'str' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (
@@ -47398,12 +47398,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (

--- a/dictionaries/autogen/CallMap_74.php
+++ b/dictionaries/autogen/CallMap_74.php
@@ -1545,7 +1545,7 @@ return array (
     '&arr1' => 'mixed',
     '&sort_order=' => 'mixed',
     '&sort_flags=' => 'mixed',
-    '...&arr2=' => 'mixed',
+    '&...arr2=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -16801,7 +16801,7 @@ return array (
   ),
   'evloop::check' => 
   array (
-    0 => 'EvCheck',
+    0 => 'mixed',
     'callback' => 'callable',
     'data=' => 'mixed',
     'priority=' => 'int',
@@ -18081,7 +18081,7 @@ return array (
     0 => 'mixed',
     'stream' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -41905,7 +41905,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -42856,7 +42856,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -43320,7 +43320,7 @@ return array (
     0 => 'mixed',
     'str' => 'mixed',
     'format' => 'mixed',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (
@@ -47894,12 +47894,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (

--- a/dictionaries/autogen/CallMap_80.php
+++ b/dictionaries/autogen/CallMap_80.php
@@ -1504,7 +1504,7 @@ return array (
   array (
     0 => 'bool',
     '&array' => 'mixed',
-    '...&rest=' => 'mixed',
+    '&...rest=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -3001,6 +3001,49 @@ return array (
   array (
     0 => 'mixed',
     'data' => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
   ),
   'co\\defer' => 
   array (
@@ -17821,7 +17864,7 @@ return array (
     0 => 'array<array-key, mixed>|false|int|null',
     'stream' => 'mixed',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -41560,7 +41603,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -42493,7 +42536,7 @@ return array (
   array (
     0 => 'mixed',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -42963,7 +43006,7 @@ return array (
     0 => 'array<array-key, mixed>|int|null',
     'string' => 'string',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (
@@ -44665,6 +44708,49 @@ return array (
   array (
     0 => 'mixed',
     'data' => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
   ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
@@ -47607,12 +47693,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -52806,6 +52892,134 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/autogen/CallMap_81.php
+++ b/dictionaries/autogen/CallMap_81.php
@@ -1509,7 +1509,7 @@ return array (
   array (
     0 => 'bool',
     '&array' => 'mixed',
-    '...&rest=' => 'mixed',
+    '&...rest=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -2988,6 +2988,49 @@ return array (
   array (
     0 => 'void',
     'data' => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
   ),
   'co\\defer' => 
   array (
@@ -16760,7 +16803,7 @@ return array (
     0 => 'array<array-key, mixed>|false|int|null',
     'stream' => 'mixed',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -22477,7 +22520,7 @@ return array (
   ),
   'imagickpixel::getcolorvaluequantum' => 
   array (
-    0 => '5',
+    0 => 'float',
     'color' => 'int',
   ),
   'imagickpixel::gethsl' => 
@@ -22531,7 +22574,7 @@ return array (
   array (
     0 => 'bool',
     'color' => 'int',
-    'value' => 'IMAGICK_QUANTUM_TYPE',
+    'value' => 'float',
   ),
   'imagickpixel::sethsl' => 
   array (
@@ -22543,7 +22586,7 @@ return array (
   'imagickpixel::setindex' => 
   array (
     0 => 'bool',
-    'index' => 'IMAGICK_QUANTUM_TYPE',
+    'index' => 'float',
   ),
   'imagickpixelexception::__construct' => 
   array (
@@ -41142,7 +41185,7 @@ return array (
   array (
     0 => 'array<array-key, mixed>|int|null',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -42080,7 +42123,7 @@ return array (
   array (
     0 => 'array<array-key, mixed>|int|null',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -42550,7 +42593,7 @@ return array (
     0 => 'array<array-key, mixed>|int|null',
     'string' => 'string',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (
@@ -44341,6 +44384,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
     0 => 'mixed',
@@ -45040,6 +45126,27 @@ return array (
     'data' => 'string',
   ),
   'swoole\\coroutine\\iterator::valid' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__construct' => 
+  array (
+    0 => 'void',
+    'shared=' => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__destruct' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\lock::lock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::trylock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::unlock' => 
   array (
     0 => 'bool',
   ),
@@ -45896,12 +46003,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -48469,10 +48576,6 @@ return array (
   array (
     0 => 'mixed',
   ),
-  'swoole\\lock::destroy' => 
-  array (
-    0 => 'void',
-  ),
   'swoole\\lock::lock' => 
   array (
     0 => 'bool',
@@ -49040,6 +49143,10 @@ return array (
   array (
     0 => 'bool',
   ),
+  'swoole\\process::getaffinity' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
   'swoole\\process::getpriority' => 
   array (
     0 => 'false|int',
@@ -49076,6 +49183,11 @@ return array (
   array (
     0 => 'void',
     'settings' => 'array<array-key, mixed>',
+  ),
+  'swoole\\process::setaffinity' => 
+  array (
+    0 => 'bool',
+    'cpu_settings' => 'array<array-key, mixed>',
   ),
   'swoole\\process::setblocking' => 
   array (
@@ -51236,6 +51348,134 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/autogen/CallMap_82.php
+++ b/dictionaries/autogen/CallMap_82.php
@@ -1513,7 +1513,7 @@ return array (
   array (
     0 => 'bool',
     '&array' => 'mixed',
-    '...&rest=' => 'mixed',
+    '&...rest=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -2992,6 +2992,49 @@ return array (
   array (
     0 => 'void',
     'data' => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
   ),
   'co\\defer' => 
   array (
@@ -16814,7 +16857,7 @@ return array (
     0 => 'array<array-key, mixed>|false|int|null',
     'stream' => 'mixed',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -41279,7 +41322,7 @@ return array (
   array (
     0 => 'array<array-key, mixed>|int|null',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -42226,7 +42269,7 @@ return array (
   array (
     0 => 'array<array-key, mixed>|int|null',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -42696,7 +42739,7 @@ return array (
     0 => 'array<array-key, mixed>|int|null',
     'string' => 'string',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (
@@ -44487,6 +44530,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
     0 => 'mixed',
@@ -45186,6 +45272,27 @@ return array (
     'data' => 'string',
   ),
   'swoole\\coroutine\\iterator::valid' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__construct' => 
+  array (
+    0 => 'void',
+    'shared=' => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__destruct' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\lock::lock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::trylock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::unlock' => 
   array (
     0 => 'bool',
   ),
@@ -46042,12 +46149,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -48615,10 +48722,6 @@ return array (
   array (
     0 => 'mixed',
   ),
-  'swoole\\lock::destroy' => 
-  array (
-    0 => 'void',
-  ),
   'swoole\\lock::lock' => 
   array (
     0 => 'bool',
@@ -49186,6 +49289,10 @@ return array (
   array (
     0 => 'bool',
   ),
+  'swoole\\process::getaffinity' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
   'swoole\\process::getpriority' => 
   array (
     0 => 'false|int',
@@ -49222,6 +49329,11 @@ return array (
   array (
     0 => 'void',
     'settings' => 'array<array-key, mixed>',
+  ),
+  'swoole\\process::setaffinity' => 
+  array (
+    0 => 'bool',
+    'cpu_settings' => 'array<array-key, mixed>',
   ),
   'swoole\\process::setblocking' => 
   array (
@@ -51382,6 +51494,134 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/autogen/CallMap_83.php
+++ b/dictionaries/autogen/CallMap_83.php
@@ -1513,7 +1513,7 @@ return array (
   array (
     0 => 'bool',
     '&array' => 'mixed',
-    '...&rest=' => 'mixed',
+    '&...rest=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -2992,6 +2992,49 @@ return array (
   array (
     0 => 'void',
     'data' => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
   ),
   'co\\defer' => 
   array (
@@ -17454,7 +17497,7 @@ return array (
     0 => 'array<array-key, mixed>|false|int|null',
     'stream' => 'mixed',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -42068,7 +42111,7 @@ return array (
   array (
     0 => 'array<array-key, mixed>|int|null',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -43015,7 +43058,7 @@ return array (
   array (
     0 => 'array<array-key, mixed>|int|null',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -43528,7 +43571,7 @@ return array (
     0 => 'array<array-key, mixed>|int|null',
     'string' => 'string',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (
@@ -45336,6 +45379,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
     0 => 'mixed',
@@ -46035,6 +46121,27 @@ return array (
     'data' => 'string',
   ),
   'swoole\\coroutine\\iterator::valid' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__construct' => 
+  array (
+    0 => 'void',
+    'shared=' => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__destruct' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\lock::lock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::trylock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::unlock' => 
   array (
     0 => 'bool',
   ),
@@ -46891,12 +46998,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -49464,10 +49571,6 @@ return array (
   array (
     0 => 'mixed',
   ),
-  'swoole\\lock::destroy' => 
-  array (
-    0 => 'void',
-  ),
   'swoole\\lock::lock' => 
   array (
     0 => 'bool',
@@ -50035,6 +50138,10 @@ return array (
   array (
     0 => 'bool',
   ),
+  'swoole\\process::getaffinity' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
   'swoole\\process::getpriority' => 
   array (
     0 => 'false|int',
@@ -50071,6 +50178,11 @@ return array (
   array (
     0 => 'void',
     'settings' => 'array<array-key, mixed>',
+  ),
+  'swoole\\process::setaffinity' => 
+  array (
+    0 => 'bool',
+    'cpu_settings' => 'array<array-key, mixed>',
   ),
   'swoole\\process::setblocking' => 
   array (
@@ -52231,6 +52343,134 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/autogen/CallMap_84.php
+++ b/dictionaries/autogen/CallMap_84.php
@@ -1537,7 +1537,7 @@ return array (
   array (
     0 => 'bool',
     '&array' => 'mixed',
-    '...&rest=' => 'mixed',
+    '&...rest=' => 'mixed',
   ),
   'array_pad' => 
   array (
@@ -3132,6 +3132,49 @@ return array (
   array (
     0 => 'void',
     'data' => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'co\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'co\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'co\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'co\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'co\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'co\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
   ),
   'co\\defer' => 
   array (
@@ -21008,7 +21051,7 @@ return array (
     0 => 'array<array-key, mixed>|false|int|null',
     'stream' => 'mixed',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'fseek' => 
   array (
@@ -46372,7 +46415,7 @@ return array (
   array (
     0 => 'array<array-key, mixed>|int|null',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'splfileobject::fseek' => 
   array (
@@ -47324,7 +47367,7 @@ return array (
   array (
     0 => 'array<array-key, mixed>|int|null',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'spltempfileobject::fseek' => 
   array (
@@ -47843,7 +47886,7 @@ return array (
     0 => 'array<array-key, mixed>|int|null',
     'string' => 'string',
     'format' => 'string',
-    '...&vars=' => 'mixed',
+    '&...vars=' => 'mixed',
   ),
   'stat' => 
   array (
@@ -49651,6 +49694,49 @@ return array (
     0 => 'void',
     'data' => 'string',
   ),
+  'swoole\\coroutine\\curl\\exception::__construct' => 
+  array (
+    0 => 'void',
+    'message=' => 'string',
+    'code=' => 'int',
+    'previous=' => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::__tostring' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::__wakeup' => 
+  array (
+    0 => 'void',
+  ),
+  'swoole\\coroutine\\curl\\exception::getcode' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\curl\\exception::getfile' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getline' => 
+  array (
+    0 => 'int',
+  ),
+  'swoole\\coroutine\\curl\\exception::getmessage' => 
+  array (
+    0 => 'string',
+  ),
+  'swoole\\coroutine\\curl\\exception::getprevious' => 
+  array (
+    0 => 'Throwable|null',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettrace' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
+  'swoole\\coroutine\\curl\\exception::gettraceasstring' => 
+  array (
+    0 => 'string',
+  ),
   'swoole\\coroutine\\deadlock_check' => 
   array (
     0 => 'mixed',
@@ -50350,6 +50436,27 @@ return array (
     'data' => 'string',
   ),
   'swoole\\coroutine\\iterator::valid' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__construct' => 
+  array (
+    0 => 'void',
+    'shared=' => 'bool',
+  ),
+  'swoole\\coroutine\\lock::__destruct' => 
+  array (
+    0 => 'mixed',
+  ),
+  'swoole\\coroutine\\lock::lock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::trylock' => 
+  array (
+    0 => 'bool',
+  ),
+  'swoole\\coroutine\\lock::unlock' => 
   array (
     0 => 'bool',
   ),
@@ -51206,12 +51313,12 @@ return array (
   array (
     0 => 'bool',
     'types' => 'mixed',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\mysqlistatementproxy::bind_result' => 
   array (
     0 => 'bool',
-    '...&arguments=' => 'mixed',
+    '&...arguments=' => 'mixed',
   ),
   'swoole\\database\\objectproxy::__call' => 
   array (
@@ -53779,10 +53886,6 @@ return array (
   array (
     0 => 'mixed',
   ),
-  'swoole\\lock::destroy' => 
-  array (
-    0 => 'void',
-  ),
   'swoole\\lock::lock' => 
   array (
     0 => 'bool',
@@ -54350,6 +54453,10 @@ return array (
   array (
     0 => 'bool',
   ),
+  'swoole\\process::getaffinity' => 
+  array (
+    0 => 'array<array-key, mixed>',
+  ),
   'swoole\\process::getpriority' => 
   array (
     0 => 'false|int',
@@ -54386,6 +54493,11 @@ return array (
   array (
     0 => 'void',
     'settings' => 'array<array-key, mixed>',
+  ),
+  'swoole\\process::setaffinity' => 
+  array (
+    0 => 'bool',
+    'cpu_settings' => 'array<array-key, mixed>',
   ),
   'swoole\\process::setblocking' => 
   array (
@@ -56546,6 +56658,153 @@ return array (
   array (
     0 => 'bool',
     'ns' => 'Swoole\\NameResolver',
+  ),
+  'swoole_native_curl_close' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_copy_handle' => 
+  array (
+    0 => 'CurlHandle|false',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_errno' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_error' => 
+  array (
+    0 => 'string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_escape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_exec' => 
+  array (
+    0 => 'bool|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_getinfo' => 
+  array (
+    0 => 'mixed',
+    'handle' => 'CurlHandle',
+    'option=' => 'int|null',
+  ),
+  'swoole_native_curl_init' => 
+  array (
+    0 => 'CurlHandle|false',
+    'url=' => 'null|string',
+  ),
+  'swoole_native_curl_multi_add_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_close' => 
+  array (
+    0 => 'void',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_errno' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_exec' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    '&still_running' => 'mixed',
+  ),
+  'swoole_native_curl_multi_getcontent' => 
+  array (
+    0 => 'null|string',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_info_read' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
+    'multi_handle' => 'CurlMultiHandle',
+    '&queued_messages=' => 'mixed',
+  ),
+  'swoole_native_curl_multi_init' => 
+  array (
+    0 => 'CurlMultiHandle',
+  ),
+  'swoole_native_curl_multi_remove_handle' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_multi_select' => 
+  array (
+    0 => 'int',
+    'multi_handle' => 'CurlMultiHandle',
+    'timeout=' => 'float',
+  ),
+  'swoole_native_curl_multi_setopt' => 
+  array (
+    0 => 'bool',
+    'multi_handle' => 'CurlMultiHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_multi_strerror' => 
+  array (
+    0 => 'null|string',
+    'error_code' => 'int',
+  ),
+  'swoole_native_curl_pause' => 
+  array (
+    0 => 'int',
+    'handle' => 'CurlHandle',
+    'flags' => 'int',
+  ),
+  'swoole_native_curl_reset' => 
+  array (
+    0 => 'void',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_setopt' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'option' => 'int',
+    'value' => 'mixed',
+  ),
+  'swoole_native_curl_setopt_array' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+    'options' => 'array<array-key, mixed>',
+  ),
+  'swoole_native_curl_strerror' => 
+  array (
+    0 => 'null|string',
+    'error_code' => 'int',
+  ),
+  'swoole_native_curl_unescape' => 
+  array (
+    0 => 'false|string',
+    'handle' => 'CurlHandle',
+    'string' => 'string',
+  ),
+  'swoole_native_curl_upkeep' => 
+  array (
+    0 => 'bool',
+    'handle' => 'CurlHandle',
+  ),
+  'swoole_native_curl_version' => 
+  array (
+    0 => 'array<array-key, mixed>|false',
   ),
   'swoole_select' => 
   array (

--- a/dictionaries/override/CallMap.php
+++ b/dictionaries/override/CallMap.php
@@ -55120,7 +55120,7 @@ return array (
     0 => 'float',
     'num' => 'float|int',
     'precision=' => 'int',
-    'mode=' => 'int<0, max>',
+    'mode=' => 'RoundingMode|int<0, max>',
   ),
   'rpm_close' => 
   array (

--- a/dictionaries/override/CallMap_81_delta.php
+++ b/dictionaries/override/CallMap_81_delta.php
@@ -1132,34 +1132,6 @@ return array (
         'filename' => 'string',
       ),
     ),
-    'imagickpixel::setcolorvaluequantum' => 
-    array (
-      'old' => 
-      array (
-        0 => 'bool',
-        'color' => 'int',
-        'value' => 'float',
-      ),
-      'new' => 
-      array (
-        0 => 'bool',
-        'color' => 'int',
-        'value' => 'IMAGICK_QUANTUM_TYPE',
-      ),
-    ),
-    'imagickpixel::setindex' => 
-    array (
-      'old' => 
-      array (
-        0 => 'bool',
-        'index' => 'float',
-      ),
-      'new' => 
-      array (
-        0 => 'bool',
-        'index' => 'IMAGICK_QUANTUM_TYPE',
-      ),
-    ),
     'imap_append' => 
     array (
       'old' => 

--- a/dictionaries/override/CallMap_82_delta.php
+++ b/dictionaries/override/CallMap_82_delta.php
@@ -143,6 +143,34 @@ return array (
         'flags=' => 'int|null',
       ),
     ),
+    'imagickpixel::setcolorvaluequantum' => 
+    array (
+      'old' => 
+      array (
+        0 => 'bool',
+        'color' => 'int',
+        'value' => 'float',
+      ),
+      'new' => 
+      array (
+        0 => 'bool',
+        'color' => 'int',
+        'value' => 'IMAGICK_QUANTUM_TYPE',
+      ),
+    ),
+    'imagickpixel::setindex' => 
+    array (
+      'old' => 
+      array (
+        0 => 'bool',
+        'index' => 'float',
+      ),
+      'new' => 
+      array (
+        0 => 'bool',
+        'index' => 'IMAGICK_QUANTUM_TYPE',
+      ),
+    ),
     'iterator_count' => 
     array (
       'old' => 

--- a/dictionaries/override/CallMap_84_delta.php
+++ b/dictionaries/override/CallMap_84_delta.php
@@ -1,87 +1,87 @@
 <?php // phpcs:ignoreFile
 
 return array (
-  'added' => 
+  'added' =>
   array (
-    'array_find_key' => 
+    'array_find_key' =>
     array (
       0 => 'array-key|null',
       'array' => 'array<array-key, mixed>',
       'callback' => 'callable',
     ),
-    'sodium_crypto_aead_aes256gcm_keygen' => 
+    'sodium_crypto_aead_aes256gcm_keygen' =>
     array (
       0 => 'non-empty-string',
     ),
   ),
-  'changed' => 
+  'changed' =>
   array (
-    'collator::setstrength' => 
+    'collator::setstrength' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'strength' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'strength' => 'int',
       ),
     ),
-    'collator_set_strength' => 
+    'collator_set_strength' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'object' => 'collator',
         'strength' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'object' => 'collator',
         'strength' => 'int',
       ),
     ),
-    'dateinterval::createfromdatestring' => 
+    'dateinterval::createfromdatestring' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'DateInterval|false',
         'datetime' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'DateInterval',
         'datetime' => 'string',
       ),
     ),
-    'domdocument::registernodeclass' => 
+    'domdocument::registernodeclass' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'baseClass' => 'string',
         'extendedClass' => 'null|string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'baseClass' => 'string',
         'extendedClass' => 'null|string',
       ),
     ),
-    'domimplementation::createdocument' => 
+    'domimplementation::createdocument' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'DOMDocument|false',
         'namespace=' => 'null|string',
         'qualifiedName=' => 'string',
         'doctype=' => 'DOMDocumentType|null',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'DOMDocument',
         'namespace=' => 'null|string',
@@ -89,147 +89,147 @@ return array (
         'doctype=' => 'DOMDocumentType|null',
       ),
     ),
-    'finfo::set_flags' => 
+    'finfo::set_flags' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'flags' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'flags' => 'int',
       ),
     ),
-    'finfo_set_flags' => 
+    'finfo_set_flags' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'finfo' => 'finfo',
         'flags' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'finfo' => 'finfo',
         'flags' => 'int',
       ),
     ),
-    'hash_update' => 
+    'hash_update' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'context' => 'HashContext',
         'data' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'context' => 'HashContext',
         'data' => 'string',
       ),
     ),
-    'highlight_string' => 
+    'highlight_string' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool|string',
         'string' => 'string',
         'return=' => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'string|true',
         'string' => 'string',
         'return=' => 'bool',
       ),
     ),
-    'imagick::convolveimage' => 
+    'imagick::convolveimage' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'kernel' => 'array<array-key, mixed>',
         'channel=' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'bool',
         'kernel' => 'ImagickKernel',
         'channel=' => 'int',
       ),
     ),
-    'imagick::evaluateimages' => 
+    'imagick::evaluateimages' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'evaluate' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'Imagick',
         'evaluate' => 'int',
       ),
     ),
-    'imagick::getimageblob' => 
+    'imagick::getimageblob' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'null|string',
       ),
     ),
-    'imagick::getregistry' => 
+    'imagick::getregistry' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'string',
         'key' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'false|string',
         'key' => 'string',
       ),
     ),
-    'imagick::getresourcelimit' => 
+    'imagick::getresourcelimit' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'int',
         'type' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'float',
         'type' => 'int',
       ),
     ),
-    'imagick::localcontrastimage' => 
+    'imagick::localcontrastimage' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'void',
         'radius' => 'float',
         'strength' => 'float',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'bool',
         'radius' => 'float',
         'strength' => 'float',
       ),
     ),
-    'imagick::newimage' => 
+    'imagick::newimage' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'columns' => 'int',
@@ -237,7 +237,7 @@ return array (
         'background_color' => 'ImagickPixel|string',
         'format=' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'bool',
         'columns' => 'int',
@@ -246,20 +246,20 @@ return array (
         'format=' => 'null|string',
       ),
     ),
-    'imagick::optimizeimagelayers' => 
+    'imagick::optimizeimagelayers' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'Imagick',
       ),
     ),
-    'imagick::similarityimage' => 
+    'imagick::similarityimage' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'Imagick',
         'image' => 'Imagick',
@@ -268,7 +268,7 @@ return array (
         'threshold=' => 'float',
         'metric=' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'Imagick',
         'image' => 'Imagick',
@@ -278,9 +278,9 @@ return array (
         'metric=' => 'int',
       ),
     ),
-    'imagick::subimagematch' => 
+    'imagick::subimagematch' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'Imagick',
         'image' => 'Imagick',
@@ -289,7 +289,7 @@ return array (
         'threshold=' => 'float',
         'metric=' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'Imagick',
         'image' => 'Imagick',
@@ -299,115 +299,115 @@ return array (
         'metric=' => 'int',
       ),
     ),
-    'imagickdraw::getclippath' => 
+    'imagickdraw::getclippath' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'false|string',
       ),
     ),
-    'imagickkernel::frommatrix' => 
+    'imagickkernel::frommatrix' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'ImagickKernel',
         'matrix' => 'list<list<float>>',
         'origin' => 'array<array-key, mixed>|null',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'ImagickKernel',
         'matrix' => 'list<list<float>>',
         'origin=' => 'array<array-key, mixed>|null',
       ),
     ),
-    'imagickpixel::ispixelsimilar' => 
+    'imagickpixel::ispixelsimilar' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'color' => 'ImagickPixel',
         'fuzz' => 'float',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'bool|null',
         'color' => 'ImagickPixel',
         'fuzz' => 'float',
       ),
     ),
-    'imagickpixel::ispixelsimilarquantum' => 
+    'imagickpixel::ispixelsimilarquantum' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'color' => 'string',
         'fuzz_quantum_range_scaled_by_square_root_of_three' => 'float',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'bool|null',
         'color' => 'string',
         'fuzz_quantum_range_scaled_by_square_root_of_three' => 'float',
       ),
     ),
-    'imagickpixel::issimilar' => 
+    'imagickpixel::issimilar' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'color' => 'ImagickPixel',
         'fuzz_quantum_range_scaled_by_square_root_of_three' => 'float',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'bool|null',
         'color' => 'ImagickPixel',
         'fuzz_quantum_range_scaled_by_square_root_of_three' => 'float',
       ),
     ),
-    'imagickpixeliterator::getcurrentiteratorrow' => 
+    'imagickpixeliterator::getcurrentiteratorrow' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'array<array-key, mixed>',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'array<array-key, mixed>|null',
       ),
     ),
-    'imagickpixeliterator::getnextiteratorrow' => 
+    'imagickpixeliterator::getnextiteratorrow' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'array<array-key, mixed>',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'array<array-key, mixed>|null',
       ),
     ),
-    'intlcalendar::clear' => 
+    'intlcalendar::clear' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'field=' => 'int|null',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'field=' => 'int|null',
       ),
     ),
-    'intlcalendar::set' => 
+    'intlcalendar::set' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'year' => 'int',
@@ -417,69 +417,7 @@ return array (
         'minute=' => 'int',
         'second=' => 'int',
       ),
-      'new' => 
-      array (
-        0 => 'true',
-        'year' => 'int',
-        'month' => 'int',
-        'dayOfMonth=' => 'int',
-        'hour=' => 'int',
-        'minute=' => 'int',
-        'second=' => 'int',
-      ),
-    ),
-    'intlcalendar::setfirstdayofweek' => 
-    array (
-      'old' => 
-      array (
-        0 => 'bool',
-        'dayOfWeek' => 'int',
-      ),
-      'new' => 
-      array (
-        0 => 'true',
-        'dayOfWeek' => 'int',
-      ),
-    ),
-    'intlcalendar::setminimaldaysinfirstweek' => 
-    array (
-      'old' => 
-      array (
-        0 => 'bool',
-        'days' => 'int',
-      ),
-      'new' => 
-      array (
-        0 => 'true',
-        'days' => 'int',
-      ),
-    ),
-    'intlgregoriancalendar::clear' => 
-    array (
-      'old' => 
-      array (
-        0 => 'bool',
-        'field=' => 'int|null',
-      ),
-      'new' => 
-      array (
-        0 => 'true',
-        'field=' => 'int|null',
-      ),
-    ),
-    'intlgregoriancalendar::set' => 
-    array (
-      'old' => 
-      array (
-        0 => 'bool',
-        'year' => 'int',
-        'month' => 'int',
-        'dayOfMonth=' => 'int',
-        'hour=' => 'int',
-        'minute=' => 'int',
-        'second=' => 'int',
-      ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'year' => 'int',
@@ -490,61 +428,123 @@ return array (
         'second=' => 'int',
       ),
     ),
-    'intlgregoriancalendar::setfirstdayofweek' => 
+    'intlcalendar::setfirstdayofweek' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'dayOfWeek' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'dayOfWeek' => 'int',
       ),
     ),
-    'intlgregoriancalendar::setminimaldaysinfirstweek' => 
+    'intlcalendar::setminimaldaysinfirstweek' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'days' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'days' => 'int',
       ),
     ),
-    'locale::setdefault' => 
+    'intlgregoriancalendar::clear' =>
     array (
-      'old' => 
+      'old' =>
+      array (
+        0 => 'bool',
+        'field=' => 'int|null',
+      ),
+      'new' =>
+      array (
+        0 => 'true',
+        'field=' => 'int|null',
+      ),
+    ),
+    'intlgregoriancalendar::set' =>
+    array (
+      'old' =>
+      array (
+        0 => 'bool',
+        'year' => 'int',
+        'month' => 'int',
+        'dayOfMonth=' => 'int',
+        'hour=' => 'int',
+        'minute=' => 'int',
+        'second=' => 'int',
+      ),
+      'new' =>
+      array (
+        0 => 'true',
+        'year' => 'int',
+        'month' => 'int',
+        'dayOfMonth=' => 'int',
+        'hour=' => 'int',
+        'minute=' => 'int',
+        'second=' => 'int',
+      ),
+    ),
+    'intlgregoriancalendar::setfirstdayofweek' =>
+    array (
+      'old' =>
+      array (
+        0 => 'bool',
+        'dayOfWeek' => 'int',
+      ),
+      'new' =>
+      array (
+        0 => 'true',
+        'dayOfWeek' => 'int',
+      ),
+    ),
+    'intlgregoriancalendar::setminimaldaysinfirstweek' =>
+    array (
+      'old' =>
+      array (
+        0 => 'bool',
+        'days' => 'int',
+      ),
+      'new' =>
+      array (
+        0 => 'true',
+        'days' => 'int',
+      ),
+    ),
+    'locale::setdefault' =>
+    array (
+      'old' =>
       array (
         0 => 'bool',
         'locale' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'locale' => 'string',
       ),
     ),
-    'locale_set_default' => 
+    'locale_set_default' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'locale' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'locale' => 'string',
       ),
     ),
-    'openssl_csr_sign' => 
+    'openssl_csr_sign' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'OpenSSLCertificate|false',
         'csr' => 'OpenSSLCertificateSigningRequest|string',
@@ -554,7 +554,7 @@ return array (
         'options=' => 'array<array-key, mixed>|null',
         'serial=' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'OpenSSLCertificate|false',
         'csr' => 'OpenSSLCertificateSigningRequest|string',
@@ -566,24 +566,24 @@ return array (
         'serial_hex=' => 'null|string',
       ),
     ),
-    'pdostatement::setfetchmode' => 
+    'pdostatement::setfetchmode' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'mode' => 'int',
         '...args=' => 'mixed',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'mode' => 'int',
         '...args=' => 'mixed',
       ),
     ),
-    'pg_select' => 
+    'pg_select' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'array<array-key, mixed>|false|string',
         'connection' => 'PgSql\\Connection',
@@ -592,7 +592,7 @@ return array (
         'flags=' => 'int',
         'mode=' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'array<array-key, mixed>|false|string',
         'connection' => 'PgSql\\Connection',
@@ -602,237 +602,237 @@ return array (
         'mode=' => 'int',
       ),
     ),
-    'phar::copy' => 
+    'phar::copy' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'from' => 'string',
         'to' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'from' => 'string',
         'to' => 'string',
       ),
     ),
-    'phar::decompressfiles' => 
+    'phar::decompressfiles' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
-    'phar::delete' => 
+    'phar::delete' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'localName' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'localName' => 'string',
       ),
     ),
-    'phar::delmetadata' => 
+    'phar::delmetadata' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
-    'phar::setalias' => 
+    'phar::setalias' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'alias' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'alias' => 'string',
       ),
     ),
-    'phar::setdefaultstub' => 
+    'phar::setdefaultstub' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'index=' => 'null|string',
         'webIndex=' => 'null|string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'index=' => 'null|string',
         'webIndex=' => 'null|string',
       ),
     ),
-    'phar::setstub' => 
+    'phar::setstub' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'stub' => 'string',
         'length=' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'stub' => 'string',
         'length=' => 'int',
       ),
     ),
-    'phar::unlinkarchive' => 
+    'phar::unlinkarchive' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'filename' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'filename' => 'string',
       ),
     ),
-    'phardata::copy' => 
+    'phardata::copy' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'from' => 'string',
         'to' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'from' => 'string',
         'to' => 'string',
       ),
     ),
-    'phardata::decompressfiles' => 
+    'phardata::decompressfiles' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
-    'phardata::delete' => 
+    'phardata::delete' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'localName' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'localName' => 'string',
       ),
     ),
-    'phardata::delmetadata' => 
+    'phardata::delmetadata' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
-    'phardata::setstub' => 
+    'phardata::setstub' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'stub' => 'string',
         'length=' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'stub' => 'string',
         'length=' => 'int',
       ),
     ),
-    'pharfileinfo::compress' => 
+    'pharfileinfo::compress' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'compression' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'compression' => 'int',
       ),
     ),
-    'pharfileinfo::decompress' => 
+    'pharfileinfo::decompress' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
-    'pharfileinfo::delmetadata' => 
+    'pharfileinfo::delmetadata' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
-    'resourcebundle::get' => 
+    'resourcebundle::get' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'mixed',
         'index' => 'int|string',
         'fallback=' => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'ResourceBundle|array<array-key, mixed>|int|null|string',
         'index' => 'int|string',
         'fallback=' => 'bool',
       ),
     ),
-    'resourcebundle_get' => 
+    'resourcebundle_get' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'mixed|null',
         'bundle' => 'ResourceBundle',
         'index' => 'int|string',
         'fallback=' => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'ResourceBundle|array<array-key, mixed>|int|null|string',
         'bundle' => 'ResourceBundle',
@@ -840,141 +840,158 @@ return array (
         'fallback=' => 'bool',
       ),
     ),
-    'splfixedarray::setsize' => 
+    'round' =>
     array (
-      'old' => 
+      'old' =>
+      array (
+        0 => 'float',
+        'num' => 'float|int',
+        'precision=' => 'int',
+        'mode=' => 'int<0, max>',
+      ),
+      'new' =>
+      array (
+        0 => 'float',
+        'num' => 'float|int',
+        'precision=' => 'int',
+        'mode=' => 'RoundingMode|int<0, max>',
+      ),
+    ),
+    'splfixedarray::setsize' =>
+    array (
+      'old' =>
       array (
         0 => 'bool',
         'size' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'size' => 'int',
       ),
     ),
-    'splheap::insert' => 
+    'splheap::insert' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'value' => 'mixed',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'value' => 'mixed',
       ),
     ),
-    'splpriorityqueue::insert' => 
+    'splpriorityqueue::insert' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'value' => 'mixed',
         'priority' => 'mixed',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'value' => 'mixed',
         'priority' => 'mixed',
       ),
     ),
-    'splpriorityqueue::recoverfromcorruption' => 
+    'splpriorityqueue::recoverfromcorruption' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'void',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
-    'sqlite3result::finalize' => 
+    'sqlite3result::finalize' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
-    'sqlite3stmt::close' => 
+    'sqlite3stmt::close' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
-    'stream_bucket_append' => 
+    'stream_bucket_append' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'void',
         'brigade' => 'resource',
         'bucket' => 'object',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'void',
         'brigade' => 'resource',
         'bucket' => 'StreamBucket',
       ),
     ),
-    'stream_bucket_make_writeable' => 
+    'stream_bucket_make_writeable' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'null|object',
         'brigade' => 'resource',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'StreamBucket|null',
         'brigade' => 'resource',
       ),
     ),
-    'stream_bucket_new' => 
+    'stream_bucket_new' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'object',
         'stream' => 'resource',
         'buffer' => 'string',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'StreamBucket',
         'stream' => 'resource',
         'buffer' => 'string',
       ),
     ),
-    'stream_bucket_prepend' => 
+    'stream_bucket_prepend' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'void',
         'brigade' => 'resource',
         'bucket' => 'object',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'void',
         'brigade' => 'resource',
         'bucket' => 'StreamBucket',
       ),
     ),
-    'stream_context_set_option' => 
+    'stream_context_set_option' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'context' => 'mixed',
@@ -982,7 +999,7 @@ return array (
         'option_name=' => 'null|string',
         'value=' => 'mixed',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'context' => 'mixed',
@@ -991,91 +1008,91 @@ return array (
         'value=' => 'mixed',
       ),
     ),
-    'stream_context_set_params' => 
+    'stream_context_set_params' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'context' => 'resource',
         'params' => 'array<array-key, mixed>',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'context' => 'resource',
         'params' => 'array<array-key, mixed>',
       ),
     ),
-    'trigger_error' => 
+    'trigger_error' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'message' => 'string',
         'error_level=' => '256|512|1024|16384',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'message' => 'string',
         'error_level=' => '256|512|1024|16384',
       ),
     ),
-    'user_error' => 
+    'user_error' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
         'message' => 'string',
         'error_level=' => 'int',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'message' => 'string',
         'error_level=' => 'int',
       ),
     ),
-    'xml_set_character_data_handler' => 
+    'xml_set_character_data_handler' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable|null',
       ),
     ),
-    'xml_set_default_handler' => 
+    'xml_set_default_handler' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable|null',
       ),
     ),
-    'xml_set_element_handler' => 
+    'xml_set_element_handler' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'start_handler' => 'callable',
         'end_handler' => 'callable',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
@@ -1083,109 +1100,109 @@ return array (
         'end_handler' => 'callable|null',
       ),
     ),
-    'xml_set_end_namespace_decl_handler' => 
+    'xml_set_end_namespace_decl_handler' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable|null',
       ),
     ),
-    'xml_set_external_entity_ref_handler' => 
+    'xml_set_external_entity_ref_handler' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable|null',
       ),
     ),
-    'xml_set_notation_decl_handler' => 
+    'xml_set_notation_decl_handler' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable|null',
       ),
     ),
-    'xml_set_processing_instruction_handler' => 
+    'xml_set_processing_instruction_handler' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable|null',
       ),
     ),
-    'xml_set_start_namespace_decl_handler' => 
+    'xml_set_start_namespace_decl_handler' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable|null',
       ),
     ),
-    'xml_set_unparsed_entity_decl_handler' => 
+    'xml_set_unparsed_entity_decl_handler' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
         'parser' => 'XMLParser',
         'handler' => 'callable|null',
       ),
     ),
-    'xmlreader::close' => 
+    'xmlreader::close' =>
     array (
-      'old' => 
+      'old' =>
       array (
         0 => 'bool',
       ),
-      'new' => 
+      'new' =>
       array (
         0 => 'true',
       ),
     ),
   ),
-  'removed' => 
+  'removed' =>
   array (
   ),
 );


### PR DESCRIPTION
This PR is for adding Roundable to the round- function as a possible parameter.

I also had to change the gen_callmap.sh to generate a new callmap.
After generation, more files did change, the changes to the round-function did pick up.