### PR TITLE
[6.x] fix tests: whitelist `Override` in SuicidalAutoloader fixture

### DIFF
--- a/tests/fixtures/SuicidalAutoloader/autoloader.php
+++ b/tests/fixtures/SuicidalAutoloader/autoloader.php
@@ -18,6 +18,7 @@ spl_autoload_register(static function (string $className) {
         'PHPUnit\Framework\DOMElement',
         'Stringable',
         'AllowDynamicProperties',
+        'Override', // PHP 8.3+ built-in attribute, used by amphp/socket and others on PHP 8.1/8.2
 
         // https://github.com/symfony/symfony/pull/40203
         // these are actually functions, referenced as `if (!function_exists(u::class))`


### PR DESCRIPTION
`SuicidalAutoloaderTest::testSucceedsWithEmptyFile` fails on PHP 8.1 and 8.2 because `Override` isn't a built-in class on those versions. When psalm scans a vendor file with `#[\Override]` (e.g. `vendor/amphp/socket/src/UnlimitedSocketPool.php`), `Scanner::fileExistsForClassLike` calls `new ReflectionClass('Override')`, which triggers the project autoloader. The fixture's autoloader exits on any unknown class, so the test crashes.

The whitelist already covers analogous version-gated names (`Stringable`, `AllowDynamicProperties`). Adding `Override` makes the test pass on 8.1/8.2 again. Verified locally on PHP 8.2.

This failure surfaced on master and 6.x as soon as a vendor dep started using `#[\Override]`. It predates and is unrelated to #11768.

Worth filing separately: `Scanner::fileExistsForClassLike` should probably skip `ReflectionClass` for known version-gated PHP attribute classes (`Override`, `NoDiscard`, etc.). End users on PHP 8.1/8.2 with a strict autoloader and a dep using `#[\Override]` would hit the same crash, which is a real product issue this fixture-only fix doesn't address.