### PR TITLE
[6.x] Add support for template default types

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ClassTemplateParamCollector.php
@@ -147,7 +147,9 @@ final class ClassTemplateParamCollector
                         $class_storage->name => $output_type_extends ?? Type::getMixed(),
                     ];
                 } else {
-                    $class_template_params[$type_name] = [$class_storage->name => Type::getMixed()];
+                    $class_template_params[$type_name] = [
+                        $class_storage->name => $class_storage->template_type_defaults[$type_name] ?? Type::getMixed(),
+                    ];
                 }
             }
         }
@@ -173,7 +175,14 @@ final class ClassTemplateParamCollector
 
                 if (!$self_call) {
                     if (!isset($class_template_params[$type_name])) {
-                        $class_template_params[$type_name][$class_storage->name] = $type;
+                        $default = (!($lhs_type_part instanceof TGenericObject)
+                            && isset($class_storage->template_type_defaults[$type_name]))
+                            ? $class_storage->template_type_defaults[$type_name]
+                            : $type;
+
+                        $class_template_params[$type_name] = [
+                            $class_storage->name => $default,
+                        ];
                     }
                 }
             }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -64,6 +64,7 @@ use Psalm\Type\Union;
 use UnexpectedValueException;
 
 use function array_diff;
+use function array_key_first;
 use function array_map;
 use function array_merge;
 use function array_shift;
@@ -178,6 +179,16 @@ final class FunctionCallAnalyzer extends CallAnalyzer
             if (isset($function_call_info->function_storage->template_types)) {
                 $template_result->template_types += $function_call_info->function_storage->template_types ?: [];
             }
+            $function_defaults = $function_call_info->function_storage->template_type_defaults ?? null;
+            $function_templates = $function_call_info->function_storage->template_types ?? null;
+            if ($function_defaults !== null && $function_templates !== null) {
+                foreach ($function_defaults as $template_name => $default_type) {
+                    if (isset($function_templates[$template_name])) {
+                        $defining_key = array_key_first($function_templates[$template_name]);
+                        $template_result->template_type_defaults[$template_name][$defining_key] = $default_type;
+                    }
+                }
+            }
 
             ArgumentsAnalyzer::analyze(
                 $statements_analyzer,
@@ -215,6 +226,7 @@ final class FunctionCallAnalyzer extends CallAnalyzer
         }
 
         $already_inferred_lower_bounds = $template_result->lower_bounds;
+        $already_inferred_defaults = $template_result->template_type_defaults;
 
         $template_result = new TemplateResult([], []);
 
@@ -241,6 +253,10 @@ final class FunctionCallAnalyzer extends CallAnalyzer
         );
 
         $template_result->lower_bounds = [...$template_result->lower_bounds, ...$already_inferred_lower_bounds];
