### PR TITLE
Fix undefined array key crash in FunctionDocblockManipulator

### DIFF
--- a/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
+++ b/src/Psalm/Internal/FileManipulation/FunctionDocblockManipulator.php
@@ -244,7 +244,9 @@ final class FunctionDocblockManipulator
                     $this->return_typehint_start = $i + $end_bracket_position + 1;
                 }
 
-                if ($chars[$i + 1] !== '\\' && !preg_match('/[\w]/', $chars[$i + 1])) {
+                if (!isset($chars[$i + 1])
+                    || ($chars[$i + 1] !== '\\' && !preg_match('/[\w]/', $chars[$i + 1]))
+                ) {
                     $this->return_typehint_end = $i + $end_bracket_position + 2;
                     break;
                 }

--- a/tests/FileManipulation/ReturnTypeManipulationTest.php
+++ b/tests/FileManipulation/ReturnTypeManipulationTest.php
@@ -180,6 +180,42 @@ final class ReturnTypeManipulationTest extends FileManipulationTestCase
                 'issues_to_fix' => ['MismatchingDocblockReturnType'],
                 'safe_types' => true,
             ],
+            'fixMismatchingDocblockReturnTypeOnInterfaceMethod70' => [
+                'input' => '<?php
+                    interface I {
+                        /**
+                         * @return int
+                         */
+                        public function foo(): string;
+                    }',
+                'output' => '<?php
+                    interface I {
+                        public function foo(): string;
+                    }',
+                'php_version' => '7.0',
+                'issues_to_fix' => ['MismatchingDocblockReturnType'],
+                'safe_types' => true,
+            ],
+            'fixMismatchingDocblockReturnTypeOnInterfaceMethodWithNamespacedTypehint70' => [
+                'input' => '<?php
+                    namespace App;
+
+                    interface I {
+                        /**
+                         * @return int
+                         */
+                        public function foo(): \DateTime;
+                    }',
+                'output' => '<?php
+                    namespace App;
+
+                    interface I {
+                        public function foo(): \DateTime;
+                    }',
+                'php_version' => '7.0',
+                'issues_to_fix' => ['MismatchingDocblockReturnType'],
+                'safe_types' => true,
+            ],
             'preserveFormat' => [
                 'input' => '<?php
                     /**


### PR DESCRIPTION
Fixes #11793

For abstract and interface methods, the function-body slice in `FunctionDocblockManipulator::__construct` excludes the trailing `;`. The return-type scanner can reach the last index of `$chars` while still inside the word-char branch, and accessing `$chars[$i + 1]` triggers an `Undefined array key` warning that Psalm's error handler turns into a `RuntimeException`.

Guard the access with `isset()`. The sibling `/` and `*` branches aren't reachable at end of scan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk bugfix that adds a bounds check to prevent a runtime exception when manipulating return types on abstract/interface methods; behavior should be unchanged except for avoiding the crash.
> 
> **Overview**
> Prevents `FunctionDocblockManipulator` from reading past the end of the return-type token stream by guarding `$chars[$i + 1]` with `isset()`, fixing a crash when processing methods whose signatures end with `;` (e.g., interface/abstract methods).
> 
> Adds regression coverage in `ReturnTypeManipulationTest` for interface methods (including namespaced return types) where fixing `MismatchingDocblockReturnType` should remove the redundant `@return` docblock without errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc877d84da86e3dc94d837ace36cc5c98a861b09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->