### PR TITLE
Fix MissingOverrideAttribute false positive for private trait methods

### DIFF
--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -999,8 +999,25 @@ final class Populator
                             = $declaring_method_id;
                     }
                 } else {
-                    $storage->overridden_method_ids[$method_name_lc][$declaring_method_id->fq_class_name]
-                        = $declaring_method_id;
+                    // A method can end up in $parent_storage->inheritable_method_ids
+                    // while being private -- this happens when it was originally declared in a trait, since
+                    // traits copy even private methods into every using class (see
+                    // FunctionLikeNodeScanner::$classlike_storage->is_trait carve-out). Such a private method
+                    // is not part of the externally visible API and PHP does not consider it overridable
+                    // across a real class boundary, so it must not be recorded as "overridden" here -- doing
+                    // so produced a MissingOverrideAttribute false positive whenever a subclass re-declared
+                    // (or re-imported via the same trait) a same-named private method.
+                    $declaring_class_storage = $this->classlike_storage_provider->get(
+                        $declaring_method_id->fq_class_name,
+                    );
+                    $declaring_method_storage = $declaring_class_storage->methods[$method_name_lc] ?? null;
+
+                    if ($declaring_method_storage === null
+                        || $declaring_method_storage->visibility !== ClassLikeAnalyzer::VISIBILITY_PRIVATE
+                    ) {
+                        $storage->overridden_method_ids[$method_name_lc][$declaring_method_id->fq_class_name]
+                            = $declaring_method_id;
+                    }
                 }
 
                 if (isset($parent_storage->overridden_method_ids[$method_name_lc])

--- a/src/Psalm/Internal/Codebase/Populator.php
+++ b/src/Psalm/Internal/Codebase/Populator.php
@@ -1012,8 +1012,16 @@ final class Populator
                     );
                     $declaring_method_storage = $declaring_class_storage->methods[$method_name_lc] ?? null;
 
+                    // A `use T { f as public; }` adaptation does not rewrite the copied method's own
+                    // visibility -- Psalm keeps it in trait_visibility_map on the using class and every
+                    // consumer overlays it (see MethodVisibilityAnalyzer). Reading only
+                    // $declaring_method_storage->visibility would therefore still see `private` for a
+                    // method the parent exposes publicly, and would wrongly drop a real override.
+                    $declaring_visibility = $parent_storage->trait_visibility_map[$method_name_lc]
+                        ?? $declaring_method_storage?->visibility;
+
                     if ($declaring_method_storage === null
-                        || $declaring_method_storage->visibility !== ClassLikeAnalyzer::VISIBILITY_PRIVATE
+                        || $declaring_visibility !== ClassLikeAnalyzer::VISIBILITY_PRIVATE
                     ) {
                         $storage->overridden_method_ids[$method_name_lc][$declaring_method_id->fq_class_name]
                             = $declaring_method_id;

--- a/tests/OverrideTest.php
+++ b/tests/OverrideTest.php
@@ -118,6 +118,21 @@ final class OverrideTest extends TestCase
                     }
                 ',
             ],
+            'traitPublicMethodDemotedToPrivateIsNotAnOverride' => [
+                'code' => '<?php
+                    trait T {
+                        public function f(): void {}
+                    }
+
+                    class A {
+                        use T { f as private; }
+                    }
+
+                    class B extends A {
+                        public function f(): void {}
+                    }
+                ',
+            ],
             'traitPrivateMethodRedeclaredByChildIsNotAnOverride' => [
                 'code' => '<?php
                     trait T {
@@ -158,6 +173,42 @@ final class OverrideTest extends TestCase
                     }
                 ',
                 'error_message' => 'InvalidOverride',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'traitPrivateMethodPromotedToPublicIsStillAnOverride' => [
+                'code' => '<?php
+                    trait T {
+                        private function f(): void {}
+                    }
+
+                    class A {
+                        use T { f as public; }
+                    }
+
+                    class B extends A {
+                        public function f(): void {}
+                    }
+                ',
+                'error_message' => 'MissingOverrideAttribute',
+                'error_levels' => [],
+                'php_version' => '8.3',
+            ],
+            'traitPrivateMethodPromotedToProtectedIsStillAnOverride' => [
+                'code' => '<?php
+                    trait T {
+                        private function f(): void {}
+                    }
+
+                    class A {
+                        use T { f as protected; }
+                    }
+
+                    class B extends A {
+                        protected function f(): void {}
+                    }
+                ',
+                'error_message' => 'MissingOverrideAttribute',
                 'error_levels' => [],
                 'php_version' => '8.3',
             ],

--- a/tests/OverrideTest.php
+++ b/tests/OverrideTest.php
@@ -118,6 +118,31 @@ final class OverrideTest extends TestCase
                     }
                 ',
             ],
+            'traitPrivateMethodRedeclaredByChildIsNotAnOverride' => [
+                'code' => '<?php
+                    trait T {
+                        private function f(): void {}
+                    }
+
+                    class A {
+                        use T;
+
+                        public function bar(): void {
+                            $this->f();
+                        }
+                    }
+
+                    class B extends A {
+                        use T;
+
+                        public function baz(): void {
+                            $this->f();
+                        }
+
+                        private function f(): void {}
+                    }
+                ',
+            ],
         ];
     }
 


### PR DESCRIPTION
Fixes #10982.

## The bug

When a trait declares a **private** method, and that trait is used by both a
parent class and a child class that re-declares the same method, Psalm
records the child's method as "overriding" the parent's copy and raises
`MissingOverrideAttribute`. But PHP does not treat private methods as part
of a class's externally visible API, and does not allow `#[\Override]`
across such a boundary — following Psalm's own suggestion produces code
that PHP itself refuses to run (`Fatal error: ... has #[\Override]
attribute, but no matching parent method exists`).

Repro (from the issue, still reproducing on current `6.x`):

```php
trait Foo {
    private function inTrait(): void { echo "foobar\n"; }
}

class A {
    use Foo;
    public function bar(): void { $this->inTrait(); }
}

class B extends A {
    use Foo;
    function baz(): void { $this->inTrait(); }
}
```

## The fix

`Populator::inheritMethodsFromParent()` in
`src/Psalm/Internal/Codebase/Populator.php` now checks the *declaring*
method's visibility before recording it as overridden, skipping private
methods the same way the code a few lines above already special-cases
abstract ones. Added `traitPrivateMethodRedeclaredByChildIsNotAnOverride`
to `tests/OverrideTest.php`, covering the exact shape from the issue.

Verified red -> green against current `6.x` (`7385c402`): the new test
fails with `MissingOverrideAttribute` without this patch and passes with
it; the full `OverrideTest.php` suite (16 tests) is green.

## Re: the prior closed PR on this issue

#10989 attempted a fix for the same issue via `FunctionLikeAnalyzer.php`
and was closed as "Resolved in #11284". I checked: #11284 is a large,
unrelated overhaul of `MissingOverrideAttribute` handling and does not
touch `Populator.php`. Testing the original reproduction against current
`6.x` (which includes #11284) still reproduces the false positive, and a
community member independently confirmed the same on 2026-05-29 with a
slightly different variant (private method re-declared as private in the
child) — see the issue thread. So the closure looks premature rather than
actually superseded; this PR targets the code path #11284 didn't touch.
