### PR TITLE
[7.x] Add `TaintedLlmPrompt` issue type for prompt injection detection

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -471,6 +471,7 @@
             <xs:element name="TaintedInclude" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TaintedInput" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TaintedLdap" type="IssueHandlerType" minOccurs="0" />
+            <xs:element name="TaintedLlmPrompt" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TaintedShell" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TaintedSleep" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="TaintedSql" type="IssueHandlerType" minOccurs="0" />

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -253,6 +253,7 @@
  - [TaintedInclude](issues/TaintedInclude.md)
  - [TaintedInput](issues/TaintedInput.md)
  - [TaintedLdap](issues/TaintedLdap.md)
+ - [TaintedLlmPrompt](issues/TaintedLlmPrompt.md)
  - [TaintedShell](issues/TaintedShell.md)
  - [TaintedSleep](issues/TaintedSleep.md)
  - [TaintedSql](issues/TaintedSql.md)

--- a/docs/running_psalm/issues/TaintedLlmPrompt.md
+++ b/docs/running_psalm/issues/TaintedLlmPrompt.md
@@ -1,0 +1,17 @@
+# TaintedLlmPrompt
+
+Emitted when user-controlled input can be passed into an LLM prompt, risking prompt injection.
+
+```php
+<?php
+
+class LlmAgent {
+    /** @psalm-taint-sink llm_prompt $prompt */
+    public function prompt(string $prompt): string {
+        return "";
+    }
+}
+
+$agent = new LlmAgent();
+$agent->prompt((string) $_GET["question"]);
+```

--- a/src/Psalm/Internal/Codebase/TaintFlowGraph.php
+++ b/src/Psalm/Internal/Codebase/TaintFlowGraph.php
@@ -20,6 +20,7 @@ use Psalm\Issue\TaintedHeader;
 use Psalm\Issue\TaintedHtml;
 use Psalm\Issue\TaintedInclude;
 use Psalm\Issue\TaintedLdap;
+use Psalm\Issue\TaintedLlmPrompt;
 use Psalm\Issue\TaintedSSRF;
 use Psalm\Issue\TaintedShell;
 use Psalm\Issue\TaintedSleep;
