### PR TITLE
[6.x] Quiet CLI output when running under an AI agent

### DIFF
--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -650,14 +650,26 @@ final class Psalm
             ? $options['show-info'] === 'true' || $options['show-info'] === '1'
             : false;
 
+        // CI takes precedence over AI detection: persistent CI logs still want
+        // per-phase breadcrumbs for humans reviewing the build. Agents that
+        // need the CI log quieted can pass --no-progress explicitly.
+        $no_progress = isset($options['no-progress'])
+            || (!$in_ci
+                && !isset($options['long-progress'])
+                && CliUtils::runningUnderAiAgent());
+
         if ($debug) {
             $progress = new DebugProgress();
-        } elseif (isset($options['no-progress'])) {
+        } elseif ($no_progress) {
             $progress = new VoidProgress();
         } else {
             $show_errors = !$config->error_baseline || isset($options['ignore-baseline']);
-            if (isset($options['long-progress'])) {
-                $progress = new LongProgress($show_errors, $show_info, $in_ci);
+            // A `\r`-based progress bar on a piped stderr just floods the log
+            // with every intermediate update. Fall back to the CI-style output,
+            // which emits one line per phase transition.
+            $quiet_progress = $in_ci || !CliUtils::streamIsInteractive(STDERR);
+            if (isset($options['long-progress']) || $quiet_progress) {
+                $progress = new LongProgress($show_errors, $show_info, $quiet_progress);
             } else {
                 $progress = new DefaultProgress($show_errors, $show_info, $in_ci);
             }
@@ -865,7 +877,9 @@ final class Psalm
         bool $in_ci,
     ): ReportOptions {
         $stdout_report_options = new ReportOptions();
-        $stdout_report_options->use_color = !array_key_exists('m', $options);
+        $stdout_report_options->use_color = !array_key_exists('m', $options)
+            && !CliUtils::noColorRequested()
+            && !CliUtils::runningUnderAiAgent();
         $stdout_report_options->show_info = $show_info;
         $stdout_report_options->show_suggestions = !array_key_exists('no-suggestions', $options);
         /**
@@ -1468,7 +1482,9 @@ final class Psalm
 
         Output:
             -m, --monochrome
-                Enable monochrome output
+                Enable monochrome output.
+                Auto-enabled when NO_COLOR is set to a non-empty value or when
+                an AI coding agent is driving the shell.
 
             --output-format=console
                 Changes the output format.
@@ -1476,10 +1492,13 @@ final class Psalm
                     $outputFormats
 
             --no-progress
-                Disable the progress indicator
+                Disable the progress indicator.
+                Auto-enabled when an AI coding agent is driving the shell
+                (CI always keeps its phase breadcrumbs).
 
             --long-progress
-                Use a progress indicator suitable for Continuous Integration logs
+                Use a progress indicator suitable for Continuous Integration logs.
+                Auto-enabled in CI and when stderr is not attached to a terminal.
 
             --stats
                 Shows a breakdown of Psalm’s ability to infer types in the codebase

--- a/src/Psalm/Internal/Cli/Psalter.php
+++ b/src/Psalm/Internal/Cli/Psalter.php
@@ -23,6 +23,7 @@ use Psalm\Internal\Scanner\ParsedDocblock;
 use Psalm\IssueBuffer;
 use Psalm\Progress\DebugProgress;
 use Psalm\Progress\DefaultProgress;
+use Psalm\Progress\LongProgress;
 use Psalm\Progress\VoidProgress;
 use Psalm\Report;
 use Psalm\Report\ReportOptions;
@@ -139,10 +140,14 @@ final class Psalter
                     Path to a psalm.xml configuration file. Run psalm --init to create one.
 
                 -m, --monochrome
-                    Enable monochrome output
+                    Enable monochrome output.
+                    Auto-enabled when NO_COLOR is set to a non-empty value or
+                    when an AI coding agent is driving the shell.
 
                 --no-progress
-                    Disable the progress indicator
+                    Disable the progress indicator.
+                    Auto-enabled when an AI coding agent is driving the shell
+                    (CI always keeps its phase breadcrumbs).
 
                 -r, --root
                     If running Psalm globally you'll need to specify a project root. Defaults to cwd
@@ -293,16 +298,26 @@ final class Psalter
         }
 
         $debug = array_key_exists('debug', $options) || array_key_exists('debug-by-line', $options);
+        // CI takes precedence over AI detection: persistent CI logs still want
+        // per-phase breadcrumbs for humans reviewing the build.
+        $no_progress = isset($options['no-progress'])
+            || (!$in_ci && CliUtils::runningUnderAiAgent());
         if ($debug) {
             $progress = new DebugProgress();
-        } elseif (isset($options['no-progress'])) {
+        } elseif ($no_progress) {
             $progress = new VoidProgress();
+        } elseif ($in_ci || !CliUtils::streamIsInteractive(STDERR)) {
+            // Same rationale as in Psalm.php: a `\r`-based progress bar on a
+            // piped stderr just floods the log with every intermediate update.
+            $progress = new LongProgress(true, false, true);
         } else {
             $progress = new DefaultProgress();
         }
 
         $stdout_report_options = new ReportOptions();
-        $stdout_report_options->use_color = !array_key_exists('m', $options);
+        $stdout_report_options->use_color = !array_key_exists('m', $options)
+            && !CliUtils::noColorRequested()
+            && !CliUtils::runningUnderAiAgent();
 
         $project_analyzer = new ProjectAnalyzer(
             $config,

--- a/src/Psalm/Internal/Cli/Refactor.php
+++ b/src/Psalm/Internal/Cli/Refactor.php
@@ -19,6 +19,7 @@ use Psalm\Internal\Provider\Providers;
 use Psalm\IssueBuffer;
 use Psalm\Progress\DebugProgress;
 use Psalm\Progress\DefaultProgress;
+use Psalm\Progress\VoidProgress;
 use Psalm\Report;
 use Psalm\Report\ReportOptions;
 
@@ -321,18 +322,30 @@ final class Refactor
         );
 
         $debug = array_key_exists('debug', $options) || array_key_exists('debug-by-line', $options);
-        $progress = $debug
-            ? new DebugProgress()
-            : new DefaultProgress();
+        // CI takes precedence over AI detection, matching Psalm.php / Psalter.php.
+        $no_progress = isset($options['no-progress'])
+            || (!$in_ci && CliUtils::runningUnderAiAgent());
+        if ($debug) {
+            $progress = new DebugProgress();
+        } elseif ($no_progress) {
+            $progress = new VoidProgress();
+        } else {
+            $progress = new DefaultProgress();
+        }
 
         if (array_key_exists('debug-emitted-issues', $options)) {
             $config->debug_emitted_issues = true;
         }
 
+        $report_options = new ReportOptions();
+        $report_options->use_color = !array_key_exists('m', $options)
+            && !CliUtils::noColorRequested()
+            && !CliUtils::runningUnderAiAgent();
+
         $project_analyzer = new ProjectAnalyzer(
             $config,
             $providers,
-            new ReportOptions(),
+            $report_options,
             [],
             $threads,
             $scanThreads,

--- a/src/Psalm/Internal/CliUtils.php
+++ b/src/Psalm/Internal/CliUtils.php
@@ -29,6 +29,7 @@ use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
 use function fwrite;
+use function getenv;
 use function implode;
 use function in_array;
 use function ini_set;
@@ -43,9 +44,11 @@ use function preg_split;
 use function realpath;
 use function str_starts_with;
 use function stream_get_meta_data;
+use function stream_isatty;
 use function stream_set_blocking;
 use function strlen;
 use function strpos;
+use function strtolower;
 use function substr;
 use function substr_replace;
 use function trim;
@@ -520,6 +523,92 @@ final class CliUtils
             || isset($_SERVER['CI'])
             || isset($_SERVER['GITHUB_WORKFLOW'])
             || isset($_SERVER['DRONE']);
+    }
+
+    /**
+     * Detects whether Psalm is being invoked by an AI coding agent.
+     *
+     * When an agent is driving the shell, `\r`-based progress bars and ANSI
+     * colors are pure token noise: the agent never renders them and just
+     * feeds the raw bytes back into its language model.
+     *
+     * The detection list is deliberately vendor-specific. The `AGENT`
+     * variable on its own is too generic to trust (it collides with shell
+     * rc files and unrelated tooling), so we only match it when paired
+     * with a known agent name.
+     */
+    public static function runningUnderAiAgent(): bool
+    {
+        // Vendor-specific presence markers. Each agent documents a variable
+        // it exports into every spawned subprocess.
+        $markers = [
+            'CLAUDECODE',            // Claude Code (Anthropic)
+            'CLAUDE_CODE',           // Claude Code (alternate)
+            'CURSOR_AGENT',          // Cursor Composer
+            'CURSOR_TRACE_ID',       // Cursor (older builds)
+            'GEMINI_CLI',            // Gemini CLI (Google)
+            'CODEX_SANDBOX',         // OpenAI Codex CLI (macOS sandbox marker)
+            'CODEX_THREAD_ID',       // OpenAI Codex CLI (cross-platform)
+            'AUGMENT_AGENT',         // Augment
+            'CLINE_ACTIVE',          // Cline
+            'OPENCODE_CLIENT',       // OpenCode (sst/opencode)
+            'OPENCODE',              // OpenCode (alternate)
+            'AMP_CURRENT_THREAD_ID', // Amp (Sourcegraph)
+            'TRAE_AI_SHELL_ID',      // TRAE AI
+            'COPILOT_CLI',           // GitHub Copilot CLI
+            'ANTIGRAVITY_AGENT',     // Google Antigravity
+            'PI_CODING_AGENT',       // Pi coding agent
+            'REPL_ID',               // Replit
+            'AI_AGENT',              // Vendor-neutral convention (@vercel/detect-agent).
+        ];
+        foreach ($markers as $var) {
+            if (self::envVarLooksTruthy($var)) {
+                return true;
+            }
+        }
+
+        // `AGENT=<name>` convention proposed in agentsmd.org/issue#136. Used
+        // by Goose. Value-gated so generic shell usage does not false-positive.
+        $agent = getenv('AGENT');
+        if (is_string($agent) && strtolower($agent) === 'goose') {
+            return true;
+        }
+
+        // Devin runs its agent in a sandbox that always contains this marker.
+        if (file_exists('/opt/.devin')) {
+            return true;
+        }
+
+        return false;
+    }
+
+    private static function envVarLooksTruthy(string $name): bool
+    {
+        $value = getenv($name);
+        return is_string($value)
+            && $value !== ''
+            && $value !== '0'
+            && $value !== 'false';
+    }
+
+    /**
+     * Returns whether the given stream is attached to an interactive terminal.
+     *
+     * @param resource $stream
+     */
+    public static function streamIsInteractive($stream): bool
+    {
+        return stream_isatty($stream);
+    }
+
+    /**
+     * Respects the https://no-color.org/ convention: ANSI colors are disabled
+     * when NO_COLOR is set to a non-empty value (any non-empty string counts).
+     */
+    public static function noColorRequested(): bool
+    {
+        $value = getenv('NO_COLOR');
+        return is_string($value) && $value !== '';
     }
 
     public static function checkRuntimeRequirements(): void

--- a/tests/EndToEnd/PsalmRunnerTrait.php
+++ b/tests/EndToEnd/PsalmRunnerTrait.php
@@ -19,6 +19,42 @@ trait PsalmRunnerTrait
     private string $psalter = __DIR__ . '/../../psalter';
 
     /**
+     * Agent-harness environment variables that, when present in the developer
+     * shell, would otherwise auto-switch Psalm to VoidProgress / monochrome.
+     * Passing each as `false` to Symfony Process unsets it for the child
+     * process, giving tests a deterministic default-output run.
+     *
+     * Kept in sync with CliUtils::runningUnderAiAgent().
+     *
+     * @return array<string, false>
+     */
+    private static function agentEnvVarsToUnset(): array
+    {
+        return [
+            'CLAUDECODE' => false,
+            'CLAUDE_CODE' => false,
+            'CURSOR_AGENT' => false,
+            'CURSOR_TRACE_ID' => false,
+            'GEMINI_CLI' => false,
+            'CODEX_SANDBOX' => false,
+            'CODEX_THREAD_ID' => false,
+            'AUGMENT_AGENT' => false,
+            'CLINE_ACTIVE' => false,
+            'OPENCODE_CLIENT' => false,
+            'OPENCODE' => false,
+            'AMP_CURRENT_THREAD_ID' => false,
+            'TRAE_AI_SHELL_ID' => false,
+            'COPILOT_CLI' => false,
+            'ANTIGRAVITY_AGENT' => false,
+            'PI_CODING_AGENT' => false,
+            'REPL_ID' => false,
+            'AI_AGENT' => false,
+            'AGENT' => false,
+            'NO_COLOR' => false,
+        ];
+    }
+
+    /**
      * @param list<string> $args
      * @return array{STDOUT: string, STDERR: string, CODE: int|null}
      */
@@ -41,9 +77,17 @@ trait PsalmRunnerTrait
         // we run `php psalm` rather than just `psalm`.
 
         if ($relyOnConfigDir) {
-            $process = new Process(array_merge([PHP_BINARY, $this->psalm, '-c=' . $workingDir . '/psalm.xml'], $args), null);
+            $process = new Process(
+                array_merge([PHP_BINARY, $this->psalm, '-c=' . $workingDir . '/psalm.xml'], $args),
+                null,
+                self::agentEnvVarsToUnset(),
+            );
         } else {
-            $process = new Process(array_merge([PHP_BINARY, $this->psalm], $args), $workingDir);
+            $process = new Process(
+                array_merge([PHP_BINARY, $this->psalm], $args),
+                $workingDir,
+                self::agentEnvVarsToUnset(),
+            );
         }
 
         if (!$shouldFail) {


### PR DESCRIPTION
## Why

AI coding agents (Claude Code, Cursor, Gemini CLI, Codex, Goose, Amp, etc.) run `psalm` and feed the combined output back into a language model. Every token spent on progress bars, ANSI colors, and `\r`-based scanning updates is wasted budget.

Related reading:
- https://alies.dev/articles/cli-output-for-ai/
- https://github.com/agentsmd/agents.md/issues/136

## What changes

Three conservative defaults that kick in only when the existing flags are not set:

1. **Under an AI coding agent**: default to `VoidProgress` and disable ANSI colors.
   - Explicit `--long-progress` still wins (escape hatch).
   - **CI takes precedence for progress**: persistent CI logs still want per-phase breadcrumbs for humans reviewing the build. If both `CI=true` and an AI marker are set, the run uses `LongProgress`. Colors still drop because most CI renderers treat ANSI inconsistently and agents reading the CI log still benefit.
2. **Non-TTY stderr (and not in CI)**: switch the default from `DefaultProgress` to the CI-flavored `LongProgress`. Previously, piping stderr to a file captured hundreds of `\r`-based "N / M..." scanning updates into one giant line. Now the CI path kicks in and we only emit per-phase output plus the compact `░`/`E` analysis dots.
3. **`NO_COLOR`** (https://no-color.org): disables ANSI colors on the stdout report when set to a non-empty value. Convention already respected by git, clang, cargo, etc.

No existing flag changes meaning. `-m`, `--no-progress`, and `--long-progress` all still win when set explicitly.

## Agent detection

Each agent exports a presence marker into every spawned subprocess. The list mirrors the coverage of [`@vercel/detect-agent`](https://www.npmjs.com/package/@vercel/detect-agent) and [shipfastlabs/agent-detector](https://github.com/shipfastlabs/agent-detector):

| Variable | Agent |
|---|---|
| `CLAUDECODE`, `CLAUDE_CODE` | Claude Code (Anthropic) |
| `CURSOR_AGENT`, `CURSOR_TRACE_ID` | Cursor Composer |
| `GEMINI_CLI` | Gemini CLI (Google) |
| `CODEX_SANDBOX`, `CODEX_THREAD_ID` | OpenAI Codex CLI |
| `AUGMENT_AGENT` | Augment |
| `CLINE_ACTIVE` | Cline |
| `OPENCODE_CLIENT`, `OPENCODE` | OpenCode (sst/opencode) |
| `AMP_CURRENT_THREAD_ID` | Amp (Sourcegraph) |
| `TRAE_AI_SHELL_ID` | TRAE AI |
| `COPILOT_CLI` | GitHub Copilot CLI |
| `ANTIGRAVITY_AGENT` | Google Antigravity |
| `PI_CODING_AGENT` | Pi coding agent |
| `REPL_ID` | Replit |
| `AI_AGENT` | Vendor-neutral convention |
| `AGENT=goose` | Goose (value-gated to dodge collisions with unrelated `AGENT` usage) |
| `/opt/.devin` | Devin (Cognition) filesystem sandbox marker |

Using `getenv()` rather than `$_SERVER` matches the dominant pattern in the CLI code and survives strict `variables_order` settings. Help text speaks of "an AI coding agent" in the abstract rather than naming vendors, so adding the next marker is a one-line change.

## Measurement

Ran on `filament/4.x` (real Laravel codebase, ~4.8K files, ~10.4K errors, cache cleared between runs):

| Scenario | stdout | stderr | total | tokens (chars/4) |
|---|---:|---:|---:|---:|
| Baseline (main 6.x) | 4,188,848 | 10,508 | 4,199,356 | 1,049,839 |
| After, under AI agent | 3,937,281 | 0 | 3,937,281 | 984,320 |
| After, under AI agent in CI | 3,937,281 | 2,818 | 3,940,099 | 985,024 |
| After, piped (no AI env) | 4,188,848 | 3,104 | 4,191,952 | 1,047,988 |

- Under an AI agent: **-262 KB / ~65K tokens (6.2%)** per run, mostly from ANSI color removal on ~10K errors.
- AI + CI: same stdout savings, plus ~3 KB of phase breadcrumbs restored on stderr for human log readers.
- Piped run (non-AI): **stderr shrinks 70%** (10.5 KB -> 3.1 KB), driven entirely by dropping the `\r`-based scanning flood.
- Output is otherwise byte-identical (same errors, same summaries, same paths, same snippets).

## Files

- `src/Psalm/Internal/CliUtils.php`: three static helpers (`runningUnderAiAgent`, `streamIsInteractive`, `noColorRequested`) plus a small `envVarLooksTruthy` internal.
- `src/Psalm/Internal/Cli/Psalm.php`: main `initProgress` and `initStdoutReportOptions` pick quieter defaults. `--help` text updated.
- `src/Psalm/Internal/Cli/Psalter.php`: same defaults for `--alter`, including the piped-stderr fallback.
- `src/Psalm/Internal/Cli/Refactor.php`: VoidProgress and color-off under AI agent.
- `tests/EndToEnd/PsalmRunnerTrait.php`: the Symfony `Process` constructor now receives an `agentEnvVarsToUnset()` map so the E2E harness doesn't silently swap to VoidProgress when an agent-using dev runs `composer phpunit`.

## Behavior matrix

| Context | Progress | Color |
|---|---|---|
| Interactive TTY, no env | DefaultProgress (unchanged) | on (unchanged) |
| Piped stderr, not CI | LongProgress (was DefaultProgress) | on |
| CI | LongProgress (unchanged) | on |
| AI agent detected (no CI) | VoidProgress | off |
| AI agent detected **in CI** | LongProgress (CI wins) | off |
| `NO_COLOR=<non-empty>` | default | off |
| `--long-progress` | LongProgress (escape hatch honored) | per other flags |
| `--no-progress` | VoidProgress | per other flags |

## BC note

Non-AI users who pipe stderr to a file will see the cleaner `LongProgress` format instead of the interleaved `\r`-based `DefaultProgress`. The old format was effectively unreadable off-TTY anyway, so this is meant as an improvement, but it is a visible change for anyone reading saved logs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes default CLI progress/color behavior based on environment detection (AI markers, NO_COLOR, non-TTY stderr), which could surprise users relying on previous log formats.
> 
> **Overview**
> Makes Psalm/psalter/refactor CLI output *quieter by default* when it would otherwise be token/log noise: auto-disables ANSI color when `NO_COLOR` is set or when `CliUtils::runningUnderAiAgent()` detects an AI agent, and auto-disables progress under AI agents unless CI/`--long-progress` is in effect.
> 
> Improves non-interactive logging by switching to `LongProgress` when `STDERR` is not a TTY (and in CI), avoiding `\r`-based progress-bar flooding; help text is updated to document these auto-defaults. Adds `CliUtils` helpers (`runningUnderAiAgent`, `streamIsInteractive`, `noColorRequested`) and updates E2E test harness to unset agent-related env vars to keep output deterministic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c7d744d10d15bbd7a7dc532c1b9b17b29a3c0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->