### PR TITLE
[7.x] Fix PHPCS line length violation in `generate_levels_doc.php`

### DIFF
--- a/bin/docs/generate_levels_doc.php
+++ b/bin/docs/generate_levels_doc.php
@@ -51,7 +51,8 @@ $result .= "\n";
 foreach ([2, 3, 4, 5, 6, 7] as $level) {
     $result .= '## Errors at level ' . $level . ' and below' . "\n\n";
 
-    $result .= 'These issues become info (non-blocking) at level ' . ($level + 1) . ($level < 7 ? ' and higher' : '') . '.' . "\n\n";
+    $suffix = $level < 7 ? ' and higher' : '';
+    $result .= 'These issues become info (non-blocking) at level ' . ($level + 1) . $suffix . '.' . "\n\n";
 
     foreach ($grouped_issues[$level] as $issue_type) {
         $result .= ' - [' . $issue_type . '](issues/' . $issue_type . '.md)' . "\n";


### PR DESCRIPTION
Line 54 of `bin/docs/generate_levels_doc.php` exceeds the 120-character limit (133 chars), causing the PHPCS code style check to fail on CI.

Introduced in #11759. Extracted the ternary into a variable to keep the line under the limit.
