### PR TITLE
Allow setting no params with provider

### DIFF
--- a/src/Psalm/Internal/Provider/FunctionParamsProvider.php
+++ b/src/Psalm/Internal/Provider/FunctionParamsProvider.php
@@ -86,7 +86,7 @@ final class FunctionParamsProvider
             );
             $result = $class_handler($event);
 
-            if ($result) {
+            if ($result !== null) {
                 return $result;
             }
         }


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/11621

This is most likely a signifcant breaking change, since I saw various plugins use `return null;` and `return [];` alternating/in the same way, where `return null;` should be used