### PR TITLE
fix: deprecated null offset

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -1312,6 +1312,7 @@ final class InstancePropertyAssignmentAnalyzer
             if (!$property_storage->readonly
                 && !$context->collect_mutations
                 && !$context->collect_initializations
+                && $lhs_var_id !== null
                 && isset($context->vars_in_scope[$lhs_var_id])
                 && !$context->vars_in_scope[$lhs_var_id]->allow_mutations
             ) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssignmentAnalyzer.php
@@ -1864,7 +1864,7 @@ final class AssignmentAnalyzer
         if ($context->inside_try) {
             // Copy previous assignment's parent nodes inside a try. Since an exception could be thrown at any
             // point this is a workaround to ensure that use of a variable also uses all previous assignments.
-            if (isset($context->vars_in_scope[$extended_var_id])) {
+            if ($extended_var_id !== null && isset($context->vars_in_scope[$extended_var_id])) {
                 $parent_nodes += $context->vars_in_scope[$extended_var_id]->parent_nodes;
             }
         }

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -533,7 +533,7 @@ final class Scanner
     ): FileScanner {
         $path_parts = explode(DIRECTORY_SEPARATOR, $file_path);
         $file_name_parts = explode('.', array_pop($path_parts));
-        $extension = count($file_name_parts) > 1 ? array_pop($file_name_parts) : null;
+        $extension = count($file_name_parts) > 1 ? array_pop($file_name_parts) : '';
 
         $file_name = $this->config->shortenFileName($file_path);
 

--- a/src/Psalm/Internal/Provider/ParamsProvider/ArrayFilterParamsProvider.php
+++ b/src/Psalm/Internal/Provider/ParamsProvider/ArrayFilterParamsProvider.php
@@ -112,7 +112,7 @@ final class ArrayFilterParamsProvider implements FunctionParamsProviderInterface
                 $call_args[0]->value,
                 null,
                 $statements_source,
-            );
+            ) ?? '';
 
             $first_arg_type = $event->getContext()->vars_in_scope[$extended_var_id] ?? null;
         }


### PR DESCRIPTION
Fixes null offsets in codebase for PHP 8.5

> PHP Error: Using null as an array offset is deprecated, use an empty string instead

Psalm check fails because another PR must be merged first: https://github.com/vimeo/psalm/pull/11596