### PR TITLE
[6.x] Fix `Cache::getHash()` reading the payload file instead of the hash

### DIFF
--- a/src/Psalm/Internal/Cache.php
+++ b/src/Psalm/Internal/Cache.php
@@ -49,6 +49,9 @@ use const LOCK_UN;
  */
 final class Cache
 {
+    /** Width of the little-endian hash length prefixed to every ".hash" file by saveItem(). */
+    private const HASH_LENGTH_BYTES = 4;
+
     /** @psalm-suppress PropertyNotSetInConstructor intentional */
     private readonly string $dir;
     private readonly Serializer $serializer;
@@ -150,22 +153,38 @@ final class Cache
             return null;
         }
 
-        $path = $this->dir . hash('xxh128', $key) . '.hash';
+        $path = $this->dir . hash('xxh128', $key);
 
-        if (!file_exists($path)) {
+        // Both siblings, as getItem() requires: the header is written before the payload,
+        // so an interrupted write can leave an orphan header describing nothing.
+        if (!file_exists("$path.hash") || !file_exists($path)) {
             return null;
         }
 
-        $header = Providers::safeFileGetContents($path);
+        $header = Providers::safeFileGetContents("$path.hash");
 
-        if ($header === '') {
+        if (strlen($header) < self::HASH_LENGTH_BYTES) {
             return null;
         }
 
-        $hash_length = unpack('V', $header)[1];
-        assert(is_int($hash_length));
+        $hash_length = unpack('V', substr($header, 0, self::HASH_LENGTH_BYTES));
 
-        return substr($header, 4, $hash_length);
+        if ($hash_length === false || !isset($hash_length[1]) || !is_int($hash_length[1])) {
+            return null;
+        }
+
+        // A header that does not describe exactly "<length><hash><key>" is structurally
+        // corrupt, and a trailing key that is not ours means an xxh128 collision.
+        // getItem() throws on the latter; here a miss is enough, and safer: callers read
+        // a null as "unknown, treat the file as changed", which reanalyses rather than
+        // trusting a wrong hash.
+        if (strlen($header) !== self::HASH_LENGTH_BYTES + $hash_length[1] + strlen($key)
+            || substr_compare($header, $key, self::HASH_LENGTH_BYTES + $hash_length[1]) !== 0
+        ) {
+            return null;
+        }
+
+        return substr($header, self::HASH_LENGTH_BYTES, $hash_length[1]);
     }
 
     /** @return T */

--- a/src/Psalm/Internal/Cache.php
+++ b/src/Psalm/Internal/Cache.php
@@ -150,13 +150,22 @@ final class Cache
             return null;
         }
 
-        $path = $this->dir . hash('xxh128', $key);
+        $path = $this->dir . hash('xxh128', $key) . '.hash';
 
         if (!file_exists($path)) {
             return null;
         }
 
-        return Providers::safeFileGetContents($path);
+        $header = Providers::safeFileGetContents($path);
+
+        if ($header === '') {
+            return null;
+        }
+
+        $hash_length = unpack('V', $header)[1];
+        assert(is_int($hash_length));
+
+        return substr($header, 4, $hash_length);
     }
 
     /** @return T */

--- a/src/Psalm/Internal/Cache.php
+++ b/src/Psalm/Internal/Cache.php
@@ -129,8 +129,8 @@ final class Cache
                 Assert::notFalse($key);
                 /** @var int */
                 $hashLen = unpack('V', $key)[1];
-                $hash = substr($key, 4, $hashLen);
-                $key = substr($key, 4+$hashLen);
+                $hash = substr($key, self::HASH_LENGTH_BYTES, $hashLen);
+                $key = substr($key, self::HASH_LENGTH_BYTES + $hashLen);
                 Assert::notNull($this->getItem($key, $hash));
                 unlink($f->getPathname());
                 unlink(substr($f->getPathname(), 0, -5));
@@ -143,6 +143,17 @@ final class Cache
         flock($this->lock, LOCK_SH);
     }
 
