### PR TITLE
Fix crash on first-class callables in taint analysis

### DIFF
--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/FunctionCallReturnTypeFetcher.php
@@ -624,6 +624,13 @@ final class FunctionCallReturnTypeFetcher
         }
 
         if ($function_storage->return_source_params) {
+            // A first-class callable has no argument list yet, and CallLike::getArgs() asserts
+            // against being called on one. Nothing downstream can propagate taint through arguments
+            // that do not exist, so stop here rather than crash under zend.assertions=1.
+            if ($stmt->isFirstClassCallable()) {
+                return $function_call_node;
+            }
+
             $removed_taints = $function_storage->removed_taints;
 
             $args = $stmt->getArgs();

--- a/tests/TaintTest.php
+++ b/tests/TaintTest.php
@@ -72,6 +72,18 @@ final class TaintTest extends TestCase
     public function providerValidCodeParse(): array
     {
         return [
+            'firstClassCallableOfTaintPropagatingFunction' => [
+                'code' => '<?php
+                    // CallLike::getArgs() asserts !isFirstClassCallable(); a taint-propagating
+                    // function referenced as a first-class callable must not reach it.
+                    $fn = strtolower(...);
+                    echo $fn("safe");',
+            ],
+            'firstClassCallableOfMultiArgTaintPropagatingFunction' => [
+                'code' => '<?php
+                    $fn = str_replace(...);
+                    echo $fn("a", "b", "safe");',
+            ],
             'taintedInputInCreatedArrayNotEchoed' => [
                 'code' => '<?php
                     $name = $_GET["name"] ?? "unknown";


### PR DESCRIPTION
### Problem

`FunctionCallReturnTypeFetcher::taintReturnType()` calls `$stmt->getArgs()` on the taint-propagation path without checking `isFirstClassCallable()`. `PhpParser\Node\Expr\CallLike::getArgs()` opens with `assert(!$this->isFirstClassCallable())`, so under `zend.assertions=1` — PHP's **development** default, and what Homebrew's PHP CLI ships — analysing a first-class callable of any function with `return_source_params` aborts the entire run.

Three lines reproduce it:

```php
<?php
$fn = strtolower(...);
echo $fn("safe");
```

```
$ php -d zend.assertions=1 psalm --taint-analysis
Uncaught Amp\Parallel\Worker\TaskFailureError: AssertionError thrown in context with message
"assert(!$this->isFirstClassCallable())" in PhpParser/Node/Expr/CallLike.php:32
  #1 FunctionCallReturnTypeFetcher.php(629): PhpParser\Node\Expr\CallLike->getArgs()
```

It only surfaces under `--taint-analysis`, because the frame above the call is `if ($function_storage->return_source_params)`.

### Why this looks like an oversight rather than a design choice

The same file already handles it in two places:

- line 83 — `if ($stmt->isFirstClassCallable()) { … }` early in the method
- line 668 — `if (!$stmt->isFirstClassCallable())` guarding the `getArgs()` at 674

Line 629 is the one that was missed, 45 lines before a site that handles it. The idiom is used across `ExpressionScanner`, `AssignmentMapVisitor`, `DynamicFunctionStorageProvider`, `HtmlFunctionTainter` and `ExpressionIdentifier` too.

### Fix

Return the node unchanged when the call is a first-class callable — the same thing the sibling path at 668 already does. A first-class callable has no argument list yet, so there are no arguments through which taint could propagate.

### Tests

Two cases added to `TaintTest::providerValidCodeParse`, covering a single-argument and a multi-argument taint-propagating function.

Verified in both directions on this branch:

```
with the fix:     OK (2 tests, 0 assertions)
without the fix:  Tests: 2, Assertions: 2, Failures: 2
```

### Impact in the wild

Found while running `--taint-analysis` across ten real PHP repositories. It aborted the run on **laravel/framework**, **symfony/symfony** and **phpmyadmin** — anything referencing a first-class callable of a taint-propagating builtin. `--threads=1` does not avoid it; only `zend.assertions=-1` does, which is a workaround rather than a fix, and one that silently doesn't apply on a default development install.

### Notes

- Branched from `6.x` at `7385c40`.
- Draft: I have not run the full suite, only the targeted `TaintTest` filter, and I have not checked whether you would prefer the guard placed at the top of the method beside the line-83 check rather than inside the `return_source_params` branch. Happy to move it.

### CI status on this PR

Both red checks are pre-existing or environmental. The first is now confirmed against the base build's own log rather than inferred.

**`ci/circleci: test-with-real-projects` — identical failure on the base commit.**

Build **48058** is this job on `6.x` for `7385c40` — the exact commit this branch is cut from, with none of this change in it. Its log and this PR's contain the same failures, in the same counts, naming the same files:

| | base build 48058 (`7385c40`) | this PR (build 48130) |
|---|---|---|
| `ImpureFunctionCall` / `ImpureMethodCall` | 7 | 7 |
| `UnusedBaselineEntry` | 5 | 5 |

Files named in both: `PHP.php`, `HRTime.php`, `MemoryUsage.php`, `TestMethod.php`, `TestUsingCallbacks.php`, `TestUsingMocks.php`, `assert-not-instance-of.php`. The other two jobs (`phar-build`, `Code Style Analysis`) pass on both. The job is also red on the three commits before `7385c40`.

The errors are `Impure*` in **phpunit's** source and `UnusedBaselineEntry` against **phpunit's** committed baselines — drift between that project's current code and its checked-in baseline, which moves independently of psalm.

**What the job is actually asserting.** `bin/ci/test-with-real-projects.sh` runs psalm with `--set-baseline`, captures psalm's exit code, and only commits the regenerated baselines when invoked in update mode:

```sh
"$PSALM_PHAR" --config=.psalm/config.xml --set-baseline=.psalm/baseline.xml || FAIL=$?
"$PSALM_PHAR" --config=.psalm/static-analysis.xml --set-baseline=.psalm/static-analysis-baseline.xml || FAIL=$?
if [ "$2" == "update" ]; then git commit -am 'Update baseline'; git push; fi
exit $FAIL
```

So it is a baseline-drift detector, and it is red because the baselines committed in `psalm/endtoend-test-phpunit` no longer match what psalm produces for that tree. **Clearing it needs `bin/ci/test-with-real-projects.sh phpunit update`, run by someone with push access to `psalm/endtoend-test-phpunit`** — no change in this pull request can affect it, and I have no way to make that job green from here.

**This change is also unreachable in those runs.** `taintReturnType()` is entered only via the guard at line 262, and returns at line 622 when the graph is not a `TaintFlowGraph`:

```php
if (!$statements_analyzer->data_flow_graph instanceof TaintFlowGraph) {
    return $function_call_node;   // line 622
}
```

The guard added here is at line 630, after it. Both failing steps run `--config=.psalm/config.xml` and `--config=.psalm/static-analysis.xml` **without** `--taint-analysis`, so line 622 returns before the modified block. The added guard also returns `$function_call_node` — the same value the method returns at its end — so it cannot suppress analysis that would otherwise happen; it skips only taint-edge construction for a call that has no arguments to build edges from.

**`TruffleHog Secret Scan` — "Workflows cannot be required from a less visible repository".**

A fork-PR limitation rather than a result: a required workflow will not run for a pull request opened from a fork. Nothing in the diff can change it, and it should clear if a maintainer runs the workflow or the branch is pushed to the upstream repository. Happy to do anything that helps here.

🤖 Generated with commitwork, some content from Claude Code.

