### PR TITLE
[6.x] Support the PHP 8.5 `#[\NoDiscard]` attribute

### DIFF
--- a/docs/running_psalm/issues/UnusedFunctionCall.md
+++ b/docs/running_psalm/issues/UnusedFunctionCall.md
@@ -9,3 +9,5 @@ $a = strlen("hello");
 strlen("goodbye"); // unused
 echo $a;
 ```
+
+It is also emitted, regardless of `--find-dead-code`, when the return value of a function annotated with PHP 8.5's `#[\NoDiscard]` attribute is discarded. Casting the call to `(void)` intentionally discards the value without triggering the issue.

--- a/docs/running_psalm/issues/UnusedMethodCall.md
+++ b/docs/running_psalm/issues/UnusedMethodCall.md
@@ -20,3 +20,5 @@ final class A {
 $a = new A("hello");
 $a->getFoo();
 ```
+
+It is also emitted, regardless of `--find-dead-code`, when the return value of a method annotated with PHP 8.5's `#[\NoDiscard]` attribute is discarded. Casting the call to `(void)` intentionally discards the value without triggering the issue.

--- a/src/Psalm/Internal/Analyzer/AttributesAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/AttributesAnalyzer.php
@@ -22,6 +22,7 @@ use Psalm\Issue\InvalidAttribute;
 use Psalm\Issue\UndefinedClass;
 use Psalm\IssueBuffer;
 use Psalm\Storage\ClassLikeStorage;
+use Psalm\Storage\FunctionLikeStorage;
 use Psalm\Storage\HasAttributesInterface;
 use Psalm\Type\Atomic\TLiteralString;
 use Psalm\Type\Union;
@@ -114,6 +115,23 @@ final class AttributesAnalyzer
                     new InvalidAttribute(
                         "Attribute {$attribute_name} cannot be used on a "
                             . self::TARGET_DESCRIPTIONS[$target],
+                        $attribute_name_location,
+                    ),
+                    $suppressed_issues,
+                );
+            }
+
+            // PHP 8.5 rejects #[\NoDiscard] at declaration time when there is no return value
+            // to discard (a fatal error for void/never native return types).
+            if ($fq_attribute_name === 'NoDiscard'
+                && $storage instanceof FunctionLikeStorage
+                && $storage->signature_return_type !== null
+                && ($storage->signature_return_type->isVoid() || $storage->signature_return_type->isNever())
+            ) {
+                IssueBuffer::maybeAdd(
+                    new InvalidAttribute(
+                        "Attribute {$attribute_name} cannot be used on a function or method with a "
+                            . 'void or never return type',
                         $attribute_name_location,
                     ),
                     $suppressed_issues,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -1163,8 +1163,9 @@ final class FunctionCallAnalyzer extends CallAnalyzer
             return;
         }
 
-        // A void/never return has nothing to discard, so the attribute is a no-op there.
-        $return_type = $function_call_info->function_storage->return_type;
+        // A void/never native return has nothing to discard. PHP rejects such a declaration
+        // outright (reported as InvalidAttribute), so this is just a defensive call-site guard.
+        $return_type = $function_call_info->function_storage->signature_return_type;
 
         if ($return_type !== null && ($return_type->isVoid() || $return_type->isNever())) {
             return;

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -357,6 +357,14 @@ final class FunctionCallAnalyzer extends CallAnalyzer
             $context,
         );
 
+        self::checkFunctionNoDiscard(
+            $statements_analyzer,
+            $stmt,
+            $function_name,
+            $function_call_info,
+            $context,
+        );
+
         if ($function_call_info->function_storage) {
             if ($function_call_info->function_storage->assertions && $function_name instanceof PhpParser\Node\Name) {
                 self::applyAssertionsToContext(
@@ -1119,6 +1127,57 @@ final class FunctionCallAnalyzer extends CallAnalyzer
                 }
             }
         }
+    }
+
+    /**
+     * Reports the return value of a `#[\NoDiscard]` function being discarded at a call site.
+     *
+     * Unlike the pure-call check in {@see self::checkFunctionCallPurity()}, this runs
+     * regardless of purity and the find-unused-variables setting, matching PHP 8.5's
+     * runtime behaviour. A `(void)` cast is the documented escape hatch: it analyses its
+     * operand with `inside_general_use`, so `$context->insideUse()` is already true there.
+     *
+     * `#[\NoDiscard]` is only enforced by PHP from 8.5, where the `(void)` escape hatch also
+     * becomes available, so the report is gated on the analysis PHP version. Below 8.5 the
+     * attribute is inert at runtime and `@psalm-suppress` remains the only way to silence it.
+     */
+    private static function checkFunctionNoDiscard(
+        StatementsAnalyzer $statements_analyzer,
+        PhpParser\Node\Expr\FuncCall $stmt,
+        PhpParser\Node $function_name,
+        FunctionCallInfo $function_call_info,
+        Context $context,
+    ): void {
+        if ($context->collect_initializations
+            || $context->collect_mutations
+            || $stmt->isFirstClassCallable()
+            || $statements_analyzer->getCodebase()->analysis_php_version_id < 8_05_00
+            || $function_call_info->function_id === null
+            || $function_call_info->function_storage === null
+            || !$function_call_info->function_storage->no_discard
+        ) {
+            return;
+        }
+
+        if ($context->inside_unset || $context->insideUse()) {
+            return;
+        }
+
+        // A void/never return has nothing to discard, so the attribute is a no-op there.
+        $return_type = $function_call_info->function_storage->return_type;
+
+        if ($return_type !== null && ($return_type->isVoid() || $return_type->isNever())) {
+            return;
+        }
+
+        IssueBuffer::maybeAdd(
+            new UnusedFunctionCall(
+                'The call to ' . $function_call_info->function_id . ' is not used',
+                new CodeLocation($statements_analyzer, $function_name),
+                $function_call_info->function_id,
+            ),
+            $statements_analyzer->getSuppressedIssues(),
+        );
     }
 
     private static function callUsesByReferenceArguments(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -133,6 +133,33 @@ final class MethodCallPurityAnalyzer
             }
         }
 