+        $template_result->template_type_defaults = [
+            ...$template_result->template_type_defaults,
+            ...$already_inferred_defaults,
+        ];
 
         if ($function_name instanceof PhpParser\Node\Name && $function_call_info->function_id) {
             $stmt_type = FunctionCallReturnTypeFetcher::fetch(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -179,13 +179,15 @@ final class FunctionCallAnalyzer extends CallAnalyzer
             if (isset($function_call_info->function_storage->template_types)) {
                 $template_result->template_types += $function_call_info->function_storage->template_types ?: [];
             }
-            $function_defaults = $function_call_info->function_storage->template_type_defaults ?? null;
-            $function_templates = $function_call_info->function_storage->template_types ?? null;
-            if ($function_defaults !== null && $function_templates !== null) {
-                foreach ($function_defaults as $template_name => $default_type) {
-                    if (isset($function_templates[$template_name])) {
-                        $defining_key = array_key_first($function_templates[$template_name]);
-                        $template_result->template_type_defaults[$template_name][$defining_key] = $default_type;
+            if ($function_call_info->function_storage !== null) {
+                $function_defaults = $function_call_info->function_storage->template_type_defaults;
+                $function_templates = $function_call_info->function_storage->template_types;
+                if ($function_defaults !== null && $function_templates !== null) {
+                    foreach ($function_defaults as $template_name => $default_type) {
+                        if (isset($function_templates[$template_name])) {
+                            $defining_key = array_key_first($function_templates[$template_name]);
+                            $template_result->template_type_defaults[$template_name][$defining_key] = $default_type;
+                        }
                     }
                 }
             }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -141,7 +141,11 @@ final class FunctionCallReturnTypeFetcher
                                         ),
                                     ],
                                 ];
-                            } else {
+                            } elseif (!isset($function_storage->template_type_defaults[$template_name])) {
+                                // Templates with a declared default are intentionally left
+                                // unbound here so TemplateInferredTypeReplacer can apply the
+                                // default. Without a default the param has no inferred value,
+                                // so we fall back to never as before.
                                 $template_result->lower_bounds[$template_name] = [
                                     'fn-' . $function_id => [
                                         new TemplateBound(
@@ -165,7 +169,9 @@ final class FunctionCallReturnTypeFetcher
                     if ($function_storage && $function_storage->return_type) {
                         $return_type = $function_storage->return_type;
 
-                        if ($template_result->lower_bounds && $function_storage->template_types) {
+                        if (($template_result->lower_bounds || $template_result->template_type_defaults)
+                            && $function_storage->template_types
+                        ) {
                             $return_type = TypeExpander::expandUnion(
                                 $codebase,
                                 $return_type,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/ExistingAtomicMethodCallAnalyzer.php
@@ -46,6 +46,7 @@ use Psalm\Type\Union;
 use UnexpectedValueException;
 
 use function array_filter;
+use function array_key_first;
 use function array_map;
 use function count;
 use function explode;
@@ -234,6 +235,14 @@ final class ExistingAtomicMethodCallAnalyzer extends CallAnalyzer
         }
         if ($method_storage && $method_storage->template_types) {
             $template_result->template_types += $method_storage->template_types;
+        }
+        if ($method_storage && $method_storage->template_type_defaults !== null) {
+            foreach ($method_storage->template_type_defaults as $template_name => $default_type) {
+                if (isset($method_storage->template_types[$template_name])) {
+                    $defining_key = array_key_first($method_storage->template_types[$template_name]);
+                    $template_result->template_type_defaults[$template_name][$defining_key] = $default_type;
+                }
+            }
         }
 
         if ($codebase->store_node_types

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -23,6 +23,7 @@ use Psalm\Internal\DataFlow\DataFlowNode;
 use Psalm\Internal\DataFlow\TaintSink;
 use Psalm\Internal\DataFlow\TaintSource;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\TemplateInferredTypeReplacer;
 use Psalm\Internal\Type\TemplateResult;
 use Psalm\Internal\Type\TemplateStandinTypeReplacer;
 use Psalm\Internal\Type\TypeExpander;
@@ -542,6 +543,12 @@ final class NewAnalyzer extends CallAnalyzer
                     } else {
                         if ($fq_class_name === 'SplObjectStorage') {
                             $generic_param_type = Type::getNever();
+                        } elseif (isset($storage->template_type_defaults[$template_name])) {
+                            $generic_param_type = TemplateInferredTypeReplacer::replace(
+                                $storage->template_type_defaults[$template_name],
+                                $template_result,
+                                $codebase,
+                            );
                         } else {
                             $generic_param_type = array_values($base_type)[0];
                         }
@@ -616,14 +623,14 @@ final class NewAnalyzer extends CallAnalyzer
                 $statements_analyzer->getSuppressedIssues(),
             );
         } elseif ($storage->template_types) {
+            $type_params = [];
+            foreach ($storage->template_types as $template_name => $type_map) {
+                $type_params[] = $storage->template_type_defaults[$template_name] ?? reset($type_map);
+            }
+
             $result_atomic_type = new TGenericObject(
                 $fq_class_name,
-                array_values(
-                    array_map(
-                        static fn($map) => reset($map),
-                        $storage->template_types,
-                    ),
-                ),
+                $type_params,
                 false,
                 $from_static,
             );

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -623,9 +623,18 @@ final class NewAnalyzer extends CallAnalyzer
                 $statements_analyzer->getSuppressedIssues(),
             );
         } elseif ($storage->template_types) {
+            $template_result ??= new TemplateResult([], []);
             $type_params = [];
             foreach ($storage->template_types as $template_name => $type_map) {
-                $type_params[] = $storage->template_type_defaults[$template_name] ?? reset($type_map);
+                if (isset($storage->template_type_defaults[$template_name])) {
+                    $type_params[] = TemplateInferredTypeReplacer::replace(
+                        $storage->template_type_defaults[$template_name],
+                        $template_result,
+                        $codebase,
+                    );
+                } else {
+                    $type_params[] = reset($type_map);
+                }
             }
 
             $result_atomic_type = new TGenericObject(

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -27,7 +27,9 @@ use Psalm\Internal\Type\TypeParser;
 use Psalm\Internal\Type\TypeTokenizer;
 
 use function array_key_first;
+use function array_search;
 use function array_shift;
+use function array_slice;
 use function count;
 use function explode;
 use function implode;
@@ -87,6 +89,14 @@ final class ClassLikeDocblockParser
                     $source_prefix = 'phpstan';
                 }
 
+                $eq_pos = array_search('=', $template_type, true);
+                $default_type_string = null;
+                if ($eq_pos !== false) {
+                    $default_tokens = array_slice($template_type, $eq_pos + 1);
+                    $default_type_string = implode(' ', $default_tokens) ?: null;
+                    $template_type = array_slice($template_type, 0, $eq_pos);
+                }
+
                 if (count($template_type) > 1
                     && in_array(strtolower($template_type[0]), ['as', 'super', 'of'], true)
                 ) {
@@ -97,6 +107,7 @@ final class ClassLikeDocblockParser
                         implode(' ', $template_type),
                         false,
                         $offset - $comment->getStartFilePos(),
+                        $default_type_string,
                     ];
                 } else {
                     $templates[$template_name][$source_prefix] = [
@@ -105,6 +116,7 @@ final class ClassLikeDocblockParser
                         null,
                         false,
                         $offset - $comment->getStartFilePos(),
+                        $default_type_string,
                     ];
                 }
             }
@@ -130,6 +142,14 @@ final class ClassLikeDocblockParser
                     $source_prefix = 'phpstan';
                 }
 
+                $eq_pos = array_search('=', $template_type, true);
+                $default_type_string = null;
+                if ($eq_pos !== false) {
+                    $default_tokens = array_slice($template_type, $eq_pos + 1);
+                    $default_type_string = implode(' ', $default_tokens) ?: null;
+                    $template_type = array_slice($template_type, 0, $eq_pos);
+                }
+
                 if (count($template_type) > 1
                     && in_array(strtolower($template_type[0]), ['as', 'super', 'of'], true)
                 ) {
@@ -140,6 +160,7 @@ final class ClassLikeDocblockParser
                         implode(' ', $template_type),
                         true,
                         $offset - $comment->getStartFilePos(),
+                        $default_type_string,
                     ];
                 } else {
                     $templates[$template_name][$source_prefix] = [
@@ -148,6 +169,7 @@ final class ClassLikeDocblockParser
                         null,
                         true,
                         $offset - $comment->getStartFilePos(),
+                        $default_type_string,
                     ];
                 }
             }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -464,6 +464,31 @@ final class ClassLikeNodeScanner
                     }
 
                     $storage->template_covariants[$i] = $template_map[3];
+
+                    $default_type_string = $template_map[5] ?? null;
+                    if ($default_type_string !== null) {
+                        $default_type_string = CommentAnalyzer::sanitizeDocblockType($default_type_string);
+                        try {
+                            $default_type = TypeParser::parseTokens(
+                                TypeTokenizer::getFullyQualifiedTokens(
+                                    $default_type_string,
+                                    $this->aliases,
+                                    $storage->template_types,
+                                    $this->type_aliases,
+                                ),
+                                null,
+                                $storage->template_types,
+                                $this->type_aliases,
+                            );
+
+                            $storage->template_type_defaults[$template_name] = $default_type;
+                        } catch (TypeParseTreeException $e) {
+                            $storage->docblock_issues[] = new InvalidDocblock(
+                                'Template ' . $template_name . ' has invalid default type - ' . $e->getMessage(),
+                                $name_location ?? $class_location,
+                            );
+                        }
+                    }
                 }
 
                 $this->class_template_types = $storage->template_types;

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -35,12 +35,14 @@ use Psalm\Internal\Provider\NodeDataProvider;
 use Psalm\Internal\Scanner\ClassLikeDocblockComment;
 use Psalm\Internal\Scanner\FileScanner;
 use Psalm\Internal\Scanner\UnresolvedConstantComponent;
+use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Internal\Type\TypeAlias;
 use Psalm\Internal\Type\TypeAlias\ClassTypeAlias;
 use Psalm\Internal\Type\TypeAlias\InlineTypeAlias;
 use Psalm\Internal\Type\TypeAlias\LinkableTypeAlias;
 use Psalm\Internal\Type\TypeParser;
 use Psalm\Internal\Type\TypeTokenizer;
+use Psalm\Internal\TypeVisitor\ContainsClassRefVisitor;
 use Psalm\Issue\ConstantDeclarationInTrait;
 use Psalm\Issue\DuplicateClass;
 use Psalm\Issue\DuplicateConstant;
@@ -80,6 +82,7 @@ use function array_values;
 use function assert;
 use function count;
 use function implode;
+use function in_array;
 use function ltrim;
 use function preg_match;
 use function preg_split;
