### PR TITLE
Fix the opcache status retrieval if restricted paths are set.

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -996,12 +996,7 @@ final class Psalm
 
         $hasJit = false;
         if (function_exists('opcache_get_status')) {
-            try {
-                $opcache_status = opcache_get_status();
-            } catch (RuntimeException) {
-                $opcache_status = [];
-            }
-            if (true === ($opcache_status['jit']['on'] ?? false)) {
+            if (true === (opcache_get_status()['jit']['on'] ?? false)) {
                 $hasJit = true;
                 $progress->write(PHP_EOL
                     . 'JIT acceleration: ON'
@@ -1045,7 +1040,7 @@ final class Psalm
                 . "This warning may be ignored by setting the PSALM_IGNORE_NO_OVERCOMMIT=1 environment variable "
                 . "(not recommended)."
                 . PHP_EOL . PHP_EOL;
-
+            
             fwrite(STDERR, $err);
             if (getenv('PSALM_IGNORE_NO_OVERCOMMIT') !== '1') {
                 exit(1);
@@ -1494,7 +1489,7 @@ final class Psalm
         Caching:
             --consolidate-cache
                 Consolidates all cache files that Psalm uses for this specific project into a single file,
-                for quicker runs when doing whole project scans.
+                for quicker runs when doing whole project scans.  
                 Make sure to consolidate the cache again after running Psalm before saving the cache via CI.
 
             --clear-cache


### PR DESCRIPTION
Fixes vimeo/psalm#11555

To avoid a `RuntimeException` if opcache API cannot be used, wrap a call to `opcache_get_status` in a `try ... catch` and use the result in the later comparisons.

### Testing instructions

 - Edit the appropriate `php.ini` file on your platform and set `opcache.restrict_api="/tmp"` or any similar path.
 - Try running `psalm` from the branch
 - It should proceed with the following message:
 
```
Running on PHP 8.4.11, Psalm 6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51.

JIT acceleration: OFF (an error occurred while enabling JIT)
Please report this to https://github.com/vimeo/psalm with your OS and PHP configuration!
```