### PR TITLE
Replace unix `clear` command with ANSI escape codes to clear the screen

### DIFF
--- a/src/Psalm/Internal/Cli/Review.php
+++ b/src/Psalm/Internal/Cli/Review.php
@@ -132,7 +132,7 @@ final class Review
             'snippet' => $snippet,
             'selected_text' => $selected,
         ]) {
-            self::r('clear');
+            echo "\033[2J\033[H"; // Clear the terminal
             echo "{$type}: {$message}" . PHP_EOL . PHP_EOL;
             echo $snippet . PHP_EOL;
         

--- a/src/Psalm/Internal/Cli/Review.php
+++ b/src/Psalm/Internal/Cli/Review.php
@@ -132,7 +132,13 @@ final class Review
             'snippet' => $snippet,
             'selected_text' => $selected,
         ]) {
-            echo "\033[2J\033[H"; // Clear the terminal
+            if (strncasecmp(PHP_OS, 'WIN', 3) === 0) {
+                // Windows
+                self::r('cls');
+            } else {
+                // Linux/macOS
+                self::r('clear');
+            }
             echo "{$type}: {$message}" . PHP_EOL . PHP_EOL;
             echo $snippet . PHP_EOL;
         


### PR DESCRIPTION
Cross platform for Windows as well.