### PR TITLE
Fix missing and inconsistent reporting of type hint issues and messages

### DIFF
--- a/src/Psalm/Internal/Analyzer/MethodComparator.php
+++ b/src/Psalm/Internal/Analyzer/MethodComparator.php
@@ -21,6 +21,7 @@ use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\ConstructorSignatureMismatch;
 use Psalm\Issue\ImplementedParamTypeMismatch;
 use Psalm\Issue\ImplementedReturnTypeMismatch;
+use Psalm\Issue\InvalidAttribute;
 use Psalm\Issue\LessSpecificImplementedReturnType;
 use Psalm\Issue\MethodSignatureMismatch;
 use Psalm\Issue\MethodSignatureMustProvideReturnType;
@@ -37,7 +38,6 @@ use Psalm\Storage\ClassLikeStorage;
 use Psalm\Storage\FunctionLikeParameter;
 use Psalm\Storage\MethodStorage;
 use Psalm\Type;
-use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TTemplateParam;
 use Psalm\Type\Union;
 
@@ -105,41 +105,76 @@ final class MethodComparator
             $suppressed_issues,
         );
 
-        if ($guide_method_storage->signature_return_type && $prevent_method_signature_mismatch) {
-            self::compareMethodSignatureReturnTypes(
-                $codebase,
-                $guide_classlike_storage,
-                $implementer_classlike_storage,
-                $guide_method_storage,
-                $implementer_method_storage,
-                $guide_method_storage->signature_return_type,
-                $cased_guide_method_id,
-                $implementer_called_class_name,
-                $cased_implementer_method_id,
-                $code_location,
-                $suppressed_issues,
-            );
+        if ($prevent_method_signature_mismatch) {
+            $guide_signature_return_type = $guide_method_storage->signature_return_type;
+
+            // CallMapHandler needed due to https://github.com/vimeo/psalm/issues/10378
+            if (!$guide_signature_return_type
+                && $codebase->analysis_php_version_id >= 8_01_00
+                && $guide_method_storage->return_type
+                && InternalCallMapHandler::inCallMap($cased_guide_method_id)
+            ) {
+                $guide_signature_return_type = TypeExpander::expandUnion(
+                    $codebase,
+                    $guide_method_storage->return_type,
+                    $guide_classlike_storage->is_trait && $guide_method_storage->abstract
+                        ? $implementer_classlike_storage->name
+                        : $guide_classlike_storage->name,
+                    $guide_classlike_storage->is_trait && $guide_method_storage->abstract
+                        ? $implementer_classlike_storage->name
+                        : $guide_classlike_storage->name,
+                    $guide_classlike_storage->is_trait && $guide_method_storage->abstract
+                        ? $implementer_classlike_storage->parent_class
+                        : $guide_classlike_storage->parent_class,
+                    true,
+                    true,
+                    false,
+                    true,
+                    true,
+                );
+
+                if ($guide_signature_return_type->hasMixed() && !$guide_signature_return_type->isSingle()) {
+                    // cannot be a type hint, since "mixed" is a standalone type
+                    $guide_signature_return_type = null;
+                }
+            }
+
+            if ($guide_signature_return_type) {
+                self::compareMethodSignatureReturnTypes(
+                    $codebase,
+                    $guide_classlike_storage,
+                    $implementer_classlike_storage,
+                    $guide_method_storage,
+                    $implementer_method_storage,
+                    $guide_signature_return_type,
+                    $cased_guide_method_id,
+                    $implementer_called_class_name,
+                    $cased_implementer_method_id,
+                    $code_location,
+                    $suppressed_issues,
+                );
+            }
         }
 
-        // CallMapHandler needed due to https://github.com/vimeo/psalm/issues/10378
-        if (!$guide_classlike_storage->user_defined
-            && $implementer_classlike_storage->user_defined
-            && $codebase->analysis_php_version_id >= 8_01_00
-            && (($guide_method_storage->return_type && InternalCallMapHandler::inCallMap($cased_guide_method_id))
-                || $guide_method_storage->signature_return_type
-            ) && !$implementer_method_storage->signature_return_type
-            && !array_any(
-                $implementer_method_storage->attributes,
-                static fn(AttributeStorage $s): bool => $s->fq_class_name === 'ReturnTypeWillChange',
-            )
-        ) {
-            IssueBuffer::maybeAdd(
-                new MethodSignatureMustProvideReturnType(
-                    'Method ' . $cased_implementer_method_id . ' must have a return type signature',
-                    $implementer_method_storage->location ?: $code_location,
-                ),
-                $suppressed_issues + $implementer_classlike_storage->suppressed_issues,
-            );
+        // if the implementer does not have a signature, we already report MethodSignatureMustProvideReturnType
+        // and we don't want duplicate errors for potentially the same thing
+        if ($implementer_method_storage->signature_return_type
+            && !InternalCallMapHandler::inCallMap($cased_guide_method_id)) {
+            foreach ($implementer_method_storage->attributes as $attribute) {
+                if ($attribute->fq_class_name !== 'ReturnTypeWillChange') {
+                    continue;
+                }
+
+                IssueBuffer::maybeAdd(
+                    new InvalidAttribute(
+                        'Attribute ReturnTypeWillChange can only be used when overriding PHP built-in methods',
+                        $attribute->name_location,
+                    ),
+                    $suppressed_issues + $implementer_classlike_storage->suppressed_issues,
+                );
+
+                break;
+            }
         }
 
         if ($guide_method_storage->return_type
@@ -427,82 +462,8 @@ final class MethodComparator
         }
 
         if ($prevent_method_signature_mismatch) {
-            if (!$guide_classlike_storage->user_defined
-                && $guide_param->type) {
-                $implementer_param_type = $implementer_param->signature_type;
-
-                $guide_param_signature_type = $guide_param->type;
-
-                $or_null_guide_param_signature_type = $guide_param->signature_type
-                    ? $guide_param->signature_type->getBuilder()
-                    : null;
-
-                if ($or_null_guide_param_signature_type) {
-                    $or_null_guide_param_signature_type->addType(new TNull);
-                }
-
-                if ($cased_guide_method_id === 'Serializable::unserialize') {
-                    $guide_param_signature_type = null;
-                    $or_null_guide_param_signature_type = null;
-                }
-
-                if (!$guide_param->type->hasMixed()
-                    && !$guide_param->type->from_docblock
-                    && ($implementer_param_type || $guide_param_signature_type)
-                ) {
-                    if ($implementer_param_type
-                        && (!$guide_param_signature_type
-                            || strtolower($implementer_param_type->getId())
-                                !== strtolower($guide_param_signature_type->getId()))
-                        && (!$or_null_guide_param_signature_type
-                            || strtolower($implementer_param_type->getId())
-                                !== strtolower($or_null_guide_param_signature_type->getId()))
-                    ) {
-                        if ($implementer_method_storage->cased_name === '__construct') {
-                            IssueBuffer::maybeAdd(
-                                new ConstructorSignatureMismatch(
-                                    'Argument ' . ($i + 1) . ' of '
-                                        . $cased_implementer_method_id . ' has wrong type \''
-                                        . $implementer_param_type . '\', expecting \''
-                                        . $guide_param_signature_type . '\' as defined by '
-                                        . $cased_guide_method_id,
-                                    $implementer_param->location
-                                        && $config->isInProjectDirs(
-                                            $implementer_param->location->file_path,
-                                        )
-                                        ? $implementer_param->location
-                                        : $code_location,
-                                ),
-                                $suppressed_issues + $implementer_classlike_storage->suppressed_issues,
-                            );
-                        } else {
-                            IssueBuffer::maybeAdd(
-                                new MethodSignatureMismatch(
-                                    'Argument ' . ($i + 1) . ' of '
-                                        . $cased_implementer_method_id . ' has wrong type \''
-                                        . $implementer_param_type . '\', expecting \''
-                                        . $guide_param_signature_type . '\' as defined by '
-                                        . $cased_guide_method_id,
-                                    $implementer_param->location
-                                        && $config->isInProjectDirs(
-                                            $implementer_param->location->file_path,
-                                        )
-                                        ? $implementer_param->location
-                                        : $code_location,
-                                ),
-                                $suppressed_issues + $implementer_classlike_storage->suppressed_issues,
-                            );
-                        }
-
-
-                        return;
-                    }
-                }
-            }
-
             if ($guide_param->name !== $implementer_param->name
                 && $guide_method_storage->allow_named_arg_calls
-                && $implementer_classlike_storage->user_defined
                 && $implementer_param->location
                 && $guide_method_storage->cased_name
                 && (!str_starts_with($guide_method_storage->cased_name, '__')
@@ -518,7 +479,7 @@ final class MethodComparator
                         && !$config->isInProjectDirs($guide_classlike_storage->location->file_path)
                     )
                 ) {
-                    if ($codebase->alter_code) {
+                    if ($codebase->alter_code && $implementer_classlike_storage->user_defined) {
                         $project_analyzer = ProjectAnalyzer::getInstance();
 
                         if ($stmt && isset($project_analyzer->getIssuesToFix()['ParamNameMismatch'])) {
@@ -553,25 +514,22 @@ final class MethodComparator
                 }
             }
 
-            if ($guide_classlike_storage->user_defined
-                && $implementer_param->signature_type
-                && $guide_param->signature_type
-            ) {
-                self::compareMethodSignatureParams(
-                    $codebase,
-                    $i,
-                    $guide_classlike_storage,
-                    $implementer_classlike_storage,
-                    $guide_method_storage,
-                    $implementer_method_storage,
-                    $guide_param,
-                    $implementer_param->signature_type,
-                    $cased_guide_method_id,
-                    $cased_implementer_method_id,
-                    $code_location,
-                    $suppressed_issues,
-                );
-            }
+            // because of contravariance, we also need to compare if the guide does not have a signature
+            // since this will result in a fatal error if the implementer has a non-mixed hint
+            self::compareMethodSignatureParams(
+                $codebase,
+                $i,
+                $guide_classlike_storage,
+                $implementer_classlike_storage,
+                $guide_method_storage,
+                $implementer_method_storage,
+                $guide_param,
+                $implementer_param->signature_type,
+                $cased_guide_method_id,
+                $cased_implementer_method_id,
+                $code_location,
+                $suppressed_issues,
+            );
         }
 
         if ($implementer_param->type
@@ -624,7 +582,7 @@ final class MethodComparator
         MethodStorage $guide_method_storage,
         MethodStorage $implementer_method_storage,
         FunctionLikeParameter $guide_param,
-        Union $implementer_param_signature_type,
+        ?Union $implementer_param_signature_type,
         string $cased_guide_method_id,
         string $cased_implementer_method_id,
         CodeLocation $code_location,
@@ -662,32 +620,128 @@ final class MethodComparator
                 $guide_classlike_storage->is_trait && $guide_method_storage->abstract
                     ? $implementer_classlike_storage->parent_class
                     : $guide_classlike_storage->parent_class,
+                true,
+                true,
+                false,
+                true,
+                true,
             );
 
-            $builder = $guide_method_storage_param_type->getBuilder();
-            foreach ($builder->getAtomicTypes() as $k => $t) {
-                if ($t instanceof TTemplateParam) {
-                    $builder->removeType($k);
-
-                    foreach ($t->as->getAtomicTypes() as $as_t) {
-                        $builder->addType($as_t);
-                    }
-                }
-            }
-
-            if ($builder->hasMixed()) {
+            if ($guide_method_storage_param_type->hasMixed() && !$guide_method_storage_param_type->isSingle()) {
+                $builder = $guide_method_storage_param_type->getBuilder();
                 foreach ($builder->getAtomicTypes() as $k => $_) {
                     if ($k !== 'mixed') {
                         $builder->removeType($k);
                     }
                 }
+
+                $guide_method_storage_param_type = $builder->freeze();
+                unset($builder);
             }
-            $guide_method_storage_param_type = $builder->freeze();
-            unset($builder);
 
             if (!$guide_method_storage_param_type->hasMixed() || $codebase->analysis_php_version_id >= 8_00_00) {
                 $guide_param_signature_type = $guide_method_storage_param_type;
             }
+        }
+
+        if ($codebase->analysis_php_version_id < 8_00_00
+            && $guide_param_signature_type
+            && (!$guide_param_signature_type->hasNamedObjectType()
+                || !$guide_param_signature_type->isSingleAndMaybeNullable())
+        ) {
+            if (!$implementer_param_signature_type) {
+                // "mixed" and union type hints are only available from PHP 8+
+                // don't report an error, as it is impossible for the user to allow a wider, contravariant type
+                // except for named objects
+                return;
+            }
+
+            // before most PHP 8 built-ins did not have type hints at all
+            // generally only some interface methods that accept object params had
+            // but the stubs/callmap does not distinguish that, leading to false positive errors
+            if (InternalCallMapHandler::inCallMap($cased_guide_method_id)) {
+                $guide_param_signature_type = null;
+            }
+        }
+
+        // built-in by-ref types don't seem to have a type hint in many cases
+        // e.g. php_user_filter::filter "&$consumed"
+        // similar to some params with default types for built-ins, e.g. __soapCall $inputHeaders
+        // if the implementer has one already
+        // keep the (possibly incorrect) parent one to prevent false positive errors
+        // at the cost of false negative/not reporting a fatal error
+        if (!$implementer_param_signature_type
+            && ($guide_param->by_ref || $guide_param->is_optional)
+            && InternalCallMapHandler::inCallMap($cased_guide_method_id)
+        ) {
+            $guide_param_signature_type = null;
+        }
+
+        // unlike for the return hint, the child param does not need a mixed hint if the parent is mixed
+        if (!$implementer_param_signature_type
+            && (!$guide_param_signature_type || $guide_param_signature_type->hasMixed())) {
+            return;
+        }
+
+        if (!$implementer_param_signature_type
+            && !$guide_classlike_storage->preserve_constructor_signature
+            && $guide_method_storage->cased_name === '__construct') {
+            return;
+        }
+
+        // invalid/impossible type hint, that sometimes is documented for internal functions
+        // since docblock and signature is not differentiated https://github.com/vimeo/psalm/issues/10378
+        if ($guide_param_signature_type
+            && $guide_param_signature_type->hasType('resource')
+            && InternalCallMapHandler::inCallMap($cased_guide_method_id)
+        ) {
+            return;
+        }
+
+        // if the parent has a non-mixed type hint, the child should too
+        // to ensure it was not accidentally forgotten
+        // at least an explicit 'mixed' to indicate intention
+        if (!$implementer_param_signature_type) {
+            $config = Config::getInstance();
+            if ($implementer_method_storage->cased_name === '__construct') {
+                IssueBuffer::maybeAdd(
+                    new ConstructorSignatureMismatch(
+                        'Argument ' . ($i + 1) . ' of '
+                        . $cased_implementer_method_id
+                        . ' does not have a type hint, expecting \''
+                        . $guide_param_signature_type->getKey() . '\' as defined by '
+                        . $cased_guide_method_id
+                        . ' or a type contravariant to it',
+                        $implementer_method_storage->params[$i]->location
+                        && $config->isInProjectDirs(
+                            $implementer_method_storage->params[$i]->location->file_path,
+                        )
+                            ? $implementer_method_storage->params[$i]->location
+                            : $code_location,
+                    ),
+                    $suppressed_issues + $implementer_classlike_storage->suppressed_issues,
+                );
+            } else {
+                IssueBuffer::maybeAdd(
+                    new MethodSignatureMismatch(
+                        'Argument ' . ($i + 1) . ' of '
+                        . $cased_implementer_method_id
+                        . ' does not have a type hint, expecting \''
+                        . $guide_param_signature_type->getKey() . '\' as defined by '
+                        . $cased_guide_method_id
+                        . ' or a type contravariant to it',
+                        $implementer_method_storage->params[$i]->location
+                        && $config->isInProjectDirs(
+                            $implementer_method_storage->params[$i]->location->file_path,
+                        )
+                            ? $implementer_method_storage->params[$i]->location
+                            : $code_location,
+                    ),
+                    $suppressed_issues + $implementer_classlike_storage->suppressed_issues,
+                );
+            }
+
+            return;
         }
 
         $implementer_param_signature_type = TypeExpander::expandUnion(
@@ -712,6 +766,8 @@ final class MethodComparator
         if (!$is_contained_by) {
             $config = Config::getInstance();
 
+            $guide_param_signature_type ??= Type::getMixed();
+
             if ($codebase->analysis_php_version_id >= 8_00_00
                 || $guide_classlike_storage->is_trait === $implementer_classlike_storage->is_trait
                 || !in_array($guide_classlike_storage->name, $implementer_classlike_storage->used_traits)
@@ -725,8 +781,8 @@ final class MethodComparator
                             'Argument ' . ($i + 1) . ' of '
                                 . $cased_implementer_method_id
                                 . ' has wrong type \''
-                                . $implementer_param_signature_type . '\', expecting \''
-                                . $guide_param_signature_type . '\' as defined by '
+                                . $implementer_param_signature_type->getKey() . '\', not contravariant to type \''
+                                . $guide_param_signature_type->getKey() . '\' as defined by '
                                 . $cased_guide_method_id,
                             $implementer_method_storage->params[$i]->location
                                 && $config->isInProjectDirs(
@@ -743,8 +799,8 @@ final class MethodComparator
                             'Argument ' . ($i + 1) . ' of '
                                 . $cased_implementer_method_id
                                 . ' has wrong type \''
-                                . $implementer_param_signature_type . '\', expecting \''
-                                . $guide_param_signature_type . '\' as defined by '
+                                . $implementer_param_signature_type->getKey() . '\', not contravariant to type \''
+                                . $guide_param_signature_type->getKey() . '\' as defined by '
                                 . $cased_guide_method_id,
                             $implementer_method_storage->params[$i]->location
                                 && $config->isInProjectDirs(
@@ -760,8 +816,8 @@ final class MethodComparator
                 IssueBuffer::maybeAdd(
                     new TraitMethodSignatureMismatch(
                         'Argument ' . ($i + 1) . ' of ' . $cased_implementer_method_id . ' has wrong type \'' .
-                            $implementer_param_signature_type . '\', expecting \'' .
-                            $guide_param_signature_type . '\' as defined by ' .
+                            $implementer_param_signature_type->getKey() . '\', not contravariant to type \'' .
+                            $guide_param_signature_type->getKey() . '\' as defined by ' .
                             $cased_guide_method_id,
                         $implementer_method_storage->params[$i]->location
                             && $config->isInProjectDirs(
@@ -979,7 +1035,7 @@ final class MethodComparator
                 ? $implementer_classlike_storage->name
                 : $guide_classlike_storage->name,
             ($guide_classlike_storage->is_trait && $guide_method_storage->abstract)
-                || $guide_classlike_storage->final
+            || $guide_classlike_storage->final
                 ? $implementer_classlike_storage->name
                 : $guide_classlike_storage->name,
             $guide_classlike_storage->is_trait && $guide_method_storage->abstract
@@ -990,21 +1046,59 @@ final class MethodComparator
             $implementer_method_storage->final,
         );
 
-        $implementer_signature_return_type = $implementer_method_storage->signature_return_type
-            ? TypeExpander::expandUnion(
-                $codebase,
-                $implementer_method_storage->signature_return_type,
-                $implementer_classlike_storage->is_trait
-                    ? $implementer_called_class_name
-                    : $implementer_classlike_storage->name,
-                $implementer_classlike_storage->is_trait
-                    ? $implementer_called_class_name
-                    : $implementer_classlike_storage->name,
-                $implementer_classlike_storage->parent_class,
-            ) : null;
+        // invalid/impossible type hint, that sometimes is documented for internal functions
+        // since docblock and signature is not differentiated https://github.com/vimeo/psalm/issues/10378
+        if ($guide_signature_return_type->hasType('resource')
+            && InternalCallMapHandler::inCallMap($cased_guide_method_id)
+        ) {
+            return;
+        }
+
+        if (!$implementer_method_storage->signature_return_type) {
+            if (!$guide_classlike_storage->user_defined
+               // must be built-in, not just stubbed
+               && InternalCallMapHandler::inCallMap($cased_guide_method_id)
+               && $codebase->analysis_php_version_id < 9_00_00
+               && ($codebase->analysis_php_version_id < 8_01_00
+                   || array_any(
+                       $implementer_method_storage->attributes,
+                       static fn(AttributeStorage $s): bool => $s->fq_class_name === 'ReturnTypeWillChange',
+                   )
+               )
+            ) {
+                // no error if return type will change for built-ins and no signature set at all
+                return;
+            }
+
+            // lack of a return type declaration is also considered a return type mismatch fatal error
+            // even if parent type hint is mixed!
+            IssueBuffer::maybeAdd(
+                new MethodSignatureMustProvideReturnType(
+                    'Method ' . $cased_implementer_method_id . ' must have a return type hint '
+                     . 'that is covariant to return type \''
+                     . $guide_signature_return_type->getKey() . '\' of inherited method '
+                     . $cased_guide_method_id,
+                    $implementer_method_storage->location ?: $code_location,
+                ),
+                $suppressed_issues + $implementer_classlike_storage->suppressed_issues,
+            );
+
+            return;
+        }
+
+        $implementer_signature_return_type = TypeExpander::expandUnion(
+            $codebase,
+            $implementer_method_storage->signature_return_type,
+            $implementer_classlike_storage->is_trait
+                ? $implementer_called_class_name
+                : $implementer_classlike_storage->name,
+            $implementer_classlike_storage->is_trait
+                ? $implementer_called_class_name
+                : $implementer_classlike_storage->name,
+            $implementer_classlike_storage->parent_class,
+        );
 
         $is_contained_by = $codebase->analysis_php_version_id >= 7_04_00
-            && $implementer_signature_return_type
             ? UnionTypeComparator::isContainedBy(
                 $codebase,
                 $implementer_signature_return_type,
@@ -1013,13 +1107,7 @@ final class MethodComparator
             : UnionTypeComparator::isContainedByInPhp($implementer_signature_return_type, $guide_signature_return_type);
 
         if (!$is_contained_by) {
-            if ($implementer_signature_return_type === null
-                && array_any(
-                    $implementer_method_storage->attributes,
-                    static fn(AttributeStorage $s): bool => $s->fq_class_name === 'ReturnTypeWillChange',
-                )) {
-                // no error if return type will change and no signature set at all
-            } elseif ($codebase->analysis_php_version_id >= 8_00_00
+            if ($codebase->analysis_php_version_id >= 8_00_00
                       || $guide_classlike_storage->is_trait === $implementer_classlike_storage->is_trait
                       || !in_array($guide_classlike_storage->name, $implementer_classlike_storage->used_traits)
                       || $implementer_method_storage->defining_fqcln !== $implementer_classlike_storage->name
@@ -1029,8 +1117,9 @@ final class MethodComparator
                 IssueBuffer::maybeAdd(
                     new MethodSignatureMismatch(
                         'Method ' . $cased_implementer_method_id . ' with return type \''
-                            . $implementer_signature_return_type . '\' is different to return type \''
-                            . $guide_signature_return_type . '\' of inherited method ' . $cased_guide_method_id,
+                            . $implementer_signature_return_type->getKey() . '\', not covariant to return type \''
+                            . $guide_signature_return_type->getKey() . '\' of inherited method '
+                            . $cased_guide_method_id,
                         $code_location,
                     ),
                     $suppressed_issues + $implementer_classlike_storage->suppressed_issues,
@@ -1039,8 +1128,9 @@ final class MethodComparator
                 IssueBuffer::maybeAdd(
                     new TraitMethodSignatureMismatch(
                         'Method ' . $cased_implementer_method_id . ' with return type \''
-                            . $implementer_signature_return_type . '\' is different to return type \''
-                            . $guide_signature_return_type . '\' of inherited method ' . $cased_guide_method_id,
+                            . $implementer_signature_return_type->getKey() . '\', not covariant to return type \''
+                            . $guide_signature_return_type->getKey() . '\' of inherited method '
+                            . $cased_guide_method_id,
                         $code_location,
                     ),
                     $suppressed_issues + $implementer_classlike_storage->suppressed_issues,

--- a/src/Psalm/Internal/Fork/PsalmRestarter.php
+++ b/src/Psalm/Internal/Fork/PsalmRestarter.php
@@ -75,6 +75,7 @@ final class PsalmRestarter extends XdebugHandler
      *
      * @param bool $default
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @psalm-suppress MethodSignatureMismatch
      */
     #[Override]
     protected function requiresRestart($default): bool
@@ -149,6 +150,7 @@ final class PsalmRestarter extends XdebugHandler
      *
      * @param non-empty-list<string> $command
      * @phpcsSuppress SlevomatCodingStandard.TypeHints.ParameterTypeHint.MissingNativeTypeHint
+     * @psalm-suppress MethodSignatureMismatch
      */
     #[Override]
     protected function restart($command): void

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -10,6 +10,8 @@ use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
 use const DIRECTORY_SEPARATOR;
+use const PHP_MAJOR_VERSION;
+use const PHP_MINOR_VERSION;
 
 final class AttributeTest extends TestCase
 {
@@ -250,32 +252,6 @@ final class AttributeTest extends TestCase
                         public function getIterator()
                         {
                             return new EmptyIterator();
-                        }
-                    }',
-                'assertions' => [],
-                'ignored_issues' => [],
-                'php_version' => '8.1',
-            ],
-            'returnTypeWillChangeNoSignatureType' => [
-                'code' => '<?php
-                    class Foo {
-                        /**
-                         * @param array<string> $arg
-                         * @return string
-                         */
-                        public function run($arg) : string {
-                            return implode("s", $arg);
-                        }
-                    }
-
-                    class Bar extends Foo {
-                        /**
-                         * @param array<string> $arg
-                         * @return string
-                         */
-                        #[ReturnTypeWillChange]
-                        public function run($arg) {
-                            return implode(" ", $arg);
                         }
                     }',
                 'assertions' => [],
@@ -840,6 +816,58 @@ final class AttributeTest extends TestCase
                 'error_message' => 'Attribute SensitiveParameter cannot be used on a method',
                 'ignored_issues' => [],
                 'php_version' => '8.2',
+            ],
+            'returnTypeWillChangeNotBuiltIn' => [
+                'code' => '<?php
+                    class Foo {
+                        /**
+                         * @param array<string> $arg
+                         * @return array|string
+                         */
+                        public function run($arg) : array|string {
+                            return rand(0, 1) ? implode("s", $arg) : $arg;
+                        }
+                    }
+
+                    class Bar extends Foo {
+                        /**
+                         * @param array<string> $arg
+                         * @return string
+                         */
+                        #[ReturnTypeWillChange]
+                        public function run($arg) : string {
+                            return implode(" ", $arg);
+                        }
+                    }',
+                'error_message' => 'Attribute ReturnTypeWillChange can only be used when overriding PHP built-in',
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'returnTypeWillChangeNoSignatureTypeNotBuiltIn' => [
+                'code' => '<?php
+                    class Foo {
+                        /**
+                         * @param array<string> $arg
+                         * @return string
+                         */
+                        public function run($arg) : string {
+                            return implode("s", $arg);
+                        }
+                    }
+
+                    class Bar extends Foo {
+                        /**
+                         * @param array<string> $arg
+                         * @return string
+                         */
+                        #[ReturnTypeWillChange]
+                        public function run($arg) {
+                            return implode(" ", $arg);
+                        }
+                    }',
+                'error_message' => 'MethodSignatureMustProvideReturnType',
+                'ignored_issues' => [],
+                'php_version' => PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION,
             ],
         ];
     }

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -51,6 +51,8 @@ final class MethodSignatureTest extends TestCase
 
     public function testExtendSoapClientWithNoDocblockTypes(): void
     {
+        $this->project_analyzer->setPhpVersion('8.0', 'tests');
+
         $this->addFile(
             'somefile.php',
             '<?php
@@ -58,7 +60,7 @@ final class MethodSignatureTest extends TestCase
                 {
                     public function __soapCall(
                         string $function_name,
-                        $arguments,
+                        array $arguments,
                         $options = [],
                         $input_headers = [],
                         &$output_headers = []
@@ -73,6 +75,8 @@ final class MethodSignatureTest extends TestCase
 
     public function testExtendSoapClientWithParamType(): void
     {
+        $this->project_analyzer->setPhpVersion('8.1', 'tests');
+
         $this->addFile(
             'somefile.php',
             '<?php
@@ -80,11 +84,11 @@ final class MethodSignatureTest extends TestCase
                 {
                     public function __soapCall(
                         string $function_name,
-                        $arguments,
+                        array $arguments,
                         $options = [],
                         $input_headers = [],
                         &$output_headers = []
-                    ) {
+                    ): mixed {
                         return $_GET["foo"];
                     }
                 }',
@@ -238,6 +242,9 @@ final class MethodSignatureTest extends TestCase
 
     public function testExtendDocblockParamTypeWithWrongDocblockParam(): void
     {
+        // from PHP 8 this will also report a MethodSignatureMismatch error
+        $this->project_analyzer->setPhpVersion('7.4', 'tests');
+
         $this->expectExceptionMessage('ImplementedParamTypeMismatch');
         $this->expectException(CodeException::class);
 
@@ -289,6 +296,40 @@ final class MethodSignatureTest extends TestCase
 
                     }
                 }',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
+    public function testStubsUseTypeHintForTypeHintsNotDocblock(): void
+    {
+        $this->addStubFile(
+            'stubOne.phpstub',
+            '<?php
+                abstract class A {
+                    /**
+                     * @param array{hello: string, world: array} $arg
+                     * @return array{hello: string, world: array}
+                     */
+                    abstract public function run( array $arg ): array;
+                }
+            ',
+        );
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                final class B extends A {
+                    /**
+                     * @param array{hello: string, world: array} $arg
+                     * @return array{hello: string, world: array}
+                     */
+                    #[Override]
+                    public function run( array $arg ): array {
+                        return $arg;
+                    }
+                }
+            ',
         );
 
         $this->analyzeFile('somefile.php', new Context());
@@ -622,6 +663,62 @@ final class MethodSignatureTest extends TestCase
                     class C implements IteratorAggregate {
                         public function getIterator(): Iterator {
                             return new ArrayIterator([]);
+                        }
+                    }',
+            ],
+            'ensureCorrectHandlingOfBuiltInsTypeHintUsingTemplate' => [
+                'code' => '<?php
+                    final class Event {}
+
+                    /**
+                     * @template-implements Iterator<int<0, max>, Event>
+                     *
+                     * @no-named-arguments
+                     */
+                    final class EventCollectionIterator implements Iterator {
+                        /**
+                         * @var list<Event>
+                         */
+                        private array $events;
+
+                        /**
+                         * @var int<0, max>
+                         */
+                        private int $position = 0;
+
+                        /**
+                         * @param list<Event> $events
+                         */
+                        public function __construct( array $events ) {
+                            $this->events = $events;
+                        }
+
+                        #[Override]
+                        public function rewind(): void {
+                            $this->position = 0;
+                        }
+
+                        #[Override]
+                        public function valid(): bool {
+                            return isset( $this->events[ $this->position ] );
+                        }
+
+                        /**
+                         * @return int<0, max>
+                         */
+                        #[Override]
+                        public function key(): int {
+                            return $this->position;
+                        }
+
+                        #[Override]
+                        public function current(): Event {
+                            return $this->events[ $this->position ];
+                        }
+
+                        #[Override]
+                        public function next(): void {
+                            $this->position++;
                         }
                     }',
             ],
@@ -992,6 +1089,9 @@ final class MethodSignatureTest extends TestCase
                         }
                     }
                 PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
         ];
     }
@@ -1059,8 +1159,8 @@ final class MethodSignatureTest extends TestCase
 
                         }
                     }',
-                'error_message' => 'Argument 2 of B::fooFoo has wrong type \'int\', expecting \'bool\' as defined ' .
-                    'by A::fooFoo',
+                'error_message' => 'Argument 2 of B::fooFoo has wrong type \'int\', not contravariant to type \'bool\' ' .
+                    'as defined by A::fooFoo',
             ],
             'differentArgumentNames' => [
                 'code' => '<?php
@@ -1105,7 +1205,8 @@ final class MethodSignatureTest extends TestCase
                             return $s;
                         }
                     }',
-                'error_message' => 'Argument 1 of B::foo has wrong type \'string\', expecting \'null|string\' as',
+                'error_message' => 'Argument 1 of B::foo has wrong type \'string\', not contravariant to '
+                    . 'type \'null|string\' as',
             ],
             'misplacedRequiredParam' => [
                 'code' => '<?php
@@ -1665,6 +1766,139 @@ final class MethodSignatureTest extends TestCase
                 'error_message' => 'MethodSignatureMustProvideReturnType',
                 'ignored_issues' => [],
                 'php_version' => '8.1',
+            ],
+            'callmapInheritedMethodParamsDoNotHavePrefixesBeforePHP8' => [
+                'code' => <<<'PHP'
+                    <?php
+
+                    class NoopFilter extends \php_user_filter
+                    {
+                        /**
+                         * @param resource $in
+                         * @param resource $out
+                         * @param int $consumed   -- this is called &rw_consumed in the callmap
+                         */
+                        public function filter($in, $out, &$consumed, bool $closing): int
+                        {
+                            return PSFS_PASS_ON;
+                        }
+                    }
+                PHP,
+                'error_message' => 'MethodSignatureMismatch',
+                'ignored_issues' => [],
+                'php_version' => '7.4',
+            ],
+            'notContravariantParamArrayNativeTypeInErrorMessageNotDocblockArrayType' => [
+                'code' => '<?php
+                    class X {
+                        /**
+                         * @psalm-pure
+                         * @return array|string
+                         */
+                        public function run( array|string $arg ) {
+                            return $arg;
+                        }
+                    }
+
+                    final class Y extends X {
+                        /**
+                         * @psalm-pure
+                         * @return array
+                         */
+                        #[Override]
+                        public function run( array $arg ) {
+                            return $arg;
+                        }
+                    }
+                ',
+                'error_message' => 'has wrong type \'array\', not contravariant to type \'array|string\' as defined by',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'missingMismatchingNotContravariantParamAbstract' => [
+                'code' => '<?php
+                    abstract class X {
+                        /**
+                         * @psalm-pure
+                         * @param array $arg
+                         * @return array
+                         */
+                        abstract public function run( $arg );
+                    }
+
+                    final class Y extends X {
+                        /**
+                         * @psalm-pure
+                         * @param array $arg
+                         * @return array
+                         */
+                        #[Override]
+                        public function run( array $arg ) {
+                            return $arg;
+                        }
+                    }
+                ',
+                'error_message' => 'MethodSignatureMismatch',
+                'ignored_issues' => [],
+                'php_version' => '7.4',
+            ],
+            'missingMismatchingNotContravariantParam' => [
+                'code' => '<?php
+                    class X {
+                        /**
+                         * @psalm-pure
+                         * @param array $arg
+                         * @return array
+                         */
+                        public function run( $arg ) {
+                            return $arg;
+                        }
+                    }
+
+                    final class Y extends X {
+                        /**
+                         * @psalm-pure
+                         * @param array $arg
+                         * @return array
+                         */
+                        #[Override]
+                        public function run( array $arg ) {
+                            return $arg;
+                        }
+                    }
+                ',
+                'error_message' => 'MethodSignatureMismatch',
+                'ignored_issues' => [],
+                'php_version' => '7.4',
+            ],
+            'missingImplementedContravariantParam' => [
+                'code' => '<?php
+                    class X {
+                        /**
+                         * @psalm-pure
+                         * @param array $arg
+                         * @return array
+                         */
+                        public function run( array $arg ) {
+                            return $arg;
+                        }
+                    }
+
+                    final class Y extends X {
+                        /**
+                         * @psalm-pure
+                         * @param array $arg
+                         * @return array
+                         */
+                        #[Override]
+                        public function run( $arg ) {
+                            return $arg;
+                        }
+                    }
+                ',
+                'error_message' => 'Argument 1 of Y::run does not have a type hint, expecting \'array\' as defined by X::run or a type contravariant to it',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'absentByRefReturnInDescendant' => [
                 'code' => '<?php

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -221,7 +221,8 @@ final class StubTest extends TestCase
     public function testStubFileParentClass(): void
     {
         $this->expectException(CodeException::class);
-        $this->expectExceptionMessage('ImplementedParamTypeMismatch');
+        // not ImplementedParamTypeMismatch since it's not a docblock issue, but a fatal signature issue
+        $this->expectExceptionMessage('MethodSignatureMismatch');
         $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
             TestConfig::loadFromXML(
                 dirname(__DIR__),

--- a/tests/UnusedCodeTest.php
+++ b/tests/UnusedCodeTest.php
@@ -797,7 +797,7 @@ final class UnusedCodeTest extends TestCase
                             return "";
                         }
 
-                        public function unserialize($data) : void {}
+                        public function unserialize(string $data) : void {}
                     }
 
                     new Foo();',


### PR DESCRIPTION
* Fix https://github.com/vimeo/psalm/issues/11686
* Fix https://github.com/vimeo/psalm/issues/11687
* Reduce duplicate code related to param type hint validation of stubbed/non-stubbed code (related to https://github.com/vimeo/psalm/issues/11687)
* Fix https://github.com/vimeo/psalm/issues/11688
* Fix https://github.com/vimeo/psalm/issues/11689
* Fix https://github.com/vimeo/psalm/issues/11690
* Fix https://github.com/vimeo/psalm/issues/4047