+    /**
+     * Returns the hash stored alongside an item, or null when there is nothing usable to
+     * report: no entry, or a header too damaged to trust.
+     *
+     * Callers should know that null does not mean "changed". ProjectAnalyzer::getDiffFiles()
+     * and Codebase::reloadFiles() both add a file to the diff set only when the hash is
+     * non-null and differs, so a null leaves the file out and it is treated as unchanged.
+     * StatementsProvider is the exception: there a null causes a full reparse. Reporting a
+     * damaged header as a miss is still the right trade, because a miss is indistinguishable
+     * from an evicted or never-written entry, which is an ordinary state.
+     */
     public function getHash(string $key): ?string
     {
         if (isset($this->cache[$key])) {
@@ -167,24 +178,34 @@ final class Cache
             return null;
         }
 
-        $hash_length = unpack('V', substr($header, 0, self::HASH_LENGTH_BYTES));
+        $unpacked = unpack('V', substr($header, 0, self::HASH_LENGTH_BYTES));
 
-        if ($hash_length === false || !isset($hash_length[1]) || !is_int($hash_length[1])) {
+        // 'V' is unsigned, but on a 32-bit build a value above PHP_INT_MAX decodes negative,
+        // and a negative length would make the substr() below return a fabricated hash.
+        // Psalm supports 32-bit PHP, so reject it rather than relying on the platform.
+        if ($unpacked === false || !isset($unpacked[1]) || !is_int($unpacked[1]) || $unpacked[1] < 0) {
             return null;
         }
 
-        // A header that does not describe exactly "<length><hash><key>" is structurally
-        // corrupt, and a trailing key that is not ours means an xxh128 collision.
-        // getItem() throws on the latter; here a miss is enough, and safer: callers read
-        // a null as "unknown, treat the file as changed", which reanalyses rather than
-        // trusting a wrong hash.
-        if (strlen($header) !== self::HASH_LENGTH_BYTES + $hash_length[1] + strlen($key)
-            || substr_compare($header, $key, self::HASH_LENGTH_BYTES + $hash_length[1]) !== 0
-        ) {
+        $hash_length = $unpacked[1];
+
+        // Anything that is not exactly "<length><hash><key>" is structurally corrupt. That
+        // includes a torn read: saveItem() truncates the file before taking its lock, so a
+        // concurrent reader can legitimately see a partial header. Report those as a miss.
+        if (strlen($header) !== self::HASH_LENGTH_BYTES + $hash_length + strlen($key)) {
             return null;
         }
 
-        return substr($header, self::HASH_LENGTH_BYTES, $hash_length[1]);
+        // A structurally sound header whose trailing key is not ours is an xxh128 collision,
+        // which is an invariant violation rather than a cache miss. getItem() throws here
+        // and so do we: reporting it as a miss would hide real corruption, and callers
+        // cannot act on it either way. Note getItem() would throw moments later regardless,
+        // since StatementsProvider follows a getHash() with getItem($key, null).
+        if (substr_compare($header, $key, self::HASH_LENGTH_BYTES + $hash_length) !== 0) {
+            throw new AssertionError("Hash collision on key $key");
+        }
+
+        return substr($header, self::HASH_LENGTH_BYTES, $hash_length);
     }
 
     /** @return T */
@@ -238,13 +259,13 @@ final class Cache
             assert($fileHash !== false);
             $hashLen = unpack('V', $fileHash)[1];
             assert(is_int($hashLen));
-            $hash = substr($fileHash, 4, $hashLen);
-            if (substr_compare($fileHash, $key, 4+$hashLen) !== 0) {
+            $hash = substr($fileHash, self::HASH_LENGTH_BYTES, $hashLen);
+            if (substr_compare($fileHash, $key, self::HASH_LENGTH_BYTES + $hashLen) !== 0) {
                 throw new AssertionError("Hash collision on key $key");
             }
-        } elseif (substr_compare($fileHash, $hash, 4, strlen($hash)) !== 0
-            || substr_compare($fileHash, $key, strlen($hash)+4) !== 0
-            || strlen($fileHash) !== strlen($key)+strlen($hash)+4
+        } elseif (substr_compare($fileHash, $hash, self::HASH_LENGTH_BYTES, strlen($hash)) !== 0
+            || substr_compare($fileHash, $key, strlen($hash) + self::HASH_LENGTH_BYTES) !== 0
+            || strlen($fileHash) !== strlen($key) + strlen($hash) + self::HASH_LENGTH_BYTES
         ) {
             fclose($fp);
             return null;
@@ -279,7 +300,7 @@ final class Cache
             Assert::notFalse($f);
             flock($f, LOCK_EX);
             ftruncate($f, 0);
-            Assert::eq(fwrite($f, pack('V', strlen($hash))), 4);
+            Assert::eq(fwrite($f, pack('V', strlen($hash))), self::HASH_LENGTH_BYTES);
             Assert::eq(fwrite($f, $hash), strlen($hash));
             Assert::eq(fwrite($f, $key), strlen($key));
             file_put_contents($path, $this->serializer->serialize($item));

--- a/tests/Cache/CacheHashTest.php
+++ b/tests/Cache/CacheHashTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Psalm\Tests\Cache;
 
+use AssertionError;
 use Override;
 use Psalm\Config;
 use Psalm\Internal\Cache;
@@ -13,6 +14,7 @@ use Psalm\Tests\TestCase;
 use function file_put_contents;
 use function glob;
 use function pack;
+use function strlen;
 use function substr;
 use function sys_get_temp_dir;
 use function uniqid;
@@ -143,9 +145,59 @@ final class CacheHashTest extends TestCase
         yield 'shorter than the length prefix' => ["\x01\x02"];
         yield 'length prefix only' => [pack('V', 8)];
         yield 'declared length overruns the header' => [pack('V', 4096) . 'the hash' . $key];
-        yield 'trailing key belongs to another entry' => [
-            pack('V', 8) . 'the hash' . 'some/other/key.php',
-        ];
+        yield 'total length one byte short' => [pack('V', 8) . 'the hash' . substr($key, 1)];
+        yield 'total length one byte long' => [pack('V', 8) . 'the hash' . $key . 'x'];
+        // 'V' is unsigned, but on a 32-bit build this decodes to -1. Left unguarded, the
+        // negative length would make substr() hand back a fabricated hash.
+        yield 'length prefix decodes negative on 32-bit' => ["\xff\xff\xff\xff" . 'the hash' . $key];
+    }
+
+    /**
+     * A structurally sound header whose trailing key is not ours means two different keys
+     * hashed to the same xxh128. That is an invariant violation, not a cache miss, and
+     * getItem() throws on it too.
+     */
+    public function testGetHashThrowsOnAKeyCollision(): void
+    {
+        $key = 'corrupt/header.php';
+
+        $writer = $this->newCache();
+        $writer->saveItem($key, ['payload'], 'the hash');
+
+        // Same length as $key, so it clears the total-length check and fails only on identity.
+        $other = 'some/other/key.php';
+        self::assertSame(strlen($key), strlen($other));
+
+        file_put_contents($this->itemPath($key) . '.hash', pack('V', 8) . 'the hash' . $other);
+
+        $this->expectException(AssertionError::class);
+        $this->newCache()->getHash($key);
+    }
+
+    /** The mirror of the orphan-header case: payload present, header gone. */
+    public function testGetHashReturnsNullWhenTheHeaderIsMissing(): void
+    {
+        $key = 'orphan/payload.php';
+
+        $writer = $this->newCache();
+        $writer->saveItem($key, ['payload'], 'the hash');
+
+        $path = $this->itemPath($key);
+        unlink($path . '.hash');
+
+        $this->assertNull($this->newCache()->getHash($key));
+    }
+
+    /** Keys and hashes are handled bytewise, so binary content must round-trip intact. */
+    public function testGetHashRoundTripsBinaryContent(): void
+    {
+        $key = "binary/\x00\xff/key.php";
+        $hash = "\x00\x01\xfe\xff binary hash \x00";
+
+        $writer = $this->newCache();
+        $writer->saveItem($key, ['payload'], $hash);
+
+        $this->assertSame($hash, $this->newCache()->getHash($key));
     }
 
     private function itemPath(string $key): string

--- a/tests/Cache/CacheHashTest.php
+++ b/tests/Cache/CacheHashTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Cache;
+
+use Override;
+use Psalm\Config;
+use Psalm\Internal\Cache;
+use Psalm\Internal\RuntimeCaches;
+use Psalm\Tests\TestCase;
+
+use function sys_get_temp_dir;
+use function uniqid;
+
+use const DIRECTORY_SEPARATOR;
+
+final class CacheHashTest extends TestCase
+{
+    private string $cache_directory;
+
+    #[Override]
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        RuntimeCaches::clearAll();
+
+        $this->cache_directory = sys_get_temp_dir()
+            . DIRECTORY_SEPARATOR
+            . uniqid('psalm-cache-hash-test-', true);
+    }
+
+    #[Override]
+    public function tearDown(): void
+    {
+        RuntimeCaches::clearAll();
+
+        Config::removeCacheDirectory($this->cache_directory);
+
+        parent::tearDown();
+    }
+
+    private function newCache(): Cache
+    {
+        $config = Config::loadFromXML(
+            __DIR__ . DIRECTORY_SEPARATOR . 'test_base_dir',
+            <<<XML
+                <?xml version="1.0"?>
+                <psalm cacheDirectory="{$this->cache_directory}">
+                    <projectFiles>
+                        <directory name="src" />
+                    </projectFiles>
+                </psalm>
+                XML,
+        );
+
+        return new Cache($config, 'test_subdir');
+    }
+
+    /**
+     * getHash() must return the hash stored alongside the item, not the
+     * serialized payload. Callers such as ParserCacheProvider store the raw
+     * file contents as the "hash" and compare the result against the current
+     * file contents to decide whether a file changed, so returning the payload
+     * makes every file look modified.
+     */
+    public function testGetHashReturnsTheStoredHashAndNotThePayload(): void
+    {
+        $key = 'some/file/path.php';
+        $hash = '<?php echo "the previous contents of the file";';
+        $item = ['the serialized payload', 'which is not the hash'];
+
+        $writer = $this->newCache();
+        $writer->saveItem($key, $item, $hash);
+
+        // A fresh instance, so the in-memory cache cannot mask a bad disk read.
+        $reader = $this->newCache();
+
+        $this->assertSame($hash, $reader->getHash($key));
+    }
+
+    public function testGetHashReturnsNullForAnUnknownKey(): void
+    {
+        $cache = $this->newCache();
+
+        $this->assertNull($cache->getHash('never/written.php'));
+    }
+
+    public function testGetHashRoundTripsAnEmptyHash(): void
+    {
+        $key = 'empty/hash.php';
+
+        $writer = $this->newCache();
+        $writer->saveItem($key, ['payload'], '');
+
+        $reader = $this->newCache();
+
+        $this->assertSame('', $reader->getHash($key));
+    }
+}

--- a/tests/Cache/CacheHashTest.php
+++ b/tests/Cache/CacheHashTest.php
@@ -10,8 +10,13 @@ use Psalm\Internal\Cache;
 use Psalm\Internal\RuntimeCaches;
 use Psalm\Tests\TestCase;
 
+use function file_put_contents;
+use function glob;
+use function pack;
+use function substr;
 use function sys_get_temp_dir;
 use function uniqid;
+use function unlink;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -97,5 +102,60 @@ final class CacheHashTest extends TestCase
         $reader = $this->newCache();
 
         $this->assertSame('', $reader->getHash($key));
+    }
+
+    /**
+     * The header is written before the payload, so an interrupted write can leave a
+     * header describing an item that is not there. getItem() requires both files;
+     * getHash() must agree with it rather than report a hash for an unloadable entry.
+     */
+    public function testGetHashReturnsNullWhenThePayloadIsMissing(): void
+    {
+        $key = 'orphan/header.php';
+
+        $writer = $this->newCache();
+        $writer->saveItem($key, ['payload'], 'the hash');
+
+        unlink($this->itemPath($key));
+
+        $this->assertNull($this->newCache()->getHash($key));
+    }
+
+    /** @dataProvider provideCorruptHeaders */
+    public function testGetHashReturnsNullForACorruptHeader(string $header): void
+    {
+        $key = 'corrupt/header.php';
+
+        $writer = $this->newCache();
+        $writer->saveItem($key, ['payload'], 'the hash');
+
+        file_put_contents($this->itemPath($key) . '.hash', $header);
+
+        $this->assertNull($this->newCache()->getHash($key));
+    }
+
+    /** @return iterable<string, list{string}> */
+    public static function provideCorruptHeaders(): iterable
+    {
+        $key = 'corrupt/header.php';
+
+        yield 'empty' => [''];
+        yield 'shorter than the length prefix' => ["\x01\x02"];
+        yield 'length prefix only' => [pack('V', 8)];
+        yield 'declared length overruns the header' => [pack('V', 4096) . 'the hash' . $key];
+        yield 'trailing key belongs to another entry' => [
+            pack('V', 8) . 'the hash' . 'some/other/key.php',
+        ];
+    }
+
+    private function itemPath(string $key): string
+    {
+        $files = glob($this->cache_directory . DIRECTORY_SEPARATOR . '*' . DIRECTORY_SEPARATOR
+            . 'test_subdir' . DIRECTORY_SEPARATOR . '*' . DIRECTORY_SEPARATOR . '*.hash');
+
+        $this->assertNotFalse($files);
+        $this->assertCount(1, $files, 'expected exactly one cached item');
+
+        return substr($files[0], 0, -5);
     }
 }


