### PR TITLE
Prevent int overflow crash when comparing against PHP_INT_MAX/MIN

### DIFF
--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1964,6 +1964,25 @@ final class SimpleAssertionReconciler extends Reconciler
         //we add 1 from the assertion value because we're on a strict operator
         $assertion_value = $assertion->value + 1;
 
+        if (!is_int($assertion_value)) {
+            // PHP_INT_MAX + 1 overflows to float; no integer can satisfy > PHP_INT_MAX.
+            if ($assertion->doesFilterNullOrFalse() &&
+                ($existing_var_type->hasType('null') || $existing_var_type->hasType('false'))
+            ) {
+                $existing_var_type->removeType('null');
+                $existing_var_type->removeType('false');
+            }
+            foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
+                if ($atomic_type instanceof TIntRange
+                    || $atomic_type instanceof TInt
+                    || $atomic_type instanceof TLiteralInt
+                ) {
+                    $existing_var_type->removeType($atomic_type->getKey());
+                }
+            }
+            return $existing_var_type->freeze();
+        }
+
         $redundant = true;
 
         if ($assertion->doesFilterNullOrFalse() &&
@@ -2013,7 +2032,7 @@ final class SimpleAssertionReconciler extends Reconciler
                         $existing_var_type->addType(new TIntRange($assertion_value, $atomic_type->value));
                     }
                 }*/
-            } elseif ($atomic_type instanceof TInt && is_int($assertion_value)) {
+            } elseif ($atomic_type instanceof TInt) {
                 $redundant = false;
                 $existing_var_type->removeType($atomic_type->getKey());
                 $existing_var_type->addType(new TIntRange($assertion_value, null));
@@ -2072,6 +2091,25 @@ final class SimpleAssertionReconciler extends Reconciler
         //we remove 1 from the assertion value because we're on a strict operator
         $assertion_value = $assertion->value - 1;
         $existing_var_type = $existing_var_type->getBuilder();
+
+        if (!is_int($assertion_value)) {
+            // PHP_INT_MIN - 1 underflows to float; no integer can satisfy < PHP_INT_MIN.
+            if ($assertion->doesFilterNullOrFalse() &&
+                ($existing_var_type->hasType('null') || $existing_var_type->hasType('false'))
+            ) {
+                $existing_var_type->removeType('null');
+                $existing_var_type->removeType('false');
+            }
+            foreach ($existing_var_type->getAtomicTypes() as $atomic_type) {
+                if ($atomic_type instanceof TIntRange
+                    || $atomic_type instanceof TInt
+                    || $atomic_type instanceof TLiteralInt
+                ) {
+                    $existing_var_type->removeType($atomic_type->getKey());
+                }
+            }
+            return $existing_var_type->freeze();
+        }
 
         $redundant = true;
 

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -1034,6 +1034,29 @@ final class IntRangeTest extends TestCase
                     '$z' => 'int<min, 9223372036854775807>|null',
                 ],
             ],
+            'noInternalErrorOnGreaterThanPhpIntMax' => [
+                'code' => '<?php
+                    function packInteger(int $value): void {
+                        if ($value >= 0) {
+                        } elseif ($value <= 9223372036854775807) {
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => ['RedundantCondition'],
+            ],
+            // Psalm does not currently emit RedundantCondition for the >= direction at PHP_INT_MIN,
+            // so no ignored_issues entry is needed here (unlike the <= PHP_INT_MAX case above).
+            'noInternalErrorOnLessThanPhpIntMin' => [
+                'code' => '<?php
+                    function checkBound(int $value): void {
+                        if ($value <= 0) {
+                        } elseif ($value >= -9223372036854775808) {
+                        }
+                    }
+                ',
+                'assertions' => [],
+            ],
         ];
     }
 


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/11209

`reconcileIsGreaterThan` computes `$assertion->value + 1`, which overflows from `int` to `float` when the assertion value is `PHP_INT_MAX`. The resulting `float` is passed to `TIntRange::contains(int $i)` under `strict_types=1`, causing a `TypeError`.

The same underflow happens in `reconcileIsLessThan` with `PHP_INT_MIN - 1`.

Added `!is_int()` guards after each arithmetic step. When overflow is detected, no integer can satisfy the comparison, so all integer types are removed from the union.