### PR TITLE
Avoid Uncaught TypeError when using str_starts_with()

### DIFF
--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -54,7 +54,7 @@ final class DocComment
         }
 
         foreach ($parsed_docblock->tags as $special_key => $_) {
-            if (str_starts_with($special_key, 'psalm-')) {
+            if (str_starts_with((string) $special_key, 'psalm-')) {
                 $special_key = substr($special_key, 6);
 
                 if (!in_array(


### PR DESCRIPTION
Cast $special_key to string to avoid Uncaught TypeError: str_starts_with(): Argument #1 ($haystack) must be of type string, int given