@@ -481,7 +484,26 @@ final class ClassLikeNodeScanner
                                 $this->type_aliases,
                             );
 
-                            $storage->template_type_defaults[$template_name] = $default_type;
+                            $bound = $storage->template_types[$template_name][$fq_classlike_name];
+                            $modifier = $template_map[1] !== null ? strtolower($template_map[1]) : null;
+
+                            $default_violates_bound = self::defaultViolatesBound(
+                                $this->codebase,
+                                $modifier,
+                                $bound,
+                                $default_type,
+                            );
+
+                            if ($default_violates_bound) {
+                                $storage->docblock_issues[] = new InvalidDocblock(
+                                    'Template ' . $template_name . ' default type '
+                                    . $default_type->getId() . ' is not within bound '
+                                    . $bound->getId(),
+                                    $name_location ?? $class_location,
+                                );
+                            } else {
+                                $storage->template_type_defaults[$template_name] = $default_type;
+                            }
                         } catch (TypeParseTreeException $e) {
                             $storage->docblock_issues[] = new InvalidDocblock(
                                 'Template ' . $template_name . ' has invalid default type - ' . $e->getMessage(),
@@ -2082,5 +2104,63 @@ final class ClassLikeNodeScanner
         }
 
         return $type_alias_tokens;
+    }
+
+    /**
+     * Returns true if the default for an `as`/`of`-bounded template clearly violates the bound.
+     *
+     * Validation runs at scan time, before Populator resolves transitive inheritance, so this
+     * is intentionally conservative: it returns false (no diagnostic) whenever the comparison
+     * would need information that isn't yet available, to avoid spurious diagnostics. Cases
+     * skipped here are not silently accepted at runtime: the analyzer will still flag a real
+     * mismatch where it matters (return-type checks, argument-type checks).
+     */
+    public static function defaultViolatesBound(
+        Codebase $codebase,
+        ?string $modifier,
+        Union $bound,
+        Union $default_type,
+    ): bool {
+        // No subtype check for `super`: the parser accepts it but Psalm has no
+        // first-class supertype-bound semantics elsewhere, so validating here
+        // would be inconsistent with the rest of the type system.
+        if (!in_array($modifier, ['as', 'of'], true)) {
+            return false;
+        }
+
+        if ($bound->isMixed()) {
+            return false;
+        }
+
+        // Skip when either side contains a template parameter at any depth — the
+        // comparison can't be resolved until the outer template is instantiated.
+        if ($bound->getTemplateTypes() !== [] || $default_type->getTemplateTypes() !== []) {
+            return false;
+        }
+
+        // Skip when either side references a named class or interface (or
+        // iterable, which is internally Traversable) at any depth. Verifying
+        // such relationships requires walking inheritance, which Populator
+        // hasn't done yet at scan time, so the comparator would produce false
+        // positives on transitive ancestors. The analyzer will still flag a
+        // genuine mismatch when the default is applied at a usage site.
+        $bound_visitor = new ContainsClassRefVisitor();
+        $bound_visitor->traverse($bound);
+        if ($bound_visitor->matches()) {
+            return false;
+        }
+        $default_visitor = new ContainsClassRefVisitor();
+        $default_visitor->traverse($default_type);
+        if ($default_visitor->matches()) {
+            return false;
+        }
+
+        try {
+            return !UnionTypeComparator::isContainedBy($codebase, $default_type, $bound);
+        } catch (InvalidArgumentException) {
+            // Classes referenced by either side may not be in storage yet at scan time;
+            // skip rather than emit a flaky InvalidDocblock based on missing data.
+            return false;
+        }
     }
 }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -2138,20 +2138,18 @@ final class ClassLikeNodeScanner
             return false;
         }
 
-        // Skip when either side references a named class or interface (or
-        // iterable, which is internally Traversable) at any depth. Verifying
-        // such relationships requires walking inheritance, which Populator
+        // Skip only when BOTH sides reference a named class or interface (or
+        // iterable, which is internally Traversable) at any depth. Comparing
+        // two named classes requires walking inheritance, which Populator
         // hasn't done yet at scan time, so the comparator would produce false
-        // positives on transitive ancestors. The analyzer will still flag a
-        // genuine mismatch when the default is applied at a usage site.
+        // positives on transitive ancestors. When only one side references a
+        // class, the comparator's verdict is purely a kind comparison
+        // (e.g. "is int an object?") and is reliable at scan time.
         $bound_visitor = new ContainsClassRefVisitor();
         $bound_visitor->traverse($bound);
-        if ($bound_visitor->matches()) {
-            return false;
-        }
         $default_visitor = new ContainsClassRefVisitor();
         $default_visitor->traverse($default_type);
-        if ($default_visitor->matches()) {
+        if ($bound_visitor->matches() && $default_visitor->matches()) {
             return false;
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -19,7 +19,9 @@ use Psalm\IssueBuffer;
 use Psalm\Type\TaintKindGroup;
 
 use function array_keys;
+use function array_search;
 use function array_shift;
+use function array_slice;
 use function array_unique;
 use function count;
 use function explode;
@@ -507,6 +509,14 @@ final class FunctionLikeDocblockParser
                     $source_prefix = 'phpstan';
                 }
 
+                $eq_pos = array_search('=', $template_type, true);
+                $default_type_string = null;
+                if ($eq_pos !== false) {
+                    $default_tokens = array_slice($template_type, $eq_pos + 1);
+                    $default_type_string = implode(' ', $default_tokens) ?: null;
+                    $template_type = array_slice($template_type, 0, $eq_pos);
+                }
+
                 if (count($template_type) > 1
                     && in_array(strtolower($template_type[0]), ['as', 'super', 'of'], true)
                 ) {
@@ -516,9 +526,16 @@ final class FunctionLikeDocblockParser
                         $template_modifier,
                         implode(' ', $template_type),
                         false,
+                        $default_type_string,
                     ];
                 } else {
-                    $templates[$template_name][$source_prefix] = [$template_name, null, null, false];
+                    $templates[$template_name][$source_prefix] = [
+                        $template_name,
+                        null,
+                        null,
+                        false,
+                        $default_type_string,
+                    ];
                 }
             }
         }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -1495,6 +1495,31 @@ final class FunctionLikeDocblockScanner
                 $storage->template_types[$template_name] = [
                     'fn-' . strtolower($cased_function_id) => $template_type,
                 ];
