### PR TITLE
Add --only-taint flag to filter output to taint issues only

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -269,8 +269,11 @@ final class ProjectAnalyzer
      * @param  array<string>  $report_file_paths
      * @return list<ReportOptions>
      */
-    public static function getFileReportOptions(array $report_file_paths, bool $show_info = true): array
-    {
+    public static function getFileReportOptions(
+        array $report_file_paths,
+        bool $show_info = true,
+        bool $only_taint = false,
+    ): array {
         $report_options = [];
 
         $mapping = Report::getMapping();
@@ -284,6 +287,7 @@ final class ProjectAnalyzer
                     $o->show_info = $show_info;
                     $o->output_path = $report_file_path;
                     $o->use_color = false;
+                    $o->only_taint = $only_taint;
                     $report_options[] = $o;
                     continue 2;
                 }

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -179,6 +179,7 @@ final class Psalm
         'dump-taint-graph:',
         'find-unused-psalm-suppress',
         'error-level:',
+        'only-taint',
     ];
 
     /**
@@ -369,6 +370,7 @@ final class Psalm
                 isset($options['report-show-info'])
                     ? $options['report-show-info'] !== 'false' && $options['report-show-info'] !== '0'
                     : true,
+                array_key_exists('only-taint', $options),
             ),
             $threads,
             $scanThreads,
@@ -888,6 +890,7 @@ final class Psalm
         $stdout_report_options->show_snippet = !isset($options['show-snippet']) || $options['show-snippet'] !== "false";
         $stdout_report_options->pretty = isset($options['pretty-print']) && $options['pretty-print'] !== "false";
         $stdout_report_options->in_ci = $in_ci;
+        $stdout_report_options->only_taint = array_key_exists('only-taint', $options);
 
         return $stdout_report_options;
     }
@@ -1457,6 +1460,11 @@ final class Psalm
 
             --taint-analysis
                 Run Psalm in taint analysis mode – see https://psalm.dev/docs/security_analysis for more info
+
+            --only-taint
+                Show only taint-related issues (those with a taint trace), suppressing all other findings.
+                Useful for security-focused scans. Works with all output formats. Exit code 2 is based
+                solely on taint issues when this flag is set (non-taint errors do not affect the exit code).
 
             --dump-taint-graph=OUTPUT_PATH
                 Output the taint graph using the DOT language – requires --taint-analysis

--- a/src/Psalm/IssueBuffer.php
+++ b/src/Psalm/IssueBuffer.php
@@ -43,6 +43,7 @@ use Psalm\Report\XmlReport;
 use RuntimeException;
 use UnexpectedValueException;
 
+use function array_filter;
 use function array_keys;
 use function array_merge;
 use function array_pop;
@@ -707,13 +708,35 @@ final class IssueBuffer
             }
         }
 
+        // When --only-taint is active, build a filtered view for output and exit-code counting.
+        // $issues_data (unfiltered) is kept for AfterAnalysisEvent so plugins always see the full dataset.
+        $display_issues_data = $issues_data;
+        if ($project_analyzer->stdout_report_options->only_taint) {
+            if (!$codebase->taint_flow_graph) {
+                fwrite(STDERR, 'Warning: --only-taint has no effect because taint analysis is not enabled. '
+                    . 'All issues are suppressed. Use --taint-analysis to enable taint tracking.' . PHP_EOL);
+            }
+
+            /** @var array<string, list<IssueData>> $display_issues_data */
+            $display_issues_data = [];
+            foreach ($issues_data as $file_path => $file_issues) {
+                $filtered = array_values(array_filter(
+                    $file_issues,
+                    static fn(IssueData $issue_data): bool => $issue_data->taint_trace !== null,
+                ));
+                if ($filtered !== []) {
+                    $display_issues_data[$file_path] = $filtered;
+                }
+            }
+        }
+
         echo self::getOutput(
-            $issues_data,
+            $display_issues_data,
             $project_analyzer->stdout_report_options,
             $codebase->analyzer->getTotalTypeCoverage($codebase),
         );
 
