### PR TITLE
Declare `NoDiscard` attribute as immutable

### DIFF
--- a/stubs/Php85.phpstub
+++ b/stubs/Php85.phpstub
@@ -5,6 +5,7 @@ namespace {
      * When applied to a function or method, a warning is emitted if the
      * return value is not used.
      *
+     * @psalm-immutable
      * @since 8.5
      */
     #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION)]


### PR DESCRIPTION
## Problem

When using the new `NoDiscard` attribute on a _named constructor_ of a immutable class and that this named constructor is declared pure then Psalm `6.14` returns an error `ImpureMethodCall` on the attribute.

Example code: https://psalm.dev/r/1c176ef8bd

## Fix

Declare the `NoDiscard` class as immutable.

## Note

I tried creating a test (by looking at the `OverrideTest` as an example) but it errors with `The class NoDiscard doesn't have the Attribute attribute`. So far I haven't had the time to investigate how to fix that.