### PR TITLE
[6.x] extract `IdeDetector`, auto-detect IDE when none specified

### DIFF
--- a/docs/running_psalm/command_line_usage.md
+++ b/docs/running_psalm/command_line_usage.md
@@ -51,16 +51,18 @@ Running them together (e.g. `--threads=8 --diff`) will result in the fastest pos
 Psalm now offers a `psalm-review` tool which allows you to manually review issues one by one in your favorite IDE.  
 
 ```bash
-./vendor/bin/psalm-review report.json code|phpstorm|code-server [ inv|rev|[~-]IssueType1 ] [ [~-]IssueType2 ] ...
+./vendor/bin/psalm-review report.json [code|phpstorm|code-server] [ inv|rev|[~-]IssueType1 ] [ [~-]IssueType2 ] ...
 ```
 
 The tool may also be run using the main `psalm` entry point, useful for example when working with the phar:
 
 ```bash
-./vendor/bin/psalm.phar --review report.json code|phpstorm|code-server [ inv|rev|[~-]IssueType1 ] [ [~-]IssueType2 ] ...
+./vendor/bin/psalm.phar --review report.json [code|phpstorm|code-server] [ inv|rev|[~-]IssueType1 ] [ [~-]IssueType2 ] ...
 ```
 
-`psalm-review` parses the Psalm JSON report in report.json (generated using `vendor/bin/psalm --report=report.json`) and open the specified IDE at the line and column of the issue, one by one for all issues; press enter to go to the next issue, `q` to quit.  
+`psalm-review` parses the Psalm JSON report in report.json (generated using `vendor/bin/psalm --report=report.json`) and opens the specified IDE at the line and column of the issue, one by one for all issues; press enter to go to the next issue, `q` to quit.
+
+The IDE argument is optional when running inside a supported IDE's integrated terminal — PhpStorm, VS Code, and code-server are auto-detected via environment variables. When running from an external terminal, the IDE must be specified explicitly.
 
 The extra arguments may be used to filter only for issues of the specified types, or for all issues except the specified types (with the `~` or `-` inversion).  
 

--- a/src/Psalm/Internal/Cli/IdeDetector.php
+++ b/src/Psalm/Internal/Cli/IdeDetector.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Cli;
+
+use function getenv;
+use function is_string;
+use function str_starts_with;
+
+/**
+ * Detects the current IDE from environment variables injected into integrated terminals.
+ *
+ * Detection is only reliable when the script runs inside the IDE's own terminal.
+ * Returns null when running from an external terminal.
+ *
+ * @internal
+ */
+final class IdeDetector
+{
+    public const PHPSTORM = 'phpstorm';
+    public const CODE = 'code';
+    public const CODE_SERVER = 'code-server';
+
+    /**
+     * @return self::PHPSTORM|self::CODE|self::CODE_SERVER|null
+     */
+    public static function detect(): ?string
+    {
+        // JetBrains IDEs (PhpStorm, IntelliJ IDEA, etc.) set TERMINAL_EMULATOR=JetBrains-JediTerm
+        $emulator = getenv('TERMINAL_EMULATOR');
+        if (is_string($emulator) && str_starts_with($emulator, 'JetBrains')) {
+            return self::PHPSTORM;
+        }
+
+        // code-server (browser-based VS Code) sets VSCODE_PROXY_URI; desktop VS Code does not
+        if (getenv('VSCODE_PROXY_URI') !== false) {
+            return self::CODE_SERVER;
+        }
+
+        // Desktop VS Code sets TERM_PROGRAM=vscode in its integrated terminal
+        if (getenv('TERM_PROGRAM') === 'vscode') {
+            return self::CODE;
+        }
+
+        return null;
+    }
+}

