### PR TITLE
Add generic type signatures for array_first, array_last, array_any and array_all

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -252,6 +252,7 @@ function array_last($array)
  *
  * @param array<TKey, TValue> $array
  * @param callable(TValue, TKey): bool $callback
+ * @psalm-pure
  */
 function array_any(array $array, callable $callback): bool
 {
@@ -263,6 +264,7 @@ function array_any(array $array, callable $callback): bool
  *
  * @param array<TKey, TValue> $array
  * @param callable(TValue, TKey): bool $callback
+ * @psalm-pure
  */
 function array_all(array $array, callable $callback): bool
 {

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -227,6 +227,52 @@ function array_key_last($array)
  *
  * @param TArray $array
  *
+ * @return (TArray is array<never, never> ? null : (TArray is non-empty-array ? value-of<TArray> : value-of<TArray>|null))
+ * @psalm-pure
+ */
+function array_first($array)
+{
+}
+
+/**
+ * @psalm-template TArray as array
+ *
+ * @param TArray $array
+ *
+ * @return (TArray is array<never, never> ? null : (TArray is non-empty-array ? value-of<TArray> : value-of<TArray>|null))
+ * @psalm-pure
+ */
+function array_last($array)
+{
+}
+
+/**
+ * @psalm-template TKey of array-key
+ * @psalm-template TValue
+ *
+ * @param array<TKey, TValue> $array
+ * @param callable(TValue, TKey): bool $callback
+ */
+function array_any(array $array, callable $callback): bool
+{
+}
+
+/**
+ * @psalm-template TKey of array-key
+ * @psalm-template TValue
+ *
+ * @param array<TKey, TValue> $array
+ * @param callable(TValue, TKey): bool $callback
+ */
+function array_all(array $array, callable $callback): bool
+{
+}
+
+/**
+ * @psalm-template TArray as array
+ *
+ * @param TArray $array
+ *
  * @return (TArray is non-empty-array ? non-empty-list<value-of<TArray>> : list<value-of<TArray>>)
  * @psalm-pure
  */

--- a/tests/ArrayFunctionCallTest.php
+++ b/tests/ArrayFunctionCallTest.php
@@ -1453,6 +1453,74 @@ final class ArrayFunctionCallTest extends TestCase
                     '$b' => 'null',
                 ],
             ],
+            'arrayFirst' => [
+                'code' => '<?php
+                    /** @return array<string, int> */
+                    function makeArray(): array { return ["one" => 1, "two" => 3]; }
+                    $a = makeArray();
+                    $b = array_first($a);',
+                'assertions' => [
+                    '$b' => 'int|null',
+                ],
+            ],
+            'arrayFirstNonEmpty' => [
+                'code' => '<?php
+                    $a = ["one" => 1, "two" => 3];
+                    $b = array_first($a);',
+                'assertions' => [
+                    '$b' => 'int',
+                ],
+            ],
+            'arrayFirstEmpty' => [
+                'code' => '<?php
+                    $a = [];
+                    $b = array_first($a);',
+                'assertions' => [
+                    '$b' => 'null',
+                ],
+            ],
+            'arrayLast' => [
+                'code' => '<?php
+                    /** @return array<string, int> */
+                    function makeArray(): array { return ["one" => 1, "two" => 3]; }
+                    $a = makeArray();
+                    $b = array_last($a);',
+                'assertions' => [
+                    '$b' => 'int|null',
+                ],
+            ],
+            'arrayLastNonEmpty' => [
+                'code' => '<?php
+                    $a = ["one" => 1, "two" => 3];
+                    $b = array_last($a);',
+                'assertions' => [
+                    '$b' => 'int',
+                ],
+            ],
+            'arrayLastEmpty' => [
+                'code' => '<?php
+                    $a = [];
+                    $b = array_last($a);',
+                'assertions' => [
+                    '$b' => 'null',
+                ],
+            ],
+            'arrayAnyReturnsBoolWithTypedCallback' => [
+                'code' => '<?php
+                    $a = ["one" => 1, "two" => 3];
+                    $b = array_any($a, fn (int $value, string $key): bool => $value > 1);',
+                'assertions' => [
+                    '$b' => 'bool',
+                ],
+            ],
+            'arrayAllReturnsBoolWithTypedCallback' => [
+                'code' => '<?php
+                    $a = ["one" => 1, "two" => 3];
+                    $b = array_all($a, fn (int $value, string $key): bool => $value > 1);',
+                'assertions' => [
+                    '$b' => 'bool',
+                ],
+            ],
             'arrayResetNonEmptyArray' => [
                 'code' => '<?php
                     /** @return non-empty-array<string, int> */


### PR DESCRIPTION
### Summary

PHP 8.4's `array_any`/`array_all` and PHP 8.5's `array_first`/`array_last` are currently only described by the autogenerated CallMap, which gives them non-generic signatures:

- `array_first(array): mixed` and `array_last(array): mixed` — the element type is lost, callers get `mixed`.
- `array_any(array, callable): bool` and `array_all(array, callable): bool` — the callback parameters are untyped `callable`, so the value/key types are not checked inside the predicate.

This adds templated stubs to `stubs/CoreGenericFunctions.phpstub`, directly mirroring the existing `array_key_first`/`array_key_last` entries that sit a few lines above:

- `array_first`/`array_last` return `value-of<TArray>`, with the same emptiness-aware conditional as `array_key_first` (`null` for a statically-empty array, the value type for a `non-empty-array`, otherwise `value-of<TArray>|null`).
- `array_any`/`array_all` keep their `bool` return but gain a typed `callable(TValue, TKey): bool` predicate so the callback body is checked against the array's value and key types. They are marked `@psalm-pure`: unlike `usort`/`uasort` (which mutate their by-reference array), these functions do not mutate, so the call is pure when given a pure callback and Psalm propagates the callback's purity. This also matches Psalm's own source, which calls `array_any` from mutation-free contexts (e.g. `Type\Atomic`).

### Tests

Adds cases to `tests/ArrayFunctionCallTest.php` covering the general, `non-empty-array` and empty-array branches for `array_first`/`array_last`, plus typed-callback `bool` results for `array_any`/`array_all`.

### Note

`array_first`/`array_last`/`array_any`/`array_all` already exist in the version CallMaps (`CallMap_84`/`CallMap_85`); placing the generic signatures in `CoreGenericFunctions.phpstub` matches where `array_key_first`/`array_key_last` already live so the improved types apply regardless of the PHP version Psalm itself runs on. Happy to move them behind version gating if you'd prefer.