### PR TITLE
Final improvements for reduced scanning

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -371,9 +371,6 @@ final class ProjectAnalyzer
     /** @psalm-mutation-free */
     public function canReportIssues(string $file_path): bool
     {
-        if (!$this->project_files_initialized) {
-            return $this->config->isInProjectDirs($file_path);
-        }
         $list = $this->project_files;
         return isset($list[$file_path]);
     }
@@ -986,7 +983,22 @@ final class ProjectAnalyzer
         $this->progress->write($this->generatePHPVersionMessage());
         $this->progress->startPhase(Phase::SCAN, $this->scanThreads);
 
-        //$this->initProjectFiles();
+        if (!$this->project_files_initialized) {
+            $file_extensions = $this->config->getFileExtensions();
+            $this->project_files = [];
+            foreach ($paths_to_check as $file_path) {
+                if (is_dir($file_path)) {
+                    foreach ($this->file_provider->getFilesInDir(
+                        $file_path,
+                        $file_extensions,
+                    ) as $file_path) {
+                        $this->project_files[$file_path] = $file_path;
+                    }
+                } elseif (is_file($file_path)) {
+                    $this->project_files[$file_path] = $file_path;
+                }
+            }
+        }
         $this->initExtraFiles();
 
         $this->config->visitPreloadedStubFiles($this->codebase, $this->progress);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes file-inclusion and issue-reporting behavior in partial scans; miscomputed `project_files` could cause missed or newly suppressed issues for some paths.
> 
> **Overview**
> Improves `checkPaths()` runs by lazily building `project_files` from the explicitly provided `paths_to_check` (including directory expansion) instead of relying on full project initialization.
> 
> Removes the `canReportIssues()` fallback that used `Config::isInProjectDirs()` when project files weren’t initialized, making issue-report eligibility depend solely on the computed `project_files` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78f338af0d5b13530963b9fc01091ad663584fb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->