### PR TITLE
Allow sebastian/diff 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
         "netresearch/jsonmapper": "^5.0",
         "nikic/php-parser": "^5.0.0",
-        "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0",
+        "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
         "symfony/console": "^6.0 || ^7.0 || ^8.0",
         "symfony/filesystem": "~6.3.12 || ~6.4.3 || ^7.0.3 || ^8.0",


### PR DESCRIPTION
This will unlock usage of PHPUnit 13 alongside Psalm

No BC are reported in this new version apart from dropping support for older PHP versions: https://github.com/sebastianbergmann/diff/blob/main/ChangeLog.md#800---2026-02-06