+
+                $default_type_string = $template_map[4] ?? null;
+                if ($default_type_string !== null) {
+                    $default_type_string = CommentAnalyzer::sanitizeDocblockType($default_type_string);
+                    try {
+                        $default_type = TypeParser::parseTokens(
+                            TypeTokenizer::getFullyQualifiedTokens(
+                                $default_type_string,
+                                $aliases,
+                                $storage->template_types + ($template_types ?? []),
+                                $type_aliases,
+                            ),
+                            null,
+                            $storage->template_types + ($template_types ?? []),
+                            $type_aliases,
+                        );
+
+                        $storage->template_type_defaults[$template_name] = $default_type;
+                    } catch (TypeParseTreeException $e) {
+                        $storage->docblock_issues[] = new InvalidDocblock(
+                            'Template ' . $template_name . ' has invalid default type - ' . $e->getMessage(),
+                            new CodeLocation($file_scanner, $stmt, null, true),
+                        );
+                    }
+                }
             }
         }
 

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -237,6 +237,7 @@ final class FunctionLikeDocblockScanner
                 $file_scanner,
                 $stmt,
                 $cased_function_id,
+                $codebase,
             );
         }
 
@@ -1438,6 +1439,7 @@ final class FunctionLikeDocblockScanner
         FileScanner $file_scanner,
         PhpParser\Node\FunctionLike $stmt,
         string $cased_function_id,
+        Codebase $codebase,
     ): array {
         $storage->template_types = [];
 
@@ -1512,7 +1514,25 @@ final class FunctionLikeDocblockScanner
                             $type_aliases,
                         );
 
-                        $storage->template_type_defaults[$template_name] = $default_type;
+                        $modifier = $template_map[1] !== null ? strtolower($template_map[1]) : null;
+
+                        $default_violates_bound = ClassLikeNodeScanner::defaultViolatesBound(
+                            $codebase,
+                            $modifier,
+                            $template_type,
+                            $default_type,
+                        );
+
+                        if ($default_violates_bound) {
+                            $storage->docblock_issues[] = new InvalidDocblock(
+                                'Template ' . $template_name . ' default type '
+                                . $default_type->getId() . ' is not within bound '
+                                . $template_type->getId(),
+                                new CodeLocation($file_scanner, $stmt, null, true),
+                            );
+                        } else {
+                            $storage->template_type_defaults[$template_name] = $default_type;
+                        }
                     } catch (TypeParseTreeException $e) {
                         $storage->docblock_issues[] = new InvalidDocblock(
                             'Template ' . $template_name . ' has invalid default type - ' . $e->getMessage(),

--- a/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
@@ -39,7 +39,7 @@ final class ClassLikeDocblockComment
     public array $mixins = [];
 
     /**
-     * @var array<int, array{string, ?string, ?string, bool, int}>
+     * @var array<int, array{string, ?string, ?string, bool, int, ?string}>
      */
     public array $templates = [];
 

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -139,7 +139,7 @@ final class FunctionDocblockComment
     public array $throws = [];
 
     /**
-     * @var array<int, array{string, ?string, ?string, bool}>
+     * @var array<int, array{string, ?string, ?string, bool, ?string}>
      */
     public array $templates = [];
 

--- a/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
@@ -6,6 +6,7 @@ namespace Psalm\Internal\Type;
 
 use InvalidArgumentException;
 use Psalm\Codebase;
+use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
 use Psalm\Type;
 use Psalm\Type\Atomic;
@@ -37,6 +38,8 @@ use function array_shift;
 use function array_values;
 use function assert;
 use function str_starts_with;
+use function strpos;
+use function substr;
 
 /**
  * @internal
@@ -52,6 +55,7 @@ final class TemplateInferredTypeReplacer
         Union $union,
         TemplateResult $template_result,
         ?Codebase $codebase,
+        bool $apply_defaults = true,
     ): Union {
         $new_types = [];
 
@@ -71,6 +75,7 @@ final class TemplateInferredTypeReplacer
                     $atomic_type,
                     $inferred_lower_bounds,
                     $key,
+                    $apply_defaults ? $template_result : null,
                 );
 
                 if ($template_type) {
@@ -250,6 +255,7 @@ final class TemplateInferredTypeReplacer
         TTemplateParam $atomic_type,
         array $inferred_lower_bounds,
         string $key,
+        ?TemplateResult $template_result = null,
     ): ?Union {
         $template_type = null;
 
@@ -326,6 +332,21 @@ final class TemplateInferredTypeReplacer
                     } catch (InvalidArgumentException) {
                     }
                 }
+            }
+        }
+
+        if ($template_type === null
+            || ($template_type->isMixed() && $atomic_type->as->isMixed())
+            || $template_type->isNever()
+        ) {
+            $default_type = self::getTemplateDefault(
+                $atomic_type,
+                $template_result,
+                $codebase,
+            );
+
+            if ($default_type !== null) {
+                $template_type = $default_type;
             }
         }
 
@@ -557,5 +578,89 @@ final class TemplateInferredTypeReplacer
         );
 
         return $class_template_type;
+    }
+
+    private static function getTemplateDefault(
+        TTemplateParam $atomic_type,
+        ?TemplateResult $template_result,
+        ?Codebase $codebase,
+    ): ?Union {
+        if ($template_result === null) {
+            return null;
+        }
+
+        $defining_class = $atomic_type->defining_class;
+        $param_name = $atomic_type->param_name;
+
+        // Check TemplateResult first (populated from method/class storage at call sites)
+        $default = $template_result->template_type_defaults[$param_name][$defining_class] ?? null;
+
+        // Fall back to storage lookup for class-level defaults
+        if ($default === null && $codebase !== null) {
+            $default = self::lookupDefaultFromStorage($codebase, $param_name, $defining_class);
+        }
+
+        if ($default === null) {
+            return null;
+        }
+
+        // Resolve any template params in the default type using current inference
+        return self::replace($default, $template_result, $codebase, false);
+    }
+
+    private static function lookupDefaultFromStorage(
+        Codebase $codebase,
+        string $param_name,
+        string $defining_class,
+    ): ?Union {
+        if (str_starts_with($defining_class, 'fn-')) {
+            // Method/function template - extract the function ID
+            $function_id = substr($defining_class, 3);
+
+            if (strpos($function_id, '::') !== false) {
+                // It's a method — look up via classlike storage to avoid issues
+                // with Methods::getStorage() requiring full class resolution
+                $method_id = MethodIdentifier::wrap($function_id);
+
+                try {
+                    $classlike_storage = $codebase->classlike_storage_provider->get(
+                        $method_id->fq_class_name,
+                    );
+                } catch (InvalidArgumentException) {
+                    return null;
+                }
+
+                $method_storage = $classlike_storage->methods[$method_id->method_name] ?? null;
+
+                if ($method_storage === null) {
+                    return null;
+                }
+
+                return $method_storage->template_type_defaults[$param_name] ?? null;
+            }
+
+            // It's a function
+            if ($function_id === '') {
+                return null;
+            }
+
+            try {
+                /** @var non-empty-lowercase-string $function_id */
+                $function_storage = $codebase->functions->getStorage(null, $function_id);
+
+                return $function_storage->template_type_defaults[$param_name] ?? null;
+            } catch (UnexpectedValueException | InvalidArgumentException) {
+                return null;
+            }
+        }
+
+        // Class-level template
+        try {
+            $classlike_storage = $codebase->classlike_storage_provider->get($defining_class);
+
+            return $classlike_storage->template_type_defaults[$param_name] ?? null;
+        } catch (InvalidArgumentException) {
+            return null;
+        }
     }
 }

