### PR TITLE
[6.x] Use macOS bundle ID for PhpStorm (support JetBrains Tool installed apps), respect `PHPSTORM` env var on Darwin

### DIFF
--- a/src/Psalm/Internal/Cli/Review.php
+++ b/src/Psalm/Internal/Cli/Review.php
@@ -88,7 +88,9 @@ final class Review
                     escapeshellarg((string)$column),
 
             'phpstorm' => static fn(string $file, int $line, int $column) => (PHP_OS_FAMILY === 'Darwin'
-                ? 'open -na \'/Applications/PhpStorm.app\' --args'
+                ? (($phpstormPath = getenv('PHPSTORM'))
+                    ? 'open -na ' . escapeshellarg($phpstormPath) . ' --args'
+                    : 'open -b com.jetbrains.PhpStorm --args')
                 : escapeshellarg(getenv('PHPSTORM') ?: 'phpstorm')
                 ). ' --line ' . escapeshellarg((string) $line) . " --column {$column} " . escapeshellarg($file),
 

--- a/src/Psalm/Internal/Cli/Review.php
+++ b/src/Psalm/Internal/Cli/Review.php
@@ -90,7 +90,7 @@ final class Review
             'phpstorm' => static fn(string $file, int $line, int $column) => (PHP_OS_FAMILY === 'Darwin'
                 ? (($phpstormPath = getenv('PHPSTORM'))
                     ? 'open -na ' . escapeshellarg($phpstormPath) . ' --args'
-                    : 'open -b com.jetbrains.PhpStorm --args')
+                    : 'open -nb com.jetbrains.PhpStorm --args')
                 : escapeshellarg(getenv('PHPSTORM') ?: 'phpstorm')
                 ). ' --line ' . escapeshellarg((string) $line) . " --column {$column} " . escapeshellarg($file),
 


### PR DESCRIPTION
1. Replace the hardcoded `/Applications/PhpStorm.app` path with `open -b com.jetbrains.PhpStorm`, which uses the macOS app registry to resolve PhpStorm regardless of where it was installed (system `/Applications/`, `~/Applications/` via JetBrains Toolbox, or any custom path)

2. Respect the `PHPSTORM` env var on Darwin as an explicit override (e.g. for EAP builds), consistent with the non-Darwin behaviour that already supported it

3. Single `getenv('PHPSTORM')` call via assignment-in-condition avoids redundancy

Fixes #11800

Follow-up PR: #11802 (incl. changes from this)
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small change to `psalm-review` IDE launch command construction, mainly affecting macOS PhpStorm invocation and environment-variable handling.
> 
> **Overview**
> Fixes `psalm-review` PhpStorm launching on macOS by avoiding a hardcoded `/Applications/PhpStorm.app` path. On Darwin it now uses `open -b com.jetbrains.PhpStorm` by default, while honoring an explicit `PHPSTORM` env var path (e.g., EAP/custom installs); non-Darwin behavior remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d77d87288fcaa569999b909765f06201fc95180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->