### PR TITLE
[7.x] Fix: `$this` failing to parse inside generic type parameters

### DIFF
--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -22,6 +22,7 @@ use function str_split;
 use function strlen;
 use function strpos;
 use function strtolower;
+use function substr;
 
 /**
  * @internal
@@ -159,8 +160,18 @@ final class TypeTokenizer
                         && ($chars[$i + 2] ?? null) === '.'
                         && ($chars[$i + 3] ?? null) === '$'))
             ) {
-                $type_tokens[++$rtc] = [' ', $i - 1];
-                $type_tokens[++$rtc] = ['', $i];
+                // "$this" in a type context is a type token (equivalent to "static"), not a parameter name
+                if ($char === '$'
+                    && substr($string_type, $i, 5) === '$this'
+                    && !preg_match('/[a-zA-Z0-9_\x7f-\xff]/', $chars[$i + 5] ?? '')
+                ) {
+                    if ($type_tokens[$rtc][0] !== '') {
+                        $type_tokens[++$rtc] = ['', $i];
+                    }
+                } else {
+                    $type_tokens[++$rtc] = [' ', $i - 1];
+                    $type_tokens[++$rtc] = ['', $i];
+                }
             } elseif ($was_space
                 && in_array(implode('', array_slice($chars, $i, 3)), ['as ', 'is ', 'of '])
             ) {

--- a/tests/TraitTest.php
+++ b/tests/TraitTest.php
@@ -1042,6 +1042,178 @@ final class TraitTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.2',
             ],
+            'thisInGenericReturnTypeParam' => [
+                'code' => '<?php
+                    /**
+                     * @template TModel of object
+                     * @template TDeclaringModel of object
+                     */
+                    class GenericContainer {
+                        /** @var TModel */
+                        public object $model;
+                        /** @var TDeclaringModel */
+                        public object $declaringModel;
+                    }
+
+                    trait MyTrait {
+                        /**
+                         * @template T of object
+                         * @param class-string<T> $related
+                         * @return GenericContainer<T, $this>
+                         */
+                        public function withThis(string $related): GenericContainer {
+                            /** @var GenericContainer<T, $this> */
+                            return new GenericContainer();
+                        }
+                    }
+
+                    final class Concrete {
+                        use MyTrait;
+                    }
+
+                    $a = (new Concrete())->withThis(stdClass::class);',
+                'assertions' => ['$a' => 'GenericContainer<stdClass, Concrete>'],
+                'ignored_issues' => ['MissingConstructor', 'InvalidReturnType', 'InvalidReturnStatement'],
+            ],
+            'thisInGenericReturnTypeParamNonFinal' => [
+                'code' => '<?php
+                    /**
+                     * @template TModel of object
+                     * @template TDeclaringModel of object
+                     */
+                    class GenericContainer {
+                        /** @var TModel */
+                        public object $model;
+                        /** @var TDeclaringModel */
+                        public object $declaringModel;
+                    }
+
+                    trait MyTrait {
+                        /**
+                         * @template T of object
+                         * @param class-string<T> $related
+                         * @return GenericContainer<T, $this>
+                         */
+                        public function withThis(string $related): GenericContainer {
+                            /** @var GenericContainer<T, $this> */
+                            return new GenericContainer();
+                        }
+                    }
+
+                    class NonFinal {
+                        use MyTrait;
+                    }
+
+                    $a = (new NonFinal())->withThis(stdClass::class);',
+                'assertions' => ['$a' => 'GenericContainer<stdClass, NonFinal>'],
+                'ignored_issues' => ['MissingConstructor', 'InvalidReturnType', 'InvalidReturnStatement'],
+            ],
+            'traitMethodWithCollectionReturnThisSecondParam' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     * @template V
+                     */
+                    class Collection {
+                        /** @var list<V> */
+                        public array $items = [];
+                    }
+
+                    trait HasItems {
+                        /**
+                         * @return Collection<int, $this>
+                         */
+                        public function toCollection(): Collection {
+                            /** @var Collection<int, $this> */
+                            return new Collection();
+                        }
+                    }
+
+                    class User {
+                        use HasItems;
+                    }
+
+                    $a = (new User())->toCollection();',
+                'assertions' => ['$a' => 'Collection<int, User>'],
+                'ignored_issues' => ['InvalidReturnType', 'InvalidReturnStatement'],
+            ],
+            'classMethodWithCollectionReturnThisSecondParam' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     * @template V
+                     */
+                    class Collection {
+                        /** @var list<V> */
+                        public array $items = [];
+                    }
+
+                    class User {
+                        /**
+                         * @return Collection<int, $this>
+                         */
+                        public function toCollection(): Collection {
+                            /** @var Collection<int, $this> */
+                            return new Collection();
+                        }
+                    }
+
+                    $a = (new User())->toCollection();',
+                'assertions' => ['$a' => 'Collection<int, User>'],
+                'ignored_issues' => ['InvalidReturnType', 'InvalidReturnStatement'],
+            ],
+            'thisInVarAnnotationInsideMethod' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     * @template V
+                     */
+                    class Collection {
+                        /** @var list<V> */
+                        public array $items = [];
+                    }
+
+                    class User {
+                        /**
+                         * @return Collection<int, $this>
+                         */
+                        public function getCollection(): Collection {
+                            /** @var Collection<int, $this> */
+                            $c = new Collection();
+                            return $c;
+                        }
+                    }
+
+                    $a = (new User())->getCollection();',
+                'assertions' => ['$a' => 'Collection<int, User>'],
+                'ignored_issues' => ['InvalidReturnType', 'InvalidReturnStatement'],
+            ],
+            'normalParamAnnotationNotAffected' => [
+                'code' => '<?php
+                    class Foo {
+                        /**
+                         * @param string $bar
+                         * @return string
+                         */
+                        public function test(string $bar): string {
+                            return $bar;
+                        }
+                    }
+
+                    $a = (new Foo())->test("hello");',
+                'assertions' => ['$a' => 'string'],
+            ],
+            'variadicCallableParam' => [
+                'code' => '<?php
+                    /**
+                     * @param Closure(string ...):void $fn
+                     */
+                    function test(Closure $fn): void {
+                        $fn("a", "b");
+                    }
+
+                    test(function(string ...$args): void {});',
+            ],
         ];
     }
 

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -58,6 +58,56 @@ final class TypeParseTest extends TestCase
         $this->assertSame('A|static', (string) Type::parseString('$this|A'));
     }
 
