### PR TITLE
Improve performance by avoiding repeated scanning of files included/required only once

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -157,9 +157,16 @@ final class IncludeAnalyzer
                 && !$current_file_analyzer->project_analyzer->isDirectory($path_to_file)) {
                 if ($statements_analyzer->hasParentFilePath($path_to_file)
                     || !$codebase->file_storage_provider->has($path_to_file)
-                    || ($statements_analyzer->hasAlreadyRequiredFilePath($path_to_file)
-                        && (!$codebase->file_storage_provider->get($path_to_file)->has_extra_statements
-                            || in_array($stmt->type, [PhpParser\Node\Expr\Include_::TYPE_INCLUDE_ONCE, PhpParser\Node\Expr\Include_::TYPE_REQUIRE_ONCE])))
+                    || (
+                        $statements_analyzer->hasAlreadyRequiredFilePath($path_to_file)
+                        && (
+                            !$codebase->file_storage_provider->get($path_to_file)->has_extra_statements
+                            || in_array($stmt->type, [
+                                PhpParser\Node\Expr\Include_::TYPE_INCLUDE_ONCE,
+                                PhpParser\Node\Expr\Include_::TYPE_REQUIRE_ONCE,
+                            ])
+                        )
+                    )
                 ) {
                     return true;
                 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -158,7 +158,8 @@ final class IncludeAnalyzer
                 if ($statements_analyzer->hasParentFilePath($path_to_file)
                     || !$codebase->file_storage_provider->has($path_to_file)
                     || ($statements_analyzer->hasAlreadyRequiredFilePath($path_to_file)
-                        && !$codebase->file_storage_provider->get($path_to_file)->has_extra_statements)
+                        && (!$codebase->file_storage_provider->get($path_to_file)->has_extra_statements
+                            || in_array($stmt->type, [PhpParser\Node\Expr\Include_::TYPE_INCLUDE_ONCE, PhpParser\Node\Expr\Include_::TYPE_REQUIRE_ONCE])))
                 ) {
                     return true;
                 }


### PR DESCRIPTION
I'm not immediately sure how to effectively add a unit test for this.  If existing unit tests pass, I'll be tempted to merge it if no one has any concerns after a week or so.  This significantly speeds up scans and prevents memory issues on few older projects of ours with a ton of include and/or require calls which Psalm was incorrectly interpreting to be circular.  This should resolve them by more accurately mimicking actual `include_once()` and `require_once()` behavior, instead of treating them more like `include()` and `require()`.  Don't hesitate to speak up if anyone has any questions/concerns.