### PR TITLE
Add max_depth option to unserialize() callmap type

### DIFF
--- a/dictionaries/CallMap_74.php
+++ b/dictionaries/CallMap_74.php
@@ -100897,7 +100897,7 @@ return array (
   array (
     0 => 'mixed',
     'variable_representation' => 'string',
-    'allowed_classes=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+    'allowed_classes=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
   ),
   'unset' => 
   array (

--- a/dictionaries/CallMap_80.php
+++ b/dictionaries/CallMap_80.php
@@ -98231,7 +98231,7 @@ return array (
   array (
     0 => 'mixed',
     'data' => 'string',
-    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
   ),
   'unset' => 
   array (

--- a/dictionaries/CallMap_81.php
+++ b/dictionaries/CallMap_81.php
@@ -96565,7 +96565,7 @@ return array (
   array (
     0 => 'mixed',
     'data' => 'string',
-    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
   ),
   'unset' => 
   array (

--- a/dictionaries/CallMap_82.php
+++ b/dictionaries/CallMap_82.php
@@ -96991,7 +96991,7 @@ return array (
   array (
     0 => 'mixed',
     'data' => 'string',
-    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
   ),
   'unset' => 
   array (

--- a/dictionaries/CallMap_83.php
+++ b/dictionaries/CallMap_83.php
@@ -97838,7 +97838,7 @@ return array (
   array (
     0 => 'mixed',
     'data' => 'string',
-    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
   ),
   'unset' => 
   array (

--- a/dictionaries/CallMap_84.php
+++ b/dictionaries/CallMap_84.php
@@ -102134,7 +102134,7 @@ return array (
   array (
     0 => 'mixed',
     'data' => 'string',
-    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
   ),
   'unset' => 
   array (

--- a/dictionaries/CallMap_85.php
+++ b/dictionaries/CallMap_85.php
@@ -83485,7 +83485,7 @@ return array (
   array (
     0 => 'mixed',
     'data' => 'string',
-    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
   ),
   'unset' => 
   array (

--- a/dictionaries/override/CallMap.php
+++ b/dictionaries/override/CallMap.php
@@ -65620,7 +65620,7 @@ return array (
   array (
     0 => 'mixed',
     'data' => 'string',
-    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+    'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
   ),
   'unset' => 
   array (

--- a/dictionaries/override/CallMap_74_delta.php
+++ b/dictionaries/override/CallMap_74_delta.php
@@ -1847,6 +1847,21 @@ return array (
         'allowable_tags=' => 'list<non-empty-string>|string',
       ),
     ),
+    'unserialize' => 
+    array (
+      'old' => 
+      array (
+        0 => 'mixed',
+        'variable_representation' => 'string',
+        'allowed_classes=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+      ),
+      'new' => 
+      array (
+        0 => 'mixed',
+        'variable_representation' => 'string',
+        'allowed_classes=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
+      ),
+    ),
   ),
   'removed' => 
   array (

--- a/dictionaries/override/CallMap_80_delta.php
+++ b/dictionaries/override/CallMap_80_delta.php
@@ -33376,13 +33376,13 @@ return array (
       array (
         0 => 'mixed',
         'variable_representation' => 'string',
-        'allowed_classes=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+        'allowed_classes=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
       ),
       'new' => 
       array (
         0 => 'mixed',
         'data' => 'string',
-        'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool}',
+        'options=' => 'array{allowed_classes?: array<array-key, class-string>|bool, max_depth?: int}',
       ),
     ),
     'urldecode' => 

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -2466,6 +2466,13 @@ final class FunctionCallTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '7.0',
             ],
+            'unserializeWithMaxDepthOption' => [
+                'code' => '<?php
+                    unserialize("", ["allowed_classes" => false, "max_depth" => 1]);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '7.4',
+            ],
         ];
     }
 
@@ -3211,6 +3218,13 @@ final class FunctionCallTest extends TestCase
                     extract($a);
                     takesInt($foo);',
                 'error_message' => 'InvalidScalarArgument',
+            ],
+            'unserializeWithInvalidMaxDepthType' => [
+                'code' => '<?php
+                    unserialize("", ["max_depth" => "foo"]);',
+                'error_message' => 'InvalidScalarArgument',
+                'ignored_issues' => [],
+                'php_version' => '7.4',
             ],
         ];
     }


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/11295

PHP 7.4 added `max_depth` as an option to `unserialize()`, but Psalm's callmap only declared `allowed_classes` in the array shape -- causing a false-positive `InvalidArgument` error.

This PR adds `max_depth?: int` to the options type, version-gated to PHP 7.4+ via a new entry in `CallMap_74_delta.php`.

https://www.php.net/manual/en/function.unserialize.php