### PR TITLE
Implement cache consolidation with --consolidate-cache flag

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.x-dev@90b5b9f5e7c8e441b191d3c82c58214753d7c7c1">
+<files psalm-version="6.x-dev@4696e07d52a656123262c12f435aa0f6bc8690d3">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$comment_block->tags['variablesfrom'][0]]]></code>
@@ -1397,6 +1397,19 @@
     <MixedAssignment>
       <code><![CDATA[$dep]]></code>
     </MixedAssignment>
+    <PossiblyFalseArgument>
+      <code><![CDATA[$fileHash]]></code>
+      <code><![CDATA[$fileHash]]></code>
+      <code><![CDATA[$fileHash]]></code>
+    </PossiblyFalseArgument>
+    <PossiblyInvalidArrayAccess>
+      <code><![CDATA[unpack('V', $fileHash)[1]]]></code>
+      <code><![CDATA[unpack('V', $key)[1]]]></code>
+    </PossiblyInvalidArrayAccess>
+    <PossiblyUndefinedIntArrayOffset>
+      <code><![CDATA[unpack('V', $fileHash)[1]]]></code>
+      <code><![CDATA[unpack('V', $key)[1]]]></code>
+    </PossiblyUndefinedIntArrayOffset>
   </file>
   <file src="src/Psalm/Internal/Cli/LanguageServer.php">
     <RiskyTruthyFalsyComparison>

--- a/src/Psalm/Internal/Cache.php
+++ b/src/Psalm/Internal/Cache.php
@@ -116,7 +116,7 @@ final class Cache
                 && $f->getExtension() !== 'hash'
             ) {
                 $this->getItem($f->getFilename());
-                unlink($f->getPathName());
+                unlink($f->getPathname());
                 unlink($f->getPathname().'.hash');
             }
         }

--- a/src/Psalm/Internal/Cache.php
+++ b/src/Psalm/Internal/Cache.php
@@ -110,12 +110,14 @@ final class Cache
         flock($this->lock, LOCK_EX);
 
         foreach (new DirectoryIterator($this->dir) as $f) {
-            if ($f->isFile() && !$f->isDot() && $f->getFilename() !== 'consolidated'
+            if ($f->isFile() && !$f->isDot()
+                && $f->getFilename() !== 'consolidated'
+                && $f->getFilename() !== 'lock'
                 && $f->getExtension() !== 'hash'
             ) {
                 $this->getItem($f->getFilename());
-                unlink($f->getPath());
-                unlink($f->getPath().'.hash');
+                unlink($f->getPathName());
+                unlink($f->getPathname().'.hash');
             }
         }
         $consolidated = $this->serializer->serialize($this->cache);

--- a/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php
@@ -54,6 +54,11 @@ final class ClassLikeStorageCacheProvider
         $this->cache = new Cache($config, 'classlike_cache', $dependencies, $noFile);
     }
 
+    public function consolidate(): void
+    {
+        $this->cache->consolidate();
+    }
+
     public function writeToCache(ClassLikeStorage $storage, string $file_path, string $file_contents): void
     {
         $fq_classlike_name_lc = strtolower($storage->name);

--- a/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileReferenceCacheProvider.php
@@ -44,6 +44,11 @@ final class FileReferenceCacheProvider
         $this->cache = new Cache($config, 'file_reference', [$composerLock], $noFile);
     }
 
+    public function consolidate(): void
+    {
+        $this->cache->consolidate();
+    }
+
     public function getCachedFileReferences(): ?array
     {
         return $this->cache->getItem(self::REFERENCE_CACHE_NAME);

--- a/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
+++ b/src/Psalm/Internal/Provider/FileStorageCacheProvider.php
@@ -55,6 +55,11 @@ final class FileStorageCacheProvider
         $this->cache = new Cache($config, self::FILE_STORAGE_CACHE_DIRECTORY, $dependencies, $noFile);
     }
 
+    public function consolidate(): void
+    {
+        $this->cache->consolidate();
+    }
+    
     public function writeToCache(FileStorage $storage, string $file_contents): void
     {
         $this->cache->saveItem(strtolower($storage->file_path), $storage, hash('xxh128', $file_contents));

--- a/src/Psalm/Internal/Provider/ParserCacheProvider.php
+++ b/src/Psalm/Internal/Provider/ParserCacheProvider.php
@@ -31,6 +31,11 @@ final class ParserCacheProvider
         $this->stmtCache = new Cache($config, self::PARSER_CACHE_DIRECTORY, $deps, $noFile);
     }
 
+    public function consolidate(): void
+    {
+        $this->stmtCache->consolidate();
+    }
+
     /**
      * @return list<PhpParser\Node\Stmt>|null
      */


### PR DESCRIPTION
The new flag consolidates all cache files that Psalm uses for this specific project into a single for quicker runs when doing whole project scans.  

Make sure to consolidate the cache again after running Psalm before saving the cache via CI.