### PR TITLE
Disable JIT by default, make it opt-in via --force-jit

### DIFF
--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -265,7 +265,7 @@ When `true`, Psalm will attempt to find all unused code (including unused variab
   forceJit="[bool]"
 >
 ```
-When `true`, Psalm will exit immediately if JIT acceleration (up to +20% performance) cannot be enabled, the equivalent of running with `--force-jit`. Defaults to `false`.
+When `true`, Psalm will enable JIT acceleration and exit immediately if it cannot be enabled, the equivalent of running with `--force-jit`. When `false` (default), Psalm runs without JIT.
 
 #### noCache
 ```xml

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -953,6 +953,7 @@ final class Psalm
         Progress $progress,
     ): void {
         $ini_handler = new PsalmRestarter('PSALM');
+        $ini_handler->enableJit = $force_jit;
 
         if (isset($options['disable-extension'])) {
             if (is_array($options['disable-extension'])) {
@@ -1001,20 +1002,20 @@ final class Psalm
                 $progress->write(PHP_EOL
                     . 'JIT acceleration: ON'
                     . PHP_EOL . PHP_EOL);
-            } else {
+            } elseif ($force_jit) {
                 $progress->write(PHP_EOL
                     . 'JIT acceleration: OFF (an error occurred while enabling JIT)' . PHP_EOL
                     . 'Please report this to https://github.com/vimeo/psalm with your OS and PHP configuration!'
                     . PHP_EOL . PHP_EOL);
             }
-        } else {
+        } elseif ($force_jit) {
             $progress->write(PHP_EOL
                 . 'JIT acceleration: OFF (opcache not installed or not enabled)' . PHP_EOL
-                . 'Install and enable the opcache extension to make use of JIT for a 20%+ performance boost!'
+                . 'Install and enable the opcache extension to use JIT with --force-jit.'
                 . PHP_EOL . PHP_EOL);
         }
         if ($force_jit && !$hasJit) {
-            $progress->write('Exiting because JIT was requested but is not available.' . PHP_EOL . PHP_EOL);
+            $progress->write('Exiting because --force-jit was set but JIT is not available.' . PHP_EOL . PHP_EOL);
             exit(1);
         }
 
@@ -1393,7 +1394,7 @@ final class Psalm
                 Used to disable certain extensions while Psalm is running.
 
             --force-jit
-                If set, requires JIT acceleration to be available in order to run Psalm, exiting immediately if it cannot be enabled.
+                Enable JIT acceleration. Exits immediately if JIT cannot be enabled.
 
             --threads=INT
                 If greater than one, Psalm will run the scan and analysis on multiple threads, speeding things up.

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -30,12 +30,20 @@ final class PsalmRestarter extends XdebugHandler
     private const REQUIRED_OPCACHE_SETTINGS = [
         'enable' => 1,
         'enable_cli' => 1,
-        'jit' => 1205,
         'validate_timestamps' => 0,
         'file_update_protection' => 0,
-        'jit_buffer_size' => 128 * 1024 * 1024,
         'max_accelerated_files' => 1_000_000,
         'interned_strings_buffer' => 64,
+        'optimization_level' => '0x7FFEBFFF',
+        'preload' => '',
+        'log_verbosity_level' => 0,
+        'save_comments' => 1,
+        'restrict_api' => '',
+    ];
+
+    private const JIT_OPCACHE_SETTINGS = [
+        'jit' => 1205,
+        'jit_buffer_size' => 128 * 1024 * 1024,
         'jit_max_root_traces' => 100_000,
         'jit_max_side_traces' => 100_000,
         'jit_max_exit_counters' => 100_000,
@@ -45,12 +53,9 @@ final class PsalmRestarter extends XdebugHandler
         'jit_hot_side_exit' => 1,
         'jit_blacklist_root_trace' => 255,
         'jit_blacklist_side_trace' => 255,
-        'optimization_level' => '0x7FFEBFFF',
-        'preload' => '',
-        'log_verbosity_level' => 0,
-        'save_comments' => 1,
-        'restrict_api' => '',
     ];
+
+    public bool $enableJit = false;
 
     private bool $required = false;
 
@@ -90,8 +95,7 @@ final class PsalmRestarter extends XdebugHandler
             return true;
         }
 
