### PR TITLE
[7.x] Add `--init-ci` command to generate GitHub Actions workflow

### DIFF
--- a/.github/stubs/github-actions-psalm.yml
+++ b/.github/stubs/github-actions-psalm.yml
@@ -12,7 +12,7 @@ jobs:
     name: Psalm
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/vimeo/psalm:__PSALM_VERSION__
+      image: ghcr.io/danog/psalm:__PSALM_VERSION__
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/stubs/github-actions-psalm.yml
+++ b/.github/stubs/github-actions-psalm.yml
@@ -1,0 +1,30 @@
+name: Psalm
+
+on:
+  pull_request: null
+# Run on push to the main branch as well:
+# push:
+#  branches:
+#   - main
+
+jobs:
+  psalm:
+    name: Psalm
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '__PHP_VERSION__'
+          coverage: none
+
+      - uses: ramsey/composer-install@v4
+
+      # Tips for enhancing this step:
+      #  - respect baseline: --use-baseline=psalm-baseline.xml
+      #  - report results to Shepherd (https://shepherd.dev) for historical type cover tracking: --shepherd
+      #  - specify a path to the config: -c psalm.xml
+      #  - disable php-cli memory limit by prefixing with: php -d memory_limit=-1
+      - name: Run Psalm
+        run: vendor/bin/psalm --output-format=github --no-progress --no-suggestions

--- a/.github/stubs/github-actions-psalm.yml
+++ b/.github/stubs/github-actions-psalm.yml
@@ -11,20 +11,17 @@ jobs:
   psalm:
     name: Psalm
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vimeo/psalm:__PSALM_VERSION__
     steps:
       - uses: actions/checkout@v4
 
-      - uses: shivammathur/setup-php@v2
-        with:
-          php-version: '__PHP_VERSION__'
-          coverage: none
-
-      - uses: ramsey/composer-install@v4
-
+      # --output-format=github annotates pull requests inline with Psalm issues.
+      # --threads=4: Psalm defaults to 1 thread in CI; standard GitHub runners have 4 cores.
+      #
       # Tips for enhancing this step:
       #  - respect baseline: --use-baseline=psalm-baseline.xml
-      #  - report results to Shepherd (https://shepherd.dev) for historical type cover tracking: --shepherd
+      #  - report results to Shepherd (https://shepherd.dev) for historical type coverage tracking: --shepherd
       #  - specify a path to the config: -c psalm.xml
-      #  - disable php-cli memory limit by prefixing with: php -d memory_limit=-1
       - name: Run Psalm
-        run: vendor/bin/psalm --output-format=github --no-progress --no-suggestions
+        run: psalm --output-format=github --threads=4 --no-progress --no-suggestions

--- a/src/Psalm/Config/CiCreator.php
+++ b/src/Psalm/Config/CiCreator.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Config;
+
+use JsonException;
+use Psalm\Internal\Composer;
+
+use function assert;
+use function dirname;
+use function file_exists;
+use function file_get_contents;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function preg_match;
+use function str_replace;
+
+use const DIRECTORY_SEPARATOR;
+use const JSON_THROW_ON_ERROR;
+
+/** @internal */
+final class CiCreator
+{
+    private const DEFAULT_PHP_VERSION = '8.3';
+
+    public static function getContents(string $current_dir): string
+    {
+        $php_version = self::detectPhpVersion($current_dir) ?? self::DEFAULT_PHP_VERSION;
+        $template = self::loadTemplate();
+
+        return str_replace('__PHP_VERSION__', $php_version, $template);
+    }
+
+    private static function loadTemplate(): string
+    {
+        $path = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '.github'
+            . DIRECTORY_SEPARATOR . 'stubs'
+            . DIRECTORY_SEPARATOR . 'github-actions-psalm.yml';
+
+        $contents = file_get_contents($path);
+        assert($contents !== false);
+
+        return $contents;
+    }
+
+    private static function detectPhpVersion(string $current_dir): ?string
+    {
+        $composer_json_path = Composer::getJsonFilePath($current_dir);
+
+        if (!file_exists($composer_json_path)) {
+            return null;
+        }
+
+        $contents = file_get_contents($composer_json_path);
+        if ($contents === false) {
+            return null;
+        }
+
+        try {
+            $composer_json = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return null;
+        }
+
+        if (!is_array($composer_json)) {
+            return null;
+        }
+
+        $php_constraint = $composer_json['require']['php'] ?? null;
+
+        if (!is_string($php_constraint)) {
+            return null;
+        }
+
+        // Extract the minimum version from common constraint patterns
+        // e.g. ">=8.1", "^8.1", "~8.1", "8.1.*", ">=8.1 <8.4"
+        if (preg_match('/(\d+\.\d+)/', $php_constraint, $matches) === 1
+            && isset($matches[1])
+        ) {
+            return $matches[1];
+        }
+
+        return null;
+    }
+}

