### PR TITLE
[6.x] Memoise vendor statements instead of re-parsing them on every request

### DIFF
--- a/src/Psalm/Internal/Provider/StatementsProvider.php
+++ b/src/Psalm/Internal/Provider/StatementsProvider.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Psalm\Internal\Provider;
 
+use Amp\Serialization\NativeSerializer;
+use Amp\Serialization\Serializer;
 use PhpParser;
 use PhpParser\ErrorHandler\Collecting;
 use PhpParser\Node\Stmt;
@@ -14,6 +16,7 @@ use Psalm\Codebase;
 use Psalm\Config;
 use Psalm\Internal\Diff\FileDiffer;
 use Psalm\Internal\Diff\FileStatementsDiffer;
+use Psalm\Internal\Fork\IgbinarySerializer;
 use Psalm\Internal\PhpTraverser\CustomTraverser;
 use Psalm\Internal\PhpVisitor\CloningVisitor;
 use Psalm\Internal\PhpVisitor\PartialParserVisitor;
@@ -30,6 +33,8 @@ use function array_intersect_key;
 use function array_map;
 use function array_merge;
 use function count;
+use function extension_loaded;
+use function hash;
 use function md5;
 use function str_starts_with;
 use function strlen;
@@ -70,7 +75,17 @@ final class StatementsProvider
      */
     private array $deletion_ranges = [];
 
+    /**
+     * Statements of vendor files, which the parser cache provider refuses to store, kept serialized so that
+     * repeated requests unserialize instead of re-parsing.
+     *
+     * @var array<string, array{string, string}> file path => [content hash, serialized statements]
+     */
+    private array $vendor_statements = [];
+
     private static ?Parser $parser = null;
