### PR TITLE
Fix invalid SARIF region for issues reported at line 0

### DIFF
--- a/src/Psalm/Report/SarifReport.php
+++ b/src/Psalm/Report/SarifReport.php
@@ -12,6 +12,7 @@ use Psalm\Report;
 
 use function file_exists;
 use function file_get_contents;
+use function max;
 use function str_starts_with;
 
 /**
@@ -82,10 +83,10 @@ final class SarifReport extends Report
                                 'uri' => $issue_data->file_name,
                             ],
                             'region' => [
-                                'startLine' => $issue_data->line_from,
-                                'endLine' => $issue_data->line_to,
-                                'startColumn' => $issue_data->column_from,
-                                'endColumn' => $issue_data->column_to,
+                                'startLine' => max(1, $issue_data->line_from),
+                                'endLine' => max(1, $issue_data->line_to),
+                                'startColumn' => max(1, $issue_data->column_from),
+                                'endColumn' => max(1, $issue_data->column_to),
                             ],
                         ],
                     ],

--- a/tests/SarifReportTest.php
+++ b/tests/SarifReportTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests;
+
+use Override;
+use PHPUnit\Framework\TestCase;
+use Psalm\Internal\Analyzer\IssueData;
+use Psalm\Internal\VersionUtils;
+use Psalm\Report\ReportOptions;
+use Psalm\Report\SarifReport;
+
+use function define;
+use function defined;
+
+final class SarifReportTest extends TestCase
+{
+    #[Override]
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('PSALM_VERSION')) {
+            define('PSALM_VERSION', VersionUtils::getPsalmVersion());
+        }
+
+        parent::setUpBeforeClass();
+    }
+
+    public function testClampsRegionToSchemaMinimum(): void
+    {
+        // An issue reported at line 0 (e.g. UnusedBaselineEntry from a stale baseline)
+        // must not emit startLine 0, which the SARIF schema rejects (minimum 1).
+        $issue_data = new IssueData(
+            IssueData::SEVERITY_ERROR,
+            0,
+            0,
+            'UnusedBaselineEntry',
+            'message',
+            'file.php',
+            '/',
+            '',
+            '',
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+        );
+
+        $report = new SarifReport([$issue_data], [], new ReportOptions());
+
+        $this->assertStringContainsString(
+            '"region":{"startLine":1,"endLine":1,"startColumn":1,"endColumn":1}',
+            $report->create(),
+        );
+    }
+}


### PR DESCRIPTION
An issue reported at line 0, such as `UnusedBaselineEntry` from a stale baseline, is written to the SARIF report with `startLine` 0. The SARIF schema requires region line and column values to be at least 1, so the report fails validation. The region values are now raised to at least 1.

Fixes #9712
