### PR TITLE
Array map impure unlink unused

### DIFF
--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -466,7 +466,15 @@ final class Functions
 
         if (!isset($function_callable->params)
             || ($args !== null && count($args) === 0)
-            || ($function_callable->return_type && $function_callable->return_type->isVoid())
+        ) {
+            $must_use = false;
+            return false;
+        }
+
+        if ($function_callable->return_type
+            && ($function_callable->return_type->isVoid()
+               || $function_callable->return_type->isNever()
+            )
         ) {
             $must_use = false;
             return false;

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -402,6 +402,7 @@ final class Functions
         bool &$must_use = true,
     ): bool {
         if (ImpureFunctionsList::isImpure($function_id)) {
+            $must_use = false;
             return false;
         }
 
@@ -422,6 +423,7 @@ final class Functions
         }
 
         if (($function_id === 'var_export' || $function_id === 'print_r') && !isset($args[1])) {
+            $must_use = false;
             return false;
         }
 
@@ -466,6 +468,7 @@ final class Functions
             || ($args !== null && count($args) === 0)
             || ($function_callable->return_type && $function_callable->return_type->isVoid())
         ) {
+            $must_use = false;
             return false;
         }
 

--- a/src/Psalm/Internal/Codebase/Functions.php
+++ b/src/Psalm/Internal/Codebase/Functions.php
@@ -6,7 +6,6 @@ namespace Psalm\Internal\Codebase;
 
 use Exception;
 use PhpParser\Node\Arg;
-use PhpParser\Node\Expr\Closure as ClosureNode;
 use PhpParser\Node\Scalar\String_;
 use Psalm\Codebase;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
@@ -480,8 +479,6 @@ final class Functions
             return false;
         }
 
-        $must_use = $function_id !== 'array_map'
-            || (isset($args[0]) && !$args[0]->value instanceof ClosureNode);
 
         foreach ($function_callable->params as $i => $param) {
             if ($param->type && $param->type->hasCallableType() && isset($args[$i])) {

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -401,7 +401,14 @@ final class Reflection
                 }
             }
 
-            $storage->pure = true;
+            $storage->pure = ! $callmap_callable
+                ? ! ImpureFunctionsList::isImpure($function_id)
+                : $this->codebase->functions->isCallMapFunctionPure(
+                    $this->codebase,
+                    null,
+                    $function_id,
+                    null,
+                );
 
             $storage->required_param_count = 0;
 

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -401,7 +401,7 @@ final class Reflection
                 }
             }
 
-            $storage->pure = ! $callmap_callable
+            $possibly_pure = ! $callmap_callable
                 ? ! ImpureFunctionsList::isImpure($function_id)
                 : $this->codebase->functions->isCallMapFunctionPure(
                     $this->codebase,
@@ -409,6 +409,17 @@ final class Reflection
                     $function_id,
                     null,
                 );
+
+            if ($possibly_pure
+                && ($storage->returns_by_ref
+                    || ($storage->return_type
+                        && !$storage->return_type->isVoid()
+                        && !$storage->return_type->isNever()
+                    )
+                )
+            ) {
+                $storage->pure = true;
+            }
 
             $storage->required_param_count = 0;
 

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1385,6 +1385,10 @@ final class UnusedCodeTest extends TestCase
                     bar(foo());
                     echo "hello";',
             ],
+            'arrayMapImpureCallback' => [
+                'code' => '<?php
+                    array_map("unlink", [__FILE__]);',
+            ],
         ];
     }
 

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -1389,6 +1389,10 @@ final class UnusedCodeTest extends TestCase
                 'code' => '<?php
                     array_map("unlink", [__FILE__]);',
             ],
+            'arrayMapImpureCallback2' => [
+                'code' => '<?php
+                    array_map("header", ["Cache-Control: no-cache"]);',
+            ],
         ];
     }
 


### PR DESCRIPTION
- Fix https://github.com/vimeo/psalm/issues/6687
- consistency/stability improvements for must-use and never return callable
- fix impure PHP native functions legacy reported as pure when using Reflection because it was forgotten to add the newly added impure handling there