### PR TITLE
Add `@only-named-arguments` annotation

### DIFF
--- a/config.xsd
+++ b/config.xsd
@@ -395,6 +395,7 @@
             <xs:element name="ParamNameMismatch" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="ParentNotFound" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PluginIssue" type="PluginIssueHandlerType" minOccurs="0" />
+            <xs:element name="PositionalArgumentNotAllowed" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="PossibleRawObjectIteration" type="IssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyFalseArgument" type="ArgumentIssueHandlerType" minOccurs="0" />
             <xs:element name="PossiblyFalseIterator" type="IssueHandlerType" minOccurs="0" />

--- a/docs/annotating_code/supported_annotations.md
+++ b/docs/annotating_code/supported_annotations.md
@@ -688,6 +688,24 @@ Incidentally, it will change the inferred type for the following code:
 ```
 The type of `$a` is `array<array-key, int>` without `@no-named-arguments` but becomes `list<int>` with it, because it excludes the case where the offset would be a string with the name of the parameter
 
+### `@only-named-arguments`
+
+This will prevent access to the function or method tagged with positional arguments (by emitting a `PositionalArgumentNotAllowed` issue).
+
+```php
+<?php
+
+/** @only-named-arguments */
+function foo(int $a, int $b): int {
+    return $a + $b;
+}
+
+foo(a: 0, b: 1); // ok
+foo(0, 1); // error: PositionalArgumentNotAllowed
+```
+
+Applying both `@no-named-arguments` and `@only-named-arguments` on the same function or method is an error.
+
 ### `@psalm-ignore-variable-property` and `@psalm-ignore-variable-method`
 
 Instructs Psalm to ignore variable property fetch / variable method call when looking for dead code.

--- a/docs/running_psalm/issues.md
+++ b/docs/running_psalm/issues.md
@@ -177,6 +177,7 @@
  - [ParentNotFound](issues/ParentNotFound.md)
  - [ParseError](issues/ParseError.md)
  - [PluginIssue](issues/PluginIssue.md)
+ - [PositionalArgumentNotAllowed](issues/PositionalArgumentNotAllowed.md)
  - [PossibleRawObjectIteration](issues/PossibleRawObjectIteration.md)
  - [PossiblyFalseArgument](issues/PossiblyFalseArgument.md)
  - [PossiblyFalseIterator](issues/PossiblyFalseIterator.md)

--- a/docs/running_psalm/issues/ParamNameMismatch.md
+++ b/docs/running_psalm/issues/ParamNameMismatch.md
@@ -73,6 +73,8 @@ This prevents any use of named params in your codebase. Ideal for self-contained
 
 It means the original code above will not emit any errors as long as the class `A` is defined in a directory that Psalm can scan.
 
+You can still require named arguments on specific functions or methods by annotating them with `@only-named-arguments`, which takes priority over this config option.
+
 ### Config allowInternalNamedArgumentCalls="false"
 
 For library authors Psalm supports a more nuanced flag that tells Psalm to prohibit any named parameter calls on `@internal` classes or methods.

--- a/docs/running_psalm/issues/PositionalArgumentNotAllowed.md
+++ b/docs/running_psalm/issues/PositionalArgumentNotAllowed.md
@@ -1,0 +1,35 @@
+# PositionalArgumentNotAllowed
+
+Emitted when a positional argument is used when calling a function with `@only-named-arguments`.
+
+```php
+<?php
+
+/** @only-named-arguments */
+function foo(int $a, int $b): int {
+	return $a + $b;
+}
+
+foo(0, 1);
+
+```
+
+## Why this is bad
+
+The `@only-named-arguments` annotation indicates that the parameter order may change in the future, and an update may break backwards compatibility with function calls using positional arguments.
+
+## How to fix
+
+Use named arguments when calling functions annotated with `@only-named-arguments`.
+
+```php
+<?php
+
+/** @only-named-arguments */
+function foo(int $a, int $b): int {
+	return $a + $b;
+}
+
+foo(a: 0, b: 1);
+
+```

--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -1163,7 +1163,14 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             $var_type = $param_type;
 
             if ($function_param->is_variadic) {
-                if ($storage->allow_named_arg_calls) {
+                if ($storage->require_named_arg_calls) {
+                    $var_type = new Union([
+                        new TArray([Type::getString(), $param_type]),
+                    ], [
+                        'by_ref' => $function_param->by_ref,
+                        'parent_nodes' => $parent_nodes,
+                    ]);
+                } elseif ($storage->allow_named_arg_calls) {
                     $var_type = new Union([
                         new TArray([Type::getArrayKey(), $param_type]),
                     ], [

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentAnalyzer.php
@@ -43,6 +43,7 @@ use Psalm\Issue\NamedArgumentNotAllowed;
 use Psalm\Issue\NoValue;
 use Psalm\Issue\NullArgument;
 use Psalm\Issue\ParentNotFound;
+use Psalm\Issue\PositionalArgumentNotAllowed;
 use Psalm\Issue\PossiblyFalseArgument;
 use Psalm\Issue\PossiblyInvalidArgument;
 use Psalm\Issue\PossiblyNullArgument;
@@ -153,6 +154,7 @@ final class ArgumentAnalyzer
         ?TemplateResult $template_result,
         bool $specialize_taint,
         bool $in_call_map,
+        bool $require_named_args,
     ): ?bool {
         $codebase = $statements_analyzer->getCodebase();
 
@@ -261,6 +263,7 @@ final class ArgumentAnalyzer
             $template_result,
             $specialize_taint,
             $in_call_map,
+            $require_named_args,
         ) === false) {
             return false;
         }
@@ -291,6 +294,7 @@ final class ArgumentAnalyzer
         ?TemplateResult $template_result,
         bool $specialize_taint,
         bool $in_call_map,
+        bool $require_named_args,
     ): ?bool {
         if (!$function_param->type) {
             if (!$codebase->infer_types_from_usage && !$statements_analyzer->data_flow_graph) {
@@ -521,10 +525,15 @@ final class ArgumentAnalyzer
             if ($arg_value_type->hasArray()) {
                 $unpacked_atomic_array = $arg_value_type->getArray();
                 $arg_key_allowed = true;
+                $positional_key_not_allowed = false;
 
                 if ($unpacked_atomic_array instanceof TKeyedArray) {
                     if (!$allow_named_args && !$unpacked_atomic_array->getGenericKeyType()->isInt()) {
                         $arg_key_allowed = false;
+                    }
+
+                    if ($require_named_args && !$unpacked_atomic_array->getGenericKeyType()->isString()) {
+                        $positional_key_not_allowed = true;
                     }
 
                     if ($function_param->is_variadic) {
@@ -561,6 +570,11 @@ final class ArgumentAnalyzer
                     if (!$allow_named_args && !$unpacked_atomic_array->type_params[0]->isInt()) {
                         $arg_key_allowed = false;
                     }
+
+                    if ($require_named_args && !$unpacked_atomic_array->type_params[0]->isString()) {
+                        $positional_key_not_allowed = true;
+                    }
+
                     $arg_value_type = $unpacked_atomic_array->type_params[1];
                 }
 
@@ -576,10 +590,24 @@ final class ArgumentAnalyzer
                         $statements_analyzer->getSuppressedIssues(),
                     );
                 }
+
+                if ($positional_key_not_allowed) {
+                    IssueBuffer::maybeAdd(
+                        new PositionalArgumentNotAllowed(
+                            'Method ' . $cased_method_id
+                                . ' called with positional unpacked array ' . $unpacked_atomic_array->getId()
+                                . ' (array with int keys)',
+                            new CodeLocation($statements_analyzer->getSource(), $arg->value),
+                            $cased_method_id,
+                        ),
+                        $statements_analyzer->getSuppressedIssues(),
+                    );
+                }
             } else {
                 $non_iterable = false;
                 $invalid_key = false;
                 $invalid_string_key = false;
+                $invalid_int_key = false;
                 $possibly_matches = false;
                 foreach ($arg_value_type->getAtomicTypes() as $atomic_type) {
                     if (!$atomic_type->isIterable($codebase)) {
@@ -599,6 +627,11 @@ final class ArgumentAnalyzer
                             && !$key_type->isInt()
                         ) {
                             $invalid_string_key = true;
+
+                            continue;
+                        }
+                        if ($require_named_args && !$key_type->isString()) {
+                            $invalid_int_key = true;
 
                             continue;
                         }
@@ -653,6 +686,18 @@ final class ArgumentAnalyzer
                         );
                     }
                 }
+                if ($invalid_int_key) {
+                    IssueBuffer::maybeAdd(
+                        new PositionalArgumentNotAllowed(
+                            'Method ' . $cased_method_id
+                                . ' called with positional unpacked iterable ' . $arg_value_type->getId()
+                                . ' (iterable with int keys)',
+                            new CodeLocation($statements_analyzer->getSource(), $arg->value),
+                            $cased_method_id,
+                        ),
+                        $statements_analyzer->getSuppressedIssues(),
+                    );
+                }
 
                 return null;
             }
@@ -661,6 +706,17 @@ final class ArgumentAnalyzer
                 IssueBuffer::maybeAdd(
                     new NamedArgumentNotAllowed(
                         'Method ' . $cased_method_id. ' called with named argument ' . $arg->name->name,
+                        new CodeLocation($statements_analyzer->getSource(), $arg->value),
+                        $cased_method_id,
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+
+            if ($require_named_args && $arg->name === null && !$arg instanceof VirtualArg) {
+                IssueBuffer::maybeAdd(
+                    new PositionalArgumentNotAllowed(
+                        'Method ' . $cased_method_id . ' must be called with named arguments',
                         new CodeLocation($statements_analyzer->getSource(), $arg->value),
                         $cased_method_id,
                     ),

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -704,6 +704,7 @@ final class ArgumentsAnalyzer
                             $template_result,
                             $function_storage->specialize_call ?? true,
                             $in_call_map,
+                            $function_storage->require_named_arg_calls ?? false,
                         );
                     }
                 }
@@ -884,6 +885,7 @@ final class ArgumentsAnalyzer
                     $template_result,
                     $function_storage->specialize_call ?? true,
                     $in_call_map,
+                    $function_storage->require_named_arg_calls ?? false,
                 ) === false) {
                     return false;
                 }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -211,6 +211,10 @@ final class ClassLikeDocblockParser
             $info->final = true;
         }
 
+        if (isset($parsed_docblock->tags['no-named-arguments'])) {
+            $info->no_named_args = true;
+        }
+
         if (isset($parsed_docblock->tags['psalm-consistent-constructor'])) {
             $info->consistent_constructor = true;
         }

--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeNodeScanner.php
@@ -631,6 +631,10 @@ final class ClassLikeNodeScanner
 
             $storage->deprecated = $docblock_info->deprecated;
 
+            if ($docblock_info->no_named_args) {
+                $storage->allow_named_arg_calls = false;
+            }
+
             if (count($docblock_info->psalm_internal) !== 0) {
                 $storage->internal = $docblock_info->psalm_internal;
             } elseif ($docblock_info->internal && $this->aliases->namespace) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockParser.php
@@ -594,6 +594,10 @@ final class FunctionLikeDocblockParser
             $info->no_named_args = true;
         }
 
+        if (isset($parsed_docblock->tags['only-named-arguments'])) {
+            $info->only_named_args = true;
+        }
+
         $info->ignore_nullable_return = isset($parsed_docblock->tags['psalm-ignore-nullable-return']);
         $info->ignore_falsable_return = isset($parsed_docblock->tags['psalm-ignore-falsable-return']);
         $info->stub_override = isset($parsed_docblock->tags['psalm-stub-override']);

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -125,12 +125,25 @@ final class FunctionLikeDocblockScanner
             $storage->internal = [NamespaceAnalyzer::getNameSpaceRoot($aliases->namespace)];
         }
 
+        if ($docblock_info->no_named_args && $docblock_info->only_named_args) {
+            $storage->docblock_issues[] = new InvalidDocblock(
+                '@no-named-arguments and @only-named-arguments are mutually exclusive in docblock for '
+                    . $cased_function_id,
+                new CodeLocation($file_scanner, $stmt, null, true),
+            );
+        }
+
         if (($storage->internal || ($classlike_storage && $classlike_storage->internal))
             && !$config->allow_internal_named_arg_calls
+            && !$docblock_info->only_named_args
         ) {
             $storage->allow_named_arg_calls = false;
         } elseif ($docblock_info->no_named_args) {
             $storage->allow_named_arg_calls = false;
+        }
+
+        if ($docblock_info->only_named_args && !$docblock_info->no_named_args) {
+            $storage->require_named_arg_calls = true;
         }
 
         if ($docblock_info->variadic) {

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -484,6 +484,14 @@ final class FunctionLikeNodeScanner
             }
         }
 
+        if ($classlike_storage
+            && !$classlike_storage->allow_named_arg_calls
+            && $storage->allow_named_arg_calls
+            && !$storage->require_named_arg_calls
+        ) {
+            $storage->allow_named_arg_calls = false;
+        }
+
         // register the functionlike once the @since check has been completed
         if ($stmt instanceof PhpParser\Node\Stmt\Function_
             && $function_id

--- a/src/Psalm/Internal/PreloaderList.php
+++ b/src/Psalm/Internal/PreloaderList.php
@@ -1218,6 +1218,7 @@ final class PreloaderList {
         \Psalm\Issue\ParentNotFound::class,
         \Psalm\Issue\ParseError::class,
         \Psalm\Issue\PluginIssue::class,
+        \Psalm\Issue\PositionalArgumentNotAllowed::class,
         \Psalm\Issue\PossibleRawObjectIteration::class,
         \Psalm\Issue\PossiblyFalseArgument::class,
         \Psalm\Issue\PossiblyFalseIterator::class,

--- a/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/ClassLikeDocblockComment.php
@@ -107,4 +107,6 @@ final class ClassLikeDocblockComment
     public ?string $description = null;
 
     public bool $public_api = false;
+
+    public bool $no_named_args = false;
 }

--- a/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
+++ b/src/Psalm/Internal/Scanner/FunctionDocblockComment.php
@@ -166,6 +166,8 @@ final class FunctionDocblockComment
 
     public bool $no_named_args = false;
 
+    public bool $only_named_args = false;
+
     public bool $stub_override = false;
 
     public int $since_php_major_version = 0;

--- a/src/Psalm/Issue/PositionalArgumentNotAllowed.php
+++ b/src/Psalm/Issue/PositionalArgumentNotAllowed.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Issue;
+
+final class PositionalArgumentNotAllowed extends ArgumentIssue
+{
+    public const ERROR_LEVEL = 7;
+    public const SHORTCODE = 362;
+}

--- a/src/Psalm/Plugin/DynamicFunctionStorage.php
+++ b/src/Psalm/Plugin/DynamicFunctionStorage.php
@@ -38,6 +38,11 @@ final class DynamicFunctionStorage
     public bool $allow_named_arg_calls = true;
 
     /**
+     * Determines if a function must be called with named arguments.
+     */
+    public bool $require_named_arg_calls = false;
+
+    /**
      * Function purity.
      * If function is pure then plugin hook should set it to true.
      */
@@ -58,6 +63,7 @@ final class DynamicFunctionStorage
         $storage->setParams($this->params);
         $storage->return_type = $this->return_type;
         $storage->allow_named_arg_calls = $this->allow_named_arg_calls;
+        $storage->require_named_arg_calls = $this->require_named_arg_calls;
         $storage->pure = $this->pure;
         $storage->variadic = $this->variadic;
 

--- a/src/Psalm/Storage/ClassLikeStorage.php
+++ b/src/Psalm/Storage/ClassLikeStorage.php
@@ -387,6 +387,8 @@ final class ClassLikeStorage implements HasAttributesInterface
 
     public bool $readonly = false;
 
+    public bool $allow_named_arg_calls = true;
+
     public function __construct(public string $name)
     {
     }

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -176,6 +176,8 @@ abstract class FunctionLikeStorage implements HasAttributesInterface, Stringable
 
     public bool $allow_named_arg_calls = true;
 
+    public bool $require_named_arg_calls = false;
+
     /**
      * @var list<AttributeStorage>
      */

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Psalm\Tests;
 
 use Override;
+use Psalm\Context;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
 
@@ -373,7 +374,107 @@ final class ArgTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'onlyNamedArgumentsFunction' => [
+                'code' => '<?php
+                    /** @only-named-arguments */
+                    function takesArguments(string $name, int $age): void {}
+
+                    takesArguments(name: "hello", age: 5);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'onlyNamedArgumentsMethod' => [
+                'code' => '<?php
+                    class CustomerData
+                    {
+                        /** @only-named-arguments */
+                        public function __construct(
+                            public string $name,
+                            public string $email,
+                            public int $age,
+                        ) {}
+                    }
+
+                    new CustomerData(name: "Alice", email: "alice@example.com", age: 30);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'variadicArgumentWithOnlyNamedArgumentsIsStringArray' => [
+                'code' => '<?php
+                    class A {
+                        /**
+                         * @only-named-arguments
+                         * @psalm-return array<string, int>
+                         */
+                        public function foo(int ...$values): array
+                        {
+                            return $values;
+                        }
+                    }
+                ',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'onlyNamedArgumentsVariadic' => [
+                'code' => '<?php
+                    /** @only-named-arguments */
+                    function foo(int ...$args): void {}
+
+                    foo(x: 0, y: 1);',
+                'assertions' => [],
+                'ignored_issues' => ['UnusedParam'],
+                'php_version' => '8.0',
+            ],
+            'onlyNamedArgumentsCallbackInArrayMap' => [
+                'code' => '<?php
+                    /** @only-named-arguments */
+                    function process(string $item): string { return strtoupper($item); }
+
+                    array_map("process", ["a", "b"]);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'onlyNamedArgumentsSpreadWithStringKeys' => [
+                'code' => '<?php
+                    /** @only-named-arguments */
+                    function foo(int $a, int $b): int { return $a + $b; }
+
+                    foo(...["a" => 0, "b" => 1]);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
         ];
+    }
+
+    public function testOnlyNamedArgumentsTakesPriorityOverAllowInternalNamedArgCalls(): void
+    {
+        // @only-named-arguments takes priority over the global allowInternalNamedArgumentCalls=false config:
+        // named args must be allowed (allow_named_arg_calls stays true),
+        // and only positional args trigger PositionalArgumentNotAllowed.
+        $this->project_analyzer->getConfig()->allow_internal_named_arg_calls = false;
+
+        $this->addFile(
+            self::$src_dir_path . 'somefile.php',
+            '<?php
+                namespace Foo;
+
+                /**
+                 * @internal
+                 * @only-named-arguments
+                 */
+                function bar(int $a, int $b): int { return $a + $b; }
+
+                bar(a: 1, b: 2);
+            ',
+        );
+
+        $this->analyzeFile(self::$src_dir_path . 'somefile.php', new Context());
+        $this->project_analyzer->getConfig()->allow_internal_named_arg_calls = true;
     }
 
     #[Override]
@@ -691,6 +792,79 @@ final class ArgTest extends TestCase
                     foo(...$test);
                 ',
                 'error_message' => 'NamedArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'onlyNamedArgsFunction' => [
+                'code' => '<?php
+                    /** @only-named-arguments */
+                    function takesArguments(string $name, int $age): void {}
+
+                    takesArguments("hello", age: 5);',
+                'error_message' => 'PositionalArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'onlyNamedArgsMethod' => [
+                'code' => '<?php
+                    class CustomerData
+                    {
+                        /** @only-named-arguments */
+                        public function __construct(
+                            public string $name,
+                            public string $email,
+                            public int $age,
+                        ) {}
+                    }
+
+                    /**
+                     * @param array{age: int, name: string, email: string} $input
+                     */
+                    function foo(array $input): CustomerData {
+                        return new CustomerData(
+                            $input["name"],
+                            $input["email"],
+                            age: $input["age"],
+                        );
+                    }',
+                'error_message' => 'PositionalArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'onlyNamedArgsVariadic' => [
+                'code' => '<?php
+                    /**
+                     * @psalm-suppress UnusedParam
+                     * @only-named-arguments
+                     */
+                    function foo(int ...$args): void {}
+
+                    foo(0, 1);
+                ',
+                'error_message' => 'PositionalArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'onlyNamedArgsSpreadWithIntKeys' => [
+                'code' => '<?php
+                    /** @only-named-arguments */
+                    function foo(int $a, int $b): int { return $a + $b; }
+
+                    foo(...[0, 1]);
+                ',
+                'error_message' => 'PositionalArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'onlyNamedArgsSpreadWithArrayKeyKeys' => [
+                'code' => '<?php
+                    /** @only-named-arguments */
+                    function foo(int $a, int $b): int { return $a + $b; }
+
+                    /** @param array<array-key, int> $arr */
+                    function bar(array $arr): void { foo(...$arr); }
+                ',
+                'error_message' => 'PositionalArgumentNotAllowed',
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],

--- a/tests/ArgTest.php
+++ b/tests/ArgTest.php
@@ -448,6 +448,24 @@ final class ArgTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'classLevelNoNamedArgumentsWithOnlyNamedArgumentsOnConstructor' => [
+                'code' => '<?php
+                    /**
+                     * @no-named-arguments
+                     */
+                    class Foo {
+                        /** @only-named-arguments */
+                        public function __construct(public string $name, public int $age) {}
+
+                        public function bar(int $a, int $b): int { return $a + $b; }
+                    }
+
+                    $foo = new Foo(name: "Alice", age: 30);
+                    $foo->bar(1, 2);',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
         ];
     }
 
@@ -863,6 +881,33 @@ final class ArgTest extends TestCase
 
                     /** @param array<array-key, int> $arr */
                     function bar(array $arr): void { foo(...$arr); }
+                ',
+                'error_message' => 'PositionalArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'classLevelNoNamedArgumentsPositionalCall' => [
+                'code' => '<?php
+                    /** @no-named-arguments */
+                    class Foo {
+                        public function bar(int $a, int $b): int { return $a + $b; }
+                    }
+
+                    (new Foo())->bar(a: 1, b: 2);
+                ',
+                'error_message' => 'NamedArgumentNotAllowed',
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'classLevelNoNamedArgumentsOnlyNamedArgumentsConstructorPositionalCall' => [
+                'code' => '<?php
+                    /** @no-named-arguments */
+                    class Foo {
+                        /** @only-named-arguments */
+                        public function __construct(public string $name, public int $age) {}
+                    }
+
+                    new Foo("Alice", 30);
                 ',
                 'error_message' => 'PositionalArgumentNotAllowed',
                 'ignored_issues' => [],


### PR DESCRIPTION
Fixes #11763

Adds a `@only-named-arguments` docblock annotation that requires callers to use named arguments. This is useful for libraries that want to enforce named-argument call sites as part of their BC policy — allowing parameter reordering or removal without breaking positional callers.

When a positional argument is passed to a function or method annotated with `@only-named-arguments`, Psalm emits the new `PositionalArgumentNotAllowed` issue. Spread/unpack calls are also covered: `foo(...[0, 1])` triggers the issue while `foo(...['a' => 0, 'b' => 1])` is allowed.

Using both `@only-named-arguments` and `@no-named-arguments` on the same declaration is flagged as `InvalidDocblock`.

For variadic parameters, the inferred type of `...$args` becomes `array<string, T>` (instead of `list<T>` with `@no-named-arguments` or `array<array-key, T>` without annotation).

`@only-named-arguments` takes priority over the global `allowInternalNamedArgumentCalls="false"` and `allowNamedArgumentCalls="false"` config options, allowing library authors to selectively enforce named arguments on specific APIs even in codebases that otherwise disable named argument calls.