@@ -608,6 +609,12 @@ final class TaintFlowGraph extends DataFlowGraph
                             ),
                             TaintKind::INPUT_EXTRACT => new TaintedExtract(
                                 'Detected tainted extract',
+                                $issue_location,
+                                $issue_trace,
+                                $path,
+                            ),
+                            TaintKind::INPUT_LLM_PROMPT => new TaintedLlmPrompt(
+                                'Detected tainted LLM prompt',
                                 $issue_location,
                                 $issue_trace,
                                 $path,

--- a/src/Psalm/Issue/TaintedLlmPrompt.php
+++ b/src/Psalm/Issue/TaintedLlmPrompt.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Issue;
+
+final class TaintedLlmPrompt extends TaintedInput
+{
+    public const SHORTCODE = 367;
+}

--- a/src/Psalm/Type/TaintKind.php
+++ b/src/Psalm/Type/TaintKind.php
@@ -30,9 +30,9 @@ final class TaintKind
     public const INPUT_XPATH = (1 << 13);
     public const INPUT_SLEEP = (1 << 14);
     public const INPUT_EXTRACT = (1 << 15);
-    public const USER_SECRET = (1 << 16);
-    public const SYSTEM_SECRET = (1 << 17);
-    public const INPUT_LLM_PROMPT = (1 << 18);
+    public const INPUT_LLM_PROMPT = (1 << 16);
+    public const USER_SECRET = (1 << 17);
+    public const SYSTEM_SECRET = (1 << 18);
 
     /**
      * Bitmask of all INPUT_* taint types. Used as the default taint for
@@ -41,11 +41,7 @@ final class TaintKind
      * Excludes USER_SECRET and SYSTEM_SECRET, which represent
      * sensitive data leaking out rather than untrusted data flowing in.
      */
-    public const ALL_INPUT = self::INPUT_CALLABLE | self::INPUT_UNSERIALIZE | self::INPUT_INCLUDE
-        | self::INPUT_EVAL | self::INPUT_LDAP | self::INPUT_SQL | self::INPUT_HTML
-        | self::INPUT_HAS_QUOTES | self::INPUT_SHELL | self::INPUT_SSRF | self::INPUT_FILE
-        | self::INPUT_COOKIE | self::INPUT_HEADER | self::INPUT_XPATH | self::INPUT_SLEEP
-        | self::INPUT_EXTRACT | self::INPUT_LLM_PROMPT;
+    public const ALL_INPUT = (1 << 17) - 1;
 
     /** @internal */
     public const NUMERIC_ONLY = self::INPUT_SLEEP;

--- a/src/Psalm/Type/TaintKind.php
+++ b/src/Psalm/Type/TaintKind.php
@@ -32,8 +32,13 @@ final class TaintKind
     public const INPUT_EXTRACT = (1 << 15);
     public const USER_SECRET = (1 << 16);
     public const SYSTEM_SECRET = (1 << 17);
+    public const INPUT_LLM_PROMPT = (1 << 18);
 
-    public const ALL_INPUT = (1 << 16) - 1;
+    public const ALL_INPUT = self::INPUT_CALLABLE | self::INPUT_UNSERIALIZE | self::INPUT_INCLUDE
+        | self::INPUT_EVAL | self::INPUT_LDAP | self::INPUT_SQL | self::INPUT_HTML
+        | self::INPUT_HAS_QUOTES | self::INPUT_SHELL | self::INPUT_SSRF | self::INPUT_FILE
+        | self::INPUT_COOKIE | self::INPUT_HEADER | self::INPUT_XPATH | self::INPUT_SLEEP
+        | self::INPUT_EXTRACT | self::INPUT_LLM_PROMPT;
 
     /** @internal */
     public const NUMERIC_ONLY = self::INPUT_SLEEP;
@@ -41,7 +46,7 @@ final class TaintKind
     public const BOOL_ONLY = self::INPUT_SLEEP;
 
     /** @internal Keep this synced with the above */
-    public const BUILTIN_TAINT_COUNT = 18;
+    public const BUILTIN_TAINT_COUNT = 19;
 
 
     // Map of taint kind names to their bitmask values, used in taint annotations
@@ -64,6 +69,7 @@ final class TaintKind
         'extract' => self::INPUT_EXTRACT,
         'user_secret' => self::USER_SECRET,
         'system_secret' => self::SYSTEM_SECRET,
+        'llm_prompt' => self::INPUT_LLM_PROMPT,
 
         'input_except_sleep' => self::ALL_INPUT & ~self::INPUT_SLEEP,
 

--- a/src/Psalm/Type/TaintKind.php
+++ b/src/Psalm/Type/TaintKind.php
@@ -34,6 +34,13 @@ final class TaintKind
     public const SYSTEM_SECRET = (1 << 17);
     public const INPUT_LLM_PROMPT = (1 << 18);
 
+    /**
+     * Bitmask of all INPUT_* taint types. Used as the default taint for
+     * user-controlled sources (e.g. $_GET, $_POST) so they propagate to any
+     * input sink.
+     * Excludes USER_SECRET and SYSTEM_SECRET, which represent
+     * sensitive data leaking out rather than untrusted data flowing in.
+     */
     public const ALL_INPUT = self::INPUT_CALLABLE | self::INPUT_UNSERIALIZE | self::INPUT_INCLUDE
         | self::INPUT_EVAL | self::INPUT_LDAP | self::INPUT_SQL | self::INPUT_HTML
         | self::INPUT_HAS_QUOTES | self::INPUT_SHELL | self::INPUT_SSRF | self::INPUT_FILE

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -187,6 +187,23 @@ final class TaintTest extends TestCase
                     $agent = new LlmAgent();
                     $agent->prompt("Summarize this document");',
             ],
