### PR TITLE
Add @psalm-fixme support and --add-fixmes generator

### DIFF
--- a/docs/running_psalm/dealing_with_code_issues.md
+++ b/docs/running_psalm/dealing_with_code_issues.md
@@ -91,6 +91,32 @@ function (int $a) : string {
 
 If you wish to suppress all issues, you can use `@psalm-suppress all` instead of multiple annotations.
 
+### Marking known problems with `@psalm-fixme`
+
+`@psalm-fixme IssueName` suppresses an issue exactly like `@psalm-suppress`, but marks it
+as a known problem that should eventually be fixed — for example when migrating a
+baseline file to inline annotations. Like any suppression, a `@psalm-fixme` that no
+longer matches an issue is reported by `--find-unused-psalm-suppress`, so fixed issues
+naturally surface their stale annotations.
+
+```php
+<?php
+/**
+ * @psalm-fixme InvalidReturnType
+ */
+function (int $a) : string {
+  return $a;
+}
+```
+
+You can generate these annotations automatically from the issues Psalm currently
+reports with `--add-fixmes`, which inserts a `@psalm-fixme` on the innermost statement
+enclosing each issue (a good way to migrate an existing baseline to inline annotations):
+
+```
+vendor/bin/psalm --add-fixmes
+```
+
 ## Using a baseline file
 
 If you have a bunch of errors and you don't want to fix them all at once, Psalm can grandfather-in errors in existing code, while ensuring that new code doesn't have those same sorts of errors.

--- a/src/Psalm/DocComment.php
+++ b/src/Psalm/DocComment.php
@@ -36,7 +36,7 @@ final class DocComment
         'taint-unescape', 'self-out', 'consistent-constructor', 'stub-override',
         'require-extends', 'require-implements', 'param-out', 'ignore-var',
         'consistent-templates', 'if-this-is', 'this-out', 'check-type', 'check-type-exact',
-        'api', 'inheritors',
+        'api', 'inheritors', 'fixme',
     ];
 
     /**
@@ -48,6 +48,13 @@ final class DocComment
             $docblock->getText(),
             $docblock->getStartFilePos(),
         );
+
+        // @psalm-fixme suppresses exactly like @psalm-suppress, but marks the
+        // issue as a known problem to fix (e.g. migrated from a baseline).
+        if (isset($parsed_docblock->tags['psalm-fixme'])) {
+            $parsed_docblock->tags['psalm-suppress'] =
+                ($parsed_docblock->tags['psalm-suppress'] ?? []) + $parsed_docblock->tags['psalm-fixme'];
+        }
 
         if ($no_psalm_error) {
             return $parsed_docblock;

--- a/src/Psalm/Internal/Cli/Psalm.php
+++ b/src/Psalm/Internal/Cli/Psalm.php
@@ -16,6 +16,7 @@ use Psalm\Internal\CliUtils;
 use Psalm\Internal\Codebase\ReferenceMapGenerator;
 use Psalm\Internal\Composer;
 use Psalm\Internal\ErrorHandler;
+use Psalm\Internal\Fixme\FixmeAdder;
 use Psalm\Internal\Fork\PsalmRestarter;
 use Psalm\Internal\IncludeCollector;
 use Psalm\Internal\Preloader;
@@ -150,6 +151,7 @@ final class Psalm
         'report-show-info:',
         'root:',
         'set-baseline::',
+        'add-fixmes',
         'show-info:',
         'show-snippet::',
         'stats',
@@ -400,6 +402,12 @@ final class Psalm
             $project_analyzer->check($current_dir, $is_diff);
         } elseif ($paths_to_check) {
             $project_analyzer->checkPaths($paths_to_check);
+        }
+
+        if (isset($options['add-fixmes'])) {
+            $added = FixmeAdder::add($project_analyzer);
+            fwrite(STDERR, $added . ' @psalm-fixme annotation(s) added' . PHP_EOL);
+            exit(0);
         }
 
         if ($find_references_to) {

--- a/src/Psalm/Internal/Fixme/FixmeAdder.php
+++ b/src/Psalm/Internal/Fixme/FixmeAdder.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Internal\Fixme;
+
+use PhpParser\Comment\Doc;
+use PhpParser\Node\Stmt;
+use PhpParser\NodeFinder;
+use Psalm\FileManipulation;
+use Psalm\Internal\Analyzer\IssueData;
+use Psalm\Internal\Analyzer\ProjectAnalyzer;
+use Psalm\IssueBuffer;
+use Throwable;
+
+use function array_keys;
+use function count;
+use function implode;
+use function preg_match_all;
+use function preg_split;
+use function sort;
+use function spl_object_id;
+use function str_contains;
+use function strlen;
+use function strrpos;
+use function substr;
+use function trim;
+use function usort;
+
+use const PREG_SET_ORDER;
+
+/**
+ * Turns the issues Psalm currently reports into inline `@psalm-fixme` annotations.
+ *
+ * For each issue it finds the innermost statement enclosing the issue and adds a
+ * `@psalm-fixme <IssueType>` to that statement's docblock (creating one if needed).
+ * When the innermost statement already carries that annotation — meaning a previous
+ * run added it there but it did not suppress the issue — the annotation is escalated
+ * to the next enclosing statement, so repeated runs converge on a working location.
+ *
+ * The adder is purely additive: it never removes annotations. A `@psalm-fixme` that
+ * ends up not suppressing anything is reported by `--find-unused-psalm-suppress`, which
+ * is the supported way to surface and prune stale annotations.
+ *
+ * @internal
+ */
+final class FixmeAdder
+{
+    /**
+     * @return int number of `@psalm-fixme` annotations added
+     */
+    public static function add(ProjectAnalyzer $project_analyzer): int
+    {
+        $codebase = $project_analyzer->getCodebase();
+        $file_provider = $codebase->file_provider;
+
+        $added = 0;
+
+        foreach (IssueBuffer::getIssuesData() as $file_path => $file_issues) {
+            if (!$file_provider->fileExists($file_path)) {
+                continue;
+            }
+
+            try {
+                $stmts = $codebase->getStatementsForFile($file_path);
+            } catch (Throwable) {
+                continue;
+            }
+
+            $contents = $file_provider->getContents($file_path);
+
+            $stmt_nodes = (new NodeFinder())->findInstanceOf($stmts, Stmt::class);
+
+            // target statement (by object id) => [stmt, types-to-add]
+            $targets = [];
+            $manipulations = [];
+
+            foreach ($file_issues as $issue) {
+                $target = self::findTargetStmt($stmt_nodes, $issue);
+
+                if ($target === null) {
+                    continue;
+                }
+
+                $id = spl_object_id($target);
+
+                if (!isset($targets[$id])) {
+                    $targets[$id] = ['stmt' => $target, 'types' => []];
+                }
+
+                $targets[$id]['types'][$issue->type] = true;
+            }
+
+            foreach ($targets as ['stmt' => $stmt, 'types' => $types]) {
+                $manipulations[] = self::buildManipulation($stmt, array_keys($types), $contents);
+                $added += count($types);
+            }
+
+            if (!$manipulations) {
+                continue;
+            }
+
+            // apply from the end of the file backwards so offsets stay valid, skipping
+            // any manipulation that overlaps one already applied (handled on a later run)
+            usort($manipulations, static fn(FileManipulation $a, FileManipulation $b): int => $b->start <=> $a->start);
+
+            $min_start = strlen($contents);
+
+            foreach ($manipulations as $manipulation) {
+                if ($manipulation->end > $min_start) {
+                    continue;
+                }
+
+                $contents = $manipulation->transform($contents);
+                $min_start = $manipulation->start;
+            }
+
+            $file_provider->setContents($file_path, $contents);
+        }
+
+        return $added;
+    }
+
+    /**
+     * @param array<Stmt> $stmt_nodes
+     */
+    private static function findTargetStmt(array $stmt_nodes, IssueData $issue): ?Stmt
+    {
+        $offset = $issue->from;
+
+        $covering = [];
+
+        foreach ($stmt_nodes as $stmt) {
+            $start = $stmt->getStartFilePos();
+            $end = $stmt->getEndFilePos();
+
+            if ($start < 0 || $end < 0) {
+                continue;
+            }
+
+            if ($start <= $offset && $offset <= $end) {
+                $covering[] = $stmt;
+            }
+        }
+
+        if (!$covering) {
+            return null;
+        }
+
+        // innermost first: the statement with the largest start position
+        usort($covering, static fn(Stmt $a, Stmt $b): int => $b->getStartFilePos() <=> $a->getStartFilePos());
+
+        foreach ($covering as $stmt) {
+            $suppressed = self::getSuppressedTypes($stmt->getDocComment());
+
+            if (isset($suppressed['all']) || isset($suppressed[$issue->type])) {
+                // already annotated here but the issue persists — escalate outwards
+                continue;
+            }
+
+            return $stmt;
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string, true>
+     */
+    private static function getSuppressedTypes(?Doc $docblock): array
+    {
+        if ($docblock === null) {
+            return [];
+        }
+
+        $match_count = preg_match_all(
+            '/@psalm-(?:suppress|fixme)\s+([^\n*]+)/',
+            $docblock->getText(),
+            $matches,
+            PREG_SET_ORDER,
+        );
+
+        if ($match_count === false || $match_count === 0) {
+            return [];
+        }
+
+        $types = [];
+
+        foreach ($matches as $match) {
+            $split = preg_split('/[\s,]+/', trim($match[1] ?? ''));
+
+            if ($split === false) {
+                continue;
+            }
+
+            foreach ($split as $type) {
+                if ($type !== '') {
+                    $types[$type] = true;
+                }
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param list<string> $types
+     */
+    private static function buildManipulation(Stmt $stmt, array $types, string $contents): FileManipulation
+    {
+        sort($types);
+
+        $docblock = $stmt->getDocComment();
+
+        if ($docblock === null) {
+            $stmt_start = $stmt->getStartFilePos();
+            $indent = self::getIndentation($contents, $stmt_start);
+
+            $text = '/** @psalm-fixme ' . implode(', ', $types) . " */\n" . $indent;
+
+            return new FileManipulation($stmt_start, $stmt_start, $text);
+        }
+
+        $docblock_start = $docblock->getStartFilePos();
+        $docblock_end = $docblock->getEndFilePos();
+        $indent = self::getIndentation($contents, $docblock_start);
+        $docblock_text = $docblock->getText();
+
+        if (!str_contains($docblock_text, "\n")) {
+            // single-line docblock — expand it to multiline so the annotations fit
+            $inner = trim(substr($docblock_text, 3, -2));
+
+            $text = "/**\n";
+            if ($inner !== '') {
+                $text .= $indent . ' * ' . $inner . "\n";
+            }
+            foreach ($types as $type) {
+                $text .= $indent . ' * @psalm-fixme ' . $type . "\n";
+            }
+            $text .= $indent . ' */';
+
+            return new FileManipulation($docblock_start, $docblock_end + 1, $text);
+        }
+
+        // multiline docblock — splice the annotations in before the closing `*/`
+        $closing_newline = strrpos($contents, "\n", $docblock_end - strlen($contents));
+        $closing_line_start = $closing_newline === false ? 0 : $closing_newline + 1;
+
+        $text = '';
+        foreach ($types as $type) {
+            $text .= $indent . ' * @psalm-fixme ' . $type . "\n";
+        }
+
+        return new FileManipulation($closing_line_start, $closing_line_start, $text);
+    }
+
+    private static function getIndentation(string $contents, int $position): string
+    {
+        $line_start = strrpos($contents, "\n", $position - strlen($contents));
+        $line_start = $line_start === false ? 0 : $line_start + 1;
+
+        $prefix = substr($contents, $line_start, $position - $line_start);
+
+        return trim($prefix) === '' ? $prefix : '';
+    }
+}

--- a/tests/FixmeAdderTest.php
+++ b/tests/FixmeAdderTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests;
+
+use Override;
+use Psalm\Config;
+use Psalm\Context;
+use Psalm\Internal\Fixme\FixmeAdder;
+
+use function getcwd;
+
+use const DIRECTORY_SEPARATOR;
+
+final class FixmeAdderTest extends TestCase
+{
+    #[Override]
+    protected function makeConfig(): Config
+    {
+        $config = parent::makeConfig();
+
+        // let issues accumulate in the IssueBuffer instead of throwing
+        $config->throw_exception = false;
+
+        return $config;
+    }
+
+    /**
+     * @dataProvider providerAddFixmes
+     */
+    public function testAddFixmes(string $input, string $expected_output, int $expected_added): void
+    {
+        $file_path = (string) getcwd() . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'somefile.php';
+
+        $this->addFile($file_path, $input);
+        $this->analyzeFile($file_path, new Context(), false);
+
+        $added = FixmeAdder::add($this->project_analyzer);
+
+        $this->assertSame($expected_added, $added);
+        $this->assertSame($expected_output, $this->file_provider->getContents($file_path));
+    }
+
+    /**
+     * @return array<string, array{input: string, expected_output: string, expected_added: int}>
+     */
+    public function providerAddFixmes(): array
+    {
+        return [
+            'addsSingleLineDocblockToUndocumentedStatement' => [
+                'input' => '<?php
+function foo(): void {
+    unknown_function_call();
+}
+',
+                'expected_output' => '<?php
+function foo(): void {
+    /** @psalm-fixme UndefinedFunction */
+    unknown_function_call();
+}
+',
+                'expected_added' => 1,
+            ],
+            'splicesIntoExistingMultilineDocblock' => [
+                'input' => '<?php
+function foo(): void {
+    /**
+     * a pre-existing comment
+     */
+    unknown_function_call();
+}
+',
+                'expected_output' => '<?php
+function foo(): void {
+    /**
+     * a pre-existing comment
+     * @psalm-fixme UndefinedFunction
+     */
+    unknown_function_call();
+}
+',
+                'expected_added' => 1,
+            ],
+            'expandsExistingSingleLineDocblock' => [
+                'input' => '<?php
+function foo(): void {
+    /** a pre-existing comment */
+    unknown_function_call();
+}
+',
+                'expected_output' => '<?php
+function foo(): void {
+    /**
+     * a pre-existing comment
+     * @psalm-fixme UndefinedFunction
+     */
+    unknown_function_call();
+}
+',
+                'expected_added' => 1,
+            ],
+            'combinesMultipleIssuesOnOneLine' => [
+                'input' => '<?php
+function foo(): void {
+    unknown_function_call($undefined_variable);
+}
+',
+                'expected_output' => '<?php
+function foo(): void {
+    /** @psalm-fixme PossiblyUndefinedVariable, UndefinedFunction */
+    unknown_function_call($undefined_variable);
+}
+',
+                'expected_added' => 2,
+            ],
+            'doesNothingWhenIssueAlreadySuppressed' => [
+                'input' => '<?php
+function foo(): void {
+    /** @psalm-suppress UndefinedFunction */
+    unknown_function_call();
+}
+',
+                'expected_output' => '<?php
+function foo(): void {
+    /** @psalm-suppress UndefinedFunction */
+    unknown_function_call();
+}
+',
+                'expected_added' => 0,
+            ],
+        ];
+    }
+}

--- a/tests/IssueSuppressionTest.php
+++ b/tests/IssueSuppressionTest.php
@@ -77,6 +77,21 @@ final class IssueSuppressionTest extends TestCase
         $this->analyzeFile((string) getcwd() . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'somefile.php', new Context());
     }
 
+    public function testUnusedFixmeIsReported(): void
+    {
+        $this->expectException(CodeException::class);
+        $this->expectExceptionMessage('UnusedPsalmSuppress');
+
+        $this->addFile(
+            (string) getcwd() . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'somefile.php',
+            '<?php
+                /** @psalm-fixme InvalidArgument */
+                echo strlen("hello");',
+        );
+
+        $this->analyzeFile((string) getcwd() . DIRECTORY_SEPARATOR . 'tests' . DIRECTORY_SEPARATOR . 'somefile.php', new Context());
+    }
+
     public function testUnusedSuppressAllOnFunction(): void
     {
         $this->expectException(CodeException::class);
@@ -417,6 +432,38 @@ final class IssueSuppressionTest extends TestCase
                      */
                     break;
                 ',
+            ],
+            'fixmeSuppressesIssueOnStatement' => [
+                'code' => '<?php
+                    function verify_return_type(): DateTime {
+                        /** @psalm-fixme UndefinedFunction */
+                        unknown_function_call();
+
+                        return new DateTime();
+                    }',
+            ],
+            'fixmeSuppressesMultipleIssuesOnFunction' => [
+                'code' => '<?php
+                    class A {
+                        /**
+                         * @psalm-fixme UndefinedClass, MixedMethodCall, MissingReturnType
+                         */
+                        public function b() {
+                            B::fooFoo()->barBar();
+                        }
+                    }',
+            ],
+            'fixmeAlongsideSuppress' => [
+                'code' => '<?php
+                    class A {
+                        /**
+                         * @psalm-suppress MissingReturnType
+                         * @psalm-fixme UndefinedClass, MixedMethodCall
+                         */
+                        public function b() {
+                            B::fooFoo()->barBar();
+                        }
+                    }',
             ],
         ];
     }


### PR DESCRIPTION
`@psalm-fixme` suppresses an issue exactly like `@psalm-suppress` but marks it as a known problem to fix. 

Treated as `@psalm-suppress` under the hood

Add an `--add-fixmes` CLI flag backed by `FixmeAdder`, which turns the issues Psalm currently reports into inline `@psalm-fixme`.

My vague plan here (and feel free to push back) is for this to replace the baseline in the Psalm repo itself.

That would add a bit of noise to the Psalm repo itself, but it would also keep us honest about the impact of new rules.