### PR TITLE
Add stub to ReflectionObject class

### DIFF
--- a/stubs/Reflection.phpstub
+++ b/stubs/Reflection.phpstub
@@ -199,9 +199,9 @@ class ReflectionClass implements Reflector {
     /**
      * @param list<mixed> $args
      *
-     * @return T
+     * @return T|null
      */
-    public function newInstanceArgs(array $args): object {}
+    public function newInstanceArgs(array $args = []): ?object {}
 
     /**
      * @return T

--- a/stubs/Reflection.phpstub
+++ b/stubs/Reflection.phpstub
@@ -286,6 +286,22 @@ class ReflectionClass implements Reflector {
     public function getAttributes(?string $name = null, int $flags = 0): array {}
 }
 
+/**
+ * @template-covariant T as object
+ *
+ * @extends \ReflectionClass<T>
+ *
+ * @property-read class-string<T> $name
+ */
+class ReflectionObject extends ReflectionClass
+{
+    /**
+     * @param T $object
+     * @psalm-pure
+     */
+    public function __construct(object $object) {}
+}
+
 abstract class ReflectionFunctionAbstract implements Reflector
 {
     /** @psalm-pure */

--- a/tests/ReflectionTest.php
+++ b/tests/ReflectionTest.php
@@ -16,6 +16,27 @@ final class ReflectionTest extends TestCase
     #[Override]
     public function providerValidCodeParse(): iterable
     {
+        yield 'ReflectionClass::newInstance' => [
+            'code' => <<<'PHP'
+                <?php
+                $a = (new ReflectionClass(stdClass::class))->newInstance();
+                PHP,
+            'assertions' => ['$a===' => 'stdClass'],
+        ];
+        yield 'ReflectionClass::newInstanceArgs' => [
+            'code' => <<<'PHP'
+                <?php
+                $a = (new ReflectionClass(stdClass::class))->newInstanceArgs();
+                PHP,
+            'assertions' => ['$a===' => 'null|stdClass'],
+        ];
+        yield 'ReflectionClass::newInstanceWithoutConstructor' => [
+            'code' => <<<'PHP'
+                <?php
+                $a = (new ReflectionClass(stdClass::class))->newInstanceWithoutConstructor();
+                PHP,
+            'assertions' => ['$a===' => 'stdClass'],
+        ];
         yield 'ReflectionClass::isSubclassOf' => [
             'code' => <<<'PHP'
                 <?php
@@ -117,7 +138,7 @@ final class ReflectionTest extends TestCase
                 $a = new Foo();
                 $b = (new ReflectionObject($a))->newInstanceArgs([]);
                 PHP,
-            'assertions' => ['$b===' => 'Foo'],
+            'assertions' => ['$b===' => 'Foo|null'],
         ];
         yield 'ReflectionObject::newInstanceWithoutConstructor' => [
             'code' => <<<'PHP'

--- a/tests/ReflectionTest.php
+++ b/tests/ReflectionTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Psalm\Tests;
 
 use Override;
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
 final class ReflectionTest extends TestCase
 {
     use ValidCodeAnalysisTestTrait;
+    use InvalidCodeAnalysisTestTrait;
 
     #[Override]
     public function providerValidCodeParse(): iterable
@@ -44,6 +46,115 @@ final class ReflectionTest extends TestCase
                 }
                 PHP,
             'assertions' => ['$a===' => 'Iterator&stdClass'],
+        ];
+        yield 'ReflectionObject infers generic type from object' => [
+            'code' => <<<'PHP'
+                <?php
+                $r = new ReflectionObject(new stdClass());
+                PHP,
+            'assertions' => ['$r===' => 'ReflectionObject<stdClass>'],
+        ];
+        yield 'ReflectionObject::getName returns class-string' => [
+            'code' => <<<'PHP'
+                <?php
+                $r = new ReflectionObject(new stdClass());
+                $name = $r->getName();
+                PHP,
+            'assertions' => ['$name===' => 'class-string<stdClass>'],
+        ];
+        yield 'ReflectionObject extends ReflectionClass' => [
+            'code' => <<<'PHP'
+                <?php
+                function foo(ReflectionClass $r): void {}
+                foo(new ReflectionObject(new stdClass()));
+                PHP,
+        ];
+        yield 'ReflectionObject::isSubclassOf' => [
+            'code' => <<<'PHP'
+                <?php
+                $a = new ReflectionObject(new stdClass());
+                if (!$a->isSubclassOf(Iterator::class)) {
+                    throw new Exception();
+                }
+                PHP,
+            'assertions' => ['$a===' => 'ReflectionObject<stdClass&Iterator>'],
+        ];
+        yield 'ReflectionObject::implementsInterface' => [
+            'code' => <<<'PHP'
+                <?php
+                $a = new ReflectionObject(new stdClass());
+                if (!$a->implementsInterface(Iterator::class)) {
+                    throw new Exception();
+                }
+                PHP,
+            'assertions' => ['$a===' => 'ReflectionObject<stdClass&Iterator>'],
+        ];
+        yield 'ReflectionObject::isInstance' => [
+            'code' => <<<'PHP'
+                <?php
+                class Foo {}
+                $a = new stdClass();
+                $b = new ReflectionObject(new Foo());
+                if (!$b->isInstance($a)) {
+                    throw new Exception();
+                }
+                PHP,
+            'assertions' => ['$a===' => 'Foo&stdClass'],
+        ];
+        yield 'ReflectionObject::newInstance' => [
+            'code' => <<<'PHP'
+                <?php
+                class Foo {}
+                $a = new Foo();
+                $b = (new ReflectionObject($a))->newInstance();
+                PHP,
+            'assertions' => ['$b===' => 'Foo'],
+        ];
+        yield 'ReflectionObject::newInstanceArgs' => [
+            'code' => <<<'PHP'
+                <?php
+                class Foo {}
+                $a = new Foo();
+                $b = (new ReflectionObject($a))->newInstanceArgs([]);
+                PHP,
+            'assertions' => ['$b===' => 'Foo'],
+        ];
+        yield 'ReflectionObject::newInstanceWithoutConstructor' => [
+            'code' => <<<'PHP'
+                <?php
+                class Foo {}
+                $a = new Foo();
+                $b = (new ReflectionObject($a))->newInstanceWithoutConstructor();
+                PHP,
+            'assertions' => ['$b===' => 'Foo'],
+        ];
+        yield 'PHP80-ReflectionObject::getAttributes' => [
+            'code' => <<<'PHP'
+                <?php
+                $a = new stdClass();
+                $b = (new ReflectionObject($a))->getAttributes();
+                PHP,
+            'assertions' => ['$b===' => 'list<ReflectionAttribute<object>>'],
+        ];
+        yield 'PHP80-ReflectionObject::getAttributes specific' => [
+            'code' => <<<'PHP'
+                <?php
+                $a = new stdClass();
+                $b = (new ReflectionObject($a))->getAttributes(Override::class);
+                PHP,
+            'assertions' => ['$b===' => 'list<ReflectionAttribute<Override>>'],
+        ];
+    }
+
+    #[Override]
+    public function providerInvalidCodeParse(): iterable
+    {
+        yield 'ReflectionObject rejects string argument' => [
+            'code' => <<<'PHP'
+                <?php
+                new ReflectionObject('stdClass');
+                PHP,
+            'error_message' => 'InvalidArgument',
         ];
     }
 }


### PR DESCRIPTION
Class `ReflectionClass` supports generic.

https://psalm.dev/r/6f73e8f1c5
https://psalm.dev/r/d91a57ae92

But `ReflectionObject`, that extends `ReflectionClass` doesn't it.

https://psalm.dev/r/700c9575b0

I am add stub of `ReflectionObject`, that supports generic.