### PR TITLE
Improve documentation for glob paths, allowMissingFiles="true"

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -101,6 +101,8 @@
             <xs:element name="file" minOccurs="0" maxOccurs="unbounded" type="NameAttributeType" />
             <xs:element name="ignoreFiles" minOccurs="0" maxOccurs="1" type="IgnoreFilesType" />
         </xs:choice>
+
+        <xs:attribute name="allowMissingFiles" type="xs:string" />
         <xs:anyAttribute processContents="skip" />
     </xs:complexType>
 
@@ -545,6 +547,7 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:attribute name="allowMissingFiles" type="xs:string" />
                     <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
@@ -564,6 +567,7 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:attribute name="allowMissingFiles" type="xs:string" />
                     <xs:anyAttribute processContents="skip"/>
                 </xs:complexType>
             </xs:element>
@@ -585,6 +589,7 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:attribute name="allowMissingFiles" type="xs:string" />
                     <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
@@ -605,6 +610,7 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:attribute name="allowMissingFiles" type="xs:string" />
                     <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
@@ -625,6 +631,7 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:attribute name="allowMissingFiles" type="xs:string" />
                     <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
@@ -645,6 +652,7 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:attribute name="allowMissingFiles" type="xs:string" />
                     <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
@@ -665,6 +673,7 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:attribute name="allowMissingFiles" type="xs:string" />
                     <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
@@ -685,6 +694,8 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:attribute name="allowMissingFiles" type="xs:string" />
+                    <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>
         </xs:sequence>
@@ -703,6 +714,7 @@
                     </xs:choice>
 
                     <xs:attribute name="type" type="ErrorLevelType" use="required" />
+                    <xs:attribute name="allowMissingFiles" type="xs:string" />
                     <xs:anyAttribute processContents="skip" />
                 </xs:complexType>
             </xs:element>

--- a/docs/running_psalm/configuration.md
+++ b/docs/running_psalm/configuration.md
@@ -635,7 +635,8 @@ is not being used to suppress an issue.
 ## Project settings
 
 #### &lt;projectFiles&gt;
-Contains a list of all the directories that Psalm should inspect. You can also specify a set of files and folders to ignore with the `<ignoreFiles>` directive.  By default, ignored files/folders are required to exist.  An `allowMissingFiles` attribute can be added for ignored files/folders than may or may not exist.
+Contains a list of all the directories that Psalm should inspect. You can also specify a set of files and folders to ignore with the `<ignoreFiles>` directive. By default, all files/folders including ignored ones are required to exist. An `allowMissingFiles` attribute can be added on `projectFiles` or `ignoreFiles` to suppress errors if any of the paths do not exist.
+Additionally PHP glob patterns are supported for all file and directory paths everywhere in the config.
 ```xml
 <projectFiles>
   <directory name="src" />
@@ -643,7 +644,8 @@ Contains a list of all the directories that Psalm should inspect. You can also s
     <directory name="src/Stubs" />
   </ignoreFiles>
   <ignoreFiles allowMissingFiles="true">
-    <directory name="path-that-may-not-exist" />
+    <directory name="path-that/**/may-not-exist" />
+    <directory name="**/foo" />
   </ignoreFiles>
 </projectFiles>
 ```

--- a/docs/running_psalm/dealing_with_code_issues.md
+++ b/docs/running_psalm/dealing_with_code_issues.md
@@ -35,6 +35,13 @@ Some issue types allow the use of `referencedMethod`, `referencedClass` or `refe
       <file name="some_bad_file.php" />  <!-- all InvalidReturnType issues in this file are suppressed -->
     </errorLevel>
   </InvalidReturnType>
+  <InvalidGlobal>
+    <errorLevel type="suppress" allowMissingFiles="true">
+      <directory name="**/emails/" />
+      <directory name="**/views/" />
+      <directory name="**/templates/" />
+    </errorLevel>
+  </InvalidGlobal>
   <UndefinedMethod>
     <errorLevel type="suppress">
       <referencedMethod name="Bar\Bat::bar" /> <!-- not supported for all types of errors -->


### PR DESCRIPTION
This has been implemented 3 years ago already, but nobody updated the docs. I guess that's good to know not only for people new to psalm

Fix https://github.com/vimeo/psalm/issues/9774