### PR TITLE
Fix various PHP 8.x "Implicit conversion from float ... to int loses precision" PHP Deprecated notices

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/ArithmeticOpAnalyzer.php
@@ -960,25 +960,25 @@ final class ArithmeticOpAnalyzer
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\Minus) {
             $result = $operand1 - $operand2;
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\Mod) {
-            if ($operand2 === 0) {
+            if ($operand2 === 0 || $operand2 === 0.0) {
                 return Type::getNever();
             }
 
-            $result = $operand1 % $operand2;
+            $result = (int) $operand1 % (int) $operand2;
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\Mul) {
             $result = $operand1 * $operand2;
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\Pow) {
             $result = $operand1 ** $operand2;
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\BitwiseOr) {
-            $result = $operand1 | $operand2;
+            $result = (int) $operand1 | (int) $operand2;
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\BitwiseAnd) {
-            $result = $operand1 & $operand2;
+            $result = (int) $operand1 & (int) $operand2;
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\BitwiseXor) {
-            $result = $operand1 ^ $operand2;
+            $result = (int) $operand1 ^ (int) $operand2;
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\ShiftLeft) {
-            $result = $operand1 << $operand2;
+            $result = (int) $operand1 << (int) $operand2;
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\ShiftRight) {
-            $result = $operand1 >> $operand2;
+            $result = (int) $operand1 >> (int) $operand2;
         } elseif ($operation instanceof PhpParser\Node\Expr\BinaryOp\Div) {
             if ($operand2 === 0 || $operand2 === 0.0) {
                 return Type::getNever();

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BitwiseNotAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BitwiseNotAnalyzer.php
@@ -59,7 +59,7 @@ final class BitwiseNotAnalyzer
                     $has_valid_operand = true;
                 } elseif ($type_part instanceof TFloat) {
                     $type_part = ($type_part instanceof TLiteralFloat) ?
-                        new TLiteralInt(~$type_part->value) :
+                        new TLiteralInt(~(int) $type_part->value) :
                         new TInt;
 
                     $stmt_expr_type->removeType($type_string);


### PR DESCRIPTION
Fix various PHP 8.x "Implicit conversion from float ... to int loses precision" PHP Deprecated notices

Perhaps error reporting in CI should include E_DEPRECATED?

No new tests added, since I actually encountered this by running the existing tests for the fixed code - however due to error reporting excluding E_DEPRECATED this was ignored