### PR TITLE
[7.x] Add missing ImpureGlobalVariable to error levels doc

### DIFF
--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -40,6 +40,7 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
  - [ImplementationRequirementViolation](issues/ImplementationRequirementViolation.md)
  - [ImpureByReferenceAssignment](issues/ImpureByReferenceAssignment.md)
  - [ImpureFunctionCall](issues/ImpureFunctionCall.md)
+ - [ImpureGlobalVariable](issues/ImpureGlobalVariable.md)
  - [ImpureMethodCall](issues/ImpureMethodCall.md)
  - [ImpurePropertyAssignment](issues/ImpurePropertyAssignment.md)
  - [ImpurePropertyFetch](issues/ImpurePropertyFetch.md)


### PR DESCRIPTION
- `ImpureGlobalVariable` has `ERROR_LEVEL = -1` but was missing from the "Always treated as errors" section in `docs/running_psalm/error_levels.md`
- Regenerated the doc via `php bin/docs/generate_levels_doc.php`