--- a/src/Psalm/Config/CiCreator.php
+++ b/src/Psalm/Config/CiCreator.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Psalm\Config;
 
 use JsonException;
-use Psalm\Internal\Composer;
 
+use function array_merge;
 use function assert;
 use function dirname;
 use function file_exists;
@@ -23,14 +23,14 @@ use const JSON_THROW_ON_ERROR;
 /** @internal */
 final class CiCreator
 {
-    private const DEFAULT_PHP_VERSION = '8.3';
+    private const DEFAULT_PSALM_VERSION = 'latest';
 
     public static function getContents(string $current_dir): string
     {
-        $php_version = self::detectPhpVersion($current_dir) ?? self::DEFAULT_PHP_VERSION;
+        $psalm_version = self::detectPsalmVersion($current_dir) ?? self::DEFAULT_PSALM_VERSION;
         $template = self::loadTemplate();
 
-        return str_replace('__PHP_VERSION__', $php_version, $template);
+        return str_replace('__PSALM_VERSION__', $psalm_version, $template);
     }
 
     private static function loadTemplate(): string
@@ -45,41 +45,52 @@ final class CiCreator
         return $contents;
     }
 
-    private static function detectPhpVersion(string $current_dir): ?string
+    private static function detectPsalmVersion(string $current_dir): ?string
     {
-        $composer_json_path = Composer::getJsonFilePath($current_dir);
+        $composer_lock_path = $current_dir . DIRECTORY_SEPARATOR . 'composer.lock';
 
-        if (!file_exists($composer_json_path)) {
+        if (!file_exists($composer_lock_path)) {
             return null;
         }
 
-        $contents = file_get_contents($composer_json_path);
+        $contents = file_get_contents($composer_lock_path);
         if ($contents === false) {
             return null;
         }
 
         try {
-            $composer_json = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
+            $lock = json_decode($contents, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException) {
             return null;
         }
 
-        if (!is_array($composer_json)) {
+        if (!is_array($lock)) {
             return null;
         }
 
-        $php_constraint = $composer_json['require']['php'] ?? null;
+        $packages = isset($lock['packages']) && is_array($lock['packages']) ? $lock['packages'] : [];
+        $packages_dev = isset($lock['packages-dev']) && is_array($lock['packages-dev']) ? $lock['packages-dev'] : [];
+        /** @var list<mixed> $all_packages */
+        $all_packages = array_merge($packages, $packages_dev);
+        foreach ($all_packages as $package) {
+            if (!is_array($package)) {
+                continue;
+            }
+            if (($package['name'] ?? null) !== 'vimeo/psalm') {
+                continue;
+            }
+            $version = $package['version'] ?? null;
+            if (!is_string($version)) {
+                return null;
+            }
+            // Extract major version from e.g. "6.8.4" or "v6.8.4"
+            if (preg_match('/v?(\d+)/', $version, $matches) === 1
+                && isset($matches[1])
+            ) {
+                return $matches[1];
+            }
 
-        if (!is_string($php_constraint)) {
             return null;
-        }
-
-        // Extract the minimum version from common constraint patterns
-        // e.g. ">=8.1", "^8.1", "~8.1", "8.1.*", ">=8.1 <8.4"
-        if (preg_match('/(\d+\.\d+)/', $php_constraint, $matches) === 1
-            && isset($matches[1])
-        ) {
-            return $matches[1];
         }
 
         return null;

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -1586,7 +1586,7 @@ final class Psalm
 
             --init-ci
                 Create a GitHub Actions workflow file at .github/workflows/psalm.yml.
-                Detects the PHP version from composer.json.
+                Uses the official Psalm Docker image, pinned to the major version from composer.lock.
 
             --debug
                 Debug information

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -7,6 +7,7 @@ namespace Psalm\Internal\Cli;
 use Composer\Autoload\ClassLoader;
 use Fidry\CpuCoreCounter\CpuCoreCounter;
 use Psalm\Config;
+use Psalm\Config\CiCreator;
 use Psalm\Config\Creator;
 use Psalm\ErrorBaseline;
 use Psalm\Exception\ConfigCreationException;
@@ -68,11 +69,13 @@ use function implode;
 use function in_array;
 use function ini_get;
 use function is_array;
+use function is_dir;
 use function is_numeric;
 use function is_string;
 use function json_encode;
 use function max;
 use function microtime;
+use function mkdir;
 use function opcache_get_status;
 use function parse_url;
 use function preg_match;
@@ -137,6 +140,7 @@ final class Psalm
         'help',
         'ignore-baseline',
         'init',
+        'init-ci',
         'memory-limit:',
         'monochrome',
         'no-diff',
@@ -234,6 +238,11 @@ final class Psalm
         }
 
         $current_dir = self::getCurrentDir($options);
+
+        if (array_key_exists('init-ci', $options)) {
+            self::generateCiConfig($current_dir);
+            exit;
+        }
 
         $path_to_config = CliUtils::getPathToConfig($options);
 
@@ -620,6 +629,34 @@ final class Psalm
 
             exit('Config file created successfully. Please re-run psalm.' . PHP_EOL);
         }
+    }
+
+    private static function generateCiConfig(string $current_dir): void
+    {
+        require_once __DIR__ . '/../../Config/CiCreator.php';
+        $workflow_dir = $current_dir . DIRECTORY_SEPARATOR . '.github'
+            . DIRECTORY_SEPARATOR . 'workflows';
+        $workflow_file = $workflow_dir . DIRECTORY_SEPARATOR . 'psalm.yml';
+
+        if (file_exists($workflow_file)) {
+            fwrite(STDERR, 'A CI workflow already exists at ' . $workflow_file . PHP_EOL);
+            exit(1);
+        }
+
+        $contents = CiCreator::getContents($current_dir);
+
+        if (!is_dir($workflow_dir) && !mkdir($workflow_dir, 0777, true)) {
+            fwrite(STDERR, 'Could not create directory ' . $workflow_dir . PHP_EOL);
+            exit(1);
+        }
+
+        if (file_put_contents($workflow_file, $contents) === false) {
+            fwrite(STDERR, 'Could not write to ' . $workflow_file . PHP_EOL);
+            exit(1);
+        }
+
+        echo 'GitHub Actions workflow created at .github/workflows/psalm.yml' . PHP_EOL
+            . 'Review the file for tips on enabling taint analysis, baselines, and more.' . PHP_EOL;
     }
 
     /** @param list<ClassLoader> $autoloaders */
@@ -1546,6 +1583,10 @@ final class Psalm
             -i, --init [source_dir=src] [level=3]
                 Create a psalm config file in the current directory that points to [source_dir]
                 at the required level, from 1, most strict, to 8, most permissive.
+
+            --init-ci
+                Create a GitHub Actions workflow file at .github/workflows/psalm.yml.
+                Detects the PHP version from composer.json.
 
             --debug
                 Debug information


### PR DESCRIPTION
## Context

Setting up Psalm in CI is a common task that requires writing boilerplate YAML, looking up the right GitHub Actions, and figuring out flags like `--output-format=github`. This friction slows adoption, especially for newcomers.

## Solution

A new `psalm --init-ci` command generates a ready-to-use GitHub Actions workflow at `.github/workflows/psalm.yml`. It auto-detects the PHP version from `composer.json` and includes inline PR annotations via `--output-format=github`. The template lives as a standalone YAML file at `.github/stubs/github-actions-psalm.yml`, making it easy to maintain and review outside of PHP code. Inspired by how Rector ships CI templates.