### PR TITLE
Fix builtin class string instantiation

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -209,6 +209,8 @@ final class NewAnalyzer extends CallAnalyzer
                     return true;
                 }
 
+                $codebase->scanner->registerReflectedClassLikeStorage($fq_class_name);
+
                 if (ClassLikeAnalyzer::checkFullyQualifiedClassLikeName(
                     $statements_analyzer,
                     $fq_class_name,

--- a/src/Psalm/Internal/Codebase/Scanner.php
+++ b/src/Psalm/Internal/Codebase/Scanner.php
@@ -32,15 +32,20 @@ use function array_filter;
 use function array_merge;
 use function array_pop;
 use function ceil;
+use function class_exists;
 use function count;
+use function enum_exists;
 use function error_reporting;
 use function explode;
 use function file_exists;
+use function interface_exists;
+use function ltrim;
 use function min;
 use function realpath;
 use function str_ends_with;
 use function strtolower;
 use function substr;
+use function trait_exists;
 
 use const DIRECTORY_SEPARATOR;
 use const PHP_EOL;
@@ -148,6 +153,25 @@ final class Scanner
         private readonly FileReferenceProvider $file_reference_provider,
         private readonly Progress $progress,
     ) {
+    }
+
+    public function registerReflectedClassLikeStorage(string $fq_classlike_name): void
+    {
+        $fq_classlike_name = ltrim($fq_classlike_name, '\\');
+        $fq_classlike_name_lc = strtolower($fq_classlike_name);
+
+        if ($this->codebase->classlike_storage_provider->has($fq_classlike_name)
+            || !$this->codebase->classlikes->doesClassLikeExist($fq_classlike_name_lc)
+            || (!class_exists($fq_classlike_name, false)
+                && !interface_exists($fq_classlike_name, false)
+                && !enum_exists($fq_classlike_name, false)
+                && !trait_exists($fq_classlike_name, false))
+        ) {
+            return;
+        }
+
+        $this->reflection->registerClass(new ReflectionClass($fq_classlike_name));
+        $this->reflected_classlikes_lc[$fq_classlike_name_lc] = true;
     }
 
     /**

--- a/tests/ClassLikeStringTest.php
+++ b/tests/ClassLikeStringTest.php
@@ -35,6 +35,31 @@ final class ClassLikeStringTest extends TestCase
         $this->analyzeFile('somefile.php', new Context());
     }
 
+    public function testAllowBuiltinClassStringStandInForNewClass(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        // Reproduces a crash present since 3.4.0@99e6cd819f829babf50c5852d6f62d40b1fec9d9 (2019-06-03).
+        Config::getInstance()->allow_string_standin_for_class = true;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                namespace Foo;
+
+                class UsesBuiltinClassString
+                {
+                    public function run(): void
+                    {
+                        $throwable_class = "\\AssertionError";
+                        throw new $throwable_class("failed");
+                    }
+                }',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+    }
+
     public function testDontAllowStringStandInForStaticMethodCall(): void
     {
         $this->expectExceptionMessage('InvalidStringClass');


### PR DESCRIPTION
Fixes #11491 

Replaces #11502 with a narrower fix.

Since 3.4.0 @ 99e6cd819f829babf50c5852d6f62d40b1fec9d9 (2019-06-03) Psalm can crash when a string literal containing a built-in/runtime class name is used for dynamic instantiation:

```php
$throwable_class = "\\AssertionError";
throw new $throwable_class("failed");
```

This PR keeps the fix at the point where the behavior is needed: dynamic instantiation analysis in NewAnalyzer.

Before validating the classlike for `new $class_name`, Psalm now ensures reflected storage exists when all of these are true:

- the class name is already known to Psalm as an existing classlike,
- storage is not already present,
- PHP already has the class/interface/enum/trait loaded.

The runtime existence checks use `*_exists(..., false)`, so this does not trigger autoloading while analyzing arbitrary values.

## Tests

Added coverage in ClassLikeStringTest for instantiating `\AssertionError` through a string variable with `allow_string_standin_for_class` is enabled.