### PR TITLE
Final improvements for reduced scanning

### DIFF
--- a/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/ProjectAnalyzer.php
@@ -371,9 +371,6 @@ final class ProjectAnalyzer
     /** @psalm-mutation-free */
     public function canReportIssues(string $file_path): bool
     {
-        if (!$this->project_files_initialized) {
-            return $this->config->isInProjectDirs($file_path);
-        }
         $list = $this->project_files;
         return isset($list[$file_path]);
     }
@@ -986,7 +983,22 @@ final class ProjectAnalyzer
         $this->progress->write($this->generatePHPVersionMessage());
         $this->progress->startPhase(Phase::SCAN, $this->scanThreads);
 
-        //$this->initProjectFiles();
+        if (!$this->project_files_initialized) {
+            $file_extensions = $this->config->getFileExtensions();
+            $this->project_files = [];
+            foreach ($paths_to_check as $file_path) {
+                if (is_dir($file_path)) {
+                    foreach ($this->file_provider->getFilesInDir(
+                        $file_path,
+                        $file_extensions,
+                    ) as $file_path) {
+                        $this->project_files[$file_path] = $file_path;
+                    }
+                } elseif (is_file($file_path)) {
+                    $this->project_files[$file_path] = $file_path;
+                }
+            }
+        }
         $this->initExtraFiles();
 
         $this->config->visitPreloadedStubFiles($this->codebase, $this->progress);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes core file-inclusion logic for issue reporting and targeted scans; incorrect `project_files` population could cause issues to be skipped or reported unexpectedly for some `checkPaths()` invocations.
> 
> **Overview**
> Tightens how Psalm decides whether it can report issues for a file by removing the fallback to `Config::isInProjectDirs()` when project files haven’t been initialized, making `canReportIssues()` rely solely on the computed `project_files` set.
> 
> To keep `checkPaths()` functional under this stricter behavior, it now lazily populates `project_files` from the explicitly provided files/directories (recursing directories via `getFilesInDir`) instead of initializing the full configured project file list, reducing scan scope for targeted runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0fee0263579a437eecd77a6ec32e7476e3a7fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->