### PR TITLE
Add `recursive-properties-of<T>` utility type

### DIFF
--- a/src/Psalm/Exception/RecursivePropertiesOfCycleException.php
+++ b/src/Psalm/Exception/RecursivePropertiesOfCycleException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Exception;
+
+use Exception;
+
+/**
+ * When `recursive-properties-of<T>` attempts to expand a cyclic reference,
+ * this exception is raised in lieu of running into a stack overflow.
+ */
+final class RecursivePropertiesOfCycleException extends Exception
+{
+}

--- a/src/Psalm/Exception/RecursivePropertiesOfIntersectionException.php
+++ b/src/Psalm/Exception/RecursivePropertiesOfIntersectionException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Exception;
+
+use Exception;
+
+/**
+ * The behaviour of intersection types within `recursive-properties-of<T>` is
+ * not defined. If an intersection type is encountered during expansion, this
+ * exception is thrown.
+ */
+final class RecursivePropertiesOfIntersectionException extends Exception
+{
+}

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -60,6 +60,7 @@ use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TObject;
 use Psalm\Type\Atomic\TObjectWithProperties;
 use Psalm\Type\Atomic\TPropertiesOf;
+use Psalm\Type\Atomic\TRecursivePropertiesOf;
 use Psalm\Type\Atomic\TString;
 use Psalm\Type\Atomic\TTemplateIndexedAccess;
 use Psalm\Type\Atomic\TTemplateKeyOf;
@@ -877,6 +878,17 @@ final class TypeParser
             return new TPropertiesOf(
                 $param_union_types[0],
                 TPropertiesOf::filterForTokenName($generic_type_value),
+                $from_docblock,
+            );
+        }
+
+        if ($generic_type_value === 'recursive-properties-of') {
+            if (count($generic_params) !== 1) {
+                throw new TypeParseTreeException('recursive-properties-of requires exactly one parameter.');
+            }
+
+            return new TRecursivePropertiesOf(
+                $generic_params[0],
                 $from_docblock,
             );
         }

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -90,6 +90,7 @@ final class TypeTokenizer
         'public-properties-of' => true,
         'protected-properties-of' => true,
         'private-properties-of' => true,
+        'recursive-properties-of' => true,
         'non-empty-countable' => true,
         'list' => true,
         'non-empty-list' => true,

--- a/src/Psalm/Type/Atomic/TKeyOf.php
+++ b/src/Psalm/Type/Atomic/TKeyOf.php
@@ -60,6 +60,7 @@ final class TKeyOf extends TArrayKey
                 && !$type instanceof TClassConstant
                 && !$type instanceof TKeyedArray
                 && !$type instanceof TPropertiesOf
+                && !$type instanceof TRecursivePropertiesOf
             ) {
                 return false;
             }

