### PR TITLE
Fix ClassMustBeFinal final insertion for #11460

### DIFF
--- a/src/Psalm/Internal/Codebase/ClassLikes.php
+++ b/src/Psalm/Internal/Codebase/ClassLikes.php
@@ -58,16 +58,25 @@ use function explode;
 use function get_declared_classes;
 use function get_declared_interfaces;
 use function implode;
+use function is_array;
+use function ltrim;
 use function preg_match;
 use function preg_quote;
 use function preg_replace;
+use function str_starts_with;
 use function strlen;
-use function strpos;
 use function strrpos;
 use function strtolower;
 use function substr;
+use function token_get_all;
 
 use const PHP_EOL;
+use const T_CLASS;
+use const T_COMMENT;
+use const T_DOC_COMMENT;
+use const T_READONLY;
+use const T_STRING;
+use const T_WHITESPACE;
 
 /**
  * @internal
@@ -868,30 +877,28 @@ final class ClassLikes
                     && !$classlike_storage->is_enum
                     && !$classlike_storage->is_interface
                 ) {
+                    $code_issue = new ClassMustBeFinal(
+                        'Class ' . $classlike_storage->name
+                            . ' is never extended and is not part of the public API, and thus must be made final.',
+                        $classlike_storage->location,
+                        $classlike_storage->name,
+                    );
+
                     IssueBuffer::maybeAdd(
-                        new ClassMustBeFinal(
-                            'Class ' . $classlike_storage->name
-                                . ' is never extended and is not part of the public API, and thus must be made final.',
-                            $classlike_storage->location,
-                            $classlike_storage->name,
-                        ),
+                        $code_issue,
                         $classlike_storage->suppressed_issues,
                         true,
                     );
                     
                     if ($codebase->alter_code
                         && $classlike_storage->stmt_location !== null
+                        && !IssueBuffer::isSuppressed($code_issue, $classlike_storage->suppressed_issues)
                         && isset($project_analyzer->getIssuesToFix()['ClassMustBeFinal'])
                     ) {
-                        $selection = $classlike_storage->stmt_location->getSnippet();
-                        $insert_pos = strpos($selection, "class");
-        
-                        if ($insert_pos === false) {
-                            $insert_pos = $classlike_storage->stmt_location->getSelectionBounds()[0];
-                        }
+                        $insert_pos = self::getFinalInsertionPosition($classlike_storage->stmt_location);
 
                         FileManipulationBuffer::add($classlike_storage->stmt_location->file_path, [
-                            new FileManipulation($insert_pos, $insert_pos, 'final ', true),
+                            new FileManipulation($insert_pos, $insert_pos, 'final '),
                         ]);
                     }
                 }
@@ -1031,6 +1038,86 @@ final class ClassLikes
         }
 
         FileManipulationBuffer::addCodeMigrations($code_migrations);
+    }
+
+    private static function getFinalInsertionPosition(CodeLocation $class_location): int
+    {
+        $selection = $class_location->getSnippet();
+        $snippet_bounds = $class_location->getSnippetBounds();
+        $tokenized_selection = str_starts_with(ltrim($selection), '<?php')
+            ? $selection
+            : '<?php ' . $selection;
+        $tokens = token_get_all($tokenized_selection);
+
+        $offset = $tokenized_selection === $selection ? 0 : -6;
+        $previous_significant_token = null;
+        $previous_significant_offset = null;
+
+        foreach ($tokens as $i => $token) {
+            if (is_array($token)) {
+                [$token_id, $token_text] = $token;
+
+                if ($token_id === T_CLASS && self::isClassDeclarationToken($tokens, $i)) {
+                    if ($previous_significant_token === T_READONLY && $previous_significant_offset !== null) {
+                        return $snippet_bounds[0] + $previous_significant_offset;
+                    }
+
+                    return $snippet_bounds[0] + $offset;
+                }
+
+                if (!self::isTriviaToken($token_id)) {
+                    $previous_significant_token = $token_id;
+                    $previous_significant_offset = $offset;
+                }
+
+                $offset += strlen($token_text);
+                continue;
+            }
+
+            if ($token !== '{'
+                && $token !== '}'
+                && $token !== '('
+                && $token !== ')'
+                && $token !== '['
+                && $token !== ']'
+            ) {
+                $previous_significant_token = $token;
+                $previous_significant_offset = $offset;
+            }
+
+            $offset += strlen($token);
+        }
+
+        return $class_location->getSelectionBounds()[0];
+    }
+
+    /**
+     * @param array<int, array{0: int, 1: string, 2: int}|string> $tokens
+     */
+    private static function isClassDeclarationToken(array $tokens, int $class_token_offset): bool
+    {
+        for ($i = $class_token_offset + 1, $c = count($tokens); $i < $c; $i++) {
+            $token = $tokens[$i];
+
+            if (is_array($token)) {
+                if (self::isTriviaToken($token[0])) {
+                    continue;
+                }
+
+                return $token[0] === T_STRING;
+            }
+
+            return false;
+        }
+
+        return false;
+    }
+
+    private static function isTriviaToken(int $token_id): bool
+    {
+        return $token_id === T_WHITESPACE
+            || $token_id === T_COMMENT
+            || $token_id === T_DOC_COMMENT;
     }
 
     public function moveProperties(Properties $properties, ?Progress $progress = null): void

