### PR TITLE
[6.x] Fix: int range in generic type parameter falsely incompatible with int

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
@@ -8,6 +8,7 @@ use Psalm\Codebase;
 use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TGenericObject;
+use Psalm\Type\Atomic\TIntRange;
 use Psalm\Type\Atomic\TIterable;
 use Psalm\Type\Atomic\TNamedObject;
 
@@ -139,7 +140,18 @@ final class GenericTypeComparator
                 && !$container_param->hasTemplate()
                 && !$input_param->hasTemplate()
             ) {
-                if ($input_param->containsAnyLiteral()) {
+                $input_has_literal_or_range = $input_param->containsAnyLiteral();
+
+                if (!$input_has_literal_or_range) {
+                    foreach ($input_param->getAtomicTypes() as $atomic_type) {
+                        if ($atomic_type instanceof TIntRange) {
+                            $input_has_literal_or_range = true;
+                            break;
+                        }
+                    }
+                }
+
+                if ($input_has_literal_or_range) {
                     if ($atomic_comparison_result_type_params !== null) {
                         $atomic_comparison_result_type_params[$i] = $container_param;
                     }

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -1034,6 +1034,48 @@ final class IntRangeTest extends TestCase
                     '$z' => 'int<min, 9223372036854775807>|null',
                 ],
             ],
+            'intRangeInGenericWidensToInt' => [
+                'code' => '<?php
+                    /**
+                     * @template T of array-key
+                     */
+                    class Box {
+                        /** @var T */
+                        private $value;
+                        /** @param T $value */
+                        public function __construct($value) { $this->value = $value; }
+                        /** @return T */
+                        public function get() { return $this->value; }
+                    }
+
+                    /** @return Box<int> */
+                    function makeBox(): Box {
+                        /** @var Box<int<0, 5>> */
+                        $box = new Box(3);
+                        return $box;
+                    }',
+            ],
+            'intRangeNegativeInGenericWidensToInt' => [
+                'code' => '<?php
+                    /**
+                     * @template T of array-key
+                     */
+                    class Box {
+                        /** @var T */
+                        private $value;
+                        /** @param T $value */
+                        public function __construct($value) { $this->value = $value; }
+                        /** @return T */
+                        public function get() { return $this->value; }
+                    }
+
+                    /** @return Box<int> */
+                    function makeBox(): Box {
+                        /** @var Box<int<min, -1>> */
+                        $box = new Box(-5);
+                        return $box;
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #11775
Fixes (partially)  #7739

`GenericTypeComparator` has an escape hatch that widens inferred literal types (e.g. `int(3)`) to their declared generic type parameter (e.g. `int`) — skipping the invariance reverse-check. However, `TIntRange` was not covered by this escape hatch.

When Psalm infers `Box<int<0, 5>>` where `Box<int>` is declared, the forward containment check passes (`int<0, 5>` ⊆ `int`), but the invariance reverse-check fails (`int` ⊄ `int<0, 5>`), producing a false `InvalidReturnStatement`.

### Changes

- **`GenericTypeComparator.php`**: Extend the literal-type escape hatch to also match `TIntRange` at the top level of a generic type parameter. Only top-level atoms are checked (via `getAtomicTypes()`) to avoid falsely matching nested array key types — `list<T>` is internally `array<int<0, max>, T>`, where the key is a `TIntRange`.
- **`IntRangeTest.php`**: Two test cases — positive range (`int<0, 5>`) and negative range (`int<min, -1>`) in generic contexts.

### Why not `ScalarTypeComparator`?

The issue description suggests adding a `TIntRange` vs `TInt` case to `ScalarTypeComparator`, but this is dead code — the early return at line 65–68 (`$container_type_part::class === TInt::class && $input_type_part instanceof TInt`) already handles it since `TIntRange extends TInt`.