--- a/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
@@ -337,7 +337,6 @@ final class TemplateInferredTypeReplacer
 
         if ($template_type === null
             || ($template_type->isMixed() && $atomic_type->as->isMixed())
-            || $template_type->isNever()
         ) {
             $default_type = self::getTemplateDefault(
                 $atomic_type,

--- a/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateInferredTypeReplacer.php
@@ -56,6 +56,7 @@ final class TemplateInferredTypeReplacer
         TemplateResult $template_result,
         ?Codebase $codebase,
         bool $apply_defaults = true,
+        array $visiting_defaults = [],
     ): Union {
         $new_types = [];
 
@@ -76,6 +77,7 @@ final class TemplateInferredTypeReplacer
                     $inferred_lower_bounds,
                     $key,
                     $apply_defaults ? $template_result : null,
+                    $visiting_defaults,
                 );
 
                 if ($template_type) {
@@ -250,12 +252,16 @@ final class TemplateInferredTypeReplacer
     /**
      * @param array<string, array<string, non-empty-list<TemplateBound>>> $inferred_lower_bounds
      */
+    /**
+     * @param array<string, true> $visiting_defaults
+     */
     private static function replaceTemplateParam(
         ?Codebase $codebase,
         TTemplateParam $atomic_type,
         array $inferred_lower_bounds,
         string $key,
         ?TemplateResult $template_result = null,
+        array $visiting_defaults = [],
     ): ?Union {
         $template_type = null;
 
@@ -342,6 +348,7 @@ final class TemplateInferredTypeReplacer
                 $atomic_type,
                 $template_result,
                 $codebase,
+                $visiting_defaults,
             );
 
             if ($default_type !== null) {
@@ -579,10 +586,14 @@ final class TemplateInferredTypeReplacer
         return $class_template_type;
     }
 
+    /**
+     * @param array<string, true> $visiting_defaults
+     */
     private static function getTemplateDefault(
         TTemplateParam $atomic_type,
         ?TemplateResult $template_result,
         ?Codebase $codebase,
+        array $visiting_defaults = [],
     ): ?Union {
         if ($template_result === null) {
             return null;
@@ -590,6 +601,13 @@ final class TemplateInferredTypeReplacer
 
         $defining_class = $atomic_type->defining_class;
         $param_name = $atomic_type->param_name;
+
+        // Cycle guard: if we are already expanding this template's default,
+        // bail out instead of recursing (e.g. `@template T = U @template U = T`).
+        $visit_key = $param_name . '::' . $defining_class;
+        if (isset($visiting_defaults[$visit_key])) {
+            return null;
+        }
 
         // Check TemplateResult first (populated from method/class storage at call sites)
         $default = $template_result->template_type_defaults[$param_name][$defining_class] ?? null;
@@ -603,8 +621,11 @@ final class TemplateInferredTypeReplacer
             return null;
         }
 
-        // Resolve any template params in the default type using current inference
-        return self::replace($default, $template_result, $codebase, false);
+        // Resolve any template params in the default type using current inference,
+        // including their own defaults — `@template U = T` should expand U through T.
+        $visiting_defaults[$visit_key] = true;
+
+        return self::replace($default, $template_result, $codebase, true, $visiting_defaults);
     }
 
     private static function lookupDefaultFromStorage(

--- a/src/Psalm/Internal/Type/TemplateResult.php
+++ b/src/Psalm/Internal/Type/TemplateResult.php
@@ -38,6 +38,14 @@ final class TemplateResult
     public array $upper_bounds = [];
 
     /**
+     * Default types for template params, keyed by param_name then defining_class.
+     * Used when a template param has no lower_bounds.
+     *
+     * @var array<string, array<string, Union>>
+     */
+    public array $template_type_defaults = [];
+
+    /**
      * If set to true then we shouldn't update the template bounds
      */
     public bool $readonly = false;
@@ -71,6 +79,7 @@ final class TemplateResult
         $lower_bounds = array_replace_recursive($instance->lower_bounds, $result->lower_bounds);
         $instance->lower_bounds = $lower_bounds;
         $instance->template_types = [...$instance->template_types, ...$result->template_types];
+        $instance->template_type_defaults = [...$instance->template_type_defaults, ...$result->template_type_defaults];
 
         return $instance;
     }

--- a/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
+++ b/src/Psalm/Internal/Type/TemplateStandinTypeReplacer.php
@@ -1256,7 +1256,15 @@ final class TemplateStandinTypeReplacer
             } elseif (!empty($class_storage->template_extended_params[$container_class])) {
                 $input_type_params = array_values($class_storage->template_extended_params[$container_class]);
             } else {
-                $input_type_params = array_fill(0, count($class_storage->template_types ?? []), Type::getMixed());
+                if ($class_storage->template_type_defaults !== null) {
+                    $input_type_params = [];
+                    foreach ($class_storage->template_types ?? [] as $template_name => $_) {
+                        $input_type_params[] = $class_storage->template_type_defaults[$template_name]
+                            ?? Type::getMixed();
+                    }
+                } else {
+                    $input_type_params = array_fill(0, count($class_storage->template_types ?? []), Type::getMixed());
+                }
             }
         } else {
             $input_type_params = [];

--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -41,7 +41,6 @@ use ReflectionProperty;
 
 use function array_any;
 use function array_filter;
-use function array_map;
 use function array_merge;
 use function array_values;
 use function count;
@@ -601,20 +600,32 @@ final class TypeExpander
                 $value,
             );
 
