### PR TITLE
Report undefined functions for older php version instead of reflecting

### DIFF
--- a/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
+++ b/src/Psalm/Internal/Codebase/InternalCallMapHandler.php
@@ -31,6 +31,9 @@ use function strpos;
 use function strtolower;
 use function substr;
 
+use const PHP_MAJOR_VERSION;
+use const PHP_MINOR_VERSION;
+
 /**
  * @internal
  *
@@ -50,9 +53,14 @@ final class InternalCallMapHandler
     private static ?array $call_map = null;
 
     /**
-     * @var array<string, non-empty-list<TCallable>>|null
+     * @var array<string, non-empty-list<TCallable>>
      */
-    private static ?array $call_map_callables = [];
+    private static array $call_map_callables = [];
+
+    /**
+     * @var non-empty-array<lowercase-string, array<int|string, string>>|null
+     */
+    private static ?array $runtime_call_map = null;
 
     /**
      * @var non-empty-array<string, non-empty-list<list<TaintKind::*>>>|null
@@ -333,10 +341,27 @@ final class InternalCallMapHandler
      * @return non-empty-array<string, array<int|string, string>>
      * @psalm-assert !null self::$taint_sink_map
      * @psalm-assert !null self::$call_map
+     * @psalm-assert !null self::$runtime_call_map
      * @psalm-suppress UnresolvableInclude
      */
     public static function getCallMap(): array
     {
+        if (self::$runtime_call_map === null) {
+            $runtime_version_int = min(
+                self::MAX_CALLMAP_VERSION,
+                max(
+                    self::MIN_CALLMAP_VERSION,
+                    (int) (PHP_MAJOR_VERSION . PHP_MINOR_VERSION),
+                ),
+            );
+
+            /** @var non-empty-array<lowercase-string, array<int|string, string>> */
+            $runtime_call_map = require(dirname(__DIR__, 4) . '/dictionaries/CallMap_' . $runtime_version_int . '.php');
+            self::$runtime_call_map = $runtime_call_map;
+
+            assert(!empty(self::$runtime_call_map));
+        }
+
         $codebase = ProjectAnalyzer::getInstance()->getCodebase();
         $analyzer_major_version = $codebase->getMajorAnalysisPhpVersion();
         $analyzer_minor_version = $codebase->getMinorAnalysisPhpVersion();
@@ -346,6 +371,11 @@ final class InternalCallMapHandler
             && $analyzer_minor_version === self::$loaded_php_minor_version
         ) {
             return self::$call_map;
+        } elseif (self::$call_map !== null) {
+            // reset it since the PHP version analyzed changed
+            self::clearCache();
+            Functions::clearCache();
+            Reflection::clearCache();
         }
 
         $analyzer_version_int = min(
@@ -385,6 +415,35 @@ final class InternalCallMapHandler
     public static function inCallMap(string $key): bool
     {
         return isset(self::getCallMap()[strtolower($key)]);
+    }
+
+    public static function allowReflection(string $function_id): bool
+    {
+        // make sure it's populated and correct for the currently checked versions everytime
+        self::getCallMap();
+
+        $function_id_lc = strtolower($function_id);
+
+        // allow reflection if it's not an internal function at all
+        if (
+            !isset(self::$runtime_call_map[$function_id_lc]) &&
+            !isset(self::$call_map[$function_id_lc])
+        ) {
+            return true;
+        }
+
+        // allow reflection if the current PHP version's callmap signature is identical to the analyzed version
+        if (
+            isset(self::$runtime_call_map[$function_id_lc]) &&
+            isset(self::$call_map[$function_id_lc]) &&
+            self::$runtime_call_map[$function_id_lc] === self::$call_map[$function_id_lc]
+        ) {
+            return true;
+        }
+
+        // e.g. running psalm with PHP 8.3 but with --php-version=7.4
+        // or vice versa psalm run with 8.1 and --php-version 8.2
+        return false;
     }
 
     public static function clearCache(): void

--- a/src/Psalm/Internal/Codebase/Reflection.php
+++ b/src/Psalm/Internal/Codebase/Reflection.php
@@ -206,6 +206,10 @@ final class Reflection
         foreach ($reflection_methods as $reflection_method) {
             $method_reflection_class = $reflection_method->getDeclaringClass();
 
+            if (!InternalCallMapHandler::allowReflection($method_reflection_class->name . '::' . $reflection_method->getName())) {
+                continue;
+            }
+
             $this->registerClass($method_reflection_class);
 
             $this->extractReflectionMethodInfo($reflection_method);
@@ -247,6 +251,11 @@ final class Reflection
             return;
         }
 
+        $declaring_class = $method->getDeclaringClass();
+        if (!InternalCallMapHandler::allowReflection($declaring_class->name . '::' . $method_name_lc)) {
+            return;
+        }
+
         $method_id = $method->class . '::' . $method_name_lc;
 
         $storage = $class_storage->methods[$method_name_lc] = new MethodStorage();
@@ -268,8 +277,6 @@ final class Reflection
                 $method_name_lc,
             );
         }
