### PR TITLE
dependencies : allow symfony 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,8 +41,8 @@
         "nikic/php-parser": "^5.0.0",
         "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
-        "symfony/console": "^6.0 || ^7.0",
-        "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3",
+        "symfony/console": "^6.0 || ^7.0 || ^8.0",
+        "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3 || ^8.0",
         "symfony/polyfill-php84": "^1.31.0"
     },
     "provide": {
@@ -64,7 +64,7 @@
         "psalm/plugin-phpunit": "^0.19",
         "slevomat/coding-standard": "^8.4",
         "squizlabs/php_codesniffer": "^3.6",
-        "symfony/process": "^6.0 || ^7.0"
+        "symfony/process": "^6.0 || ^7.0 || ^8.0"
     },
     "suggest": {
         "ext-igbinary": "^2.0.5 is required, used to serialize caching data",


### PR DESCRIPTION
Symfony 8 is now released (https://symfony.com/releases/8.0)

I've added ^8.0 as an allowed version for symfony dependencies on this project.
