### PR TITLE
:sparkles: Full support for iterables for `iterator_to_array`

### DIFF
--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/IteratorToArrayReturnTypeProvider.php
@@ -65,6 +65,12 @@ final class IteratorToArrayReturnTypeProvider implements FunctionReturnTypeProvi
                     continue;
                 }
 
+                if ($call_arg_atomic_type instanceof TIterable) {
+                    $key_type = $call_arg_atomic_type->type_params[0];
+                    $value_type = $call_arg_atomic_type->type_params[1];
+                    continue;
+                }
+
                 if ($call_arg_atomic_type instanceof TNamedObject
                     && AtomicTypeComparator::isContainedBy(
                         $codebase,

--- a/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/UnionTypeComparator.php
@@ -246,6 +246,13 @@ final class UnionTypeComparator
                     $is_atomic_contained_by = true;
                 }
 
+                if ($input_type_part instanceof Atomic\TIterable
+                    && ($container_type->hasArray() || $container_type->containsClassLike('traversable'))
+                ) {
+                    $scalar_type_match_found = false;
+                    $is_atomic_contained_by = true;
+                }
+
                 if ($atomic_comparison_result) {
                     if ($atomic_comparison_result->type_coerced) {
                         $some_type_coerced = true;

--- a/tests/Php82Test.php
+++ b/tests/Php82Test.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests;
+
+use Override;
+use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+final class Php82Test extends TestCase
+{
+    use ValidCodeAnalysisTestTrait;
+
+    #[Override]
+    public function providerValidCodeParse(): iterable
+    {
+        return [
+            'anyIterableConvert' => [
+                'code' => '<?php
+                    function castToArray(iterable $arr): array {
+                        return iterator_to_array($arr, false);
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.2',
+            ],
+            'iterator_to_arrayMixedKey' => [
+                'code' => '<?php
+                    /**
+                     * @template TKey
+                     * @template TValue
+                     * @param iterable<TKey, TValue> $iterable
+                     * @return array<TKey, TValue>
+                     */
+                    function toArray(iterable $iterable): array
+                    {
+                        return iterator_to_array($iterable);
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.2',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/vimeo/psalm/issues/11007, https://github.com/vimeo/psalm/issues/8824