+            $template_type_defaults = $container_class_storage->template_type_defaults ?? [];
+
             if ($container_class_storage->template_types
                 && array_any(
                     $container_class_storage->template_types,
-                    static fn($type_map): bool => !reset($type_map)->hasMixed(),
+                    static fn($type_map, $template_name): bool => isset($template_type_defaults[$template_name])
+                        || !reset($type_map)->hasMixed(),
                 )
             ) {
+                $template_result = new TemplateResult([], []);
+                $type_params = [];
+                foreach ($container_class_storage->template_types as $template_name => $type_map) {
+                    if (isset($template_type_defaults[$template_name])) {
+                        $type_params[] = TemplateInferredTypeReplacer::replace(
+                            $template_type_defaults[$template_name],
+                            $template_result,
+                            $codebase,
+                        );
+                    } else {
+                        $type_params[] = reset($type_map);
+                    }
+                }
+
                 $return_type = new TGenericObject(
                     $return_type->value,
-                    array_values(
-                        array_map(
-                            static fn($type_map) => reset($type_map),
-                            $container_class_storage->template_types,
-                        ),
-                    ),
+                    $type_params,
                 );
 
                 // we don't want to expand generic types recursively

--- a/src/Psalm/Internal/TypeVisitor/ContainsClassRefVisitor.php
+++ b/src/Psalm/Internal/TypeVisitor/ContainsClassRefVisitor.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\TypeVisitor;
+
+use Override;
+use Psalm\Type\Atomic\TIterable;
+use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\TypeNode;
+use Psalm\Type\TypeVisitor;
+
+/**
+ * Detects whether a type tree contains a named class reference (TNamedObject and
+ * its descendants like TGenericObject) or TIterable. Used to decide whether a
+ * subtype check involving the type can be performed safely at scan time, before
+ * Populator has resolved transitive inheritance chains.
+ *
+ * @internal
+ */
+final class ContainsClassRefVisitor extends TypeVisitor
+{
+    private bool $contains_class_ref = false;
+
+    #[Override]
+    protected function enterNode(TypeNode $type): ?int
+    {
+        if ($type instanceof TNamedObject || $type instanceof TIterable) {
+            $this->contains_class_ref = true;
+
+            return self::STOP_TRAVERSAL;
+        }
+
+        return null;
+    }
+
+    public function matches(): bool
+    {
+        return $this->contains_class_ref;
+    }
+}

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -278,6 +278,15 @@ final class ClassLikeStorage implements HasAttributesInterface
     public ?array $template_types = null;
 
     /**
+     * An array holding default types for template parameters.
+     *
+     * When a template parameter is not explicitly provided, the default type is used instead of mixed.
+     *
+     * @var array<string, Union>|null
+     */
+    public ?array $template_type_defaults = null;
+
+    /**
      * @var array<int, bool>|null
      */
     public ?array $template_covariants = null;

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -95,6 +95,15 @@ abstract class FunctionLikeStorage implements HasAttributesInterface, Stringable
     public ?array $template_types = null;
 
     /**
+     * An array holding default types for template parameters.
+     *
+     * When a template parameter cannot be inferred, the default type is used instead of mixed.
+     *
+     * @var array<string, Union>|null
+     */
+    public ?array $template_type_defaults = null;
+
+    /**
      * @var array<int, Possibilities>
      */
     public array $assertions = [];

--- a/tests/ClassLikeDocblockParserTest.php
+++ b/tests/ClassLikeDocblockParserTest.php
@@ -37,7 +37,31 @@ final class ClassLikeDocblockParserTest extends TestCase
         $node = new Class_(null);
         $php_parser_doc = new Doc($doc);
         $class_docblock = ClassLikeDocblockParser::parse($node, $php_parser_doc, new Aliases());
-        $this->assertSame([['T', 'of', 'string', true, 33]], $class_docblock->templates);
+        $this->assertSame([['T', 'of', 'string', true, 33, null]], $class_docblock->templates);
+    }
+
+    public function testTemplateDefaultWithoutBound(): void
+    {
+        $doc = '/**
+ * @template T = string
+ */
+';
+        $node = new Class_(null);
+        $php_parser_doc = new Doc($doc);
+        $class_docblock = ClassLikeDocblockParser::parse($node, $php_parser_doc, new Aliases());
+        $this->assertSame([['T', null, null, false, 15, 'string']], $class_docblock->templates);
+    }
+
+    public function testTemplateDefaultWithBound(): void
+    {
+        $doc = '/**
+ * @template T of object = stdClass
+ */
+';
+        $node = new Class_(null);
+        $php_parser_doc = new Doc($doc);
+        $class_docblock = ClassLikeDocblockParser::parse($node, $php_parser_doc, new Aliases());
+        $this->assertSame([['T', 'of', 'object', false, 15, 'stdClass']], $class_docblock->templates);
     }
 
     /**

--- a/tests/ClassLikeDocblockParserTest.php
+++ b/tests/ClassLikeDocblockParserTest.php
@@ -49,7 +49,7 @@ final class ClassLikeDocblockParserTest extends TestCase
         $node = new Class_(null);
         $php_parser_doc = new Doc($doc);
         $class_docblock = ClassLikeDocblockParser::parse($node, $php_parser_doc, new Aliases());
-        $this->assertSame([['T', null, null, false, 15, 'string']], $class_docblock->templates);
+        $this->assertSame([['T', null, null, false, 17, 'string']], $class_docblock->templates);
     }
 
     public function testTemplateDefaultWithBound(): void
@@ -61,7 +61,7 @@ final class ClassLikeDocblockParserTest extends TestCase
         $node = new Class_(null);
         $php_parser_doc = new Doc($doc);
         $class_docblock = ClassLikeDocblockParser::parse($node, $php_parser_doc, new Aliases());
-        $this->assertSame([['T', 'of', 'object', false, 15, 'stdClass']], $class_docblock->templates);
+        $this->assertSame([['T', 'of', 'object', false, 17, 'stdClass']], $class_docblock->templates);
     }
 
     /**

--- a/tests/FunctionLikeDocblockParserTest.php
+++ b/tests/FunctionLikeDocblockParserTest.php
@@ -129,7 +129,37 @@ final class FunctionLikeDocblockParserTest extends BaseTestCase
             $this->test_code_location,
             $this->test_cased_function_id,
         );
-        $this->assertSame([['T', 'of', 'string', false]], $function_docblock->templates);
+        $this->assertSame([['T', 'of', 'string', false, null]], $function_docblock->templates);
+    }
+
+    public function testTemplateDefaultWithoutBound(): void
+    {
+        $doc = '/**
+ * @template T = int
+ */
+';
+        $php_parser_doc = new Doc($doc);
+        $function_docblock = FunctionLikeDocblockParser::parse(
+            $php_parser_doc,
+            $this->test_code_location,
+            $this->test_cased_function_id,
+        );
+        $this->assertSame([['T', null, null, false, 'int']], $function_docblock->templates);
+    }
+
+    public function testTemplateDefaultWithBound(): void
+    {
+        $doc = '/**
+ * @template T of object = stdClass
+ */
+';
+        $php_parser_doc = new Doc($doc);
+        $function_docblock = FunctionLikeDocblockParser::parse(
+            $php_parser_doc,
+            $this->test_code_location,
+            $this->test_cased_function_id,
+        );
+        $this->assertSame([['T', 'of', 'object', false, 'stdClass']], $function_docblock->templates);
     }
 
     public function testReturnsUnexpectedTags(): void

