### PR TITLE
[6.x] fix tests: drop incorrect `impure-` Closure prefix in TypeParseTest

### DIFF
--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -100,12 +100,12 @@ final class TypeParseTest extends TestCase
 
     public function testThisAsCallableReturnType(): void
     {
-        $this->assertSame('impure-Closure(Foo):static', (string) Type::parseString('Closure(Foo): $this'));
+        $this->assertSame('Closure(Foo):static', (string) Type::parseString('Closure(Foo): $this'));
     }
 
     public function testThisModelVariableNotTreatedAsThis(): void
     {
-        $this->assertSame('impure-Closure(string):void', (string) Type::parseString('Closure(string $thisModel): void'));
+        $this->assertSame('Closure(string):void', (string) Type::parseString('Closure(string $thisModel): void'));
     }
 
     public function testIntOrString(): void


### PR DESCRIPTION
The two new tests added in #11768 (`testThisAsCallableReturnType`, `testThisModelVariableNotTreatedAsThis`) were written for master/7.x where Closure types render with an `impure-` prefix. On 6.x there's no purity tracking on Closures, so the actual output is just `Closure(...)`.

The other 10 new tests from that PR don't materialize a Closure literal, so they pass on 6.x as-is.

Failing CI runs:
* https://github.com/vimeo/psalm/actions/runs/25312086158/job/74201098963 (Windows, PHP 8.5)
* https://github.com/vimeo/psalm/actions/runs/25312086171/job/74201100657 (Linux, PHP 8.1)

Locally `vendor/bin/phpunit tests/TypeParseTest.php` is green (170/170).