### PR TITLE
[6.x] Fix: accept TLiteralClassString of a trait as trait-string

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/ScalarTypeComparator.php
@@ -450,6 +450,13 @@ final class ScalarTypeComparator
             return false;
         }
 
+        if ($container_type_part instanceof TTraitString
+            && $input_type_part instanceof TLiteralClassString
+            && $codebase->classlikes->traitExists($input_type_part->value)
+        ) {
+            return true;
+        }
+
         if (($input_type_part instanceof TClassString
             || $input_type_part instanceof TLiteralClassString)
             && ($container_type_part::class === TSingleLetter::class

--- a/tests/ClassLikeStringTest.php
+++ b/tests/ClassLikeStringTest.php
@@ -285,6 +285,15 @@ final class ClassLikeStringTest extends TestCase
                         use T;
                     }',
             ],
+            'literalClassStringOfTraitSatisfiesTraitString' => [
+                'code' => '<?php
+                    trait MyTrait {}
+
+                    /** @param trait-string $t */
+                    function takesTrait(string $t): void {}
+
+                    takesTrait(MyTrait::class);',
+            ],
             'refineStringToClassString' => [
                 'code' => '<?php
                     class A {}


### PR DESCRIPTION
## `trait-string` parameter rejects `SomeTrait::class` literal with `InvalidArgument`

Reproduced: https://psalm.dev/r/45438666d1

Tested and fixed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes scalar type containment rules for `trait-string` and alters interface method analysis control flow in edge cases involving duplicate FQCN storage overwrites.
> 
> **Overview**
> Psalm now treats a `TLiteralClassString` that points to an actual trait as valid for `trait-string`, allowing calls like `takesTrait(MyTrait::class)`.
> 
> Separately, `InterfaceAnalyzer` now skips analyzing interface methods when the backing storage no longer contains those methods (e.g., storage overwritten by another class-like with the same FQCN), preventing a crash; new regression tests cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e15bf027ee764b168a85d5e7310f9422a5969aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->