### PR TITLE
Add generic return type for the PHP 8.5 clone() function

### DIFF
--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1856,3 +1856,13 @@ function register_tick_function(callable $callback, mixed ...$args): bool {}
  * @psalm-taint-sink extract $array
  */
 function extract(array &$array, int $flags = EXTR_OVERWRITE, string $prefix = ""): int {}
+
+/**
+ * @psalm-template T of object
+ *
+ * @param T $object
+ * @param array<string, mixed> $withProperties
+ *
+ * @return T
+ */
+function clone(object $object, array $withProperties = []): object {}

--- a/stubs/CoreGenericFunctions.phpstub
+++ b/stubs/CoreGenericFunctions.phpstub
@@ -1856,13 +1856,3 @@ function register_tick_function(callable $callback, mixed ...$args): bool {}
  * @psalm-taint-sink extract $array
  */
 function extract(array &$array, int $flags = EXTR_OVERWRITE, string $prefix = ""): int {}
-
-/**
- * @psalm-template T of object
- *
- * @param T $object
- * @param array<string, mixed> $withProperties
- *
- * @return T
- */
-function clone(object $object, array $withProperties = []): object {}

--- a/stubs/Php85.phpstub
+++ b/stubs/Php85.phpstub
@@ -24,4 +24,16 @@ namespace {
     final class CurlSharePersistentHandle
     {
     }
+
+    /**
+     * @psalm-template T of object
+     *
+     * @param T $object
+     * @param array<string, mixed> $withProperties
+     *
+     * @return T
+     *
+     * @since 8.5
+     */
+    function clone(object $object, array $withProperties = []): object {}
 }

--- a/tests/CloneTest.php
+++ b/tests/CloneTest.php
@@ -44,6 +44,21 @@ final class CloneTest extends TestCase
                         }
                     }',
             ],
+            'cloneFunctionPreservesType' => [
+                'code' => '<?php
+                    class A {
+                        public int $foo = 1;
+                    }
+                    function bar(A $a): A {
+                        return clone($a, ["foo" => 2]);
+                    }
+                    $b = bar(new A());',
+                'assertions' => [
+                    '$b' => 'A',
+                ],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
         ];
     }
 


### PR DESCRIPTION
### Summary

PHP 8.5 adds a function form of `clone`, `clone(object $object, array $withProperties = [])`, which PR #11604 registered in `CallMap_85` with a plain `object` return type. That loses the concrete type of the cloned object, so `clone($user, [...])` is inferred as `object` rather than `User`.

This adds a templated stub to `stubs/Php85.phpstub` so the function form returns the same type as its first argument:

```php
/**
 * @psalm-template T of object
 * @param T $object
 * @param array<string, mixed> $withProperties
 * @return T
 */
function clone(object $object, array $withProperties = []): object {}
```

This mirrors what `CloneAnalyzer` already does for the `clone $x` operator form (it preserves the operand's type).

### Tests

Adds a case to `tests/CloneTest.php` (pinned to `php_version: 8.5`) asserting `clone($a, [...])` is inferred as the argument's class.

### Notes

I split this out from the `array_first`/`array_last`/`array_any`/`array_all` generics (separate PR) because `clone` is a reserved keyword and this needs your eyes.

**Routing** — `CloneAnalyzer` handles the `Clone_` AST node (the `clone $x` operator). I'm assuming the two-argument function form `clone($x, [...])` is parsed as a regular call and resolves against the CallMap/stub (consistent with #11604 adding `clone` to `CallMap_85`). If it is instead routed through `Clone_`/`CloneAnalyzer`, this stub won't apply and the fix belongs there or in a return-type provider instead.

**Placement** — the stub lives in `stubs/Php85.phpstub`, which is only registered when `analysis_php_version_id >= 8_05_00`. This gates the function to PHP 8.5+ so Psalm doesn't treat `clone(...)` as a valid call when analyzing code targeting earlier versions (an earlier revision placed it in `CoreGenericFunctions.phpstub`, which is loaded unconditionally — fixed per Cursor Bugbot's review).