--- a/tests/FileManipulation/UnusedCodeManipulationTest.php
+++ b/tests/FileManipulation/UnusedCodeManipulationTest.php
@@ -12,6 +12,83 @@ final class UnusedCodeManipulationTest extends FileManipulationTestCase
     public function providerValidCodeParse(): array
     {
         return [
+            'addFinalToUnusedClassAfterUseStatements' => [
+                'input' => '<?php
+                    namespace Foo;
+
+                    use DateTimeImmutable;
+                    use RuntimeException;
+
+                    class A {
+                        public function foo(DateTimeImmutable $date) : void {
+                            throw new RuntimeException($date->format("c"));
+                        }
+                    }',
+                'output' => '<?php
+                    namespace Foo;
+
+                    use DateTimeImmutable;
+                    use RuntimeException;
+
+                    final class A {
+                        public function foo(DateTimeImmutable $date) : void {
+                            throw new RuntimeException($date->format("c"));
+                        }
+                    }',
+                'php_version' => '8.1',
+                'issues_to_fix' => ['ClassMustBeFinal'],
+                'safe_types' => true,
+            ],
+            'addFinalToReadonlyUnusedClass' => [
+                'input' => '<?php
+                    readonly class A {
+                        public function __construct(public string $name) {}
+                    }',
+                'output' => '<?php
+                    final readonly class A {
+                        public function __construct(public string $name) {}
+                    }',
+                'php_version' => '8.2',
+                'issues_to_fix' => ['ClassMustBeFinal'],
+                'safe_types' => true,
+            ],
+            'addFinalAfterAttributeOnUnusedClass' => [
+                'input' => '<?php
+                    #[Attribute]
+                    class A {}',
+                'output' => '<?php
+                    #[Attribute]
+                    final class A {}',
+                'php_version' => '8.1',
+                'issues_to_fix' => ['ClassMustBeFinal'],
+                'safe_types' => true,
+            ],
+            'dontAddFinalToSuppressedUnusedClass' => [
+                'input' => '<?php
+                    /** @psalm-suppress ClassMustBeFinal */
+                    class A {}',
+                'output' => '<?php
+                    /** @psalm-suppress ClassMustBeFinal */
+                    class A {}',
+                'php_version' => '8.1',
+                'issues_to_fix' => ['ClassMustBeFinal'],
+                'safe_types' => true,
+            ],
+            'addFinalAfterDocblockThatMentionsClass' => [
+                'input' => '<?php
+                    /**
+                     * Example: class A is documented here.
+                     */
+                    class A {}',
+                'output' => '<?php
+                    /**
+                     * Example: class A is documented here.
+                     */
+                    final class A {}',
+                'php_version' => '8.1',
+                'issues_to_fix' => ['ClassMustBeFinal'],
+                'safe_types' => true,
+            ],
             'removePossiblyUnusedMethod' => [
                 'input' => '<?php
                     class A {


### PR DESCRIPTION
ClassMustBeFinal used a text search over the class statement snippet and treated the relative match offset as a file offset. During --alter this could insert "final" near the start of the file, such as before <?php, before a namespace/use statement, or inside leading text.

The fixes implemented:

- uses an absolute file offset instead of a relative snippet offset
- inserts before readonly class, producing final readonly class
- avoids adding manipulations for suppressed ClassMustBeFinal issues

It also fixes remaining cases not covered by PR #11542:

- preserves attribute placement by inserting after attributes and before class
- avoids duplicate indentation by not preserving indentation for "final "
- avoids matching "class" inside docblocks or other non-declaration text
- there are PHPUnit tests

The insertion point is now derived from the actual class declaration token in the snippet, then translated back to the corresponding file offset before the file manipulation is added. This should fix Issue #11460.

---

This is LLM-assisted code, GPT-5.5 Low in Codex. I did review it, and looks like it does what it should do. I see [`token-get-all()`](https://www.php.net/manual/en/function.token-get-all.php) is also used to (re-)parse PHP in some other gnarly spots. Further fixes of the regex code from the original PR did not seem to be a viable approach.