### PR TITLE
[6.x] Skip trait in `getMethodMutations` when storage is missing (fixes "Could not get class storage")

### DIFF
--- a/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php
@@ -133,6 +133,10 @@ abstract class ClassLikeAnalyzer extends SourceAnalyzer
                         $this->source->getAliases(),
                     );
 
+                    if (!$codebase->classlike_storage_provider->has($fq_trait_name)) {
+                        continue;
+                    }
+
                     $trait_file_analyzer = $project_analyzer->getFileAnalyzerForClassLike($fq_trait_name);
                     $trait_node = $codebase->classlikes->getTraitNode($fq_trait_name);
                     $trait_storage = $codebase->classlike_storage_provider->get($fq_trait_name);

--- a/tests/IncludeTest.php
+++ b/tests/IncludeTest.php
@@ -988,4 +988,89 @@ final class IncludeTest extends TestCase
         // from MethodAnalyzer when the method was missing from storage.
         $file_analyzer->analyze();
     }
+
+    /**
+     * Regression test: ClassLikeAnalyzer::getMethodMutations() must not crash
+     * when a used trait's storage is missing (e.g. a vendor trait that was
+     * registered via reflection but never scanned). The trait should be
+     * skipped gracefully instead of throwing InvalidArgumentException.
+     *
+     * Real-world scenario: Illuminate\Console\Command uses trait
+     * PromptsForMissingInput. The trait exists (registered via reflection)
+     * but was never scanned, so ClassLikeStorageProvider has no entry for it.
+     * When Psalm analyzes a user class extending Command and traces
+     * constructor mutations, ClassLikeAnalyzer::getMethodMutations() iterates
+     * the AST's TraitUse nodes and must handle missing storage gracefully.
+     */
+    public function testGetMethodMutationsDoesNotCrashWhenTraitStorageMissing(): void
+    {
+        $codebase = $this->project_analyzer->getCodebase();
+        $config = $codebase->config;
+
+        $config->throw_exception = false;
+
+        // Two files: parent class uses a trait, child class triggers
+        // getMethodMutations by calling parent::__construct().
+        $parent_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'parent.php';
+        $child_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'child.php';
+
+        // The parent class uses a trait whose storage will be removed.
+        // The trait is intentionally empty — it has no methods, so its
+        // removal won't leave stale declaring_method_ids in class storage.
+        $this->addFile($parent_path, '<?php
+            namespace Foo;
+
+            trait MyTrait {}
+
+            class Base {
+                use MyTrait;
+
+                public function __construct() {}
+            }
+        ');
+
+        // The child class has an uninitialized typed property and calls
+        // parent::__construct(). This triggers collect_initializations,
+        // which calls getMethodMutations on Base to trace mutations.
+        // Base's AST has "use MyTrait", and getMethodMutations will
+        // try to resolve that trait.
+        $this->addFile($child_path, '<?php
+            namespace Foo;
+
+            class Child extends Base {
+                public string $name;
+
+                public function __construct() {
+                    parent::__construct();
+                    $this->name = "test";
+                }
+            }
+        ');
+
+        $codebase->addFilesToAnalyze([
+            $parent_path => $parent_path,
+            $child_path => $child_path,
+        ]);
+        $codebase->scanFiles();
+
+        // Remove the trait storage but keep it in existing_traits — this
+        // simulates a trait registered via reflection but never scanned
+        // (exactly what happens with PromptsForMissingInput).
+        $ref = new ReflectionProperty(ClassLikeStorageProvider::class, 'storage');
+        /** @var array<string, ClassLikeStorage> $all */
+        $all = $ref->getValue();
+        unset($all['foo\\mytrait']);
+        $ref->setValue(null, $all);
+
+        // Analyze only the child file — this triggers getMethodMutations
+        // on the parent class's constructor, which iterates TraitUse nodes.
+        $file_analyzer = new FileAnalyzer(
+            $this->project_analyzer,
+            $child_path,
+            $config->shortenFileName($child_path),
+        );
+        // This must not crash — previously threw InvalidArgumentException
+        // from ClassLikeStorageProvider::get() for the missing trait.
+        $file_analyzer->analyze();
+    }
 }


### PR DESCRIPTION
Fixes #8953

Psalm 6.x crashes with `InvalidArgumentException: Could not get class storage for illuminate\console\concerns\promptsformissinginput` when analyzing Laravel projects containing classes that extend `Illuminate\Console\Command`.

**Root cause**: `ClassLikeAnalyzer::getMethodMutations()` iterates AST `TraitUse` nodes unconditionally. A trait may be registered via reflection (present in `existing_traits`) but absent from `ClassLikeStorageProvider::$storage`. The call to `getTraitNode()` → `classlike_storage_provider->get()` throws `InvalidArgumentException`.
**Fix**: Add a 4-line `has()` guard before accessing trait storage, same pattern as the interface fix in 03037f74.
**Real-world trigger**: Any Laravel class extending `Illuminate\Console\Command` (which uses `PromptsForMissingInput` trait) with an uninitialized typed property that triggers `collect_initializations` → `getMethodMutations` → crash.

## Stack Trace

```
InvalidArgumentException: Could not get class storage for illuminate\console\concerns\promptsformissinginput
  at src/Psalm/Internal/Provider/ClassLikeStorageProvider.php:45
  ClassLikes.php:771       → getTraitNode("Illuminate\Console\Concerns\PromptsForMissingInput")
  ClassLikeAnalyzer.php:141 → getTraitNode(...)        ← CRASH SITE
  FileAnalyzer.php:409     → getMethodMutations(...)
  ProjectAnalyzer.php:1205 → getMethodMutations(...)
  FileAnalyzer.php:372     → analyzing ExportMakeCommand.php
```

## Test

```
php vendor/bin/phpunit tests/IncludeTest.php --filter=testGetMethodMutationsDoesNotCrashWhenTraitStorageMissing
```

It failed with:

```
InvalidArgumentException: Could not get class storage for foo\mytrait
  at src/Psalm/Internal/Analyzer/ClassLikeAnalyzer.php:137
```

The stack trace matched the expected crash path through `ClassLikeAnalyzer::getMethodMutations()` → `ClassLikeStorageProvider::get()`.

## Notes

Follows the same guard pattern as the interface fix in 03037f74 (#11760)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core mutation-tracking logic for traits; while the change is a small guard, it can alter analysis behavior by silently skipping unscanned traits and should be validated against real-world projects.
> 
> **Overview**
> Prevents `ClassLikeAnalyzer::getMethodMutations()` from throwing when encountering a `TraitUse` whose `ClassLikeStorage` is missing by adding a `classlike_storage_provider->has()` guard and skipping that trait.
> 
> Adds a regression test in `IncludeTest` that simulates a trait registered via reflection but absent from storage (by removing it from `ClassLikeStorageProvider::$storage`) and asserts analyzing a child class no longer crashes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit deff79deaa0b1d6bc1fd06a43177c40f5b905e75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->