### PR TITLE
[7.x] Enhanced compact format: drop ERROR prefix, add taint chain summary

### DIFF
--- a/src/Psalm/Report/CompactReport.php
+++ b/src/Psalm/Report/CompactReport.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Psalm\Report;
 
 use Override;
-use Psalm\Config;
 use Psalm\Internal\Analyzer\DataFlowNodeData;
 use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
@@ -15,7 +14,6 @@ use function count;
 use function implode;
 use function in_array;
 use function str_contains;
-use function strtoupper;
 
 /**
  * @psalm-external-mutation-free
@@ -34,9 +32,6 @@ final class CompactReport extends Report
         $output = '';
 
         foreach ($this->issues_data as $issue_data) {
-            $is_error = $issue_data->severity === Config::REPORT_ERROR;
-            $prefix = $is_error ? '' : strtoupper($issue_data->severity) . ' ';
-
             $chain_parts = $issue_data->taint_trace !== null
                 ? $this->buildChainParts($issue_data)
                 : null;
@@ -45,11 +40,11 @@ final class CompactReport extends Report
                 $hop_count = count($chain_parts) - 1;
                 $hop_label = $hop_count <= 1 ? 'direct' : (string) $hop_count;
 
-                $output .= $prefix . $issue_data->file_name . ':' . $issue_data->line_from
+                $output .= $issue_data->file_name . ':' . $issue_data->line_from
                     . ':' . $issue_data->column_from . ' ' . $issue_data->type . ' [' . $hop_label . ']' . "\n";
                 $output .= '  ' . implode(' → ', $chain_parts) . "\n";
             } else {
-                $output .= $prefix . $issue_data->file_name . ':' . $issue_data->line_from
+                $output .= $issue_data->file_name . ':' . $issue_data->line_from
                     . ':' . $issue_data->column_from . ' ' . $issue_data->type . ': ' . $issue_data->message . "\n";
             }
         }

--- a/src/Psalm/Report/CompactReport.php
+++ b/src/Psalm/Report/CompactReport.php
@@ -6,8 +6,15 @@ namespace Psalm\Report;
 
 use Override;
 use Psalm\Config;
+use Psalm\Internal\Analyzer\DataFlowNodeData;
+use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Report;
 
+use function basename;
+use function count;
+use function implode;
+use function in_array;
+use function str_contains;
 use function strtoupper;
 
 /**
@@ -15,6 +22,9 @@ use function strtoupper;
  */
 final class CompactReport extends Report
 {
+    /** @var list<string> */
+    private const SYNTHETIC_LABELS = ['variable-use', 'arrayvalue-fetch', 'coalesce', 'concat'];
+
     /**
      * @psalm-mutation-free
      */
@@ -25,16 +35,82 @@ final class CompactReport extends Report
 
         foreach ($this->issues_data as $issue_data) {
             $is_error = $issue_data->severity === Config::REPORT_ERROR;
-            if ($is_error) {
-                $severity = $this->use_color ? "\e[0;31mERROR\e[0m" : 'ERROR';
-            } else {
-                $severity = strtoupper($issue_data->severity);
-            }
+            $prefix = $is_error ? '' : strtoupper($issue_data->severity) . ' ';
 
-            $output .= $severity . ' ' . $issue_data->file_name . ':' . $issue_data->line_from
-                . ':' . $issue_data->column_from . ' ' . $issue_data->type . ': ' . $issue_data->message . "\n";
+            $chain_parts = $issue_data->taint_trace !== null
+                ? $this->buildChainParts($issue_data)
+                : null;
+
+            if ($chain_parts !== null && $chain_parts !== []) {
+                $hop_count = count($chain_parts) - 1;
+                $hop_label = $hop_count <= 1 ? 'direct' : (string) $hop_count;
+
+                $output .= $prefix . $issue_data->file_name . ':' . $issue_data->line_from
+                    . ':' . $issue_data->column_from . ' ' . $issue_data->type . ' [' . $hop_label . ']' . "\n";
+                $output .= '  ' . implode(' → ', $chain_parts) . "\n";
+            } else {
+                $output .= $prefix . $issue_data->file_name . ':' . $issue_data->line_from
+                    . ':' . $issue_data->column_from . ' ' . $issue_data->type . ': ' . $issue_data->message . "\n";
+            }
         }
 
         return $output;
+    }
+
+    /**
+     * @return list<string>
+     * @psalm-mutation-free
+     */
+    private function buildChainParts(IssueData $issue_data): array
+    {
+        if ($issue_data->taint_trace === null) {
+            return [];
+        }
+
+        $app_nodes = [];
+        foreach ($issue_data->taint_trace as $trace) {
+            if (!($trace instanceof DataFlowNodeData)) {
+                continue; // Skip entry-type-only array nodes (no location)
+            }
+            if ($trace->line_from === 0) {
+                continue; // Skip stubs
+            }
+            if (str_contains($trace->file_path, '/vendor/')) {
+                continue; // Skip vendor nodes
+            }
+            if (in_array($trace->label, self::SYNTHETIC_LABELS, true)) {
+                continue; // Skip Psalm-internal graph nodes
+            }
+            $app_nodes[] = $trace;
+        }
+
+        if ($app_nodes === []) {
+            return [];
+        }
+
+        $sink_file = $issue_data->file_name;
+        $parts = [];
+        $last_idx = count($app_nodes) - 1;
+
+        foreach ($app_nodes as $i => $node) {
+            $label = $node->label;
+
+            if ($i === 0) {
+                // Source: annotate with location
+                if ($node->file_name === $sink_file) {
+                    $label .= '@' . $node->line_from;
+                } else {
+                    $label .= '@[' . basename($node->file_name) . ':' . $node->line_from . ']';
+                }
+            } elseif ($i === $last_idx) {
+                // Sink: annotate with line number
+                $label .= '@' . $node->line_from;
+            }
+            // Intermediate nodes: label only, no line numbers
+
+            $parts[] = $label;
+        }
+
+        return $parts;
     }
 }

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -8,6 +8,7 @@ use DOMDocument;
 use Override;
 use Psalm\Config;
 use Psalm\Context;