--- a/src/Psalm/Internal/Cli/IdeDetector.php
+++ b/src/Psalm/Internal/Cli/IdeDetector.php
@@ -18,29 +18,29 @@ use function str_starts_with;
  */
 final class IdeDetector
 {
-    public const PHPSTORM = 'phpstorm';
-    public const CODE = 'code';
-    public const CODE_SERVER = 'code-server';
+    public const IDE_PHPSTORM = 'phpstorm';
+    public const IDE_VS_CODE = 'code';
+    public const IDE_VS_CODE_SERVER = 'code-server';
 
     /**
-     * @return self::PHPSTORM|self::CODE|self::CODE_SERVER|null
+     * @return self::IDE_*|null
      */
     public static function detect(): ?string
     {
         // JetBrains IDEs (PhpStorm, IntelliJ IDEA, etc.) set TERMINAL_EMULATOR=JetBrains-JediTerm
         $emulator = getenv('TERMINAL_EMULATOR');
         if (is_string($emulator) && str_starts_with($emulator, 'JetBrains')) {
-            return self::PHPSTORM;
+            return self::IDE_PHPSTORM;
         }
 
         // code-server (browser-based VS Code) sets VSCODE_PROXY_URI; desktop VS Code does not
         if (getenv('VSCODE_PROXY_URI') !== false) {
-            return self::CODE_SERVER;
+            return self::IDE_VS_CODE_SERVER;
         }
 
         // Desktop VS Code sets TERM_PROGRAM=vscode in its integrated terminal
         if (getenv('TERM_PROGRAM') === 'vscode') {
-            return self::CODE;
+            return self::IDE_VS_CODE;
         }
 
         return null;

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -476,7 +476,7 @@ final class Psalm
      */
     private static function findDefaultOutputFormat(): string
     {
-        if (IdeDetector::detect() === IdeDetector::PHPSTORM) {
+        if (IdeDetector::detect() === IdeDetector::IDE_PHPSTORM) {
             return Report::TYPE_PHP_STORM;
         }
 

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -476,8 +476,7 @@ final class Psalm
      */
     private static function findDefaultOutputFormat(): string
     {
-        $emulator = getenv('TERMINAL_EMULATOR');
-        if (is_string($emulator) && str_starts_with($emulator, 'JetBrains')) {
+        if (IdeDetector::detect() === IdeDetector::PHPSTORM) {
             return Report::TYPE_PHP_STORM;
         }
 

--- a/src/Psalm/Internal/Cli/Review.php
+++ b/src/Psalm/Internal/Cli/Review.php
@@ -61,7 +61,7 @@ final class Review
             exit("Return code {$result}\n");
         }
     }
-    
+
     /** @param list<string> $argv */
     public static function run(array $argv): void
     {
@@ -78,10 +78,13 @@ final class Review
         }
 
         $issues = array_shift($args);
-        $mode = array_shift($args);
+        $modeKey = array_shift($args) ?? IdeDetector::detect() ?? throw new AssertionError(
+            'No IDE was specified and none could be auto-detected. ' .
+            "Pass 'code', 'phpstorm', or 'code-server' as the second argument.",
+        );
 
         /** @psalm-suppress RiskyTruthyFalsyComparison */
-        $mode = match ($mode) {
+        $mode = match ($modeKey) {
             'code-server' => static fn(string $file, int $line, int $column) => 'code-server -r ' .
                     escapeshellarg($file) . ':' .
                     escapeshellarg((string)$line) . ':' .
@@ -98,15 +101,14 @@ final class Review
                  => 'code --goto ' . escapeshellarg($file) . ':' .
                  escapeshellarg((string) $line) . ':' .
                  escapeshellarg((string) $column),
-            
-            null => throw new AssertionError("No IDE was specified as second parameter!"),
-            default => throw new AssertionError("The only allowed IDEs are vscode, phpstorm, code-server, got $mode")
+
+            default => throw new AssertionError("The only allowed IDEs are code, phpstorm, code-server, got $modeKey"),
         };
 
         if (!file_exists($issues)) {
             throw new RuntimeException("$issues does not exist!");
         }
-        
+
         $issues = file_get_contents($issues);
         if ($issues === false) {
             throw new AssertionError("Could not read issues");
@@ -124,7 +126,7 @@ final class Review
                 $issues = array_filter($issues, static fn(array $i) => $i['type'] === $issue);
             }
         }
-        
+
         $allCount = count($issues);
         $issues = array_values($issues);
         foreach ($issues as $k => [
@@ -145,20 +147,20 @@ final class Review
             }
             echo "{$type}: {$message}" . PHP_EOL . PHP_EOL;
             echo $snippet . PHP_EOL;
-        
+
             $pos = strpos($snippet, $selected);
             assert($pos !== false);
             $snippetTrimmed = ltrim($snippet);
             $lenTab = strlen($snippet) - strlen($snippetTrimmed);
-        
+
             echo substr($snippet, 0, $lenTab);
             echo str_repeat(' ', $pos - $lenTab);
             echo str_repeat('^', strlen($selected));
             echo PHP_EOL . PHP_EOL;
-        
+
             printf('%d%% (%d/%d)', (int)($k * 100 / $allCount), $k, $allCount);
             echo PHP_EOL;
-        
+
             self::r($mode($file, $line, $column));
 
             /** @psalm-suppress RiskyTruthyFalsyComparison */
@@ -173,13 +175,15 @@ final class Review
         fputs(
             STDERR,
             PHP_EOL . "Usage:" . PHP_EOL . PHP_EOL .
-                "psalm-review report.json code|phpstorm|code-server " .
+                "psalm-review report.json [code|phpstorm|code-server] " .
                 "[ inv|rev|[~-]IssueType1 ] [ [~-]IssueType2 ] ... " . PHP_EOL .
-                "psalm --review report.json code|phpstorm|code-server " .
+                "psalm --review report.json [code|phpstorm|code-server] " .
                 "[ inv|rev|[~-]IssueType1 ] [ [~-]IssueType2 ] ... " . PHP_EOL . PHP_EOL .
                 "Will parse the Psalm JSON report in report.json ".
                 "and open the specified IDE at the line and column of the issue, ".
                 "one by one for all issues.".PHP_EOL.
+                "The IDE argument is optional when running inside a supported IDE's integrated terminal ".
+                "(PhpStorm, VS Code, code-server are auto-detected).".PHP_EOL.
                 "Press enter to go to the next issue, q to quit.".PHP_EOL.PHP_EOL.
                 "The extra arguments may be used to filter only for issues of the specified types, ".
                 "or for all issues except the specified types (with the ~ or - inversion);".PHP_EOL.

--- a/src/Psalm/Internal/Cli/Review.php
+++ b/src/Psalm/Internal/Cli/Review.php
@@ -88,7 +88,9 @@ final class Review
                     escapeshellarg((string)$column),
 
             'phpstorm' => static fn(string $file, int $line, int $column) => (PHP_OS_FAMILY === 'Darwin'
-                ? 'open -na \'/Applications/PhpStorm.app\' --args'
+                ? (($phpstormPath = getenv('PHPSTORM'))
+                    ? 'open -na ' . escapeshellarg($phpstormPath) . ' --args'
+                    : 'open -b com.jetbrains.PhpStorm --args')
                 : escapeshellarg(getenv('PHPSTORM') ?: 'phpstorm')
                 ). ' --line ' . escapeshellarg((string) $line) . " --column {$column} " . escapeshellarg($file),
 

--- a/src/Psalm/Internal/Cli/Review.php
+++ b/src/Psalm/Internal/Cli/Review.php
@@ -23,6 +23,7 @@ use function fputs;
 use function gc_collect_cycles;
 use function gc_disable;
 use function getenv;
+use function in_array;
 use function json_decode;
 use function ltrim;
 use function passthru;
@@ -78,10 +79,20 @@ final class Review
         }
 
         $issues = array_shift($args);
-        $modeKey = array_shift($args) ?? IdeDetector::detect() ?? throw new AssertionError(
-            'No IDE was specified and none could be auto-detected. ' .
-            "Pass 'code', 'phpstorm', or 'code-server' as the second argument.",
-        );
+
+        // Peek at the next argument: if it's a known IDE name consume it, otherwise
+        // leave it in $args as a filter and fall back to auto-detection.
+        $knownIdes = [IdeDetector::IDE_PHPSTORM, IdeDetector::IDE_VS_CODE, IdeDetector::IDE_VS_CODE_SERVER];
+        $peeked = $args[0] ?? null;
+        if ($peeked !== null && in_array($peeked, $knownIdes, true)) {
+            array_shift($args);
+            $modeKey = $peeked;
+        } else {
+            $modeKey = IdeDetector::detect() ?? throw new AssertionError(
+                'No IDE was specified and none could be auto-detected. ' .
+                "Pass 'code', 'phpstorm', or 'code-server' as the second argument.",
+            );
+        }
 
         /** @psalm-suppress RiskyTruthyFalsyComparison */
         $mode = match ($modeKey) {

--- a/src/Psalm/Internal/Cli/Review.php
+++ b/src/Psalm/Internal/Cli/Review.php
@@ -90,7 +90,7 @@ final class Review
             'phpstorm' => static fn(string $file, int $line, int $column) => (PHP_OS_FAMILY === 'Darwin'
                 ? (($phpstormPath = getenv('PHPSTORM'))
                     ? 'open -na ' . escapeshellarg($phpstormPath) . ' --args'
-                    : 'open -b com.jetbrains.PhpStorm --args')
+                    : 'open -nb com.jetbrains.PhpStorm --args')
                 : escapeshellarg(getenv('PHPSTORM') ?: 'phpstorm')
                 ). ' --line ' . escapeshellarg((string) $line) . " --column {$column} " . escapeshellarg($file),
 

--- a/src/Psalm/Internal/Cli/Review.php
+++ b/src/Psalm/Internal/Cli/Review.php
@@ -85,19 +85,19 @@ final class Review
 
         /** @psalm-suppress RiskyTruthyFalsyComparison */
         $mode = match ($modeKey) {
-            'code-server' => static fn(string $file, int $line, int $column) => 'code-server -r ' .
+            IdeDetector::IDE_VS_CODE_SERVER => static fn(string $file, int $line, int $column) => 'code-server -r ' .
                     escapeshellarg($file) . ':' .
                     escapeshellarg((string)$line) . ':' .
                     escapeshellarg((string)$column),
 
-            'phpstorm' => static fn(string $file, int $line, int $column) => (PHP_OS_FAMILY === 'Darwin'
+            IdeDetector::IDE_PHPSTORM => static fn(string $file, int $line, int $column) => (PHP_OS_FAMILY === 'Darwin'
                 ? (($phpstormPath = getenv('PHPSTORM'))
                     ? 'open -na ' . escapeshellarg($phpstormPath) . ' --args'
                     : 'open -nb com.jetbrains.PhpStorm --args')
                 : escapeshellarg(getenv('PHPSTORM') ?: 'phpstorm')
                 ). ' --line ' . escapeshellarg((string) $line) . " --column {$column} " . escapeshellarg($file),
 
-            'code' => static fn(string $file, int $line, int $column)
+            IdeDetector::IDE_VS_CODE => static fn(string $file, int $line, int $column)
                  => 'code --goto ' . escapeshellarg($file) . ':' .
                  escapeshellarg((string) $line) . ':' .
                  escapeshellarg((string) $column),

--- a/src/Psalm/Internal/PreloaderList.php
+++ b/src/Psalm/Internal/PreloaderList.php
@@ -737,6 +737,7 @@ final class PreloaderList {
         \Psalm\Internal\Cache::class,
         \Psalm\Internal\Clause::class,
         \Psalm\Internal\CliUtils::class,
+        \Psalm\Internal\Cli\IdeDetector::class,
         \Psalm\Internal\Cli\LanguageServer::class,
         \Psalm\Internal\Cli\Plugin::class,
         \Psalm\Internal\Cli\Psalm::class,


### PR DESCRIPTION
Stacks on top of #11801 (includes those commits; best reviewed from that PR's base).


- Adds `IdeDetector::detect()` — a single place for reading IDE env vars across the codebase
- `psalm-review` now auto-detects the IDE when the mode argument is omitted; falls back to a clear error only when no supported IDE is detected
- `Psalm::findDefaultOutputFormat()` delegates to `IdeDetector` instead of duplicating the `TERMINAL_EMULATOR` check inline
- `IdeDetector` added to `PreloaderList` in alphabetical order

## Detection logic

| IDE | Env var | Value |
|-----|---------|-------|
| PhpStorm / JetBrains | `TERMINAL_EMULATOR` | starts with `JetBrains` (existing Psalm convention) |
| code-server | `VSCODE_PROXY_URI` | any (only set by code-server, not desktop VS Code) |
| VS Code desktop | `TERM_PROGRAM` | `vscode` |

Auto-detection only works in the IDE's integrated terminal — external terminals still require an explicit argument.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI argument parsing and environment-based IDE detection for `psalm-review`, which could affect developer workflows and IDE launching if detection/argument consumption is wrong. Scope is limited to CLI tooling and documentation updates.
> 
> **Overview**
> Adds a new internal `IdeDetector` utility to centralize IDE detection via integrated-terminal environment variables (PhpStorm/JetBrains, VS Code, and code-server).
> 
> Updates `psalm-review` so the IDE argument is *optional*: it now only consumes the next arg if it matches a known IDE, otherwise it treats it as an issue-type filter and falls back to auto-detection (failing with a clearer error when nothing is detected). `Psalm::findDefaultOutputFormat()` is also updated to use `IdeDetector` for PhpStorm default output selection, and the docs/help text are updated accordingly; `IdeDetector` is added to the preloader list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f287f571013db3d2b2d4079704ad5c3b56ff2bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->