### PR TITLE
[Doc] Clarify union vs. intersection for `numeric` supertype

### DIFF
--- a/docs/annotating_code/type_syntax/scalar_types.md
+++ b/docs/annotating_code/type_syntax/scalar_types.md
@@ -37,7 +37,7 @@ This is the same concept as [`int-mask`](#int-mask1-2-4) but this type is used w
 
 ## numeric
 
-`numeric` is a supertype of `int` or `float` and [`numeric-string`](#numeric-string).
+`numeric` is a supertype of `int` or `float` or [`numeric-string`](#numeric-string).
 
 ## class-string, interface-string
 


### PR DESCRIPTION
I guess it's `int|float|numeric-string`, and not `int|(float&numeric-string)` since `float` and `numeric-string` has no intersection. Since "or" and "and" was used in the same sentence, it was initially confusing me.