### PR TITLE
Fix ??= in a condition not removing null from the assigned variable

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -645,6 +645,7 @@
       <code><![CDATA[$var_name]]></code>
       <code><![CDATA[$var_name]]></code>
       <code><![CDATA[$var_name]]></code>
+      <code><![CDATA[$var_name]]></code>
       <code><![CDATA[$var_name_left]]></code>
       <code><![CDATA[$var_name_right]]></code>
       <code><![CDATA[$var_type]]></code>

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -185,6 +185,22 @@ final class AssertionFinder
             return $if_types ? [$if_types] : [];
         }
 
+        // `$a ??= b` evaluates to the new value of `$a`, so a truthy result means `$a` is truthy.
+        // The right-hand side is not asserted, because when `$a` was already set the result is the old value.
+        if ($conditional instanceof PhpParser\Node\Expr\AssignOp\Coalesce) {
+            $var_name = ExpressionIdentifier::getExtendedVarId(
+                $conditional->var,
+                $this_class_name,
+                $source,
+            );
+
+            if ($var_name) {
+                $if_types[$var_name] = [[new Truthy()]];
+            }
+
+            return $if_types ? [$if_types] : [];
+        }
+
         $var_name = ExpressionIdentifier::getExtendedVarId(
             $conditional,
             $this_class_name,
@@ -2077,13 +2093,17 @@ final class AssertionFinder
         }
 
         $var_name = ExpressionIdentifier::getExtendedVarId(
-            $base_conditional,
+            $base_conditional instanceof PhpParser\Node\Expr\AssignOp\Coalesce
+                ? $base_conditional->var
+                : $base_conditional,
             $this_class_name,
             $source,
         );
 
         if ($var_name) {
-            if ($base_conditional instanceof PhpParser\Node\Expr\Assign) {
+            if ($base_conditional instanceof PhpParser\Node\Expr\Assign
+                || $base_conditional instanceof PhpParser\Node\Expr\AssignOp\Coalesce
+            ) {
                 $var_name = '=' . $var_name;
             }
 
@@ -2799,12 +2819,17 @@ final class AssertionFinder
         }
 
         $var_name = ExpressionIdentifier::getExtendedVarId(
-            $base_conditional,
+            $base_conditional instanceof PhpParser\Node\Expr\AssignOp\Coalesce
+                ? $base_conditional->var
+                : $base_conditional,
             $this_class_name,
             $source,
         );
 
-        if ($var_name && $base_conditional instanceof PhpParser\Node\Expr\Assign) {
+        if ($var_name
+            && ($base_conditional instanceof PhpParser\Node\Expr\Assign
+                || $base_conditional instanceof PhpParser\Node\Expr\AssignOp\Coalesce)
+        ) {
             $var_name = '=' . $var_name;
         }
 

--- a/tests/TypeReconciliation/AssignmentInConditionalTest.php
+++ b/tests/TypeReconciliation/AssignmentInConditionalTest.php
@@ -327,6 +327,86 @@ final class AssignmentInConditionalTest extends TestCase
                         echo $row[0];
                     }',
             ],
+            'negatedCoalesceAssignmentInIf' => [
+                'code' => '<?php
+                    function f(): object|null {
+                        return null;
+                    }
+
+                    function a(object|null $s): object {
+                        if (!($s ??= f())) {
+                            exit;
+                        }
+                        return $s;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'coalesceAssignmentIdenticalNull' => [
+                'code' => '<?php
+                    function f(): object|null {
+                        return null;
+                    }
+
+                    function a(object|null $s): object {
+                        if (($s ??= f()) === null) {
+                            exit;
+                        }
+                        return $s;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'coalesceAssignmentNotIdenticalNull' => [
+                'code' => '<?php
+                    function f(): object|null {
+                        return null;
+                    }
+
+                    function a(object|null $s): object {
+                        if (($s ??= f()) !== null) {
+                            return $s;
+                        }
+                        exit;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'coalesceAssignmentNullIdentical' => [
+                'code' => '<?php
+                    function f(): object|null {
+                        return null;
+                    }
+
+                    function a(object|null $s): object {
+                        if (null === ($s ??= f())) {
+                            exit;
+                        }
+                        return $s;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
+            'coalesceAssignmentNullNotIdentical' => [
+                'code' => '<?php
+                    function f(): object|null {
+                        return null;
+                    }
+
+                    function a(object|null $s): object {
+                        if (null !== ($s ??= f())) {
+                            return $s;
+                        }
+                        exit;
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.0',
+            ],
             'ifNotEqualsFalse' => [
                 'code' => '<?php
                     if (($row = rand(0,10) ? [1] : false) !== false) {


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/11158

A null coalescing assignment used inside a condition, like `if (!($s ??= f()))`, did not remove null from `$s` afterward, so `$s` stayed nullable even though the same logic written with `=` narrows it. `AssertionFinder` special-cased plain assignment but not `??=`.

Handle `AssignOp\Coalesce` like `Assign` when it is used as a condition or compared against null. Add regressions for both forms. The issue still reproduces on 6.x.
