### PR TITLE
ci: add nikic/php-parser deprecations to Psalm baseline

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.x-dev@cf420941d061a57050b6c468ef2c778faf40aee2">
+<files psalm-version="6.x-dev@2b0ff73c8bed091af231a0a80ac109126c92083a">
   <file src="examples/TemplateChecker.php">
     <PossiblyUndefinedIntArrayOffset>
       <code><![CDATA[$comment_block->tags['variablesfrom'][0]]]></code>
@@ -2005,6 +2005,20 @@
     <RiskyTruthyFalsyComparison>
       <code><![CDATA[!$this->enabled_plugins]]></code>
     </RiskyTruthyFalsyComparison>
+  </file>
+  <file src="src/Psalm/Internal/PreloaderList.php">
+    <DeprecatedClass>
+      <code><![CDATA[\PhpParser\Node\Expr\ArrayItem::class]]></code>
+      <code><![CDATA[\PhpParser\Node\Expr\ClosureUse::class]]></code>
+      <code><![CDATA[\PhpParser\Node\Scalar\DNumber::class]]></code>
+      <code><![CDATA[\PhpParser\Node\Scalar\Encapsed::class]]></code>
+      <code><![CDATA[\PhpParser\Node\Scalar\EncapsedStringPart::class]]></code>
+      <code><![CDATA[\PhpParser\Node\Scalar\LNumber::class]]></code>
+      <code><![CDATA[\PhpParser\Node\Stmt\DeclareDeclare::class]]></code>
+      <code><![CDATA[\PhpParser\Node\Stmt\PropertyProperty::class]]></code>
+      <code><![CDATA[\PhpParser\Node\Stmt\StaticVar::class]]></code>
+      <code><![CDATA[\PhpParser\Node\Stmt\UseUse::class]]></code>
+    </DeprecatedClass>
   </file>
   <file src="src/Psalm/Internal/Provider/ClassLikeStorageCacheProvider.php">
     <InvalidPropertyAssignmentValue>

--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -41,7 +41,7 @@
             <directory name="vendor/netresearch/jsonmapper" />
             <directory name="vendor/phpunit" />
             <directory name="vendor/mockery/mockery"/>
-            <file name="vendor/nikic/php-parser/lib/PhpParser/Node/UnionType.php" />
+            <directory name="vendor/nikic/php-parser"/>
         </ignoreFiles>
     </projectFiles>
 
@@ -80,7 +80,6 @@
         <MissingConstructor>
             <errorLevel type="suppress">
                 <directory name="tests"/>
-                <file name="vendor/nikic/php-parser/lib/PhpParser/Node/Name.php" />
             </errorLevel>
         </MissingConstructor>
 
@@ -135,38 +134,6 @@
                 <directory name="tests"/>
             </errorLevel>
         </PossiblyUndefinedStringArrayOffset>
-
-        <MixedPropertyTypeCoercion>
-            <errorLevel type="suppress">
-                <directory name="vendor/nikic/php-parser" />
-            </errorLevel>
-        </MixedPropertyTypeCoercion>
-
-        <PropertyTypeCoercion>
-            <errorLevel type="suppress">
-                <directory name="vendor/nikic/php-parser" />
-            </errorLevel>
-        </PropertyTypeCoercion>
-
-        <InvalidArrayOffset>
-            <errorLevel type="suppress">
-                <file name="vendor/nikic/php-parser/lib/PhpParser/Node/Stmt/Class_.php" />
-                <file name="vendor/nikic/php-parser/lib/PhpParser/Node/Stmt/ClassMethod.php" />
-            </errorLevel>
-        </InvalidArrayOffset>
-
-        <InvalidPropertyAssignmentValue>
-            <errorLevel type="suppress">
-                <file name="vendor/nikic/php-parser/lib/PhpParser/Node/MatchArm.php" />
-            </errorLevel>
-        </InvalidPropertyAssignmentValue>
-
-        <MixedAssignment>
-            <errorLevel type="suppress">
-                <directory name="vendor/nikic/php-parser" />
-            </errorLevel>
-        </MixedAssignment>
-
         <PropertyNotSetInConstructor>
             <errorLevel type="suppress">
                 <referencedProperty name="PhpParser\Node\Const_::$namespacedName" />


### PR DESCRIPTION
There are new deprecations in nikic
PHP-Parser v5.6.2

 https://github.com/nikic/PHP-Parser/commit/3374502720536d6a2d8c24de12be34ab2820cded