### PR TITLE
[7.x] Improve error levels documentation presentation

### DIFF
--- a/bin/docs/generate_levels_doc.php
+++ b/bin/docs/generate_levels_doc.php
@@ -30,11 +30,17 @@ foreach ($grouped_issues as &$i) {
 
 $result = "<!-- begin list -->\n## Always treated as errors\n\n";
 
+$result .= 'These issues have very low false-positive rates and indicate definite problems.'
+    . ' They cannot be suppressed by changing the error level.' . "\n\n";
+
 foreach ($grouped_issues[-1] as $issue_type) {
     $result .= ' - [' . $issue_type . '](issues/' . $issue_type . '.md)' . "\n";
 }
 
 $result .= "## Errors that only appear at level 1\n\n";
+
+$result .= 'At the default level (2), these are reported as info.'
+    . ' Set `errorLevel="1"` to treat them as errors.' . "\n\n";
 
 foreach ($grouped_issues[1] as $issue_type) {
     $result .= ' - [' . $issue_type . '](issues/' . $issue_type . '.md)' . "\n";
@@ -43,9 +49,9 @@ foreach ($grouped_issues[1] as $issue_type) {
 $result .= "\n";
 
 foreach ([2, 3, 4, 5, 6, 7] as $level) {
-    $result .= '## Errors ignored at level ' . ($level + 1) . ($level < 7 ? ' and higher' : '') . "\n\n";
+    $result .= '## Errors at level ' . $level . ' and below' . "\n\n";
 
-    $result .= 'These issues are treated as errors at level ' . $level . ' and below.' . "\n\n";
+    $result .= 'These issues become info (non-blocking) at level ' . ($level + 1) . ($level < 7 ? ' and higher' : '') . '.' . "\n\n";
 
     foreach ($grouped_issues[$level] as $issue_type) {
         $result .= ' - [' . $issue_type . '](issues/' . $issue_type . '.md)' . "\n";
@@ -55,6 +61,10 @@ foreach ([2, 3, 4, 5, 6, 7] as $level) {
 }
 
 $result .= "## Feature-specific errors\n\n";
+
+$result .= 'These issues are only reported when their corresponding feature is enabled'
+    . ' (e.g., `--taint-analysis` for Tainted* issues, `--find-unused-code` for Unused* issues).'
+    . ' When enabled, they are always treated as errors.' . "\n\n";
 
 foreach ($grouped_issues[-2] as $issue_type) {
     $result .= ' - [' . $issue_type . '](issues/' . $issue_type . '.md)' . "\n";

--- a/docs/running_psalm/error_levels.md
+++ b/docs/running_psalm/error_levels.md
@@ -1,25 +1,31 @@
 # Error levels
 
-You can run Psalm in at different levels of strictness from 1 to 8.
+Psalm can run at error levels 1 (strictest) through 8 (most lenient). The default is **level 2**.
 
-Level 1 is the most strict, level 8 is the most lenient.
+A stricter level (lower number) reports more issues as errors. A more lenient level (higher number) demotes issues to info (non-blocking).
 
-When no level is explicitly defined, psalm defaults to level 2.
+### Quick-reference summary
 
-Some issues are always treated as errors. These are issues with a very low probability of false-positives.
+| Level | Strictness | What changes compared to the level above |
+|-------|-----------|-------------------------------|
+| 1 (strictest) | Everything is an error | Adds `Mixed*` issues, `LessSpecificReturnType` as errors |
+| **2 (default)** | Most issues | `Mixed*` demoted to info |
+| 3 | Moderate | `Deprecated*`, `MissingParamType`, `PropertyNotSetInConstructor` demoted to info |
+| 4 | Lenient | `Possibly*` issues demoted to info |
+| 5 | More lenient | `InvalidScalarArgument`, `RedundantCondition`, `TooManyArguments` demoted to info |
+| 6 | Very lenient | `FalsableReturnStatement`, `InvalidNullableReturnType` demoted to info |
+| 7 | Extremely lenient | `InvalidArgument`, `InvalidMethodCall`, `UndefinedMethod` demoted to info |
+| 8 (most lenient) | Almost nothing | `MethodSignatureMismatch`, `UninitializedProperty` demoted to info |
 
-At level 1 all issues (except those emitted for opt-in features) that Psalm can find are treated as errors. Those issues include any situation where Psalm cannot infer the type of a given expression.
+### Special categories
 
-At level 2 Psalm ignores those `Mixed*` issues, but treats most other issues as errors.
-
-At level 3 Psalm starts to be a little more lenient. For example Psalm allows missing param types, return types and property types.
-
-At level 4 Psalm ignores issues for _possible_ problems. These are more likely to be false positives – where the application code may guarantee behaviour that Psalm isn't able to infer.
-
-Level 5 and above allows a more non-verifiable code, and higher levels are even more permissive.
+- **Always errors**: Issues with very low false-positive rates (e.g., `UndefinedClass`, `UndefinedVariable`). These cannot be suppressed by changing the error level.
+- **Feature-specific errors**: Issues only reported when their feature is enabled (e.g., `--taint-analysis` for `Tainted*`, `--find-unused-code` for `Unused*`). When enabled, they are always treated as errors.
 
 <!-- begin list -->
 ## Always treated as errors
+
+These issues have very low false-positive rates and indicate definite problems. They cannot be suppressed by changing the error level.
 
  - [AbstractMethodCall](issues/AbstractMethodCall.md)
  - [ComplexFunction](issues/ComplexFunction.md)
@@ -108,7 +114,10 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
  - [UnusedFunctionCall](issues/UnusedFunctionCall.md)
  - [UnusedIssueHandlerSuppression](issues/UnusedIssueHandlerSuppression.md)
  - [UnusedMethodCall](issues/UnusedMethodCall.md)
+
 ## Errors that only appear at level 1
+
+At the default level (2), these are reported as info. Set `errorLevel="1"` to treat them as errors.
 
  - [ImmutableDependency](issues/ImmutableDependency.md)
  - [InvalidClassConstantType](issues/InvalidClassConstantType.md)
@@ -137,9 +146,9 @@ Level 5 and above allows a more non-verifiable code, and higher levels are even 
  - [RedundantIdentityWithTrue](issues/RedundantIdentityWithTrue.md)
  - [Trace](issues/Trace.md)
 
-## Errors ignored at level 3 and higher
+## Errors at level 2 and below
 
-These issues are treated as errors at level 2 and below.
+These issues become info (non-blocking) at level 3 and higher.
 
  - [ClassMustBeFinal](issues/ClassMustBeFinal.md)
  - [DeprecatedClass](issues/DeprecatedClass.md)
@@ -177,9 +186,9 @@ These issues are treated as errors at level 2 and below.
  - [UnsafeInstantiation](issues/UnsafeInstantiation.md)
  - [UnsupportedReferenceUsage](issues/UnsupportedReferenceUsage.md)
 
-## Errors ignored at level 4 and higher
+## Errors at level 3 and below
 
-These issues are treated as errors at level 3 and below.
+These issues become info (non-blocking) at level 4 and higher.
 
  - [ArgumentTypeCoercion](issues/ArgumentTypeCoercion.md)
  - [LessSpecificReturnStatement](issues/LessSpecificReturnStatement.md)
@@ -220,9 +229,9 @@ These issues are treated as errors at level 3 and below.
  - [PropertyTypeCoercion](issues/PropertyTypeCoercion.md)
  - [RiskyCast](issues/RiskyCast.md)
 
-## Errors ignored at level 5 and higher
+## Errors at level 4 and below
 
-These issues are treated as errors at level 4 and below.
+These issues become info (non-blocking) at level 5 and higher.
 
  - [FalseOperand](issues/FalseOperand.md)
  - [ForbiddenCode](issues/ForbiddenCode.md)
@@ -258,9 +267,9 @@ These issues are treated as errors at level 4 and below.
  - [UndefinedMagicPropertyAssignment](issues/UndefinedMagicPropertyAssignment.md)
  - [UndefinedMagicPropertyFetch](issues/UndefinedMagicPropertyFetch.md)
 
-## Errors ignored at level 6 and higher
+## Errors at level 5 and below
 
-These issues are treated as errors at level 5 and below.
+These issues become info (non-blocking) at level 6 and higher.
 
  - [ConstructorSignatureMismatch](issues/ConstructorSignatureMismatch.md)
  - [FalsableReturnStatement](issues/FalsableReturnStatement.md)
@@ -271,9 +280,9 @@ These issues are treated as errors at level 5 and below.
  - [UndefinedInterfaceMethod](issues/UndefinedInterfaceMethod.md)
  - [UndefinedThisPropertyAssignment](issues/UndefinedThisPropertyAssignment.md)
 
-## Errors ignored at level 7 and higher
+## Errors at level 6 and below
 
-These issues are treated as errors at level 6 and below.
+These issues become info (non-blocking) at level 7 and higher.
 
  - [AmbiguousConstantInheritance](issues/AmbiguousConstantInheritance.md)
  - [InvalidArgument](issues/InvalidArgument.md)
@@ -306,9 +315,9 @@ These issues are treated as errors at level 6 and below.
  - [UndefinedPropertyFetch](issues/UndefinedPropertyFetch.md)
  - [UndefinedThisPropertyFetch](issues/UndefinedThisPropertyFetch.md)
 
-## Errors ignored at level 8
+## Errors at level 7 and below
 
-These issues are treated as errors at level 7 and below.
+These issues become info (non-blocking) at level 8.
 
  - [AbstractInstantiation](issues/AbstractInstantiation.md)
  - [AssignmentToVoid](issues/AssignmentToVoid.md)
@@ -328,6 +337,8 @@ These issues are treated as errors at level 7 and below.
  - [UninitializedProperty](issues/UninitializedProperty.md)
 
 ## Feature-specific errors
+
+These issues are only reported when their corresponding feature is enabled (e.g., `--taint-analysis` for Tainted* issues, `--find-unused-code` for Unused* issues). When enabled, they are always treated as errors.
 
  - [LiteralKeyUnshapedArray](issues/LiteralKeyUnshapedArray.md)
  - [MissingOverrideAttribute](issues/MissingOverrideAttribute.md)


### PR DESCRIPTION
## Summary

- Rewrites the header of `error_levels.md` with a quick-reference summary table showing what each level does at a glance
- Reframes auto-generated section headings from "Errors ignored at level N" to "Errors at level N and below" — matching how users think ("I'm at level 4, what's an error?")
- Adds contextual notes to special sections (always-errors, level-1-only, feature-specific)

Both the static header and the generator script (`bin/docs/generate_levels_doc.php`) are updated so future `composer build` runs produce the improved format.

## Test plan

- [x] `php bin/docs/generate_levels_doc.php` runs successfully and produces correct output
- [ ] Verify rendered markdown reads well on GitHub