### PR TITLE
Fix: Stub generation for union types that result to scalar could not be converted to identifier

### DIFF
--- a/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
+++ b/src/Psalm/Internal/Stubs/Generator/StubsGenerator.php
@@ -18,6 +18,7 @@ use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TObject;
+use Psalm\Type\Atomic\TScalar;
 use Psalm\Type\Atomic\TTrue;
 use Psalm\Type\Atomic\Scalar;
 use PhpParser;
@@ -314,7 +315,7 @@ final class StubsGenerator
         $nullable = $type->isNullable();
 
         foreach ($type->getAtomicTypes() as $atomic_type) {
-            if ($atomic_type instanceof TNull) {
+            if ($atomic_type instanceof TNull || $atomic_type instanceof TScalar) {
                 continue;
             }
 
@@ -345,7 +346,6 @@ final class StubsGenerator
                 if ($nullable) {
                     return new VirtualNullableType($name_node);
                 }
-
                 return $name_node;
             }
         }

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -6,6 +6,8 @@ namespace Psalm\Type\Atomic;
 
 use Override;
 
+use function is_nan;
+
 /**
  * Denotes a floating point value where the exact numeric value is known.
  *


### PR DESCRIPTION
Encountered the same issue described in detail [here](https://github.com/vimeo/psalm/issues/11805) by @alies-dev and wanted to fix this issue.

If atomic_type is an object from class TScalar, treat it like TNull

TScalar is an instance of Scalar, though `toPhpString` would always return `null`, thus we would always encounter an UnexpectedValueException.

Fixes: #11805 