### PR TITLE
[6.x] Fix conditional `@return` collapse when stub redeclares scanned method

### DIFF
--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeDocblockScanner.php
@@ -476,11 +476,34 @@ final class FunctionLikeDocblockScanner
                     if ('$' . $param_storage->name === $token_body) {
                         if (!isset($param_type_mapping[$token_body])) {
                             $template_name = 'TGeneratedFromParam' . $j;
-                            if (isset($storage->template_types[$template_name])) {
+
+                            $already_wrapped = false;
+                            if ($param_storage->type !== null) {
+                                foreach ($param_storage->type->getAtomicTypes() as $atomic) {
+                                    if ($atomic instanceof TTemplateParam
+                                        && $atomic->param_name === $template_name
+                                    ) {
+                                        $already_wrapped = true;
+                                        break;
+                                    }
+                                }
+                            }
+
+                            if ($already_wrapped) {
+                                // A prior handler in this scan (e.g. handleRemovedTaint vs
+                                // handleReturn) already wrapped this param. Re-wrapping would nest
+                                // TTemplateParam.as_type inside itself once per docblock annotation,
+                                // producing an exponentially-long type signature (filter_var carries
+                                // ~50 conditional taint-escape annotations on the same `$filter`).
                                 $function_template_types[$template_name]
                                     = $storage->template_types[$template_name];
                                 $param_type_mapping[$token_body] = $template_name;
                             } else {
+                                // First touch in this scan, or rescan after a stub override (params
+                                // were reset, template_types kept). Build the wrap from the fresh
+                                // param type, otherwise argument binding sets no lower bound at call
+                                // time and replaceConditional falls back to `never`, collapsing the
+                                // conditional return to its null branch.
                                 $template_as_type = $param_storage->type ?: Type::getMixed();
 
                                 $storage->template_types[$template_name] = [

--- a/tests/StubTest.php
+++ b/tests/StubTest.php
@@ -129,6 +129,204 @@ final class StubTest extends TestCase
         $this->analyzeFile($file_path, new Context());
     }
 
+    public function testStubOverridingScannedConditionalReturnPreservesParamBinding(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm errorLevel="1">
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/conditional_return_with_this_overrides_extra.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $extra_path = (string) getcwd() . '/extra/Route.php';
+        $this->addFile(
+            $extra_path,
+            '<?php
+                namespace Psalm\Tests\Fixtures\ConditionalThisOverride;
+
+                class Route
+                {
+                    /**
+                     * @param array|string|null $middleware
+                     * @return ($middleware is null ? array : $this)
+                     */
+                    public function middleware($middleware = null)
+                    {
+                        if ($middleware === null) {
+                            return [];
+                        }
+                        return $this;
+                    }
+                }',
+        );
+
+        $file_path = (string) getcwd() . '/src/somefile.php';
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Psalm\Tests\Fixtures\ConditionalThisOverride\Route;
+
+                /** @return Route */
+                function returnsRouteFromNonNullArg(Route $route): Route {
+                    return $route->middleware(["x"]);
+                }
+
+                /** @return string[] */
+                function returnsArrayFromNullArg(Route $route): array {
+                    return $route->middleware(null);
+                }',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    public function testStubOverridingScannedTraitConditionalReturnPreservesParamBinding(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm errorLevel="1">
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/conditional_return_scalar_trait_overrides_extra.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $extra_trait_path = (string) getcwd() . '/extra/MyTrait.php';
+        $this->addFile(
+            $extra_trait_path,
+            '<?php
+                namespace Psalm\Tests\Fixtures\ConditionalScalarTraitOverride;
+
+                trait MyTrait
+                {
+                    /**
+                     * @param string|null $key
+                     * @return ($key is null ? array<string, int> : int|null)
+                     */
+                    public function get($key = null)
+                    {
+                        return $key === null ? [] : null;
+                    }
+                }',
+        );
+
+        $extra_class_path = (string) getcwd() . '/extra/MyClass.php';
+        $this->addFile(
+            $extra_class_path,
+            '<?php
+                namespace Psalm\Tests\Fixtures\ConditionalScalarTraitOverride;
+
+                class MyClass
+                {
+                    use MyTrait;
+                }',
+        );
+
+        $file_path = (string) getcwd() . '/src/somefile.php';
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Psalm\Tests\Fixtures\ConditionalScalarTraitOverride\MyClass;
+
+                /** @return array<string, int> */
+                function returnsArrayFromNullArg(MyClass $c): array {
+                    return $c->get();
+                }
+
+                /** @return int|null */
+                function returnsIntOrNullFromNonNullArg(MyClass $c): ?int {
+                    return $c->get("x");
+                }',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
+
+    public function testClassLevelStubOverridingTraitMethodResolvesConditional(): void
+    {
+        $this->project_analyzer = $this->getProjectAnalyzerWithConfig(
+            TestConfig::loadFromXML(
+                dirname(__DIR__),
+                '<?xml version="1.0"?>
+                <psalm errorLevel="1">
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+
+                    <stubs>
+                        <file name="tests/fixtures/stubs/conditional_return_class_level_trait_override.phpstub" />
+                    </stubs>
+                </psalm>',
+            ),
+        );
+
+        $extra_trait_path = (string) getcwd() . '/extra/MyTrait.php';
+        $this->addFile(
+            $extra_trait_path,
+            '<?php
+                namespace Psalm\Tests\Fixtures\ConditionalClassLevelTraitOverride;
+
+                trait MyTrait
+                {
+                    /**
+                     * @param string|null $key
+                     * @return ($key is null ? array<string, int> : int|null)
+                     */
+                    public function get($key = null)
+                    {
+                        return $key === null ? [] : null;
+                    }
+                }',
+        );
+
+        $extra_class_path = (string) getcwd() . '/extra/MyClass.php';
+        $this->addFile(
+            $extra_class_path,
+            '<?php
+                namespace Psalm\Tests\Fixtures\ConditionalClassLevelTraitOverride;
+
+                class MyClass
+                {
+                    use MyTrait;
+                }',
+        );
+
+        $file_path = (string) getcwd() . '/src/somefile.php';
+        $this->addFile(
+            $file_path,
+            '<?php
+                use Psalm\Tests\Fixtures\ConditionalClassLevelTraitOverride\MyClass;
+
+                /** @return array<string, int> */
+                function returnsArrayFromNullArg(MyClass $c): array {
+                    return $c->get();
+                }
+
+                /** @return int|null */
+                function returnsIntOrNullFromNonNullArg(MyClass $c): ?int {
+                    return $c->get("x");
+                }',
+        );
+
+        $this->analyzeFile($file_path, new Context());
+    }
+
     /**
      * @psalm-pure
      */

--- a/tests/fixtures/stubs/conditional_return_class_level_trait_override.phpstub
+++ b/tests/fixtures/stubs/conditional_return_class_level_trait_override.phpstub
@@ -1,0 +1,11 @@
+<?php
+namespace Psalm\Tests\Fixtures\ConditionalClassLevelTraitOverride;
+
+class MyClass
+{
+    /**
+     * @param string|null $key
+     * @return ($key is null ? array<string, int> : int|null)
+     */
+    public function get($key = null) {}
+}

--- a/tests/fixtures/stubs/conditional_return_scalar_trait_overrides_extra.phpstub
+++ b/tests/fixtures/stubs/conditional_return_scalar_trait_overrides_extra.phpstub
@@ -1,0 +1,11 @@
+<?php
+namespace Psalm\Tests\Fixtures\ConditionalScalarTraitOverride;
+
+trait MyTrait
+{
+    /**
+     * @param string|null $key
+     * @return ($key is null ? array<string, int> : int|null)
+     */
+    public function get($key = null) {}
+}

--- a/tests/fixtures/stubs/conditional_return_with_this_overrides_extra.phpstub
+++ b/tests/fixtures/stubs/conditional_return_with_this_overrides_extra.phpstub
@@ -1,0 +1,11 @@
+<?php
+namespace Psalm\Tests\Fixtures\ConditionalThisOverride;
+
+class Route
+{
+    /**
+     * @param string[]|string|null $middleware
+     * @return ($middleware is null ? string[] : $this)
+     */
+    public function middleware($middleware = null) {}
+}


### PR DESCRIPTION
Fixes #11837.

When a stub redeclares a method whose source was scanned but not analyzed (in `<extraFiles>` or any non-`<projectFiles>` location), the conditional `@return` collapsed to its null branch for every call, regardless of the actual argument.

`FunctionLikeNodeScanner` reuses the existing `MethodStorage` on the stub pass and calls `setParams([])` to clear params, but leaves `$storage->template_types` intact. `getConditionalSanitizedTypeTokens` saw an existing `TGeneratedFromParam{n}` entry and skipped the re-wrap of the fresh `$param_storage->type` as a `TTemplateParam`. At call time, argument binding then had nothing to bind onto, so `MethodCallReturnTypeFetcher::replaceTemplateTypes` fell back to a `Type::getNever()` lower bound, `replaceConditional` treated the param as `never` (contained by the `null` check), and the conditional collapsed to its null branch.

The original branch-split that distinguished first-scan from rescan no longer serves a purpose once the rescan path must rebuild the wrap anyway. The fix drops the split, derives `$template_as_type` from the current `$param_storage->type` in all cases, and unconditionally seeds both `$storage->template_types[$template_name]` and the wrap from it. Stubs that change a param type relative to the source are now reflected, not silently masked by the first-scan entry.

The bug is wider than the original report suggested. The 2026-05-15 issue comment narrowed it: pure scalar branches (no `$this`) also reproduce, and the bug existed in 6.16.1 and 7.0.0-beta19 too. The `$this` shape was a separate regression from #11768 layered on top.

Surfaces in `psalm/plugin-laravel`: `Illuminate\Routing\Route::middleware()` ships in Laravel source as `@return ($middleware is null ? array : $this)` and the plugin stub redeclares it. Calling `->middleware(['x'])` returned `array<array-key, string>` instead of `$this`, breaking every chained call. Trait-based methods like `Illuminate\Http\Request::file()` hit the same path; the plugin's [#935 workaround](https://github.com/psalm/psalm-plugin-laravel/pull/935) (move conditional to consuming class) is no longer needed after this fix, but a regression test locks in that the workaround path keeps working.

Regression tests cover three shapes:
- class stub override carrying `$this` in the conditional (the original `Route::middleware` reproducer),
- trait stub override with a pure scalar conditional (the wider shape from the 2026-05-15 comment),
- class-level stub override of a trait method (the workaround path).

The sibling `&static` leak in invariant generic args (also reported under #11837) has a different mechanism and ships in a separate PR (#11839).

`composer cs` clean. StubTest, Template/ConditionalReturnTypeTest, TraitTest, Template/ClassTemplateTest, and Template/FunctionTemplateTest all pass on the worktree.