### PR TITLE
Fix false positive PropertyNotSetInConstructor for overridden and stubbed properties/classes

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -817,7 +817,8 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
                         // therefore invariance is not a problem, if the parent type contains the child type
                     } elseif ($property_storage->location
                         && !$property_type->equals($guide_property_type, false)
-                        && $guide_class_storage->user_defined
+                        // do not check $guide_class_storage->user_defined here
+                        // otherwise all stubbed won't report an error
                     ) {
                         IssueBuffer::maybeAdd(
                             new NonInvariantDocblockPropertyType(

--- a/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassAnalyzer.php
@@ -834,16 +834,40 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
                 }
             }
 
+            $is_promoted = $property_storage->is_promoted;
+
+            // handle if the current class does not have a constructor
+            // but overwrites the property declaration #11261
+            if (!$is_promoted
+                && !isset($storage->methods['__construct'])
+                && isset($storage->declaring_method_ids['__construct'])
+            ) {
+                $construct_fq_class_name = $storage->declaring_method_ids['__construct']->fq_class_name;
+                $construct_class_storage = $codebase->classlike_storage_provider->get($construct_fq_class_name);
+                if (isset($construct_class_storage->properties[$property_name])) {
+                    $is_promoted = $construct_class_storage->properties[$property_name]->is_promoted;
+                }
+            } elseif ($is_promoted
+                && !isset($storage->declaring_method_ids['__construct'])
+            ) {
+                // impossible unless someone created a bug
+                $is_promoted = false;
+            } elseif ($is_promoted) {
+                // handle if class that contains the __construct in use does not declare the property #10786
+                $construct_fq_class_name = $storage->declaring_method_ids['__construct']->fq_class_name;
+                $construct_class_storage = $codebase->classlike_storage_provider->get($construct_fq_class_name);
+                if (!isset($construct_class_storage->properties[$property_name])
+                    || !$construct_class_storage->properties[$property_name]->is_promoted
+                ) {
+                    $is_promoted = false;
+                }
+            }
+
             if ($property_storage->type) {
                 $property_type = $property_storage->type;
 
                 if (!$property_type->isMixed()
-                    && (!$property_storage->is_promoted
-                        || (strtolower($fq_class_name) !== strtolower($property_class_name)
-                            && isset($storage->declaring_method_ids['__construct'])
-                            && strtolower(
-                                $storage->declaring_method_ids['__construct']->fq_class_name,
-                            ) === strtolower($fq_class_name)))
+                    && !$is_promoted
                     && !$property_storage->has_default
                     && !($property_type->isNullable() && $property_type->from_docblock)
                 ) {
@@ -855,12 +879,7 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
                 }
             } else {
                 if (!$property_storage->has_default
-                    && (!$property_storage->is_promoted
-                        || (strtolower($fq_class_name) !== strtolower($property_class_name)
-                            && isset($storage->declaring_method_ids['__construct'])
-                            && strtolower(
-                                $storage->declaring_method_ids['__construct']->fq_class_name,
-                            ) === strtolower($fq_class_name)))) {
+                    && !$is_promoted) {
                     $property_type = new Union([new TMixed()], [
                         'initialized' => false,
                         'from_property' => true,
@@ -1070,24 +1089,50 @@ final class ClassAnalyzer extends ClassLikeAnalyzer
 
             $property = $property_class_storage->properties[$property_name];
 
-            $property_is_initialized = isset($property_class_storage->initialized_properties[$property_name]);
-
             if ($property->is_static) {
                 continue;
             }
 
-            if ($property->is_promoted
-                && strtolower($property_class_name) !== $fq_class_name_lc
-                && isset($storage->declaring_method_ids['__construct'])
-                && strtolower($storage->declaring_method_ids['__construct']->fq_class_name) === $fq_class_name_lc) {
-                $property_is_initialized = false;
-            }
-
-            if ($property->has_default || $property_is_initialized) {
+            if ($property->has_default) {
                 continue;
             }
 
             if ($property->type && $property->type->from_docblock && $property->type->isNullable()) {
+                continue;
+            }
+
+            $property_is_initialized = isset($property_class_storage->initialized_properties[$property_name]);
+
+            // handle if the current class does not have a constructor
+            // but overwrites the property declaration #11261
+            if (!$property_is_initialized
+                && !$property->is_promoted
+                && !isset($storage->methods['__construct'])
+                && isset($storage->declaring_method_ids['__construct'])
+            ) {
+                $construct_fq_class_name = $storage->declaring_method_ids['__construct']->fq_class_name;
+                $construct_class_storage = $codebase->classlike_storage_provider->get($construct_fq_class_name);
+                if (isset($construct_class_storage->properties[$property_name])) {
+                    $property_is_initialized = $construct_class_storage->properties[$property_name]->is_promoted;
+                }
+            } elseif ($property_is_initialized
+                && $property->is_promoted
+                && !isset($storage->declaring_method_ids['__construct'])
+            ) {
+                // impossible unless someone created a bug
+                $property_is_initialized = false;
+            } elseif ($property_is_initialized && $property->is_promoted) {
+                // handle if class that contains the __construct in use does not declare the property #10786
+                $construct_fq_class_name = $storage->declaring_method_ids['__construct']->fq_class_name;
+                $construct_class_storage = $codebase->classlike_storage_provider->get($construct_fq_class_name);
+                if (!isset($construct_class_storage->properties[$property_name])
+                    || !$construct_class_storage->properties[$property_name]->is_promoted
+                ) {
+                    $property_is_initialized = false;
+                }
+            }
+
+            if ($property_is_initialized) {
                 continue;
             }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Assignment/InstancePropertyAssignmentAnalyzer.php
@@ -703,7 +703,7 @@ final class InstancePropertyAssignmentAnalyzer
             $statements_analyzer,
         );
 
-        $var_id = ExpressionIdentifier::getVarId(
+        $var_id = ExpressionIdentifier::getExtendedVarId(
             $stmt,
             $statements_analyzer->getFQCLN(),
             $statements_analyzer,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticCallAnalyzer.php
@@ -93,8 +93,21 @@ final class StaticCallAnalyzer extends CallAnalyzer
                         $construct_fq_class_name = $construct_class_storage->name;
 
                         foreach ($construct_class_storage->properties as $property_name => $property_storage) {
+                            if (!isset($context->vars_in_scope['$this->' . $property_name])) {
+                                continue;
+                            }
+
+                            if ($property_storage->visibility === ClassLikeAnalyzer::VISIBILITY_PRIVATE) {
+                                continue;
+                            }
+
+                            if ($context->vars_in_scope['$this->' . $property_name]->initialized) {
+                                continue;
+                            }
+
                             if ($property_storage->is_promoted
-                                && isset($context->vars_in_scope['$this->' . $property_name])) {
+                                || ($construct_class_storage->stubbed && !empty($property_storage->type->initialized))
+                            ) {
                                 $context_type = $context->vars_in_scope['$this->' . $property_name];
                                 $context->vars_in_scope['$this->' . $property_name] = $context_type->setProperties(
                                     [

--- a/tests/InterfaceTest.php
+++ b/tests/InterfaceTest.php
@@ -756,7 +756,7 @@ final class InterfaceTest extends TestCase
                         return $r->value;
                     }',
                 'assertions' => [],
-                'ignored_issues' => [],
+                'ignored_issues' => ['MissingConstructor'],
                 'php_version' => '8.4',
             ],
             'interfacePropertyWithSetHook' => [
@@ -800,7 +800,7 @@ final class InterfaceTest extends TestCase
                         echo $rw->name;
                     }',
                 'assertions' => [],
-                'ignored_issues' => [],
+                'ignored_issues' => ['MissingConstructor'],
                 'php_version' => '8.4',
             ],
         ];

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -812,6 +812,19 @@ final class PropertyTypeTest extends TestCase
                         return $e->attributes->item(0);
                     }',
             ],
+            'variablePropertyAssignment' => [
+                'code' => '<?php
+                    class MyClass
+                    {
+                        protected int $num;
+
+                        public function __construct()
+                        {
+                            $myString = "num";
+                            $this->$myString = 5;
+                        }
+                    }',
+            ],
             'goodArrayProperties' => [
                 'code' => '<?php
                     interface I1 {}

--- a/tests/PropertyTypeTest.php
+++ b/tests/PropertyTypeTest.php
@@ -607,6 +607,65 @@ final class PropertyTypeTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'promotedPropertyOverwrittenNoConstructor' => [
+                'code' => '<?php
+                    class A
+                    {
+                        public function __construct(
+                            public array $abc,
+                        ) {}
+                    }
+
+                    class B extends A
+                    {
+                        public array $abc;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'promotedPropertyOverwrittenNoConstructorDeep' => [
+                'code' => '<?php
+                    class A
+                    {
+                        public function __construct(
+                            public array $abc,
+                        ) {}
+                    }
+
+                    class B extends A
+                    {
+                    }
+
+                    class C extends B
+                    {
+                        public array $abc;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'promotedPropertyOverwrittenNoConstructorDeep2' => [
+                'code' => '<?php
+                    class A
+                    {
+                        public function __construct(
+                            public array $abc,
+                        ) {}
+                    }
+
+                    class B extends A
+                    {
+                        public array $abc;
+                    }
+
+                    class C extends B
+                    {
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
             'propertyWithoutTypeSuppressingIssueAndAssertingNull' => [
                 'code' => '<?php
                     class A {
@@ -3606,6 +3665,25 @@ final class PropertyTypeTest extends TestCase
                     }
 
                     class B extends A
+                    {
+                        public function __construct() {}
+                    }',
+                'error_message' => 'PropertyNotSetInConstructor',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'promotedPropertyNotSetInExtendedConstructorDeep' => [
+                'code' => '<?php
+                    class A
+                    {
+                        public function __construct(
+                            public string $name,
+                        ) {}
+                    }
+
+                    class B extends A {}
+
+                    class C extends B
                     {
                         public function __construct() {}
                     }',

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -1474,4 +1474,330 @@ final class StubTest extends TestCase
         $this->expectExceptionMessage('TaintedHtml - src/somefile.php');
         $this->analyzeFile($file_path, new Context());
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPropertyNotSetInConstructorWithStubParent(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/ParentClassWithProperty.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $file_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Foo\Bar;
+
+                final class Xyz extends Bar {
+                	/**
+                     * @var string
+                     */
+                    private $world;
+
+                    public function __construct() {
+                        parent::__construct("b");
+                    }
+                }
+            ',
+        );
+
+        $this->expectException(CodeException::class);
+        $this->expectExceptionMessage('PropertyNotSetInConstructor');
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPropertyNotSetInConstructorWithStubParentNoError(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/ParentClassWithProperty.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $file_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Foo\Bar;
+
+                final class Xyz extends Bar {
+                	/**
+                     * @var string
+                     */
+                    private $world;
+
+                    public function __construct() {
+                        parent::__construct("b");
+
+                        $this->world = "xyz";
+                    }
+                }
+            ',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPropertyNotSetInConstructorWithStubParentNotCalled(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/ParentClassWithProperty.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $file_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Foo\Bar;
+
+                final class Xyz extends Bar {
+                	/**
+                     * @var string
+                     */
+                    private $world;
+
+                    public function __construct() {
+                        $this->world = "xyz";
+                    }
+                }
+            ',
+        );
+
+        $this->expectException(CodeException::class);
+        $this->expectExceptionMessage('PropertyNotSetInConstructor');
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPropertyNotSetInConstructorWithStubParentNotCalledNoConstruct(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/ParentClassWithProperty.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $file_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Foo\Bar;
+
+                final class Xyz extends Bar {
+                }
+            ',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPropertyNotSetInConstructorWithSelfStubbed(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/SelfWithProperty.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $file_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Foo\Bar;
+
+                final class Xyz extends Bar {
+                	/**
+                     * @var string
+                     */
+                    private $world;
+
+                    public function __construct() {
+                        $this->world = "xyz";
+                    }
+                }
+            ',
+        );
+
+        $this->expectException(CodeException::class);
+        $this->expectExceptionMessage('PropertyNotSetInConstructor');
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPropertyNotSetInConstructorWithSelfStubbedPrivateProperty(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/SelfWithProperty.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $file_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Foo\Bar;
+
+                final class Xyz extends Bar {
+                	/**
+                     * @var string
+                     */
+                    private $world;
+
+                    public function __construct() {
+                        parent::__construct("b");
+                    }
+                }
+            ',
+        );
+
+        $this->expectException(CodeException::class);
+        $this->expectExceptionMessage('PropertyNotSetInConstructor');
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPropertyNotSetInConstructorWithSelfStubbedNoError(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/SelfWithProperty.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $file_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Foo\Bar;
+
+                final class Xyz extends Bar {
+                	/**
+                     * @var string
+                     */
+                    private $world;
+
+                    public function __construct() {
+                        parent::__construct("b");
+
+                        $this->world = "xyz";
+                    }
+                }
+            ',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
 }

--- a/tests/fixtures/stubs/ParentClassWithProperty.phpstub
+++ b/tests/fixtures/stubs/ParentClassWithProperty.phpstub
@@ -1,0 +1,23 @@
+<?php
+
+namespace Foo;
+
+class Bar {
+	/**
+	 * @var string
+	 */
+	public $hello;
+
+	/**
+     * @var string
+     */
+    private $world;
+
+    /**
+     * @var string
+     */
+    private $abc;
+
+	public function __construct(string $a) {
+	}
+}

--- a/tests/fixtures/stubs/SelfWithProperty.phpstub
+++ b/tests/fixtures/stubs/SelfWithProperty.phpstub
@@ -1,0 +1,35 @@
+<?php
+
+namespace Foo {
+    class Bar {
+        /**
+         * @var string
+         */
+        public $hello;
+
+        /**
+         * @var string
+         */
+        private $world;
+
+        /**
+         * @var string
+         */
+        private $abc;
+
+        public function __construct(string $a) {
+        }
+    }
+}
+
+namespace {
+    final class Xyz extends \Foo\Bar {
+        /**
+         * @var string
+         */
+        private $world;
+
+        public function __construct() {
+        }
+    }
+}


### PR DESCRIPTION
Fix 4 false positives for `PropertyNotSetInConstructor`
- Improve and deduplicate logic of previous PR https://github.com/vimeo/psalm/pull/10817
- Fix https://github.com/vimeo/psalm/issues/11261
- Fix https://github.com/vimeo/psalm/issues/2319 - for stubbed classes, which generally do not contain any statements, assume that when calling parent::__construct(); all inherited, non-initialized properties are intialized. This assumption makes sense, since otherwise it would mean the stubbed class itself has PropertyNotSetInConstructor errors
- Fix https://github.com/vimeo/psalm/issues/9374