### PR TITLE
Psalm used wrong autoloader from parent directory in monorepos

### DIFF
--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -87,27 +87,33 @@ final class CliUtils
         }
 
         $autoload_files = [];
-
         foreach ($autoload_roots as $autoload_root) {
             $has_autoloader = false;
 
-            $nested_autoload_file = dirname($autoload_root, 2) . DIRECTORY_SEPARATOR . 'autoload.php';
-
-            // note: don't realpath $nested_autoload_file, or phar version will fail
-            if (file_exists($nested_autoload_file)) {
-                if (!in_array($nested_autoload_file, $autoload_files, false)) {
-                    $autoload_files[] = $nested_autoload_file;
-                }
-                $has_autoloader = true;
-            }
-
+            // check if the current dir has a vendor first, before loading any parent directories
+            // since composer uses a flat dependency model, there's only 1 vendor and no nesting
+            // except if psalm would scope the vendor with php-scoper - which we do, but only distribute as phar
+            // therefore that's not an issue here
+            // unless there's a different composer.json path, but that means a different autoload_root iteration too
+            // fix https://github.com/vimeo/psalm/issues/7381
             $vendor_autoload_file =
                 $autoload_root . DIRECTORY_SEPARATOR . $vendor_dir . DIRECTORY_SEPARATOR . 'autoload.php';
 
             // note: don't realpath $vendor_autoload_file, or phar version will fail
             if (file_exists($vendor_autoload_file)) {
-                if (!in_array($vendor_autoload_file, $autoload_files, false)) {
+                if (!in_array($vendor_autoload_file, $autoload_files, true)) {
                     $autoload_files[] = $vendor_autoload_file;
+                }
+                $has_autoloader = true;
+            }
+
+            // if the working/root dir is not vendor/vimeo/psalm, make sure we load psalm's autoloader too
+            $nested_autoload_file = dirname($autoload_root, 2) . DIRECTORY_SEPARATOR . 'autoload.php';
+
+            // note: don't realpath $nested_autoload_file, or phar version will fail
+            if (!$has_autoloader && file_exists($nested_autoload_file)) {
+                if (!in_array($nested_autoload_file, $autoload_files, true)) {
+                    $autoload_files[] = $nested_autoload_file;
                 }
                 $has_autoloader = true;
             }


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/7381

That's an issue I've had since forever (essentially since starting to contribute to psalm), which was the reason why tests for PR often worked locally but failed in the CI.

Since the originally reported ticket doesn't have a reproduction, here's 1 case how it visible happened in my case with psalm itself (had this issue in various other cases too though, not just with psalm itself - whenever a monorepo or phpscoper-scoped program with nested vendor directories existed)

```
echo '{"name": "te/st", "authors": [{"name": "test"}], "require-dev": {"vimeo/psalm": "6.x-dev"}, "config": {"optimize-autoloader": false, "classmap-authoritative": false, "preferred-install": {"vimeo/psalm": "source", "*": "dist"}}}' > composer.json
composer install --no-progress
cd ./vendor/vimeo/psalm
composer install --no-progress
composer psalm
```

Then reported errors from the parent vendor directory, like:
>ERROR: DeprecatedClass - ../../nikic/php-parser/lib/PhpParser/Node/UseItem.php:55:29

I didn't add additional tests, since I'm not  sure that scripting the composer bash provided above is what we want, but manually "faking" the test directory/scenario is pointless since nothing really gets tested by that (and I don't have a lot of time right now to dig into this)