### PR TITLE
Keep the type of variables assigned in only some branches

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElse/IfAnalyzer.php
@@ -430,6 +430,14 @@ final class IfAnalyzer
     ): void {
         $redefined_vars = $if_context->getRedefinedVars($outer_context->vars_in_scope);
 
+        foreach (array_diff_key($if_context->vars_in_scope, $outer_context->vars_in_scope) as $new_var => $type) {
+            $if_scope->possibly_new_vars[$new_var] = Type::combineUnionTypes(
+                $type,
+                $if_scope->possibly_new_vars[$new_var] ?? null,
+                $codebase,
+            );
+        }
+
         if ($if_scope->new_vars === null) {
             if ($update_new_vars) {
                 $if_scope->new_vars = array_diff_key($if_context->vars_in_scope, $outer_context->vars_in_scope);

--- a/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Block/IfElseAnalyzer.php
@@ -38,6 +38,7 @@ use function in_array;
 use function preg_match;
 use function preg_quote;
 use function spl_object_id;
+use function strpos;
 use function substr;
 
 /**
@@ -376,6 +377,31 @@ final class IfElseAnalyzer
             $context->assigned_var_ids,
             $if_scope->assigned_var_ids ?: [],
         );
+
+        foreach ($if_scope->possibly_new_vars as $var_id => $type) {
+            if (isset($context->vars_in_scope[$var_id])
+                || !isset($if_scope->new_vars_possibly_in_scope[$var_id])
+                || isset($if_scope->new_vars[$var_id])
+            ) {
+                continue;
+            }
+
+            // only plain variables: offsets and properties of a narrowed root would leak out here
+            if (strpos($var_id, '[') !== false
+                || strpos($var_id, '->') !== false
+                || strpos($var_id, '::') !== false
+            ) {
+                continue;
+            }
+
+            if ($statements_analyzer->data_flow_graph) {
+                $type = $type->addParentNodes(
+                    $statements_analyzer->getParentNodesForPossiblyUndefinedVariable($var_id),
+                );
+            }
+
+            $context->vars_in_scope[$var_id] = $type->setPossiblyUndefined(true);
+        }
 
         if ($if_scope->new_vars) {
             foreach ($if_scope->new_vars as $var_id => &$type) {

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Fetch/VariableFetchAnalyzer.php
@@ -381,23 +381,49 @@ final class VariableFetchAnalyzer
             $context->vars_in_scope[$var_name] = $stmt_type;
             $statements_analyzer->node_data->setType($stmt, $stmt_type);
 
-            if ($stmt_type->possibly_undefined_from_try && !$context->inside_isset) {
-                if ($context->is_global) {
+            if (($stmt_type->possibly_undefined_from_try || $stmt_type->possibly_undefined)
+                && !$context->inside_isset
+                && !$context->inside_unset
+            ) {
+                $suffix = $stmt_type->possibly_undefined_from_try
+                    ? ' defined in try block'
+                    : '';
+
+                $first_appearance = $statements_analyzer->getFirstAppearance($var_name);
+
+                if (!$suffix && $first_appearance) {
+                    $suffix = ', first seen on line ' . $first_appearance->getLineNumber();
+                }
+
+                if ($codebase->alter_code
+                    && !$stmt_type->possibly_undefined_from_try
+                    && isset($project_analyzer->getIssuesToFix()[$context->is_global
+                        ? 'PossiblyUndefinedGlobalVariable'
+                        : 'PossiblyUndefinedVariable'])
+                ) {
+                    $branch_point = $statements_analyzer->getBranchPoint($var_name);
+
+                    if ($branch_point !== null) {
+                        $statements_analyzer->addVariableInitialization($var_name, $branch_point);
+                    }
+                } elseif ($context->is_global) {
                     IssueBuffer::maybeAdd(
                         new PossiblyUndefinedGlobalVariable(
-                            'Possibly undefined global variable ' . $var_name . ' defined in try block',
+                            'Possibly undefined global variable ' . $var_name . $suffix,
                             new CodeLocation($statements_analyzer->getSource(), $stmt),
                             $var_name,
                         ),
                         $statements_analyzer->getSuppressedIssues(),
+                        (bool) $statements_analyzer->getBranchPoint($var_name),
                     );
                 } else {
                     IssueBuffer::maybeAdd(
                         new PossiblyUndefinedVariable(
-                            'Possibly undefined variable ' . $var_name . ' defined in try block',
+                            'Possibly undefined variable ' . $var_name . $suffix,
                             new CodeLocation($statements_analyzer->getSource(), $stmt),
                         ),
                         $statements_analyzer->getSuppressedIssues(),
+                        (bool) $statements_analyzer->getBranchPoint($var_name),
                     );
                 }
             }

--- a/src/Psalm/Internal/Scope/IfScope.php
+++ b/src/Psalm/Internal/Scope/IfScope.php
@@ -25,6 +25,13 @@ final class IfScope
     public array $new_vars_possibly_in_scope = [];
 
     /**
+     * Types of vars that are defined in at least one branch, but not in all of them.
+     *
+     * @var array<string, Union>
+     */
+    public array $possibly_new_vars = [];
+
+    /**
      * @var array<string, Union>|null
      */
     public ?array $redefined_vars = null;

--- a/tests/TypeReconciliation/IssetTest.php
+++ b/tests/TypeReconciliation/IssetTest.php
@@ -1008,6 +1008,37 @@ final class IssetTest extends TestCase
                         }
                     }',
             ],
