### PR TITLE
Introduce psalm plugin API

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,6 +2,12 @@
 
 ## Changed
 
+- Backwards compatibility for the plugin API is now covered by a separate metapackage, [psalm/psalm-plugin-api](https://packagist.org/packages/psalm/psalm-plugin-api).  
+
+  This is a separate, empty metapackage: its major version will be bumped every time a breaking change occurs within Psalm's plugin API; minors will also be bumped when adding new features to Psalm's plugin API.  
+
+  Plugins, starting from the first stable release of v7, need to explicitly require a caret range (i.e. ^1, NOT 1.0.0) that package in order to avoid breaking changes during Psalm upgrades.  
+
 - [BC] The parameters $calling_fq_class_name and $calling_method_id of Psalm\Codebase#classOrInterfaceExists() were removed and replaced with a single Psalm\Context|null parameter
 - [BC] The parameters $calling_fq_class_name and $calling_method_id of Psalm\Codebase#classOrInterfaceOrEnumExists() were removed and replaced with a single Psalm\Context|null parameter
 - [BC] The parameters $calling_fq_class_name and $calling_method_id of Psalm\Codebase#classExists() were removed and replaced with a single Psalm\Context|null parameter

--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,7 @@
         "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
         "netresearch/jsonmapper": "^5.0",
         "nikic/php-parser": "^5.0.0",
+        "psalm/psalm-plugin-api": "1.0.0",
         "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
         "symfony/console": "^6.0 || ^7.0 || ^8.0",

--- a/docs/running_psalm/plugins/authoring_plugins.md
+++ b/docs/running_psalm/plugins/authoring_plugins.md
@@ -10,6 +10,13 @@ Head over to [plugin template repository](https://github.com/weirdan/psalm-plugi
 
 Run `composer create-project weirdan/psalm-plugin-skeleton:dev-master your-plugin-name` to quickly bootstrap a new plugin project in `your-plugin-name` folder. Make sure you adjust namespaces in `composer.json`, `Plugin.php` and `tests` folder.
 
+## Psalm plugin API
+
+Backwards compatibility for the plugin API is now covered by a separate metapackage, [psalm/psalm-plugin-api](https://packagist.org/packages/psalm/psalm-plugin-api).  
+
+This is a separate, empty metapackage: its major version will be bumped every time a breaking change occurs within Psalm's plugin API; minors will also be bumped when adding new features to Psalm's plugin API.  
+
+Plugins, starting from the first stable release of v7, need to explicitly require a caret range (i.e. ^1, NOT 1.0.0) that package in order to avoid breaking changes during Psalm upgrades.  
 
 ## Stub files
 


### PR DESCRIPTION
1.0.0 covers the first **stable** release of Psalm v7 (yet to be released, hopefully soon).