--- a/tests/Template/TemplateDefaultTest.php
+++ b/tests/Template/TemplateDefaultTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Template;
+
+use Override;
+use Psalm\Tests\TestCase;
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+final class TemplateDefaultTest extends TestCase
+{
+    use InvalidCodeAnalysisTestTrait;
+    use ValidCodeAnalysisTestTrait;
+
+    #[Override]
+    public function providerValidCodeParse(): iterable
+    {
+        return [
+            'classTemplateDefaultBasic' => [
+                'code' => '<?php
+                    /**
+                     * @template T = string
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get() {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Foo $foo */
+                    function test(Foo $foo): string {
+                        return $foo->get();
+                    }',
+            ],
+            'classTemplateDefaultWithBound' => [
+                'code' => '<?php
+                    /**
+                     * @template T of string = "hello"
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get(): string {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Foo $foo */
+                    function test(Foo $foo): string {
+                        return $foo->get();
+                    }',
+            ],
+            'classTemplateDefaultExplicitOverride' => [
+                'code' => '<?php
+                    /**
+                     * @template T = string
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get() {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Foo<int> $foo */
+                    function test(Foo $foo): int {
+                        return $foo->get();
+                    }',
+            ],
+            'methodTemplateDefaultReferencingClassTemplate' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     */
+                    interface I {
+                        /**
+                         * @template TResult = T
+                         * @param (callable(T): TResult)|null $a
+                         * @return I<TResult>
+                         */
+                        public function work(?callable $a = null): self;
+                    }
+
+                    /**
+                     * @param I<string> $i
+                     * @return I<string>
+                     */
+                    function test(I $i): I {
+                        return $i->work(null);
+                    }',
+            ],
+            'methodTemplateDefaultWithCallable' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     */
+                    interface I {
+                        /**
+                         * @template TResult = T
+                         * @param (callable(T): TResult)|null $a
+                         * @return I<TResult>
+                         */
+                        public function work(?callable $a = null): self;
+                    }
+
+                    /**
+                     * @param I<string> $i
+                     */
+                    function test(I $i): void {
+                        /** @var I<int> */
+                        $result = $i->work(
+                            /** @param string $s @return int */
+                            function (string $s): int { return 1; },
+                        );
+                    }',
+            ],
+            'multipleTemplateDefaults' => [
+                'code' => '<?php
+                    /**
+                     * @template T = string
+                     * @template U = int
+                     */
+                    class Pair {
+                        /** @return T */
+                        public function first() {
+                            throw new \RuntimeException();
+                        }
+                        /** @return U */
+                        public function second() {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Pair $p */
+                    function testFirst(Pair $p): string {
+                        return $p->first();
+                    }
+
+                    /** @param Pair $p */
+                    function testSecond(Pair $p): int {
+                        return $p->second();
+                    }',
+            ],
+            'templateDefaultNever' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     */
+                    interface Promise {
+                        /**
+                         * @template TResult1 = T
+                         * @template TResult2 = never
+                         * @param (callable(T): TResult1)|null $onFulfilled
+                         * @param (callable(mixed): TResult2)|null $onRejected
+                         * @return Promise<TResult1|TResult2>
+                         */
+                        public function then(
+                            ?callable $onFulfilled = null,
+                            ?callable $onRejected = null
+                        ): self;
+                    }
+
+                    /**
+                     * @param Promise<int> $promise
+                     * @return Promise<int>
+                     */
+                    function testNulls(Promise $promise): Promise {
+                        return $promise->then(null, null);
+                    }',
+            ],
+            'classTemplateDefaultCovariant' => [
+                'code' => '<?php
+                    /**
+                     * @template-covariant T = string
+                     */
+                    class Box {
+                        /** @return T */
+                        public function get() {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Box $b */
+                    function test(Box $b): string {
+                        return $b->get();
+                    }',
+            ],
+            'classTemplateDefaultOnNew' => [
+                'code' => '<?php
+                    /**
+                     * @template T = int
+                     */
+                    class Container {
+                        /** @var T */
+                        public $value;
+
+                        /** @param T $value */
+                        public function __construct($value) {
+                            $this->value = $value;
+                        }
+                    }
+
+                    $c = new Container(42);',
+                'assertions' => [
+                    '$c===' => 'Container<42>',
+                ],
+            ],
+            'phpstanTemplateSyntax' => [
+                'code' => '<?php
+                    /**
+                     * @phpstan-template T = string
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get() {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Foo $foo */
+                    function test(Foo $foo): string {
+                        return $foo->get();
+                    }',
+            ],
+            'functionTemplateDefault' => [
+                'code' => '<?php
+                    /**
+                     * @template TResult = string
+                     * @param (callable(): TResult)|null $callback
+                     * @return TResult
+                     */
+                    function resolve(?callable $callback = null) {
+                        throw new \RuntimeException();
+                    }
+
+                    function test(): string {
+                        return resolve(null);
+                    }',
+            ],
+            'templateDefaultWithAsKeyword' => [
+                'code' => '<?php
+                    /**
+                     * @template T as object = stdClass
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get(): object {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Foo $foo */
+                    function test(Foo $foo): object {
+                        return $foo->get();
+                    }',
+            ],
+        ];
+    }
+
+    #[Override]
+    public function providerInvalidCodeParse(): iterable
+    {
+        return [
+            'classTemplateDefaultMismatch' => [
+                'code' => '<?php
+                    /**
+                     * @template T = string
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get() {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Foo $foo */
+                    function test(Foo $foo): int {
+                        return $foo->get();
+                    }',
+                'error_message' => 'InvalidReturnStatement',
+            ],
+        ];
+    }
+}

--- a/tests/Template/TemplateDefaultTest.php
+++ b/tests/Template/TemplateDefaultTest.php
@@ -430,6 +430,37 @@ final class TemplateDefaultTest extends TestCase
 
                     new Cycle();',
             ],
+            'functionTemplateDefaultAppliedWhenNoArguments' => [
+                'code' => '<?php
+                    /**
+                     * @template T = string
+                     * @return T
+                     */
+                    function defaultNoParam() {
+                        throw new \RuntimeException();
+                    }
+
+                    $r = defaultNoParam();',
+                'assertions' => [
+                    '$r===' => 'string',
+                ],
+            ],
+            'functionTemplateChainedDefaultsAppliedWhenNoArguments' => [
+                'code' => '<?php
+                    /**
+                     * @template T = string
+                     * @template U = T
+                     * @return U
+                     */
+                    function defaultChainNoParam() {
+                        throw new \RuntimeException();
+                    }
+
+                    $r = defaultChainNoParam();',
+                'assertions' => [
+                    '$r===' => 'string',
+                ],
+            ],
         ];
     }
 

--- a/tests/Template/TemplateDefaultTest.php
+++ b/tests/Template/TemplateDefaultTest.php
@@ -373,6 +373,63 @@ final class TemplateDefaultTest extends TestCase
                      */
                     class Foo {}',
             ],
