### PR TITLE
Fix var this psalm scope this false positives

### DIFF
--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -92,9 +92,6 @@ final class CommentAnalyzer
     ): array {
         $var_id = null;
 
-        $var_type_tokens = null;
-        $original_type = null;
-
         $var_comments = [];
 
         $comment_text = $comment->getText();
@@ -112,6 +109,9 @@ final class CommentAnalyzer
 
         if ($var_tags !== []) {
             foreach ($var_tags as $offset => $var_line) {
+                $var_type_tokens = null;
+                $original_type = null;
+
                 $var_line = trim($var_line);
 
                 if (!$var_line) {
@@ -170,7 +170,7 @@ final class CommentAnalyzer
                     }
                 }
 
-                if (!$var_type_tokens || !$original_type) {
+                if (!$var_type_tokens || $original_type === null) {
                     continue;
                 }
 
@@ -210,6 +210,9 @@ final class CommentAnalyzer
 
         if (isset($parsed_docblock->tags['psalm-scope-this'])) {
             foreach ($parsed_docblock->tags['psalm-scope-this'] as $offset => $var_line) {
+                $var_type_tokens = null;
+                $original_type = null;
+
                 $var_line = trim($var_line);
 
                 if (!$var_line) {
@@ -266,7 +269,7 @@ final class CommentAnalyzer
                     }
                 }
 
-                if (!$var_type_tokens || !$original_type) {
+                if (!$var_type_tokens || $original_type === null) {
                     continue;
                 }
 
@@ -274,8 +277,8 @@ final class CommentAnalyzer
                     $defined_type = TypeParser::parseTokens(
                         $var_type_tokens,
                         null,
-                        $template_type_map ?: [],
-                        $type_aliases ?: [],
+                        $template_type_map ?? [],
+                        $type_aliases ?? [],
                         true,
                     );
                 } catch (TypeParseTreeException $e) {

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -208,6 +208,102 @@ final class CommentAnalyzer
             }
         }
 
+        if (isset($parsed_docblock->tags['psalm-scope-this'])) {
+            foreach ($parsed_docblock->tags['psalm-scope-this'] as $offset => $var_line) {
+                $var_line = trim($var_line);
+
+                if (!$var_line) {
+                    continue;
+                }
+
+                $type_start = null;
+                $type_end = null;
+
+                $line_parts = self::splitDocLine($var_line);
+
+                $line_number = $comment->getStartLine() + substr_count(
+                    $comment_text,
+                    "\n",
+                    0,
+                    $offset - $comment->getStartFilePos(),
+                );
+                $description = $parsed_docblock->description;
+
+                if ($line_parts[0]) {
+                    $type_start = $offset;
+                    $type_end = $type_start + strlen($line_parts[0]);
+
+                    $line_parts[0] = self::sanitizeDocblockType($line_parts[0]);
+
+                    if ($line_parts[0] === ''
+                        || $line_parts[0][0] === '$'
+                    ) {
+                        throw new IncorrectDocblockException('Misplaced variable');
+                    }
+
+                    try {
+                        $var_type_tokens = TypeTokenizer::getFullyQualifiedTokens(
+                            $line_parts[0],
+                            $aliases,
+                            $template_type_map,
+                            $type_aliases,
+                        );
+                    } catch (TypeParseTreeException) {
+                        throw new DocblockParseException($line_parts[0] . ' is not a valid type');
+                    }
+
+                    $original_type = $line_parts[0];
+
+                    $var_line_number = $line_number;
+
+                    if (count($line_parts) > 1) {
+                        if ($line_parts[1][0] === '$') {
+                            $description = trim(substr($var_line, strlen($line_parts[0]) + strlen($line_parts[1]) + 2));
+                        } else {
+                            $description = trim(substr($var_line, strlen($line_parts[0]) + 1));
+                        }
+                        $description = (string) preg_replace('/\\n \\*\\s+/um', ' ', $description);
+                    }
+                }
+
+                if (!$var_type_tokens || !$original_type) {
+                    continue;
+                }
+
+                try {
+                    $defined_type = TypeParser::parseTokens(
+                        $var_type_tokens,
+                        null,
+                        $template_type_map ?: [],
+                        $type_aliases ?: [],
+                        true,
+                    );
+                } catch (TypeParseTreeException $e) {
+                    throw new DocblockParseException(
+                        $line_parts[0] .
+                        ' is not a valid type' .
+                        ' ('.$e->getMessage().' in ' .
+                        $source->getFilePath() .
+                        ':' .
+                        $comment->getStartLine() .
+                        ')',
+                    );
+                }
+
+                $var_comment = new VarDocblockComment();
+                $var_comment->type = $defined_type;
+                $var_comment->var_id = '$this';
+                $var_comment->line_number = $var_line_number;
+                $var_comment->type_start = $type_start;
+                $var_comment->type_end = $type_end;
+                $var_comment->description = $description;
+
+                self::decorateVarDocblockComment($var_comment, $parsed_docblock);
+
+                $var_comments[] = $var_comment;
+            }
+        }
+
         if (!$var_comments
             && (isset($parsed_docblock->tags['deprecated'])
                 || isset($parsed_docblock->tags['internal'])

--- a/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/CommentAnalyzer.php
@@ -29,6 +29,7 @@ use UnexpectedValueException;
 
 use function count;
 use function is_string;
+use function ksort;
 use function preg_match;
 use function preg_replace;
 use function preg_split;
@@ -59,6 +60,7 @@ final class CommentAnalyzer
         Aliases $aliases,
         ?array $template_type_map = null,
         ?array $type_aliases = null,
+        bool $allow_global_tag = false,
     ): array {
         $parsed_docblock = DocComment::parsePreservingLength($comment);
 
@@ -69,6 +71,7 @@ final class CommentAnalyzer
             $aliases,
             $template_type_map,
             $type_aliases,
+            $allow_global_tag,
         );
     }
 
@@ -85,6 +88,7 @@ final class CommentAnalyzer
         Aliases $aliases,
         ?array $template_type_map = null,
         ?array $type_aliases = null,
+        bool $allow_global_tag = false,
     ): array {
         $var_id = null;
 
@@ -96,9 +100,18 @@ final class CommentAnalyzer
         $comment_text = $comment->getText();
 
         $var_line_number = $comment->getStartLine();
-
+        $var_tags = [];
         if (isset($parsed_docblock->combined_tags['var'])) {
-            foreach ($parsed_docblock->combined_tags['var'] as $offset => $var_line) {
+            $var_tags = $parsed_docblock->combined_tags['var'];
+        }
+
+        if ($allow_global_tag && isset($parsed_docblock->tags['global'])) {
+            $var_tags = $var_tags + $parsed_docblock->tags['global'];
+            ksort($var_tags);
+        }
+
+        if ($var_tags !== []) {
+            foreach ($var_tags as $offset => $var_line) {
                 $var_line = trim($var_line);
 
                 if (!$var_line) {
@@ -421,6 +434,7 @@ final class CommentAnalyzer
         PhpParser\Comment\Doc $doc_comment,
         StatementsAnalyzer $statements_analyzer,
         PhpParser\Node\Expr\Variable $var,
+        bool $allow_global_tag = false,
     ): array {
         $codebase = $statements_analyzer->getCodebase();
         $parsed_docblock = $statements_analyzer->getParsedDocblock();
@@ -445,6 +459,7 @@ final class CommentAnalyzer
                     $statements_analyzer->getSource()->getAliases(),
                     $statements_analyzer->getSource()->getTemplateTypeMap(),
                     $file_storage->type_aliases,
+                    $allow_global_tag,
                 );
         } catch (IncorrectDocblockException $e) {
             IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
@@ -60,7 +60,7 @@ final class GlobalAnalyzer
             $comment_type = null;
 
             if ($doc_comment) {
-                $var_comments = CommentAnalyzer::getVarComments($doc_comment, $statements_analyzer, $var);
+                $var_comments = CommentAnalyzer::getVarComments($doc_comment, $statements_analyzer, $var, true);
                 $comment_type = CommentAnalyzer::populateVarTypesFromDocblock(
                     $var_comments,
                     $var,

--- a/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/GlobalAnalyzer.php
@@ -29,7 +29,7 @@ final class GlobalAnalyzer
         Context $context,
         ?Context $global_context,
     ): void {
-        if (!$context->collect_initializations && !$global_context) {
+        if (!$context->collect_initializations && !$global_context && $context->self !== null) {
             IssueBuffer::maybeAdd(
                 new InvalidGlobal(
                     'Cannot use global scope here (unless this file is included from a non-global scope)',

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -428,12 +428,7 @@ final class StatementsAnalyzer extends SourceAnalyzer
                 }
             }
 
-            if (isset($statements_analyzer->parsed_docblock->combined_tags['var'])
-                && !($stmt instanceof PhpParser\Node\Stmt\Expression
-                    && $stmt->expr instanceof PhpParser\Node\Expr\Assign)
-                && !$stmt instanceof PhpParser\Node\Stmt\Foreach_
-                && !$stmt instanceof PhpParser\Node\Stmt\Return_
-            ) {
+            if (isset($statements_analyzer->parsed_docblock->combined_tags['var'])) {
                 $file_path = $statements_analyzer->getRootFilePath();
 
                 $file_storage_provider = $codebase->file_storage_provider;
@@ -443,6 +438,17 @@ final class StatementsAnalyzer extends SourceAnalyzer
                 $template_type_map = $statements_analyzer->getTemplateTypeMap();
 
                 $var_comments = [];
+
+                // since it will be processed later when analyzing the assignment
+                // however we must never ignore $this comments
+                // to keep it consistent with @psalm-scope-this
+                $ignore_comment = true;
+                if (!($stmt instanceof PhpParser\Node\Stmt\Expression
+                      && $stmt->expr instanceof PhpParser\Node\Expr\Assign)
+                    && !$stmt instanceof PhpParser\Node\Stmt\Foreach_
+                    && !$stmt instanceof PhpParser\Node\Stmt\Return_) {
+                    $ignore_comment = false;
+                }
 
                 try {
                     $var_comments = $codebase->config->disable_var_parsing
@@ -456,22 +462,32 @@ final class StatementsAnalyzer extends SourceAnalyzer
                             $file_storage->type_aliases,
                         );
                 } catch (IncorrectDocblockException $e) {
-                    IssueBuffer::maybeAdd(
-                        new MissingDocblockType(
-                            $e->getMessage(),
-                            new CodeLocation($statements_analyzer->getSource(), $stmt),
-                        ),
-                    );
+                    if (!$ignore_comment) {
+                        IssueBuffer::maybeAdd(
+                            new MissingDocblockType(
+                                $e->getMessage(),
+                                new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            ),
+                        );
+                    }
                 } catch (DocblockParseException $e) {
-                    IssueBuffer::maybeAdd(
-                        new InvalidDocblock(
-                            $e->getMessage(),
-                            new CodeLocation($statements_analyzer->getSource(), $stmt),
-                        ),
-                    );
+                    if (!$ignore_comment) {
+                        IssueBuffer::maybeAdd(
+                            new InvalidDocblock(
+                                $e->getMessage(),
+                                new CodeLocation($statements_analyzer->getSource(), $stmt),
+                            ),
+                        );
+                    }
                 }
 
                 foreach ($var_comments as $var_comment) {
+                    // don't check if the class exists yet
+                    if ($ignore_comment
+                        && ($var_comment->var_id !== '$this' || !$var_comment->type)) {
+                        continue;
+                    }
+
                     AssignmentAnalyzer::assignTypeFromVarDocblock(
                         $statements_analyzer,
                         $stmt,
@@ -483,7 +499,11 @@ final class StatementsAnalyzer extends SourceAnalyzer
                         && $var_comment->type
                         && $codebase->classExists((string)$var_comment->type)
                     ) {
-                        $statements_analyzer->setFQCLN((string)$var_comment->type);
+                        $scope_fqcn = (string) $var_comment->type;
+                        $this_type = Type::parseString($scope_fqcn);
+                        $context->self = $scope_fqcn;
+                        $context->vars_in_scope['$this'] = $this_type;
+                        $statements_analyzer->setFQCLN($scope_fqcn);
                     }
                 }
             }

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -504,6 +504,7 @@ final class StatementsAnalyzer extends SourceAnalyzer
                         $context->self = $scope_fqcn;
                         $context->vars_in_scope['$this'] = $this_type;
                         $statements_analyzer->setFQCLN($scope_fqcn);
+                        $context->is_global = false;
                     }
                 }
             }
@@ -855,6 +856,7 @@ final class StatementsAnalyzer extends SourceAnalyzer
                 $context->self = $scope_fqcn;
                 $context->vars_in_scope['$this'] = $this_type;
                 $this->setFQCLN($scope_fqcn);
+                $context->is_global = false;
             }
         }
     }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -415,7 +415,7 @@ final class FunctionLikeDocblockParser
                 } else {
                     IssueBuffer::maybeAdd(
                         new InvalidDocblock(
-                            'Badly-formatted @param in docblock for ' . $cased_function_id,
+                            'Badly-formatted @global in docblock for ' . $cased_function_id,
                             $code_location,
                         ),
                     );

--- a/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
+++ b/src/Psalm/Internal/PhpVisitor/ReflectorVisitor.php
@@ -373,6 +373,7 @@ final class ReflectorVisitor extends PhpParser\NodeVisitorAbstract implements Fi
                     $this->aliases,
                     $template_types,
                     $this->type_aliases,
+                    $node instanceof PhpParser\Node\Stmt\Global_,
                 );
             } catch (DocblockParseException) {
                 // do nothing

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -103,7 +103,7 @@ final class TypeTokenizer
     ];
 
     /**
-     * @var array<string, list<array{0: string, 1: int}>>
+     * @var array<string, non-empty-list<array{0: string, 1: int}>>
      */
     private static array $memoized_tokens = [];
 
@@ -111,7 +111,7 @@ final class TypeTokenizer
      * Tokenises a type string into an array of tuples where the first element
      * contains the string token and the second element contains its offset,
      *
-     * @return list<array{0: string, 1: int}>
+     * @return non-empty-list<array{0: string, 1: int}>
      */
     public static function tokenize(string $string_type, bool $ignore_space = true): array
     {
@@ -303,7 +303,7 @@ final class TypeTokenizer
             $was_space = false;
         }
 
-        /** @var list<array{0: string, 1: int}> $type_tokens */
+        /** @var non-empty-list<array{0: string, 1: int}> $type_tokens */
         self::$memoized_tokens[$string_type] = $type_tokens;
 
         return $type_tokens;
@@ -333,7 +333,7 @@ final class TypeTokenizer
     /**
      * @param  array<string, mixed>|null       $template_type_map
      * @param  array<string, TypeAlias>|null   $type_aliases
-     * @return list<array{0: string, 1: int, 2?: string}>
+     * @return non-empty-list<array{0: string, 1: int, 2?: string}>
      */
     public static function getFullyQualifiedTokens(
         string $string_type,
@@ -486,7 +486,7 @@ final class TypeTokenizer
             }
         }
 
-        /** @var list<array{0: string, 1: int, 2?: string}> */
+        /** @var non-empty-list<array{0: string, 1: int, 2?: string}> */
         return $type_tokens;
     }
 

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -1474,4 +1474,86 @@ final class StubTest extends TestCase
         $this->expectExceptionMessage('TaintedHtml - src/somefile.php');
         $this->analyzeFile($file_path, new Context());
     }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testPsalmScopeThisAutoloader(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                    autoloader="tests/fixtures/stubs/this-scope-loader.php"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+                </psalm>',
+            ),
+        );
+
+        $file_path = (string) getcwd() . '/src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                namespace A\B;
+
+                use X\Y;
+
+                /**
+                * @psalm-scope-this Y
+                */
+                $a = $this->run();
+
+                echo "a" . $a;
+                ',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    /**
+     * @runInSeparateProcess
+     */
+    public function testVarThisAutoloader(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm
+                    errorLevel="1"
+                    autoloader="tests/fixtures/stubs/this-scope-loader.php"
+                >
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+                </psalm>',
+            ),
+        );
+
+        $file_path = (string) getcwd() . '/src/somefile.php';
+
+        $this->addFile(
+            $file_path,
+            '<?php
+                namespace A\B;
+
+                use X\Y;
+
+                /**
+                * @var Y $this
+                */
+                $a = $this->run();
+
+                echo "a" . $a;
+                ',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
 }

