### PR TITLE
Fix CI setup, static analysis, and dependency compatibility

### DIFF
--- a/.github/workflows/bcc.yml
+++ b/.github/workflows/bcc.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
-          php-version: '8.1'
+          php-version: '8.5'
           tools: composer:v2
           coverage: none
         env:
@@ -50,4 +50,3 @@ jobs:
         run: vendor/bin/roave-backward-compatibility-check --from="origin/$GITHUB_BASE_REF" --format=github-actions
         env:
           COMPOSER_ROOT_VERSION: dev-master
-

--- a/.github/workflows/macos-scan.yml
+++ b/.github/workflows/macos-scan.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-    - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+    - uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
       with:
         php-version: '8.5'
         ini-values: zend.assertions=1, assert.exception=1, opcache.enable_cli=1, opcache.jit=off

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -56,7 +56,8 @@ jobs:
         with:
           php-version: '8.5'
           #ini-values: zend.assertions=1, assert.exception=1, opcache.enable_cli=1, opcache.jit=function, opcache.jit_buffer_size=512M
-          ini-values: zend.assertions=1, assert.exception=1, opcache.enable_cli=1, opcache.jit=off
+          # Windows workers share OPcache; cached final classes bypass BypassFinals' source rewriting.
+          ini-values: zend.assertions=1, assert.exception=1, opcache.enable_cli=0, opcache.jit=off
           tools: composer:v2
           coverage: none
           #extensions: none, curl, dom, filter, intl, json, libxml, mbstring, openssl, opcache, pcre, phar, reflection, simplexml, spl, tokenizer, xml, xmlwriter

--- a/.roave-backward-compatibility-check.xml
+++ b/.roave-backward-compatibility-check.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<roave-bc-check xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="vendor-bin/bcc/vendor/roave/backward-compatibility-check/Resources/schema.xsd">
+    <baseline>
+        <!-- Correct the duplicate issue code; 362 remains assigned to ImpureGlobalVariable. -->
+        <ignored-regex>#^\[BC\] CHANGED: Value of constant Psalm\\Issue\\IncompatibleTypeParameters::SHORTCODE changed from 362 to 368$#</ignored-regex>
+    </baseline>
+</roave-bc-check>

--- a/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/Statements/Expression/Call/NewAnalyzer.php
@@ -1110,6 +1110,8 @@ final class NewAnalyzer extends CallAnalyzer
      * Whether the constructor binds the given template through a `class-string<T>`
      * (`T::class`) parameter position, which names the template's type exactly
      * rather than providing a value of it.
