### PR TITLE
[6.x] Support PHP 8.5 clone-with-properties

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -113,6 +113,7 @@ final class FunctionCallAnalyzer extends CallAnalyzer
             // usual path. Route it in to preserve the cloned type and run the clone-validity
             // and withProperties checks. `clone` is a reserved keyword, so it is
             // case-insensitive and can never be a user-defined or namespaced function.
+            // analyzeFuncCall reports the function form as unsupported below PHP 8.5.
             if (strtolower($original_function_id) === 'clone') {
                 return CloneAnalyzer::analyzeFuncCall($statements_analyzer, $stmt, $context);
             }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallAnalyzer.php
@@ -13,6 +13,7 @@ use Psalm\Internal\Algebra\FormulaGenerator;
 use Psalm\Internal\Analyzer\AlgebraAnalyzer;
 use Psalm\Internal\Analyzer\FunctionLikeAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\CallAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\CloneAnalyzer;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\Analyzer\TraitAnalyzer;
@@ -106,6 +107,15 @@ final class FunctionCallAnalyzer extends CallAnalyzer
             && !$stmt->getArgs()[0]->unpack
         ) {
             $original_function_id = implode('\\', $function_name->getParts());
+
+            // PHP 8.5 clone-with-properties: `clone($object, [...])` is parsed as a call
+            // to `clone`, not a Clone_ node, so it never reaches CloneAnalyzer via the
+            // usual path. Route it in to preserve the cloned type and run the clone-validity
+            // and withProperties checks. `clone` is a reserved keyword, so it is
+            // case-insensitive and can never be a user-defined or namespaced function.
+            if (strtolower($original_function_id) === 'clone') {
+                return CloneAnalyzer::analyzeFuncCall($statements_analyzer, $stmt, $context);
+            }
 
             if ($original_function_id === 'call_user_func') {
                 $other_args = array_slice($stmt->getArgs(), 1);

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
@@ -17,13 +17,16 @@ use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
 use Psalm\Internal\Type\Comparator\TypeComparisonResult;
 use Psalm\Internal\Type\Comparator\UnionTypeComparator;
+use Psalm\Internal\Type\TypeExpander;
 use Psalm\Issue\InvalidArgument;
 use Psalm\Issue\InvalidClone;
+use Psalm\Issue\InvalidNamedArgument;
 use Psalm\Issue\InvalidPropertyAssignmentValue;
 use Psalm\Issue\MixedClone;
 use Psalm\Issue\ParseError;
 use Psalm\Issue\PossiblyInvalidClone;
 use Psalm\Issue\PossiblyInvalidPropertyAssignmentValue;
+use Psalm\Issue\TooManyArguments;
 use Psalm\Issue\UndefinedPropertyAssignment;
 use Psalm\IssueBuffer;
 use Psalm\Storage\ClassLikeStorage;
@@ -39,6 +42,7 @@ use UnexpectedValueException;
 
 use function array_merge;
 use function array_pop;
+use function count;
 
 /**
  * @internal
@@ -109,16 +113,58 @@ final class CloneAnalyzer
             }
         }
 
+        // Resolve the object/withProperties arguments by position or name, and report
+        // argument-count and unknown-named-argument errors the normal call path would
+        // otherwise raise (it is skipped because clone is intercepted before it runs).
         $object_arg = null;
         $with_properties_arg = null;
+        $positional_count = 0;
 
-        foreach ($stmt->getArgs() as $i => $arg) {
+        foreach ($stmt->getArgs() as $arg) {
             $arg_name = $arg->name?->name;
 
-            if ($arg_name === 'object' || ($arg_name === null && $i === 0)) {
+            if ($arg_name === null) {
+                if ($positional_count === 0) {
+                    $object_arg = $arg;
+                } elseif ($positional_count === 1) {
+                    $with_properties_arg = $arg;
+                } else {
+                    IssueBuffer::maybeAdd(
+                        new TooManyArguments(
+                            'Too many arguments for clone - expecting 2 but saw ' . count($stmt->getArgs()),
+                            new CodeLocation($statements_analyzer->getSource(), $arg),
+                            'clone',
+                        ),
+                        $statements_analyzer->getSuppressedIssues(),
+                    );
+                }
+
+                ++$positional_count;
+            } elseif (($arg_name === 'object' && $object_arg !== null)
+                || ($arg_name === 'withProperties' && $with_properties_arg !== null)
+            ) {
+                // Named argument overwrites one already passed by position.
+                IssueBuffer::maybeAdd(
+                    new InvalidNamedArgument(
+                        'Parameter $' . $arg_name . ' of function clone is already passed by position',
+                        new CodeLocation($statements_analyzer->getSource(), $arg),
+                        'clone',
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            } elseif ($arg_name === 'object') {
                 $object_arg = $arg;
-            } elseif ($arg_name === 'withProperties' || ($arg_name === null && $i === 1)) {
+            } elseif ($arg_name === 'withProperties') {
                 $with_properties_arg = $arg;
+            } else {
+                IssueBuffer::maybeAdd(
+                    new InvalidNamedArgument(
+                        'Parameter $' . $arg_name . ' does not exist on function clone',
+                        new CodeLocation($statements_analyzer->getSource(), $arg),
+                        'clone',
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
             }
         }
 
@@ -377,14 +423,31 @@ final class CloneAnalyzer
         $property_id = $fq_class_name . '::$' . $prop_name;
 
         if (!$codebase->properties->propertyExists($property_id, false, $statements_analyzer, $context)) {
-            $has_magic_setter = $codebase->methods->methodExists(
-                new MethodIdentifier($fq_class_name, '__set'),
-            );
+            // A declared @property-write key is accepted, and its write type is checked.
+            $pseudo_set_type = $class_storage->pseudo_property_set_types['$' . $prop_name] ?? null;
 
-            // A magic __set (or a declared @property-write) can accept an unknown key.
-            if (!$has_magic_setter
-                && !isset($class_storage->pseudo_property_set_types['$' . $prop_name])
-            ) {
+            if ($pseudo_set_type !== null) {
+                if ($class_storage->template_types === null) {
+                    self::validatePropertyValueType(
+                        $statements_analyzer,
+                        $value_type,
+                        TypeExpander::expandUnion(
+                            $codebase,
+                            $pseudo_set_type,
+                            $fq_class_name,
+                            $fq_class_name,
+                            $class_storage->parent_class,
+                        ),
+                        $property_id,
+                        $location,
+                    );
+                }
+
+                return;
+            }
+
+            // Otherwise only a magic __set can accept the unknown key.
+            if (!$codebase->methods->methodExists(new MethodIdentifier($fq_class_name, '__set'))) {
                 IssueBuffer::maybeAdd(
                     new UndefinedPropertyAssignment(
                         'Instance property ' . $property_id . ' is not defined',
@@ -421,26 +484,46 @@ final class CloneAnalyzer
             return;
         }
 
-        // The value comparison is skipped when it cannot be performed faithfully:
-        //  - a generic cloned class, whose property types may reference template
-        //    parameters that are not resolved here (the type arguments are not threaded
-        //    into getExpandedPropertyType, so they stay as `T as ...`), or
-        //  - a null/mixed declared or value type.
-        // Skipping avoids false positives at the cost of not validating these values.
-        if ($class_property_type === null
-            || $class_storage->template_types !== null
-            || $class_property_type->hasMixed()
-            || $value_type->hasMixed()
-        ) {
+        // The value comparison is skipped for a generic cloned class, whose property
+        // types may reference template parameters that are not resolved here (the type
+        // arguments are not threaded into getExpandedPropertyType, so they stay as
+        // `T as ...`). Skipping avoids false positives at the cost of not validating.
+        if ($class_property_type === null || $class_storage->template_types !== null) {
             return;
         }
 
+        self::validatePropertyValueType(
+            $statements_analyzer,
+            $value_type,
+            $class_property_type,
+            $property_id,
+            $location,
+        );
+    }
+
+    /**
+     * Reports InvalidPropertyAssignmentValue / PossiblyInvalidPropertyAssignmentValue
+     * when the assigned value is not (possibly) assignable to the property's declared
+     * type, mirroring InstancePropertyAssignmentAnalyzer's value check.
+     */
+    private static function validatePropertyValueType(
+        StatementsAnalyzer $statements_analyzer,
+        Union $value_type,
+        Union $declared_type,
+        string $property_id,
+        CodeLocation $location,
+    ): void {
+        if ($declared_type->hasMixed() || $value_type->hasMixed()) {
+            return;
+        }
+
+        $codebase = $statements_analyzer->getCodebase();
         $comparison_result = new TypeComparisonResult();
 
         $type_match_found = UnionTypeComparator::isContainedBy(
             $codebase,
             $value_type,
-            $class_property_type,
+            $declared_type,
             true,
             true,
             $comparison_result,
@@ -450,10 +533,10 @@ final class CloneAnalyzer
             return;
         }
 
-        if (UnionTypeComparator::canBeContainedBy($codebase, $value_type, $class_property_type, true, true)) {
+        if (UnionTypeComparator::canBeContainedBy($codebase, $value_type, $declared_type, true, true)) {
             IssueBuffer::maybeAdd(
                 new PossiblyInvalidPropertyAssignmentValue(
-                    $property_id . ' with declared type \'' . $class_property_type->getId()
+                    $property_id . ' with declared type \'' . $declared_type->getId()
                         . '\' cannot be assigned possibly different type \'' . $value_type->getId() . '\'',
                     $location,
                     $property_id,
@@ -466,7 +549,7 @@ final class CloneAnalyzer
 
         IssueBuffer::maybeAdd(
             new InvalidPropertyAssignmentValue(
-                $property_id . ' with declared type \'' . $class_property_type->getId()
+                $property_id . ' with declared type \'' . $declared_type->getId()
                     . '\' cannot be assigned type \'' . $value_type->getId() . '\'',
                 $location,
                 $property_id,

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
@@ -6,22 +6,35 @@ namespace Psalm\Internal\Analyzer\Statements\Expression;
 
 use PhpParser;
 use Psalm\CodeLocation;
+use Psalm\Codebase;
 use Psalm\Context;
+use Psalm\Internal\Analyzer\ClassLikeAnalyzer;
 use Psalm\Internal\Analyzer\MethodAnalyzer;
+use Psalm\Internal\Analyzer\Statements\Expression\Assignment\InstancePropertyAssignmentAnalyzer;
 use Psalm\Internal\Analyzer\Statements\Expression\Call\Method\MethodCallProhibitionAnalyzer;
 use Psalm\Internal\Analyzer\Statements\ExpressionAnalyzer;
 use Psalm\Internal\Analyzer\StatementsAnalyzer;
 use Psalm\Internal\MethodIdentifier;
+use Psalm\Internal\Type\Comparator\TypeComparisonResult;
+use Psalm\Internal\Type\Comparator\UnionTypeComparator;
+use Psalm\Issue\InvalidArgument;
 use Psalm\Issue\InvalidClone;
+use Psalm\Issue\InvalidPropertyAssignmentValue;
 use Psalm\Issue\MixedClone;
 use Psalm\Issue\PossiblyInvalidClone;
+use Psalm\Issue\PossiblyInvalidPropertyAssignmentValue;
+use Psalm\Issue\UndefinedPropertyAssignment;
 use Psalm\IssueBuffer;
+use Psalm\Storage\ClassLikeStorage;
+use Psalm\Type;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TMixed;
 use Psalm\Type\Atomic\TNamedObject;
 use Psalm\Type\Atomic\TNull;
 use Psalm\Type\Atomic\TObject;
 use Psalm\Type\Atomic\TTemplateParam;
+use Psalm\Type\Union;
+use UnexpectedValueException;
 
 use function array_merge;
 use function array_pop;
@@ -36,8 +49,6 @@ final class CloneAnalyzer
         PhpParser\Node\Expr\Clone_ $stmt,
         Context $context,
     ): bool {
-        $codebase = $statements_analyzer->getCodebase();
-        $codebase_methods = $codebase->methods;
         if (ExpressionAnalyzer::analyze($statements_analyzer, $stmt->expr, $context) === false) {
             return false;
         }
@@ -46,117 +57,448 @@ final class CloneAnalyzer
         $stmt_expr_type = $statements_analyzer->node_data->getType($stmt->expr);
 
         if ($stmt_expr_type) {
-            $clone_type = $stmt_expr_type;
+            $result_type = self::analyzeClonedType(
+                $statements_analyzer,
+                $context,
+                $location,
+                $stmt_expr_type,
+            );
 
-            $immutable_cloned = false;
+            if ($result_type !== null) {
+                $statements_analyzer->node_data->setType($stmt, $result_type);
+            }
+        }
 
-            $invalid_clones = [];
-            $mixed_clone = false;
+        return true;
+    }
 
-            $possibly_valid = false;
-            $atomic_types = $clone_type->getAtomicTypes();
+    /**
+     * Handles the PHP 8.5 clone-with-properties form, which php-parser routes as a
+     * call to the `clone` function rather than a `Clone_` node:
+     *   - `clone($object, ['prop' => $value, ...])`
+     *   - `clone(object: $object, withProperties: [...])`
+     *
+     * The cloned type is preserved (instead of the flat `object` the CallMap would
+     * return) and the same validity checks as the bare `clone $x` form are applied.
+     */
+    public static function analyzeFuncCall(
+        StatementsAnalyzer $statements_analyzer,
+        PhpParser\Node\Expr\FuncCall $stmt,
+        Context $context,
+    ): bool {
+        $location = new CodeLocation($statements_analyzer->getSource(), $stmt);
 
-            while ($atomic_types) {
-                $clone_type_part = array_pop($atomic_types);
+        // Analyze every argument value up front so no sub-expression is skipped, even
+        // for malformed calls (extra or unknown-named arguments).
+        foreach ($stmt->getArgs() as $arg) {
+            if (ExpressionAnalyzer::analyze($statements_analyzer, $arg->value, $context) === false) {
+                return false;
+            }
+        }
 
-                if ($clone_type_part instanceof TMixed) {
-                    $mixed_clone = true;
-                } elseif ($clone_type_part instanceof TObject) {
-                    $possibly_valid = true;
-                } elseif ($clone_type_part instanceof TNamedObject) {
-                    if (!$codebase->classlikes->classOrInterfaceExists($clone_type_part->value)) {
+        $object_arg = null;
+        $with_properties_arg = null;
+
+        foreach ($stmt->getArgs() as $i => $arg) {
+            $arg_name = $arg->name?->name;
+
+            if ($arg_name === 'object' || ($arg_name === null && $i === 0)) {
+                $object_arg = $arg;
+            } elseif ($arg_name === 'withProperties' || ($arg_name === null && $i === 1)) {
+                $with_properties_arg = $arg;
+            }
+        }
+
+        // No object to clone (e.g. `clone(withProperties: [...])`); fall back to `object`.
+        $object_type = $object_arg !== null
+            ? $statements_analyzer->node_data->getType($object_arg->value)
+            : null;
+
+        $result_type = $object_type !== null
+            ? self::analyzeClonedType($statements_analyzer, $context, $location, $object_type)
+            : null;
+
+        if ($object_arg !== null && $with_properties_arg !== null) {
+            self::analyzeWithProperties(
+                $statements_analyzer,
+                $context,
+                $location,
+                $with_properties_arg,
+                $object_type,
+            );
+        }
+
+        // Always set a type so downstream analysis never sees null for this expression.
+        $statements_analyzer->node_data->setType($stmt, $result_type ?? Type::getObject());
+
+        return true;
+    }
+
+    /**
+     * Validates a clone of the given type, emitting clone-validity issues
+     * (MixedClone/InvalidClone/PossiblyInvalidClone, __clone visibility) and
+     * returning the result type with immutability flags applied.
+     *
+     * Returns null when the clone is invalid (the relevant issue has already
+     * been emitted), mirroring the bare `clone $x` behaviour of leaving the
+     * expression untyped.
+     */
+    public static function analyzeClonedType(
+        StatementsAnalyzer $statements_analyzer,
+        Context $context,
+        CodeLocation $location,
+        Union $clone_type,
+    ): ?Union {
+        $codebase = $statements_analyzer->getCodebase();
+        $codebase_methods = $codebase->methods;
+
+        $immutable_cloned = false;
+
+        $invalid_clones = [];
+        $mixed_clone = false;
+
+        $possibly_valid = false;
+        $atomic_types = $clone_type->getAtomicTypes();
+
+        while ($atomic_types) {
+            $clone_type_part = array_pop($atomic_types);
+
+            if ($clone_type_part instanceof TMixed) {
+                $mixed_clone = true;
+            } elseif ($clone_type_part instanceof TObject) {
+                $possibly_valid = true;
+            } elseif ($clone_type_part instanceof TNamedObject) {
+                if (!$codebase->classlikes->classOrInterfaceExists($clone_type_part->value)) {
+                    $invalid_clones[] = $clone_type_part->getId();
+                } else {
+                    $clone_method_id = new MethodIdentifier(
+                        $clone_type_part->value,
+                        '__clone',
+                    );
+
+                    $does_method_exist = $codebase_methods->methodExists(
+                        $clone_method_id,
+                        $context->calling_method_id,
+                        $location,
+                    );
+                    $is_method_visible = MethodAnalyzer::isMethodVisible(
+                        $clone_method_id,
+                        $context,
+                        $statements_analyzer->getSource(),
+                    );
+                    if ($does_method_exist && !$is_method_visible) {
                         $invalid_clones[] = $clone_type_part->getId();
                     } else {
-                        $clone_method_id = new MethodIdentifier(
-                            $clone_type_part->value,
-                            '__clone',
-                        );
-
-                        $does_method_exist = $codebase_methods->methodExists(
-                            $clone_method_id,
-                            $context->calling_method_id,
-                            $location,
-                        );
-                        $is_method_visible = MethodAnalyzer::isMethodVisible(
-                            $clone_method_id,
+                        MethodCallProhibitionAnalyzer::analyze(
+                            $codebase,
                             $context,
-                            $statements_analyzer->getSource(),
+                            $clone_method_id,
+                            $statements_analyzer->getNamespace(),
+                            $location,
+                            $statements_analyzer->getSuppressedIssues(),
                         );
-                        if ($does_method_exist && !$is_method_visible) {
-                            $invalid_clones[] = $clone_type_part->getId();
-                        } else {
-                            MethodCallProhibitionAnalyzer::analyze(
-                                $codebase,
-                                $context,
-                                $clone_method_id,
-                                $statements_analyzer->getNamespace(),
-                                $location,
-                                $statements_analyzer->getSuppressedIssues(),
-                            );
-                            $possibly_valid = true;
-                            $immutable_cloned = true;
-                        }
+                        $possibly_valid = true;
+                        $immutable_cloned = true;
                     }
-                } elseif ($clone_type_part instanceof TTemplateParam) {
-                    $atomic_types = array_merge($atomic_types, $clone_type_part->as->getAtomicTypes());
-                } else {
-                    if ($clone_type_part instanceof TFalse
-                        && $clone_type->ignore_falsable_issues
-                    ) {
-                        continue;
-                    }
-
-                    if ($clone_type_part instanceof TNull
-                        && $clone_type->ignore_nullable_issues
-                    ) {
-                        continue;
-                    }
-
-                    $invalid_clones[] = $clone_type_part->getId();
                 }
-            }
+            } elseif ($clone_type_part instanceof TTemplateParam) {
+                $atomic_types = array_merge($atomic_types, $clone_type_part->as->getAtomicTypes());
+            } else {
+                if ($clone_type_part instanceof TFalse
+                    && $clone_type->ignore_falsable_issues
+                ) {
+                    continue;
+                }
 
-            if ($mixed_clone) {
+                if ($clone_type_part instanceof TNull
+                    && $clone_type->ignore_nullable_issues
+                ) {
+                    continue;
+                }
+
+                $invalid_clones[] = $clone_type_part->getId();
+            }
+        }
+
+        if ($mixed_clone) {
+            IssueBuffer::maybeAdd(
+                new MixedClone(
+                    'Cannot clone mixed',
+                    $location,
+                ),
+                $statements_analyzer->getSuppressedIssues(),
+            );
+        }
+
+        if ($invalid_clones) {
+            if ($possibly_valid) {
                 IssueBuffer::maybeAdd(
-                    new MixedClone(
-                        'Cannot clone mixed',
+                    new PossiblyInvalidClone(
+                        'Cannot clone ' . $invalid_clones[0],
+                        $location,
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            } else {
+                IssueBuffer::maybeAdd(
+                    new InvalidClone(
+                        'Cannot clone ' . $invalid_clones[0],
                         $location,
                     ),
                     $statements_analyzer->getSuppressedIssues(),
                 );
             }
 
-            if ($invalid_clones) {
-                if ($possibly_valid) {
-                    IssueBuffer::maybeAdd(
-                        new PossiblyInvalidClone(
-                            'Cannot clone ' . $invalid_clones[0],
-                            $location,
-                        ),
-                        $statements_analyzer->getSuppressedIssues(),
-                    );
-                } else {
-                    IssueBuffer::maybeAdd(
-                        new InvalidClone(
-                            'Cannot clone ' . $invalid_clones[0],
-                            $location,
-                        ),
-                        $statements_analyzer->getSuppressedIssues(),
-                    );
-                }
-
-                return true;
-            }
-
-            if ($immutable_cloned) {
-                $stmt_expr_type = $stmt_expr_type->setProperties([
-                    'reference_free' => true,
-                    'allow_mutations' => true,
-                ]);
-            }
-            $statements_analyzer->node_data->setType($stmt, $stmt_expr_type);
+            return null;
         }
 
-        return true;
+        if ($immutable_cloned) {
+            $clone_type = $clone_type->setProperties([
+                'reference_free' => true,
+                'allow_mutations' => true,
+            ]);
+        }
+
+        return $clone_type;
+    }
+
+    /**
+     * Validates the `withProperties` array of a clone-with expression.
+     *
+     * Each literal-string key must name an accessible property of the cloned class,
+     * and each value must be assignable to that property's declared type. Unlike a
+     * regular property write, replacing `readonly` properties is permitted here (the
+     * point of the RFC), so this validation deliberately does not route through
+     * InstancePropertyAssignmentAnalyzer, whose readonly write guard would reject
+     * top-level clone-with calls (it requires `$context->self`, which is null outside
+     * a class). The type/visibility/existence checks are replicated instead.
+     *
+     * Not (yet) replicated from the regular property-write path: data-flow/taint of the
+     * replacement values, magic `__set` value typing, and the softer coercion diagnostics
+     * (PropertyTypeCoercion, ImplicitToStringCast, PossiblyNull/FalsePropertyAssignmentValue).
+     */
+    private static function analyzeWithProperties(
+        StatementsAnalyzer $statements_analyzer,
+        Context $context,
+        CodeLocation $location,
+        PhpParser\Node\Arg $with_properties_arg,
+        ?Union $object_type,
+    ): void {
+        $codebase = $statements_analyzer->getCodebase();
+        $with_properties_value = $with_properties_arg->value;
+        $with_properties_type = $statements_analyzer->node_data->getType($with_properties_value);
+
+        // A second argument that cannot be an array is always invalid.
+        if ($with_properties_type !== null
+            && !$with_properties_type->hasArray()
+            && !$with_properties_type->hasMixed()
+            && !$with_properties_type->hasTemplate()
+        ) {
+            IssueBuffer::maybeAdd(
+                new InvalidArgument(
+                    'Argument 2 of clone expects array<string, mixed>, but '
+                        . $with_properties_type->getId() . ' provided',
+                    $location,
+                    'clone',
+                ),
+                $statements_analyzer->getSuppressedIssues(),
+            );
+
+            return;
+        }
+
+        // Per-key validation needs both a literal array and a single, known class.
+        // Anything else (dynamic array, union/templated/object target) is left
+        // unchecked to avoid false positives; the result type is preserved regardless.
+        if (!$with_properties_value instanceof PhpParser\Node\Expr\Array_) {
+            return;
+        }
+
+        $fq_class_name = self::getClonedClassName($codebase, $object_type);
+
+        if ($fq_class_name === null) {
+            return;
+        }
+
+        $class_storage = $codebase->classlike_storage_provider->get($fq_class_name);
+
+        foreach ($with_properties_value->items as $item) {
+            if ($item === null || $item->unpack || $item->key === null) {
+                continue;
+            }
+
+            $prop_name = self::getLiteralPropertyName($statements_analyzer, $item->key);
+
+            if ($prop_name === null) {
+                continue;
+            }
+
+            $value_type = $statements_analyzer->node_data->getType($item->value) ?? Type::getMixed();
+
+            self::validateClonedProperty(
+                $statements_analyzer,
+                $context,
+                $class_storage,
+                $fq_class_name,
+                $prop_name,
+                $value_type,
+                new CodeLocation($statements_analyzer->getSource(), $item->value),
+            );
+        }
+    }
+
+    /**
+     * Validates a single `prop => value` entry of a clone-with array against the
+     * cloned class, emitting undefined-property, visibility and value-type issues.
+     */
+    private static function validateClonedProperty(
+        StatementsAnalyzer $statements_analyzer,
+        Context $context,
+        ClassLikeStorage $class_storage,
+        string $fq_class_name,
+        string $prop_name,
+        Union $value_type,
+        CodeLocation $location,
+    ): void {
+        $codebase = $statements_analyzer->getCodebase();
+        $property_id = $fq_class_name . '::$' . $prop_name;
+
+        if (!$codebase->properties->propertyExists($property_id, false, $statements_analyzer, $context)) {
+            $has_magic_setter = $codebase->methods->methodExists(
+                new MethodIdentifier($fq_class_name, '__set'),
+            );
+
+            // A magic __set (or a declared @property-write) can accept an unknown key.
+            if (!$has_magic_setter
+                && !isset($class_storage->pseudo_property_set_types['$' . $prop_name])
+            ) {
+                IssueBuffer::maybeAdd(
+                    new UndefinedPropertyAssignment(
+                        'Instance property ' . $property_id . ' is not defined',
+                        $location,
+                        $property_id,
+                    ),
+                    $statements_analyzer->getSuppressedIssues(),
+                );
+            }
+
+            return;
+        }
+
+        try {
+            // Emits InaccessibleProperty when the property is not visible from here.
+            // The readonly write guard is intentionally skipped (see analyzeWithProperties).
+            ClassLikeAnalyzer::checkPropertyVisibility(
+                $property_id,
+                $context,
+                $statements_analyzer,
+                $location,
+                $statements_analyzer->getSuppressedIssues(),
+            );
+
+            $class_property_type = InstancePropertyAssignmentAnalyzer::getExpandedPropertyType(
+                $codebase,
+                $fq_class_name,
+                $prop_name,
+                $class_storage,
+            );
+        } catch (UnexpectedValueException) {
+            // A plugin can report a property as existing without a resolvable declaring
+            // class; skip the value check rather than crash.
+            return;
+        }
+
+        // The value comparison is skipped when it cannot be performed faithfully:
+        //  - a generic cloned class, whose property types may reference template
+        //    parameters that are not resolved here (the type arguments are not threaded
+        //    into getExpandedPropertyType, so they stay as `T as ...`), or
+        //  - a null/mixed declared or value type.
+        // Skipping avoids false positives at the cost of not validating these values.
+        if ($class_property_type === null
+            || $class_storage->template_types !== null
+            || $class_property_type->hasMixed()
+            || $value_type->hasMixed()
+        ) {
+            return;
+        }
+
+        $comparison_result = new TypeComparisonResult();
+
+        $type_match_found = UnionTypeComparator::isContainedBy(
+            $codebase,
+            $value_type,
+            $class_property_type,
+            true,
+            true,
+            $comparison_result,
+        );
+
+        if ($type_match_found || $comparison_result->type_coerced) {
+            return;
+        }
+
+        if (UnionTypeComparator::canBeContainedBy($codebase, $value_type, $class_property_type, true, true)) {
+            IssueBuffer::maybeAdd(
+                new PossiblyInvalidPropertyAssignmentValue(
+                    $property_id . ' with declared type \'' . $class_property_type->getId()
+                        . '\' cannot be assigned possibly different type \'' . $value_type->getId() . '\'',
+                    $location,
+                    $property_id,
+                ),
+                $statements_analyzer->getSuppressedIssues(),
+            );
+
+            return;
+        }
+
+        IssueBuffer::maybeAdd(
+            new InvalidPropertyAssignmentValue(
+                $property_id . ' with declared type \'' . $class_property_type->getId()
+                    . '\' cannot be assigned type \'' . $value_type->getId() . '\'',
+                $location,
+                $property_id,
+            ),
+            $statements_analyzer->getSuppressedIssues(),
+        );
+    }
+
+    /**
+     * Returns the single named class behind the cloned object's type, or null when it
+     * is not exactly one known class (union, intersection, template, plain object,
+     * interface, ...), in which case per-key validation is skipped.
+     */
+    private static function getClonedClassName(Codebase $codebase, ?Union $object_type): ?string
+    {
+        if ($object_type === null || !$object_type->isSingle()) {
+            return null;
+        }
+
+        $atomic = $object_type->getSingleAtomic();
+
+        if (!$atomic instanceof TNamedObject
+            || $atomic->extra_types // intersection: members beyond the primary are not validated
+            || !$codebase->classlikes->classExists($atomic->value)
+        ) {
+            return null;
+        }
+
+        return $atomic->value;
+    }
+
+    private static function getLiteralPropertyName(
+        StatementsAnalyzer $statements_analyzer,
+        PhpParser\Node\Expr $key,
+    ): ?string {
+        if ($key instanceof PhpParser\Node\Scalar\String_) {
+            return $key->value;
+        }
+
+        $key_type = $statements_analyzer->node_data->getType($key);
+
+        if ($key_type !== null && $key_type->isSingleStringLiteral()) {
+            return $key_type->getSingleStringLiteral()->value;
+        }
+
+        return null;
     }
 }

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/CloneAnalyzer.php
@@ -21,6 +21,7 @@ use Psalm\Issue\InvalidArgument;
 use Psalm\Issue\InvalidClone;
 use Psalm\Issue\InvalidPropertyAssignmentValue;
 use Psalm\Issue\MixedClone;
+use Psalm\Issue\ParseError;
 use Psalm\Issue\PossiblyInvalidClone;
 use Psalm\Issue\PossiblyInvalidPropertyAssignmentValue;
 use Psalm\Issue\UndefinedPropertyAssignment;
@@ -87,6 +88,18 @@ final class CloneAnalyzer
         Context $context,
     ): bool {
         $location = new CodeLocation($statements_analyzer->getSource(), $stmt);
+
+        // The function form of clone only exists on PHP 8.5+. Below that it is a
+        // compile error, so report it while still analysing the call for tooling.
+        if ($statements_analyzer->getCodebase()->analysis_php_version_id < 8_05_00) {
+            IssueBuffer::maybeAdd(
+                new ParseError(
+                    'Calling clone() as a function with arguments requires PHP 8.5',
+                    $location,
+                ),
+                $statements_analyzer->getSuppressedIssues(),
+            );
+        }
 
         // Analyze every argument value up front so no sub-expression is skipped, even
         // for malformed calls (extra or unknown-named arguments).

--- a/tests/CloneTest.php
+++ b/tests/CloneTest.php
@@ -459,6 +459,43 @@ final class CloneTest extends TestCase
                 'error_levels' => [],
                 'php_version' => '8.5',
             ],
+            'cloneWithUnknownNamedArgument' => [
+                'code' => '<?php
+                    class Foo {}
+                    $o = new Foo();
+                    clone(foo: $o);',
+                'error_message' => 'InvalidNamedArgument',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithExtraPositionalArgument' => [
+                'code' => '<?php
+                    class Foo {}
+                    $o = new Foo();
+                    clone($o, [], []);',
+                'error_message' => 'TooManyArguments',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithPropertyWriteAnnotationInvalidValue' => [
+                'code' => '<?php
+                    /** @property-write string $dynamic */
+                    class Foo {}
+                    $o = new Foo();
+                    clone($o, ["dynamic" => 1]);',
+                'error_message' => 'InvalidPropertyAssignmentValue',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithObjectPassedByPositionAndName' => [
+                'code' => '<?php
+                    class Foo {}
+                    $o = new Foo();
+                    clone($o, object: $o);',
+                'error_message' => 'InvalidNamedArgument',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
         ];
     }
 }

--- a/tests/CloneTest.php
+++ b/tests/CloneTest.php
@@ -44,6 +44,185 @@ final class CloneTest extends TestCase
                         }
                     }',
             ],
+            'cloneWithPropertiesPreservesType' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    $o = new Foo(1);
+                    $b = clone($o, ["x" => 2]);',
+                'assertions' => ['$b===' => 'Foo'],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithReadonlyPropertyAllowed' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(
+                            public int $x,
+                            public readonly string $y,
+                        ) {}
+                    }
+                    $o = new Foo(1, "a");
+                    $b = clone($o, ["y" => "b"]);',
+                'assertions' => ['$b===' => 'Foo'],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithNamedArguments' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    $o = new Foo(1);
+                    $b = clone(object: $o, withProperties: ["x" => 2]);',
+                'assertions' => ['$b===' => 'Foo'],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneFuncCallWithSingleNamedObjectArg' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    $o = new Foo(1);
+                    $b = clone(object: $o);',
+                'assertions' => ['$b===' => 'Foo'],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithDynamicPropertiesArrayNoFalsePositive' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    /** @param array<string, mixed> $props */
+                    function withProps(Foo $o, array $props): Foo {
+                        return clone($o, $props);
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithMagicSetterUnknownKeyAllowed' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                        public function __set(string $name, mixed $value): void {}
+                    }
+                    $o = new Foo(1);
+                    $b = clone($o, ["dynamic" => "anything"]);',
+                'assertions' => ['$b===' => 'Foo'],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithPropertyWriteAnnotationAllowed' => [
+                'code' => '<?php
+                    /** @property-write string $dynamic */
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    $o = new Foo(1);
+                    $b = clone($o, ["dynamic" => "anything"]);',
+                'assertions' => ['$b===' => 'Foo'],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithMultipleProperties' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x, public string $y) {}
+                    }
+                    $o = new Foo(1, "a");
+                    $b = clone($o, ["x" => 2, "y" => "b"]);',
+                'assertions' => ['$b===' => 'Foo'],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithNonLiteralKeyNoFalsePositive' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    function withDynamicKey(Foo $o, string $k): Foo {
+                        return clone($o, [$k => 2]);
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithPropertiesOnGenericClass' => [
+                'code' => '<?php
+                    /** @template T */
+                    class Box {
+                        /** @param T $value */
+                        public function __construct(public mixed $value) {}
+                    }
+                    /** @param Box<int> $o */
+                    function withValue(Box $o): Box {
+                        return clone($o, ["value" => 2]);
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithPropertiesOnGenericClassNestedTemplate' => [
+                'code' => '<?php
+                    /** @template T */
+                    class Box {
+                        /** @var list<T> */
+                        public array $items = [];
+                    }
+                    /** @param Box<int> $o */
+                    function withItems(Box $o): Box {
+                        return clone($o, ["items" => [1, 2, 3]]);
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithPropertiesOnIntersectionType' => [
+                'code' => '<?php
+                    class A {
+                        public int $a = 0;
+                    }
+                    class B {
+                        public int $b = 0;
+                    }
+                    /** @param A&B $o */
+                    function withMember($o): object {
+                        return clone($o, ["b" => 5]);
+                    }',
+                'assertions' => [],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneFuncCallCaseInsensitive' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    $o = new Foo(1);
+                    $b = Clone($o, ["x" => 2]);',
+                'assertions' => ['$b===' => 'Foo'],
+                'ignored_issues' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithSpreadArgsFallsBackGracefully' => [
+                // An unpacked first arg skips the clone-with intercept and falls back to
+                // normal call analysis (CallMap). That path is conservative about spreads;
+                // the point here is that the intercept is bypassed without a crash and the
+                // result type stays object.
+                'code' => '<?php
+                    class Foo {}
+                    /** @param array{0: Foo} $args */
+                    function cloneSpread(array $args): object {
+                        return clone(...$args);
+                    }',
+                'assertions' => [],
+                'ignored_issues' => ['MixedArgument', 'TooFewArguments'],
+                'php_version' => '8.5',
+            ],
         ];
     }
 
@@ -160,6 +339,114 @@ final class CloneTest extends TestCase
                     /** @psalm-suppress UndefinedDocblockClass */
                     clone get();',
                 'error_message' => 'InvalidClone',
+            ],
+            'cloneWithUnknownProperty' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    $o = new Foo(1);
+                    clone($o, ["nope" => 1]);',
+                'error_message' => 'UndefinedPropertyAssignment',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithInvalidValueType' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    $o = new Foo(1);
+                    clone($o, ["x" => "str"]);',
+                'error_message' => 'InvalidPropertyAssignmentValue',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithInaccessiblePrivateProperty' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(private int $x) {}
+                    }
+                    $o = new Foo(1);
+                    clone($o, ["x" => 2]);',
+                'error_message' => 'InaccessibleProperty',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithNonArrayProperties' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    $o = new Foo(1);
+                    clone($o, 5);',
+                'error_message' => 'InvalidArgument',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithPropertiesOnInt' => [
+                'code' => '<?php
+                    $a = 5;
+                    clone($a, ["x" => 1]);',
+                'error_message' => 'InvalidClone',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithPropertiesOnMixed' => [
+                'code' => '<?php
+                    /** @var mixed $a */
+                    $a = 5;
+                    clone($a, ["x" => 1]);',
+                'error_message' => 'MixedClone',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithPossiblyInvalidValue' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    /** @param int|string $v */
+                    function make(Foo $o, $v): void {
+                        clone($o, ["x" => $v]);
+                    }',
+                'error_message' => 'PossiblyInvalidPropertyAssignmentValue',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithMultiplePropertiesSecondInvalid' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x, public string $y) {}
+                    }
+                    $o = new Foo(1, "a");
+                    clone($o, ["x" => 2, "y" => 5]);',
+                'error_message' => 'InvalidPropertyAssignmentValue',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithPropertiesAndInaccessibleCloneMethod' => [
+                'code' => '<?php
+                    class Foo {
+                        public int $x = 0;
+                        private function __clone() {}
+                    }
+                    $o = new Foo();
+                    clone($o, ["x" => 2]);',
+                'error_message' => 'InvalidClone',
+                'error_levels' => [],
+                'php_version' => '8.5',
+            ],
+            'cloneWithInaccessibleProtectedProperty' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(protected int $x) {}
+                    }
+                    $o = new Foo(1);
+                    clone($o, ["x" => 2]);',
+                'error_message' => 'InaccessibleProperty',
+                'error_levels' => [],
+                'php_version' => '8.5',
             ],
         ];
     }