-        foreach ($issues_data as $file_issues) {
+        foreach ($display_issues_data as $file_issues) {
             foreach ($file_issues as $issue_data) {
                 if ($issue_data->severity === Config::REPORT_ERROR) {
                     ++$error_count;
@@ -757,7 +780,7 @@ final class IssueBuffer
             file_put_contents(
                 $report_options->output_path,
                 self::getOutput(
-                    $issues_data,
+                    $display_issues_data,
                     $report_options,
                     $codebase->analyzer->getTotalTypeCoverage($codebase),
                 ),
@@ -775,6 +798,8 @@ final class IssueBuffer
                     ? "\e[0;31m" . $error_count . " errors\e[0m"
                     : $error_count . ' errors'
                 ) . ' found' . "\n";
+            } elseif ($project_analyzer->stdout_report_options->only_taint) {
+                echo "No taint issues found!\n";
             } else {
                 self::printSuccessMessage($project_analyzer);
             }

--- a/src/Psalm/Report.php
+++ b/src/Psalm/Report.php
@@ -65,14 +65,23 @@ abstract class Report
         protected int $total_expression_count = 1,
     ) {
         if (!$report_options->show_info) {
-            $this->issues_data = array_filter(
+            $issues_data = array_filter(
                 $issues_data,
                 static fn(IssueData $issue_data): bool => $issue_data->severity !== IssueData::SEVERITY_INFO,
             );
-        } else {
-            $this->issues_data = $issues_data;
         }
 
+        // This filter is the guard for direct API use (e.g. constructing a Report subclass directly).
+        // When called through the standard CLI path, IssueBuffer::finish() pre-filters the issues
+        // before passing them here, so this check is a no-op in that case.
+        if ($report_options->only_taint) {
+            $issues_data = array_filter(
+                $issues_data,
+                static fn(IssueData $issue_data): bool => $issue_data->taint_trace !== null,
+            );
+        }
+
+        $this->issues_data = $issues_data;
         $this->use_color = $report_options->use_color;
         $this->show_snippet = $report_options->show_snippet;
         $this->show_info = $report_options->show_info;

--- a/src/Psalm/Report/ReportOptions.php
+++ b/src/Psalm/Report/ReportOptions.php
@@ -26,4 +26,6 @@ final class ReportOptions
     public bool $show_suggestions = true;
 
     public bool $in_ci = false;
+
+    public bool $only_taint = false;
 }

--- a/tests/ReportOutputTest.php
+++ b/tests/ReportOutputTest.php
@@ -761,6 +761,144 @@ final class ReportOutputTest extends TestCase
         unlink(__DIR__ . '/test-report.json');
     }
 
+    public function testOnlyTaintFilterKeepsTaintIssuesAndDropsOthers(): void
+    {
+        $taint_issue = new IssueData(
+            IssueData::SEVERITY_ERROR,
+            10,
+            10,
+            'TaintedInput',
+            'Detected tainted input',
+            'somefile.php',
+            'somefile.php',
+            'echo $tainted;',
+            '$tainted',
+            100,
+            108,
+            95,
+            109,
+            6,
+            14,
+            0,
+            -1,
+            [['label' => 'taint source', 'entry_path_type' => 'arg']],
+        );
+
+        $non_taint_issue = new IssueData(
+            IssueData::SEVERITY_ERROR,
+            5,
+            5,
+            'UndefinedVariable',
+            'Cannot find referenced variable $x',
+            'somefile.php',
+            'somefile.php',
+            'echo $x;',
+            '$x',
+            50,
+            52,
+            45,
+            53,
+            6,
+            8,
+        );
+
+        $issues_data = [$taint_issue, $non_taint_issue];
+
+        $report_options = new ReportOptions();
+        $report_options->only_taint = true;
+
+        $report = new JsonReport($issues_data, [], $report_options);
+        $decoded = json_decode($report->create(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertCount(1, $decoded);
+        $this->assertSame('TaintedInput', $decoded[0]['type']);
+    }
+
+    public function testOnlyTaintFilterWithNoTaintIssuesReturnsEmpty(): void
+    {
+        $non_taint_issue = new IssueData(
+            IssueData::SEVERITY_ERROR,
+            5,
+            5,
+            'UndefinedVariable',
+            'Cannot find referenced variable $x',
+            'somefile.php',
+            'somefile.php',
+            'echo $x;',
+            '$x',
+            50,
+            52,
+            45,
+            53,
+            6,
+            8,
+        );
+
+        $issues_data = [$non_taint_issue];
+
+        $report_options = new ReportOptions();
+        $report_options->only_taint = true;
+
+        $report = new JsonReport($issues_data, [], $report_options);
+        $decoded = json_decode($report->create(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame([], $decoded);
+    }
+
+    public function testOnlyTaintFilterTreatsEmptyTaintTraceAsTaintIssue(): void
+    {
+        // taint_trace = [] (empty array) is non-null, so it passes the filter.
+        // This documents the contract: only null means "no taint info".
+        $issue_with_empty_trace = new IssueData(
+            IssueData::SEVERITY_ERROR,
+            5,
+            5,
+            'TaintedInput',
+            'Detected tainted input',
+            'somefile.php',
+            'somefile.php',
+            'echo $x;',
+            '$x',
+            50,
+            52,
+            45,
+            53,
+            6,
+            8,
+            0,
+            -1,
+            [], // empty taint_trace — non-null, so treated as a taint issue
+        );
+
+        $report_options = new ReportOptions();
+        $report_options->only_taint = true;
+
+        $report = new JsonReport([$issue_with_empty_trace], [], $report_options);
+        $decoded = json_decode($report->create(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertCount(1, $decoded);
+    }
+
+    public function testGetFileReportOptionsPropagatesToOnlyTaint(): void
+    {
+        $options = ProjectAnalyzer::getFileReportOptions(
+            [__DIR__ . '/test-report.json'],
+            true,
+            true,
+        );
+
+        $this->assertCount(1, $options);
+        $this->assertTrue($options[0]->only_taint);
+    }
+
+    public function testGetFileReportOptionsDefaultsOnlyTaintToFalse(): void
+    {
+        $options = ProjectAnalyzer::getFileReportOptions([__DIR__ . '/test-report.json']);
+
+        $this->assertCount(1, $options);
+        $this->assertFalse($options[0]->only_taint);
+    }
+
     /**
      * Needed when running on Windows
      *


### PR DESCRIPTION
Closes #11796

Adds `--only-taint` to filter all output — stdout and file reports — to taint-related issues only (those with a non-null `taint_trace`). Designed for security-focused CI gates and taint-only audits where type errors are noise.

### What changed

- **`ReportOptions::$only_taint`** — new `false`-defaulting property
- **`Report` constructor** — secondary filter for direct API use; a no-op in the standard CLI path (data is already pre-filtered)
- **`IssueBuffer::finish()`** — primary filter: builds `$display_issues_data` for output and exit-code counting; keeps `$issues_data` intact for `AfterAnalysisEvent` so plugins always see the full dataset
- **`ProjectAnalyzer::getFileReportOptions()`** — new `bool $only_taint = false` parameter for explicit propagation to file reports
- **CLI** — `--only-taint` wired through `initStdoutReportOptions()` and `getFileReportOptions()`; help text updated; stderr warning when used without taint analysis

### Behaviour

```bash
# Show all issues — default
./vendor/bin/psalm

# Show only taint issues; exit 2 only on taint findings
./vendor/bin/psalm --only-taint

# Clean security scan output (pairs with #11795)
./vendor/bin/psalm --only-taint --no-progress --output-format=compact
```

Exit code 2 is based solely on taint issues when `--only-taint` is active — non-taint errors do not affect the exit code. `AfterAnalysisEvent` always receives the full, unfiltered dataset.

### Tests added

- `testOnlyTaintFilterKeepsTaintIssuesAndDropsOthers` — mixed issues; only taint passes through
- `testOnlyTaintFilterWithNoTaintIssuesReturnsEmpty` — all non-taint; empty result
- `testOnlyTaintFilterTreatsEmptyTaintTraceAsTaintIssue` — documents `[] !== null` contract
- `testGetFileReportOptionsPropagatesToOnlyTaint` — explicit propagation verified
- `testGetFileReportOptionsDefaultsOnlyTaintToFalse` — backward-compatible default verified