--- a/tests/TypeReconciliation/ScopeTest.php
+++ b/tests/TypeReconciliation/ScopeTest.php
@@ -234,6 +234,20 @@ final class ScopeTest extends TestCase
                     }
                     PHP,
             ],
+            'psalmVarThisInTemplateVariableAssigned' => [
+                'code' => '<?php
+                    /** @var Exception $this */
+                    $m = $this->getMessage();
+                ?>
+                <h1><?php echo $m; ?></h1>',
+            ],
+            'psalmScopeThisInTemplateVariableAssigned' => [
+                'code' => '<?php
+                    /** @psalm-scope-this Exception */
+                    $m = $this->getMessage();
+                ?>
+                <h1><?php echo $m; ?></h1>',
+            ],
         ];
     }
 

--- a/tests/TypeReconciliation/ScopeTest.php
+++ b/tests/TypeReconciliation/ScopeTest.php
@@ -248,6 +248,28 @@ final class ScopeTest extends TestCase
                 ?>
                 <h1><?php echo $m; ?></h1>',
             ],
+            'psalmVarThisGlobal' => [
+                'code' => '<?php
+                    /**
+                     * @global string $my_global
+                     *
+                     * @var Exception $this
+                     */
+                    global $my_global;
+                ?>
+                <h1><?php echo $my_global; ?></h1>',
+            ],
+            'psalmScopeThisGlobal' => [
+                'code' => '<?php
+                    /**
+                     * @global string $my_global
+                     *
+                     * @psalm-scope-this Exception
+                     */
+                    global $my_global;
+                ?>
+                <h1><?php echo $my_global; ?></h1>',
+            ],
         ];
     }
 

