### PR TITLE
[6.x] Ignore inline `covariant`/`contravariant` keywords in generic type parameters (backport)

### DIFF
--- a/src/Psalm/Internal/Type/ParseTreeCreator.php
+++ b/src/Psalm/Internal/Type/ParseTreeCreator.php
@@ -145,6 +145,15 @@ final class ParseTreeCreator
                     $this->handleIsOrAs($type_token);
                     break;
 
+                case 'covariant':
+                case 'contravariant':
+                    if ($this->t + 1 < $this->type_token_count
+                        && $this->type_tokens[$this->t + 1][0] === ' '
+                    ) {
+                        $this->t++;
+                    }
+                    break;
+
                 default:
                     $this->handleValue($type_token);
                     break;

--- a/src/Psalm/Internal/Type/TypeTokenizer.php
+++ b/src/Psalm/Internal/Type/TypeTokenizer.php
@@ -165,6 +165,10 @@ final class TypeTokenizer
                 $type_tokens[++$rtc] = ['', ++$i];
                 $was_char = false;
                 continue;
+            } elseif ($was_space
+                && in_array($type_tokens[$rtc][0], ['covariant', 'contravariant'], true)
+            ) {
+                $type_tokens[++$rtc] = ['', $i];
             } elseif ($was_char) {
                 $type_tokens[++$rtc] = ['', $i];
             }
@@ -364,6 +368,7 @@ final class TypeTokenizer
                 $string_type_token[0],
                 [
                     '<', '>', '|', '?', ',', '{', '}', ':', '::', '[', ']', '(', ')', '&', '=', '...', 'as', 'is',
+                    'covariant', 'contravariant',
                 ],
                 true,
             )) {

--- a/tests/Template/ClassTemplateCovarianceTest.php
+++ b/tests/Template/ClassTemplateCovarianceTest.php
@@ -532,6 +532,37 @@ final class ClassTemplateCovarianceTest extends TestCase
 
                     run(new Container(new TypeA()));',
             ],
+            'inlineCovariantModifierIgnored' => [
+                'code' => '<?php
+                    /**
+                     * @template-covariant T
+                     * @template TParent
+                     */
+                    class Container {}
+
+                    /**
+                     * @template T of object
+                     * @param class-string<T> $class
+                     * @return Container<covariant T, covariant string>
+                     */
+                    function wrap(string $class): Container
+                    {
+                        /** @var Container<covariant T, covariant string> */
+                        return new Container();
+                    }',
+            ],
+            'inlineContravariantModifierIgnored' => [
+                'code' => '<?php
+                    /**
+                     * @template T
+                     */
+                    class Box {}
+
+                    /**
+                     * @param Box<contravariant string> $box
+                     */
+                    function consume(Box $box): void {}',
+            ],
         ];
     }
 

--- a/tests/TypeParseTest.php
+++ b/tests/TypeParseTest.php
@@ -191,6 +191,26 @@ final class TypeParseTest extends TestCase
         $this->assertSame('B<int>', (string) Type::parseString('B<int>'));
     }
 
+    public function testGenericWithInlineCovariant(): void
+    {
+        $this->assertSame('B<int>', (string) Type::parseString('B<covariant int>'));
+    }
+
+    public function testGenericWithInlineContravariant(): void
+    {
+        $this->assertSame('B<int>', (string) Type::parseString('B<contravariant int>'));
+    }
+
+    public function testGenericWithMultipleInlineVariance(): void
+    {
+        $this->assertSame('B<int, string>', (string) Type::parseString('B<covariant int, contravariant string>'));
+    }
+
+    public function testGenericWithInlineVarianceAndUnion(): void
+    {
+        $this->assertSame('B<int|string>', (string) Type::parseString('B<covariant int|string>'));
+    }
+
     public function testIntersection(): void
     {
         $this->assertSame('I1&I2&I3', (string) Type::parseString('I1&I2&I3'));


### PR DESCRIPTION
Silently skip `covariant`/`contravariant` inline variance modifiers (PHPStan syntax) instead of misinterpreting them as class names, which caused UndefinedDocblockClass errors.

Fixes vimeo/psalm#11772

(cherry picked from commit 05e843a3b53ae47a08a521f2ddd89091fa425930)