### PR TITLE
[7.x] Allow plugin issues to specify custom documentation URLs

### DIFF
--- a/src/Psalm/Internal/Analyzer/IssueData.php
+++ b/src/Psalm/Internal/Analyzer/IssueData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\Internal\Analyzer;
 
+use function is_string;
 use function str_pad;
 
 use const STR_PAD_LEFT;
@@ -45,7 +46,12 @@ final class IssueData
         public ?array $taint_trace = null,
         public ?array $other_references = null,
         public readonly ?string $dupe_key = null,
+        ?string $documentation_url = null,
     ) {
-        $this->link = $shortcode ? 'https://psalm.dev/' . str_pad((string) $shortcode, 3, "0", STR_PAD_LEFT) : '';
+        $this->link = match (true) {
+            is_string($documentation_url) => $documentation_url,
+            $shortcode > 0 => 'https://psalm.dev/' . str_pad((string) $shortcode, 3, "0", STR_PAD_LEFT),
+            default => '',
+        };
     }
 }

--- a/src/Psalm/Issue/CodeIssue.php
+++ b/src/Psalm/Issue/CodeIssue.php
@@ -16,6 +16,8 @@ abstract class CodeIssue
     public const ERROR_LEVEL = -1;
     /** @var int<0, max> */
     public const SHORTCODE = 0;
+    /** @var non-empty-string|null */
+    public const DOCUMENTATION_URL = null;
 
     public ?string $dupe_key = null;
 
@@ -107,6 +109,7 @@ abstract class CodeIssue
                 ]
                 : null,
             $this->dupe_key,
+            static::DOCUMENTATION_URL,
         );
     }
 }

--- a/tests/Internal/Analyzer/IssueDataTest.php
+++ b/tests/Internal/Analyzer/IssueDataTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Internal\Analyzer;
+
+use PHPUnit\Framework\TestCase;
+use Psalm\Internal\Analyzer\IssueData;
+
+final class IssueDataTest extends TestCase
+{
+    public function testLinkUsesDocumentationUrlWhenProvided(): void
+    {
+        $issue = new IssueData(
+            IssueData::SEVERITY_ERROR,
+            1,
+            1,
+            'CustomIssue',
+            'message',
+            'file.php',
+            '/path/file.php',
+            'snippet',
+            'selected',
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            documentation_url: 'https://example.com/docs/CustomIssue',
+        );
+
+        self::assertSame('https://example.com/docs/CustomIssue', $issue->link);
+    }
+
+    public function testLinkUsesPsalmDevWhenShortcodeProvidedWithoutDocumentationUrl(): void
+    {
+        $issue = new IssueData(
+            IssueData::SEVERITY_ERROR,
+            1,
+            1,
+            'SomeIssue',
+            'message',
+            'file.php',
+            '/path/file.php',
+            'snippet',
+            'selected',
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            42,
+        );
+
+        self::assertSame('https://psalm.dev/042', $issue->link);
+    }
+
+    public function testDocumentationUrlTakesPriorityOverShortcode(): void
+    {
+        $issue = new IssueData(
+            IssueData::SEVERITY_ERROR,
+            1,
+            1,
+            'CustomIssue',
+            'message',
+            'file.php',
+            '/path/file.php',
+            'snippet',
+            'selected',
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            42,
+            documentation_url: 'https://example.com/docs',
+        );
+
+        self::assertSame('https://example.com/docs', $issue->link);
+    }
+
+    public function testLinkIsEmptyWhenNoShortcodeOrDocumentationUrl(): void
+    {
+        $issue = new IssueData(
+            IssueData::SEVERITY_ERROR,
+            1,
+            1,
+            'CustomIssue',
+            'message',
+            'file.php',
+            '/path/file.php',
+            'snippet',
+            'selected',
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        );
+
+        self::assertSame('', $issue->link);
+    }
+}


### PR DESCRIPTION
## Summary

Plugin-defined issues (subclasses of `PluginIssue`) had no mechanism to provide custom documentation URLs. The `link` field in `IssueData` was derived exclusively from `SHORTCODE` and hardcoded to the `psalm.dev` domain, which is not meaningful for third-party plugin issues.

This adds a `DOCUMENTATION_URL` constant to `CodeIssue` that plugin authors can override to link to their own documentation:

```php
final class NoEnvOutsideConfig extends PluginIssue
{
    public const DOCUMENTATION_URL = 'https://github.com/psalm/psalm-plugin-laravel/blob/master/docs/issues/NoEnvOutsideConfig.md';
}
```

The custom URL takes priority over the shortcode-based psalm.dev link. Fully backward-compatible — existing behavior is unchanged.

Fixes #11732