+            'issetOnVariableAssignedInOneBranchKeepsItsType' => [
+                'code' => '<?php
+                    function foo(): ?DateTime {
+                        if (rand(0, 1)) {
+                            $d = new DateTime();
+                        }
+
+                        return isset($d) ? $d : null;
+                    }',
+            ],
+            'nullCoalesceOnVariableAssignedInOneBranchKeepsItsType' => [
+                'code' => '<?php
+                    function foo(): DateTime {
+                        if (rand(0, 1)) {
+                            $d = new DateTime();
+                        }
+
+                        return $d ?? new DateTime();
+                    }',
+            ],
+            'nullCoalesceAssignOnVariableAssignedInOneBranchKeepsItsType' => [
+                'code' => '<?php
+                    function foo(): DateTime {
+                        if (rand(0, 1)) {
+                            $d = new DateTime();
+                        }
+                        $d ??= new DateTime();
+
+                        return $d;
+                    }',
+            ],
             'assertOnPossiblyDefined' => [
                 'code' => '<?php
                     function crashes(): void {
@@ -1016,7 +1047,7 @@ final class IssetTest extends TestCase
                         }
                         /**
                          * @psalm-suppress PossiblyUndefinedVariable
-                         * @psalm-suppress MixedArgument
+                         * @psalm-suppress InvalidScalarArgument
                          */
                         assert($dt);
                     }',

--- a/tests/TypeReconciliation/RedundantConditionTest.php
+++ b/tests/TypeReconciliation/RedundantConditionTest.php
@@ -382,12 +382,9 @@ final class RedundantConditionTest extends TestCase
                         $options = ["option" => true];
                     }
 
-                    /** @psalm-suppress PossiblyUndefinedGlobalVariable */
                     $option = $options["option"] ?? false;
 
                     if ($option !== false) {}',
-                'assertions' => [],
-                'ignored_issues' => ['MixedAssignment', 'MixedArrayAccess'],
             ],
             'allowIntValueCheckAfterComparisonDueToOverflow' => [
                 'code' => '<?php

--- a/tests/UnusedVariableTest.php
+++ b/tests/UnusedVariableTest.php
@@ -1854,10 +1854,7 @@ final class UnusedVariableTest extends TestCase
                             $hue = "goodbye";
                         }
 
-                        /**
-                         * @psalm-suppress PossiblyUndefinedVariable
-                         * @psalm-suppress MixedArgument
-                         */
+                        /** @psalm-suppress PossiblyUndefinedVariable */
                         echo $hue;
                     }',
             ],
@@ -1932,7 +1929,6 @@ final class UnusedVariableTest extends TestCase
                         }
 
                         if (isset($j)) {
-                            /** @psalm-suppress MixedArgument */
                             echo $j;
                         }
                     }',
@@ -2138,7 +2134,6 @@ final class UnusedVariableTest extends TestCase
                             $maybe_undefined = $arr;
                         }
 
-                        /** @psalm-suppress MixedAssignment */
                         $maybe_undefined = $maybe_undefined ?? [0];
 
                         print_r($maybe_undefined);


### PR DESCRIPTION
Fixes #9615.

When a variable is assigned in only some branches of an `if` statement, Psalm drops it from `vars_in_scope` and only keeps it in `vars_possibly_in_scope`, which holds no type. Every later read of that variable falls back to `mixed`.

This is wider than the `??=` case from the issue. All of these lose the type today:

```php
function foo(): DateTime {
    if (rand(0, 1)) {
        $d = new DateTime();
    }

    return $d ?? new DateTime(); // DateTime|mixed
}
```

```php
if (rand(0, 1)) {
    $d = new DateTime();
}
echo $d->format('c'); // PossiblyUndefinedVariable, plus MixedMethodCall
```

## Changes

`IfScope::$possibly_new_vars` collects, in `IfAnalyzer::updateIfScope()`, the combined type of the variables defined in at least one branch but not in all of them. `IfElseAnalyzer` puts them back into `$context->vars_in_scope` with `possibly_undefined` set to true, keeping their data flow nodes.

This is limited to plain variables. Letting array offsets and properties through made a narrowed root leak out of the block, so `$obj->b === "baz"` was reported as always true after an `if`/`elseif` chain that tested it.

`VariableFetchAnalyzer` now reports `PossiblyUndefinedVariable` and `PossiblyUndefinedGlobalVariable` from that flag, and handles the matching `--alter-code` path. The `isset` reconciliation already cleared the flag, so nothing was needed there.

Side effect: possibly undefined variables keep their real type, so the `MixedArgument` and `MixedMethodCall` issues that used to come with them are gone. Six now useless `@psalm-suppress Mixed*` annotations were removed from existing tests.

One test needed a different suppression: in `IssetTest::assertOnPossiblyDefined`, `assert($dt)` on a `DateTime` now reports `InvalidScalarArgument` instead of `MixedArgument`, because the callmap declares `assert(bool|int|string)` while PHP 8 accepts `mixed`. That callmap entry is a separate pre-existing inaccuracy, left alone here.