### PR TITLE
Fix ignoreFiles would not prevent autoloaded paths from being scanned

### DIFF
--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -445,6 +445,14 @@ final class Scanner
             return;
         }
 
+        // don't scan autoloaded files that should be ignored according to the config
+        // only exemption for stubs, not for  && $this->codebase->register_autoload_files
+        // since stubs are hardcoded list of files, but for autoloaded files
+        // there would no way to ignore them otherwise https://github.com/vimeo/psalm/issues/11433
+        if (!$this->codebase->register_stub_files && $this->config->mustBeIgnored($file_path)) {
+            return;
+        }
+
         $file_contents = $this->file_provider->getContents($file_path);
 
         $from_cache = $this->file_storage_provider->has($file_path, $file_contents);


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/11433 and speed up psalm by around 10% (depending on number of dependencies that get autoloaded unnecessarily)