### PR TITLE
Fix for coding standard issue in commit ca15124

### DIFF
--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -6,6 +6,8 @@ namespace Psalm\Type\Atomic;
 
 use Override;
 
+use function is_nan;
+
 /**
  * Denotes a floating point value where the exact numeric value is known.
  *


### PR DESCRIPTION
Current PHPCS/Slevomat requires is_nan() to be imported instead of referenced through the fallback global namespace.