### PR TITLE
Fix abstract __construct must be consistent constructor, since this is a runtime time fatal error

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -1088,6 +1088,10 @@ final class FunctionLikeNodeScanner
             $storage->is_static = $stmt->isStatic();
             $storage->abstract = $stmt->isAbstract();
 
+            if ($storage->abstract && $method_name_lc === '__construct') {
+                $classlike_storage->preserve_constructor_signature = true;
+            }
+
             if ($stmt->isPrivate() && $stmt->isFinal() && $method_name_lc !== '__construct') {
                 IssueBuffer::maybeAdd(
                     new PrivateFinalMethod(

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -466,6 +466,30 @@ final class AttributeTest extends TestCase
                     }
                 ',
             ],
+            'abstractConstructImplementerOverrideIsValid' => [
+                'code' => '<?php
+                    trait B {
+                        abstract public function __construct();
+                    }
+
+                    final class A {
+                        use B;
+
+                        #[Override]
+                        public function __construct() {}
+                    }',
+            ],
+            'abstractConstructTraitImplementerOverrideIsValid' => [
+                'code' => '<?php
+                    abstract class B {
+                        abstract public function __construct();
+                    }
+
+                    final class A {
+                        #[Override]
+                        public function __construct() {}
+                    }',
+            ],
         ];
     }
 

--- a/tests/MethodSignatureTest.php
+++ b/tests/MethodSignatureTest.php
@@ -505,6 +505,30 @@ final class MethodSignatureTest extends TestCase
                         use T;
                     }',
             ],
+            'abstractConstructImplementerMismatchIsFatal' => [
+                'code' => '<?php
+                    trait B {
+                        abstract public function __construct();
+                    }
+
+                    final class A {
+                        use B;
+
+                        public function __construct(string $foo) {}
+                    }',
+                'error_message' => 'MethodSignatureMismatch',
+            ],
+            'abstractConstructTraitImplementerMismatchIsFatalFrom8' => [
+                'code' => '<?php
+                    abstract class B {
+                        abstract public function __construct();
+                    }
+
+                    final class A {
+                        public function __construct(string $foo) {}
+                    }',
+                'error_message' => 'MethodSignatureMismatch',
+            ],
             'inheritsSplClasses' => [
                 'code' => '<?php
                     namespace App;


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/4003 for trait as well as for abstract class constructs https://github.com/vimeo/psalm/issues/4003#issuecomment-675017229

Fix false positive errors for InvalidAttribute for "Override" on abstract construct https://github.com/vimeo/psalm/issues/4003#issuecomment-3979624475