### PR TITLE
Fix: unused import, duplicate issue shortcode, Windows CI opcache/bypass-finals conflict

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           php-version: '8.5'
           #ini-values: zend.assertions=1, assert.exception=1, opcache.enable_cli=1, opcache.jit=function, opcache.jit_buffer_size=512M
-          ini-values: zend.assertions=1, assert.exception=1, opcache.enable_cli=1, opcache.jit=off
+          ini-values: zend.assertions=1, assert.exception=1
           tools: composer:v2
           coverage: none
           #extensions: none, curl, dom, filter, intl, json, libxml, mbstring, openssl, opcache, pcre, phar, reflection, simplexml, spl, tokenizer, xml, xmlwriter

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -1110,6 +1110,8 @@ final class NewAnalyzer extends CallAnalyzer
      * Whether the constructor binds the given template through a `class-string<T>`
      * (`T::class`) parameter position, which names the template's type exactly
      * rather than providing a value of it.
+     *
+     * @psalm-mutation-free
      */
     private static function templateBoundThroughClassString(
         MethodStorage $method_storage,
@@ -1139,6 +1141,7 @@ final class NewAnalyzer extends CallAnalyzer
      * only have been fixed at the construction site.
      *
      * @return array<string, true>
+     * @psalm-mutation-free
      */
     private static function getUnconstrainableTemplates(ClassLikeStorage $storage): array
     {

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -168,8 +168,16 @@ final class StatementsAnalyzer extends SourceAnalyzer
      */
     public readonly bool $owns_type_variable_tracker;
 
-    public function __construct(protected SourceAnalyzer $source, public NodeDataProvider $node_data)
-    {
+    private int $depth = 0;
+
+    /**
+     * @psalm-mutation-free
+     */
+    public function __construct(
+        protected SourceAnalyzer $source,
+        public NodeDataProvider $node_data,
+        private readonly bool $root_scope,
+    ) {
         $this->file_analyzer = $source->getFileAnalyzer();
         $this->codebase = $source->getCodebase();
 
@@ -185,10 +193,17 @@ final class StatementsAnalyzer extends SourceAnalyzer
             $this->owns_type_variable_tracker = true;
         }
 
-        if ($this->codebase->taint_flow_graph) {
-            $this->data_flow_graph = new TaintFlowGraph();
-        } elseif ($this->codebase->find_unused_variables) {
-            $this->data_flow_graph = new VariableUseGraph();
+        if ($this->codebase->taint_flow_graph
+            && $root_scope
+            && $this->codebase->config->trackTaintsInPath($this->getFilePath())
+        ) {
+            $this->data_flow_graph = $this->taint_flow_graph = $this->codebase->taint_flow_graph;
+        }
+        if ($this->codebase->find_unused_variables) {
+            $this->data_flow_graph = $this->variable_use_graph = new VariableUseGraph();
+        }
+        if ($this->taint_flow_graph && $this->variable_use_graph) {
+            $this->data_flow_graph = new CombinedFlowGraph($this->variable_use_graph, $this->taint_flow_graph);
         }
     }
 

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterUtils.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterUtils.php
@@ -20,7 +20,6 @@ use Psalm\Type;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TArrayKey;
 use Psalm\Type\Atomic\TBool;
-use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;

--- a/src/Psalm/Internal/Type/TypeVariableBounds.php
+++ b/src/Psalm/Internal/Type/TypeVariableBounds.php
@@ -12,6 +12,10 @@ use function count;
  * when the surrounding function-like has been analyzed.
  *
  * @internal
+ * @psalm-suppress MissingImmutableAnnotation TypeVariableTracker::addBounds()
+ *     appends to lower_bounds/upper_bounds in place, on purpose: every
+ *     TTypeVariable holding a reference to this object needs to see later
+ *     constraints as they're recorded during analysis.
  */
 final class TypeVariableBounds
 {
@@ -24,6 +28,7 @@ final class TypeVariableBounds
     /**
      * @param list<TemplateBound> $lower_bounds
      * @param list<TemplateBound> $upper_bounds
+     * @psalm-mutation-free
      */
     public function __construct(
         public array $lower_bounds = [],

--- a/src/Psalm/Internal/Type/TypeVariableTracker.php
+++ b/src/Psalm/Internal/Type/TypeVariableTracker.php
@@ -40,6 +40,8 @@ final class TypeVariableTracker
 
     /**
      * Mints a fresh type variable name, registering its bound storage.
+     *
+     * @psalm-external-mutation-free
      */
     public function addVariable(TypeVariableBounds $bounds): string
     {
@@ -80,6 +82,8 @@ final class TypeVariableTracker
      * below. Used where a concrete shape is required (property reads, method
      * call returns); the variable itself stays in the object's type params,
      * so later uses still constrain it.
+     *
+     * @psalm-external-mutation-free
      */
     public static function resolveTypeVariables(Union $type, ?Codebase $codebase): Union
     {
@@ -327,6 +331,7 @@ final class TypeVariableTracker
      *
      * @param list<TemplateBound> $lower_bounds
      * @return list<TemplateBound>
+     * @psalm-mutation-free
      */
     private static function getRelevantBounds(array $lower_bounds): array
     {

--- a/src/Psalm/Internal/TypeVisitor/TypeVariableResolver.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeVariableResolver.php
@@ -29,6 +29,9 @@ final class TypeVariableResolver extends MutableTypeVisitor
 {
     public bool $resolved_a_variable = false;
 
+    /**
+     * @psalm-mutation-free
+     */
     public function __construct(
         private readonly ?Codebase $codebase,
     ) {

--- a/src/Psalm/Issue/IncompatibleTypeParameters.php
+++ b/src/Psalm/Issue/IncompatibleTypeParameters.php
@@ -7,5 +7,5 @@ namespace Psalm\Issue;
 final class IncompatibleTypeParameters extends CodeIssue
 {
     public const ERROR_LEVEL = 1;
-    public const SHORTCODE = 362;
+    public const SHORTCODE = 368;
 }

--- a/src/Psalm/Type/Atomic/TTypeVariable.php
+++ b/src/Psalm/Type/Atomic/TTypeVariable.php
@@ -66,7 +66,8 @@ final class TTypeVariable extends Atomic
     }
 
     /**
-     * @param  array<lowercase-string, string> $aliased_classes
+     * @param array<lowercase-string, string> $aliased_classes
+     * @psalm-pure
      */
     #[Override]
     public function toPhpString(
@@ -78,6 +79,9 @@ final class TTypeVariable extends Atomic
         return null;
     }
 
+    /**
+     * @psalm-pure
+     */
     #[Override]
     public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {

--- a/tests/Template/TypeVariableTest.php
+++ b/tests/Template/TypeVariableTest.php
@@ -16,6 +16,9 @@ final class TypeVariableTest extends TestCase
     use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
 
+    /**
+     * @psalm-pure
+     */
     #[Override]
     public function providerValidCodeParse(): iterable
     {
@@ -84,6 +87,9 @@ final class TypeVariableTest extends TestCase
         ];
     }
 
+    /**
+     * @psalm-pure
+     */
     #[Override]
     public function providerInvalidCodeParse(): iterable
     {


### PR DESCRIPTION
## Context

Stacked on #11900 (branched from `fix/11899-statementsanalyzer-depth`; this diff will shrink to just this branch's own commits once #11900 merges). While investigating why CI was still red on #11900 after fixing the `StatementsAnalyzer` regression, I found several unrelated pre-existing issues that #11900's fix let the test suite and self-analysis reach for the first time (previously everything crashed before getting this far):

- `Code Style Analysis`: an unused `TClosure` import in `FilterUtils.php`.
- `DocumentationTest::testShortcodesAreUnique`: `IncompatibleTypeParameters` (added in #11875) reused shortcode 362, already owned by `ImpureGlobalVariable`.
- Windows unit tests (2 of 8 chunks, intermittently): `Class Psalm\Tests\TestConfig cannot extend final class Psalm\Config`. `dg/bypass-finals` strips `final` from source at require-time via a stream wrapper, a known incompatibility with OPcache (cached bytecode bypasses the wrapper). `windows-ci.yml` is the only workflow that sets `opcache.enable_cli=1`; Linux's `ci.yml` doesn't. Confirmed via the Windows job log: `Zend OPcache v8.5.7` is active there. Could not reproduce locally (different OS), so this fix is based on the config asymmetry and the well-documented bypass-finals/OPcache incompatibility rather than a local repro.
- `Run Shepherd` (self-analysis): 12 pre-existing `MissingPureAnnotation`/`MissingImmutableAnnotation` findings, all in the type-variable-support feature (#11875), which never got these annotations added.

## Solution

Independent, minimal fixes, one per commit:
- Remove the unused import.
- Reassign `IncompatibleTypeParameters` to shortcode 368 (next free one).
- Drop `opcache.enable_cli=1` from the Windows CI ini-values, matching Linux.
- Add the missing purity annotations via `psalm --alter`, reviewed individually. One of the twelve (`TypeVariableBounds`) is genuinely mutable by design (`TypeVariableTracker` appends to its bounds arrays in place so `TTypeVariable` instances already holding a reference see later constraints), so that one is `@psalm-suppress`ed with a reason rather than incorrectly marked `@psalm-immutable`.

Full suite locally: 72 failing tests → 71 (the shortcode test now passes; the remaining 71 are the pre-existing PHP-8.5-host `InternalCallMapHandlerTest` baseline (70) plus one unrelated `ReportOutputTest` SARIF-metadata drift, both out of scope here). Self-analysis: 12 issues → 0.

**Known remaining CI failure on this PR:** `Check backward compatibility` will still flag the shortcode reassignment as a breaking constant-value change. `roave-backward-compatibility-check` compares straight against `origin/master` and has no baseline/ignore mechanism, so it can't distinguish "this class was merged three commits ago and never released" from "long-standing public API" — renumbering either colliding class trips it the same way. Since `IncompatibleTypeParameters` has never shipped in a tagged release, I don't think this is a real-world break, but flagging it explicitly rather than silently reverting the correct fix (which would just re-break `testShortcodesAreUnique` instead). Happy to revert the shortcode commit if maintainers would rather see BCC green here.

`Run Psalm (mac OS)` is unrelated to any of this: `setup-php` fails to install PHP 8.5 on the macOS runner itself (`php: command not found`), reproducing identically on `master` HEAD regardless of PR content.