+    public function testThisInGenericTypeParam(): void
+    {
+        $this->assertSame('B<static>', (string) Type::parseString('B<$this>'));
+    }
+
+    public function testThisAsFirstGenericTypeParam(): void
+    {
+        $this->assertSame('B<static, A>', (string) Type::parseString('B<$this, A>'));
+    }
+
+    public function testThisInMultipleGenericTypeParams(): void
+    {
+        $this->assertSame('B<A, static>', (string) Type::parseString('B<A, $this>'));
+    }
+
+    public function testThisInNestedGenericTypeParam(): void
+    {
+        $this->assertSame('A<B<static>>', (string) Type::parseString('A<B<$this>>'));
+    }
+
+    public function testThisIntersection(): void
+    {
+        $this->assertSame('Foo', (string) Type::parseString('$this&Foo'));
+    }
+
+    public function testThisIntersectionInsideGenericParam(): void
+    {
+        $this->assertSame('B<Foo>', (string) Type::parseString('B<$this&Foo>'));
+    }
+
+    public function testThisUnionInsideGenericParam(): void
+    {
+        $this->assertSame('B<Foo|static>', (string) Type::parseString('B<$this|Foo>'));
+    }
+
+    public function testThisInKeyedArrayValue(): void
+    {
+        $this->assertSame('array{key: static}', (string) Type::parseString('array{key: $this}'));
+    }
+
+    public function testThisAsCallableReturnType(): void
+    {
+        $this->assertSame('impure-Closure(Foo):static', (string) Type::parseString('Closure(Foo): $this'));
+    }
+
+    public function testThisModelVariableNotTreatedAsThis(): void
+    {
+        $this->assertSame('impure-Closure(string):void', (string) Type::parseString('Closure(string $thisModel): void'));
+    }
+
     public function testIntOrString(): void
     {
         $this->assertSame('int|string', (string) Type::parseString('int|string'));


### PR DESCRIPTION
Is solves the biggest blocker for the psalm/plugin-laravel package: [psalm/psalm-plugin-laravel#593](https://github.com/psalm/psalm-plugin-laravel/issues/593) 🔥

I think it's also safe enough to be back-ported to 6.x (pls let me know if I need to do something for this).


Closes #11770

`$this` inside generic type parameters (e.g., `@return HasMany<T, $this>`) causes an `InvalidDocblock: Unexpected space` error, discarding the entire return type annotation. This breaks all Laravel relationship methods that use `$this` in their generic return types (~200 false `MixedReturnStatement` on a typical app).

### Root cause

`TypeTokenizer::tokenize()` has space-before-dollar logic for separating types from parameter names (e.g., `@param Type $paramName`). When `$this` appeared after a comma and space inside generic brackets like `<T, $this>`, the `$` triggered a space token insertion. `ParseTreeCreator::handleSpace()` then rejected this as "Unexpected space" in a non-callable context.

`static` in the same position works fine because it doesn't start with `$`.

### Fix

Added a lookahead in the tokenizer to check if the dollar-prefixed token is exactly `$this` (with a proper PHP identifier boundary check via `preg_match('/[a-zA-Z0-9_\x7f-\xff]/')`). If so, no space token is inserted — `$this` is treated as a type token (equivalent to `static`), not a parameter name.

### Before / After

```
@return HasMany<T, $this>  →  Before: InvalidDocblock (falls back to HasMany<Model, Model>)
                               After:  Parses correctly → HasMany<Comment, Post>
```

### Boundary safety

The fix does NOT affect other `$`-prefixed tokens:
- `$thisModel`, `$thisArg` — boundary check ensures only exact `$this` matches
- `Closure(string $param): void` — parameter names still get space tokens correctly
- `Closure(string ...$args): void` — variadic params unaffected (handled by separate `...` branch)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core type tokenizer used for parsing docblocks, so subtle regressions in `$`-prefixed token handling are possible despite the narrow boundary check and added test coverage.
> 
> **Overview**
> Fixes type tokenization so an exact `$this` token is no longer split by the “space before `$`” logic, allowing `$this` to be parsed as a type (equivalent to `static`) inside generic parameters and other type expressions.
> 
> Adds regression tests covering `$this` in generic type params (including nested/union/intersection/keyed-array/callable return positions) and verifies that normal parameter-name cases like `Closure(string $thisModel): void` and variadic callable params remain unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb9b230fed6b79e000dbd44db4adccc4af8f6920. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->