### PR TITLE
Keep foreach key/value non-nullable after a breaking loop

### DIFF
--- a/src/Psalm/Codebase.php
+++ b/src/Psalm/Codebase.php
@@ -1328,9 +1328,6 @@ final class Codebase
             return null;
         }
 
-        $start_pos = null;
-        $end_pos = null;
-
         ksort($argument_map);
 
         foreach ($argument_map as $start_pos => [$end_pos, $possible_reference, $possible_argument_number]) {
@@ -1346,7 +1343,7 @@ final class Codebase
             $argument_number = $possible_argument_number;
         }
 
-        if ($reference === null || $start_pos === null || $end_pos === null || $argument_number === null) {
+        if ($reference === null || $argument_number === null) {
             return null;
         }
 

--- a/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
@@ -23,9 +23,11 @@ use Psalm\Type\Reconciler;
 use Psalm\Type\Union;
 use UnexpectedValueException;
 
+use function array_filter;
 use function array_keys;
 use function array_merge;
 use function array_unique;
+use function array_values;
 use function count;
 use function in_array;
 use function is_string;

--- a/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/LoopAnalyzer.php
@@ -490,7 +490,21 @@ final class LoopAnalyzer
         }
 
         if ($always_enters_loop) {
-            self::setLoopVars($continue_context, $loop_parent_context, $loop_scope);
+            // Variables assigned before the loop body (e.g. a foreach key/value)
+            // that are never reassigned inside the body are guaranteed to hold
+            // their loop-assigned type after the loop, even if it breaks or
+            // continues, so they must not be merged back to their pre-loop type.
+            $always_assigned_unmodified_vars = array_values(array_filter(
+                $always_assigned_before_loop_body_vars,
+                static fn(string $var_id): bool => !isset($assignment_map[$var_id]),
+            ));
+
+            self::setLoopVars(
+                $continue_context,
+                $loop_parent_context,
+                $loop_scope,
+                $always_assigned_unmodified_vars,
+            );
         }
 
         if ($inner_do_context) {
@@ -589,14 +603,25 @@ final class LoopAnalyzer
         return null;
     }
 
-    public static function setLoopVars(Context $inner_context, Context $context, LoopScope $loop_scope): void
-    {
+    /**
+     * @param list<string> $always_assigned_before_loop_body_vars
+     */
+    public static function setLoopVars(
+        Context $inner_context,
+        Context $context,
+        LoopScope $loop_scope,
+        array $always_assigned_before_loop_body_vars = [],
+    ): void {
         foreach ($inner_context->vars_in_scope as $var_id => $type) {
             // if there are break statements in the loop it's not certain
             // that the loop has finished executing, so the assertions at the end
-            // the loop in the while conditional may not hold
-            if (in_array(ScopeAnalyzer::ACTION_BREAK, $loop_scope->final_actions, true)
-                || in_array(ScopeAnalyzer::ACTION_CONTINUE, $loop_scope->final_actions, true)
+            // the loop in the while conditional may not hold.
+            // This does not apply to variables assigned before the loop body
+            // (e.g. a foreach key/value), which are guaranteed to be assigned at
+            // the start of every iteration, even one that breaks or continues.
+            if ((in_array(ScopeAnalyzer::ACTION_BREAK, $loop_scope->final_actions, true)
+                    || in_array(ScopeAnalyzer::ACTION_CONTINUE, $loop_scope->final_actions, true))
+                && !in_array($var_id, $always_assigned_before_loop_body_vars, true)
             ) {
                 if (isset($loop_scope->possibly_defined_loop_parent_vars[$var_id])) {
                     $context->vars_in_scope[$var_id] = Type::combineUnionTypes(

--- a/src/Psalm/Type/Atomic/TLiteralFloat.php
+++ b/src/Psalm/Type/Atomic/TLiteralFloat.php
@@ -6,6 +6,8 @@ namespace Psalm\Type\Atomic;
 
 use Override;
 
+use function is_nan;
+
 /**
  * Denotes a floating point value where the exact numeric value is known.
  *

--- a/tests/Loop/ForeachTest.php
+++ b/tests/Loop/ForeachTest.php
@@ -1252,6 +1252,29 @@ final class ForeachTest extends TestCase
     public function providerInvalidCodeParse(): iterable
     {
         return [
+            'foreachKeyAndDestructuredValueNotNullAfterBreakingLoopOnNonEmptyArray' => [
+                'code' => '<?php
+                    /** @param non-empty-array<int, array{int, string|null}> $argument_map */
+                    function f(array $argument_map, int $offset): ?string {
+                        $start_pos = null;
+                        $end_pos = null;
+                        $reference = null;
+                        foreach ($argument_map as $start_pos => [$end_pos, $possible_reference]) {
+                            if ($offset < $start_pos) {
+                                break;
+                            }
+                            if ($offset > $end_pos) {
+                                continue;
+                            }
+                            $reference = $possible_reference;
+                        }
+                        if ($reference === null || $start_pos === null || $end_pos === null) {
+                            return null;
+                        }
+                        return $reference;
+                    }',
+                'error_message' => 'DocblockTypeContradiction',
+            ],
             'switchVariableWithContinueOnce' => [
                 'code' => '<?php
                     foreach (["a", "b", "c"] as $letter) {


### PR DESCRIPTION
Caught a small bug as part of a broader exercise:

## Summary

Psalm fails to report a contradiction in code like this, even though the array is provably non-empty:

```php
/** @param non-empty-array<int, array{int, string|null}> $argument_map */
function f(array $argument_map, int $offset): ?string {
    $start_pos = null;
    $end_pos = null;
    $reference = null;
    foreach ($argument_map as $start_pos => [$end_pos, $possible_reference]) {
        if ($offset < $start_pos) {
            break;
        }
        if ($offset > $end_pos) {
            continue;
        }
        $reference = $possible_reference;
    }
    // $start_pos / $end_pos are guaranteed `int` here, so these are contradictions
    if ($reference === null || $start_pos === null || $end_pos === null) {
        return null;
    }
    return $reference;
}
```

The foreach key and destructured value are assigned at the *start* of every iteration, before any `break`/`continue`. Since the array is non-empty the loop always runs, so `$start_pos`/`$end_pos` are guaranteed to be `int` afterwards. But `LoopAnalyzer::setLoopVars` applied its break/continue caution uniformly and merged those variables back to their pre-loop `null` type, inferring `int|null` and suppressing the `DocblockTypeContradiction`.

## Fix

`setLoopVars` now exempts variables that are assigned before the loop body **and never reassigned inside it** (detected via the existing assignment map) from the break/continue caution, so they keep their loop-assigned type. Variables that *are* reassigned in the body keep the existing behaviour, so the `bleedVarIntoOuterContext*` cases are unaffected.

The fix surfaced five true positives in `Codebase::getFunctionArgumentAtPosition` (the real-world origin of the example above); its now-redundant null guards are removed in a follow-up commit so the self-check stays clean.

## Test plan

- [x] New `ForeachTest` invalid-code case asserting `DocblockTypeContradiction` is reported
- [x] All `tests/Loop/` tests pass (184 tests)
- [x] `./psalm` self-check reports "No errors found"