+use Psalm\Internal\Analyzer\DataFlowNodeData;
 use Psalm\Internal\Analyzer\IssueData;
 use Psalm\Internal\Analyzer\ProjectAnalyzer;
 use Psalm\Internal\Provider\FakeFileProvider;
@@ -15,6 +16,7 @@ use Psalm\Internal\Provider\Providers;
 use Psalm\Internal\RuntimeCaches;
 use Psalm\IssueBuffer;
 use Psalm\Report;
+use Psalm\Report\CompactReport;
 use Psalm\Report\JsonReport;
 use Psalm\Report\ReportOptions;
 use Psalm\Tests\Internal\Provider\FakeParserCacheProvider;
@@ -25,6 +27,7 @@ use function json_decode;
 use function ob_end_clean;
 use function ob_start;
 use function preg_replace;
+use function strlen;
 use function unlink;
 
 use const JSON_THROW_ON_ERROR;
@@ -554,13 +557,116 @@ final class ReportOutputTest extends TestCase
 
         $this->assertSame(
             <<<'EOF'
-            ERROR somefile.php:4:10 UndefinedVariable: Cannot find referenced variable $as_you_____type
-            ERROR somefile.php:4:10 MixedReturnStatement: Could not infer a return type
-            ERROR somefile.php:9:6 UndefinedConstant: Const CHANGE_ME is not defined, consider enabling the allConstantsGlobal config option if scanning legacy codebases
+            somefile.php:4:10 UndefinedVariable: Cannot find referenced variable $as_you_____type
+            somefile.php:4:10 MixedReturnStatement: Could not infer a return type
+            somefile.php:9:6 UndefinedConstant: Const CHANGE_ME is not defined, consider enabling the allConstantsGlobal config option if scanning legacy codebases
             INFO somefile.php:18:6 PossiblyUndefinedGlobalVariable: Possibly undefined global variable $a, first seen on line 12
 
             EOF,
             $this->toUnixLineEndings(IssueBuffer::getOutput(IssueBuffer::getIssuesData(), $compact_report_options)),
+        );
+    }
+
+    public function testCompactReportWithTaintChain(): void
+    {
+        $make_node = static fn(
+            string $label,
+            int $line,
+            string $file_name,
+            string $file_path,
+        ): DataFlowNodeData => new DataFlowNodeData(
+            $label,
+            $line,
+            $line,
+            $file_name,
+            $file_path,
+            $label,
+            0,
+            strlen($label),
+            0,
+            1,
+            strlen($label) + 1,
+        );
+
+        $source_node = $make_node('$_GET[\'query\']', 5, 'test.php', '/app/test.php');
+        $var_node    = $make_node('$cmd', 7, 'test.php', '/app/test.php');
+        $sink_node   = $make_node('shell_exec($cmd)', 10, 'test.php', '/app/test.php');
+
+        $make_issue = static fn(array $trace): IssueData => new IssueData(
+            IssueData::SEVERITY_ERROR,
+            10, 10,
+            'TaintedShell',
+            'Detected tainted shell code',
+            'test.php',
+            '/app/test.php',
+            'shell_exec($cmd);',
+            'shell_exec($cmd)',
+            0, 16, 0, 17,
+            1, 17,
+            taint_trace: $trace,
+        );
+
+        $report_options = new ReportOptions();
+        $report_options->format = Report::TYPE_COMPACT;
+        $report_options->use_color = false;
+
+        // Direct: source → sink (no intermediates)
+        $direct_report = new CompactReport(
+            [$make_issue([$source_node, $sink_node])],
+            [],
+            $report_options,
+        );
+        $this->assertSame(
+            "test.php:10:1 TaintedShell [direct]\n  \$_GET['query']@5 → shell_exec(\$cmd)@10\n",
+            $direct_report->create(),
+        );
+
+        // Two hops: source → $var → sink
+        $indirect_report = new CompactReport(
+            [$make_issue([$source_node, $var_node, $sink_node])],
+            [],
+            $report_options,
+        );
+        $this->assertSame(
+            "test.php:10:1 TaintedShell [2]\n  \$_GET['query']@5 → \$cmd → shell_exec(\$cmd)@10\n",
+            $indirect_report->create(),
+        );
+
+        // Stub and vendor nodes are stripped from the chain; valid source/sink remain
+        $stub_node   = $make_node('stub-source', 0, 'stubs/http.php', '/vendor/stubs/http.php');
+        $vendor_node = $make_node('SomeClass::method', 8, 'vendor/lib/Foo.php', '/app/vendor/lib/Foo.php');
+        $synth_node  = $make_node('variable-use', 6, 'test.php', '/app/test.php');
+        $strip_report = new CompactReport(
+            [$make_issue([$stub_node, $source_node, $synth_node, $vendor_node, $sink_node])],
+            [],
+            $report_options,
+        );
+        $this->assertSame(
+            "test.php:10:1 TaintedShell [direct]\n  \$_GET['query']@5 → shell_exec(\$cmd)@10\n",
+            $strip_report->create(),
+        );
+
+        // When all nodes are filtered, fall back to the standard single-line format
+        $all_filtered_report = new CompactReport(
+            [$make_issue([$stub_node, $vendor_node, $synth_node])],
+            [],
+            $report_options,
+        );
+        $this->assertSame(
+            "test.php:10:1 TaintedShell: Detected tainted shell code\n",
+            $all_filtered_report->create(),
+        );
+
+        // Cross-file source: source in a different file gets @[OtherFile.php:line] notation
+        $cross_file_source = $make_node('$request->input(\'q\')', 12, 'OtherController.php', '/app/OtherController.php');
+        $cross_file_report = new CompactReport(
+            [$make_issue([$cross_file_source, $sink_node])],
+            [],
+            $report_options,
+        );
+        $this->assertSame(
+            "test.php:10:1 TaintedShell [direct]\n  \$request->input('q')@[OtherController.php:12] → shell_exec(\$cmd)@10\n",
+            $cross_file_report->create(),
         );
     }
 

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -560,7 +560,7 @@ final class ReportOutputTest extends TestCase
             somefile.php:4:10 UndefinedVariable: Cannot find referenced variable $as_you_____type
             somefile.php:4:10 MixedReturnStatement: Could not infer a return type
             somefile.php:9:6 UndefinedConstant: Const CHANGE_ME is not defined, consider enabling the allConstantsGlobal config option if scanning legacy codebases
