### PR TITLE
[7.x] Rename `compact` output format to `table`, add new truly compact format

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -2792,7 +2792,7 @@
       <code><![CDATA[ini_get('xdebug.file_link_format') ?: get_cfg_var('xdebug.file_link_format')]]></code>
     </RiskyTruthyFalsyComparison>
   </file>
-  <file src="src/Psalm/Report/CompactReport.php">
+  <file src="src/Psalm/Report/TableReport.php">
     <ImmutableDependency>
       <code><![CDATA[#[Override]]]></code>
       <code><![CDATA[Report]]></code>

--- a/src/Psalm/Internal/PreloaderList.php
+++ b/src/Psalm/Internal/PreloaderList.php
@@ -1618,6 +1618,7 @@ final class PreloaderList {
         \Psalm\Report\ReportOptions::class,
         \Psalm\Report\SarifReport::class,
         \Psalm\Report\SonarqubeReport::class,
+        \Psalm\Report\TableReport::class,
         \Psalm\Report\TextReport::class,
         \Psalm\Report\XmlReport::class,
         \Psalm\SourceControl\Git\CommitInfo::class,

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -37,6 +37,7 @@ use Psalm\Report\PylintReport;
 use Psalm\Report\ReportOptions;
 use Psalm\Report\SarifReport;
 use Psalm\Report\SonarqubeReport;
+use Psalm\Report\TableReport;
 use Psalm\Report\TextReport;
 use Psalm\Report\XmlReport;
 use RuntimeException;
@@ -935,6 +936,11 @@ final class IssueBuffer
                 $report_options,
             ),
             Report::TYPE_EMACS => new EmacsReport(
+                $normalized_data,
+                self::$fixable_issue_counts,
+                $report_options,
+            ),
+            Report::TYPE_TABLE => new TableReport(
                 $normalized_data,
                 self::$fixable_issue_counts,
                 $report_options,

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -28,6 +28,7 @@ abstract class Report
     final public const TYPE_XML = 'xml';
     final public const TYPE_JUNIT = 'junit';
     final public const TYPE_CHECKSTYLE = 'checkstyle';
+    final public const TYPE_TABLE = 'table';
     final public const TYPE_TEXT = 'text';
     final public const TYPE_GITHUB_ACTIONS = 'github';
     final public const TYPE_PHP_STORM = 'phpstorm';

--- a/src/Psalm/Report/CompactReport.php
+++ b/src/Psalm/Report/CompactReport.php
@@ -6,82 +6,35 @@ namespace Psalm\Report;
 
 use Override;
 use Psalm\Config;
-use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
-use Symfony\Component\Console\Helper\Table;
-use Symfony\Component\Console\Output\BufferedOutput;
 
-use function implode;
-use function str_split;
-use function strlen;
 use function strtoupper;
 
+/**
+ * @psalm-external-mutation-free
+ */
 final class CompactReport extends Report
 {
     /**
-     * @psalm-suppress PossiblyNullReference
+     * @psalm-mutation-free
      */
     #[Override]
     public function create(): string
     {
-        /** @var BufferedOutput|null $buffer */
-        $buffer = null;
+        $output = '';
 
-        /** @var Table|null $table */
-        $table = null;
-
-        /** @var string|null $current_file */
-        $current_file = null;
-
-        $output = [];
         foreach ($this->issues_data as $issue_data) {
-            if (!$this->show_info && $issue_data->severity === IssueData::SEVERITY_INFO) {
-                continue;
-            }
-
-            if ($current_file === null || $current_file !== $issue_data->file_name) {
-                // If we're processing a new file, then wrap up the last table and render it out.
-                if ($buffer !== null) {
-                    $table->render();
-                    $output[] = $buffer->fetch();
-                }
-
-                $output[] = 'FILE: ' . $issue_data->file_name . "\n";
-
-                $buffer = new BufferedOutput();
-                $table = new Table($buffer);
-                $table->setHeaders(['SEVERITY', 'LINE', 'ISSUE', 'DESCRIPTION']);
-            }
-
             $is_error = $issue_data->severity === Config::REPORT_ERROR;
             if ($is_error) {
-                $severity = ($this->use_color ? "\e[0;31mERROR\e[0m" : 'ERROR');
+                $severity = $this->use_color ? "\e[0;31mERROR\e[0m" : 'ERROR';
             } else {
                 $severity = strtoupper($issue_data->severity);
             }
 
-            // Since `Table::setColumnMaxWidth` is only available in symfony/console 4.2+ we need do something similar
-            // so we have clean tables.
-            $message = $issue_data->message;
-            if (strlen($message) > 70) {
-                $message = implode("\n", str_split($message, 70));
-            }
-
-            $table->addRow([
-                $severity,
-                $issue_data->line_from,
-                $issue_data->type,
-                $message,
-            ]);
-
-            $current_file = $issue_data->file_name;
+            $output .= $severity . ' ' . $issue_data->file_name . ':' . $issue_data->line_from
+                . ':' . $issue_data->column_from . ' ' . $issue_data->type . ': ' . $issue_data->message . "\n";
         }
 
-        if ($buffer !== null) {
-            $table->render();
-            $output[] = $buffer->fetch();
-        }
-
-        return implode("\n", $output);
+        return $output;
     }
 }

--- a/src/Psalm/Report/TableReport.php
+++ b/src/Psalm/Report/TableReport.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Report;
+
+use Override;
+use Psalm\Config;
+use Psalm\Report;
+use Symfony\Component\Console\Helper\Table;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function implode;
+use function str_split;
+use function strlen;
+use function strtoupper;
+
+final class TableReport extends Report
+{
+    /**
+     * @psalm-suppress PossiblyNullReference
+     */
+    #[Override]
+    public function create(): string
+    {
+        /** @var BufferedOutput|null $buffer */
+        $buffer = null;
+
+        /** @var Table|null $table */
+        $table = null;
+
+        /** @var string|null $current_file */
+        $current_file = null;
+
+        $output = [];
+        foreach ($this->issues_data as $issue_data) {
+            if ($current_file === null || $current_file !== $issue_data->file_name) {
+                // If we're processing a new file, then wrap up the last table and render it out.
+                if ($buffer !== null) {
+                    $table->render();
+                    $output[] = $buffer->fetch();
+                }
+
+                $output[] = 'FILE: ' . $issue_data->file_name . "\n";
+
+                $buffer = new BufferedOutput();
+                $table = new Table($buffer);
+                $table->setHeaders(['SEVERITY', 'LINE', 'ISSUE', 'DESCRIPTION']);
+            }
+
+            $is_error = $issue_data->severity === Config::REPORT_ERROR;
+            if ($is_error) {
+                $severity = ($this->use_color ? "\e[0;31mERROR\e[0m" : 'ERROR');
+            } else {
+                $severity = strtoupper($issue_data->severity);
+            }
+
+            // Since `Table::setColumnMaxWidth` is only available in symfony/console 4.2+ we need do something similar
+            // so we have clean tables.
+            $message = $issue_data->message;
+            if (strlen($message) > 70) {
+                $message = implode("\n", str_split($message, 70));
+            }
+
+            $table->addRow([
+                $severity,
+                $issue_data->line_from,
+                $issue_data->type,
+                $message,
+            ]);
+
+            $current_file = $issue_data->file_name;
+        }
+
+        if ($buffer !== null) {
+            $table->render();
+            $output[] = $buffer->fetch();
+        }
+
+        return implode("\n", $output);
+    }
+}

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -517,13 +517,13 @@ final class ReportOutputTest extends TestCase
         );
     }
 
-    public function testCompactReport(): void
+    public function testTableReport(): void
     {
         $this->analyzeFileForReport();
 
-        $compact_report_options = new ReportOptions();
-        $compact_report_options->format = Report::TYPE_COMPACT;
-        $compact_report_options->use_color = false;
+        $table_report_options = new ReportOptions();
+        $table_report_options->format = Report::TYPE_TABLE;
+        $table_report_options->use_color = false;
 
         $this->assertSame(
             <<<'EOF'
@@ -538,6 +538,26 @@ final class ReportOutputTest extends TestCase
             |          |      |                                 | al config option if scanning legacy codebases                          |
             | INFO     | 18   | PossiblyUndefinedGlobalVariable | Possibly undefined global variable $a, first seen on line 12           |
             +----------+------+---------------------------------+------------------------------------------------------------------------+
+
+            EOF,
+            $this->toUnixLineEndings(IssueBuffer::getOutput(IssueBuffer::getIssuesData(), $table_report_options)),
+        );
+    }
+
+    public function testCompactReport(): void
+    {
+        $this->analyzeFileForReport();
+
+        $compact_report_options = new ReportOptions();
+        $compact_report_options->format = Report::TYPE_COMPACT;
+        $compact_report_options->use_color = false;
+
+        $this->assertSame(
+            <<<'EOF'
+            ERROR somefile.php:4:10 UndefinedVariable: Cannot find referenced variable $as_you_____type
+            ERROR somefile.php:4:10 MixedReturnStatement: Could not infer a return type
+            ERROR somefile.php:9:6 UndefinedConstant: Const CHANGE_ME is not defined, consider enabling the allConstantsGlobal config option if scanning legacy codebases
+            INFO somefile.php:18:6 PossiblyUndefinedGlobalVariable: Possibly undefined global variable $a, first seen on line 12
 
             EOF,
             $this->toUnixLineEndings(IssueBuffer::getOutput(IssueBuffer::getIssuesData(), $compact_report_options)),


### PR DESCRIPTION
BC breaking change, good timing for 7.x 😎

## Problem

The current `compact` format is the **most token-heavy** format Psalm offers — the exact opposite of what developers and AI agents expect when they pick "compact":

```
FILE: app/Models/Coach.php

+----------+------+------------------------+---------------------------------------------+
| SEVERITY | LINE | ISSUE                  | DESCRIPTION                                 |
+----------+------+------------------------+---------------------------------------------+
| ERROR    | 101  | InvalidReturnType      | The declared return type 'HasMany' for      |
|          |      |                        | Coach::activeCoachings is incorrect, got    |
|          |      |                        | 'Builder<TRelatedModel:HasMany as Model>    |
|          |      |                        | &static'                                    |
+----------+------+------------------------+---------------------------------------------+
```

AI coding agents (Claude Code, Cursor, Copilot, etc.) feed CLI output into LLM context windows. Box-drawing characters, padded columns, and decorative borders waste tokens — often 60-90% of output is noise. When an AI agent picks `compact` expecting minimal output, it gets the worst possible format.

## New `compact` format

Clean, one-line-per-issue output with full location context (`file:line:col`):

```
ERROR somefile.php:4:10 UndefinedVariable: Cannot find referenced variable $as_you_____type
ERROR somefile.php:4:10 MixedReturnStatement: Could not infer a return type
ERROR somefile.php:9:6 UndefinedConstant: Const CHANGE_ME is not defined
INFO somefile.php:18:6 PossiblyUndefinedGlobalVariable: Possibly undefined global variable $a
```

Every line contains severity, file path with line and column, issue type, and message — everything an AI agent or developer needs to act on an issue immediately.