### PR TITLE
Fix crash when a property assertion targets a non-variable argument

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/AssertionFinder.php
@@ -1045,7 +1045,6 @@ final class AssertionFinder
                         }
 
                         $arg_value = $args[$var_id_int]->value;
-                        assert($arg_value instanceof PhpParser\Node\Expr\Variable);
 
                         $arg_var_id = ExpressionIdentifier::getExtendedVarId($arg_value, null, $source);
 
@@ -1172,7 +1171,6 @@ final class AssertionFinder
                             );
                             continue;
                         }
-                        /** @var PhpParser\Node\Expr\Variable $arg_value */
                         $arg_value = $args[$var_id_int]->value;
 
                         $arg_var_id = ExpressionIdentifier::getExtendedVarId($arg_value, null, $source);
@@ -4228,11 +4226,15 @@ final class AssertionFinder
     }
 
     public static function isPropertyImmutableOnArgument(
-        string                       $property,
-        NodeDataProvider             $node_provider,
-        ClassLikeStorageProvider     $class_provider,
-        PhpParser\Node\Expr\Variable $arg_expr,
+        string $property,
+        NodeDataProvider $node_provider,
+        ClassLikeStorageProvider $class_provider,
+        PhpParser\Node\Expr $arg_expr,
     ): ?string {
+        if (!$arg_expr instanceof PhpParser\Node\Expr\Variable) {
+            return 'Argument is not a variable so the assertion cannot be applied';
+        }
+
         $type = $node_provider->getType($arg_expr);
         /** @var string $name */
         $name = $arg_expr->name;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CallAnalyzer.php
@@ -700,7 +700,6 @@ abstract class CallAnalyzer
                     continue;
                 }
 
-                /** @var PhpParser\Node\Expr\Variable $arg_value */
                 $arg_value = $args[$var_id]->value;
 
                 $arg_var_id = ExpressionIdentifier::getExtendedVarId($arg_value, null, $statements_analyzer);

--- a/tests/AssertAnnotationTest.php
+++ b/tests/AssertAnnotationTest.php
@@ -3066,6 +3066,50 @@ final class AssertAnnotationTest extends TestCase
     public function providerInvalidCodeParse(): iterable
     {
         return [
+            'assertIfTruePropertyOnNonVariableArgument' => [
+                'code' => '<?php
+                    /**
+                     * @param object{hasFoo: bool} $obj
+                     * @psalm-assert-if-true true $obj->hasFoo
+                     */
+                    function validateFoo(object $obj): bool {
+                        return $obj->hasFoo;
+                    }
+
+                    $arr = [(object) ["hasFoo" => true]];
+                    validateFoo($arr[0]);',
+                'error_message' => 'InvalidDocblock',
+            ],
+            'assertIfFalsePropertyOnNonVariableArgument' => [
+                'code' => '<?php
+                    /**
+                     * @param object{hasFoo: bool} $obj
+                     * @psalm-assert-if-false true $obj->hasFoo
+                     */
+                    function validateFoo(object $obj): bool {
+                        return $obj->hasFoo;
+                    }
+
+                    $arr = [(object) ["hasFoo" => true]];
+                    validateFoo($arr[0]);',
+                'error_message' => 'InvalidDocblock',
+            ],
+            'assertPropertyOnNonVariableArgument' => [
+                'code' => '<?php
+                    /**
+                     * @param object{hasFoo: bool} $obj
+                     * @psalm-assert true $obj->hasFoo
+                     */
+                    function validateFoo(object $obj): void {
+                        if ($obj->hasFoo !== true) {
+                            throw new \Exception();
+                        }
+                    }
+
+                    $arr = [(object) ["hasFoo" => true]];
+                    validateFoo($arr[0]);',
+                'error_message' => 'InvalidDocblock',
+            ],
             'assertInstanceOfMultipleInterfaces' => [
                 'code' => '<?php
                     class A {


### PR DESCRIPTION
Fix https://github.com/vimeo/psalm/issues/11386

A `@psalm-assert` on an argument's property crashes Psalm when the argument is not a plain variable, such as an array element. The call sites pass the expression to `isPropertyImmutableOnArgument`, which only accepts a `Variable`, so an `ArrayDimFetch` throws there.

Psalm now reports `InvalidDocblock` instead of crashing.
