### PR TITLE
[6.x] Fix: comparison with int range variable not narrowing the other operand

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -83,6 +83,7 @@ use Psalm\Type\Atomic\TClassString;
 use Psalm\Type\Atomic\TClosedResource;
 use Psalm\Type\Atomic\TEnumCase;
 use Psalm\Type\Atomic\TFalse;
+use Psalm\Type\Atomic\TIntRange;
 use Psalm\Type\Atomic\TKeyedArray;
 use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralFloat;
@@ -1709,6 +1710,21 @@ final class AssertionFinder
             return self::ASSIGNMENT_TO_RIGHT;
         }
 
+        // If the right operand is a variable with an int range type,
+        // extract its min_bound to narrow the left operand.
+        // e.g. $max >= $min where $min: int<5, max> → $max >= 5
+        if ($source instanceof StatementsAnalyzer
+            && ($type = $source->node_data->getType($conditional->right))
+        ) {
+            foreach ($type->getAtomicTypes() as $atomic_type) {
+                if ($atomic_type instanceof TIntRange && $atomic_type->min_bound !== null) {
+                    $literal_value_comparison = $atomic_type->min_bound;
+
+                    return self::ASSIGNMENT_TO_RIGHT;
+                }
+            }
+        }
+
         $left_assignment = false;
         $value_left = null;
         if ($source instanceof StatementsAnalyzer
@@ -1731,6 +1747,21 @@ final class AssertionFinder
             $literal_value_comparison = $value_left;
 
             return self::ASSIGNMENT_TO_LEFT;
+        }
+
+        // If the left operand is a variable with an int range type,
+        // extract its max_bound to narrow the right operand.
+        // e.g. $min <= $max where $min: int<min, 5> → $max <= 5
+        if ($source instanceof StatementsAnalyzer
+            && ($type = $source->node_data->getType($conditional->left))
+        ) {
+            foreach ($type->getAtomicTypes() as $atomic_type) {
+                if ($atomic_type instanceof TIntRange && $atomic_type->max_bound !== null) {
+                    $literal_value_comparison = $atomic_type->max_bound;
+
+                    return self::ASSIGNMENT_TO_LEFT;
+                }
+            }
         }
 
         return false;
@@ -1791,6 +1822,36 @@ final class AssertionFinder
             $literal_value_comparison = $value_left;
 
             return self::ASSIGNMENT_TO_LEFT;
+        }
+
+        // If the right operand is a variable with an int range type,
+        // extract its max_bound to narrow the left operand.
+        // e.g. $a < $b where $b: int<min, 5> → $a < 5
+        if ($source instanceof StatementsAnalyzer
+            && ($type = $source->node_data->getType($conditional->right))
+        ) {
+            foreach ($type->getAtomicTypes() as $atomic_type) {
+                if ($atomic_type instanceof TIntRange && $atomic_type->max_bound !== null) {
+                    $literal_value_comparison = $atomic_type->max_bound;
+
+                    return self::ASSIGNMENT_TO_RIGHT;
+                }
+            }
+        }
+
+        // If the left operand is a variable with an int range type,
+        // extract its min_bound to narrow the right operand.
+        // e.g. $a < $b where $a: int<5, max> → $b > 5
+        if ($source instanceof StatementsAnalyzer
+            && ($type = $source->node_data->getType($conditional->left))
+        ) {
+            foreach ($type->getAtomicTypes() as $atomic_type) {
+                if ($atomic_type instanceof TIntRange && $atomic_type->min_bound !== null) {
+                    $literal_value_comparison = $atomic_type->min_bound;
+
+                    return self::ASSIGNMENT_TO_LEFT;
+                }
+            }
         }
 
         return false;

--- a/tests/IntRangeTest.php
+++ b/tests/IntRangeTest.php
@@ -1034,6 +1034,39 @@ final class IntRangeTest extends TestCase
                     '$z' => 'int<min, 9223372036854775807>|null',
                 ],
             ],
+            'assertGreaterOrEqualNarrowsToIntRange' => [
+                'code' => '<?php
+                    /**
+                     * @param int<0, max> $min
+                     * @return int<0, max>
+                     */
+                    function f(int $min, int $max): int {
+                        assert($max >= $min);
+                        return $max;
+                    }',
+            ],
+            'assertGreaterThanNarrowsToIntRange' => [
+                'code' => '<?php
+                    /**
+                     * @param int<0, max> $min
+                     * @return int<0, max>
+                     */
+                    function f(int $min, int $max): int {
+                        assert($max > $min);
+                        return $max;
+                    }',
+            ],
+            'assertLessThanOrEqualNarrowsToIntRange' => [
+                'code' => '<?php
+                    /**
+                     * @param int<min, 10> $max
+                     * @return int<min, 10>
+                     */
+                    function f(int $min, int $max): int {
+                        assert($min <= $max);
+                        return $min;
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #11764

When comparing two variables where one has an int range type (e.g. `assert($max >= $min)` where `$min: int<0, max>`), the assertion finder only checked for literal int values. Variable-to-variable comparisons produced no assertions, so the other operand stayed as plain `int`.

### Before

```php
/**
 * @param int<0,max> $min
 * @return int<0,max>
 */
function f(int $min, int $max): int {
    assert($max >= $min);
    return $max; // ❌ ERROR: LessSpecificReturnStatement
}
```

### After

No errors — `$max` is narrowed to `int<0, max>` after the assertion.

### Changes

**`AssertionFinder.php`**: In both `hasSuperiorNumberCheck` (for `>`/`>=`) and `hasInferiorNumberCheck` (for `<`/`<=`), added fallback logic that extracts the relevant bound from an int range type when no literal value is found:

- Right operand has range → extract `min_bound` (for `>=`) or `max_bound` (for `<`) to narrow the left operand
- Left operand has range → extract `max_bound` (for `>=`) or `min_bound` (for `<`) to narrow the right operand

This reuses the existing assertion infrastructure (`IsGreaterThan`, `IsGreaterThanOrEqualTo`, etc.) without new assertion types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core assertion inference for numeric comparisons, which can subtly change type narrowing across analyses, but the logic is small and guarded to `TIntRange` bounds with added tests.
> 
> **Overview**
> Fixes numeric comparison assertion extraction so variable-to-variable comparisons can still narrow types when one side is an `int` range.
> 
> `AssertionFinder` now falls back to using `TIntRange` bounds (`min_bound`/`max_bound`) as the effective comparison value when no int literal is present, enabling narrowing for `>`/`>=` and `<`/`<=` cases. Adds new `IntRangeTest` coverage for `assert($max >= $min)`, `assert($max > $min)`, and `assert($min <= $max)` narrowing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cc62a28fd923bd8cfe2cc416417582172ffece4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->