### PR TITLE
array_map with mutation-free callable-array considered impure

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -288,7 +288,12 @@ final class ExistingAtomicStaticCallAnalyzer
             }
 
             if (!$context->inside_throw) {
-                if ($context->pure && !$method_storage->pure) {
+                if ($context->pure
+                    && !$method_storage->pure
+                    && !$method_storage->immutable
+                    && !$method_storage->mutation_free
+                    && !$method_storage->mutation_free_inferred
+                ) {
                     IssueBuffer::maybeAdd(
                         new ImpureMethodCall(
                             'Cannot call an impure method from a pure context',
@@ -296,7 +301,12 @@ final class ExistingAtomicStaticCallAnalyzer
                         ),
                         $statements_analyzer->getSuppressedIssues(),
                     );
-                } elseif ($context->mutation_free && !$method_storage->mutation_free) {
+                } elseif ($context->mutation_free
+                    && !$method_storage->pure
+                    && !$method_storage->immutable
+                    && !$method_storage->mutation_free
+                    && !$method_storage->mutation_free_inferred
+                ) {
                     IssueBuffer::maybeAdd(
                         new ImpureMethodCall(
                             'Cannot call a possibly-mutating method from a mutation-free context',
@@ -309,7 +319,7 @@ final class ExistingAtomicStaticCallAnalyzer
                     && $statements_analyzer->getSource()->track_mutations
                     && !$method_storage->pure
                 ) {
-                    if (!$method_storage->mutation_free) {
+                    if (!$method_storage->mutation_free && !$method_storage->immutable) {
                         $statements_analyzer->getSource()->inferred_has_mutation = true;
                     }
 

--- a/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/CallableTypeComparator.php
@@ -385,7 +385,10 @@ final class CallableTypeComparator
                         'callable',
                         $method_storage->params,
                         $converted_return_type,
-                        $method_storage->pure,
+                        $method_storage->pure
+                            || $method_storage->immutable
+                            || $method_storage->mutation_free
+                            || $method_storage->mutation_free_inferred,
                     );
                 } catch (UnexpectedValueException) {
                     // do nothing
@@ -453,7 +456,10 @@ final class CallableTypeComparator
                         'callable',
                         $method_storage->params,
                         $converted_return_type,
-                        $method_storage->pure,
+                        $method_storage->pure
+                            || $method_storage->immutable
+                            || $method_storage->mutation_free
+                            || $method_storage->mutation_free_inferred,
                     );
 
                     if ($template_result) {

--- a/tests/ImmutableAnnotationTest.php
+++ b/tests/ImmutableAnnotationTest.php
@@ -548,6 +548,40 @@ final class ImmutableAnnotationTest extends TestCase
                         return getData()[$key] ?? null;
                     }',
             ],
+            'allowMutationFreeCallableArrayInPureContext' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-mutation-free
+                     */
+                    final class PriceScopeCriteria {
+                        private array $priceCriteria;
+
+                        public function __construct(
+                            array $priceCriteria,
+                        ) {
+                            $this->priceCriteria = $priceCriteria;
+                        }
+
+                        /** @return self[] */
+                        public function splitToBatches(int $batchSize): array {
+                            return array_map(
+                                [ $this, "withPriceCriteria" ],
+                                array_chunk($this->priceCriteria, $batchSize),
+                            );
+                        }
+
+                        public function withPriceCriteria(array $priceCriteria): self {
+                            $self = clone $this;
+                            $self->priceCriteria = $priceCriteria;
+
+                            return $self;
+                        }
+                    }
+
+                    $x = new PriceScopeCriteria([]);
+                    $y = $x->splitToBatches(3);
+                    array_pop($y);',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fix [#8417](https://github.com/vimeo/psalm/issues/8417) previously incompletely fixed in [#2112](https://github.com/vimeo/psalm/issues/2112#issuecomment-1216195063)