### PR TITLE
Fix --show-snippet option silently consuming next CLI argument

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -151,7 +151,7 @@ final class Psalm
         'root:',
         'set-baseline::',
         'show-info:',
-        'show-snippet:',
+        'show-snippet::',
         'stats',
         'threads:',
         'scan-threads:',


### PR DESCRIPTION
- Fix `--show-snippet` long option definition: use double colon (`::`, optional value) instead of single colon (`:`, required value)
- This prevents `getopt()` from silently consuming the next CLI argument as `--show-snippet`'s value

Fixes #11683
