### PR TITLE
[6.x] Accept string pseudo-type intersections in docblocks

### DIFF
--- a/src/Psalm/Internal/Type/TypeParser.php
+++ b/src/Psalm/Internal/Type/TypeParser.php
@@ -52,10 +52,15 @@ use Psalm\Type\Atomic\TLiteralClassString;
 use Psalm\Type\Atomic\TLiteralFloat;
 use Psalm\Type\Atomic\TLiteralInt;
 use Psalm\Type\Atomic\TLiteralString;
+use Psalm\Type\Atomic\TLowercaseString;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNever;
 use Psalm\Type\Atomic\TNonEmptyArray;
+use Psalm\Type\Atomic\TNonEmptyLowercaseString;
+use Psalm\Type\Atomic\TNonEmptyNonspecificLiteralString;
+use Psalm\Type\Atomic\TNonEmptyString;
+use Psalm\Type\Atomic\TNonspecificLiteralString;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TObject;
 use Psalm\Type\Atomic\TObjectWithProperties;
@@ -90,6 +95,7 @@ use function defined;
 use function end;
 use function explode;
 use function in_array;
+use function is_a;
 use function is_int;
 use function is_numeric;
 use function preg_match;
@@ -1206,6 +1212,15 @@ final class TypeParser
             );
         }
 
+        $collapsed_string = self::collapseStringPseudoTypeIntersection(
+            $intersection_types,
+            $from_docblock,
+        );
+
+        if ($collapsed_string !== null) {
+            return $collapsed_string;
+        }
+
         $keyed_intersection_types = self::extractKeyedIntersectionTypes(
             $codebase,
             $intersection_types,
@@ -1254,6 +1269,104 @@ final class TypeParser
         }
 
         return $first_type;
+    }
+
+    /**
+     * Mirrors the narrowing rules in Type::intersectAtomicTypes so that a
+     * docblock intersection like `non-empty-string&lowercase-string` collapses
+     * to its single-token equivalent (`non-empty-lowercase-string`) at parse
+     * time. Returns null when the intersection is not made of allow-listed
+     * string pseudo-types or has no known single-atomic equivalent.
+     *
+     * @param non-empty-array<array-key, Atomic> $intersection_types
+     */
+    private static function collapseStringPseudoTypeIntersection(
+        array $intersection_types,
+        bool $from_docblock,
+    ): ?TString {
+        $combined = null;
+
+        foreach ($intersection_types as $type) {
+            if (!$type instanceof TNonEmptyString
+                && !$type instanceof TLowercaseString
+                && !$type instanceof TNonspecificLiteralString
+            ) {
+                return null;
+            }
+
+            if ($combined === null) {
+                $combined = $type;
+                continue;
+            }
+
+            $combined = self::intersectStringPseudoTypePair($combined, $type, $from_docblock);
+
+            if ($combined === null) {
+                return null;
+            }
+        }
+
+        return $combined;
+    }
+
+    /**
+     * Reduces two allow-listed string pseudo-types to their narrower common
+     * subtype. Returns null when no safe single-atomic representation exists
+     * (e.g. `non-falsy-string & lowercase-string`, which has no single-token
+     * equivalent). Widening such cases to `non-empty-lowercase-string` would
+     * silently drop the non-falsy constraint.
+     */
+    private static function intersectStringPseudoTypePair(
+        TString $a,
+        TString $b,
+        bool $from_docblock,
+    ): ?TString {
+        if (is_a($a, $b::class)) {
+            return $a;
+        }
+
+        if (is_a($b, $a::class)) {
+            return $b;
+        }
+
+        // TNonEmptyLowercaseString extends TNonEmptyString but not
+        // TLowercaseString, so the is_a checks above miss the subtype
+        // relationship with TLowercaseString.
+        if ($a instanceof TNonEmptyLowercaseString && $b instanceof TLowercaseString) {
+            return $a;
+        }
+
+        if ($a instanceof TLowercaseString && $b instanceof TNonEmptyLowercaseString) {
+            return $b;
+        }
+
+        // TNonEmptyNonspecificLiteralString extends TNonspecificLiteralString
+        // but not TNonEmptyString, so the is_a checks miss the subtype
+        // relationship with TNonEmptyString.
+        if ($a instanceof TNonEmptyNonspecificLiteralString && $b::class === TNonEmptyString::class) {
+            return $a;
+        }
+
+        if ($a::class === TNonEmptyString::class && $b instanceof TNonEmptyNonspecificLiteralString) {
+            return $b;
+        }
+
+        // Exact-class matching only: mirrors Type::intersectAtomicTypes. Using
+        // instanceof here would widen subclasses like TNumericString or
+        // TNonFalsyString and drop their extra constraints.
+        if (($a::class === TNonspecificLiteralString::class && $b::class === TNonEmptyString::class)
+            || ($a::class === TNonEmptyString::class && $b::class === TNonspecificLiteralString::class)
+        ) {
+            return new TNonEmptyNonspecificLiteralString($from_docblock);
+        }
+
+        if (($a::class === TLowercaseString::class && $b::class === TNonEmptyString::class)
+            || ($a::class === TNonEmptyString::class && $b::class === TLowercaseString::class)
+        ) {
+            return new TNonEmptyLowercaseString($from_docblock);
+        }
+
+        return null;
     }
 
     /**

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -1343,6 +1343,56 @@ final class ReturnTypeTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'nonEmptyStringLowercaseStringIntersection' => [
+                'code' => '<?php
+                    /**
+                     * @return non-empty-string&lowercase-string
+                     */
+                    function lower(): string {
+                        return "abc";
+                    }
+
+                    $a = lower();
+                ',
+                'assertions' => [
+                    '$a===' => 'non-empty-lowercase-string',
+                ],
+            ],
+            'nonEmptyStringLiteralStringIntersection' => [
+                'code' => '<?php
+                    /**
+                     * @return non-empty-string&literal-string
+                     */
+                    function lit(): string {
+                        return "abc";
+                    }
+
+                    $a = lit();
+                ',
+                'assertions' => [
+                    '$a===' => 'non-empty-literal-string',
+                ],
+            ],
+            'laravelStyleStrLowerConditionalReturnType' => [
+                'code' => '<?php
+                    /**
+                     * @param string $value
+                     * @return ($value is "" ? "" : non-empty-string&lowercase-string)
+                     */
+                    function lower(string $value): string {
+                        return strtolower($value);
+                    }
+
+                    $a = lower("FOO");
+                    /** @var "" $empty */
+                    $empty = "";
+                    $b = lower($empty);
+                ',
+                'assertions' => [
+                    '$a===' => 'non-empty-lowercase-string',
+                    '$b===' => "''",
+                ],
+            ],
         ];
     }
 

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -269,6 +269,110 @@ final class TypeParseTest extends TestCase
         Type::parseString('array{a: int}&T1');
     }
 
