### PR TITLE
Fix `Imagick::getImageBlob()` return type

### DIFF
--- a/dictionaries/CallMap_84.php
+++ b/dictionaries/CallMap_84.php
@@ -40021,7 +40021,7 @@ return array (
   ),
   'imagick::getimageblob' => 
   array (
-    0 => 'null|string',
+    0 => 'string',
   ),
   'imagick::getimageblueprimary' => 
   array (

--- a/dictionaries/autogen/CallMap_84.php
+++ b/dictionaries/autogen/CallMap_84.php
@@ -24098,7 +24098,7 @@ return array (
   ),
   'imagick::getimageblob' => 
   array (
-    0 => 'null|string',
+    0 => 'string',
   ),
   'imagick::getimageblueprimary' => 
   array (

--- a/dictionaries/override/CallMap.php
+++ b/dictionaries/override/CallMap.php
@@ -25639,7 +25639,7 @@ return array (
   ),
   'imagick::getimageblob' => 
   array (
-    0 => 'null|string',
+    0 => 'string',
   ),
   'imagick::getimageblueprimary' => 
   array (

--- a/dictionaries/override/CallMap_84_delta.php
+++ b/dictionaries/override/CallMap_84_delta.php
@@ -213,17 +213,6 @@ return array (
         'evaluate' => 'int',
       ),
     ),
-    'imagick::getimageblob' => 
-    array (
-      'old' => 
-      array (
-        0 => 'string',
-      ),
-      'new' => 
-      array (
-        0 => 'null|string',
-      ),
-    ),
     'imagick::getregistry' => 
     array (
       'old' => 


### PR DESCRIPTION
The [latest version](https://github.com/Imagick/imagick/releases/tag/3.8.1) of the Imagick extension [fixes the return type](https://github.com/Imagick/imagick/pull/735) of `Imagick::getImageBlob()`, which was previously incorrectly marked as nullable. This PR updates the callmap to align with this change.