### PR TITLE
Fix coalesce with function call array key

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/BinaryOp/CoalesceAnalyzer.php
@@ -6,6 +6,7 @@ namespace Psalm\Internal\Analyzer\Statements\Expression\BinaryOp;
 
 use PhpParser;
 use Psalm\Context;
+use Psalm\Internal\Analyzer\Statements\Expression\ExpressionIdentifier;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Node\Expr\VirtualIsset;
@@ -45,6 +46,12 @@ final class CoalesceAnalyzer
             || $root_expr instanceof PhpParser\Node\Expr\NullsafePropertyFetch
             || $root_expr instanceof PhpParser\Node\Expr\NullsafeMethodCall
             || $root_expr instanceof PhpParser\Node\Expr\Ternary
+            || ($left_expr instanceof PhpParser\Node\Expr\ArrayDimFetch
+                && ExpressionIdentifier::getExtendedVarId(
+                    $left_expr,
+                    $statements_analyzer->getFQCLN(),
+                    $statements_analyzer,
+                ) === null)
         ) {
             $left_var_id = '$<tmp coalesce var>' . (int) $left_expr->getAttribute('startFilePos');
 

--- a/tests/TypeReconciliation/ConditionalTest.php
+++ b/tests/TypeReconciliation/ConditionalTest.php
@@ -1396,6 +1396,17 @@ final class ConditionalTest extends TestCase
                         return $arr["b"] ?? "bar";
                     }',
             ],
+            'nullCoalesceNullableArrayValueWithFunctionCallKey' => [
+                'code' => '<?php
+                    /** @param array<string, ?string> $foo */
+                    function foo(array $foo, string $key, string $default): string {
+                        return $foo[bar($key)] ?? $default;
+                    }
+
+                    function bar(string $key): string {
+                        return "aa$key";
+                    }',
+            ],
             'nullCoalesceTypedValue' => [
                 'code' => '<?php
                     function foo(?string $s) : string {


### PR DESCRIPTION
Fixes #11857

ExpressionIdentifier::getExtendedVarId() is used to find out whether Psalm can give the entire left-hand array lookup a stable internal id. If it can, normal isset() reconciliation is enough. If it cannot, as with bar($key), then the id === null, and we create a temporary variable so Psalm can narrow that temporary instead.

It does not try to prove that `bar($key)`  is stable, pure, or repeatable.