-
-        $declaring_class = $method->getDeclaringClass();
 
         $storage->is_static = $method->isStatic();
         $storage->abstract = $method->isAbstract();
@@ -358,25 +365,22 @@ final class Reflection
      */
     public function registerFunction(string $function_id): ?bool
     {
+        if (isset(self::$builtin_functions[$function_id])) {
+            return null;
+        }
+
+        $callmap_callable = null;
+        if (InternalCallMapHandler::inCallMap($function_id)) {
+            $callmap_callable = InternalCallMapHandler::getCallableFromCallMapById(
+                $this->codebase,
+                $function_id,
+                [],
+                null,
+            );
+        }
+
         try {
-            $reflection_function = new ReflectionFunction($function_id);
-
-            $callmap_callable = null;
-
-            if (isset(self::$builtin_functions[$function_id])) {
-                return null;
-            }
-
             $storage = self::$builtin_functions[$function_id] = new FunctionStorage();
-
-            if (InternalCallMapHandler::inCallMap($function_id)) {
-                $callmap_callable = InternalCallMapHandler::getCallableFromCallMapById(
-                    $this->codebase,
-                    $function_id,
-                    [],
-                    null,
-                );
-            }
 
             if ($callmap_callable !== null
                 && $callmap_callable->params !== null
@@ -384,7 +388,18 @@ final class Reflection
             ) {
                 $storage->setParams($callmap_callable->params);
                 $storage->return_type = $callmap_callable->return_type;
-            } else {
+
+                // nested, since want to use the callmap anyway, even if we cannot get the cased name
+                try {
+                    // just the cased name can be reflected in all cases
+                    $reflection_function = new ReflectionFunction($function_id);
+                    $storage->cased_name = $reflection_function->getName();
+                } catch (ReflectionException) {
+                    // doesn't exist yet/anymore in the current PHP runtime
+                }
+            } elseif (InternalCallMapHandler::allowReflection($function_id)) {
+                $reflection_function = new ReflectionFunction($function_id);
+
                 $reflection_params = $reflection_function->getParameters();
 
                 foreach ($reflection_params as $param) {
@@ -399,9 +414,21 @@ final class Reflection
                 ) : $reflection_function->getReturnType())) {
                     $storage->return_type = self::getPsalmTypeFromReflectionType($reflection_return_type);
                 }
+
+                $storage->cased_name = $reflection_function->getName();
+            } else {
+                unset(self::$builtin_functions[$function_id]);
+                return false;
             }
 
-            $storage->pure = true;
+            $must_use = true;
+            $storage->pure = $this->codebase->functions->isCallMapFunctionPure(
+                $this->codebase,
+                null,
+                $function_id,
+                [],
+                $must_use
+            );
 
             $storage->required_param_count = 0;
 
@@ -410,9 +437,8 @@ final class Reflection
                     $storage->required_param_count = $i + 1;
                 }
             }
