### PR TITLE
:bug: [#11828] Fix handling `$this` in conditional return

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -471,6 +471,17 @@ final class FunctionLikeDocblockScanner
         foreach ($fixed_type_tokens as $i => $type_token) {
             $token_body = $type_token[0];
 
+            if ($token_body === '$this') {
+                if ($i > 0
+                    && isset($fixed_type_tokens[$i - 1])
+                    && $fixed_type_tokens[$i - 1][0] === ' '
+                ) {
+                    unset($fixed_type_tokens[$i - 1]);
+                }
+
+                continue;
+            }
+
             if ($token_body[0] === '$') {
                 foreach ($storage->params as $j => $param_storage) {
                     if ('$' . $param_storage->name === $token_body) {

--- a/tests/Template/ConditionalReturnTypeTest.php
+++ b/tests/Template/ConditionalReturnTypeTest.php
@@ -229,6 +229,38 @@ final class ConditionalReturnTypeTest extends TestCase
                         return true;
                     }',
             ],
+            'conditionalReturnTypeWithThisInElseBranch' => [
+                'code' => '<?php
+                    final class Fluent
+                    {
+                        /**
+                         * @psalm-mutation-free
+                         * @param array|string|null $middleware
+                         * @return ($middleware is null ? array<never, never> : $this)
+                         */
+                        public function middleware($middleware = null)
+                        {
+                            if ($middleware === null) {
+                                return [];
+                            }
+
+                            return $this;
+                        }
+
+                        /**
+                         * @psalm-mutation-free
+                         * @return static
+                         */
+                        public function name(string $name)
+                        {
+                            return $this;
+                        }
+                    }
+
+                    (new Fluent())
+                        ->middleware("throttle:6,1")
+                        ->name("user-password.update");',
+            ],
             'variableConditionalSyntaxWithNewlines' => [
                 'code' => '<?php
                     /**


### PR DESCRIPTION
Fixes https://github.com/vimeo/psalm/issues/11828

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core docblock return-type token sanitization used broadly across analyses; while the change is small, it could affect parsing of conditional return types in many projects.
> 
> **Overview**
> Fixes conditional return-type parsing when a docblock uses `$this` in a conditional branch by skipping `$this` during parameter-template substitution (and trimming preceding whitespace) in `FunctionLikeDocblockScanner::getConditionalSanitizedTypeTokens`.
> 
> Adds a regression test covering a fluent method with `@return ($middleware is null ? array<never, never> : $this)` to ensure chaining continues to typecheck.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 68a13e4cab5afdd227052a6a8431d0ccd5c1d81f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->