### PR TITLE
Add a missing argument of PDO::sqliteCreateFunction().

### DIFF
--- a/dictionaries/CallMap_84.php
+++ b/dictionaries/CallMap_84.php
@@ -63149,6 +63149,7 @@ return array (
     'function_name' => 'string',
     'callback' => 'callable',
     'num_args=' => 'int',
+    'flags=' => 'int',
   ),
   'pdo\\mysql::__construct' => 
   array (


### PR DESCRIPTION
The method `PDO::sqliteCreateFunction()` which is an alias of `Pdo\Sqlite::createFunction()` is missing the `$flags` parameter declaration. This PR fixes this.

https://www.php.net/manual/en/pdo.sqlitecreatefunction.php
https://www.php.net/manual/en/pdo-sqlite.createfunction.php