+    public function testIntersectionOfNonEmptyStringAndLowercaseString(): void
+    {
+        $this->assertSame(
+            'non-empty-lowercase-string',
+            Type::parseString('non-empty-string&lowercase-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfLowercaseStringAndNonEmptyString(): void
+    {
+        $this->assertSame(
+            'non-empty-lowercase-string',
+            Type::parseString('lowercase-string&non-empty-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfNonEmptyStringAndLiteralString(): void
+    {
+        $this->assertSame(
+            'non-empty-literal-string',
+            Type::parseString('non-empty-string&literal-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfLiteralStringAndNonEmptyString(): void
+    {
+        $this->assertSame(
+            'non-empty-literal-string',
+            Type::parseString('literal-string&non-empty-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfSameNonEmptyString(): void
+    {
+        $this->assertSame(
+            'non-empty-string',
+            Type::parseString('non-empty-string&non-empty-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfNonEmptyLowercaseStringAndNonEmptyString(): void
+    {
+        $this->assertSame(
+            'non-empty-lowercase-string',
+            Type::parseString('non-empty-lowercase-string&non-empty-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfNonEmptyLowercaseStringAndLowercaseString(): void
+    {
+        $this->assertSame(
+            'non-empty-lowercase-string',
+            Type::parseString('non-empty-lowercase-string&lowercase-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfNonEmptyLiteralStringAndNonEmptyString(): void
+    {
+        $this->assertSame(
+            'non-empty-literal-string',
+            Type::parseString('non-empty-literal-string&non-empty-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfNonEmptyStringAndNonFalsyString(): void
+    {
+        $this->assertSame(
+            'non-falsy-string',
+            Type::parseString('non-empty-string&non-falsy-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfNumericStringAndNonEmptyString(): void
+    {
+        $this->assertSame(
+            'numeric-string',
+            Type::parseString('numeric-string&non-empty-string')->getId(),
+        );
+    }
+
+    public function testIntersectionOfStringPseudoTypeAndNonStringRejected(): void
+    {
+        $this->expectException(TypeParseTreeException::class);
+        Type::parseString('non-empty-string&int');
+    }
+
+    public function testIntersectionOfNumericStringAndLowercaseStringRejected(): void
+    {
+        $this->expectException(TypeParseTreeException::class);
+        Type::parseString('numeric-string&lowercase-string');
+    }
+
+    public function testIntersectionOfNonFalsyStringAndLowercaseStringRejected(): void
+    {
+        $this->expectException(TypeParseTreeException::class);
+        Type::parseString('non-falsy-string&lowercase-string');
+    }
+
+    public function testIntersectionOfNonEmptyStringAndCallableStringRejected(): void
+    {
+        $this->expectException(TypeParseTreeException::class);
+        Type::parseString('callable-string&lowercase-string');
+    }
+
     public function testIterableContainingTKeyedArray(): void
     {
         $this->assertSame('iterable<string, list{int}>', Type::parseString('iterable<string, array{int}>')->getId());


### PR DESCRIPTION
## Summary

Fixes #11821.

Parse-time intersections like `non-empty-string&lowercase-string` now collapse to their single-atomic equivalent (`non-empty-lowercase-string`) instead of throwing `InvalidDocblock: Intersection types must be all objects, Psalm\Type\Atomic\TNonEmptyString provided`.

This mirrors the runtime narrowing already present in `Type::intersectAtomicTypes` and unblocks Laravel's `Illuminate\Support\Str::lower()` return type:

```php
/**
 * @param  string  $value
 * @return ($value is '' ? '' : non-empty-string&lowercase-string)
 */
public static function lower($value)
```

## How it works

`TypeParser::getTypeFromIntersectionTree()` now calls a new `collapseStringPseudoTypeIntersection()` helper before the existing `extractKeyedIntersectionTypes()`. If the helper recognizes a known string pseudo-type combination, it returns the equivalent single atomic; otherwise it returns `null` and the existing rejection path runs unchanged.

### Design notes

- **Positive allowlist**: only `TNonEmptyString`, `TLowercaseString`, `TNonspecificLiteralString` (and their subclasses) participate in the collapse. Anything else falls through to the original error path.
- **Exact-class narrowing**: the two rules mirrored from `Type::intersectAtomicTypes` (`non-empty-string & literal-string → non-empty-literal-string`, `non-empty-string & lowercase-string → non-empty-lowercase-string`) use exact `::class` matching rather than `instanceof`, so subclasses like `TNumericString` or `TNonFalsyString` paired with `TLowercaseString` are rejected rather than silently widened.
- **Subtype cases**: `is_a()` handles natural subtype relationships (e.g. `numeric-string & non-empty-string → numeric-string`).
- **Class-hierarchy quirks**: explicit handlers cover two cases where the class hierarchy lags behind semantic subtyping:
  - `TNonEmptyLowercaseString` extends `TNonEmptyString` but not `TLowercaseString`.
  - `TNonEmptyNonspecificLiteralString` extends `TNonspecificLiteralString` but not `TNonEmptyString`.

### Scope

This PR addresses the specific Laravel/`Str::lower()` case from #11821. It is related to but does not fully close #9628 (which covers other combinations such as `numeric-string & truthy-string` that have no single-atomic equivalent). Those can be added incrementally on top of the same machinery.

## Tests

- `tests/TypeParseTest.php` — 14 new tests covering accepted combinations, subtype resolution, class-hierarchy quirks, and rejection of unsafe/unknown pairs (to lock in that no widening occurs).
- `tests/ReturnTypeTest.php` — 3 functional tests including the Laravel-style conditional return type.

## Verification

- `composer phpunit-std` (targeted): 174 / 174 TypeParseTest tests pass, including all pre-existing cases.
- `composer psalm`: no errors.
- `composer cs`: no errors.
- `composer lint`: no errors.
- End-to-end: the exact reproduction from #11821 (https://psalm.dev/r/b51da730d4) now produces no errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core type parsing for intersection types; while behavior is narrowly allow-listed, it can change how certain docblocks are interpreted and could affect downstream analysis results.
> 
> **Overview**
> Docblock intersections involving specific *string pseudo-types* are now accepted and collapsed to a single narrower atomic during parsing (e.g. `non-empty-string&lowercase-string` → `non-empty-lowercase-string`, `non-empty-string&literal-string` → `non-empty-literal-string`) instead of throwing an invalid intersection error.
> 
> `TypeParser::getTypeFromIntersectionTree()` calls a new helper to safely reduce allow-listed string pseudo-type pairs (including a few hierarchy edge-cases) and otherwise falls through to the existing rejection logic unchanged, with new unit/analysis tests covering accepted, subtype, and rejected combinations (including a Laravel-style conditional return type).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0290de1666b9df6f394460d41607efcab958bb7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->