### PR TITLE
[6.x] Fix: int range comparison not detected as redundant when already satisfied

### DIFF
--- a/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
+++ b/src/Psalm/Internal/Type/SimpleAssertionReconciler.php
@@ -1978,7 +1978,6 @@ final class SimpleAssertionReconciler extends Reconciler
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
                     // if the range contains the assertion, the range must be adapted
-                    $redundant = false;
                     $existing_var_type->removeType($atomic_type->getKey());
                     $min_bound = $atomic_type->min_bound;
                     if ($min_bound === null) {
@@ -1988,6 +1987,9 @@ final class SimpleAssertionReconciler extends Reconciler
                             $assertion_value,
                             $min_bound,
                         );
+                    }
+                    if ($min_bound !== $atomic_type->min_bound) {
+                        $redundant = false;
                     }
                     $existing_var_type->addType(new TIntRange(
                         $min_bound,
@@ -2087,13 +2089,15 @@ final class SimpleAssertionReconciler extends Reconciler
             if ($atomic_type instanceof TIntRange) {
                 if ($atomic_type->contains($assertion_value)) {
                     // if the range contains the assertion, the range must be adapted
-                    $redundant = false;
                     $existing_var_type->removeType($atomic_type->getKey());
                     $max_bound = $atomic_type->max_bound;
                     if ($max_bound === null) {
                         $max_bound = $assertion_value;
                     } else {
                         $max_bound = min($max_bound, $assertion_value);
+                    }
+                    if ($max_bound !== $atomic_type->max_bound) {
+                        $redundant = false;
                     }
                     $existing_var_type->addType(new TIntRange(
                         $atomic_type->min_bound,

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -1034,6 +1034,26 @@ final class IntRangeTest extends TestCase
                     '$z' => 'int<min, 9223372036854775807>|null',
                 ],
             ],
+            'positiveIntGreaterThan1IsNotRedundant' => [
+                'code' => '<?php
+                    /**
+                     * @param positive-int $a
+                     */
+                    function scope(int $a): int{
+                        assert($a > 1);
+                        return $a;
+                    }',
+            ],
+            'boundedRangeGreaterThanMinIsNotRedundant' => [
+                'code' => '<?php
+                    /**
+                     * @param int<5, 10> $a
+                     */
+                    function scope(int $a): int{
+                        assert($a > 5);
+                        return $a;
+                    }',
+            ],
         ];
     }
 
@@ -1062,6 +1082,36 @@ final class IntRangeTest extends TestCase
                         assert($a === 0);
                     }',
                 'error_message' => 'DocblockTypeContradiction',
+            ],
+            'positiveIntGreaterThanZeroIsRedundant' => [
+                'code' => '<?php
+                    /**
+                     * @param positive-int $a
+                     */
+                    function scope(int $a): void{
+                        assert($a > 0);
+                    }',
+                'error_message' => 'RedundantConditionGivenDocblockType',
+            ],
+            'negativeIntLessThanZeroIsRedundant' => [
+                'code' => '<?php
+                    /**
+                     * @param negative-int $a
+                     */
+                    function scope(int $a): void{
+                        assert($a < 0);
+                    }',
+                'error_message' => 'RedundantConditionGivenDocblockType',
+            ],
+            'boundedRangeGreaterThanBelowMinIsRedundant' => [
+                'code' => '<?php
+                    /**
+                     * @param int<5, 10> $a
+                     */
+                    function scope(int $a): void{
+                        assert($a > 4);
+                    }',
+                'error_message' => 'RedundantConditionGivenDocblockType',
             ],
             'assertRedundantInferior' => [
                 'code' => '<?php


### PR DESCRIPTION
Fixes #8059

When an int range already fully satisfies a greater-than or less-than assertion (e.g. `positive-int > 0`), the reconciler unconditionally set `$redundant = false` even though the range wasn't actually narrowed. This prevented `RedundantConditionGivenDocblockType` from firing.

### Before

```php
/** @param positive-int $a */
function foo(int $a): void {
    if ($a > 0) { // No warning — should be RedundantConditionGivenDocblockType
        echo "always true";
    }
}
```

### After

```
RedundantConditionGivenDocblockType — Condition ($a > 0) is always true
```

### Changes

**`SimpleAssertionReconciler.php`**: In both `reconcileIsGreaterThan` and `reconcileIsLessThan`, only clear the `$redundant` flag when the computed bound actually differs from the original range bound. If the bound is unchanged, the assertion doesn't narrow the type, so the condition is redundant.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core type reconciliation logic for integer comparisons, which can change emitted issues and inferred ranges across analyses. The change is narrowly scoped and backed by new tests, reducing regression risk.
> 
> **Overview**
> Fixes redundancy detection in `SimpleAssertionReconciler` for strict `>`/`<` assertions on `TIntRange` values by only clearing the `$redundant` flag when the assertion actually narrows the range bound.
> 
> Adds coverage in `IntRangeTest` for both non-redundant narrowing cases (e.g. `positive-int > 1`, `int<5,10> > 5`) and redundant conditions that should now raise `RedundantConditionGivenDocblockType` (e.g. `positive-int > 0`, `negative-int < 0`, `int<5,10> > 4`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34dfff569dd2f969c83a6c539ba76c82791c9d7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->