### PR TITLE
PoC: Add `@psalm-check-return-type` annotation

### DIFF
--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -583,6 +583,33 @@ Like `@psalm-check-type`, but checks the exact type of the variable without allo
 $foo = 1; // Checked variable $foo = int does not match $foo = 1
 ```
 
+### `@psalm-check-return-type`
+
+Like `@psalm-check-type`, but checks the type of a return expression instead of a variable.
+
+```php
+<?php
+
+/** @psalm-check-return-type array{name: string, driver: string} */
+return ['name' => 'primary', 'driver' => 'mysql']; // No issue
+
+/** @psalm-check-return-type array{name: string, driver: string} */
+return ['name' => 'primary']; // Checked return type does not match inferred type
+```
+
+### `@psalm-check-return-type-exact`
+
+Like `@psalm-check-return-type`, but checks the exact type without allowing subtypes.
+
+```php
+<?php
+
+function foo(string $s): string {
+    /** @psalm-check-return-type-exact string */
+    return $s; // No issue
+}
+```
+
 ### `@psalm-taint-*`
 
 See [Security Analysis annotations](../security_analysis/annotations.md).

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -36,7 +36,7 @@ final class DocComment
         'taint-unescape', 'self-out', 'consistent-constructor', 'stub-override',
         'require-extends', 'require-implements', 'param-out', 'ignore-var',
         'consistent-templates', 'if-this-is', 'this-out', 'check-type', 'check-type-exact',
-        'api', 'inheritors',
+        'api', 'inheritors', 'check-return-type', 'check-return-type-exact',
     ];
 
     /**

--- a/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/ReturnAnalyzer.php
@@ -10,6 +10,7 @@ use Psalm\CodeLocation\DocblockTypeLocation;
 use Psalm\Codebase;
 use Psalm\Context;
 use Psalm\Exception\DocblockParseException;
+use Psalm\Exception\TypeParseTreeException;
 use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Analyzer\ClassLikeNameOptions;
 use Psalm\Internal\Analyzer\ClosureAnalyzer;
@@ -27,6 +28,9 @@ use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Type\TemplateInferredTypeReplacer;
 use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TypeExpander;
+use Psalm\Internal\Type\TypeParser;
+use Psalm\Internal\Type\TypeTokenizer;
+use Psalm\Issue\CheckType;
 use Psalm\Issue\FalsableReturnStatement;
 use Psalm\Issue\InvalidDocblock;
 use Psalm\Issue\InvalidReturnStatement;
@@ -54,6 +58,7 @@ use function explode;
 use function implode;
 use function reset;
 use function strtolower;
+use function trim;
 
 /**
  * @internal
@@ -206,6 +211,8 @@ final class ReturnAnalyzer
         }
 
         $statements_analyzer->node_data->setType($stmt, $stmt_type);
+
+        self::checkReturnType($statements_analyzer, $stmt, $codebase, $stmt_type);
 
         if ($context->finally_scope) {
             foreach ($context->vars_in_scope as $var_id => &$type) {
@@ -715,5 +722,84 @@ final class ReturnAnalyzer
             return $parent_return_type;
         }
         return $return_type;
+    }
+
+    private static function checkReturnType(
+        StatementsAnalyzer $statements_analyzer,
+        PhpParser\Node\Stmt\Return_ $stmt,
+        Codebase $codebase,
+        Union $stmt_type,
+    ): void {
+        $parsed_docblock = $statements_analyzer->getParsedDocblock();
+        if ($parsed_docblock === null) {
+            return;
+        }
+
+        $checked_return_types = [];
+        foreach ($parsed_docblock->tags['psalm-check-return-type'] ?? [] as $check) {
+            $checked_return_types[] = [trim($check), false];
+        }
+        foreach ($parsed_docblock->tags['psalm-check-return-type-exact'] ?? [] as $check) {
+            $checked_return_types[] = [trim($check), true];
+        }
+
+        if ($checked_return_types === []) {
+            return;
+        }
+
+        $source = $statements_analyzer->getSource();
+
+        foreach ($checked_return_types as [$check_type_string, $is_exact]) {
+            if ($check_type_string === '') {
+                IssueBuffer::maybeAdd(
+                    new InvalidDocblock(
+                        'Invalid format for @psalm-check-return-type' . ($is_exact ? '-exact' : ''),
+                        new CodeLocation($source, $stmt),
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+                continue;
+            }
+
+            try {
+                $path = $statements_analyzer->getRootFilePath();
+                $file_storage = $codebase->file_storage_provider->get($path);
+
+                $check_tokens = TypeTokenizer::getFullyQualifiedTokens(
+                    $check_type_string,
+                    $statements_analyzer->getAliases(),
+                    $statements_analyzer->getTemplateTypeMap(),
+                    $file_storage->type_aliases,
+                );
+                $check_type = TypeParser::parseTokens(
+                    $check_tokens,
+                    null,
+                    $statements_analyzer->getTemplateTypeMap() ?? [],
+                    $file_storage->type_aliases,
+                    true,
+                );
+
+                if (!UnionTypeComparator::isContainedBy($codebase, $stmt_type, $check_type)
+                    || ($is_exact && !UnionTypeComparator::isContainedBy($codebase, $check_type, $stmt_type))
+                ) {
+                    IssueBuffer::maybeAdd(
+                        new CheckType(
+                            "Checked return type {$check_type->getId()} does not match "
+                                . "inferred type {$stmt_type->getId()}",
+                            new CodeLocation($source, $stmt),
+                        ),
+                        $statements_analyzer->getSuppressedIssues(),
+                    );
+                }
+            } catch (TypeParseTreeException $e) {
+                IssueBuffer::maybeAdd(
+                    new InvalidDocblock(
+                        $e->getMessage(),
+                        new CodeLocation($source, $stmt),
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+        }
     }
 }

--- a/tests/CheckTypeTest.php
+++ b/tests/CheckTypeTest.php
@@ -51,6 +51,71 @@ final class CheckTypeTest extends TestCase
                 $_a = 1;
                 /** @psalm-check-type $_a = A */',
         ];
+        yield 'checkReturnTypeSubtype' => [
+            'code' => '<?php
+                function foo(): int {
+                    /** @psalm-check-return-type int */
+                    return 1;
+                }
+            ',
+        ];
+        yield 'checkReturnTypeExactMatch' => [
+            'code' => '<?php
+                function foo(string $s): string {
+                    /** @psalm-check-return-type-exact string */
+                    return $s;
+                }
+            ',
+        ];
+        yield 'checkReturnTypeArray' => [
+            'code' => '<?php
+                /** @psalm-check-return-type array{name: string, driver: string} */
+                return ["name" => "primary", "driver" => "mysql"];
+            ',
+        ];
+        yield 'checkReturnTypeVoid' => [
+            'code' => '<?php
+                function foo(): void {
+                    /** @psalm-check-return-type void */
+                    return;
+                }
+            ',
+        ];
+        yield 'checkReturnTypeNullable' => [
+            'code' => '<?php
+                function foo(?string $s): ?string {
+                    /** @psalm-check-return-type null|string */
+                    return $s;
+                }
+            ',
+        ];
+        yield 'checkReturnTypeUnion' => [
+            'code' => '<?php
+                /** @return int|string */
+                function foo(bool $b) {
+                    /** @psalm-check-return-type int|string */
+                    return $b ? 1 : "hello";
+                }
+            ',
+        ];
+        yield 'checkReturnTypeOnNonReturnIsIgnored' => [
+            'code' => '<?php
+                /** @psalm-check-return-type string */
+                $x = 1;
+            ',
+        ];
+        yield 'checkReturnTypeNamespaced' => [
+            'code' => '<?php
+                namespace X;
+
+                final class A {}
+
+                function foo(): A {
+                    /** @psalm-check-return-type A */
+                    return new A();
+                }
+            ',
+        ];
     }
 
     #[Override]
@@ -113,6 +178,57 @@ final class CheckTypeTest extends TestCase
         yield 'invalidIncompleteSyntaxNoType' => [
             'code' => '<?php
                 /** @psalm-check-type $var = */
+            ',
+            'error_message' => 'InvalidDocblock',
+        ];
+        yield 'checkReturnTypeMismatch' => [
+            'code' => '<?php
+                function foo(): string {
+                    /** @psalm-check-return-type int */
+                    return "hello";
+                }
+            ',
+            'error_message' => 'CheckType',
+        ];
+        yield 'checkReturnTypeExactLiteralMoreSpecific' => [
+            'code' => '<?php
+                // return 1 infers as literal 1, which is more specific than int
+                function foo(): int {
+                    /** @psalm-check-return-type-exact int */
+                    return 1;
+                }
+            ',
+            'error_message' => 'CheckType',
+        ];
+        yield 'checkReturnTypeVoidMismatch' => [
+            'code' => '<?php
+                function foo(): void {
+                    /** @psalm-check-return-type string */
+                    return;
+                }
+            ',
+            'error_message' => 'CheckType',
+        ];
+        yield 'checkReturnTypeNullableMismatch' => [
+            'code' => '<?php
+                function foo(?string $s): ?string {
+                    /** @psalm-check-return-type string */
+                    return $s;
+                }
+            ',
+            'error_message' => 'CheckType',
+        ];
+        yield 'checkReturnTypeArrayMissingKey' => [
+            'code' => '<?php
+                /** @psalm-check-return-type array{name: string, driver: string} */
+                return ["name" => "primary"];
+            ',
+            'error_message' => 'CheckType',
+        ];
+        yield 'checkReturnTypeEmpty' => [
+            'code' => '<?php
+                /** @psalm-check-return-type */
+                return 1;
             ',
             'error_message' => 'InvalidDocblock',
         ];


### PR DESCRIPTION

Proof of concept for `@psalm-check-return-type` and `@psalm-check-return-type-exact` annotations that validate return expression types against a declared type in the docblock.

- Registers two new annotations in `DocComment.php`
- Adds `checkReturnType()` method in `ReturnAnalyzer.php` (~80 lines), following the existing `@psalm-check-type` pattern
- Reuses the existing `CheckType` issue type — no new classes
- 14 new test cases (8 valid, 6 invalid) covering subtypes, exact match, void, nullable, union, namespaced types, array shapes, and error cases

### Use case

Validates return expressions in Laravel config files, factories, and similar patterns without extracting values into intermediate variables:

```php
/** @psalm-check-return-type array<string, array{name: string, driver: string}> */
return [
    'default' => ['name' => 'primary', 'driver' => 'mysql'],
    'secondary' => ['name' => 'replica'], // ← CheckType: missing 'driver'
];
```

Closes #11780

## Alternatives considered

### 1. `@var` on return statements (override, not check)

`ReturnAnalyzer` already processes `@var` comments on return statements — but `@var` **overrides** the inferred type rather than checking it:

```php
/** @var int */
return "hello"; // Psalm treats this as returning int — no error!
```

This is the opposite of the desired behavior. We need "assert the inferred type matches X", not "tell Psalm the type is X".

### 2. Inline `@return` on the return statement

`@return` is a function-level tag processed during the **scanning phase** by `FunctionLikeDocblockScanner`. Statement-level inline docblocks are parsed by `StatementsAnalyzer::parseStatementDocblock()`, which doesn't look for `@return`. We could wire it up, but:

- **Semantic overload**: `@return` on a function means "declare the return type"; on a return statement it would mean "check this expression's type" — two different operations sharing one tag name
- **Top-level returns**: config files use top-level `return [...]` outside any function, so there's no function-level `@return` to piggyback on
- **Confusion risk**: a `@return` on a return statement inside a function could be mistaken for a redundant function-level annotation

### 3. Extend `@psalm-check-type` with a `return` pseudo-variable

```php
/** @psalm-check-type return = array{name: string, driver: string} */
return ['name' => 'primary', 'driver' => 'mysql'];
```

This avoids introducing new annotation names, but:

- The parser currently expects `$`-prefixed variable names — `return` would be a special case
- `return` isn't conceptually a variable, so the `$var = type` format is misleading
- If someone has a variable called `$return`, it becomes ambiguous

Could be revisited if there's a preference for fewer annotation names.

### 4. Intermediate variable with existing `@psalm-check-type`

```php
/** @psalm-check-type $config = array{name: string, driver: string} */
$config = ['name' => 'primary', 'driver' => 'mysql'];
return $config;
```

Works today with no code changes, but requires extracting the return expression into a temporary variable — exactly what this feature aims to eliminate for config files, seeders, and factories.

### Why a dedicated annotation

The `@psalm-check-return-type` approach was chosen because it:
- Mirrors the established `@psalm-check-type` pattern (check, not override)
- Has unambiguous semantics on any statement (silently ignored on non-return statements)
- Works in all contexts: functions, closures, and top-level returns
- Requires no special-casing of existing annotation parsers