+        // PHP 8.5's #[\NoDiscard] requires the return value to be used. Unlike the
+        // pure/mutation-free check above, this runs regardless of purity and the
+        // find-unused-variables setting. It is gated on PHP 8.5 (where the attribute is
+        // enforced and the (void) escape hatch exists). A void/never return has nothing
+        // to discard.
+        if ($method_storage->no_discard
+            && $codebase->analysis_php_version_id >= 8_05_00
+            && !$context->collect_initializations
+            && !$context->collect_mutations
+            && !$stmt->isFirstClassCallable()
+            && !$context->inside_unset
+            && !$context->insideUse()
+            && !(
+                $method_storage->return_type
+                && ($method_storage->return_type->isVoid() || $method_storage->return_type->isNever())
+            )
+        ) {
+            IssueBuffer::maybeAdd(
+                new UnusedMethodCall(
+                    'The call to ' . $cased_method_id . ' is not used',
+                    new CodeLocation($statements_analyzer, $stmt->name),
+                    (string) $method_id,
+                ),
+                $statements_analyzer->getSuppressedIssues(),
+            );
+        }
+
         if ($statements_analyzer->getSource() instanceof FunctionLikeAnalyzer
             && $statements_analyzer->getSource()->track_mutations
             && !$method_storage->mutation_free

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/Method/MethodCallPurityAnalyzer.php
@@ -136,9 +136,12 @@ final class MethodCallPurityAnalyzer
         // PHP 8.5's #[\NoDiscard] requires the return value to be used. Unlike the
         // pure/mutation-free check above, this runs regardless of purity and the
         // find-unused-variables setting. It is gated on PHP 8.5 (where the attribute is
-        // enforced and the (void) escape hatch exists). A void/never return has nothing
-        // to discard.
+        // enforced and the (void) escape hatch exists). PHP does not inherit the attribute
+        // onto an implementation, so an abstract/interface declaration alone never fires;
+        // a void/never native return has nothing to discard.
         if ($method_storage->no_discard
+            && !$method_storage->abstract
+            && !$class_storage->is_interface
             && $codebase->analysis_php_version_id >= 8_05_00
             && !$context->collect_initializations
             && !$context->collect_mutations
@@ -146,8 +149,9 @@ final class MethodCallPurityAnalyzer
             && !$context->inside_unset
             && !$context->insideUse()
             && !(
-                $method_storage->return_type
-                && ($method_storage->return_type->isVoid() || $method_storage->return_type->isNever())
+                $method_storage->signature_return_type
+                && ($method_storage->signature_return_type->isVoid()
+                    || $method_storage->signature_return_type->isNever())
             )
         ) {
             IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -321,8 +321,12 @@ final class ExistingAtomicStaticCallAnalyzer
             // PHP 8.5's #[\NoDiscard] requires the return value to be used, including for
             // static calls. Runs regardless of purity and the find-unused-variables setting,
             // but is gated on PHP 8.5 (where the attribute is enforced and the (void) escape
-            // hatch exists); a void/never return has nothing to discard.
+            // hatch exists). PHP does not inherit the attribute onto an implementation, so an
+            // abstract declaration alone never fires; a void/never native return has nothing
+            // to discard.
             if ($method_storage->no_discard
+                && !$method_storage->abstract
+                && !$class_storage->is_interface
                 && $codebase->analysis_php_version_id >= 8_05_00
                 && !$context->collect_initializations
                 && !$context->collect_mutations
@@ -330,8 +334,9 @@ final class ExistingAtomicStaticCallAnalyzer
                 && !$context->inside_unset
                 && !$context->insideUse()
                 && !(
-                    $method_storage->return_type
-                    && ($method_storage->return_type->isVoid() || $method_storage->return_type->isNever())
+                    $method_storage->signature_return_type
+                    && ($method_storage->signature_return_type->isVoid()
+                        || $method_storage->signature_return_type->isNever())
                 )
             ) {
                 IssueBuffer::maybeAdd(

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/StaticMethod/ExistingAtomicStaticCallAnalyzer.php
@@ -28,6 +28,7 @@ use Psalm\Internal\Type\TypeExpander;
 use Psalm\Internal\TypeVisitor\ContainsStaticVisitor;
 use Psalm\Issue\AbstractMethodCall;
 use Psalm\Issue\ImpureMethodCall;
+use Psalm\Issue\UnusedMethodCall;
 use Psalm\IssueBuffer;
 use Psalm\Plugin\EventHandler\Event\AfterMethodCallAnalysisEvent;
 use Psalm\Storage\ClassLikeStorage;
@@ -315,6 +316,32 @@ final class ExistingAtomicStaticCallAnalyzer
 
                     $statements_analyzer->getSource()->inferred_impure = true;
                 }
+            }
+
+            // PHP 8.5's #[\NoDiscard] requires the return value to be used, including for
+            // static calls. Runs regardless of purity and the find-unused-variables setting,
+            // but is gated on PHP 8.5 (where the attribute is enforced and the (void) escape
+            // hatch exists); a void/never return has nothing to discard.
+            if ($method_storage->no_discard
+                && $codebase->analysis_php_version_id >= 8_05_00
+                && !$context->collect_initializations
+                && !$context->collect_mutations
+                && !$stmt->isFirstClassCallable()
+                && !$context->inside_unset
+                && !$context->insideUse()
+                && !(
+                    $method_storage->return_type
+                    && ($method_storage->return_type->isVoid() || $method_storage->return_type->isNever())
+                )
+            ) {
+                IssueBuffer::maybeAdd(
+                    new UnusedMethodCall(
+                        'The call to ' . $cased_method_id . ' is not used',
+                        new CodeLocation($statements_analyzer, $stmt_name),
+                        (string) $method_id,
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
             }
 
             $assertionsResolver = new AssertionsFromInheritanceResolver($codebase);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -300,10 +300,22 @@ final class CastAnalyzer
 
         if ($stmt instanceof PhpParser\Node\Expr\Cast\Void_) {
             // PHP 8.5's (void) cast evaluates its operand and explicitly discards the result.
-            // It is the documented escape hatch for #[\NoDiscard]: analysing the operand under
-            // inside_general_use marks it as used, so no discarded-return-value issue is raised.
-            // The parser only produces this node when targeting PHP 8.5+, so no version guard
-            // is needed here.
+            // It is only valid as a statement; consuming its result is a compile error in PHP
+            // (the parser nikic/php-parser accepts more leniently), so reject it in any
+            // value-consuming position. Otherwise it is the documented escape hatch for
+            // #[\NoDiscard]: analysing the operand under inside_general_use marks it as used, so
+            // no discarded-return-value issue is raised. The parser only produces this node when
+            // targeting PHP 8.5+, so no version guard is needed here.
+            if ($context->insideUse()) {
+                IssueBuffer::maybeAdd(
+                    new InvalidCast(
+                        'The (void) cast can only be used as a statement, not as an expression',
+                        new CodeLocation($statements_analyzer->getSource(), $stmt),
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+
             $expression_result = self::checkExprGeneralUse($statements_analyzer, $stmt, $context);
 
             $statements_analyzer->node_data->setType($stmt, Type::getVoid());

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CastAnalyzer.php
@@ -298,6 +298,19 @@ final class CastAnalyzer
             return true;
         }
 
+        if ($stmt instanceof PhpParser\Node\Expr\Cast\Void_) {
+            // PHP 8.5's (void) cast evaluates its operand and explicitly discards the result.
+            // It is the documented escape hatch for #[\NoDiscard]: analysing the operand under
+            // inside_general_use marks it as used, so no discarded-return-value issue is raised.
+            // The parser only produces this node when targeting PHP 8.5+, so no version guard
+            // is needed here.
+            $expression_result = self::checkExprGeneralUse($statements_analyzer, $stmt, $context);
+
+            $statements_analyzer->node_data->setType($stmt, Type::getVoid());
+
+            return $expression_result;
+        }
+
         IssueBuffer::maybeAdd(
             new UnrecognizedExpression(
                 'Psalm does not understand the cast ' . $stmt::class,

--- a/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
+++ b/src/Psalm/Internal/PhpVisitor/Reflector/FunctionLikeNodeScanner.php
@@ -683,6 +683,10 @@ final class FunctionLikeNodeScanner
                     }
                 }
 
+                if ($attribute->fq_class_name === 'NoDiscard') {
+                    $storage->no_discard = true;
+                }
+
                 if ($attribute->fq_class_name === 'Psalm\\Deprecated'
                     || $attribute->fq_class_name === 'Deprecated'
                     || $attribute->fq_class_name === 'JetBrains\\PhpStorm\\Deprecated'

--- a/src/Psalm/Storage/FunctionLikeStorage.php
+++ b/src/Psalm/Storage/FunctionLikeStorage.php
@@ -144,6 +144,15 @@ abstract class FunctionLikeStorage implements HasAttributesInterface, Stringable
     public bool $pure = false;
 
     /**
+     * Whether the return value of this function/method must be used by callers.
+     *
+     * Set when the function-like is annotated with PHP 8.5's `#[\NoDiscard]` attribute.
+     * When true, Psalm reports the return value being discarded at a call site
+     * independently of purity and the find-unused-variables setting.
+     */
+    public bool $no_discard = false;
+
+    /**
      * Whether or not the function output is dependent solely on input - a function can be
      * impure but still have this property (e.g. var_export). Useful for taint analysis.
      */

--- a/tests/CastTest.php
+++ b/tests/CastTest.php
@@ -14,6 +14,17 @@ final class CastTest extends TestCase
     #[Override]
     public function providerValidCodeParse(): iterable
     {
+        yield 'voidCastDiscardsValueWithoutError' => [
+            'code' => '<?php
+                $x = strlen("hello");
+                (void) $x;
+                (void) strlen("world");
+                echo "reachable";
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
         yield 'SKIPPED-castFalseOrIntToInt' => [
             'code' => '<?php
                 /** @var false|int<10, 20> */

--- a/tests/NoDiscardTest.php
+++ b/tests/NoDiscardTest.php
@@ -184,16 +184,34 @@ final class NoDiscardTest extends TestCase
             'php_version' => '8.5',
         ];
 
-        yield 'noDiscardVoidOrNeverReturnIsNoOp' => [
+        yield 'noDiscardOnInterfaceMethodNotInherited' => [
             'code' => '<?php
-                #[\NoDiscard]
-                function f(): void {}
+                interface I {
+                    #[\NoDiscard]
+                    public function bar(): int;
+                }
 
-                #[\NoDiscard]
-                function g(): never { exit; }
+                // PHP does not inherit #[\NoDiscard] onto implementations, so a call resolved
+                // to the interface declaration must not report.
+                function takesI(I $i): void {
+                    $i->bar();
+                }
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
 
-                f();
-                g();
+        yield 'noDiscardOnAbstractMethodNotInherited' => [
+            'code' => '<?php
+                abstract class A {
+                    #[\NoDiscard]
+                    abstract public function bar(): int;
+                }
+
+                function takesA(A $a): void {
+                    $a->bar();
+                }
             ',
             'assertions' => [],
             'ignored_issues' => [],
@@ -432,18 +450,34 @@ final class NoDiscardTest extends TestCase
             'php_version' => '8.5',
         ];
 
-        yield 'noDiscardInterfaceMethodReturnValueDiscarded' => [
+        yield 'noDiscardOnVoidReturnIsInvalidDeclaration' => [
             'code' => '<?php
-                interface I {
-                    #[\NoDiscard]
-                    public function bar(): int;
-                }
-
-                function takesI(I $i): void {
-                    $i->bar();
-                }
+                #[\NoDiscard]
+                function f(): void {}
             ',
-            'error_message' => 'UnusedMethodCall',
+            'error_message' => 'InvalidAttribute',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardOnNeverReturnIsInvalidDeclaration' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): never { exit; }
+            ',
+            'error_message' => 'InvalidAttribute',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'voidCastInValuePositionIsInvalid' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                $x = (void) f();
+            ',
+            'error_message' => 'InvalidCast',
             'ignored_issues' => [],
             'php_version' => '8.5',
         ];

--- a/tests/NoDiscardTest.php
+++ b/tests/NoDiscardTest.php
@@ -1,0 +1,463 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests;
+
+use Override;
+use Psalm\Context;
+use Psalm\IssueBuffer;
+use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
+use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+use function array_filter;
+
+final class NoDiscardTest extends TestCase
+{
+    use InvalidCodeAnalysisTestTrait;
+    use ValidCodeAnalysisTestTrait;
+
+    /**
+     * A function that is both pure and `#[\NoDiscard]` is matched by the pure-call check and
+     * the NoDiscard check. Both emit an identical UnusedFunctionCall at the same location, so
+     * IssueBuffer must deduplicate them into a single report.
+     */
+    public function testPureNoDiscardFunctionIsReportedOnce(): void
+    {
+        $this->project_analyzer->setPhpVersion('8.5', 'tests');
+        $codebase = $this->project_analyzer->getCodebase();
+        $codebase->find_unused_variables = true;
+        $codebase->config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                /** @psalm-pure */
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                f();
+            ',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+
+        $unused_calls = array_filter(
+            IssueBuffer::getIssuesData()['somefile.php'] ?? [],
+            static fn($issue): bool => $issue->type === 'UnusedFunctionCall',
+        );
+
+        $this->assertCount(1, $unused_calls);
+    }
+
+    /**
+     * A mutation-free `#[\NoDiscard]` method is matched by the mutation-free unused-call check
+     * and the NoDiscard check. Both emit an identical UnusedMethodCall, so IssueBuffer must
+     * deduplicate them into a single report.
+     */
+    public function testMutationFreeNoDiscardMethodIsReportedOnce(): void
+    {
+        $this->project_analyzer->setPhpVersion('8.5', 'tests');
+        $codebase = $this->project_analyzer->getCodebase();
+        $codebase->find_unused_variables = true;
+        $codebase->config->throw_exception = false;
+
+        $this->addFile(
+            'somefile.php',
+            '<?php
+                class Foo {
+                    /** @psalm-mutation-free */
+                    #[\NoDiscard]
+                    public function bar(): int { return 1; }
+                }
+
+                (new Foo())->bar();
+            ',
+        );
+
+        $this->analyzeFile('somefile.php', new Context());
+
+        $unused_calls = array_filter(
+            IssueBuffer::getIssuesData()['somefile.php'] ?? [],
+            static fn($issue): bool => $issue->type === 'UnusedMethodCall',
+        );
+
+        $this->assertCount(1, $unused_calls);
+    }
+
+    #[Override]
+    public function providerValidCodeParse(): iterable
+    {
+        yield 'noDiscardFunctionReturnValueAssigned' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                $x = f();
+                echo $x;
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardFunctionReturnValueReturned' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                function g(): int { return f(); }
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardFunctionReturnValueUsedAsCondition' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                if (f()) {}
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardFunctionReturnValuePassedAsArgument' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                function takesInt(int $i): void {}
+
+                takesInt(f());
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardFunctionResultDiscardedViaVoidCast' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                (void) f();
+                echo "still reachable";
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardWithMessageArgumentStillResolves' => [
+            'code' => '<?php
+                #[\NoDiscard("use the handle")]
+                function f(): int { return 1; }
+
+                $x = f();
+                echo $x;
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardMethodReturnValueUsed' => [
+            'code' => '<?php
+                class Foo {
+                    #[\NoDiscard]
+                    public function bar(): int { return 1; }
+
+                    #[\NoDiscard]
+                    public static function baz(): int { return 1; }
+                }
+
+                $x = (new Foo())->bar();
+                $y = Foo::baz();
+                echo $x + $y;
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardVoidOrNeverReturnIsNoOp' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): void {}
+
+                #[\NoDiscard]
+                function g(): never { exit; }
+
+                f();
+                g();
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardResultDiscardedViaVoidCastOnMethods' => [
+            'code' => '<?php
+                class Foo {
+                    #[\NoDiscard]
+                    public function bar(): int { return 1; }
+
+                    #[\NoDiscard]
+                    public static function baz(): int { return 1; }
+                }
+
+                (void) (new Foo())->bar();
+                (void) Foo::baz();
+                echo "still reachable";
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardSuppressedViaAnnotation' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                /** @psalm-suppress UnusedFunctionCall */
+                f();
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardResultUsedInMatchAndTernaryAndBinaryOp' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                function takesBool(bool $b): void {
+                    $x = $b ? f() : 0;
+                    $y = match (true) { default => f() };
+                    echo $x + $y + f();
+                }
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardNamedMessageArgumentUsed' => [
+            'code' => '<?php
+                #[\NoDiscard(message: "use the handle")]
+                function f(): int { return 1; }
+
+                $x = f();
+                echo $x;
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardAttributeNotEnforcedBelowPhp85' => [
+            'code' => '<?php
+                #[\Attribute(\Attribute::TARGET_FUNCTION | \Attribute::TARGET_METHOD)]
+                final class NoDiscard {
+                    public function __construct(public ?string $message = null) {}
+                }
+
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                f();
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.4',
+        ];
+
+        yield 'noDiscardOverrideThatDropsAttribute' => [
+            'code' => '<?php
+                class A {
+                    #[\NoDiscard]
+                    public function foo(): int { return 1; }
+                }
+
+                class B extends A {
+                    public function foo(): int { return 2; }
+                }
+
+                (new B())->foo();
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardFirstClassCallableCreation' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                $c = f(...);
+                echo $c();
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardNullsafeMethodReturnValueUsed' => [
+            'code' => '<?php
+                class Foo {
+                    #[\NoDiscard]
+                    public function bar(): int { return 1; }
+                }
+
+                function takesFoo(?Foo $foo): void {
+                    $x = $foo?->bar();
+                    echo $x ?? 0;
+                }
+            ',
+            'assertions' => [],
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+    }
+
+    #[Override]
+    public function providerInvalidCodeParse(): iterable
+    {
+        yield 'noDiscardFunctionReturnValueDiscarded' => [
+            'code' => '<?php
+                #[\NoDiscard]
+                function f(): int { return 1; }
+
+                f();
+            ',
+            'error_message' => 'UnusedFunctionCall',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardFunctionWithMessageDiscarded' => [
+            'code' => '<?php
+                #[\NoDiscard("use the handle")]
+                function f(): int { return 1; }
+
+                f();
+            ',
+            'error_message' => 'UnusedFunctionCall',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardInstanceMethodReturnValueDiscarded' => [
+            'code' => '<?php
+                class Foo {
+                    #[\NoDiscard]
+                    public function bar(): int { return 1; }
+                }
+
+                (new Foo())->bar();
+            ',
+            'error_message' => 'UnusedMethodCall',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardStaticMethodReturnValueDiscarded' => [
+            'code' => '<?php
+                class Foo {
+                    #[\NoDiscard]
+                    public static function baz(): int { return 1; }
+                }
+
+                Foo::baz();
+            ',
+            'error_message' => 'UnusedMethodCall',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardInheritedMethodReturnValueDiscarded' => [
+            'code' => '<?php
+                class A {
+                    #[\NoDiscard]
+                    public function foo(): int { return 1; }
+                }
+
+                class C extends A {}
+
+                (new C())->foo();
+            ',
+            'error_message' => 'UnusedMethodCall',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardNullsafeMethodReturnValueDiscarded' => [
+            'code' => '<?php
+                class Foo {
+                    #[\NoDiscard]
+                    public function bar(): int { return 1; }
+                }
+
+                function takesFoo(?Foo $foo): void {
+                    $foo?->bar();
+                }
+            ',
+            'error_message' => 'UnusedMethodCall',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardTraitMethodReturnValueDiscarded' => [
+            'code' => '<?php
+                trait T {
+                    #[\NoDiscard]
+                    public function bar(): int { return 1; }
+                }
+
+                class Foo {
+                    use T;
+                }
+
+                (new Foo())->bar();
+            ',
+            'error_message' => 'UnusedMethodCall',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardInterfaceMethodReturnValueDiscarded' => [
+            'code' => '<?php
+                interface I {
+                    #[\NoDiscard]
+                    public function bar(): int;
+                }
+
+                function takesI(I $i): void {
+                    $i->bar();
+                }
+            ',
+            'error_message' => 'UnusedMethodCall',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+
+        yield 'noDiscardNamedMessageArgumentDiscarded' => [
+            'code' => '<?php
+                #[\NoDiscard(message: "use the handle")]
+                function f(): int { return 1; }
+
+                f();
+            ',
+            'error_message' => 'UnusedFunctionCall',
+            'ignored_issues' => [],
+            'php_version' => '8.5',
+        ];
+    }
+}


### PR DESCRIPTION
PHP 8.5 adds `#[\NoDiscard]`, which marks a function or method whose return value is meant to be used. Ignoring the result raises an `E_WARNING`, and the new `(void)` cast is the documented way to opt out at one call site. This teaches Psalm both halves.

The attribute is recorded on `FunctionLikeStorage` during scanning, and discarding the result now reports the existing `UnusedFunctionCall` / `UnusedMethodCall` issue, covering plain functions, instance methods and static methods, including inherited concrete methods, trait methods and nullsafe calls. Reusing those issues rather than adding a new one keeps the user-facing meaning ("this return value is not used") consistent with the existing pure-call detection. A function that is both pure and `#[\NoDiscard]` is matched by both checks and still reported once.

`NoDiscardAnalyzer` holds the one decision the three call sites share, so the semantics live in a single place. Each rule in it was checked against PHP 8.5:

* PHP does not inherit the attribute onto an implementation, so a call resolved to an interface or abstract declaration does not report, and neither does an override that drops the attribute. The declaration that actually runs has to carry it.
* Applying it to a `void` or `never` return type is a fatal error (`A void function does not return a value, but #[\NoDiscard] requires a return value`), so such a declaration is reported as `InvalidAttribute`, checked against the native signature return type.
* Reporting is gated on the analysis PHP version being 8.5 or higher, where the attribute is enforced and the `(void)` escape hatch parses. Below that the attribute class does not exist, Psalm already reports it as unknown, and `@psalm-suppress` remains the way to silence anything.

The `(void)` cast is a prerequisite, and was previously reported as `UnrecognizedExpression`. The first commit analyses it like the other general-use casts, which both fixes that and supplies the escape hatch, since `(void) f();` analyses its operand as used. `nikic/php-parser` accepts the cast in value positions that PHP rejects at parse time (`$x = (void) f();` is a syntax error on 8.5), so consuming its result is reported as `InvalidCast`.

One gap worth naming: PHP 8.5 marks a number of native functions such as `flock()` with `#[\NoDiscard]`, but those reach Psalm through the call map rather than as scanned attributes, so discarding them is not caught yet. Annotating the call map is the natural follow-up.

Fixes #11381
