### PR TITLE
Fix binding of T of static when called from a class scope

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -417,7 +417,7 @@ final class ArgumentAnalyzer
                 $argument_offset,
                 !$statements_analyzer->isStatic()
                     && (!$method_id || $method_id->method_name !== '__construct')
-                    ? $context->self
+                    ? ($method_id ? $method_id->fq_class_name : $context->self)
                     : null,
                 $context->calling_method_id ?: $context->calling_function_id,
             );

--- a/tests/Template/FunctionTemplateTest.php
+++ b/tests/Template/FunctionTemplateTest.php
@@ -1850,12 +1850,35 @@ final class FunctionTemplateTest extends TestCase
                     );
 
                     $test = $list->sortByArr(
-                        /** 
+                        /**
                          * @return list{0: mixed, 1: mixed}
                          */
                         static fn ($item): array => [$item, $item],
                         1,
                     );',
+            ],
+            'staticScope#11368' => [
+                'code' => '<?php
+                    abstract class Uuid
+                    {
+                        /**
+                         * @template T of self
+                         * @param T $uuid
+                         */
+                        final public function equals($uuid): void {}
+                    }
+
+                    class UserId1 extends Uuid {}
+                    class UserId2 extends Uuid {}
+
+                    class User
+                    {
+                        public function equals(self $user): void
+                        {
+                            (new UserId1())->equals(new UserId1());
+                        }
+                    }
+                ',
             ],
         ];
     }
@@ -2476,6 +2499,30 @@ final class FunctionTemplateTest extends TestCase
                      */
                     function test2(BType $_value): void {}',
                 'error_message' => 'InvalidTemplateParam',
+            ],
+            'staticScope#11368' => [
+                'code' => '<?php
+                    abstract class Uuid
+                    {
+                        /**
+                         * @template T of static
+                         * @param T $uuid
+                         */
+                        final public function equals($uuid): void {}
+                    }
+
+                    class UserId1 extends Uuid {}
+                    class UserId2 extends Uuid {}
+
+                    class User
+                    {
+                        public function equals(self $user): void
+                        {
+                            (new UserId1())->equals(new UserId2());
+                        }
+                    }
+                ',
+                'error_message' => 'ArgumentTypeCoercion',
             ],
         ];
     }


### PR DESCRIPTION
Partial fix for #11368

Issue appears to cement itself here - 
https://github.com/vimeo/psalm/blob/e052de4275fb6cdbfedfef1d883a7e90732ea609/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php#L418-L421
as `context->self = "User"` but the method was called on an instance of `UserId`

After updating to 

```php
 !$statements_analyzer->isStatic()
    && (!$method_id || $method_id->method_name !== '__construct')
    ? ($method_id ? $method_id->fq_class_name : $context->self)
    : null,
```

https://psalm.dev/r/a32e05de27
> ERROR: [ArgumentTypeCoercion](https://psalm.dev/193) - 19:33 - Argument 1 of UserId1::equals expects User&static, but parent type UserId1 provided

becomes 

> ERROR: [ArgumentTypeCoercion](https://psalm.dev/193) - 19:33 - Argument 1 of UserId1::equals expects UserId1&static, but parent type UserId1 provided

Now, using self instead of static works
```
    /**
     * @template T of self
     * @param T $uuid
     */
    final public function equals($uuid): void {}
```

I've seen the "A&static, but parent type A" style messaging elsewhere and unsure if this is now a legitimate issue or not.