### PR TITLE
Docs: mention MegaLinter as a way to run Psalm in CI

### DIFF
--- a/docs/running_psalm/installation.md
+++ b/docs/running_psalm/installation.md
@@ -65,3 +65,7 @@ Alternatively, you can use Composer to install the Phar:
 ```bash
 composer require --dev psalm/phar
 ```
+
+## Running Psalm via MegaLinter
+
+If you want to run Psalm in CI alongside other linters, [MegaLinter](https://megalinter.io/), an open-source linters aggregator, ships with Psalm out of the box — see its [Psalm page](https://megalinter.io/latest/descriptors/php_psalm/) for details.


### PR DESCRIPTION
Hi! I maintain [MegaLinter](https://megalinter.io/), an open-source linters aggregator for CI that ships with Psalm preinstalled and preconfigured.

This adds a short note at the end of the installation docs pointing to it, for folks who want to run Psalm in CI alongside other linters without installing it themselves. Happy to reword or move it elsewhere if you'd prefer!