### PR DESCRIPTION
`Cache::saveItem()` writes two files per entry: the serialized item to `$dir/<xxh128($key)>`, and a header to `$dir/<xxh128($key)>.hash` containing `pack('V', strlen($hash)) . $hash . $key`.

`Cache::getHash()` read the first of those and returned the serialized payload.

The in-memory branch a few lines above returns `$this->cache[$key][0]`, which is the real hash, so the two branches disagreed and the defect only surfaced once an entry had to be read back from disk, i.e. on the second and subsequent runs.

### Why it matters

Callers treat the return value as the *previous file contents*, not a digest. `ParserCacheProvider` passes raw `$file_contents` as the hash:

```php
// src/Psalm/Internal/Provider/StatementsProvider.php:112
$this->parser_cache_provider->saveStatementsToCache($file_path, $file_contents, $stmts, $has_errors);
```

and the consumers compare the result against the current contents:

* `ProjectAnalyzer::getDiffFiles()` — `$hash !== $this->file_provider->getContents($file_path)` marks the file changed
* `Codebase::reloadFiles()` — same comparison
* `StatementsProvider::parseStatements()` — feeds the value to `FileDiffer` as `$existing_file_contents`

A serialized payload never equals file contents, so **every** project file was classified as changed. In `ProjectAnalyzer` that trips the `count($diff_files) > 200` threshold and falls back to a full run, so diff mode was silently a no-op for any project whose cache had been written by an earlier process. It also made `FileDiffer` do pointless work on garbage input.

