### PR TITLE
[7.x] Fix: restore `StatementsAnalyzer`'s dropped `$depth`/`$root_scope` properties

### DIFF
--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -168,8 +168,16 @@ final class StatementsAnalyzer extends SourceAnalyzer
      */
     public readonly bool $owns_type_variable_tracker;
 
-    public function __construct(protected SourceAnalyzer $source, public NodeDataProvider $node_data)
-    {
+    private int $depth = 0;
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        protected SourceAnalyzer $source,
+        public NodeDataProvider $node_data,
+        private readonly bool $root_scope,
+    ) {
         $this->file_analyzer = $source->getFileAnalyzer();
         $this->codebase = $source->getCodebase();
 
@@ -185,10 +193,17 @@ final class StatementsAnalyzer extends SourceAnalyzer
             $this->owns_type_variable_tracker = true;
         }
 
-        if ($this->codebase->taint_flow_graph) {
-            $this->data_flow_graph = new TaintFlowGraph();
-        } elseif ($this->codebase->find_unused_variables) {
-            $this->data_flow_graph = new VariableUseGraph();
+        if ($this->codebase->taint_flow_graph
+            && $root_scope
+            && $this->codebase->config->trackTaintsInPath($this->getFilePath())
+        ) {
+            $this->data_flow_graph = $this->taint_flow_graph = $this->codebase->taint_flow_graph;
+        }
+        if ($this->codebase->find_unused_variables) {
+            $this->data_flow_graph = $this->variable_use_graph = new VariableUseGraph();
+        }
+        if ($this->taint_flow_graph && $this->variable_use_graph) {
+            $this->data_flow_graph = new CombinedFlowGraph($this->variable_use_graph, $this->taint_flow_graph);
         }
     }
 


### PR DESCRIPTION
## Context

Merge 290eaec2 resolved a conflict in `StatementsAnalyzer.php` by taking 6.x's constructor wholesale while keeping master's `analyze()` wholesale. That dropped `private int $depth = 0;`, the `$root_scope` constructor property, and the constructor logic populating `$taint_flow_graph`/`$variable_use_graph` — not just `$depth` as #11899 describes. Result: PHP 8.2+ crashes (dynamic-property deprecation, converted to an uncaught `RuntimeException` by Psalm's own `ErrorHandler`), and even without the crash (e.g. under PHPUnit) unused-variable/taint detection silently no-ops since `$variable_use_graph` stays null.

As a solution, I restored all three to match the pre-merge master constructor 5c1c31c62, interleaved with 6.x's later `type_variable_tracker` addition. All 6 `new StatementsAnalyzer(...)` call sites already pass the 3rd argument PHP was silently dropping.

Validated:
 - crash gone
 - full suite 374 failing/erroring tests → 72 (all pre-existing, unrelated)
 - self-analysis 6139 issues → 12 (all pre-existing, unrelated)

I'm ready to recover remaining issues in separate PR.

Fixes #11899

