### PR TITLE
[6.x] Fix parallel scan crash on PHP-native intersection types

### DIFF
--- a/src/Psalm/Type.php
+++ b/src/Psalm/Type.php
@@ -805,32 +805,36 @@ abstract class Type
 
             //if a type is contained by the other, the intersection is the narrowest type
             if (!$intersection_performed) {
-                $type_1_in_2 = UnionTypeComparator::isContainedBy(
-                    $codebase,
-                    $type_1,
-                    $type_2,
-                    false,
-                    false,
-                    null,
-                    $allow_interface_equality,
-                    $allow_float_int_equality,
-                );
-                $type_2_in_1 = UnionTypeComparator::isContainedBy(
-                    $codebase,
-                    $type_2,
-                    $type_1,
-                    false,
-                    false,
-                    null,
-                    $allow_interface_equality,
-                    $allow_float_int_equality,
-                );
-                if ($type_1_in_2) {
-                    $intersection_performed = true;
-                    $combined_type = $type_1->getBuilder();
-                } elseif ($type_2_in_1) {
-                    $intersection_performed = true;
-                    $combined_type = $type_2->getBuilder();
+                try {
+                    $type_1_in_2 = UnionTypeComparator::isContainedBy(
+                        $codebase,
+                        $type_1,
+                        $type_2,
+                        false,
+                        false,
+                        null,
+                        $allow_interface_equality,
+                        $allow_float_int_equality,
+                    );
+                    $type_2_in_1 = UnionTypeComparator::isContainedBy(
+                        $codebase,
+                        $type_2,
+                        $type_1,
+                        false,
+                        false,
+                        null,
+                        $allow_interface_equality,
+                        $allow_float_int_equality,
+                    );
+                    if ($type_1_in_2) {
+                        $intersection_performed = true;
+                        $combined_type = $type_1->getBuilder();
+                    } elseif ($type_2_in_1) {
+                        $intersection_performed = true;
+                        $combined_type = $type_2->getBuilder();
+                    }
+                } catch (InvalidArgumentException) {
+                    // Ignore non-existing classes during initial scan
                 }
             }
 


### PR DESCRIPTION
Scanning a codebase that uses PHP-native intersection types in function signatures (e.g. `Map&ResultInterface&stdClass&Vector` from azjezz/psl) intermittently crashed parallel scan workers with `Could not get class storage for stdclass` (or various other class names) thrown from `ClassLikeStorageProvider::get`.

The crash path is `FunctionLikeNodeScanner::start` → `getTranslatedFunctionParam` → `TypeHintResolver::resolve` (intersection branch) → `Type::intersectUnionTypes`. Inside `intersectUnionTypes` there is a per-atomic-pair narrowing pass and a final union-level narrowing pass. The per-atomic pass already wraps `UnionTypeComparator::isContainedBy` in `try { ... } catch (InvalidArgumentException) { /* Ignore non-existing classes during initial scan */ }` because this exact scenario was anticipated. The final union-level narrowing block at line 808 was missing the same guard, so it bubbled the throw out of the worker.

That block only runs when `$intersection_performed` is false after the cross-product loop, which happens for pairs of `TNamedObject` where `mayHaveIntersection` returns false on at least one side (a final class with storage already populated). Whether a given parallel worker has the storage for the final class depends on the order in which it scanned files — Vector and Map in psl are both `final readonly class`, so workers that processed those files before `intersection.php` hit the crash, and workers that didn't processed it via the defensive `mayHaveIntersection=true` path. Hence the ~50% crash rate. Confirmed via debug logging: when `mhi1=0 mhi2=1` (Vector storage present, ResultInterface storage absent) the unwrapped narrowing block ran and threw on the missing class.

The fix wraps the union-level narrowing block in the same `try`/`catch` already used at lines 928 and 988 of the same function. When containment can't be determined because storage is missing, the narrowing optimization is skipped and the un-narrowed type is returned, which is exactly what the user-visible "lighter-weight intersection that doesn't need containment data" should look like.

Verification:
* 30+30+20 parallel runs of psl (Psalm 6.x with this fix) on a host that previously crashed ~50% of the time: zero crashes.
* 20 runs of psl with `--scan-threads=1`: zero crashes, deterministic 3127 errors (matches single-thread baseline).
* Full paratest suite: 21115 tests, 76 failures, 78 skipped — identical to the pre-fix baseline. The earlier draft of this fix that guarded `classExtends` directly broke 8 of those tests because `InternalCallMapHandlerTest::assertTypeValidity` explicitly catches `InvalidArgumentException` from that path as a "skip this assertion when storage isn't loaded" signal; that contract is preserved here.
* Real-app benchmark across 14 apps (laravel-framework, symfony, drupal, sylius, rector, php-cs-fixer, monica, bagisto, etc.) shows the psl crash is gone and 13 of 14 apps are at exactly the same issue count as the pre-fix baseline. Two divergences worth noting: php-cs-fixer goes from 7,638 to 7,642 because the previous wrong-type narrowing was hiding four real `DocblockTypeContradiction`/`NullableReturnStatement` issues in a `getBlockType` function whose `?int` native return contradicts its `@return Tokens::BLOCK_TYPE_*` docblock; psl goes from 3,473 to 3,474 because the test file `packages/type/tests/static-analysis/intersection.php` (designed specifically to exercise `Map&ResultInterface&stdClass&Vector`) now consistently flags that the docblock and native parsers produce different intersection representations for the same syntax. The +1 in psl is a side effect of `intersectUnionTypes` returning null when narrowing fails, which `TypeHintResolver` then converts to `Type::getNever()`; the previous behavior was to either crash or non-deterministically hit the defensive `mayHaveIntersection=true` path. A follow-up could refine the null-degradation path to preserve the cross-product, but that is a separate, pre-existing issue.

Bench summary table (relevant column = `6.16.1-12-32347e114`):

| App | 6.16.1-11-6ff4aa2b4 | 6.16.1-12 (this fix) | Delta |
|---|---:|---:|---:|
| psl | 3,473 | 3,474 | +1 (test file) |
| php-cs-fixer | 7,638 | 7,642 | +4 (real bugs surfaced) |
| all 12 others | unchanged | unchanged | 0 |
