### PR TITLE
Restore ReflectionClass template covariance in PHP 8.4 stub

### DIFF
--- a/stubs/Php84.phpstub
+++ b/stubs/Php84.phpstub
@@ -1,7 +1,7 @@
 <?php
 namespace {
     /**
-     * @template T of object
+     * @template-covariant T as object
      */
     class ReflectionClass implements Reflector {
         /**

--- a/tests/ReflectionTest.php
+++ b/tests/ReflectionTest.php
@@ -45,5 +45,19 @@ final class ReflectionTest extends TestCase
                 PHP,
             'assertions' => ['$a===' => 'Iterator&stdClass'],
         ];
+        yield 'ReflectionClass template parameter stays covariant on PHP 8.4' => [
+            'code' => <<<'PHP'
+                <?php
+                /** @param ReflectionClass<object> $class */
+                function takesObjectReflection(ReflectionClass $class): string {
+                    return $class->getName();
+                }
+
+                echo takesObjectReflection(new ReflectionClass(stdClass::class));
+                PHP,
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.4',
+        ];
     }
 }


### PR DESCRIPTION
The PHP 8.4 stub (added in 21fe8ef16 to type the lazy-object methods) redeclares ReflectionClass with an invariant `@template T of object`, dropping the `@template-covariant` used by the base Reflection.phpstub and Php80.phpstub. Because a redeclaration with an explicit `@template` overrides the inherited one, analysing code against PHP 8.4/8.5 makes `ReflectionClass<Foo>` no longer assignable to `ReflectionClass<object>`, producing false-positive InvalidArgument errors.

The Php81/Php82 stubs redeclare `ReflectionClass` without an `@template` line and therefore correctly inherit the covariant parameter; only the 8.4 stub regressed. Restore `@template-covariant T as object` to match the base stub.

Adds a regression test (gated to php_version 8.4) that fails on the 8.4/8.5 CI runners without this change.