### PR TITLE
[6.x] Fix `&static` leak in invariant generic type-param comparison

### DIFF
--- a/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
+++ b/src/Psalm/Internal/Type/Comparator/GenericTypeComparator.php
@@ -10,6 +10,7 @@ use Psalm\Type\Atomic;
 use Psalm\Type\Atomic\TGenericObject;
 use Psalm\Type\Atomic\TIterable;
 use Psalm\Type\Atomic\TNamedObject;
+use Psalm\Type\Union;
 
 /**
  * @internal
@@ -162,6 +163,19 @@ final class GenericTypeComparator
                                 && $input_param->isStaticObject()
                             ) {
                                 // do nothing
+                            } elseif (($container_param->hasStaticObject()
+                                    || $input_param->hasStaticObject())
+                                && self::isContainedByIgnoringStatic(
+                                    $codebase,
+                                    $container_param,
+                                    $input_param,
+                                    $allow_interface_equality,
+                                )
+                            ) {
+                                // LSB tracking via `&static` is meaningless inside an invariant
+                                // template arg. Accept when the only obstacle is `&static` on
+                                // either side (e.g. `Wrapper<Sub>` accepting `Wrapper<Sub&static>`).
+                                // do nothing
                             } else {
                                 $all_types_contain = false;
 
@@ -194,5 +208,53 @@ final class GenericTypeComparator
         }
 
         return false;
+    }
+
+    /**
+     * Runs `isContainedBy($input, $container)` after stripping `is_static` markers from both sides.
+     * Used inside generic type-param comparison so that `&static` (LSB tracking) is not treated as
+     * a meaningful difference when the underlying classes are compatible.
+     */
+    private static function isContainedByIgnoringStatic(
+        Codebase $codebase,
+        Union $input,
+        Union $container,
+        bool $allow_interface_equality,
+    ): bool {
+        $stripped_input = self::eraseStatic($input);
+        $stripped_container = self::eraseStatic($container);
+
+        $check_result = new TypeComparisonResult();
+
+        return UnionTypeComparator::isContainedBy(
+            $codebase,
+            $stripped_input,
+            $stripped_container,
+            $stripped_input->ignore_nullable_issues,
+            $stripped_input->ignore_falsable_issues,
+            $check_result,
+            $allow_interface_equality,
+        ) && !$check_result->type_coerced;
+    }
+
+    /**
+     * Returns a copy of `$param` where every top-level `TNamedObject` atomic has `is_static` cleared.
+     * `is_static` markers nested inside intersection (`extra_types`) or template bounds are not touched.
+     * Returns the original instance if nothing changed.
+     */
+    private static function eraseStatic(Union $param): Union
+    {
+        $changed = false;
+        $atomics = [];
+        foreach ($param->getAtomicTypes() as $key => $atomic) {
+            if ($atomic instanceof TNamedObject && $atomic->is_static) {
+                $atomics[$key] = $atomic->setIsStatic(false, false);
+                $changed = true;
+            } else {
+                $atomics[$key] = $atomic;
+            }
+        }
+
+        return $changed ? $param->setTypes($atomics) : $param;
     }
 }

--- a/tests/Template/ClassTemplateExtendsTest.php
+++ b/tests/Template/ClassTemplateExtendsTest.php
@@ -4699,6 +4699,32 @@ final class ClassTemplateExtendsTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.0',
             ],
+            'invariantTemplateArgWithThisAcceptsConcreteEquivalent' => [
+                'code' => '<?php
+                    /** @template T */
+                    final class Wrapper {
+                        /** @var T */
+                        public $value;
+                        /** @param T $v */
+                        public function __construct($v) { $this->value = $v; }
+                    }
+
+                    class Foo {
+                        /** @return Wrapper<$this> */
+                        public function rel(): Wrapper {
+                            return new Wrapper($this);
+                        }
+                    }
+
+                    class Sub extends Foo {}
+
+                    final class Caller {
+                        /** @return Wrapper<Sub> */
+                        public function callIt(Sub $s): Wrapper {
+                            return $s->rel();
+                        }
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #11837 (sibling regression) and the `psalm/plugin-laravel` errors that follow from it.

After PR #11768 made `$this` reachable inside generic args, expanding `Wrapper<$this>` produces a `Sub&static` type-param. When that flows into invariant-generic comparison against a declared `Wrapper<Sub>`, `AtomicTypeComparator` fails the line-364 strict `is_static` check and the existing line-161 bypass does not catch it (the bypass requires `is_static` on *both* sides).

`&static` inside an invariant template arg carries no nominal type information beyond the underlying class. Extend the bypass with a helper that strips `is_static` from both sides and re-runs the containment check; if the only obstacle was the LSB marker, accept. The relaxation is strictly stricter than the original both-static bypass.

The forward-fail `LessSpecificImplementedReturnType` path is intentionally untouched. Existing tests `preventBadOverrideWhenVerifyingNonFinalChildReturnType` and siblings still pass.

`composer cs` clean. Existing template/trait tests all pass; new `invariantTemplateArgWithThisAcceptsConcreteEquivalent` covers the regression.

Another bug in the issue (conditional `@return` collapse on stub override) is fixed in a separate PR: https://github.com/vimeo/psalm/pull/11840