### PR TITLE
Fix false RedundantCondition for instanceof on a class-string variable

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -1292,9 +1292,14 @@ final class AssertionFinder
                             ),
                         );
                     } elseif ($atomic_type instanceof TClassString && $atomic_type->as !== 'object') {
-                        $literal_class_strings[] = new IsType(
-                            $atomic_type->as_type ?: new TNamedObject($atomic_type->as),
-                        );
+                        $as_type = $atomic_type->as_type ?: new TNamedObject($atomic_type->as);
+                        // an interface class-string can hold any implementor, so this is is_a, not a
+                        // fixed type, and must not read as redundant (#11076)
+                        if ($source->getCodebase()->interfaceExists($atomic_type->as)) {
+                            $literal_class_strings[] = new IsAClass($as_type, false);
+                        } else {
+                            $literal_class_strings[] = new IsType($as_type);
+                        }
                     }
                 }
 

--- a/tests/TypeReconciliation/RedundantConditionTest.php
+++ b/tests/TypeReconciliation/RedundantConditionTest.php
@@ -983,6 +983,18 @@ final class RedundantConditionTest extends TestCase
                         assert(!!$p);
                     }',
             ],
+            'instanceofClassStringVarIsNotRedundant' => [
+                'code' => '<?php
+                    /**
+                     * @param class-string<Traversable> $class
+                     */
+                    function test(Traversable $input, string $class): bool {
+                        if ($input instanceof $class) {
+                            return true;
+                        }
+                        return false;
+                    }',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/11076

`$x instanceof $class` where `$class` is a `class-string<I>` for an interface `I` was reported as `RedundantCondition` when `$x` was already `I`. The variable can name any class implementing `I`, so the check can be false (an `ArrayIterator` is not a `DirectoryIterator`, though both are `Traversable`). Interface class-strings now resolve through `is_a` instead of a fixed type, like `is_a($x, $class)` already does.