-
-            $storage->cased_name = $reflection_function->getName();
         } catch (ReflectionException) {
+            unset(self::$builtin_functions[$function_id]);
             return false;
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -26,6 +26,7 @@ use Psalm\Internal\Analyzer\CommentAnalyzer;
 use Psalm\Internal\Analyzer\NamespaceAnalyzer;
 use Psalm\Internal\Analyzer\ScopeAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\SimpleTypeInferer;
+use Psalm\Internal\Codebase\InternalCallMapHandler;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Provider\NodeDataProvider;
 use Psalm\Internal\Scanner\FileScanner;
@@ -414,7 +415,6 @@ final class FunctionLikeNodeScanner
 
         $doc_comment = $stmt->getDocComment() ?? $doc_comment;
 
-
         if ($classlike_storage && !$classlike_storage->is_trait) {
             $storage->internal = [...$classlike_storage->internal, ...$storage->internal];
         }
@@ -489,8 +489,13 @@ final class FunctionLikeNodeScanner
             && $function_id
             && $storage instanceof FunctionStorage
         ) {
-            if ($this->codebase->all_functions_global
-                || $this->codebase->register_stub_files
+            if ((($this->codebase->all_functions_global || $this->codebase->register_stub_files)
+                    && (InternalCallMapHandler::allowReflection($function_id)
+                        // if the stub is for a specific PHP version, which is equal or lower than the analyzed version
+                        // as otherwise we would have returned already above
+                        // we also want to use the stub, since it contains the correct types for the current version
+                        || !empty($docblock_info->since_php_major_version)))
+                // if the function is autoloaded we want to register it even if it has a delta, since there's a polyfill
                 || ($this->codebase->register_autoload_files
                     && !$this->codebase->functions->hasStubbedFunction($function_id))
             ) {
@@ -924,10 +929,12 @@ final class FunctionLikeNodeScanner
                     && ($this->codebase->register_stub_files
                         || !$this->codebase->functions->hasStubbedFunction($function_id))
                 ) {
-                    $this->codebase->functions->addGlobalFunction(
-                        $function_id,
-                        $this->file_storage->functions[$function_id],
-                    );
+                    if (!$this->codebase->register_stub_files || InternalCallMapHandler::allowReflection($function_id)) {
+                        $this->codebase->functions->addGlobalFunction(
+                            $function_id,
+                            $this->file_storage->functions[$function_id],
+                        );
+                    }
 
                     $storage = $this->storage = $this->file_storage->functions[$function_id];
 

--- a/src/Psalm/Internal/RuntimeCaches.php
+++ b/src/Psalm/Internal/RuntimeCaches.php
@@ -7,6 +7,7 @@ namespace Psalm\Internal;
 use Psalm\Internal\Analyzer\FileAnalyzer;
 use Psalm\Internal\Analyzer\FunctionLikeAnalyzer;
 use Psalm\Internal\Codebase\Functions;
+use Psalm\Internal\Codebase\InternalCallMapHandler;
 use Psalm\Internal\Codebase\Reflection;
 use Psalm\Internal\FileManipulation\ClassDocblockManipulator;
 use Psalm\Internal\FileManipulation\FileManipulationBuffer;
@@ -29,6 +30,7 @@ abstract class RuntimeCaches
     {
         IssueBuffer::clearCache();
         Reflection::clearCache();
+        InternalCallMapHandler::clearCache();
         Functions::clearCache();
         TypeTokenizer::clearCache();
         FileReferenceProvider::clearCache();

--- a/stubs/CoreImmutableClasses.phpstub
+++ b/stubs/CoreImmutableClasses.phpstub
@@ -98,6 +98,13 @@ class DateTimeImmutable implements DateTimeInterface
      * @return static
      */
     public static function createFromMutable(DateTime $object) {}
+
+    /**
+     * @psalm-mutation-free
+     * @return static
+     * @since 8.4.0
+     */
+    public function setMicrosecond(int $microsecond) {}
 }
 
 /**

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -679,6 +679,8 @@ final class AttributeTest extends TestCase
                     $r->getAttributes(Attr::class);
                 ',
                 'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:8:39 - Attribute Attr cannot be used on a class',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'getAttributesOnFunctionWithNonFunctionAttribute' => [
                 'code' => '<?php
@@ -692,6 +694,8 @@ final class AttributeTest extends TestCase
                     $r->getAttributes(Attr::class);
                 ',
                 'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:9:39 - Attribute Attr cannot be used on a function',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'getAttributesOnMethodWithNonMethodAttribute' => [
                 'code' => '<?php
@@ -707,6 +711,8 @@ final class AttributeTest extends TestCase
                     $r->getAttributes(Attr::class);
                 ',
                 'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:11:39 - Attribute Attr cannot be used on a method',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'getAttributesOnPropertyWithNonPropertyAttribute' => [
                 'code' => '<?php
@@ -722,6 +728,8 @@ final class AttributeTest extends TestCase
                     $r->getAttributes(Attr::class);
                 ',
                 'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:11:39 - Attribute Attr cannot be used on a property',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'getAttributesOnClassConstantWithNonClassConstantAttribute' => [
                 'code' => '<?php
@@ -737,6 +745,8 @@ final class AttributeTest extends TestCase
                     $r->getAttributes(Attr::class);
                 ',
                 'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:11:39 - Attribute Attr cannot be used on a class constant',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'getAttributesOnParameterWithNonParameterAttribute' => [
                 'code' => '<?php
@@ -749,6 +759,8 @@ final class AttributeTest extends TestCase
                     $r->getAttributes(Attr::class);
                 ',
                 'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:8:39 - Attribute Attr cannot be used on a function/method parameter',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'getAttributesWithNonAttribute' => [
                 'code' => '<?php
@@ -760,6 +772,8 @@ final class AttributeTest extends TestCase
                     $r->getAttributes(NonAttr::class);
                 ',
                 'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:7:39 - The class NonAttr doesn\'t have the Attribute attribute',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
             ],
             'analyzeConstructorForNonexistentAttributes' => [
                 'code' => '<?php

--- a/tests/FunctionCallTest.php
+++ b/tests/FunctionCallTest.php
@@ -2473,6 +2473,37 @@ final class FunctionCallTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '7.4',
             ],
+            'functionStubbedAddedBeforeAnalyzedVersion' => [
+                'code' => '<?php
+                    $array = array(rand(10, 20) => "bar");
+                    echo array_key_first($array);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'functionAddedBeforeAnalyzedVersion' => [
+                'code' => '<?php
+                    json_validate("asdf");',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
+            'functionReturnTypeChangedAnalyzedVersion' => [
+                'code' => '<?php
+                    $array = array("b", "a");
+                    $x = natsort($array);',
+                'assertions' => ['$x===' => 'bool'],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'functionReturnTypeChangedAnalyzedVersionNew' => [
+                'code' => '<?php
+                    $array = array("b", "a");
+                    $x = natsort($array);',
+                'assertions' => ['$x===' => 'true'],
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
         ];
     }
 
@@ -3225,6 +3256,21 @@ final class FunctionCallTest extends TestCase
                 'error_message' => 'InvalidScalarArgument',
                 'ignored_issues' => [],
                 'php_version' => '7.4',
+            ],
+            'functionStubbedDoesNotExistYetInAnalyzedVersion' => [
+                'code' => '<?php
+                    $array = array(rand(10, 20) => "bar");
+                    echo array_key_first($array);',
+                'error_message' => 'UndefinedFunction',
+                'ignored_issues' => [],
+                'php_version' => '7.2',
+            ],
+            'functionDoesNotExistYetInAnalyzedVersion' => [
+                'code' => '<?php
+                    json_validate("asdf");',
+                'error_message' => 'UndefinedFunction',
+                'ignored_issues' => [],
+                'php_version' => '8.2',
             ],
         ];
     }

--- a/tests/MethodCallTest.php
+++ b/tests/MethodCallTest.php
@@ -1261,6 +1261,23 @@ final class MethodCallTest extends TestCase
                         }
                     }',
             ],
+            'classAddedBeforeAnalyzedVersion' => [
+                'code' => '<?php
+                    $w = new WeakMap();
+                    $w->count();',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'methodAddedBeforeAnalyzedVersion' => [
+                'code' => '<?php
+                    $date = new DateTimeImmutable();
+                    $date->setMicrosecond(426286);
+                    $r = $date->getMicrosecond();',
+                'assertions' => ['$r' => 'int'],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
         ];
     }
 
@@ -1831,6 +1848,49 @@ final class MethodCallTest extends TestCase
                     $_a = (new A)->foo(...);
                 PHP,
                 'error_message' => 'UndefinedMethod',
+            ],
+            'SKIPPED-classDoesNotExistYetInAnalyzedVersion' => [
+                'code' => '<?php
+                    new WeakMap();',
+                'error_message' => 'UndefinedClass',
+                'ignored_issues' => [],
+                'php_version' => '7.4',
+            ],
+            'SKIPPED-classAndMethodDoesNotExistYetInAnalyzedVersion' => [
+                'code' => '<?php
+                    /**
+                     * @var WeakMap $w
+                     */
+                    $w->count();',
+                'error_message' => 'MixedMethodCall',
+                'ignored_issues' => ['UndefinedClass'],
+                'php_version' => '7.4',
+            ],
+            'classAndMethodDoesNotExistYetInAnalyzedVersion' => [
+                'code' => '<?php
+                    /**
+                     * @var WeakMap $w
+                     */
+                    $w->count();',
+                'error_message' => 'UndefinedMethod',
+                'ignored_issues' => [],
+                'php_version' => '7.4',
+            ],
+            'methodDoesNotExistYetInInterfaceInAnalyzedVersion' => [
+                'code' => '<?php
+                $date = new DateTimeImmutable();
+                echo $date->getMicrosecond();',
+                'error_message' => 'UndefinedMethod',
+                'ignored_issues' => [],
+                'php_version' => '8.3',
+            ],
+            'methodDoesNotExistYetInClassInAnalyzedVersion' => [
+                'code' => '<?php
+                    $date = new DateTimeImmutable();
+                    $date->setMicrosecond(426286);',
+                'error_message' => 'UndefinedMethod',
+                'ignored_issues' => [],
+                'php_version' => '8.3',
             ],
         ];
     }


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/6935

- this also fixes a bug where the callmaps cache wasn't cleared in a case where it should be cleared
- this also fixes a bug where a function would not report as undefined if reflection encountered an error
- this also fixes an issue where reflection would incorrectly modify function/method info if the PHP version running Psalm is older than the declared --php-version (or via config)

(replaces https://github.com/vimeo/psalm/pull/10771 which already fixed this in 5.x branch, now slightly more efficiently in 6.x)

Requires https://github.com/vimeo/psalm/pull/11707 to be merged, since it reports false positive errors for getmicrosecond, since the callmap is incorrect atm.

Otherwise, as can be seen, lots of test failures exactly because psalm did not correctly handle differing runtime + analysis version correctly. Will fix those too, by specifiying a PHP version they should run at.