### PR TITLE
InvalidArgumentException due to dynamic class instantiation using a variable

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -33,6 +33,7 @@ use Psalm\Internal\GzipSerializer;
 use Psalm\Internal\IncludeCollector;
 use Psalm\Internal\Lz4Serializer;
 use Psalm\Internal\Provider\AddRemoveTaints\HtmlFunctionTainter;
+use Psalm\Internal\StringInterpreter\ClassStringInterpreter;
 use Psalm\Internal\Scanner\FileScanner;
 use Psalm\Issue\ArgumentIssue;
 use Psalm\Issue\ClassConstantIssue;
@@ -1668,6 +1669,10 @@ final class Config
         new HtmlFunctionTainter();
 
         $socket->registerHooksFromClass(HtmlFunctionTainter::class);
+
+        new ClassStringInterpreter();
+
+        $socket->registerHooksFromClass(ClassStringInterpreter::class);
     }
 
     private function loadPlugin(ProjectAnalyzer $projectAnalyzer, string $pluginClassName): PluginInterface

--- a/src/Psalm/Internal/PreloaderList.php
+++ b/src/Psalm/Internal/PreloaderList.php
@@ -851,6 +851,7 @@ final class PreloaderList {
         \Psalm\Internal\Preloader::class,
         \Psalm\Internal\PreloaderList::class,
         \Psalm\Internal\Provider\AddRemoveTaints\HtmlFunctionTainter::class,
+        \Psalm\Internal\StringInterpreter\ClassStringInterpreter::class,
         \Psalm\Internal\Provider\ClassLikeStorageCacheProvider::class,
         \Psalm\Internal\Provider\ClassLikeStorageProvider::class,
         \Psalm\Internal\Provider\DynamicFunctionStorageProvider::class,

--- a/src/Psalm/Internal/StringInterpreter/ClassStringInterpreter.php
+++ b/src/Psalm/Internal/StringInterpreter/ClassStringInterpreter.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\StringInterpreter;
+
+use AssertionError;
+use Exception;
+use InvalidArgumentException;
+use LogicException;
+use Override;
+use Psalm\Exception\CodeException;
+use Psalm\Exception\TypeParseTreeException;
+use Psalm\Exception\UnpopulatedClasslikeException;
+use Psalm\Exception\UnresolvableConstantException;
+use Psalm\Internal\Codebase\Reflection;
+use Psalm\Plugin\EventHandler\Event\StringInterpreterEvent;
+use Psalm\Plugin\EventHandler\StringInterpreterInterface;
+use Psalm\Type\Atomic\TLiteralClassString;
+use Psalm\Type\Atomic\TLiteralString;
+use ReflectionClass;
+use ReflectionException;
+use UnexpectedValueException;
+
+use function class_exists;
+use function enum_exists;
+use function interface_exists;
+use function ltrim;
+use function strtolower;
+use function trait_exists;
+
+/**
+ * @internal
+ */
+final class ClassStringInterpreter implements StringInterpreterInterface
+{
+    /**
+     * @throws AssertionError
+     * @throws Exception
+     * @throws InvalidArgumentException
+     * @throws LogicException
+     * @throws CodeException
+     * @throws TypeParseTreeException
+     * @throws UnpopulatedClasslikeException
+     * @throws UnresolvableConstantException
+     * @throws UnexpectedValueException
+     */
+    #[Override]
+    public static function getTypeFromValue(StringInterpreterEvent $event): ?TLiteralString
+    {
+        $value = $event->getValue();
+        if ($value === '') {
+            return null;
+        }
+
+        $value = ltrim($value, '\\');
+        $codebase = $event->getCodebase();
+        $value_lc = strtolower($value);
+
+        // Bunch of _exists() to make $value match the type class-string|object|trait-string
+        if ((class_exists($value) || interface_exists($value) || enum_exists($value) || trait_exists($value)) &&
+            $codebase->classlikes->doesClassLikeExist($value_lc)) {
+            if (!$codebase->classlike_storage_provider->has($value)) {
+                $reflection = new Reflection($codebase->classlike_storage_provider, $codebase);
+                try {
+                    $reflection->registerClass(new ReflectionClass($value));
+                } catch (ReflectionException) {
+                    // `new ReflectionClass()` only throws if the class, interface, enum, or trait does not exist.
+                    // Which we check, so this should never happen.
+                    return null;
+                }
+            }
+
+            return new TLiteralClassString($value);
+        }
+
+        return null;
+    }
+}

--- a/tests/DynamicClassInstantiationUsingAVariable.php
+++ b/tests/DynamicClassInstantiationUsingAVariable.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests;
+
+use Psalm\Config;
+use Psalm\Context;
+
+final class DynamicClassInstantiationUsingAVariable extends TestCase
+{
+    /**
+     * Reproduces crash from GitHub issue #11491.
+     *
+     * Psalm fails to handle dynamic class instantiation when the throwable
+     * class is provided via a string variable, and the \Class or Class::class
+     * is not mentioned parsable by AST elsewhere in the code.
+     */
+    public function testDynamicThrowableCrash(): void
+    {
+        /*
+         * To make this a passing test case for the current failure in Psalm
+         * From:
+         *  - 3.4.0@99e6cd819f829babf50c5852d6f62d40b1fec9d9 (2019-06-03)
+         * To at least:
+         *  -  Psalm 6.12.0@cf420941d061a57050b6c468ef2c778faf40aee2
+         * There is sadly no ->notExpectException()
+         */
+        // $this->expectException(InvalidArgumentException::class);
+        // $this->expectExceptionMessage('Could not get class storage for assertionerror');
+
+        /*
+         * Setting allow_string_standin_for_class to false turns the thrown exception into:
+         * Psalm\Exception\CodeException: InvalidStringClass - somefile.php:9:31 - String cannot be used as a class
+         */
+        // Config::getInstance()->allow_string_standin_for_class = false;
+
+        // Current exception:
+        //  InvalidArgumentException: Could not get class storage for assertionerror
+        Config::getInstance()->allow_string_standin_for_class = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace Foo;
+
+                class CrashingClass
+                {
+                    public function crashingFunction(): void
+                    {
+                        $variableThatPointsToThrowable = "\\AssertionError";
+                        throw new $variableThatPointsToThrowable("failed");
+                    }
+                }
+            ',
+        );
+
+        $context = new Context();
+
+        $this->analyzeFile('somefile.php', $context);
+    }
+}

--- a/tests/DynamicClassInstantiationUsingAVariable.php
+++ b/tests/DynamicClassInstantiationUsingAVariable.php
@@ -55,6 +55,8 @@ final class DynamicClassInstantiationUsingAVariable extends TestCase
             ',
         );
 
+        $this->project_analyzer->getCodebase()->config->initializePlugins($this->project_analyzer);
+
         $context = new Context();
 
         $this->analyzeFile('somefile.php', $context);


### PR DESCRIPTION
Add missing (built-in?) classes in Codebase->classlike_storage_provider using ReflectionClass.

Similar to \Psalm\Internal\Codebase\Scanner::convertClassesToFilePaths()

Should fix issue https://github.com/vimeo/psalm/issues/11491.