### PR TITLE
Update nikic/php-parser version to ^5.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "felixfbecker/language-server-protocol": "^1.5.3",
         "fidry/cpu-core-counter": "^0.4.1 || ^0.5.1 || ^1.0.0",
         "netresearch/jsonmapper": "^5.0",
-        "nikic/php-parser": "^5.0.0",
+        "nikic/php-parser": "^5.2.0",
         "sebastian/diff": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0",
         "spatie/array-to-xml": "^2.17.0 || ^3.0",
         "symfony/console": "^6.0 || ^7.0 || ^8.0",


### PR DESCRIPTION
Psalm added PHP 8.4 hooks support in https://github.com/vimeo/psalm/pull/11569. However, depends on `PhpParser\Node\Stmt\Property::$hooks` which was not added to `nikic/php-parser` until version 5.2.0 see https://github.com/nikic/PHP-Parser/commit/03caf4cc9946a04526b2494834aede03257dfbff.

Running Psalm with `nikic/php-parser` version 5.0.0 installed will result in a fatal error.

This PR just bumps the minimum version of `nikic/php-parser` to 5.2.0.