--- a/tests/fixtures/stubs/this-scope-loader.php
+++ b/tests/fixtures/stubs/this-scope-loader.php
@@ -1,0 +1,17 @@
+<?php
+
+use X\Y;
+
+/**
+ * @param string $class_name
+ * @return void
+ */
+function autoload_xy($class_name) {
+    if ($class_name === Y::class) {
+        spl_autoload_unregister(__FUNCTION__);
+
+        require __DIR__ . DIRECTORY_SEPARATOR . 'this-scope-xy.php';
+    }
+}
+
+spl_autoload_register('autoload_xy');

--- a/tests/fixtures/stubs/this-scope-xy.php
+++ b/tests/fixtures/stubs/this-scope-xy.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace X;
+
+class Y {
+    protected function run(): string {
+        return ' is xy';
+    }
+}


### PR DESCRIPTION
Fixes @var $this and @psalm-scope-this behaving inconsistently (what worked for one, didn't work for the other and vice versa) as well as @global behaving inconsistently/not supported generally in relation to these 2.

Fix [#8811](https://github.com/vimeo/psalm/issues/8811)
Fix [#4916](https://github.com/vimeo/psalm/issues/4916) again since it wasn't working for various cases
Fix [#9773](https://github.com/vimeo/psalm/issues/9773)