### PR TITLE
[6.x] Allow `#[\Override]` on properties (PHP 8.5)

### DIFF
--- a/stubs/CoreGenericAttributes.phpstub
+++ b/stubs/CoreGenericAttributes.phpstub
@@ -8,7 +8,7 @@ final class AllowDynamicProperties
 }
 
 /** @psalm-immutable */
-#[Attribute(Attribute::TARGET_METHOD)]
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_PROPERTY)]
 final class Override
 {
     public function __construct() {}

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -43,6 +43,32 @@ final class AttributeTest extends TestCase
     public function providerValidCodeParse(): iterable
     {
         return [
+            'overrideAttributeOnOverriddenMethod' => [
+                'code' => '<?php
+                    class A
+                    {
+                        public function f(): void {}
+                    }
+
+                    class B extends A
+                    {
+                        #[\Override]
+                        public function f(): void {}
+                    }',
+            ],
+            'overrideAttributeOnOverriddenProperty' => [
+                'code' => '<?php
+                    class A
+                    {
+                        protected int $x = 1;
+                    }
+
+                    class B extends A
+                    {
+                        #[\Override]
+                        protected int $x = 2;
+                    }',
+            ],
             'classAndPropertyAttributesExists' => [
                 'code' => '<?php
                     namespace Foo;
@@ -737,6 +763,18 @@ final class AttributeTest extends TestCase
                     $r->getAttributes(Attr::class);
                 ',
                 'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:11:39 - Attribute Attr cannot be used on a class constant',
+            ],
+            'getAttributesOnClassConstantWithOverrideAttribute' => [
+                'code' => '<?php
+                    class Foo
+                    {
+                        public const BAR = "baz";
+                    }
+
+                    $r = new ReflectionClassConstant(Foo::class, "BAR");
+                    $r->getAttributes(\Override::class);
+                ',
+                'error_message' => 'InvalidAttribute - src' . DIRECTORY_SEPARATOR . 'somefile.php:8:39 - Attribute Override cannot be used on a class constant',
             ],
             'getAttributesOnParameterWithNonParameterAttribute' => [
                 'code' => '<?php


### PR DESCRIPTION
PHP 8.5 lets you put `#[\Override]` on a property, but Psalm reported `InvalidAttribute` for it. The bundled stub declared the attribute as `TARGET_METHOD` only, so `AttributesAnalyzer` rejected it anywhere other than a method. Promoted constructor properties hit the same false positive.

Adding `TARGET_PROPERTY` to the stub fixes it. Class constants stay excluded, since the engine fatals there ("allowed targets: method, property").

One caveat: the stub loads for every `phpVersion`, not just 8.5 and above, so the property target now applies no matter what you target. A per-version attribute target set can't be expressed through stubs, because version stubs are cumulative and redeclaring the class only appends a second `#[Attribute]` that `getAttributeClassFlags` never reads. Psalm is already this loose about attribute availability elsewhere (`Deprecated`, for one).

Tests cover a plain property, a promoted property, and the method case that has to keep working. A negative case keeps `#[\Override]` rejected on class constants.

Fixes #11890
