### PR TITLE
Fix DateInterval::createFromDateString return type for PHP 8.3+

### DIFF
--- a/dictionaries/CallMap_83.php
+++ b/dictionaries/CallMap_83.php
@@ -13170,7 +13170,7 @@ return array (
   ),
   'dateinterval::createfromdatestring' => 
   array (
-    0 => 'DateInterval|false',
+    0 => 'DateInterval',
     'datetime' => 'string',
   ),
   'dateinterval::format' => 

--- a/dictionaries/override/CallMap_83_delta.php
+++ b/dictionaries/override/CallMap_83_delta.php
@@ -28,6 +28,19 @@ return array (
         'timezone' => 'DateTimeZone|IntlTimeZone|null|string',
       ),
     ),
+    'dateinterval::createfromdatestring' =>
+    array (
+      'old' =>
+      array (
+        0 => 'DateInterval|false',
+        'datetime' => 'string',
+      ),
+      'new' =>
+      array (
+        0 => 'DateInterval',
+        'datetime' => 'string',
+      ),
+    ),
     'gc_status' => 
     array (
       'old' => 

--- a/dictionaries/override/CallMap_84_delta.php
+++ b/dictionaries/override/CallMap_84_delta.php
@@ -44,19 +44,6 @@ return array (
         'strength' => 'int',
       ),
     ),
-    'dateinterval::createfromdatestring' => 
-    array (
-      'old' => 
-      array (
-        0 => 'DateInterval|false',
-        'datetime' => 'string',
-      ),
-      'new' => 
-      array (
-        0 => 'DateInterval',
-        'datetime' => 'string',
-      ),
-    ),
     'domdocument::registernodeclass' => 
     array (
       'old' => 

--- a/src/Psalm/Config.php
+++ b/src/Psalm/Config.php
@@ -2360,6 +2360,10 @@ final class Config
             $this->php_extensions['random'] = true; // random is a part of the PHP core starting from PHP 8.2
         }
 
+        if ($codebase->analysis_php_version_id >= 8_03_00) {
+            $this->internal_stubs[] = $stubsDir . 'Php83.phpstub';
+        }
+
         if ($codebase->analysis_php_version_id >= 8_04_00) {
             $this->internal_stubs[] = $stubsDir . 'Php84.phpstub';
         }

--- a/stubs/Php83.phpstub
+++ b/stubs/Php83.phpstub
@@ -1,0 +1,11 @@
+<?php
+namespace {
+    class DateInterval
+    {
+        /**
+         * @return DateInterval
+         * @throws DateMalformedIntervalStringException
+         */
+        public static function createFromDateString(string $datetime = ''): DateInterval {}
+    }
+}

--- a/tests/CoreStubsTest.php
+++ b/tests/CoreStubsTest.php
@@ -107,6 +107,27 @@ final class CoreStubsTest extends TestCase
             'ignored_issues' => ['RedundantCondition'],
             'php_version' => '8.0',
         ];
+        yield 'DateInterval::createFromDateString returns DateInterval|false on PHP 8.2' => [
+            'code' => '<?php
+
+            $i = DateInterval::createFromDateString("42 days");',
+            'assertions' => [
+                '$i' => 'DateInterval|false',
+            ],
+            'ignored_issues' => [],
+            'php_version' => '8.2',
+        ];
+        yield 'DateInterval::createFromDateString returns DateInterval on PHP 8.3' => [
+            'code' => '<?php
+
+            $i = DateInterval::createFromDateString("42 days");
+            echo $i->format("%d");',
+            'assertions' => [
+                '$i' => 'DateInterval',
+            ],
+            'ignored_issues' => [],
+            'php_version' => '8.3',
+        ];
         yield 'sprintf yields a non-empty-string for non-empty-string value' => [
             'code' => '<?php
 


### PR DESCRIPTION
On PHP 8.3 and newer `DateInterval::createFromDateString()` throws `DateMalformedIntervalStringException` on failure instead of returning `false` (see php/php-src#10366). Psalm still reports `PossiblyFalseReference` when calling a method on the return value of `createFromDateString`, even when targeting PHP 8.3 and newer.

See also https://www.php.net/manual/en/dateinterval.createfromdatestring.php#refsect1-dateinterval.createfromdatestring-changelog

The return type change was considered in `CallMap_84_delta.php`, but I think it should be in `CallMap_83_delta.php`.

The CallMap lookup seems to be skipped for Psalm's own stubs. I added a `Php83.phpstub` that overrides the `createFromDateString` definition in `stubs/CoreGenericClasses.phpstub` with return type `DateInterval`.

https://github.com/vimeo/psalm/blob/ca151242c84d8962b921bf59c509b49362ce0eec/stubs/CoreGenericClasses.phpstub#L624-L631

There are two new test cases in `CoreStubsTest`. One is confirming the return type is still `DateInterval|false` for PHP 8.2 and the other one is confirming it's `DateInterval` on PHP 8.3.