-            // restart to enable JIT if it's not configured in the optimal way
-        foreach (self::REQUIRED_OPCACHE_SETTINGS as $ini_name => $required_value) {
+        foreach ($this->getEffectiveOpcacheSettings() as $ini_name => $required_value) {
             $value = (string) ini_get("opcache.$ini_name");
             if ($ini_name === 'jit_buffer_size') {
                 $value = self::toBytes($value);
@@ -105,7 +109,7 @@ final class PsalmRestarter extends XdebugHandler
             }
         }
 
-            $requiredMemoryConsumption = self::getRequiredMemoryConsumption();
+        $requiredMemoryConsumption = $this->getRequiredMemoryConsumption();
 
         if ((int)ini_get('opcache.memory_consumption') < $requiredMemoryConsumption) {
             return true;
@@ -169,16 +173,15 @@ final class PsalmRestarter extends XdebugHandler
         // if it wasn't loaded then we apparently don't have opcache installed and there's no point trying
         // to tweak it
         $additional_options = $opcache_loaded ? [] : ['-dzend_extension=opcache'];
-        foreach (self::REQUIRED_OPCACHE_SETTINGS as $key => $value) {
+        foreach ($this->getEffectiveOpcacheSettings() as $key => $value) {
             $additional_options []= "-dopcache.{$key}={$value}";
         }
 
-        $requiredMemoryConsumption = self::getRequiredMemoryConsumption();
+        $requiredMemoryConsumption = $this->getRequiredMemoryConsumption();
 
         if ((int)ini_get('opcache.memory_consumption') < $requiredMemoryConsumption) {
             $additional_options []= "-dopcache.memory_consumption={$requiredMemoryConsumption}";
         }
-
 
         array_splice(
             $command,
@@ -192,15 +195,27 @@ final class PsalmRestarter extends XdebugHandler
     }
 
     /**
+     * @return array<string, int|string>
+     */
+    private function getEffectiveOpcacheSettings(): array
+    {
+        if ($this->enableJit) {
+            return self::REQUIRED_OPCACHE_SETTINGS + self::JIT_OPCACHE_SETTINGS;
+        }
+
+        return self::REQUIRED_OPCACHE_SETTINGS;
+    }
+
+    /**
      * @return positive-int
      */
-    private static function getRequiredMemoryConsumption(): int
+    private function getRequiredMemoryConsumption(): int
     {
         // Reserve for byte-codes
         $result = 256;
 
-        if (isset(self::REQUIRED_OPCACHE_SETTINGS['jit_buffer_size'])) {
-            $result += self::REQUIRED_OPCACHE_SETTINGS['jit_buffer_size'] / 1024 / 1024;
+        if ($this->enableJit) {
+            $result += self::JIT_OPCACHE_SETTINGS['jit_buffer_size'] / 1024 / 1024;
         }
 
         if (isset(self::REQUIRED_OPCACHE_SETTINGS['interned_strings_buffer'])) {


### PR DESCRIPTION
## Summary

Disable JIT by default and make it opt-in via the existing `--force-jit` flag / `forceJit` config option.

Recent PHP JIT changes (bug fixes and refactors that increased compilation times) have shifted the performance tradeoff — as confirmed by @danog's own benchmarks in #11589. Additionally, JIT causes segfaults (exit code 139) during taint analysis on certain platforms due to PHP core JIT bugs (php/php-src#17858, php/php-src#13180).

## Changes

- **`PsalmRestarter`**: Split `REQUIRED_OPCACHE_SETTINGS` into base opcache settings (always applied) and `JIT_OPCACHE_SETTINGS` (only applied when `enableJit` is true)
- **`Psalm.php`**: Pass `forceJit` to the restarter; JIT status messages only shown when `--force-jit` is set
- **Docs**: Updated `forceJit` description to reflect it now *enables* JIT rather than just guarding availability

## What stays the same

- Opcache is still always enabled and optimized
- `--force-jit` / `forceJit="true"` works exactly as before for users who want JIT
- Preloading behavior unchanged
- No new flags — the existing `forceJit` naturally becomes the opt-in

## DX

Default `psalm` just works — no JIT overhead, no segfaults, no misleading messages. Users who want JIT explicitly opt in.

## Open for discussion

This PR takes the simplest approach (JIT off by default). As a next step, we have a PoC for a `JitMode` enum with three modes — `auto` (default), `on`, `off` — providing more granular control: https://github.com/alies-dev/psalm/pull/2

Happy to iterate on the approach.

## Related

- #11589 — JIT performance discussion with benchmarks
- #11613 (@theodorejb) — original proposal to make JIT opt-in, which inspired this PR
- #11681 — minimal fix for the misleading "an error occurred" message (superseded by this PR)

Refs #11589