+            'classTemplateDefaultAppliedThroughFunctionReturn' => [
+                'code' => '<?php
+                    /**
+                     * @template T of string = "hello"
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get(): string { throw new \RuntimeException(); }
+                    }
+
+                    /** @return Foo */
+                    function makeFoo(): Foo { throw new \RuntimeException(); }
+
+                    $r = makeFoo()->get();',
+                'assertions' => [
+                    "\$r===" => "'hello'",
+                ],
+            ],
+            'classDefaultReferencingAnotherDefaultResolves' => [
+                'code' => '<?php
+                    /**
+                     * @template T = string
+                     * @template U = T
+                     */
+                    class Pair {}
+
+                    $p = new Pair();',
+                'assertions' => [
+                    '$p===' => 'Pair<string, string>',
+                ],
+            ],
+            'classChainedDefaultsAppliedThroughFunctionReturn' => [
+                'code' => '<?php
+                    /**
+                     * @template T = string
+                     * @template U = T
+                     */
+                    class Pair {}
+
+                    /** @return Pair */
+                    function makePair(): Pair { throw new \RuntimeException(); }
+
+                    $p = makePair();',
+                'assertions' => [
+                    '$p===' => 'Pair<string, string>',
+                ],
+            ],
+            'classCyclicDefaultsDoNotInfiniteLoop' => [
+                'code' => '<?php
+                    /**
+                     * @template T = U
+                     * @template U = T
+                     */
+                    class Cycle {}
+
+                    new Cycle();',
+            ],
         ];
     }
 
@@ -423,6 +480,14 @@ final class TemplateDefaultTest extends TestCase
                     function foo() {
                         throw new \RuntimeException();
                     }',
+                'error_message' => 'is not within bound',
+            ],
+            'classTemplateDefaultScalarViolatesNamedClassBound' => [
+                'code' => '<?php
+                    /**
+                     * @template T of \DateTimeInterface = int
+                     */
+                    class Foo {}',
                 'error_message' => 'is not within bound',
             ],
         ];

--- a/tests/Template/TemplateDefaultTest.php
+++ b/tests/Template/TemplateDefaultTest.php
@@ -256,6 +256,123 @@ final class TemplateDefaultTest extends TestCase
                         return $foo->get();
                     }',
             ],
+            'inferredNeverPreservedOverDefault' => [
+                'code' => '<?php
+                    /**
+                     * @template T = string
+                     * @param list<T> $items
+                     * @return list<T>
+                     */
+                    function passThrough(array $items): array {
+                        return $items;
+                    }
+
+                    /** @var list<never> $empty */
+                    $empty = [];
+                    $result = passThrough($empty);',
+                'assertions' => [
+                    '$result===' => 'list<never>',
+                ],
+            ],
+            'classTemplateDefaultEqualsBound' => [
+                'code' => '<?php
+                    /**
+                     * @template T of stdClass = stdClass
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get(): stdClass {
+                            throw new \RuntimeException();
+                        }
+                    }',
+            ],
+            'classTemplateDefaultReferencingClassNotYetLoaded' => [
+                'code' => '<?php
+                    /**
+                     * @template T of \DateTimeInterface = \DateTimeImmutable
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get(): \DateTimeInterface {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Foo $foo */
+                    function test(Foo $foo): \DateTimeInterface {
+                        return $foo->get();
+                    }',
+            ],
+            'classTemplateDefaultWithTemplateBound' => [
+                'code' => '<?php
+                    /**
+                     * @template TKey of array-key
+                     * @template T of TKey = string
+                     */
+                    class Foo {}',
+            ],
+            'classTemplateDefaultWithNestedTemplateInBound' => [
+                'code' => '<?php
+                    /**
+                     * @template TKey of string
+                     * @template T of array<TKey, mixed> = array<string, mixed>
+                     */
+                    class Foo {}',
+            ],
+            'classTemplateDefaultTransitiveInheritance' => [
+                'code' => '<?php
+                    class Z {}
+                    class A extends Z {}
+                    class Child extends A {}
+
+                    /**
+                     * @template T of Z = Child
+                     */
+                    class Foo {
+                        /** @return T */
+                        public function get(): Z {
+                            throw new \RuntimeException();
+                        }
+                    }
+
+                    /** @param Foo $foo */
+                    function test(Foo $foo): Z {
+                        return $foo->get();
+                    }',
+            ],
+            'classTemplateDefaultArrayWithTransitiveInheritance' => [
+                'code' => '<?php
+                    class Z {}
+                    class A extends Z {}
+                    class Child extends A {}
+
+                    /**
+                     * @template T of array<int, Z> = array<int, Child>
+                     */
+                    class Foo {}',
+            ],
+            'classTemplateDefaultClassStringWithTransitiveInheritance' => [
+                'code' => '<?php
+                    class Z {}
+                    class A extends Z {}
+                    class Child extends A {}
+
+                    /**
+                     * @template T of class-string<Z> = class-string<Child>
+                     */
+                    class Foo {}',
+            ],
+            'classTemplateDefaultIterableWithTransitiveInheritance' => [
+                'code' => '<?php
+                    class Z {}
+                    class A extends Z {}
+                    class Child extends A {}
+
+                    /**
+                     * @template T of iterable<Z> = array<Child>
+                     */
+                    class Foo {}',
+            ],
         ];
     }
 
@@ -280,6 +397,33 @@ final class TemplateDefaultTest extends TestCase
                         return $foo->get();
                     }',
                 'error_message' => 'InvalidReturnStatement',
+            ],
+            'classTemplateDefaultViolatesBound' => [
+                'code' => '<?php
+                    /**
+                     * @template T of object = int
+                     */
+                    class Foo {}',
+                'error_message' => 'is not within bound',
+            ],
+            'classTemplateDefaultViolatesAsBound' => [
+                'code' => '<?php
+                    /**
+                     * @template T as string = 42
+                     */
+                    class Foo {}',
+                'error_message' => 'is not within bound',
+            ],
+            'functionTemplateDefaultViolatesBound' => [
+                'code' => '<?php
+                    /**
+                     * @template T of object = int
+                     * @return T
+                     */
+                    function foo() {
+                        throw new \RuntimeException();
+                    }',
+                'error_message' => 'is not within bound',
             ],
         ];
     }


### PR DESCRIPTION
Implements support for `@template T = DefaultType` syntax (#5407), allowing template parameters to specify default types used when the type cannot be inferred from context.

- Parses `@template T = DefaultType` and `@template T of Bound = DefaultType` in both class and function docblocks
- Stores defaults in `ClassLikeStorage` and `FunctionLikeStorage`
- Applies defaults during template type resolution when no lower bounds are inferred
- Compatible with PHPStan syntax (`@phpstan-template T = string`)
- Supports defaults referencing other template params (`@template TResult = T`)

Closes #5407