--- a/src/Psalm/Type/Atomic/TRecursivePropertiesOf.php
+++ b/src/Psalm/Type/Atomic/TRecursivePropertiesOf.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Type\Atomic;
+
+use Override;
+use Psalm\Codebase;
+use Psalm\Internal\Analyzer\StatementsAnalyzer;
+use Psalm\Internal\Type\TemplateInferredTypeReplacer;
+use Psalm\Internal\Type\TemplateResult;
+use Psalm\Internal\Type\TemplateStandinTypeReplacer;
+use Psalm\Storage\UnserializeMemoryUsageSuppressionTrait;
+use Psalm\Type\Atomic;
+use Psalm\Type\Union;
+
+/**
+ * Type that resolves to a keyed-array with properties of a class as keys and
+ * their appropriate types as values. Recursively expands class-like properties
+ * in the same way. Refer to `RecursivePropertiesOfExpander` for details on
+ * expansion.
+ *
+ * @internal
+ * @psalm-immutable
+ */
+final class TRecursivePropertiesOf extends Atomic
+{
+    use UnserializeMemoryUsageSuppressionTrait;
+
+    public function __construct(
+        public Union $types,
+        bool $from_docblock = false,
+    ) {
+        parent::__construct($from_docblock);
+    }
+
+    #[Override]
+    public function getKey(bool $include_extra = true): string
+    {
+        return 'recursive-properties-of<' . (string)$this->types . '>';
+    }
+
+    #[Override]
+    protected function getChildNodeKeys(): array
+    {
+        return ['types'];
+    }
+
+    /**
+     * @param  array<lowercase-string, string> $aliased_classes
+     */
+    #[Override]
+    public function toPhpString(
+        ?string $namespace,
+        array $aliased_classes,
+        ?string $this_class,
+        int $analysis_php_version_id,
+    ): string {
+        return $this->getKey();
+    }
+
+    #[Override]
+    public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return static
+     */
+    #[Override]
+    public function replaceTemplateTypesWithStandins(
+        TemplateResult $template_result,
+        Codebase $codebase,
+        ?StatementsAnalyzer $statements_analyzer = null,
+        ?Atomic $input_type = null,
+        ?int $input_arg_offset = null,
+        ?string $calling_class = null,
+        ?string $calling_function = null,
+        bool $replace = true,
+        bool $add_lower_bound = false,
+        int $depth = 0,
+    ): self {
+        $types_param = null;
+
+        if ($input_type instanceof TRecursivePropertiesOf) {
+            $types_param = $input_type->types;
+        }
+
+        $types = TemplateStandinTypeReplacer::replace(
+            $this->types,
+            $template_result,
+            $codebase,
+            $statements_analyzer,
+            $types_param,
+            $input_arg_offset,
+            $calling_class,
+            $calling_function,
+            $replace,
+            $add_lower_bound,
+            null,
+            $depth,
+        );
+
+        if ($types !== $this->types) {
+            $cloned = clone $this;
+            $cloned->types = $types;
+            return $cloned;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return static
+     */
+    #[Override]
+    public function replaceTemplateTypesWithArgTypes(
+        TemplateResult $template_result,
+        ?Codebase $codebase,
+    ): self {
+        $types = TemplateInferredTypeReplacer::replace(
+            $this->types,
+            $template_result,
+            $codebase,
+        );
+
+        if ($types !== $this->types) {
+            $cloned = clone $this;
+            $cloned->types = $types;
+            return $cloned;
+        }
+
+        return $this;
+    }
+
+    #[Override]
+    public function equals(Atomic $other_type, bool $ensure_source_equality): bool
+    {
+        if ($other_type::class !== static::class) {
+            return false;
+        }
+
+        /** @var static $other_type */
+        return $this->types->equals($other_type->types);
+    }
+}

--- a/src/Psalm/Type/Atomic/TValueOf.php
+++ b/src/Psalm/Type/Atomic/TValueOf.php
@@ -100,6 +100,7 @@ final class TValueOf extends Atomic
                 && !$type instanceof TClassConstant
                 && !$type instanceof TKeyedArray
                 && !$type instanceof TPropertiesOf
+                && !$type instanceof TRecursivePropertiesOf
                 && !$type instanceof TNamedObject
             ) {
                 return false;

--- a/src/Psalm/Type/RecursivePropertiesOfExpander.php
+++ b/src/Psalm/Type/RecursivePropertiesOfExpander.php
@@ -1,0 +1,511 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Type;
+
+use Psalm\Codebase;
+use Psalm\Exception\RecursivePropertiesOfCycleException;
+use Psalm\Exception\RecursivePropertiesOfIntersectionException;
+use Psalm\Internal\Type\TypeCombiner;
+use Psalm\Internal\Type\TypeExpander;
+use Psalm\Type;
+use Psalm\Type\Atomic;
+use Psalm\Type\Atomic\TArray;
+use Psalm\Type\Atomic\TCallableObject;
+use Psalm\Type\Atomic\TIterable;
+use Psalm\Type\Atomic\TKeyedArray;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Atomic\TObject;
+use Psalm\Type\Atomic\TObjectWithProperties;
+use Psalm\Type\Atomic\TPropertiesOf;
+use Psalm\Type\Atomic\TRecursivePropertiesOf;
+use Psalm\Type\Atomic\TTemplateParam;
+
+use function array_pop;
+use function array_search;
+use function array_slice;
+use function array_values;
+use function assert;
+use function count;
+use function implode;
+
+/**
+ * @internal
+ * @psalm-immutable
+ * @psalm-internal Psalm\Internal\Type\TypeExpander
+ * @psalm-suppress InternalClass,InternalMethod This class is calling its own methods.
+ */
+final class RecursivePropertiesOfExpander
+{
+    /**
+     * Expand `recursive-properties-of<T>`, where `T` is a union.
+     *
+     * Unions expand into the union of `recursive-properties-of<T>` applied to
+     * each part separately. E.g. `recursive-properties-of<T|U>` becomes
+     * `recursive-properties-of<T>|recursive-properties-of<U>`.
+     *
+     * @param list<TNamedObject> $expanded_parents
+     * @psalm-suppress InaccessibleProperty We just created the type.
+     */
+    public static function expandUnion(
+        Codebase $codebase,
+        Union $return_type,
+        ?string $self_class,
+        string|TNamedObject|TTemplateParam|null $static_class_type,
+        ?string $parent_class,
+        bool $evaluate_class_constants = true,
+        bool $evaluate_conditional_types = false,
+        bool $final = false,
+        bool $expand_generic = false,
+        bool $expand_templates = false,
+        bool $throw_on_unresolvable_constant = false,
+        array $expanded_parents = [],
+    ): Union {
+        $new_return_type_parts = [];
+
+        foreach ($return_type->getAtomicTypes() as $return_type_part) {
+            $parts = self::expandAtomic(
+                $codebase,
+                $return_type_part,
+                $self_class,
+                $static_class_type,
+                $parent_class,
+                $evaluate_class_constants,
+                $evaluate_conditional_types,
+                $final,
+                $expand_generic,
+                $expand_templates,
+                $throw_on_unresolvable_constant,
+                $expanded_parents,
+            );
+
+            $new_return_type_parts = [...$new_return_type_parts, ...$parts];
+        }
+
+        $fleshed_out_type = TypeCombiner::combine(
+            $new_return_type_parts,
+            $codebase,
+        );
+
+        $fleshed_out_type->from_docblock = $return_type->from_docblock;
+        $fleshed_out_type->ignore_nullable_issues = $return_type->ignore_nullable_issues;
+        $fleshed_out_type->ignore_falsable_issues = $return_type->ignore_falsable_issues;
+        $fleshed_out_type->possibly_undefined = $return_type->possibly_undefined;
+        $fleshed_out_type->possibly_undefined_from_try = $return_type->possibly_undefined_from_try;
+        $fleshed_out_type->by_ref = $return_type->by_ref;
+        $fleshed_out_type->initialized = $return_type->initialized;
+        $fleshed_out_type->from_property = $return_type->from_property;
+        $fleshed_out_type->from_static_property = $return_type->from_static_property;
+        $fleshed_out_type->explicit_never = $return_type->explicit_never;
+        $fleshed_out_type->had_template = $return_type->had_template;
+        $fleshed_out_type->parent_nodes = $return_type->parent_nodes;
+
+        return $fleshed_out_type;
+    }
+
+    /**
+     * Expand `recursive-properties-of<T>`, where `T` is an atomic type.
+     *
+     * - Arrays, lists, and objects with properties expand to array shapes,
+     *   with `recursive-properties-of<T>` applied to their value parameters.
+     * - `iterable`, equivalent to `array|\Traversable`, expands to `array`.
+     *     - `array` expands to `array` (`recursive-properties-of<mixed>` is
+     *       `mixed`), and `\Traversable` expands to `array<never, never>`. The
+     *       union `array|array<never, never>` simplifies to `array`.
+     * - Named objects are expanded to `recursive-properties-of<properties-of<T>>`.
+     * - Templates are not expanded, returning `recursive-properties-of<T>`,
+     *   where `T` is the original template. This defers expansion until the
+     *   template can be realized.
+     * - If another `recursive-properties-of<T>` is encountered during
+     *   expansion, it transparently expands its parameter.
+     * - All other types return themselves.
+     *
+     * When `recursive-properties-of<T>` attempts to expand a cyclic reference,
+     * a `RecursivePropertiesOfCycleException` is raised in lieu of running into
+     * a stack overflow.
+     *
+     * The behaviour of intersection types within `recursive-properties-of<T>` is
+     * not defined. If an intersection type is encountered during expansion, a
+     * `RecursivePropertiesOfIntersectionException` is thrown.
+     *
+     * @param list<TNamedObject> $expanded_parents
+     * @return (
+     *     $return_type is TIterable              ? list{TArray} :
+     *     $return_type is TNamedObject           ? list{TKeyedArray|TPropertiesOf} :
+     *     $return_type is TObject                ? list{TArray|TKeyedArray} :
+     *     $return_type is TRecursivePropertiesOf ? non-empty-list<Atomic> :
+     *     $return_type is TTemplateParam         ? list{TRecursivePropertiesOf} :
+     *     list{$return_type}
+     * )
+     */
+    public static function expandAtomic(
+        Codebase $codebase,
+        Atomic $return_type,
+        ?string $self_class,
+        string|TNamedObject|TTemplateParam|null $static_class_type,
+        ?string $parent_class,
+        bool $evaluate_class_constants = true,
+        bool $evaluate_conditional_types = false,
+        bool $final = false,
+        bool $expand_generic = false,
+        bool $expand_templates = false,
+        bool $throw_on_unresolvable_constant = false,
+        array $expanded_parents = [],
+    ): array {
+        if (Type::isIntersectionType($return_type)) {
+            /** @var TNamedObject|TTemplateParam|TIterable|TObjectWithProperties|TCallableObject $return_type */
+            if (count($return_type->getIntersectionTypes()) > 0) {
+                throw new RecursivePropertiesOfIntersectionException(
+                    'Intersections are not allowed in recursive-properties-of param (' . (string)$return_type . ').',
+                );
+            }
+        }
+
+        if ($return_type instanceof TArray) {
+            return [self::expandArray(
+                $codebase,
+                $return_type,
+                $self_class,
+                $static_class_type,
+                $parent_class,
+                $evaluate_class_constants,
+                $evaluate_conditional_types,
+                $final,
+                $expand_generic,
+                $expand_templates,
+                $throw_on_unresolvable_constant,
+                $expanded_parents,
+            )];
+        }
+
+        if ($return_type instanceof TKeyedArray) {
+            return [self::expandKeyedArray(
+                $codebase,
+                $return_type,
+                $self_class,
+                $static_class_type,
+                $parent_class,
+                $evaluate_class_constants,
+                $evaluate_conditional_types,
+                $final,
+                $expand_generic,
+                $expand_templates,
+                $throw_on_unresolvable_constant,
+                $expanded_parents,
+            )];
+        }
+
+        if ($return_type instanceof TIterable) {
+            return [new TArray([Type::getArrayKey(), Type::getMixed()])];
+        }
+
+        if ($return_type instanceof TNamedObject) {
+            return [self::expandNamedObject(
+                $codebase,
+                $return_type,
+                $self_class,
+                $static_class_type,
+                $parent_class,
+                $evaluate_class_constants,
+                $evaluate_conditional_types,
+                $final,
+                $expand_generic,
+                $expand_templates,
+                $throw_on_unresolvable_constant,
+                $expanded_parents,
+            )];
+        }
+
+        if ($return_type instanceof TObject) {
+            if ($return_type instanceof TObjectWithProperties) {
+                return [self::expandObjectWithProperties(
+                    $codebase,
+                    $return_type,
+                    $self_class,
+                    $static_class_type,
+                    $parent_class,
+                    $evaluate_class_constants,
+                    $evaluate_conditional_types,
+                    $final,
+                    $expand_generic,
+                    $expand_templates,
+                    $throw_on_unresolvable_constant,
+                    $expanded_parents,
+                )];
+            }
+
+            return [new TArray([Type::getNever(), Type::getNever()])];
+        }
+
+        if ($return_type instanceof TRecursivePropertiesOf) {
+            return array_values(self::expandUnion(
+                $codebase,
+                $return_type->types,
+                $self_class,
+                $static_class_type,
+                $parent_class,
+                $evaluate_class_constants,
+                $evaluate_conditional_types,
+                $final,
+                $expand_generic,
+                $expand_templates,
+                $throw_on_unresolvable_constant,
+                $expanded_parents,
+            )->getAtomicTypes());
+        }
+
+        if ($return_type instanceof TTemplateParam) {
+            return [new TRecursivePropertiesOf(new Union([$return_type]))];
+        }
+
+        return [$return_type];
+    }
+
+    /**
+     * Expand `recursive-properties-of<T>`, where `T` is an array type.
+     *
+     * Array types expand by applying `recursive-properties-of<T>` to their
+     * value parameters. E.g. `recursive-properties-of<array<K, V>>` expands to
+     * `array<K, recursive-properties-of<V>>`.
+     *
+     * @param list<TNamedObject> $expanded_parents
+     */
+    private static function expandArray(
+        Codebase $codebase,
+        TArray $return_type,
+        ?string $self_class,
+        string|TNamedObject|TTemplateParam|null $static_class_type,
+        ?string $parent_class,
+        bool $evaluate_class_constants = true,
+        bool $evaluate_conditional_types = false,
+        bool $final = false,
+        bool $expand_generic = false,
+        bool $expand_templates = false,
+        bool $throw_on_unresolvable_constant = false,
+        array $expanded_parents = [],
+    ): TArray {
+        return new TArray(
+            [
+                $return_type->type_params[0],
+                self::expandUnion(
+                    $codebase,
+                    $return_type->type_params[1],
+                    $self_class,
+                    $static_class_type,
+                    $parent_class,
+                    $evaluate_class_constants,
+                    $evaluate_conditional_types,
+                    $final,
+                    $expand_generic,
+                    $expand_templates,
+                    $throw_on_unresolvable_constant,
+                    $expanded_parents,
+                ),
+            ],
+        );
+    }
+
+    /**
+     * Expand `recursive-properties-of<T>`, where `T` is an array shape type.
+     *
+     * Array shape types expand by applying `recursive-properties-of<T>` to
+     * their value parameters. E.g. `recursive-properties-of<array{x: T}>`
+     * expands to `array{x: recursive-properties-of<T>}`.
+     *
+     * @param list<TNamedObject> $expanded_parents
+     */
+    private static function expandKeyedArray(
+        Codebase $codebase,
+        TKeyedArray $return_type,
+        ?string $self_class,
+        string|TNamedObject|TTemplateParam|null $static_class_type,
+        ?string $parent_class,
+        bool $evaluate_class_constants = true,
+        bool $evaluate_conditional_types = false,
+        bool $final = false,
+        bool $expand_generic = false,
+        bool $expand_templates = false,
+        bool $throw_on_unresolvable_constant = false,
+        array $expanded_parents = [],
+    ): TKeyedArray {
+        $new_properties = [];
+
+        foreach ($return_type->properties as $key => $value) {
+            $new_properties[$key] = self::expandUnion(
+                $codebase,
+                $value,
+                $self_class,
+                $static_class_type,
+                $parent_class,
+                $evaluate_class_constants,
+                $evaluate_conditional_types,
+                $final,
+                $expand_generic,
+                $expand_templates,
+                $throw_on_unresolvable_constant,
+                $expanded_parents,
+            );
+        }
+
+        $new_fallback_params = null;
+
+        if ($return_type->fallback_params !== null) {
+            $new_fallback_params = [
+                $return_type->fallback_params[0],
+                self::expandUnion(
+                    $codebase,
+                    $return_type->fallback_params[1],
+                    $self_class,
+                    $static_class_type,
+                    $parent_class,
+                    $evaluate_class_constants,
+                    $evaluate_conditional_types,
+                    $final,
+                    $expand_generic,
+                    $expand_templates,
+                    $throw_on_unresolvable_constant,
+                    $expanded_parents,
+                ),
+            ];
+        }
+
+        return new TKeyedArray(
+            $new_properties,
+            $return_type->class_strings,
+            $new_fallback_params,
+            $return_type->is_list,
+        );
+    }
+
+    /**
+     * Expand `recursive-properties-of<T>`, where `T` is a named object type.
+     *
+     * Named object types expand into `recursive-properties-of<properties-of<T>>`.
+     *
+     * @param list<TNamedObject> $expanded_parents
+     */
+    private static function expandNamedObject(
+        Codebase $codebase,
+        TNamedObject $return_type,
+        ?string $self_class,
+        string|TNamedObject|TTemplateParam|null $static_class_type,
+        ?string $parent_class,
+        bool $evaluate_class_constants = true,
+        bool $evaluate_conditional_types = false,
+        bool $final = false,
+        bool $expand_generic = false,
+        bool $expand_templates = false,
+        bool $throw_on_unresolvable_constant = false,
+        array $expanded_parents = [],
+    ): TKeyedArray|TPropertiesOf {
+        if (($cycle_start = array_search($return_type, $expanded_parents)) !== false) {
+            $cycle_path = implode(' -> ', array_slice($expanded_parents, $cycle_start)) . ' -> ' . (string)$return_type;
+
+            throw new RecursivePropertiesOfCycleException(
+                'Cyclic types are not allowed in recursive-properties-of param (' . $cycle_path . ').',
+            );
+        }
+
+        $properties_of = new TPropertiesOf($return_type, null);
+
+        $expanded_type = TypeExpander::expandAtomic(
+            $codebase,
+            $properties_of,
+            $self_class,
+            $static_class_type,
+            $parent_class,
+            $evaluate_class_constants,
+            $evaluate_conditional_types,
+            $final,
+            $expand_generic,
+            $expand_templates,
+            $throw_on_unresolvable_constant,
+        );
+
+        assert(
+            count($expanded_type) === 1 &&
+                ($expanded_type[0] instanceof TKeyedArray || $expanded_type[0] instanceof TPropertiesOf),
+            'Expanding TPropertiesOf should return either one TKeyedArray on success or one TPropertiesOf on failure'
+                . ' to find the requested class.',
+        );
+
+        $expanded_type = $expanded_type[0];
+
+        if ($expanded_type instanceof TKeyedArray) {
+            $expanded_parents[] = $return_type;
+
+            $expanded_type = self::expandKeyedArray(
+                $codebase,
+                $expanded_type,
+                $self_class,
+                $static_class_type,
+                $parent_class,
+                $evaluate_class_constants,
+                $evaluate_conditional_types,
+                $final,
+                $expand_generic,
+                $expand_templates,
+                $throw_on_unresolvable_constant,
+                $expanded_parents,
+            );
+
+            array_pop($expanded_parents);
+        }
+
+        return $expanded_type;
+    }
+
+    /**
+     * Expand `recursive-properties-of<T>`, where `T` is an object type with
+     * properties.
+     *
+     * Object types with properties expand into array shapes, applying
+     * `recursive-properties-of<T>` to their value parameters. E.g.
+     * `recursive-properties-of<object{x: T}>` expands to
+     * `array{x: recursive-properties-of<T>}`.
+     *
+     * @param list<TNamedObject> $expanded_parents
+     */
+    private static function expandObjectWithProperties(
+        Codebase $codebase,
+        TObjectWithProperties $return_type,
+        ?string $self_class,
+        string|TNamedObject|TTemplateParam|null $static_class_type,
+        ?string $parent_class,
+        bool $evaluate_class_constants = true,
+        bool $evaluate_conditional_types = false,
+        bool $final = false,
+        bool $expand_generic = false,
+        bool $expand_templates = false,
+        bool $throw_on_unresolvable_constant = false,
+        array $expanded_parents = [],
+    ): TArray|TKeyedArray {
+        $new_properties = [];
+
+        foreach ($return_type->properties as $key => $value) {
+            $new_properties[$key] = self::expandUnion(
+                $codebase,
+                $value,
+                $self_class,
+                $static_class_type,
+                $parent_class,
+                $evaluate_class_constants,
+                $evaluate_conditional_types,
+                $final,
+                $expand_generic,
+                $expand_templates,
+                $throw_on_unresolvable_constant,
+                $expanded_parents,
+            );
+        }
+
+        if (count($new_properties) === 0) {
+            return new TArray([Type::getNever(), Type::getNever()]);
+        }
+
+        return new TKeyedArray(
+            $new_properties,
+        );
+    }
+}

--- a/tests/RecursivePropertiesOfTest.php
+++ b/tests/RecursivePropertiesOfTest.php
@@ -1,0 +1,307 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests;
+
+use Exception;
+use Override;
+use Psalm\Config;
+use Psalm\Context;
+use Psalm\Exception\RecursivePropertiesOfCycleException;
+use Psalm\Exception\RecursivePropertiesOfIntersectionException;
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+use function str_replace;
+use function strpos;
+use function strtoupper;
+use function substr;
+
+use const PHP_OS;
+use const PHP_VERSION_ID;
+
+final class RecursivePropertiesOfTest extends TestCase
+{
+    use ValidCodeAnalysisTestTrait;
+    use InvalidCodeAnalysisTestTrait;
+
+    #[Override]
+    public function providerValidCodeParse(): iterable
+    {
+        return [
+            'recursivePropertiesOfNamedObjects' => [
+                'code' => '<?php
+                    final class A {
+                        function __construct(
+                            public B $a,
+                        ) {}
+                    }
+
+                    final class B {
+                        /** @var int */
+                        public $b = 0;
+                    }
+
+                    /** @var recursive-properties-of<A> $a */
+                ',
+                'assertions' => [
+                    '$a===' => 'array{a: array{b: int}}',
+                ],
+            ],
+            'recursivePropertiesOfArrayLikes' => [
+                'code' => '<?php
+                    final class A {
+                        /** @var int */
+                        public $a = 0;
+                    }
+
+                    /** @var recursive-properties-of<array<A>> $array */
+                    /** @var recursive-properties-of<array{b: A}> $keyed_array */
+                    /** @var recursive-properties-of<list<A>> $list */
+                    /** @var recursive-properties-of<list{A}> $tuple */
+                    /** @var recursive-properties-of<object> $object */
+                    /** @var recursive-properties-of<object{b: A}> $object_with_properties */
+                ',
+                'assertions' => [
+                    '$array===' => 'array<array-key, array{a: int}>',
+                    '$keyed_array===' => 'array{b: array{a: int}}',
+                    '$list===' => 'list<array{a: int}>',
+                    '$tuple===' => 'list{array{a: int}}',
+                    '$object===' => 'array<never, never>',
+                    '$object_with_properties===' => 'array{b: array{a: int}}',
+                ],
+            ],
+            'recursivePropertiesOfUnions' => [
+                'code' => '<?php
+                    final class A {
+                        /** @var int */
+                        public $a = 0;
+                    }
+
+                    final class B {
+                        /** @var int */
+                        public $b = 0;
+                    }
+
+                    class C {
+                        /** @var int */
+                        public $a = 0;
+                        /** @var int */
+                        public $c = 0;
+                    }
+
+                    /** @var recursive-properties-of<A|B> $a_or_b */
+                    /** @var recursive-properties-of<A|C> $a_or_c */
+                    /** @var recursive-properties-of<A|B|C> $a_or_b_or_c */
+                ',
+                'assertions' => [
+                    '$a_or_b' => 'array{a?: int, b?: int}',
+                    '$a_or_c' => 'array{a: int, c?: int, ...<string, mixed>}',
+                    '$a_or_b_or_c' => 'array{a?: int, b?: int|mixed, c?: int, ...<string, mixed>}',
+                ],
+            ],
+            'recursivePropertiesOfIterable' => [
+                'code' => '<?php
+                    /** @var recursive-properties-of<iterable> $iterable */
+                ',
+                'assertions' => [
+                    '$iterable===' => 'array<array-key, mixed>',
+                ],
+            ],
+            'recursivePropertiesOfRecursivePropertiesOf' => [
+                'code' => '<?php
+                    final class A {
+                        /** @var int */
+                        public $a = 0;
+                    }
+
+                    /** @var recursive-properties-of<recursive-properties-of<A>> $a */
+                ',
+                'assertions' => [
+                    '$a===' => 'array{a: int}',
+                ],
+            ],
+            'recursivePropertiesOfOthers' => [
+                'code' => '<?php
+                    /** @var recursive-properties-of<int> $int */
+                    /** @var recursive-properties-of<bool> $bool */
+                    /** @var recursive-properties-of<string> $string */
+                    /** @var recursive-properties-of<callable(int): bool> $callable */
+                    /** @var recursive-properties-of<resource> $resource */
+                    /** @var recursive-properties-of<int-mask<1, 2, 4>> $int_mask */
+                ',
+                'assertions' => [
+                    '$int===' => 'int',
+                    '$bool===' => 'bool',
+                    '$string===' => 'string',
+                    '$callable===' => 'callable(int):bool',
+                    '$resource===' => 'resource',
+                    '$int_mask===' => '0|1|2|3|4|5|6|7',
+                ],
+            ],
+            'recursivePropertiesOfTemplates' => [
+                'code' => '<?php
+                    final class A {
+                        function __construct(
+                            public B $a,
+                        ) {}
+                    }
+
+                    final class B {
+                        /** @var int */
+                        public $b = 0;
+                    }
+
+                    class C {
+                        /** @var int */
+                        public $c = 0;
+                    }
+
+                    /**
+                     * @return recursive-properties-of<$a>
+                     * @psalm-suppress InvalidReturnType
+                     */
+                    function f($a) {}
+
+                    /** @var A $a */
+                    $namedObject = f($a);
+                    /** @var list<B> $a */
+                    $list = f($a);
+                    /** @var B|C $a */
+                    $union = f($a);
+                    /** @var iterable $a */
+                    $iterable = f($a);
+                    /** @var recursive-properties-of<B> $a */
+                    $recursive = f($a);
+                    /** @var int $a */
+                    $int = f($a);
+                ',
+                'assertions' => [
+                    '$namedObject===' => 'array{a: array{b: int}}',
+                    '$list===' => 'list<array{b: int}>',
+                    '$union===' => 'array{b?: int|mixed, c?: int, ...<string, mixed>}',
+                    '$iterable===' => 'array<array-key, mixed>',
+                    '$recursive===' => 'array{b: int}',
+                    '$int===' => 'int',
+                ],
+            ],
+        ];
+    }
+
+    #[Override]
+    public function providerInvalidCodeParse(): iterable
+    {
+        return [
+            'onlyOneParam' => [
+                'code' => '<?php
+                    class A {}
+
+                    class B {}
+
+                    /** @var recursive-properties-of<A, B> $two_params */
+                ',
+                'error_message' => 'InvalidDocblock',
+            ],
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     code: string,
+     *     exception: class-string<Exception>,
+     * }>
+     */
+    public function providerExceptionCodeParse(): iterable
+    {
+        return [
+            'noCyclicTypes' => [
+                'code' => '<?php
+                    class A {
+                        function __construct(
+                            public B $a,
+                        ) {}
+                    }
+
+                    class B {
+                        function __construct(
+                            public A $b,
+                        ) {}
+                    }
+
+                    /** @var recursive-properties-of<A> $cyclic */
+                ',
+                'exception' => RecursivePropertiesOfCycleException::class,
+            ],
+            'noIntersectionTypes' => [
+                'code' => '<?php
+                    class A {}
+
+                    class B {}
+
+                    /** @var recursive-properties-of<A&B> $cyclic */
+                ',
+                'exception' => RecursivePropertiesOfIntersectionException::class,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider providerExceptionCodeParse
+     * @small
+     * @param class-string<Exception> $exception
+     * @param list<string> $error_levels
+     */
+    public function testExceptionCode(
+        string $code,
+        string $exception,
+        array  $error_levels = [],
+        ?string $php_version = null,
+    ): void {
+        $test_name = $this->getTestName();
+        if (strpos($test_name, 'PHP80-') !== false) {
+            if (PHP_VERSION_ID < 8_00_00) {
+                $this->markTestSkipped('Test case requires PHP 8.0.');
+            }
+
+            if ($php_version === null) {
+                $php_version = '8.0';
+            }
+        } elseif (strpos($test_name, 'SKIPPED-') !== false) {
+            $this->markTestSkipped('Skipped due to a bug.');
+        }
+
+        if ($php_version === null) {
+            $php_version = '7.4';
+        }
+
+        // sanity check - do we have a PHP tag?
+        if (strpos($code, '<?php') === false) {
+            $this->fail('Test case must have a <?php tag');
+        }
+
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            $code = str_replace("\n", "\r\n", $code);
+        }
+
+        foreach ($error_levels as $error_level) {
+            $issue_name = $error_level;
+            $error_level = Config::REPORT_SUPPRESS;
+
+            Config::getInstance()->setCustomErrorLevel($issue_name, $error_level);
+        }
+
+        $this->project_analyzer->setPhpVersion($php_version, 'tests');
+
+        $file_path = self::$src_dir_path . 'somefile.php';
+
+        $this->expectException($exception);
+
+        $codebase = $this->project_analyzer->getCodebase();
+        $codebase->enterServerMode();
+        $codebase->config->visitPreloadedStubFiles($codebase);
+
+        $this->addFile($file_path, $code);
+        $this->analyzeFile($file_path, new Context());
+    }
+}

--- a/tests/TypeComparatorTest.php
+++ b/tests/TypeComparatorTest.php
@@ -72,6 +72,7 @@ final class TypeComparatorTest extends TestCase
             'int-mask-of' => true,
             'int-mask' => true,
             'pure-Closure' => true,
+            'recursive-properties-of' => true,
         ];
         foreach (TPropertiesOf::tokenNames() as $token_name) {
             $basic_generic_types[$token_name] = true;


### PR DESCRIPTION
My work is in the process of migrating from using array shapes to using classes. While the `properties-of<T>` utility type allows us to encode array shapes using classes, there are many cases where we have multi-level array shapes. Ideally, we could expand these additional levels as well.

This PR expands upon the `properties-of<T>` type added in #7359 by introducing a new `recursive-properties-of<T>` type that will recursively apply `properties-of<T>` to the values of array shapes.

```php
<?php

final class A
{
    public int $a;
    public B $b;
}

final class B
{
    public int $b;
}

/** @return properties-of<$a> */
function propertiesOf($a) {}

/** @return recursive-properties-of<$a> */
function recursivePropertiesOf($a) {}

// Returns array{a: int, b: B}
$properties_of = propertiesOf(new A);

// Returns array{a: int, b: array{b: int}}
$recursivePropertiesOf = recursivePropertiesOf(new A);
```

In the `recursive-properties-of<A>` case, the property `$b` is expanded into `properties-of<B>`. In addition to expanding class types, `recursive-properties-of<T>` will expand the values of arrays, lists, and objects with properties (converting the latter to an array shape). Union types are also supported.

```php
<?php

final class C
{
    public int $c;
}

// Returns list<array{c: int}>
/** @var list<C> $a */
$recursivePropertiesOfList = recursivePropertiesOf($a);

// Returns array{b?: int, c?: int}
/** @var B|C $a */
$recursivePropertiesOfUnion = recursivePropertiesOf($a);
```

For ease of implementation, applying `recursive-properties-of<T>` to any other type yields itself.

```php
<?php

// Returns int
/** @var int $a */
$recursivePropertiesOfInt = recursivePropertiesOf($a);
```

## Known Issues

At present, expansion will throw an exception if it encounters cyclic or intersection types. These exceptions are thrown in the output of Psalm itself. There may be a way to turn these into code issues, but all expansion currently takes place under `TypeExpander::expandAtomic()`, where there is no access to the list of suppressed issues needed by `IssueBuffer::maybeAdd()`.

## TODO

`recursive-properties-of<T>` still needs to be documented within the `doc/` section of the Psalm repository. How this type is documented will in part depend on whether or not `recursive-properties-of<T>` is to be considered a new variant of `properties-of<T>`, or a separate, but related, type.

## Psalm 7 Compatability

The `RecursivePropertiesOfExpander` class makes two calls to `TKeyedArray::__construct()`, which will be replaced by `TKeyedArray::make()` in Psalm 7. I believe these are the only changes that will need to be made at this time.