### PR TITLE
Fix method name casing in `MissingOverrideAttribute` check

### DIFF
--- a/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/FunctionLikeAnalyzer.php
@@ -2091,7 +2091,7 @@ abstract class FunctionLikeAnalyzer extends SourceAnalyzer
             ) {
                 IssueBuffer::maybeAdd(
                     new MissingOverrideAttribute(
-                        'Method ' . $method_id . ' should have the "Override" attribute',
+                        'Method ' . $cased_method_id . ' should have the "Override" attribute',
                         $codeLocation,
                     ),
                     $this->getSuppressedIssues(),


### PR DESCRIPTION
It seems odd that `MissingOverrideAttribute` check returns lowercased method name instead of the original one.

Now:
```
Method App\Models\Check::setparams should have the "Override" attribute
```

I propose:
```
Method App\Models\Check::setParams should have the "Override" attribute
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String-only change to an issue message; no behavioral impact on analysis or code transformation logic.
> 
> **Overview**
> Fixes the `MissingOverrideAttribute` diagnostic to report the *correctly cased* method identifier (using `cased_method_id`) instead of the lowercased `method_id`, improving clarity of reported method names when `ensure_override_attribute` is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e1a257e3578eb6e3f5363bd178109f9e8c6c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->