### PR TITLE
Add ignoreIncludeSideEffects configuration key

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -39,6 +39,7 @@
 
         <xs:attribute name="addParamDefaultToDocblockType" type="xs:boolean" default="false" />
         <xs:attribute name="allowFileIncludes" type="xs:boolean" default="true" />
+        <xs:attribute name="ignoreIncludeSideEffects" type="xs:boolean" default="false" />
         <xs:attribute name="allowStringToStandInForClass" type="xs:boolean" default="false" />
         <xs:attribute name="checkForThrowsDocblock" type="xs:boolean" default="false" />
         <xs:attribute name="checkForThrowsInGlobalScope" type="xs:boolean" default="false" />

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -465,6 +465,18 @@ Defaults to `$XDG_CACHE_HOME/psalm`. If `$XDG_CACHE_HOME` is either not set or e
 ```
 Whether or not to allow `require`/`include` calls in your PHP. Defaults to `true`.
 
+#### ignoreIncludeSideEffects
+```xml
+<psalm
+  ignoreIncludeSideEffects="[bool]"
+>
+```
+Whether or not to ignore side effects of includes.  
+
+Ignoring include side effects can significantly speed up scans on legacy codebases, but changes to variables or variables defined inside of included files will not be visible to Psalm (functions, constants and classes will still be visible anyway, especially if the hoistConstants, allConstantsGlobal, allFunctionsGlobal configuration parameters are set to true).  
+
+Defaults to `false`.
+
 #### serializer
 ```xml
 <psalm

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -300,6 +300,8 @@ final class Config
 
     public bool $allow_includes = true;
 
+    public bool $ignore_include_side_effects = false;
+
     /** @var 1|2|3|4|5|6|7|8 */
     public int $level = 1;
 
@@ -948,6 +950,7 @@ final class Config
             'hideAllErrorsExceptPassedFiles' => 'hide_all_errors_except_passed_files',
             'resolveFromConfigFile' => 'resolve_from_config_file',
             'allowFileIncludes' => 'allow_includes',
+            'ignoreIncludeSideEffects' => 'ignore_include_side_effects',
             'strictBinaryOperands' => 'strict_binary_operands',
             'allowBoolToLiteralBoolComparison' => 'allow_bool_to_literal_bool_comparison',
             'rememberPropertyAssignmentsAfterCall' => 'remember_property_assignments_after_call',

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -166,6 +166,9 @@ final class IncludeAnalyzer
 
             if ($current_file_analyzer->project_analyzer->fileExists($path_to_file)
                 && !$current_file_analyzer->project_analyzer->isDirectory($path_to_file)) {
+                if ($config->ignore_include_side_effects) {
+                    return true;
+                }
                 if ($statements_analyzer->hasParentFilePath($path_to_file)
                     || !$codebase->file_storage_provider->has($path_to_file)
                     || ($statements_analyzer->hasAlreadyRequiredFilePath($path_to_file)


### PR DESCRIPTION
Ignoring include side effects can significantly speed up scans on legacy codebases, but changes to variables or variables defined inside of included files will not be visible to Psalm (functions, constants and classes will still be visible anyway, especially if the hoistConstants, allConstantsGlobal, allFunctionsGlobal configuration parameters are set to true).  