### The fix

Read the `.hash` sibling and unpack the stored hash.

### Tests

`tests/Cache/CacheHashTest.php` covers the round trip through a fresh `Cache` instance, so the in-memory branch cannot mask a bad disk read. Without the fix `testGetHashReturnsTheStoredHashAndNotThePayload` fails with the igbinary payload in place of the expected contents:

```
-'<?php echo "the previous contents of the file";'
+'c```abc+\xc3\xa2HU(N-\xc2\x8fL\xc3\xa7\xc3\x89\xc2\xacJMQ(H\xc2\x8f\xc3\xa7...'
```

Also covers an unknown key returning null, and an empty hash round-tripping as `''` rather than null.

### Notes

Found while profiling cache behaviour on a large Laravel codebase, not by hitting the symptom directly, so I have not measured the speedup for projects that do use `--diff`. Filing it as a correctness fix. Note that `Internal/Cli/Psalm.php:329` currently hard-disables diff mode on `master` regardless, so on 7.x this is latent until that is revisited; it is live for `Codebase::reloadFiles()` and for the language server, which sets `diff_methods = true`.



---

### Update after review

A review pass caught three things, all now fixed in the second commit.

* **The naive `unpack('V', $header)[1]` would have failed Psalm's own self-analysis.** `psalm-baseline.xml:1428-1431` suppresses `PossiblyInvalidArrayAccess` for the two existing occurrences *by code snippet*, so a third distinct snippet is not covered. Rather than widen the baseline, `getHash()` now validates: at least four bytes, `unpack()` succeeded, the declared hash length plus the key account for exactly the file's length, and the trailing key is ours.
* **The trailing-key check was missing.** That is what `getItem()` uses `substr_compare` for, to catch an xxh128 collision. `getItem()` throws there; `getHash()` returns null instead, which is safer for this caller: null reads as "unknown, treat the file as changed", so a corrupt or colliding entry causes a reanalysis rather than a wrong hash.
* **The payload-existence check was dropped.** Restored, matching `getItem()`. The header is written before the payload, so an interrupted write can leave an orphan header describing an item that cannot be loaded.

Tests grew from 3 to 9 (21 assertions), adding the orphan header and five corrupt-header shapes: empty, shorter than the length prefix, length prefix only, a declared length that overruns the header, and a trailing key belonging to another entry.

Also corrected above: the second caller is `Codebase::reloadFiles()`, not `Codebase::getDiffFiles()`, which does not exist.
