### PR TITLE
Add support for reading inheritors from a phpstan-sealed tag

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/ClassLikeDocblockParser.php
@@ -253,8 +253,8 @@ final class ClassLikeDocblockParser
             }
         }
 
-        if (isset($parsed_docblock->tags['psalm-inheritors'])) {
-            foreach ($parsed_docblock->tags['psalm-inheritors'] as $template_line) {
+        if (isset($parsed_docblock->combined_tags['psalm-inheritors'])) {
+            foreach ($parsed_docblock->combined_tags['psalm-inheritors'] as $template_line) {
                 $doc_line_parts = CommentAnalyzer::splitDocLine($template_line);
                 $doc_line_parts[0] = CommentAnalyzer::sanitizeDocblockType($doc_line_parts[0]);
                 $info->inheritors = $doc_line_parts[0];

--- a/src/Psalm/Internal/Scanner/DocblockParser.php
+++ b/src/Psalm/Internal/Scanner/DocblockParser.php
@@ -279,6 +279,16 @@ final class DocblockParser
                 + ($docblock->tags['phpstan-param-out'] ?? [])
                 + ($docblock->tags['psalm-param-out'] ?? []);
         }
+
+        if (isset($docblock->tags['psalm-inheritors'])
+            || isset($docblock->tags['phpstan-sealed'])
+        ) {
+            if (isset($docblock->tags['psalm-inheritors'])) {
+                $docblock->combined_tags['psalm-inheritors'] = $docblock->tags['psalm-inheritors'];
+            } else {
+                $docblock->combined_tags['psalm-inheritors'] = $docblock->tags['phpstan-sealed'];
+            }
+        }
     }
 
     /**

--- a/tests/ClassTest.php
+++ b/tests/ClassTest.php
@@ -1426,6 +1426,18 @@ final class ClassTest extends TestCase
                 'error_message' => 'InheritorViolation',
                 'ignored_issues' => [],
             ],
+            'classCannotExtendIfNotInInheritorsUsingPhpstanSealed' => [
+                'code' => <<<'PHP'
+                    <?php
+                    /**
+                     * @phpstan-sealed FooClass|BarClass
+                     */
+                    class BaseClass {}
+                    class BazClass extends BaseClass {} // this is an error
+                    PHP,
+                'error_message' => 'InheritorViolation',
+                'ignored_issues' => [],
+            ],
             'classCannotImplementIfNotInInheritors' => [
                 'code' => <<<'PHP'
                     <?php


### PR DESCRIPTION
This improves interoperability for vendor libraries that are using phpstan. The `@phpstan-sealed` tag has the same semantic than `@psalm-inheritors`.

Closes https://github.com/vimeo/psalm/issues/11510

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates docblock parsing to alias `@phpstan-sealed` into the inheritors constraint logic, which can change class/interface inheritance validation outcomes for existing codebases.
> 
> **Overview**
> Adds interoperability with PHPStan’s `@phpstan-sealed` by mapping it to Psalm’s `@psalm-inheritors` during docblock parsing (via `combined_tags`).
> 
> Updates `ClassLikeDocblockParser` to read inheritors only from `combined_tags`, and extends the test suite to assert that extending a `@phpstan-sealed` base class triggers `InheritorViolation` the same way `@psalm-inheritors` does.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd4ae22ff086d92ba1e76e25b6f97cf32b8baced. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->