### PR TITLE
Test

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -371,6 +371,9 @@ final class ProjectAnalyzer
     /** @psalm-mutation-free */
     public function canReportIssues(string $file_path): bool
     {
+        if (!$this->project_files_initialized) {
+            return $this->config->isInProjectDirs($file_path);
+        }
         $list = $this->project_files;
         return isset($list[$file_path]);
     }
@@ -983,7 +986,7 @@ final class ProjectAnalyzer
         $this->progress->write($this->generatePHPVersionMessage());
         $this->progress->startPhase(Phase::SCAN, $this->scanThreads);
 
-        $this->initProjectFiles();
+        //$this->initProjectFiles();
         $this->initExtraFiles();
 
         $this->config->visitPreloadedStubFiles($this->codebase, $this->progress);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the criteria for whether issues are reported/hidden during `checkPaths()` runs, which could lead to missing or newly surfaced diagnostics depending on initialization order and configured project directories.
> 
> **Overview**
> Adjusts `ProjectAnalyzer::canReportIssues()` to handle runs where project files haven’t been initialized yet by falling back to `Config::isInProjectDirs()`.
> 
> In `checkPaths()`, disables the eager `initProjectFiles()` call, meaning path-based analysis no longer builds the full project file list up front (potentially reducing overhead but changing which files are considered “in project” during reporting/filters).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1660c138bb95f91795fee719fc0ca9f83b45b43e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->