### PR TITLE
Fix false positives on a nullable enum property under null coalesce

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/AtomicPropertyFetchAnalyzer.php
@@ -218,12 +218,16 @@ final class AtomicPropertyFetchAnalyzer
         if ($class_storage->is_enum || in_array('UnitEnum', $codebase->getParentInterfaces($fq_class_name))) {
             if ($prop_name === 'value' && !$class_storage->is_enum) {
                 $has_valid_fetch_type = true;
+                $stmt_type = $statements_analyzer->node_data->getType($stmt);
                 $statements_analyzer->node_data->setType(
                     $stmt,
-                    new Union([
-                        new TString(),
-                        new TInt(),
-                    ]),
+                    Type::combineUnionTypes(
+                        new Union([
+                            new TString(),
+                            new TInt(),
+                        ]),
+                        $stmt_type,
+                    ),
                 );
             } elseif ($prop_name === 'value' && $class_storage->enum_type !== null && $class_storage->enum_cases) {
                 $has_valid_fetch_type = true;
@@ -1024,14 +1028,18 @@ final class AtomicPropertyFetchAnalyzer
             $relevant_enum_case_names = array_keys($class_storage->enum_cases);
         }
 
+        $stmt_type = $statements_analyzer->node_data->getType($stmt);
         $statements_analyzer->node_data->setType(
             $stmt,
-            empty($relevant_enum_case_names)
-                ? Type::getNonEmptyString()
-                : new Union(array_map(
-                    static fn(string $name): TString => Type::getAtomicStringFromLiteral($name),
-                    $relevant_enum_case_names,
-                )),
+            Type::combineUnionTypes(
+                empty($relevant_enum_case_names)
+                    ? Type::getNonEmptyString()
+                    : new Union(array_map(
+                        static fn(string $name): TString => Type::getAtomicStringFromLiteral($name),
+                        $relevant_enum_case_names,
+                    )),
+                $stmt_type,
+            ),
         );
     }
 
@@ -1067,10 +1075,14 @@ final class AtomicPropertyFetchAnalyzer
             $case_values[] = $case_value ?? new TMixed();
         }
 
+        $stmt_type = $statements_analyzer->node_data->getType($stmt);
         /** @psalm-suppress ArgumentTypeCoercion */
         $statements_analyzer->node_data->setType(
             $stmt,
-            new Union($case_values),
+            Type::combineUnionTypes(
+                new Union($case_values),
+                $stmt_type,
+            ),
         );
     }
 

--- a/tests/EnumTest.php
+++ b/tests/EnumTest.php
@@ -742,6 +742,51 @@ final class EnumTest extends TestCase
                 'ignored_issues' => [],
                 'php_version' => '8.1',
             ],
+            'nullCoalesceOnNullableBackedEnumValue #11171' => [
+                'code' => <<<'PHP'
+                    <?php
+                    enum Suit: string {
+                        case Hearts = "H";
+                        case Spades = "S";
+                    }
+                    function plain(?Suit $suit): string {
+                        return $suit->value ?? "none";
+                    }
+                    function nullsafe(?Suit $suit): string {
+                        return $suit?->value ?? "none";
+                    }
+                    PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nullCoalesceOnNullableEnumName #11171' => [
+                'code' => <<<'PHP'
+                    <?php
+                    enum Direction {
+                        case North;
+                        case South;
+                    }
+                    function name(?Direction $dir): string {
+                        return $dir->name ?? "unknown";
+                    }
+                    PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
+            'nullCoalesceOnNullableBackedEnumInterfaceValue #11171' => [
+                'code' => <<<'PHP'
+                    <?php
+                    interface HasBackingValue extends \BackedEnum {}
+                    function value(?HasBackingValue $enum): string|int {
+                        return $enum->value ?? "none";
+                    }
+                    PHP,
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.1',
+            ],
         ];
     }
 


### PR DESCRIPTION
`$foo->value` (or `->name`) on a nullable enum is treated as always-set under `??`, so psalm emits a false `RedundantCondition` and `TypeDoesNotContainType`. The enum value/name fetch replaced the node type with the case values, which dropped the null a nullable receiver carries inside isset. Real property fetches keep it. The fix combines with the existing node type the same way.

Fixes #11171