--- a/tests/CloneTest.php
+++ b/tests/CloneTest.php
@@ -340,6 +340,17 @@ final class CloneTest extends TestCase
                     clone get();',
                 'error_message' => 'InvalidClone',
             ],
+            'cloneWithFunctionFormRequiresPhp85' => [
+                'code' => '<?php
+                    class Foo {
+                        public function __construct(public int $x) {}
+                    }
+                    $o = new Foo(1);
+                    $b = clone($o, ["x" => 2]);',
+                'error_message' => 'ParseError',
+                'error_levels' => [],
+                'php_version' => '8.4',
+            ],
             'cloneWithUnknownProperty' => [
                 'code' => '<?php
                     class Foo {


### PR DESCRIPTION
PHP 8.5 adds a function form of clone, `clone(object $object, array $withProperties = [])`, that returns a copy with some properties replaced. The vendored php-parser keeps `clone $o` and `clone($o)` as a `Clone_` node, but a two-argument or named-argument call, such as `clone($o, [...])` or `clone(object: $o)`, is parsed as a plain `FuncCall` to `clone`. That form never reached `CloneAnalyzer`: the cloned type collapsed to a flat `object`, none of the usual clone checks ran, and `withProperties` went unchecked.

This routes that `FuncCall` into `CloneAnalyzer`, preserving the type of the cloned expression and running the same validity checks as bare `clone`. The `withProperties` array is validated against the cloned class: each literal-string key must name an accessible property, and each value must be assignable to its declared type. Replacing `readonly` properties is allowed by design. The analyzer also reports argument-count and named-argument misuse, and emits `ParseError` when the function form is used below PHP 8.5.

This is a superset of #11884, which only preserves the type via a stub. The two are alternatives, not complements: if this lands, the stub is unnecessary for the two-argument form.