+            'llmPromptEscaped' => [
+                'code' => '<?php
+                    class LlmAgent {
+                        /** @psalm-taint-sink llm_prompt $prompt */
+                        public function prompt(string $prompt): string {
+                            return "";
+                        }
+                    }
+
+                    /** @psalm-taint-escape llm_prompt */
+                    function sanitize_for_llm(string $input): string {
+                        return $input;
+                    }
+
+                    $agent = new LlmAgent();
+                    $agent->prompt(sanitize_for_llm((string) $_GET["question"]));',
+            ],
             'taintedInputToParamButSafe' => [
                 'code' => '<?php
                     class A {
@@ -853,6 +870,23 @@ final class TaintTest extends TestCase
 
                     $agent = new LlmAgent();
                     $agent->prompt("Tell me about " . (string) $_GET["topic"]);',
+                'error_message' => 'TaintedLlmPrompt',
+            ],
+            'taintedLlmPromptThroughFunction' => [
+                'code' => '<?php
+                    class LlmAgent {
+                        /** @psalm-taint-sink llm_prompt $prompt */
+                        public function prompt(string $prompt): string {
+                            return "";
+                        }
+                    }
+
+                    function buildPrompt(string $userInput): string {
+                        return "Tell me about " . $userInput;
+                    }
+
+                    $agent = new LlmAgent();
+                    $agent->prompt(buildPrompt((string) $_GET["topic"]));',
                 'error_message' => 'TaintedLlmPrompt',
             ],
             'taintedInputFromMethodReturnTypeSimple' => [

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -173,6 +173,20 @@ final class TaintTest extends TestCase
                         public function exec(string $sql) : void {}
                     }',
             ],
+            'llmPromptWithSafeInput' => [
+                'code' => '<?php
+                    class LlmAgent {
+                        /**
+                         * @psalm-taint-sink llm_prompt $prompt
+                         */
+                        public function prompt(string $prompt): string {
+                            return "";
+                        }
+                    }
+
+                    $agent = new LlmAgent();
+                    $agent->prompt("Summarize this document");',
+            ],
             'taintedInputToParamButSafe' => [
                 'code' => '<?php
                     class A {
@@ -815,6 +829,32 @@ final class TaintTest extends TestCase
     public function providerInvalidCodeParse(): array
     {
         return [
+            'taintedLlmPromptFromUserInput' => [
+                'code' => '<?php
+                    class LlmAgent {
+                        /** @psalm-taint-sink llm_prompt $prompt */
+                        public function prompt(string $prompt): string {
+                            return "";
+                        }
+                    }
+
+                    $agent = new LlmAgent();
+                    $agent->prompt((string) $_GET["question"]);',
+                'error_message' => 'TaintedLlmPrompt',
+            ],
+            'taintedLlmPromptFromConcatenatedInput' => [
+                'code' => '<?php
+                    class LlmAgent {
+                        /** @psalm-taint-sink llm_prompt $prompt */
+                        public function prompt(string $prompt): string {
+                            return "";
+                        }
+                    }
+
+                    $agent = new LlmAgent();
+                    $agent->prompt("Tell me about " . (string) $_GET["topic"]);',
+                'error_message' => 'TaintedLlmPrompt',
+            ],
             'taintedInputFromMethodReturnTypeSimple' => [
                 'code' => '<?php
                     class A {


### PR DESCRIPTION
Adds a first-class `TaintedLlmPrompt` taint issue type for detecting prompt injection vulnerabilities — when user input flows unsanitized into LLM prompts (OWASP LLM01:2025).

Ref: psalm/psalm-plugin-laravel#484

### Design decisions

- **Included in `ALL_INPUT`**: LLM prompt injection is an input taint (user data → LLM), unlike `USER_SECRET`/`SYSTEM_SECRET` (sensitive data leaking out), so it belongs in `ALL_INPUT`.

### Usage

```php
/** @psalm-taint-sink llm_prompt $prompt */
function askLlm(string $prompt): string { /* ... */ }

askLlm($_GET['question']);                        // TaintedLlmPrompt
askLlm("Tell me about " . $_GET['topic']);        // TaintedLlmPrompt
askLlm("Summarize this document");                // OK
```
PS: once merged, it will be nice to release it (as new beta) ASAP, as I have some ideas for https://github.com/psalm/psalm-plugin-laravel to use it (the plugin already tagged as major 4.x and supports Psalm 7.x only)