### PR TITLE
Fix inherited static return type on parent:: and static:: calls

### DIFF
--- a/src/Psalm/Internal/Type/TypeExpander.php
+++ b/src/Psalm/Internal/Type/TypeExpander.php
@@ -690,6 +690,16 @@ final class TypeExpander
                 $static_class_type,
                 false,
             );
+        } elseif ($return_type->is_static
+            && !$final
+            && is_string($static_class_type)
+            && $return_type->value !== $static_class_type
+            && $codebase->classExtendsOrImplements($static_class_type, $return_type->value)
+        ) {
+            // `static` is stored bound to the class that declared it (`A` for
+            // `A::test(): static`). Rebind it to the more derived static context
+            // of a `parent::`/`static::` call, keeping it polymorphic.
+            $return_type = $return_type->setValueIsStatic($static_class_type, true);
         } elseif ($self_class && $return_type_lc === 'self') {
             $return_type = $return_type->setValue($self_class);
         } elseif ($parent_class && $return_type_lc === 'parent') {

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -988,6 +988,44 @@ final class ReturnTypeTest extends TestCase
 
                     (new B)->getThis()->foo();',
             ],
+            'inheritedStaticReturnTypeThroughParentCall' => [
+                'code' => '<?php
+                    namespace Foo;
+
+                    interface HasSelf {
+                        public function get(): static;
+                    }
+
+                    class A implements HasSelf {
+                        public function get(): static {
+                            return $this;
+                        }
+                    }
+
+                    class B extends A {
+                        public function get(): static {
+                            return parent::get();
+                        }
+                    }',
+            ],
+            'inheritedStaticReturnTypeThroughStaticCall' => [
+                'code' => '<?php
+                    namespace Foo;
+
+                    class Base {
+                        final public function __construct() {}
+
+                        public static function make(): static {
+                            return new static();
+                        }
+                    }
+
+                    class Derived extends Base {
+                        public static function makeToo(): static {
+                            return static::make();
+                        }
+                    }',
+            ],
             'returnMixed' => [
                 'code' => '<?php
                     namespace Foo;


### PR DESCRIPTION
`parent::foo()` and `static::foo()` calls to a method that returns `static` resolved to the declaring class (`A&static`) rather than the calling class (`B&static`). A method declared `: static` returning one of those calls then got a false `MoreSpecificReturnType` and `LessSpecificReturnStatement`.

`TypeExpander` now resolves the `static` return type against the more derived static context when it meets a plain class name, the way the literal `static`/`$this` form already is.

The trait `MethodSignatureMismatch` snippet in the issue has a different cause and is not covered here.

Refs #11139
