### PR TITLE
Fix: Stub generation for union types that result to scalar could not be converted to identifier

### DIFF
--- a/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
@@ -313,6 +313,9 @@ final class StubsGenerator
     {
         $nullable = $type->isNullable();
 
+        // just a stupid test
+        var_dump($type->getAtomicTypes());
+
         foreach ($type->getAtomicTypes() as $atomic_type) {
             if ($atomic_type instanceof TNull) {
                 continue;


### PR DESCRIPTION
Encountered the same issue described in detail [here](https://github.com/vimeo/psalm/issues/11805) by `alies-dev`  and wanted to fix this issue

This is just a test to see if things work out like I expect them to locally. In case anybody except me does see this... Damn it