### PR TITLE
fix: class-string with template contains non-object type

### DIFF
--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -542,7 +542,7 @@ final class TypeParser
 
         if ($last_invalid_type !== null) {
             throw new TypeParseTreeException(
-                'Invalid templated classname \'' . $t->getId() . '\'',
+                'Invalid templated classname \'' . $last_invalid_type->getId() . '\'',
             );
         }
 

--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -458,6 +458,7 @@ final class TypeParser
         Union &$as,
         string $defining_class,
         bool $from_docblock = false,
+        bool $allow_skip_invalid_type = false,
     ): TTemplateParamClass {
         if ($as->hasMixed()) {
             return new TTemplateParamClass(
@@ -468,6 +469,8 @@ final class TypeParser
                 $from_docblock,
             );
         }
+
+        $last_invalid_type = null;
 
         foreach ($as->getAtomicTypes() as $t) {
             if ($t instanceof TObject) {
@@ -518,6 +521,11 @@ final class TypeParser
             }
 
             if (!$t instanceof TNamedObject) {
+                if ($allow_skip_invalid_type) {
+                    $last_invalid_type = $t;
+                    continue;
+                }
+
                 throw new TypeParseTreeException(
                     'Invalid templated classname \'' . $t->getId() . '\'',
                 );
@@ -529,6 +537,12 @@ final class TypeParser
                 $t,
                 $defining_class,
                 $from_docblock,
+            );
+        }
+
+        if ($last_invalid_type !== null) {
+            throw new TypeParseTreeException(
+                'Invalid templated classname \'' . $t->getId() . '\'',
             );
         }
 
@@ -766,6 +780,7 @@ final class TypeParser
                     $template_type_map[$class_name][$first_class],
                     $first_class,
                     $from_docblock,
+                    true,
                 );
             }
 

--- a/tests/ClassLikeStringTest.php
+++ b/tests/ClassLikeStringTest.php
@@ -916,6 +916,26 @@ final class ClassLikeStringTest extends TestCase
                     '$r' => 'class-string<A>',
                 ],
             ],
+            'classStringOfUnionTypeArrayOrObject' => [
+                'code' => '<?php
+
+                    class A {}
+
+                    /**
+                     * @template T as array|object
+                     *
+                     * @param class-string<T> $class
+                     * @return class-string<T>
+                     */
+                    function test(string $class): string {
+                        return $class;
+                    }
+
+                    $r = test(A::class);',
+                'assertions' => [
+                    '$r' => 'class-string<A>',
+                ],
+            ],
         ];
     }
 
@@ -1051,6 +1071,17 @@ final class ClassLikeStringTest extends TestCase
                         return $s;
                     }',
                 'error_message' => 'InvalidReturnStatement',
+            ],
+            'genericTypeWithoutAnyValidType' => [
+                'code' => '<?php
+                    /**
+                     * @param class-string<T> $s
+                     * @template T as string|bool
+                     */
+                    function foo(string $s) : string {
+                        return $s;
+                    }',
+                'error_message' => 'InvalidDocblock',
             ],
         ];
     }


### PR DESCRIPTION
When using `class-string<T>` with generic type `T` which has union type constraint with some non-object type  (for example: `@template T as array|object`), psalm will raise `InvalidDocblock` error if the first type of the union is non-object.

When the template has no constraint, it will be asumed as mixed and ignore the error.

See: https://psalm.dev/r/2cc5078909

This fix will simply skip invalid (i.e. non-object) types in case of class like string parsing.