### PR TITLE
Add "memcached" to list of supported extensions.

### DIFF
--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -518,6 +518,7 @@ final class Config
         "geos" => null,
         "gmp" => null,
         "ibm_db2" => null,
+        "memcached" => null,
         "mongodb" => null,
         "mysqli" => null,
         "pdo" => null,


### PR DESCRIPTION
Currently adding "memcached" to the "enableExtensions" list in `psalm.xml` generates an assertion error.