### PR TITLE
Clean up redundant assignment-conditions and repeated getArgs() calls

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1676,7 +1676,6 @@
   </file>
   <file src="src/Psalm/Internal/ExecutionEnvironment/GitInfoCollector.php">
     <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$exploded[1]]]></code>
       <code><![CDATA[$url]]></code>
     </PossiblyUndefinedArrayOffset>
   </file>

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/ArgumentsAnalyzer.php
@@ -1644,8 +1644,7 @@ final class ArgumentsAnalyzer
                         }
 
                         if ($arg_value_type->isSingle()
-                            && ($atomic_arg_type = $arg_value_type->getSingleAtomic())
-                            && $atomic_arg_type instanceof TKeyedArray
+                            && ($atomic_arg_type = $arg_value_type->getSingleAtomic()) instanceof TKeyedArray
                             && !$atomic_arg_type->is_list
                         ) {
                             //if we have a single shape, we'll check param names

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -626,9 +626,10 @@ final class FunctionCallReturnTypeFetcher
         if ($function_storage->return_source_params) {
             $removed_taints = $function_storage->removed_taints;
 
-            if ($function_id === 'preg_replace' && count($stmt->getArgs()) > 2) {
-                $first_stmt_type = $statements_analyzer->node_data->getType($stmt->getArgs()[0]->value);
-                $second_stmt_type = $statements_analyzer->node_data->getType($stmt->getArgs()[1]->value);
+            $args = $stmt->getArgs();
+            if ($function_id === 'preg_replace' && count($args) > 2) {
+                $first_stmt_type = $statements_analyzer->node_data->getType($args[0]->value);
+                $second_stmt_type = $statements_analyzer->node_data->getType($args[1]->value);
 
                 if ($first_stmt_type
                     && $second_stmt_type

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/IncludeAnalyzer.php
@@ -353,15 +353,16 @@ final class IncludeAnalyzer
             $stmt->name instanceof PhpParser\Node\Name &&
             $stmt->name->getParts() === ['dirname']
         ) {
-            if ($stmt->getArgs()) {
+            $args = $stmt->getArgs();
+            if ($args) {
                 $dir_level = 1;
 
-                if (isset($stmt->getArgs()[1])) {
-                    if ($stmt->getArgs()[1]->value instanceof PhpParser\Node\Scalar\Int_) {
-                        $dir_level = $stmt->getArgs()[1]->value->value;
+                if (isset($args[1])) {
+                    if ($args[1]->value instanceof PhpParser\Node\Scalar\Int_) {
+                        $dir_level = $args[1]->value->value;
                     } else {
                         if ($statements_analyzer) {
-                            $t = $statements_analyzer->node_data->getType($stmt->getArgs()[1]->value);
+                            $t = $statements_analyzer->node_data->getType($args[1]->value);
                             if ($t && $t->isSingleIntLiteral()) {
                                 $dir_level = $t->getSingleIntLiteral()->value;
                             } else {
@@ -374,7 +375,7 @@ final class IncludeAnalyzer
                 }
 
                 $evaled_path = self::getPathTo(
-                    $stmt->getArgs()[0]->value,
+                    $args[0]->value,
                     $type_provider,
                     $statements_analyzer,
                     $file_name,

--- a/src/Psalm/Internal/ExecutionEnvironment/GitInfoCollector.php
+++ b/src/Psalm/Internal/ExecutionEnvironment/GitInfoCollector.php
@@ -16,6 +16,7 @@ use function explode;
 use function range;
 use function str_contains;
 use function str_starts_with;
+use function substr;
 use function trim;
 
 /**
@@ -64,9 +65,7 @@ final class GitInfoCollector
 
         foreach ($branchesResult as $result) {
             if (str_starts_with($result, '* ')) {
-                $exploded = explode('* ', $result, 2);
-
-                return $exploded[1];
+                return substr($result, 2);
             }
         }
 

--- a/src/Psalm/Internal/Provider/ParamsProvider/ArrayFilterParamsProvider.php
+++ b/src/Psalm/Internal/Provider/ParamsProvider/ArrayFilterParamsProvider.php
@@ -122,8 +122,7 @@ final class ArrayFilterParamsProvider implements FunctionParamsProviderInterface
             $first_arg_array = $fallback;
         } else {
             $first_arg_array = $first_arg_type->hasType('array')
-                               && ($array_atomic_type = $first_arg_type->getArray())
-                               && ($array_atomic_type instanceof TArray
+                               && (($array_atomic_type = $first_arg_type->getArray()) instanceof TArray
                                    || $array_atomic_type instanceof TKeyedArray)
                 ? $array_atomic_type
                 : $fallback;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayFilterReturnTypeProvider.php
@@ -73,8 +73,7 @@ final class ArrayFilterReturnTypeProvider implements FunctionReturnTypeProviderI
                 $first_arg_array = $fallback;
             } else {
                 $first_arg_array = $first_arg_type->hasType('array')
-                                   && ($array_atomic_type = $first_arg_type->getArray())
-                                   && ($array_atomic_type instanceof TArray
+                                   && (($array_atomic_type = $first_arg_type->getArray()) instanceof TArray
                                        || $array_atomic_type instanceof TKeyedArray)
                     ? $array_atomic_type
                     : $fallback;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPopReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayPopReturnTypeProvider.php
@@ -45,8 +45,7 @@ final class ArrayPopReturnTypeProvider implements FunctionReturnTypeProviderInte
             && ($first_arg_type = $statements_source->node_data->getType($first_arg))
             && $first_arg_type->hasType('array')
             && !$first_arg_type->hasMixed()
-            && ($array_atomic_type = $first_arg_type->getArray())
-            && ($array_atomic_type instanceof TArray
+            && (($array_atomic_type = $first_arg_type->getArray()) instanceof TArray
                 || $array_atomic_type instanceof TKeyedArray)
         ? $array_atomic_type
         : null;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayRandReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayRandReturnTypeProvider.php
@@ -42,8 +42,7 @@ final class ArrayRandReturnTypeProvider implements FunctionReturnTypeProviderInt
         $first_arg_array = $first_arg
             && ($first_arg_type = $statements_source->node_data->getType($first_arg))
             && $first_arg_type->hasType('array')
-            && ($array_atomic_type = $first_arg_type->getArray())
-            && ($array_atomic_type instanceof TArray
+            && (($array_atomic_type = $first_arg_type->getArray()) instanceof TArray
                 || $array_atomic_type instanceof TKeyedArray)
         ? $array_atomic_type
         : null;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReverseReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArrayReverseReturnTypeProvider.php
@@ -48,8 +48,7 @@ final class ArrayReverseReturnTypeProvider implements FunctionReturnTypeProvider
             && ($first_arg_type = $statements_source->node_data->getType($first_arg))
             && $first_arg_type->hasType('array')
             && $first_arg_type->isArray()
-            && ($array_atomic_type = $first_arg_type->getArray())
-            && ($array_atomic_type instanceof TArray
+            && (($array_atomic_type = $first_arg_type->getArray()) instanceof TArray
                 || $array_atomic_type instanceof TKeyedArray)
         ? $array_atomic_type
         : null;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySpliceReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/ArraySpliceReturnTypeProvider.php
@@ -41,8 +41,7 @@ final class ArraySpliceReturnTypeProvider implements FunctionReturnTypeProviderI
         $array_type = $first_arg
             && ($first_arg_type = $statements_source->node_data->getType($first_arg))
             && $first_arg_type->hasType('array')
-            && ($array_atomic_type = $first_arg_type->getArray())
-            && ($array_atomic_type instanceof TArray
+            && (($array_atomic_type = $first_arg_type->getArray()) instanceof TArray
                 || $array_atomic_type instanceof TKeyedArray)
         ? $array_atomic_type
         : null;

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterInputReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterInputReturnTypeProvider.php
@@ -238,8 +238,7 @@ final class FilterInputReturnTypeProvider implements FunctionReturnTypeProviderI
                 $input_type = $input_type->setPossiblyUndefined(true);
             }
         } elseif ($global_type->isArray()
-            && ($array_atomic = $global_type->getArray())
-            && $array_atomic instanceof TArray) {
+            && ($array_atomic = $global_type->getArray()) instanceof TArray) {
             [$_, $input_type] = $array_atomic->type_params;
             $input_type = $input_type->setPossiblyUndefined(true);
         } else {

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterUtils.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterUtils.php
@@ -241,8 +241,7 @@ final class FilterUtils
                             ),
                             $statements_analyzer->getSuppressedIssues(),
                         );
-                    } elseif (($options_array = $atomic_type->properties['options']->getArray())
-                              && $options_array instanceof TKeyedArray) {
+                    } elseif (($options_array = $atomic_type->properties['options']->getArray()) instanceof TKeyedArray) {
                         $defaults['options'] = $options_array;
                     } else {
                         // cannot infer a 100% correct specific return type

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterUtils.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterUtils.php
@@ -188,9 +188,10 @@ final class FilterUtils
                 }
 
                 if (isset($atomic_type->properties['options'])) {
+                    $options_type = $atomic_type->properties['options'];
                     if ($filter_int_used === FILTER_CALLBACK) {
                         $only_callables = true;
-                        foreach ($atomic_type->properties['options']->getAtomicTypes() as $option_atomic) {
+                        foreach ($options_type->getAtomicTypes() as $option_atomic) {
                             if ($option_atomic->isCallableType()) {
                                 continue;
                             }
@@ -206,7 +207,7 @@ final class FilterUtils
 
                             $only_callables = false;
                         }
-                        if ($atomic_type->properties['options']->possibly_undefined) {
+                        if ($options_type->possibly_undefined) {
                             $only_callables = false;
                         }
 
@@ -231,7 +232,7 @@ final class FilterUtils
                         );
                     }
 
-                    if (! $atomic_type->properties['options']->isArray()) {
+                    if (! $options_type->isArray()) {
                         // silently ignored by the function, but this usually indicates a bug
                         IssueBuffer::maybeAdd(
                             new InvalidArgument(
@@ -241,7 +242,7 @@ final class FilterUtils
                             ),
                             $statements_analyzer->getSuppressedIssues(),
                         );
-                    } elseif (($options_array = $atomic_type->properties['options']->getArray()) instanceof TKeyedArray) {
+                    } elseif (($options_array = $options_type->getArray()) instanceof TKeyedArray) {
                         $defaults['options'] = $options_array;
                     } else {
                         // cannot infer a 100% correct specific return type

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/InArrayReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/InArrayReturnTypeProvider.php
@@ -62,9 +62,7 @@ final class InArrayReturnTypeProvider implements FunctionReturnTypeProviderInter
         /**
          * @var TKeyedArray|TArray|null
          */
-        $array_arg_type = isset($types['array'])
-            ? $types['array']
-            : null;
+        $array_arg_type = $types['array'] ?? null;
 
         if ($array_arg_type instanceof TKeyedArray) {
             $array_arg_type = $array_arg_type->getGenericArrayType();

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/InArrayReturnTypeProvider.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/InArrayReturnTypeProvider.php
@@ -58,10 +58,11 @@ final class InArrayReturnTypeProvider implements FunctionReturnTypeProviderInter
             return $bool;
         }
 
+        $types = $haystack_type->getAtomicTypes();
         /**
          * @var TKeyedArray|TArray|null
          */
-        $array_arg_type = ($types = $haystack_type->getAtomicTypes()) && isset($types['array'])
+        $array_arg_type = isset($types['array'])
             ? $types['array']
             : null;
 


### PR DESCRIPTION
A set of small, behaviour-preserving tidy-ups in the analyzer/providers. Each removes a real (if minor) code smell; no functional change is intended.

### Redundant assignment-in-condition (always-truthy test)

Several call providers test the result of a `@psalm-mutation-free`, non-falsable getter *inside* a condition, e.g.:

```php
... && ($x = $type->getArray()) && ($x instanceof TArray || $x instanceof TKeyedArray)
```

`getArray()` / `getSingleAtomic()` can never return a falsy value, so the `&& ($x = ...)` operand is always true — it only binds the variable. Because `getArray()` returns `$this->types['array']` and therefore relies on the preceding `hasType('array')`/`isArray()` guard, the assignment is folded into the adjacent `instanceof` rather than hoisted, keeping the call guarded:

```php
... && (($x = $type->getArray()) instanceof TArray || $x instanceof TKeyedArray)
```

Touched: `ArgumentsAnalyzer`, `ArrayFilterParamsProvider`, `ArrayFilter`/`ArrayPop`/`ArrayRand`/`ArrayReverse`/`ArraySplice`ReturnTypeProvider, `FilterInputReturnTypeProvider`, `FilterUtils`. For `in_array`, `getAtomicTypes()` is unconditional, so the call is hoisted to a plain statement instead.

### Repeated memoized `getArgs()` → local

`IncludeAnalyzer` (`dirname`) and `FunctionCallReturnTypeFetcher` (`preg_replace`) guard on `getArgs()` / `count(getArgs())` and then index `getArgs()[n]`, calling the memoized method several times over. Binding `$args = $stmt->getArgs()` once and reusing it keeps the non-empty / length narrowing attached to the indexed accesses and drops the duplicate calls.

### `GitInfoCollector::collectBranch`

After `str_starts_with($result, '* ')`, `explode('* ', $result, 2)[1]` always exists and equals `substr($result, 2)`, but reads as a possibly-undefined offset (currently baselined). Switched to `substr()` and removed the stale baseline entry.

### Verification

- `php -l` clean on all changed files.
- Psalm on its own codebase: **No errors found!** — baselined issue count 1659 → 1658 (exactly the removed `$exploded[1]` offset); no new findings at any changed line.
- Unit tests: `ArrayFunctionCallTest` (260) and `FunctionCallTest` + `Php80Test` + `UnusedCodeTest` (284) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014CUuwJRfj6cG8rqz8a34d2)_