### PR TITLE
Don't report an issue if there were no matching files/directories that had the issue suppressed

### DIFF
--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -656,6 +656,20 @@ final class IssueBuffer
                         if ($filter->suppressions > 0 || $filter->getErrorLevel() != Config::REPORT_SUPPRESS) {
                             continue;
                         }
+
+                        $suppression_paths = str_replace(
+                            $codebase->config->base_dir,
+                            '',
+                            implode(', ', [...$filter->getFiles(), ...$filter->getDirectories()]),
+                        );
+
+                        // if allowMissingFiles="true" with a glob pattern
+                        // and the directories/files do not exist, it can be empty
+                        // since this can only happen with allowMissingFiles="true", we also want to ignore it here
+                        if ($suppression_paths === '') {
+                            continue;
+                        }
+
                         $issues_data['config'][] = new IssueData(
                             IssueData::SEVERITY_ERROR,
                             0,
@@ -664,11 +678,7 @@ final class IssueBuffer
                             sprintf(
                                 'Suppressed issue type "%s" for %s was not thrown.',
                                 $type,
-                                str_replace(
-                                    $codebase->config->base_dir,
-                                    '',
-                                    implode(', ', [...$filter->getFiles(), ...$filter->getDirectories()]),
-                                ),
+                                $suppression_paths,
                             ),
                             $codebase->config->source_filename ?? '',
                             '',


### PR DESCRIPTION
Bug I encountered when updating my config to suppress errors for some directories https://github.com/vimeo/psalm/issues/9774#issuecomment-3998693577 and updating the docs for it in https://github.com/vimeo/psalm/pull/11709

If a path does not exist (which is possible, since we explicitly have the "allowMissingFiles" config), and it therefore does not report an errors, it will report an error message with no path (but 2 spaces around it) - which obviously does not make sense.