+     *
+     * @psalm-mutation-free
      */
     private static function templateBoundThroughClassString(
         MethodStorage $method_storage,
@@ -1139,6 +1141,7 @@ final class NewAnalyzer extends CallAnalyzer
      * only have been fixed at the construction site.
      *
      * @return array<string, true>
+     * @psalm-mutation-free
      */
     private static function getUnconstrainableTemplates(ClassLikeStorage $storage): array
     {

--- a/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
+++ b/src/Psalm/Internal/Analyzer/StatementsAnalyzer.php
@@ -170,6 +170,9 @@ final class StatementsAnalyzer extends SourceAnalyzer
 
     private int $depth = 0;
 
+    /**
+     * @psalm-mutation-free
+     */
     public function __construct(
         protected SourceAnalyzer $source,
         public NodeDataProvider $node_data,

--- a/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterUtils.php
+++ b/src/Psalm/Internal/Provider/ReturnTypeProvider/FilterUtils.php
@@ -20,7 +20,6 @@ use Psalm\Type;
 use Psalm\Type\Atomic\TArray;
 use Psalm\Type\Atomic\TArrayKey;
 use Psalm\Type\Atomic\TBool;
-use Psalm\Type\Atomic\TClosure;
 use Psalm\Type\Atomic\TFalse;
 use Psalm\Type\Atomic\TFloat;
 use Psalm\Type\Atomic\TInt;

--- a/src/Psalm/Internal/Type/TypeVariableBounds.php
+++ b/src/Psalm/Internal/Type/TypeVariableBounds.php
@@ -12,6 +12,7 @@ use function count;
  * when the surrounding function-like has been analyzed.
  *
  * @internal
+ * @psalm-mutable
  */
 final class TypeVariableBounds
 {
@@ -24,6 +25,7 @@ final class TypeVariableBounds
     /**
      * @param list<TemplateBound> $lower_bounds
      * @param list<TemplateBound> $upper_bounds
+     * @psalm-mutation-free
      */
     public function __construct(
         public array $lower_bounds = [],

--- a/src/Psalm/Internal/Type/TypeVariableTracker.php
+++ b/src/Psalm/Internal/Type/TypeVariableTracker.php
@@ -40,6 +40,8 @@ final class TypeVariableTracker
 
     /**
      * Mints a fresh type variable name, registering its bound storage.
+     *
+     * @psalm-external-mutation-free
      */
     public function addVariable(TypeVariableBounds $bounds): string
     {
@@ -80,6 +82,8 @@ final class TypeVariableTracker
      * below. Used where a concrete shape is required (property reads, method
      * call returns); the variable itself stays in the object's type params,
      * so later uses still constrain it.
+     *
+     * @psalm-external-mutation-free
      */
     public static function resolveTypeVariables(Union $type, ?Codebase $codebase): Union
     {
@@ -327,6 +331,7 @@ final class TypeVariableTracker
      *
      * @param list<TemplateBound> $lower_bounds
      * @return list<TemplateBound>
+     * @psalm-mutation-free
      */
     private static function getRelevantBounds(array $lower_bounds): array
     {

--- a/src/Psalm/Internal/TypeVisitor/TypeVariableResolver.php
+++ b/src/Psalm/Internal/TypeVisitor/TypeVariableResolver.php
@@ -29,6 +29,9 @@ final class TypeVariableResolver extends MutableTypeVisitor
 {
     public bool $resolved_a_variable = false;
 
+    /**
+     * @psalm-mutation-free
+     */
     public function __construct(
         private readonly ?Codebase $codebase,
     ) {

--- a/src/Psalm/Issue/IncompatibleTypeParameters.php
+++ b/src/Psalm/Issue/IncompatibleTypeParameters.php
@@ -7,5 +7,5 @@ namespace Psalm\Issue;
 final class IncompatibleTypeParameters extends CodeIssue
 {
     public const ERROR_LEVEL = 1;
-    public const SHORTCODE = 362;
+    public const SHORTCODE = 368;
 }

--- a/src/Psalm/Plugin/Shepherd.php
+++ b/src/Psalm/Plugin/Shepherd.php
@@ -33,11 +33,13 @@ use function strlen;
 use function var_export;
 
 use const CURLINFO_HEADER_OUT;
+use const CURLOPT_CONNECTTIMEOUT;
 use const CURLOPT_FOLLOWLOCATION;
 use const CURLOPT_HTTPHEADER;
 use const CURLOPT_POST;
 use const CURLOPT_POSTFIELDS;
 use const CURLOPT_RETURNTRANSFER;
+use const CURLOPT_TIMEOUT;
 use const JSON_THROW_ON_ERROR;
 use const PHP_EOL;
 use const PHP_URL_HOST;
@@ -130,6 +132,9 @@ final class Shepherd implements AfterAnalysisInterface
         // Prepare new cURL resource
         $ch = curl_init($endpoint);
         assert($ch !== false);
+        // Reporting is best-effort and must not stall the analysis result.
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 30);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         curl_setopt($ch, CURLINFO_HEADER_OUT, true);

--- a/src/Psalm/Type/Atomic/TTypeVariable.php
+++ b/src/Psalm/Type/Atomic/TTypeVariable.php
@@ -67,6 +67,7 @@ final class TTypeVariable extends Atomic
 
     /**
      * @param  array<lowercase-string, string> $aliased_classes
+     * @psalm-pure
      */
     #[Override]
     public function toPhpString(
@@ -78,6 +79,9 @@ final class TTypeVariable extends Atomic
         return null;
     }
 
+    /**
+     * @psalm-pure
+     */
     #[Override]
     public function canBeFullyExpressedInPhp(int $analysis_php_version_id): bool
     {

--- a/tests/Config/PluginListTest.php
+++ b/tests/Config/PluginListTest.php
@@ -33,13 +33,13 @@ final class PluginListTest extends TestCase
         RuntimeCaches::clearAll();
 
         $this->config = Mockery::mock(Config::class);
-        $this->config->allows()->getPluginClasses()->andReturns([])->byDefault();
+        $this->config->shouldReceive('getPluginClasses')->withNoArgs()->andReturns([])->byDefault();
 
         $this->config_file = Mockery::mock(ConfigFile::class);
-        $this->config_file->allows()->getConfig()->andReturns($this->config)->byDefault();
+        $this->config_file->shouldReceive('getConfig')->withNoArgs()->andReturns($this->config)->byDefault();
 
         $this->composer_lock = Mockery::mock(ComposerLock::class);
-        $this->composer_lock->allows()->getPlugins()->andReturns([])->byDefault();
+        $this->composer_lock->shouldReceive('getPlugins')->withNoArgs()->andReturns([])->byDefault();
     }
 
     /**
@@ -47,7 +47,7 @@ final class PluginListTest extends TestCase
      */
     public function pluginsPresentInConfigAreEnabled(): void
     {
-        $this->config->expects()->getPluginClasses()->andReturns([
+        $this->config->shouldReceive('getPluginClasses')->once()->withNoArgs()->andReturns([
             ['class' => 'a\b\c', 'config' => null],
             ['class' => 'c\d\e', 'config' => null],
         ]);
@@ -65,11 +65,11 @@ final class PluginListTest extends TestCase
      */
     public function pluginsPresentInPackageLockOnlyAreAvailable(): void
     {
-        $this->config->expects()->getPluginClasses()->andReturns([
+        $this->config->shouldReceive('getPluginClasses')->once()->withNoArgs()->andReturns([
             ['class' => 'a\b\c', 'config' => null],
         ]);
 
-        $this->composer_lock->expects()->getPlugins()->andReturns([
+        $this->composer_lock->shouldReceive('getPlugins')->once()->withNoArgs()->andReturns([
             'vendor/package' => 'a\b\c',
             'another-vendor/another-package' => 'c\d\e',
         ]);
@@ -86,11 +86,11 @@ final class PluginListTest extends TestCase
      */
     public function pluginsPresentInPackageLockAndConfigHavePluginPackageName(): void
     {
-        $this->config->expects()->getPluginClasses()->andReturns([
+        $this->config->shouldReceive('getPluginClasses')->once()->withNoArgs()->andReturns([
             ['class' => 'a\b\c', 'config' => null],
         ]);
 
-        $this->composer_lock->expects()->getPlugins()->andReturns([
+        $this->composer_lock->shouldReceive('getPlugins')->once()->withNoArgs()->andReturns([
             'vendor/package' => 'a\b\c',
         ]);
 
@@ -115,7 +115,7 @@ final class PluginListTest extends TestCase
      */
     public function canFindPluginClassByPackageName(): void
     {
-        $this->composer_lock->expects()->getPlugins()->andReturns([
+        $this->composer_lock->shouldReceive('getPlugins')->once()->withNoArgs()->andReturns([
             'vendor/package' => 'a\b\c',
         ]);
 
@@ -128,7 +128,7 @@ final class PluginListTest extends TestCase
      */
     public function canShowAvailablePluginsWithoutAConfigFile(): void
     {
-        $this->composer_lock->expects()->getPlugins()->andReturns([
+        $this->composer_lock->shouldReceive('getPlugins')->once()->withNoArgs()->andReturns([
             'vendor/package' => 'a\b\c',
             'another-vendor/another-package' => 'c\d\e',
         ]);
@@ -145,7 +145,7 @@ final class PluginListTest extends TestCase
      */
     public function enabledPackageIsEnabled(): void
     {
-        $this->config->expects()->getPluginClasses()->andReturns([
+        $this->config->shouldReceive('getPluginClasses')->once()->withNoArgs()->andReturns([
             ['class' => 'a\b\c', 'config' => null],
         ]);
 
@@ -172,7 +172,7 @@ final class PluginListTest extends TestCase
     {
         $plugin_list = new PluginList($this->config_file, $this->composer_lock);
 
-        $this->config_file->expects()->addPlugin('a\b\c');
+        $this->config_file->shouldReceive('addPlugin')->once()->with('a\b\c');
 
         $plugin_list->enable('a\b\c');
     }
@@ -184,7 +184,7 @@ final class PluginListTest extends TestCase
     {
         $plugin_list = new PluginList($this->config_file, $this->composer_lock);
 
-        $this->config_file->expects()->removePlugin('a\b\c');
+        $this->config_file->shouldReceive('removePlugin')->once()->with('a\b\c');
 
         $plugin_list->disable('a\b\c');
     }

--- a/tests/PsalmPluginTest.php
+++ b/tests/PsalmPluginTest.php
@@ -39,7 +39,7 @@ final class PsalmPluginTest extends TestCase
         $this->plugin_list = Mockery::mock(PluginList::class);
         $this->plugin_list_factory = Mockery::mock(PluginListFactory::class);
         $this->plugin_list_factory
-            ->allows()->__invoke(Mockery::andAnyOtherArgs())
+            ->shouldReceive('__invoke')->with(Mockery::andAnyOtherArgs())
             ->andReturns($this->plugin_list)
             ->byDefault();
 
@@ -56,8 +56,8 @@ final class PsalmPluginTest extends TestCase
 
         $this->app->setDefaultCommand('show');
 
-        $this->plugin_list->allows()->getEnabled()->andReturns([])->byDefault();
-        $this->plugin_list->allows()->getAvailable()->andReturns([])->byDefault();
+        $this->plugin_list->shouldReceive('getEnabled')->withNoArgs()->andReturns([])->byDefault();
+        $this->plugin_list->shouldReceive('getAvailable')->withNoArgs()->andReturns([])->byDefault();
     }
 
     /**
@@ -78,7 +78,11 @@ final class PsalmPluginTest extends TestCase
      */
     public function showsEnabledPlugins(): void
     {
-        $this->plugin_list->expects()->getEnabled()->andReturns(['a\b\c' => 'vendor/package']);
+        $this->plugin_list
+            ->shouldReceive('getEnabled')
+            ->once()
+            ->withNoArgs()
+            ->andReturns(['a\b\c' => 'vendor/package']);
 
         $show_command = new CommandTester($this->app->find('show'));
         $show_command->execute([]);
@@ -93,7 +97,11 @@ final class PsalmPluginTest extends TestCase
      */
     public function showsAvailablePlugins(): void
     {
-        $this->plugin_list->expects()->getAvailable()->andReturns(['a\b\c' => 'vendor/package']);
+        $this->plugin_list
+            ->shouldReceive('getAvailable')
+            ->once()
+            ->withNoArgs()
+            ->andReturns(['a\b\c' => 'vendor/package']);
 
         $show_command = new CommandTester($this->app->find('show'));
         $show_command->execute([]);
@@ -108,7 +116,11 @@ final class PsalmPluginTest extends TestCase
      */
     public function passesExplicitConfigToPluginListFactory(): void
     {
-        $this->plugin_list_factory->expects()->__invoke(Mockery::any(), '/a/b/c')->andReturns($this->plugin_list);
+        $this->plugin_list_factory
+            ->shouldReceive('__invoke')
+            ->once()
+            ->with(Mockery::any(), '/a/b/c')
+            ->andReturns($this->plugin_list);
 
         $show_command = new CommandTester($this->app->find('show'));
         $show_command->execute([
@@ -173,7 +185,11 @@ final class PsalmPluginTest extends TestCase
      */
     public function enableComplainsWhenPassedUnresolvablePlugin(): void
     {
-        $this->plugin_list->expects()->resolvePluginClass(Mockery::any())->andThrows(new InvalidArgumentException());
+        $this->plugin_list
+            ->shouldReceive('resolvePluginClass')
+            ->once()
+            ->with(Mockery::any())
+            ->andThrows(new InvalidArgumentException());
 
         $enable_command = new CommandTester($this->app->find('enable'));
         $enable_command->execute(['pluginName' => 'vendor/package']);
@@ -191,8 +207,12 @@ final class PsalmPluginTest extends TestCase
     public function enableComplainsWhenPassedAlreadyEnabledPlugin(): void
     {
         $plugin_class = 'Vendor\Package\PluginClass';
-        $this->plugin_list->expects()->resolvePluginClass('vendor/package')->andReturns($plugin_class);
-        $this->plugin_list->expects()->isEnabled($plugin_class)->andReturns(true);
+        $this->plugin_list
+            ->shouldReceive('resolvePluginClass')
+            ->once()
+            ->with('vendor/package')
+            ->andReturns($plugin_class);
+        $this->plugin_list->shouldReceive('isEnabled')->once()->with($plugin_class)->andReturns(true);
 
         $enable_command = new CommandTester($this->app->find('enable'));
         $enable_command->execute(['pluginName' => 'vendor/package']);
@@ -208,9 +228,13 @@ final class PsalmPluginTest extends TestCase
     public function enableReportsSuccessWhenItEnablesPlugin(): void
     {
         $plugin_class = 'Vendor\Package\PluginClass';
-        $this->plugin_list->expects()->resolvePluginClass('vendor/package')->andReturns($plugin_class);
-        $this->plugin_list->expects()->isEnabled($plugin_class)->andReturns(false);
-        $this->plugin_list->expects()->enable($plugin_class);
+        $this->plugin_list
+            ->shouldReceive('resolvePluginClass')
+            ->once()
+            ->with('vendor/package')
+            ->andReturns($plugin_class);
+        $this->plugin_list->shouldReceive('isEnabled')->once()->with($plugin_class)->andReturns(false);
+        $this->plugin_list->shouldReceive('enable')->once()->with($plugin_class);
 
         $enable_command = new CommandTester($this->app->find('enable'));
         $enable_command->execute(['pluginName' => 'vendor/package']);
@@ -235,7 +259,11 @@ final class PsalmPluginTest extends TestCase
      */
     public function disableComplainsWhenPassedUnresolvablePlugin(): void
     {
-        $this->plugin_list->expects()->resolvePluginClass(Mockery::any())->andThrows(new InvalidArgumentException());
+        $this->plugin_list
+            ->shouldReceive('resolvePluginClass')
+            ->once()
+            ->with(Mockery::any())
+            ->andThrows(new InvalidArgumentException());
 
         $disable_command = new CommandTester($this->app->find('disable'));
         $disable_command->execute(['pluginName' => 'vendor/package']);
@@ -253,8 +281,12 @@ final class PsalmPluginTest extends TestCase
     public function disableComplainsWhenPassedNotEnabledPlugin(): void
     {
         $plugin_class = 'Vendor\Package\PluginClass';
-        $this->plugin_list->expects()->resolvePluginClass('vendor/package')->andReturns($plugin_class);
-        $this->plugin_list->expects()->isEnabled($plugin_class)->andReturns(false);
+        $this->plugin_list
+            ->shouldReceive('resolvePluginClass')
+            ->once()
+            ->with('vendor/package')
+            ->andReturns($plugin_class);
+        $this->plugin_list->shouldReceive('isEnabled')->once()->with($plugin_class)->andReturns(false);
 
         $disable_command = new CommandTester($this->app->find('disable'));
         $disable_command->execute(['pluginName' => 'vendor/package']);
@@ -270,9 +302,13 @@ final class PsalmPluginTest extends TestCase
     public function disableReportsSuccessWhenItDisablesPlugin(): void
     {
         $plugin_class = 'Vendor\Package\PluginClass';
-        $this->plugin_list->expects()->resolvePluginClass('vendor/package')->andReturns($plugin_class);
-        $this->plugin_list->expects()->isEnabled($plugin_class)->andReturns(true);
-        $this->plugin_list->expects()->disable($plugin_class);
+        $this->plugin_list
+            ->shouldReceive('resolvePluginClass')
+            ->once()
+            ->with('vendor/package')
+            ->andReturns($plugin_class);
+        $this->plugin_list->shouldReceive('isEnabled')->once()->with($plugin_class)->andReturns(true);
+        $this->plugin_list->shouldReceive('disable')->once()->with($plugin_class);
 
         $disable_command = new CommandTester($this->app->find('disable'));
         $disable_command->execute(['pluginName' => 'vendor/package']);

--- a/tests/ReturnTypeTest.php
+++ b/tests/ReturnTypeTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Psalm\Tests;
 
+use Composer\InstalledVersions;
 use Override;
 use Psalm\Tests\Traits\InvalidCodeAnalysisTestTrait;
 use Psalm\Tests\Traits\ValidCodeAnalysisTestTrait;
+
+use function version_compare;
 
 use const DIRECTORY_SEPARATOR;
 
@@ -14,6 +17,16 @@ final class ReturnTypeTest extends TestCase
 {
     use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
+
+    public function testVoidParameterType(): void
+    {
+        // PHP-Parser 5.8 rejects void parameters before Psalm analyzes the body.
+        $parser_version = InstalledVersions::getVersion('nikic/php-parser') ?? '5.0.0';
+        $this->testInvalidCode(
+            '<?php function f(void $p): void {}',
+            version_compare($parser_version, '5.8.0', '>=') ? 'ParseError' : 'ParadoxicalCondition',
+        );
+    }
 
     /**
      * @psalm-pure
@@ -1445,11 +1458,6 @@ final class ReturnTypeTest extends TestCase
                     function doSomething(resource $res): void {
                     }',
                 'error_message' => 'ReservedWord',
-            ],
-            'voidParamType' => [
-                'code' => '<?php
-                    function f(void $p): void {}',
-                'error_message' => 'ParadoxicalCondition',
             ],
             'voidClass' => [
                 'code' => '<?php

--- a/tests/Template/TypeVariableTest.php
+++ b/tests/Template/TypeVariableTest.php
@@ -16,6 +16,9 @@ final class TypeVariableTest extends TestCase
     use InvalidCodeAnalysisTestTrait;
     use ValidCodeAnalysisTestTrait;
 
+    /**
+     * @psalm-pure
+     */
     #[Override]
     public function providerValidCodeParse(): iterable
     {
@@ -84,6 +87,9 @@ final class TypeVariableTest extends TestCase
         ];
     }
 
+    /**
+     * @psalm-pure
+     */
     #[Override]
     public function providerInvalidCodeParse(): iterable
     {

--- a/vendor-bin/bcc/composer.json
+++ b/vendor-bin/bcc/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "roave/backward-compatibility-check": "^8.2.1"
+        "roave/backward-compatibility-check": "^8.21"
     }
 }


### PR DESCRIPTION
CI on master is failing on macOS PHP setup, duplicate diagnostic shortcodes, self-analysis errors, and test expectations affected by newer dependencies.

This PR:
- Updates the pinned macOS setup-php action to v2.37.2 for Homebrew tap trust support.
- Gives IncompatibleTypeParameters the unique shortcode 368, retaining 362 for ImpureGlobalVariable.
- Corrects purity and mutation annotations in type-variable analysis and removes an unused import.
- Uses explicit Mockery expectations while preserving argument matching and call counts.
- Handles PHP-Parser 5.8's earlier rejection of void parameters while retaining coverage for older parsers.
- Bounds best-effort Shepherd reporting with connection and total timeouts.
- Runs Roave BCC on PHP 8.5 with ^8.21 and allows only the exact intentional shortcode transition from 362 to 368; other API changes remain checked.

Validation: full PHPCS and PHP 8.5 Psalm self-analysis pass; Roave detects no backward-incompatible changes after the exact shortcode exception. Focused regressions pass on PHP 8.3 and 8.5 (38 tests each), DocumentationTest passes (359 tests), ReturnTypeTest passes (129 tests), and the void-parameter case also passes with PHP-Parser 5.7. The uploaded git tree matches the locally tested tree exactly.

Hosted macOS/Windows/PHP matrix and the full PHPUnit suite still need CI validation. Local analysis used one analysis/scanning thread because worker sockets are unavailable in the execution environment. PHP 8.3 self-analysis additionally reports four unrelated array_any polyfill purity diagnostics; the PHP 8.5 CI analysis passes.

This PR contains the master fixes. The 6.x backport and the additional changes for #11887 are separate.