### PR TITLE
Disable diff mode

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -322,7 +322,7 @@ final class Psalm
 
         $show_info = self::initShowInfo($options);
 
-        $is_diff = self::initIsDiff($options);
+        $is_diff = false; // self::initIsDiff($options);
 
         $find_unused_code = self::shouldFindUnusedCode($options, $config);
 
@@ -489,12 +489,12 @@ final class Psalm
             : false;
     }
 
-    private static function initIsDiff(array $options): bool
+    /*private static function initIsDiff(array $options): bool
     {
         return !isset($options['no-diff'])
             && !isset($options['set-baseline'])
             && !isset($options['update-baseline']);
-    }
+    }*/
 
     /**
      * @param array<int,string> $args

--- a/tests/EndToEnd/PsalmEndToEndTest.php
+++ b/tests/EndToEnd/PsalmEndToEndTest.php
@@ -164,6 +164,7 @@ final class PsalmEndToEndTest extends TestCase
         );
     }
 
+    /*
     public function testPsalmDiff(): void
     {
         copy(__DIR__ . '/../fixtures/DummyProjectWithErrors/diff_composer.lock', self::$tmpDir . '/composer.lock');
@@ -187,7 +188,7 @@ final class PsalmEndToEndTest extends TestCase
         $this->assertSame(2, $result['CODE']);
 
         @unlink(self::$tmpDir . '/composer.lock');
-    }
+    }*/
 
     public function testTainting(): void
     {


### PR DESCRIPTION
Forcefully disables diff mode to avoid a whole set of issues.
Proper fixes will be coming up, in the meantime this means caching can be safely re-enabled.