-            INFO somefile.php:18:6 PossiblyUndefinedGlobalVariable: Possibly undefined global variable $a, first seen on line 12
+            somefile.php:18:6 PossiblyUndefinedGlobalVariable: Possibly undefined global variable $a, first seen on line 12
 
             EOF,
             $this->toUnixLineEndings(IssueBuffer::getOutput(IssueBuffer::getIssuesData(), $compact_report_options)),


### PR DESCRIPTION
Two improvements to `--output-format=compact` output quality.

## Change 1: Drop severity prefix entirely

The severity prefix (`ERROR`, `INFO`) carries no information — the issue type already encodes it (`TaintedSql` is always an error; `PossiblyUndefinedVariable` signals uncertainty). Removing all prefixes makes output shorter with no information loss.

**Before:**
```
ERROR app/Http/Auth/LoginController.php:45:35 TaintedHeader: Detected tainted header
INFO  somefile.php:18:6 PossiblyUndefined: Possibly undefined variable $a
```

**After:**
```
app/Http/Auth/LoginController.php:45:35 TaintedHeader: Detected tainted header
somefile.php:18:6 PossiblyUndefined: Possibly undefined variable $a
```

## Change 2: Include source→sink chain for taint findings

Current compact output for taint issues gives no triage context — determining whether a finding is real requires re-running without `--output-format`, or manually tracing the data flow.

When `taint_trace` is populated, a second line now shows the chain:

```
app/Http/PaymentController.php:34:35 TaintedHeader [2]
  $request->input('redirect_url')@28 → $nextStepUrl → Redirector::to()@34

app/Services/ReportBuilder.php:94:23 TaintedSql [3]
  $request->input('sort_by')@[AdminController.php:50] → $this->sortBy → Builder::orderBy()@94
```

- **Hop count** — `[direct]` for source→sink with nothing between; `[N]` otherwise
- **Source annotation** — `@line` (same file) or `@[OtherFile.php:line]` (cross-file)
- **Sink annotation** — `@line` always
- **Intermediate nodes** — label only (variable names), no line numbers
- **Stripped from chain** — vendor nodes, stubs (`line_from === 0`), and Psalm-internal synthetic labels (`variable-use`, `arrayvalue-fetch`, `coalesce`, `concat`)
- **Fallback** — when all trace nodes are filtered, falls back to the standard single-line message format

## Implementation notes

- `buildChainParts()` reuses the same filtering logic `SarifReport` already applies (`line_from > 0` for stub removal)
- No changes to other output formats

Closes #11795
