### PR TITLE
push original callable when creating callable-object in order to keep return type

### DIFF
--- a/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleNegatedAssertionReconciler.php
@@ -1698,7 +1698,7 @@ final class SimpleNegatedAssertionReconciler extends Reconciler
                 }
             } elseif ($type instanceof TCallable) {
                 $non_array_types[] = new TCallableString();
-                $non_array_types[] = new TCallableObject();
+                $non_array_types[] = new TCallableObject($type->from_docblock, $type);
                 $redundant = false;
             } elseif ($type instanceof TIterable) {
                 if (!$type->type_params[0]->isMixed() || !$type->type_params[1]->isMixed()) {

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -2387,9 +2387,9 @@ final class CallableTest extends TestCase
             'callableWithoutArray' => [
                 'code' => '<?php
                     /**
-                     * @psalm-param array|(callable():array) $var
+                     * @param array|(callable():array) $var
                      */
-                    function text(mixed $var): array
+                    function text($var): array
                     {
                         if (is_array($var)) {
                             return $var;

--- a/tests/CallableTest.php
+++ b/tests/CallableTest.php
@@ -2384,6 +2384,21 @@ final class CallableTest extends TestCase
                 f($ca);
                 PHP,
             ],
+            'callableWithoutArray' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-param array|(callable():array) $var
+                     */
+                    function text(mixed $var): array
+                    {
+                        if (is_array($var)) {
+                            return $var;
+                        }
+
+                        //callable-string can\'t specify return type but it doesn\'t error
+                        return call_user_func($var);
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
This should fix https://github.com/vimeo/psalm/issues/11062 (technically not optimally, when removing array from callable, Psalm transform it to callable-object|callable-string, however, callable-object can have a return type, callable-string can't. 

Psalm should probably complain that the callable-string doesn't allow to check the return type but somehow it doesn't)