+
+    private static ?Serializer $serializer = null;
 
     public function __construct(
         private readonly FileProvider $file_provider,
@@ -100,11 +115,36 @@ final class StatementsProvider
         if (!$this->parser_cache_provider
             || (!$config->isInProjectDirs($file_path) && strpos($file_path, 'vendor'))
         ) {
+            // Vendor files reach this branch on every request, and ProjectAnalyzer::getMethodMutations() asks
+            // for the same vendor base classes and traits over and over, so they get re-parsed dozens of times.
+            // Keeping their statements serialized turns those repeats into an unserialize, which yields the same
+            // fresh node graph a re-parse would, for a fraction of the cost.
+            //
+            // Files that land here only because there is no parser cache provider at all (--no-cache) are
+            // deliberately left alone: that path also carries every project file, and holding all of them is what
+            // made the former StatementsVolatileCache use 8GB+ (#9899, removed in da8c1da8b).
+            $vendor_hash = $this->parser_cache_provider === null
+                ? null
+                : hash('xxh128', $analysis_php_version_id . "\0" . $file_contents);
+
+            $memoised = $this->vendor_statements[$file_path] ?? null;
+
+            if ($memoised !== null && $memoised[0] === $vendor_hash) {
+                /** @var list<Stmt> */
+                return self::getSerializer()->unserialize($memoised[1]);
+            }
+
             $progress->debug('Parsing ' . $file_path . " because we cannot use cache\n");
 
             $has_errors = false;
 
-            return self::parseStatements($file_contents, $analysis_php_version_id, $has_errors, $file_path);
+            $stmts = self::parseStatements($file_contents, $analysis_php_version_id, $has_errors, $file_path);
+
+            if ($vendor_hash !== null && !$has_errors) {
+                $this->vendor_statements[$file_path] = [$vendor_hash, self::getSerializer()->serialize($stmts)];
+            }
+
+            return $stmts;
         }
 
         $stmts = $this->parser_cache_provider->loadStatementsFromCache(
@@ -434,6 +474,17 @@ final class StatementsProvider
         $resolving_traverser->traverse($stmts);
 
         return $stmts;
+    }
+
+    /**
+     * The parser cache serializer is not reused here: it wraps the payload in the configured compressor, and
+     * compressing a value that never leaves the process only buys memory at the price of the CPU this is saving.
+     */
+    private static function getSerializer(): Serializer
+    {
+        return self::$serializer ??= extension_loaded('igbinary')
+            ? new IgbinarySerializer
+            : new NativeSerializer;
     }
 
     public static function clearParser(): void

--- a/tests/Internal/Provider/RecordingProgress.php
+++ b/tests/Internal/Provider/RecordingProgress.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Internal\Provider;
+
+use Override;
+use Psalm\Progress\Progress;
+
+use function str_contains;
+
+final class RecordingProgress extends Progress
+{
+    /** @var list<string> */
+    private array $debug_messages = [];
+
+    #[Override]
+    public function debug(string $message): void
+    {
+        $this->debug_messages[] = $message;
+    }
+
+    public function countDebugMessagesContaining(string $needle): int
+    {
+        $count = 0;
+
+        foreach ($this->debug_messages as $message) {
+            if (str_contains($message, $needle)) {
+                $count++;
+            }
+        }
+
+        return $count;
+    }
+
+    #[Override]
+    public function write(string $message): void
+    {
+    }
+}

--- a/tests/Internal/Provider/StatementsProviderTest.php
+++ b/tests/Internal/Provider/StatementsProviderTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Psalm\Tests\Internal\Provider;
+
+use Psalm\Internal\Provider\FakeFileProvider;
+use Psalm\Internal\Provider\StatementsProvider;
+use Psalm\Tests\TestCase;
+
+use const DIRECTORY_SEPARATOR;
+
+final class StatementsProviderTest extends TestCase
+{
+    private const PHP_VERSION_ID = 8_02_00;
+
+    private const PARSING_MESSAGE = 'because we cannot use cache';
+
+    private const CONTENTS = '<?php class Acme { public function f(): void {} }';
+
+    public function testVendorFileIsParsedOnlyOnce(): void
+    {
+        $provider = new StatementsProvider(self::vendorFileProvider(), new FakeParserCacheProvider());
+        $progress = new RecordingProgress();
+
+        $first = $provider->getStatementsForFile(self::vendorFilePath(), self::PHP_VERSION_ID, false, $progress);
+        $second = $provider->getStatementsForFile(self::vendorFilePath(), self::PHP_VERSION_ID, false, $progress);
+
+        $this->assertSame(1, $progress->countDebugMessagesContaining(self::PARSING_MESSAGE));
+        $this->assertEquals($first, $second);
+    }
+
+    public function testMemoisedVendorStatementsAreNotSharedBetweenCallers(): void
+    {
+        $provider = new StatementsProvider(self::vendorFileProvider(), new FakeParserCacheProvider());
+
+        $first = $provider->getStatementsForFile(self::vendorFilePath(), self::PHP_VERSION_ID, false);
+        $second = $provider->getStatementsForFile(self::vendorFilePath(), self::PHP_VERSION_ID, false);
+
+        $this->assertNotSame($first[0], $second[0]);
+    }
+
+    public function testChangedVendorFileIsParsedAgain(): void
+    {
+        $files = self::vendorFileProvider();
+        $provider = new StatementsProvider($files, new FakeParserCacheProvider());
+        $progress = new RecordingProgress();
+
+        $provider->getStatementsForFile(self::vendorFilePath(), self::PHP_VERSION_ID, false, $progress);
+        $files->setContents(self::vendorFilePath(), '<?php class Acme { public function g(): void {} }');
+        $provider->getStatementsForFile(self::vendorFilePath(), self::PHP_VERSION_ID, false, $progress);
+
+        $this->assertSame(2, $progress->countDebugMessagesContaining(self::PARSING_MESSAGE));
+    }
+
+    public function testStatementsAreNotMemoisedWithoutAParserCacheProvider(): void
+    {
+        $provider = new StatementsProvider(self::vendorFileProvider());
+        $progress = new RecordingProgress();
+
+        $provider->getStatementsForFile(self::vendorFilePath(), self::PHP_VERSION_ID, false, $progress);
+        $provider->getStatementsForFile(self::vendorFilePath(), self::PHP_VERSION_ID, false, $progress);
+
+        $this->assertSame(2, $progress->countDebugMessagesContaining(self::PARSING_MESSAGE));
+    }
+
+    /**
+     * A path the parser cache provider refuses to store: outside the project dirs and below a vendor directory.
+     *
+     * @psalm-pure
+     */
+    private static function vendorFilePath(): string
+    {
+        return __DIR__ . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'Acme.php';
+    }
+
+    private static function vendorFileProvider(): FakeFileProvider
+    {
+        $files = new FakeFileProvider();
+        $files->registerFile(self::vendorFilePath(), self::CONTENTS);
+
+        return $files;
+    }
+}


### PR DESCRIPTION
### First, the elephant: this is not `StatementsVolatileCache`

An in-memory cache lived at this exact call site and was deleted in da8c1da8b, "remove StementsVolatileCache for perf reasons", after [#9899](https://github.com/vimeo/psalm/issues/9899) reported it driving runs past 8 GB. Anyone who remembers that will reasonably want to reject this on sight, so here is how it differs before anything else:

- **It stores serialized bytes, not live node graphs.** The old cache retained up to 4096 live ASTs. This one holds igbinary blobs, which is how 1395 files fit in 21 MB.
- **It covers vendor files only.** The old cache also caught every file that reached this branch because there was *no parser cache provider at all*, which under `--no-cache` is the entire project. That is exactly the configuration measured in #9899 (orklah's numbers there were all `--no-cache` runs). Here the memo is skipped when `parser_cache_provider` is null, so `--no-cache` behaviour is untouched.
- **No LRU bookkeeping.** The old cache ran an `array_search()` over a list of up to 4096 keys on every access, then an `array_splice()`. That alone is a plausible reading of "for perf reasons". Entries here are keyed by file path and invalidated by hash.

### The problem

`StatementsProvider::getStatementsForFile()` refuses the parser cache for any file outside the project dirs whose path contains `vendor`, and parses it from source again on every call (`src/Psalm/Internal/Provider/StatementsProvider.php:100-108`):

```php
if (!$this->parser_cache_provider
    || (!$config->isInProjectDirs($file_path) && strpos($file_path, 'vendor'))
) {
    $progress->debug('Parsing ' . $file_path . " because we cannot use cache\n");

    $has_errors = false;

    return self::parseStatements($file_contents, $analysis_php_version_id, $has_errors, $file_path);
}
```

Nothing holds on to the result, on disk or in memory. `ProjectAnalyzer::getMethodMutations()` calls `Codebase::getStatementsForFile()` on every invocation, and it is reached from `FileAnalyzer::getMethodMutations()` and from `CallAnalyzer` on the `collect_initializations` path that `ClassAnalyzer::checkPropertyInitialization()` drives. On a codebase whose classes extend vendor classes and use vendor traits, the same vendor files are parsed over and over within one run.

### The change

Keep the statements of those files serialized on the provider, so a repeat request unserializes instead of re-parsing. Unserializing produces the same fresh node graph a re-parse would, at a fraction of the cost.

igbinary is used when the extension is loaded and the native serializer otherwise, the same choice `ForkContext::start()` makes. `Config::getCacheSerializer()` is deliberately not reused: it wraps the payload in the configured compressor, which defaults to `deflate` whenever zlib is present, and compressing a value that never leaves the process would spend the CPU this is trying to save.

### Measurements

A 7,600-file Laravel application, warm cache, igbinary loaded, PHP 8.5.9 on an Apple-silicon laptop. Variants alternated run by run to absorb thermal drift.

`--threads=8`, medians of n=5:

| | before | after | |
|---|---|---|---|
| analysis phase | 26.30 s | 21.80 s | −17.1% |
| `Checks took` | 52.73 s | 47.87 s | −9.2% |
| scan phase | 17.00 s | 17.50 s | within noise |

`--threads=1`, medians of n=2, which removes worker scheduling noise: analysis 160.25 s → 129.05 s (−19.5%), total 179.06 s → 148.36 s (−17.1%).

So roughly a tenth off the wall clock of a warm 8-thread run, effectively all of it in the analysis phase.

I would not oversell this. The gain is proportional to how much a codebase drives `getMethodMutations()` into vendor code. A project that barely touches vendor base classes will see close to nothing.

One caveat on provenance: the timings were taken against the released `7.0.0-beta19` (the `master` line), because that is what the application under test vendors. The patched code is character-for-character the same on both branches; `6.x` and `master` differ here only by `@psalm-mutation-free` annotations that `master` added elsewhere in the class. I have not re-timed on a `6.x` build.

### Correctness

Both variants were run against an empty baseline with `--output-format=json` and `--threads=8`: 1020 issues each, and the two issue sets are identical when compared order-independently on type, file, line, column, message, severity and snippet. The JSON files are not byte-identical, but the only difference is the order files come back from the workers.

### Memory

Instrumenting the memo to report itself at shutdown: **1395 entries totalling 21.2 MB** of serialized statements over a complete single-threaded run (1339 entries / 20.1 MB in the main process of an 8-thread run).

That is corroborated by process-level numbers rather than resting on the instrumentation alone:

- `--threads=1`, medians of n=2, where max RSS is unambiguous because there is a single process: **8250.5 MB → 8290.5 MB, +40 MB (+0.5%)**. Psalm's own reported peak over the same runs: 8002.3 MB → 8038.3 MB, +36 MB. Run-to-run spread was under 3 MB on both sides.
- `--threads=8`, medians of n=5, Psalm's reported peak for the main process: 8956 MB → 8974 MB, **+17 MB, +0.2%**, with non-overlapping spreads (8943-8958 before, 8972-8989 after). `/usr/bin/time -l` max RSS at 8 threads is measuring the forking parent and its spread swamps the signal, so I am not quoting it.

With `--threads=N` each worker keeps its own memo, so the cost multiplies by the number of workers.

### Tests

`tests/Internal/Provider/StatementsProviderTest.php` pins four behaviours: a vendor file is parsed once across repeated requests; successive callers get distinct objects, so nobody is handed a node graph someone else may mutate; a vendor file whose contents change is parsed again; and nothing is memoised when there is no parser cache provider, which is the #9899 guard above. The first fails without this change.

`composer psalm` passes with no new issues and `psalm-baseline.xml` is untouched.
