### PR TITLE
Distinguish intentional JIT disable from unexpected failure in status message

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -1002,10 +1002,19 @@ final class Psalm
                     . 'JIT acceleration: ON'
                     . PHP_EOL . PHP_EOL);
             } else {
-                $progress->write(PHP_EOL
-                    . 'JIT acceleration: OFF (an error occurred while enabling JIT)' . PHP_EOL
-                    . 'Please report this to https://github.com/vimeo/psalm with your OS and PHP configuration!'
-                    . PHP_EOL . PHP_EOL);
+                $jitSetting = ini_get('opcache.jit');
+                if ($jitSetting === false || $jitSetting === '' || $jitSetting === '0'
+                    || in_array(strtolower($jitSetting), ['off', 'disable', 'disabled'], true)
+                ) {
+                    $progress->write(PHP_EOL
+                        . 'JIT acceleration: OFF (opcache.jit is disabled)'
+                        . PHP_EOL . PHP_EOL);
+                } else {
+                    $progress->write(PHP_EOL
+                        . 'JIT acceleration: OFF (an error occurred while enabling JIT)' . PHP_EOL
+                        . 'Please report this to https://github.com/vimeo/psalm with your OS and PHP configuration!'
+                        . PHP_EOL . PHP_EOL);
+                }
             }
         } else {
             $progress->write(PHP_EOL


### PR DESCRIPTION
## Summary

When opcache is loaded but JIT is off, Psalm currently displays:

```
JIT acceleration: OFF (an error occurred while enabling JIT)
Please report this to https://github.com/vimeo/psalm with your OS and PHP configuration!
```

This is misleading when JIT was **intentionally disabled** (e.g. via `-d opcache.jit=disable` to work around PHP JIT segfaults during taint analysis).

This PR checks `ini_get('opcache.jit')` to distinguish between intentional disabling and unexpected failure:

- **Intentionally disabled** (`off`, `disable`, `0`, etc.) → `"JIT acceleration: OFF (opcache.jit is disabled)"`
- **Failed unexpectedly** → keeps the current error message + "Please report this"

## Context

We hit JIT segfaults (exit code 139) running `--taint-analysis` on a large Laravel codebase (~3400 files). The workaround is `PSALM_ALLOW_XDEBUG=1` + `-d opcache.jit=disable`, but the alarming error message causes confusion.

## Limitations

This is a minimal DX fix for the misleading message only. It does **not** address the underlying issue that `PsalmRestarter` force-enables JIT regardless of user intent.

The proper solution would be making JIT opt-in rather than forced — @theodorejb's approach in #11613 is the right direction for that. The benchmarks in #11589 consistently show JIT hurting performance across platforms, and it also causes stability issues (segfaults) during taint analysis. I'd love to see that work land.

Fixes **messaging** issue from #11589